### PR TITLE
 Add deprecation notice for iotedgectl

### DIFF
--- a/edge-bootstrap/python/README
+++ b/edge-bootstrap/python/README
@@ -6,8 +6,8 @@ Deprecation Notice
 The azure-iot-edge-runtime-ctl (iotedgectl) tool has now been deprecated!
 The Azure IoT Edge runtime (Edge Agent and Edge Hub)
 will continue to work when launched using this utility. However since the official release of the
-Edge security daemon, using in this utility to launch the Edge runtime is discouraged.
-To learn more about the officially supported Azure Edge please visit:
+Edge security daemon, using this utility to launch the IoT Edge runtime is discouraged.
+To learn more about the officially supported Azure IoT Edge please visit:
 <https://docs.microsoft.com/en-us/azure/iot-edge/>`__.
 
 Introduction

--- a/edge-bootstrap/python/README
+++ b/edge-bootstrap/python/README
@@ -1,6 +1,15 @@
 Azure IoT Edge Runtime Control
 ==============================
 
+Deprecation Notice
+------------------
+The azure-iot-edge-runtime-ctl (iotedgectl) tool has now been deprecated!
+The Azure IoT Edge runtime (Edge Agent and Edge Hub)
+will continue to work when launched using this utility. However since the official release of the
+Edge security daemon, using in this utility to launch the Edge runtime is discouraged.
+To learn more about the officially supported Azure Edge please visit:
+<https://docs.microsoft.com/en-us/azure/iot-edge/>`__.
+
 Introduction
 ------------
 
@@ -361,8 +370,8 @@ appropriate input data would have to provided.
       "logLevel": "info",
 
       // Upstream protocol to be used by the Edge runtime (and possibly other module)
-      // when connecting to IoTHub. The permitted values are Amqp and AmqpWs. 
-      // This is an optional setting. 
+      // when connecting to IoTHub. The permitted values are Amqp and AmqpWs.
+      // This is an optional setting.
       "upstreamProtocol": "Amqp",
 
       // Configuration settings for the IoT Edge Runtime

--- a/edge-bootstrap/python/edgectl/cli/edgecli.py
+++ b/edge-bootstrap/python/edgectl/cli/edgecli.py
@@ -157,7 +157,8 @@ class EdgeCLI(object):
     def _process_cli_args(self):
         parser = argparse.ArgumentParser(prog=EdgeCLI._prog(),
                                          formatter_class=argparse.RawTextHelpFormatter,
-                                         description='Azure IoT Edge Runtime Control Interface',
+                                         description='Azure IoT Edge Runtime Control Interface (DEPRECATED).\n' +
+                                                     'For more information visit: https://docs.microsoft.com/en-us/azure/iot-edge/',
                                          epilog='''''')
         parser.add_argument('--version',
                             action='version',


### PR DESCRIPTION
Output of iotedgectl --help

```
usage: iotedgectl [-h] [--version] [--verbose]
                  {setup,start,restart,stop,status,update,uninstall,login} ...

Azure IoT Edge Runtime Control Interface (DEPRECATED).
For more information visit: https://docs.microsoft.com/en-us/azure/iot-edge/

optional arguments:
  -h, --help            show this help message and exit

...
...
```