### PR TITLE
EdgeHub: Fix handling of duplicate system properties in Protocol gateway message converter

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -25,7 +25,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
         IDeviceProxy underlyingProxy;
 
         // IoTHub error codes
-        const int GatewayTimeoutErrorCode = 504101;
         const int GenericBadRequest = 400000;
 
         public DeviceMessageHandler(IIdentity identity, IEdgeHub edgeHub, IConnectionManager connectionManager)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             {
                 if (SystemProperties.OutgoingSystemPropertiesMap.TryGetValue(systemProperty.Key, out string onWirePropertyName))
                 {
-                    properties.Add(onWirePropertyName, systemProperty.Value);
+                    properties[onWirePropertyName] = systemProperty.Value;
                 }
             }
 


### PR DESCRIPTION
Issue: If the user sets some system properties as user properties, then the code tries to add them again and throws a "duplicate key in dictionary" exception. 

Fix: Override the user property with the system property if necessary