### PR TITLE
Reduce the "unsafe" code to a minimum.

### DIFF
--- a/edgelet/edgelet-http/src/pid.rs
+++ b/edgelet/edgelet-http/src/pid.rs
@@ -66,33 +66,33 @@ mod impl_unix {
     }
 
     pub fn get_pid(sock: &UnixStream) -> io::Result<Pid> {
-        unsafe {
-            let raw_fd = sock.as_raw_fd();
-            let mut ucred = ucred {
-                pid: 0,
-                uid: 0,
-                gid: 0,
-            };
-            let ucred_size = mem::size_of::<ucred>();
+        let raw_fd = sock.as_raw_fd();
+        let mut ucred = ucred {
+            pid: 0,
+            uid: 0,
+            gid: 0,
+        };
+        let ucred_size = mem::size_of::<ucred>();
 
-            // These paranoid checks should be optimized-out
-            assert!(mem::size_of::<u32>() <= mem::size_of::<usize>());
-            assert!(ucred_size <= u32::max_value() as usize);
+        // These paranoid checks should be optimized-out
+        assert!(mem::size_of::<u32>() <= mem::size_of::<usize>());
+        assert!(ucred_size <= u32::max_value() as usize);
 
-            let mut ucred_size = ucred_size as u32;
+        let mut ucred_size = ucred_size as u32;
 
-            let ret = getsockopt(
+        let ret = unsafe {
+            getsockopt(
                 raw_fd,
                 SOL_SOCKET,
                 SO_PEERCRED,
                 &mut ucred as *mut ucred as *mut c_void,
                 &mut ucred_size,
-            );
-            if ret == 0 && ucred_size as usize == mem::size_of::<ucred>() {
-                Ok(Pid::Value(ucred.pid))
-            } else {
-                Err(io::Error::last_os_error())
-            }
+            )
+        };
+        if ret == 0 && ucred_size as usize == mem::size_of::<ucred>() {
+            Ok(Pid::Value(ucred.pid))
+        } else {
+            Err(io::Error::last_os_error())
         }
     }
 }


### PR DESCRIPTION
Reduce the amount of code wrapped in "unsafe".  In this case, only "getsockopt" needed to be marked as unsafe.
