### PR TITLE
Add support for iotedged+Windows to quickstart

### DIFF
--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -103,13 +103,6 @@ Defaults:
         // ReSharper disable once UnusedMember.Local
         async Task<int> OnExecuteAsync()
         {
-            if (this.BootstrapperType == BootstrapperType.Iotedged &&
-                RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Console.WriteLine("IotEdgeQuickstart parameter '--bootstrapper' does not yet support 'iotedged' on Windows. Please specify 'iotedgectl' instead.");
-                return 1;
-            }
-
             try
             {
                 string address = this.RegistryAddress;
@@ -130,11 +123,18 @@ Defaults:
                 {
                     case BootstrapperType.Iotedged:
                         {
-                            (bool useHttp, string hostname) = this.UseHttp;
-                            Option<HttpUris> uris = useHttp
-                                ? Option.Some(string.IsNullOrEmpty(hostname) ? new HttpUris() : new HttpUris(hostname))
-                                : Option.None<HttpUris>();
-                            bootstrapper = new IotedgedLinux(this.BootstrapperArchivePath, credentials, uris);
+                            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                            {
+                                bootstrapper = new IotedgedWindows(this.BootstrapperArchivePath, credentials);
+                            }
+                            else
+                            {
+                                (bool useHttp, string hostname) = this.UseHttp;
+                                Option<HttpUris> uris = useHttp
+                                    ? Option.Some(string.IsNullOrEmpty(hostname) ? new HttpUris() : new HttpUris(hostname))
+                                    : Option.None<HttpUris>();
+                                bootstrapper = new IotedgedLinux(this.BootstrapperArchivePath, credentials, uris);
+                            }
                         }
                         break;
                     case BootstrapperType.Iotedgectl:

--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -134,7 +134,7 @@ Defaults:
                             Option<HttpUris> uris = useHttp
                                 ? Option.Some(string.IsNullOrEmpty(hostname) ? new HttpUris() : new HttpUris(hostname))
                                 : Option.None<HttpUris>();
-                            bootstrapper = new Iotedged(this.BootstrapperArchivePath, credentials, uris);
+                            bootstrapper = new IotedgedLinux(this.BootstrapperArchivePath, credentials, uris);
                         }
                         break;
                     case BootstrapperType.Iotedgectl:

--- a/smoke/IotEdgeQuickstart/Quickstart.cs
+++ b/smoke/IotEdgeQuickstart/Quickstart.cs
@@ -54,7 +54,7 @@ namespace IotEdgeQuickstart
                     if (!this.noDeployment)
                     {
                         await DeployToEdgeDevice();
-                        if (!this.deploymentFileName.HasValue)
+                        if (!this.DeploymentFileName.HasValue)
                         {
                             await VerifyTempSensorIsRunning();
                             await VerifyTempSensorIsSendingDataToIotHub();

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -25,7 +25,7 @@ namespace IotEdgeQuickstart.Details
         readonly string imageTag;
         readonly string deviceId;
         readonly string hostname;
-        public readonly Option<string> deploymentFileName;
+        public readonly Option<string> DeploymentFileName;
 
         DeviceContext context;
 
@@ -47,7 +47,7 @@ namespace IotEdgeQuickstart.Details
             this.imageTag = imageTag;
             this.deviceId = deviceId;
             this.hostname = hostname;
-            this.deploymentFileName = deploymentFileName;
+            this.DeploymentFileName = deploymentFileName;
         }
 
         protected Task VerifyEdgeIsNotAlreadyActive() => this.bootstrapper.VerifyNotActive();
@@ -299,31 +299,28 @@ namespace IotEdgeQuickstart.Details
             string edgeAgentImage = this.EdgeAgentImage();
             string edgeHubImage = this.EdgeHubImage();
             string tempSensorImage = this.TempSensorImage();
-            string deployJson = this.deploymentFileName.Match(f => {
-                JObject o1 = JObject.Parse(File.ReadAllText(f));
-                string json = o1.ToString();
-                return json;
-            }, () => {
-                string deployJsonRegistry = this.credentials.Match(
-                c =>
-                    {
-                        string json = DeployJsonRegistry;
-                        json = Regex.Replace(json, "<registry-address>", c.Address);
-                        json = Regex.Replace(json, "<registry-username>", c.User);
-                        json = Regex.Replace(json, "<registry-password>", c.Password);
-                        return json;
-                    },
-                    () => string.Empty
-                );
+            string deployJson = this.DeploymentFileName.Match(
+                f => JObject.Parse(File.ReadAllText(f)).ToString(),
+                () => {
+                    string deployJsonRegistry = this.credentials.Match(
+                    c =>
+                        {
+                            string jsonRegistry = DeployJsonRegistry;
+                            jsonRegistry = Regex.Replace(jsonRegistry, "<registry-address>", c.Address);
+                            jsonRegistry = Regex.Replace(jsonRegistry, "<registry-username>", c.User);
+                            jsonRegistry = Regex.Replace(jsonRegistry, "<registry-password>", c.Password);
+                            return jsonRegistry;
+                        },
+                        () => string.Empty
+                    );
 
-                string deployJsonTemplate = DeployJson;
-                deployJson = Regex.Replace(deployJsonTemplate, "<image-edge-agent>", edgeAgentImage);
-                deployJson = Regex.Replace(deployJsonTemplate, "<image-edge-hub>", edgeHubImage);
-                deployJson = Regex.Replace(deployJsonTemplate, "<image-temp-sensor>", tempSensorImage);
-                deployJson = Regex.Replace(deployJsonTemplate, "<registry-info>", deployJsonRegistry);
-                return deployJsonTemplate;
-            });
-            
+                    string json = DeployJson;
+                    json = Regex.Replace(json, "<image-edge-agent>", edgeAgentImage);
+                    json = Regex.Replace(json, "<image-edge-hub>", edgeHubImage);
+                    json = Regex.Replace(json, "<image-temp-sensor>", tempSensorImage);
+                    json = Regex.Replace(json, "<registry-info>", deployJsonRegistry);
+                    return json;
+                });
 
             return (deployJson, new [] { edgeAgentImage, edgeHubImage, tempSensorImage });
         }

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -59,13 +59,13 @@ namespace IotEdgeQuickstart.Details
         }
     }
 
