### PR TITLE
Adding No Verify Scenarios Flag.

### DIFF
--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -49,7 +49,7 @@ Defaults:
                             switch form uses local IP address as hostname
   --username                anonymous, or Key Vault if --registry is specified
   --no-deployment           deploy Edge Hub and temperature sensor modules
-  --no-verify               verify scenarios is true by defaul and will check temperature sensor sent data to cloud.
+  --no-verify               false
   --deployment              deployment json file
 "
         )]

--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -98,8 +98,8 @@ Defaults:
         [Option("--no-deployment", CommandOptionType.NoValue, Description = "Don't deploy Edge Hub and temperature sensor modules")]
         public bool NoDeployment { get; } = false;
 
-        [Option("--no-verify-scenarios", CommandOptionType.NoValue, Description = "Don't verify scenarios. E.g: verify is temperature sensor sent data")]
-        public bool NoVerifyScenarios { get; } = false;
+        [Option("--no-verify", CommandOptionType.NoValue, Description = "Don't verify the behavior of the deployment (e.g.: temp sensor)")]
+        public bool NoVerify { get; } = false;
 
         [Option("-l|--deployment <filename>", Description = "Deployment json file")]
         public string DeploymentFileName { get; } = Environment.GetEnvironmentVariable("deployment");
@@ -168,7 +168,7 @@ Defaults:
                     this.EdgeHostname,
                     this.LeaveRunning,
                     this.NoDeployment,
-                    this.NoVerifyScenarios,
+                    this.NoVerify,
                     deployment);
                 await test.RunAsync();
             }

--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -49,6 +49,7 @@ Defaults:
                             switch form uses local IP address as hostname
   --username                anonymous, or Key Vault if --registry is specified
   --no-deployment           deploy Edge Hub and temperature sensor modules
+  --no-verify               verify scenarios is true by defaul and will check temperature sensor sent data to cloud.
   --deployment              deployment json file
 "
         )]
@@ -96,6 +97,9 @@ Defaults:
 
         [Option("--no-deployment", CommandOptionType.NoValue, Description = "Don't deploy Edge Hub and temperature sensor modules")]
         public bool NoDeployment { get; } = false;
+
+        [Option("--no-verify-scenarios", CommandOptionType.NoValue, Description = "Don't verify scenarios. E.g: verify is temperature sensor sent data")]
+        public bool NoVerifyScenarios { get; } = false;
 
         [Option("-l|--deployment <filename>", Description = "Deployment json file")]
         public string DeploymentFileName { get; } = Environment.GetEnvironmentVariable("deployment");
@@ -164,6 +168,7 @@ Defaults:
                     this.EdgeHostname,
                     this.LeaveRunning,
                     this.NoDeployment,
+                    this.NoVerifyScenarios,
                     deployment);
                 await test.RunAsync();
             }

--- a/smoke/IotEdgeQuickstart/Quickstart.cs
+++ b/smoke/IotEdgeQuickstart/Quickstart.cs
@@ -12,7 +12,7 @@ namespace IotEdgeQuickstart
     {
         readonly LeaveRunning leaveRunning;
         readonly bool noDeployment;
-        private readonly bool noVerifyScenarios;
+        readonly bool noVerifyScenarios;
 
         public Quickstart(
             IBootstrapper bootstrapper,

--- a/smoke/IotEdgeQuickstart/Quickstart.cs
+++ b/smoke/IotEdgeQuickstart/Quickstart.cs
@@ -12,7 +12,7 @@ namespace IotEdgeQuickstart
     {
         readonly LeaveRunning leaveRunning;
         readonly bool noDeployment;
-        readonly bool noVerifyScenarios;
+        readonly bool noVerify;
 
         public Quickstart(
             IBootstrapper bootstrapper,
@@ -30,7 +30,7 @@ namespace IotEdgeQuickstart
         {
             this.leaveRunning = leaveRunning;
             this.noDeployment = noDeployment;
-            this.noVerifyScenarios = noVerify;
+            this.noVerify = noVerify;
         }
 
         public async Task RunAsync()
@@ -57,7 +57,7 @@ namespace IotEdgeQuickstart
                     if (!this.noDeployment)
                     {
                         await DeployToEdgeDevice();
-                        if (!this.noVerifyScenarios)
+                        if (!this.noVerify)
                         {
                             await VerifyTempSensorIsRunning();
                             await VerifyTempSensorIsSendingDataToIotHub();

--- a/smoke/IotEdgeQuickstart/Quickstart.cs
+++ b/smoke/IotEdgeQuickstart/Quickstart.cs
@@ -12,6 +12,7 @@ namespace IotEdgeQuickstart
     {
         readonly LeaveRunning leaveRunning;
         readonly bool noDeployment;
+        private readonly bool noVerifyScenarios;
 
         public Quickstart(
             IBootstrapper bootstrapper,
@@ -23,11 +24,13 @@ namespace IotEdgeQuickstart
             string hostname,
             LeaveRunning leaveRunning,
             bool noDeployment,
+            bool noVerify,
             Option<string> deploymentFileName) :
             base(bootstrapper, credentials, iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, imageTag, deviceId, hostname, deploymentFileName)
         {
             this.leaveRunning = leaveRunning;
             this.noDeployment = noDeployment;
+            this.noVerifyScenarios = noVerify;
         }
 
         public async Task RunAsync()
@@ -54,7 +57,7 @@ namespace IotEdgeQuickstart
                     if (!this.noDeployment)
                     {
                         await DeployToEdgeDevice();
-                        if (!this.DeploymentFileName.HasValue)
+                        if (!this.noVerifyScenarios)
                         {
                             await VerifyTempSensorIsRunning();
                             await VerifyTempSensorIsSendingDataToIotHub();


### PR DESCRIPTION
This is instead of turning off verification if deployment file is set.

For some End2End tests scenarios, we will use deployment file, instead of changing the default deployment.
This is just the 1st pr to enable multiple verification in the future.