### PR TITLE
Clean up reSharper warnings (variable related)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planners/HealthRestartPlanner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planners/HealthRestartPlanner.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Planners
             Events.LogDesired(desired);
             Events.LogCurrent(current);
             // extract list of modules that need attention
-            var (added, updateDeployed, updateStateChanged, removed, runningGreat) = this.ProcessDiff(desired, current);
+            (IList<IModule> added, IList<IModule> updateDeployed, IList<IRuntimeModule> updateStateChanged, IList<IRuntimeModule> removed, IList<IRuntimeModule> runningGreat) = this.ProcessDiff(desired, current);
 
             var updateRuntimeCommands = new List<ICommand>();
             IModule edgeAgentModule = updateDeployed.FirstOrDefault(m => m.Name.Equals(Constants.EdgeAgentModuleName, StringComparison.OrdinalIgnoreCase));

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planrunners/OrdererdRetryPlanRunner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planrunners/OrdererdRetryPlanRunner.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.PlanRunners
                 bool skippedModules = false;
                 foreach (ICommand command in plan.Commands)
                 {
-                    var (shouldRun, runCount, coolOffPeriod, elapsedTime) = this.ShouldRunCommand(command);
+                    (bool shouldRun, int runCount, TimeSpan coolOffPeriod, TimeSpan elapsedTime) = this.ShouldRunCommand(command);
                     try
                     {
                         if (token.IsCancellationRequested)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/planners/HealthRestartPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/planners/HealthRestartPlannerTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         [Unit]
         public void TestCreateValidation()
         {
-            var (factory, store, restartManager, _) = CreatePlanner();
+            (TestCommandFactory factory, Mock<IEntityStore<string, ModuleState>> store, IRestartPolicyManager restartManager, _) = CreatePlanner();
 
             Assert.Throws<ArgumentNullException>(() => new HealthRestartPlanner(null, store.Object, IntensiveCareTime, restartManager));
             Assert.Throws<ArgumentNullException>(() => new HealthRestartPlanner(factory, null, IntensiveCareTime, restartManager));
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         public async void TestMinimalTest()
         {
             // Arrange
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
             var token = new CancellationToken();
             var expectedExecutionList = new List<TestRecordType>();
 
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         [Unit]
         public async void TestAddRunningModule()
         {
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
             IModule addModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, EnvVars);
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { addModule });
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         [Unit]
         public async void TestAddStoppedModule()
         {
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
             IModule addModule = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, EnvVars);
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { addModule });
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         [Unit]
         public async void TestUpdateModule()
         {
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
             IRuntimeModule currentModule = new TestRuntimeModule(
                 "mod1", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1,
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         [Unit]
         public async void TestRemoveModule()
         {
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
             IRuntimeModule removeModule = new TestRuntimeModule(
                 "mod1", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1,
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         [Unit]
         public async Task TestRemoveKitchenSink()
         {
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
             IRuntimeModule[] removedModules = GetRemoveTestData();
 
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
             // on whether it undergoes a re-deploy or not.
 
             // Arrange
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
             (IRuntimeModule RunningModule, IModule UpdatedModule)[] data = GetUpdateDeployTestData();
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(data.Select(d => d.UpdatedModule).ToList());
             // build "current" and "desired" module sets
@@ -804,7 +804,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         public async Task TestUpdateStateChangedKitchenSink()
         {
             // Arrange
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
             // prepare list of modules whose configurations have been updated
             (IRuntimeModule RunningModule, IModule UpdatedModule)[] updateDeployModules = GetUpdateDeployTestData();
@@ -866,7 +866,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         public async Task TestResetStatsForHealthyModules()
         {
             // Arrange
-            var (factory, store, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, Mock<IEntityStore<string, ModuleState>> store, _, HealthRestartPlanner planner) = CreatePlanner();
 
             // derive list of "running great" modules from GetUpdateStateChangeTestData()
             IList<IRuntimeModule> runningGreatModules = GetUpdateStateChangeTestData()
@@ -897,7 +897,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         public async Task CreateShutdownPlanTest()
         {
             // Arrange
-            var (factory, _, _, planner) = CreatePlanner();
+            (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
             IModule module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, EnvVars);
             IModule edgeAgentModule = new TestModule(Constants.EdgeAgentModuleName, "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, EnvVars);

--- a/edge-modules/load-gen/Timers.cs
+++ b/edge-modules/load-gen/Timers.cs
@@ -19,7 +19,7 @@ namespace LoadGen
             {
                 if (disposing)
                 {
-                    foreach (var task in this.timerTasks)
+                    foreach (TimerTask task in this.timerTasks)
                     {
                         task.Timer.Dispose();
                     }
@@ -44,7 +44,7 @@ namespace LoadGen
 
         public void Start()
         {
-            foreach (var task in this.timerTasks)
+            foreach (TimerTask task in this.timerTasks)
             {
                 task.Timer.Start();
             }
@@ -52,7 +52,7 @@ namespace LoadGen
 
         public void Stop()
         {
-            foreach (var task in this.timerTasks)
+            foreach (TimerTask task in this.timerTasks)
             {
                 task.Timer.Stop();
                 task.Quit = true;

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ShutdownHandler.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ShutdownHandler.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
         {
             var cts = new CancellationTokenSource();
             var completed = new ManualResetEventSlim();
-            var handler = Option.None<object>();
+            Option<object> handler = Option.None<object>();
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 WindowsShutdownHandler.HandlerRoutine hr = WindowsShutdownHandler.Init(cts, completed, shutdownWaitPeriod, logger);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/uds/HttpBufferedStream.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/uds/HttpBufferedStream.cs
@@ -41,13 +41,13 @@ namespace Microsoft.Azure.Devices.Edge.Util.Uds
         public async Task<string> ReadLineAsync(CancellationToken cancellationToken)
         {
             int position = 0;
-            byte[] buffer = new byte[1];
+            var buffer = new byte[1];
             bool crFound = false;
             var builder = new StringBuilder();
             while (true)
             {
               
-                var length = await this.innerStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
+                int length = await this.innerStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken)
                     .ConfigureAwait(false);
 
                 if (length == 0)

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/uds/HttpRequestResponseSerializer.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/uds/HttpRequestResponseSerializer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Uds
 
             PreProcessRequest(request);
 
-            StringBuilder builder = new StringBuilder();
+            var builder = new StringBuilder();
             // request-line   = method SP request-target SP HTTP-version CRLF
             builder.Append(request.Method);
             builder.Append(SP);
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Uds
 
             if (request.Content != null)
             {
-                var contentLength = request.Content.Headers.ContentLength;
+                long? contentLength = request.Content.Headers.ContentLength;
                 if (contentLength.HasValue)
                 {
                     request.Content.Headers.ContentLength = contentLength.Value;
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Uds
             }
 
             httpResponse.Content = new StreamContent(bufferedStream);
-            foreach (var header in headers)
+            foreach (string header in headers)
             {
                 if (string.IsNullOrWhiteSpace(header))
                 {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/TaskExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/TaskExTest.cs
@@ -39,11 +39,11 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
         [Unit]
         public async Task WhenAllTuple()
         {
-            var (val1, val2) = await TaskEx.WhenAll(Task.FromResult(12), Task.FromResult("hello"));
+            (int val1, string val2) = await TaskEx.WhenAll(Task.FromResult(12), Task.FromResult("hello"));
             Assert.Equal(12, val1);
             Assert.Equal("hello", val2);
 
-            var (a1, a2, a3, a4, a5, a6, a7, a8) = await TaskEx.WhenAll(
+            (int a1, int a2, int a3, int a4, int a5, int a6, int a7, int a8) = await TaskEx.WhenAll(
                 Task.FromResult(1),
                 Task.FromResult(2),
                 Task.FromResult(3),

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/uds/HttpRequestResponseSerializerTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/uds/HttpRequestResponseSerializerTest.cs
@@ -22,7 +22,7 @@ Content-Type: application/json
 Content-Length: 100
 
 ";
-            HttpRequestMessage request = new HttpRequestMessage();
+            var request = new HttpRequestMessage();
             request.RequestUri = new Uri("http://localhost:8081/modules/testModule/sign?api-version=2018-06-28", UriKind.Absolute);
             request.Version = Version.Parse("1.1");
             request.Content = new ByteArrayContent(Encoding.UTF8.GetBytes("test"));
@@ -44,7 +44,7 @@ Content-Type: application/json
 Content-Length: 100
 
 ";
-            HttpRequestMessage request = new HttpRequestMessage();
+            var request = new HttpRequestMessage();
             request.RequestUri = new Uri("http://localhost:8081/modules/testModule/sign?api-version=2018-06-28", UriKind.Absolute);
             request.Method = HttpMethod.Post;
             request.Content = new ByteArrayContent(Encoding.UTF8.GetBytes("test"));
@@ -66,7 +66,7 @@ Content-Type: application/json
 Content-Length: 4
 
 ";
-            HttpRequestMessage request = new HttpRequestMessage();
+            var request = new HttpRequestMessage();
             request.RequestUri = new Uri("http://localhost:8081/modules/testModule/sign?api-version=2018-06-28", UriKind.Absolute);
             request.Method = HttpMethod.Post;
             request.Content = new ByteArrayContent(Encoding.UTF8.GetBytes("test"));
@@ -85,7 +85,7 @@ Host: localhost:8081
 Connection: close
 
 ";
-            HttpRequestMessage request = new HttpRequestMessage();
+            var request = new HttpRequestMessage();
             request.RequestUri = new Uri("http://localhost:8081/modules/testModule/sign?api-version=2018-06-28", UriKind.Absolute);
             request.Method = HttpMethod.Get;
 
@@ -103,7 +103,7 @@ Connection: close
         [Fact]
         public void TestSerializeRequest_RequestUriIsNull_ShouldThrowArgumentNullException()
         {
-            HttpRequestMessage request = new HttpRequestMessage();
+            var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
             request.Content = new ByteArrayContent(Encoding.UTF8.GetBytes("test"));
             request.Content.Headers.TryAddWithoutValidation("content-type", "application/json");
@@ -121,7 +121,7 @@ Content-Type: application/json
 Content-Length: 100
 
 ";
-            HttpRequestMessage request = new HttpRequestMessage();
+            var request = new HttpRequestMessage();
             request.Method = HttpMethod.Post;
             request.RequestUri = new Uri("http://localhost:8081/modules/testModule/sign?api-version=2018-06-28", UriKind.Absolute);
             request.Version = Version.Parse("1.1");
@@ -140,7 +140,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("invalid");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -151,7 +151,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("invalid\r\n");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -162,7 +162,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/11 200 OK\r\n");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -173,7 +173,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP-1.1 200 OK\r\n");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -184,7 +184,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 2000 OK\r\n");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -195,7 +195,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 200\r\n");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -206,7 +206,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 200 OK \r\n");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -217,7 +217,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 200 OK\r\n\r\n");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             HttpResponseMessage response = await new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken);
@@ -232,7 +232,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 200 OK\r\nContent-length: 5\r\n\r\nMessage is longer");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -243,7 +243,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 200 OK\r\nContent-length=5\r\n\r\nMessage is longer");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -254,7 +254,7 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 200 OK\r\nContent-length: 5\r\n");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
             Assert.ThrowsAsync<HttpRequestException>(() => new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken));
@@ -265,10 +265,10 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 200 OK\r\nTest-header: 4\r\n\r\nTest");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
-            var response = await new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken);
+            HttpResponseMessage response = await new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken);
 
             Assert.Equal(response.Version, Version.Parse("1.1"));
             Assert.Equal(response.StatusCode, System.Net.HttpStatusCode.OK);
@@ -282,10 +282,10 @@ Content-Length: 100
         {
             byte[] expected = Encoding.UTF8.GetBytes("HTTP/1.1 200 OK\r\nContent-length: 4\r\n\r\nTest");
             var memory = new MemoryStream(expected, true);
-            HttpBufferedStream stream = new HttpBufferedStream(memory);
+            var stream = new HttpBufferedStream(memory);
 
             System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken);
-            var response = await new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken);
+            HttpResponseMessage response = await new HttpRequestResponseSerializer().DeserializeResponse(stream, cancellationToken);
 
             Assert.Equal(response.Version, Version.Parse("1.1"));
             Assert.Equal(response.StatusCode, System.Net.HttpStatusCode.OK);


### PR DESCRIPTION
We have 30 warnings + Hints. All related with Variable (var vs explicit). 
Cleaning these up so we can come back to 0 warnings. 