### PR TITLE
Fix a strict-mode bug in the Windows install script

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -215,6 +215,7 @@ function Get-ContainerOs {
 
 function Get-SecurityDaemon {
     try {
+        $DeleteArchive = $false
         if (-not $ArchivePath) {
             $ArchivePath = "$env:TEMP\iotedged-windows.zip"
             $DeleteArchive = $true


### PR DESCRIPTION
Initialize the variable `$DeleteArchive` at a higher scope so it is declared no matter which path we take through the function.