### PR TITLE
Fix failing test - AsyncEndpointExecutorTest.TestBatchTimeout

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/AsyncEndpointExecutorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/AsyncEndpointExecutorTest.cs
@@ -116,23 +116,21 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints
             await executor.Invoke(Message1);
             await executor.Invoke(Message1);
 
-            await Task.Delay(100);
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
             
             var expected = new List<IMessage> { Message1, Message1 };
             Assert.Equal(expected, endpoint1.Processed);
 
             await executor.Invoke(Message2);
-
-            await Task.Delay(100);
             expected.Add(Message2);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500));            
             Assert.Equal(expected, endpoint1.Processed);
-
-            await Task.Delay(200);
-
+            
             await executor.Invoke(Message2);
-
-            await Task.Delay(100);
             expected.Add(Message2);
+
+            await Task.Delay(TimeSpan.FromMilliseconds(500));
             Assert.Equal(expected, endpoint1.Processed);
 
             await executor.CloseAsync();


### PR DESCRIPTION
Made some minor updates to fix the flaky test. I was able to get 3 consecutive green runs with the updates.