### PR TITLE
Fix some minor startup issues for clarity and usefulness.

### DIFF
--- a/edgelet/iotedged/src/config/unix/default.yaml
+++ b/edgelet/iotedged/src/config/unix/default.yaml
@@ -1,6 +1,6 @@
 provisioning:
   source: "manual"
-  device_connection_string: "HostName=something.some.com;DeviceId=some;SharedAccessKey=some"
+  device_connection_string: "<ADD DEVICE CONNECTION STRING HERE>"
 
 agent:
   name: "edgeAgent"
@@ -20,7 +20,7 @@ listen:
   management_uri: "unix:///var/run/iotedge/mgmt.sock"
   workload_uri: "unix:///var/run/iotedge/workload.sock"
 
-homedir: "/tmp/iotedge"
+homedir: "/var/lib/iotedge"
 
 moby_runtime:
   uri: "unix:///var/run/docker.sock"

--- a/edgelet/iotedged/src/config/windows/default.yaml
+++ b/edgelet/iotedged/src/config/windows/default.yaml
@@ -1,6 +1,6 @@
 provisioning:
   source: "manual"
-  device_connection_string: "HostName=something.some.com;DeviceId=some;SharedAccessKey=some"
+  device_connection_string: "<ADD DEVICE CONNECTION STRING HERE>"
 
 agent:
   name: "edgeAgent"
@@ -20,7 +20,7 @@ listen:
   management_uri: "http://0.0.0.0:15580"
   workload_uri: "http://0.0.0.0:15581"
 
-homedir: "C:\\Temp\\iotedge"
+homedir: "C:\\ProgramData\\iotedge"
 
 moby_runtime:
   uri: "npipe://./pipe/docker_engine"

--- a/edgelet/iotedged/src/error.rs
+++ b/edgelet/iotedged/src/error.rs
@@ -54,6 +54,20 @@ pub enum ErrorKind {
     Parse,
     #[fail(display = "An http error occurred.")]
     Http,
+    #[cfg(target_os = "windows")]
+    #[fail(
+        display = "Edge device information is required.\n\
+        Please edit your config.yaml and provide information to connection the Edge to the IoT Hub.\n\
+        See https://aka.ms/iot-edge-configure-windows"
+    )]
+    Unconfigured,
+    #[cfg(not(target_os = "windows"))]
+    #[fail(
+        display = "Edge device information is required.\n\
+        Please edit your config.yaml and provide information to connection the Edge to the IoT Hub.\n\
+        See https://aka.ms/iot-edge-configure-linux"
+    )]
+    Unconfigured,
     #[fail(display = "A provisioning error occurred.")]
     Provisioning,
     #[fail(display = "A hardware hsm error occurred.")]

--- a/edgelet/iotedged/src/error.rs
+++ b/edgelet/iotedged/src/error.rs
@@ -30,7 +30,7 @@ pub struct Error {
     inner: Context<ErrorKind>,
 }
 
-#[derive(Debug, Fail)]
+#[derive(Debug, Fail, PartialEq)]
 pub enum ErrorKind {
     #[fail(display = "Invalid configuration file")]
     Settings,
@@ -57,15 +57,15 @@ pub enum ErrorKind {
     #[cfg(target_os = "windows")]
     #[fail(
         display = "Edge device information is required.\n\
-        Please edit your config.yaml and provide information to connection the Edge to the IoT Hub.\n\
-        See https://aka.ms/iot-edge-configure-windows"
+                   Please update the config.yaml and provide the IoTHub connection information.\n\
+                   See https://aka.ms/iot-edge-configure-windows for more details."
     )]
     Unconfigured,
     #[cfg(not(target_os = "windows"))]
     #[fail(
         display = "Edge device information is required.\n\
-        Please edit your config.yaml and provide information to connection the Edge to the IoT Hub.\n\
-        See https://aka.ms/iot-edge-configure-linux"
+                   Please update the config.yaml and provide the IoTHub connection information.\n\
+                   See https://aka.ms/iot-edge-configure-linux for more details"
     )]
     Unconfigured,
     #[fail(display = "A provisioning error occurred.")]
