### PR TITLE
Fix Windows VSTS builds

### DIFF
--- a/edgelet/build/windows/openssl.ps1
+++ b/edgelet/build/windows/openssl.ps1
@@ -36,12 +36,12 @@ function Get-OpenSSL
         # When executing within TF (VSTS) environment, install the env variable
         # such that all follow up build tasks have visibility of the env variable
         Write-Host "VSTS installation detected"
-        Write-Host "##vso[task.setvariable variable=OPENSSL_ROOT_DIR;]$env:HOMEDRIVE\vcpkg\packages\openssl_x64-windows"
+        Write-Host "##vso[task.setvariable variable=OPENSSL_ROOT_DIR;]$env:HOMEDRIVE\vcpkg\packages\openssl-windows_x64-windows"
     }
     else
     {
         # for local installation, set the env variable within the USER scope
         Write-Host "Local installation detected"
-        [System.Environment]::SetEnvironmentVariable("OPENSSL_ROOT_DIR", "$env:HOMEDRIVE\vcpkg\packages\openssl_x64-windows", [System.EnvironmentVariableTarget]::User)
+        [System.Environment]::SetEnvironmentVariable("OPENSSL_ROOT_DIR", "$env:HOMEDRIVE\vcpkg\packages\openssl-windows_x64-windows", [System.EnvironmentVariableTarget]::User)
     }
 }


### PR DESCRIPTION
vcpkg changed location of windows openssl library, which we use to set the OPENSSL_ROOT_DIR and find the openssl libraries. This change points to the new location. 