### PR TITLE
Update Functions binding and Temp sensor to use MQTT

### DIFF
--- a/edge-modules/SimulatedTemperatureSensor/src/Program.cs
+++ b/edge-modules/SimulatedTemperatureSensor/src/Program.cs
@@ -54,7 +54,7 @@ namespace SimulatedTemperatureSensor
                 HumidityPercent = configuration.GetValue("ambientHumidity", 25)
             };
 
-            TransportType transportType = configuration.GetValue("ClientTransportType", TransportType.Mqtt_Tcp_Only);
+            TransportType transportType = configuration.GetValue("ClientTransportType", TransportType.Amqp_Tcp_Only);
             Console.WriteLine($"Using transport {transportType.ToString()}");
 
             var retryPolicy = new RetryPolicy(TimeoutErrorDetectionStrategy, TransientRetryStrategy);

--- a/edge-modules/SimulatedTemperatureSensor/src/Program.cs
+++ b/edge-modules/SimulatedTemperatureSensor/src/Program.cs
@@ -54,7 +54,7 @@ namespace SimulatedTemperatureSensor
                 HumidityPercent = configuration.GetValue("ambientHumidity", 25)
             };
 
-            TransportType transportType = configuration.GetValue("ClientTransportType", TransportType.Amqp_Tcp_Only);
+            TransportType transportType = configuration.GetValue("ClientTransportType", TransportType.Mqtt_Tcp_Only);
             Console.WriteLine($"Using transport {transportType.ToString()}");
 
             var retryPolicy = new RetryPolicy(TimeoutErrorDetectionStrategy, TransientRetryStrategy);

--- a/edge-modules/functions/binding/src/Microsoft.Azure.Devices.Edge.Functions.Binding/ModuleClientCache.cs
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.Devices.Edge.Functions.Binding/ModuleClientCache.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Azure.Devices.Edge.Functions.Binding
 
         async Task<ModuleClient> CreateModuleClient()
         {
-            ModuleClient moduleClient = await ModuleClient.CreateFromEnvironmentAsync().ConfigureAwait(false);
+            ModuleClient moduleClient = await ModuleClient.CreateFromEnvironmentAsync(TransportType.Mqtt_Tcp_Only)
+                .ConfigureAwait(false);
 
             moduleClient.ProductInfo = "Microsoft.Azure.Devices.Edge.Functions.Binding";
             return moduleClient;


### PR DESCRIPTION
With the update of the Device SDK to v 1.18.0, MQTT seems to have better reconnect/reliability behavior. So updating Temp sensor and Functions binding (which are the most used custom modules) to MQTT.