### PR TITLE
EdgeHub: Add option to turn off protocol heads

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Hosting.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Hosting.cs
@@ -9,20 +9,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class Hosting
     {
-        const int SslPortNumber = 443;
-
         Hosting(IWebHost webHost, IContainer container)
         {
             this.WebHost = webHost;
             this.Container = container;
         }
 
-        public static Hosting Initialize()
+        public static Hosting Initialize(int port)
         {
             IWebHostBuilder webHostBuilder = new WebHostBuilder()
                 .UseKestrel(options =>
                 {
-                    options.Listen(!Socket.OSSupportsIPv6 ? IPAddress.Any : IPAddress.IPv6Any, SslPortNumber, listenOptions =>
+                    options.Listen(!Socket.OSSupportsIPv6 ? IPAddress.Any : IPAddress.IPv6Any, port, listenOptions =>
                     {
                         listenOptions.UseHttps(ServerCertificateCache.X509Certificate);
                     });

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -70,7 +70,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
             // TODO: set certificate for Startup without the cache
             ServerCertificateCache.X509Certificate = cert;
-            Hosting hosting = Hosting.Initialize();
+
+            int port = configuration.GetValue("httpSettings:port", 443);
+            Hosting hosting = Hosting.Initialize(port);
 
             IContainer container = hosting.Container;
 
@@ -111,13 +113,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler)
                 = ShutdownHandler.Init(ShutdownWaitPeriod, logger);
 
-            using (IProtocolHead protocolHead = new EdgeHubProtocolHead(
-                new IProtocolHead[]
-                {
-                    new HttpProtocolHead(hosting.WebHost),
-                    await container.Resolve<Task<MqttProtocolHead>>(),
-                    await container.Resolve<Task<AmqpProtocolHead>>()
-                }, logger))
+            var protocolHeads = new List<IProtocolHead>();
+            if (configuration.GetValue("mqttSettings:enabled", true))
+            {
+                protocolHeads.Add(await container.Resolve<Task<MqttProtocolHead>>());
+            }
+
+            if (configuration.GetValue("amqpSettings:enabled", true))
+            {
+                protocolHeads.Add(await container.Resolve<Task<AmqpProtocolHead>>());
+            }
+
+            if (configuration.GetValue("httpSettings:enabled", true))
+            {
+                protocolHeads.Add(new HttpProtocolHead(hosting.WebHost));
+            }
+
+            using (IProtocolHead protocolHead = new EdgeHubProtocolHead(protocolHeads, logger))
             {
                 await protocolHead.StartAsync();
                 await cts.Token.WhenCanceled();

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             var routes = this.Configuration.GetSection("routes").Get<Dictionary<string, string>>();
             (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward = this.GetStoreAndForwardConfiguration();
 
-            IConfiguration mqttSettingsConfiguration = this.Configuration.GetSection("appSettings");
+            IConfiguration mqttSettingsConfiguration = this.Configuration.GetSection("mqttSettings");
             Option<UpstreamProtocol> upstreamProtocolOption = Enum.TryParse(this.Configuration.GetValue("UpstreamProtocol", string.Empty), false, out UpstreamProtocol upstreamProtocol)
                 ? Option.Some(upstreamProtocol)
                 : Option.None<UpstreamProtocol>();
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             // n Clients + 1 Edgehub
             int maxConnectedClients = this.Configuration.GetValue("MaxConnectedClients", 100) + 1;
 
-            IConfiguration amqpSettings = this.Configuration.GetSection("amqp");
+            IConfiguration amqpSettings = this.Configuration.GetSection("amqpSettings");
 
             var builder = new ContainerBuilder();
             builder.Populate(services);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
@@ -1,5 +1,6 @@
 ﻿{
-  "appSettings": {
+  "mqttSettings": {
+    "enabled":  true, 
     "MaxPendingInboundAcknowledgements": 16,
     "DeviceReceiveAckTimeout": "00:00:00",
     "MaxInboundMessageSize": "262144",
@@ -19,10 +20,15 @@
     "TableQos2StatePersistenceProvider.StorageConnectionString": "UseDevelopmentStorage=true",
     "TableQos2StatePersistenceProvider.StorageTableName": "mqttqos2"
   },
-  "amqp": {
+  "amqpSettings": {
+    "enabled":  true, 
     "scheme": "amqps",
     "port": 5671
   },
+  "httpSettings": {
+    "enabled":  true, 
+    "port": 443
+  }, 
   "IotHubConnectionPoolSize": 1,
   "IotHubConnectionString": "",
   "mqttTopicNameConversion": {


### PR DESCRIPTION
Add config options to turn off one or more of the protocol heads. This is for customer using only one protocol head, and running on low power devices, so that they can reduce the memory used by EdgeHub.