-    class Iotedged : IBootstrapper
+    class IotedgedLinux : IBootstrapper
     {
         readonly string archivePath;
         readonly Option<RegistryCredentials> credentials;
         readonly Option<HttpUris> httpUris;
 
-        public Iotedged(string archivePath, Option<RegistryCredentials> credentials, Option<HttpUris> httpUris)
+        public IotedgedLinux(string archivePath, Option<RegistryCredentials> credentials, Option<HttpUris> httpUris)
         {
             this.archivePath = archivePath;
             this.credentials = credentials;
@@ -77,7 +77,7 @@ namespace IotEdgeQuickstart.Details
             string[] result = await Process.RunAsync("bash", "-c \"systemctl --no-pager show iotedge | grep ActiveState=\"");
             if (result.First().Split("=").Last() == "active")
             {
-                throw new Exception("IoT Edge Security Daemon is already active. If you want this test to overwrite the active configuration, please run `systemctl stop iotedged` first.");
+                throw new Exception("IoT Edge Security Daemon is already active. If you want this test to overwrite the active configuration, please run `systemctl stop iotedge` first.");
             }
         }
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -1,0 +1,147 @@
+namespace IotEdgeQuickstart.Details
+{
+    using System;
+    using System.ComponentModel;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    class IotedgedWindows : IBootstrapper
+    {
+        readonly string archivePath;
+        readonly Option<RegistryCredentials> credentials;
+        string scriptDir;
+
+        public IotedgedWindows(string archivePath, Option<RegistryCredentials> credentials)
+        {
+            this.archivePath = archivePath;
+            this.credentials = credentials;
+        }
+
+        public async Task VerifyNotActive()
+        {
+            bool active = true;
+            try
+            {
+                await Process.RunAsync("sc", "query iotedge");
+            }
+            catch (Win32Exception e) when (e.NativeErrorCode == 1060)
+            {
+                // The specified service does not exist as an installed service.
+                active = false;
+            }
+
+            if (active)
+            {
+                throw new Exception("IoT Edge Security Daemon is already installed and may have an active configuration. If you want this run this test, please uninstall the daemon first.");
+            }
+        }
+
+        public Task VerifyDependenciesAreInstalled() => Task.CompletedTask;
+
+        public async Task VerifyModuleIsRunning(string name)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+            {
+                string errorMessage = null;
+
+                try
+                {
+                    while (true)
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(3), cts.Token);
+
+                        string[] result = await Process.RunAsync("iotedge", "list", cts.Token);
+                        string status = result
+                            .Where(ln => ln.Split(null as char[], StringSplitOptions.RemoveEmptyEntries).First() == name)
+                            .DefaultIfEmpty("name status")
+                            .Single()
+                            .Split(null as char[], StringSplitOptions.RemoveEmptyEntries)
+                            .ElementAt(1);  // second column is STATUS
+
+                        if (status == "running") break;
+
+                        errorMessage = "Not found";
+                    }
+                }
+                catch (OperationCanceledException e)
+                {
+                    throw new Exception($"Error searching for {name} module: {errorMessage ?? e.Message}");
+                }
+                catch (Exception e)
+                {
+                    throw new Exception($"Error searching for {name} module: {e.Message}");
+                }
+            }
+        }
+
+        public Task Install()
+        {
+            // Windows installation does install + configure in one step. Since we need to connection string
+            // to configure and we don't have that information here, we'll do installation in Configure().
+
+            return Task.CompletedTask;
+        }
+
+
+        public async Task Configure(string connectionString, string image, string hostname)
+        {
+            Console.WriteLine($"Installing iotedged from {this.archivePath ?? "default location"}");
+            Console.WriteLine($"Setting up iotedged with agent image '{image}'");
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+            {
+                if (!string.IsNullOrEmpty(this.archivePath))
+                {
+                    this.scriptDir = File.GetAttributes(this.archivePath).HasFlag(FileAttributes.Directory)
+                        ? this.archivePath
+                        : new FileInfo(this.archivePath).DirectoryName;
+                }
+                else
+                {
+                    this.scriptDir = Path.GetTempPath();
+                    await Process.RunAsync("powershell",
+                        $"iwr -useb -o '{this.scriptDir}\\IotEdgeSecurityDaemon.ps1' aka.ms/iotedge-win",
+                        cts.Token);
+                }
+
+                string args = $". {this.scriptDir}\\IotEdgeSecurityDaemon.ps1; Install-SecurityDaemon -Manual " +
+                    $"-ContainerOs Windows -DeviceConnectionString '{connectionString}' -AgentImage '{image}'";
+
+                foreach (RegistryCredentials c in this.credentials)
+                {
+                    args += $" -Username '{c.User}' -Password (ConvertTo-SecureString '{c.Password}' -AsPlainText -Force)";
+                }
+
+                if (this.archivePath != null)
+                {
+                    args += $" -ArchivePath '{this.archivePath}'";
+                }
+
+                // note: ignore hostname for now
+
+                await Process.RunAsync("powershell", args, cts.Token);
+            }
+        }
+
+        public Task Start() => Task.CompletedTask; // Runtime starts automatically when it's installed
+
+        public async Task Stop()
+        {
+            await Process.RunAsync("powershell", "Stop-Service -NoWait iotedge");
+            await Task.Delay(TimeSpan.FromSeconds(3));
+        }
+
+        public async Task Reset()
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))
+            {
+                await Process.RunAsync("powershell",
+                    $". {this.scriptDir}\\IotEdgeSecurityDaemon.ps1; Uninstall-SecurityDaemon",
+                    cts.Token);
+            }
+        }
+    }
+}


### PR DESCRIPTION
- Adds support for Windows in the `-b iotedged` case
- Fixes a bug: when you don't provide your own deployment.json file, quickstart is building the deployment JSON incorrectly, causing a crash.