@@ -79,6 +79,12 @@ pub enum ErrorKind {
     #[cfg(target_os = "windows")]
     #[fail(display = "Windows service error")]
     WindowsService,
+}
+
+impl Error {
+    pub fn kind(&self) -> &ErrorKind {
+        self.inner.get_context()
+    }
 }
 
 impl Fail for Error {

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -98,7 +98,7 @@ use sha2::{Digest, Sha256};
 use tokio_core::reactor::{Core, Handle};
 use url::Url;
 
-use settings::{Dps, Manual, Provisioning, Settings};
+use settings::{Dps, Manual, Provisioning, Settings, DEFAULT_CONNECTION_STRING};
 
 pub use self::error::{Error, ErrorKind};
 
@@ -197,6 +197,12 @@ impl Main {
             settings,
             reactor: mut core,
         } = self;
+
+        if let Provisioning::Manual(ref manual) = settings.provisioning() {
+            if manual.device_connection_string() == DEFAULT_CONNECTION_STRING {
+                Err(ErrorKind::Unconfigured)?;
+            }
+        }
 
         let handle: Handle = core.handle().clone();
         let hyper_client = HyperClient::configure()
@@ -726,6 +732,16 @@ mod tests {
         fn destroy_key(&self) -> Result<(), edgelet_core::Error> {
             Ok(())
         }
+    }
+
+    #[test]
+    fn default_settings_raise_unconfigured_error() {
+        let settings = Settings::<DockerConfig>::new(None).unwrap();
+        let main = Main::new(settings).unwrap();
+        let shutdown_signal = signal::shutdown(&main.handle());
+        let result = main.run_until(shutdown_signal);
+
+        assert_eq!(ErrorKind::Unconfigured, *result.unwrap_err().kind());
     }
 
     #[test]

--- a/edgelet/iotedged/src/settings.rs
+++ b/edgelet/iotedged/src/settings.rs
@@ -16,10 +16,13 @@ use url::Url;
 use url_serde;
 
 use edgelet_core::ModuleSpec;
-use error::Error;
+use error::{Error, ErrorKind};
 
 /// This is the name of the network created by the iotedged
 const DEFAULT_NETWORKID: &str = "azure-iot-edge";
+
+/// This is the default connection string
+const DEFAULT_CONNECTION_STRING: &str = "<ADD DEVICE CONNECTION STRING HERE>";
 
 #[cfg(unix)]
 static DEFAULTS: &str = include_str!("config/unix/default.yaml");
@@ -167,14 +170,20 @@ where
     pub fn new(filename: Option<&str>) -> Result<Self, Error> {
         let mut config = Config::default();
         config.merge(File::from_str(DEFAULTS, FileFormat::Yaml))?;
-
         if let Some(file) = filename {
             config.merge(File::with_name(file).required(true))?;
         }
 
         config.merge(Environment::with_prefix("iotedge"))?;
 
-        let settings = config.try_into()?;
+        let settings: Self = config.try_into()?;
+
+        if let Provisioning::Manual(manual) = settings.provisioning() {
+            if manual.device_connection_string() == DEFAULT_CONNECTION_STRING {
+                Err(ErrorKind::Unconfigured)?;
+            }
+        }
+
         Ok(settings)
     }
 
@@ -244,6 +253,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use config::{Config, File, FileFormat};
     use edgelet_docker::DockerConfig;
     use std::io::Write;
     use tempdir::TempDir;
@@ -274,16 +284,28 @@ mod tests {
     }
 
     #[test]
-    fn manual_gets_default_connection_string() {
-        let settings = Settings::<DockerConfig>::new(None);
-        assert_eq!(settings.is_ok(), true);
-        let s = settings.unwrap();
-        let p = s.provisioning();
-        let connection_string = unwrap_manual_provisioning(p);
-        assert_eq!(
-            connection_string,
-            "HostName=something.some.com;DeviceId=some;SharedAccessKey=some"
-        );
+    fn default_in_yaml_matches_constant() {
+        let mut config = Config::default();
+        config
+            .merge(File::from_str(DEFAULTS, FileFormat::Yaml))
+            .unwrap();
+        let settings: Settings<DockerConfig> = config.try_into().unwrap();
+
+        match settings.provisioning() {
+            Provisioning::Manual(ref manual) => {
+                assert_eq!(manual.device_connection_string(), DEFAULT_CONNECTION_STRING)
+            }
+            _ => assert!(false),
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "Edge device information is required.\n\
+        Please edit your config.yaml and provide information to connection the Edge to the IoT Hub."
+    )]
+    fn warn_user_on_default() {
+        let _settings = Settings::<DockerConfig>::new(None).unwrap();
     }
 
     #[test]

--- a/edgelet/iotedged/src/settings.rs
+++ b/edgelet/iotedged/src/settings.rs
@@ -16,13 +16,13 @@ use url::Url;
 use url_serde;
 
 use edgelet_core::ModuleSpec;
-use error::{Error, ErrorKind};
+use error::Error;
 
 /// This is the name of the network created by the iotedged
 const DEFAULT_NETWORKID: &str = "azure-iot-edge";
 
 /// This is the default connection string
-const DEFAULT_CONNECTION_STRING: &str = "<ADD DEVICE CONNECTION STRING HERE>";
+pub const DEFAULT_CONNECTION_STRING: &str = "<ADD DEVICE CONNECTION STRING HERE>";
 
 #[cfg(unix)]
 static DEFAULTS: &str = include_str!("config/unix/default.yaml");
@@ -178,12 +178,6 @@ where
 
         let settings: Self = config.try_into()?;
 
-        if let Provisioning::Manual(manual) = settings.provisioning() {
-            if manual.device_connection_string() == DEFAULT_CONNECTION_STRING {
-                Err(ErrorKind::Unconfigured)?;
-            }
-        }
-
         Ok(settings)
     }
 
@@ -297,15 +291,6 @@ mod tests {
             }
             _ => assert!(false),
         }
-    }
-
-    #[test]
-    #[should_panic(
-        expected = "Edge device information is required.\n\
-        Please edit your config.yaml and provide information to connection the Edge to the IoT Hub."
-    )]
-    fn warn_user_on_default() {
-        let _settings = Settings::<DockerConfig>::new(None).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
It didn't really make sense that the default config.yaml had a different default home directory than the 
configuration in the packaging.  I also changed the default value for the connection string to make it clear that it needs to be updated.

Based on that default value, once configuration is loaded, if that default connection string is still set, we will generate explicit error message to indicate we need the user to configure IoT Edge.