### PR TITLE
Fix SDL build failures

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Microsoft.Azure.Devices.Edge.Agent.Core.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Microsoft.Azure.Devices.Edge.Agent.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Microsoft.Azure.Devices.Edge.Agent.Docker.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Microsoft.Azure.Devices.Edge.Agent.Docker.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <ItemGroup>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/Microsoft.Azure.Devices.Edge.Agent.Edgelet.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/Microsoft.Azure.Devices.Edge.Agent.Edgelet.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Microsoft.Azure.Devices.Edge.Agent.Service.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Microsoft.Azure.Devices.Edge.Agent.Service.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
   <!--
     Normally, the 'Debug' configuration would work for code coverage, but Microsoft.CodeCoverage currently requires '<DebugType>full</DebugType>' for .NET Core.

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/Microsoft.Azure.Devices.Edge.Agent.Core.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/Microsoft.Azure.Devices.Edge.Agent.Core.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Microsoft.Azure.Devices.Edge.Hub.Amqp.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Microsoft.Azure.Devices.Edge.Hub.Amqp.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-	<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-	<Configurations>Debug;Release;CodeCoverage</Configurations>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
   <!--
     Normally, the 'Debug' configuration would work for code coverage, but Microsoft.CodeCoverage currently requires '<DebugType>full</DebugType>' for .NET Core.

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/Microsoft.Azure.Devices.Edge.Hub.Http.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/Microsoft.Azure.Devices.Edge.Hub.Http.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--
@@ -34,5 +35,5 @@
     <ProjectReference Include="..\..\..\edge-util\src\Microsoft.Azure.Devices.Edge.Util\Microsoft.Azure.Devices.Edge.Util.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.Devices.Edge.Hub.Core\Microsoft.Azure.Devices.Edge.Hub.Core.csproj" />
   </ItemGroup>
-  
+
 </Project>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Microsoft.Azure.Devices.Routing.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Microsoft.Azure.Devices.Routing.Core.csproj
@@ -4,6 +4,7 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <NoWarn>3021</NoWarn>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--
@@ -76,8 +77,8 @@
     <Exec Command="java -version" EchoOff="true" />
     <MakeDir Directories="grammar\generated" />
     <Exec Command="java -jar $(FullAntlr4ToolLocation) %(Antlr4Inputs.Identity) -package Microsoft.Azure.Devices.Routing.Core -Dlanguage=CSharp_v4_5 -visitor -listener -o grammar/generated" />
-    <CreateProperty Value="true">  
-      <Output TaskParameter="ValueSetByTask" PropertyName="Antlr4CodeGenRan" />  
+    <CreateProperty Value="true">
+      <Output TaskParameter="ValueSetByTask" PropertyName="Antlr4CodeGenRan" />
     </CreateProperty>
   </Target>
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/Microsoft.Azure.Devices.Edge.Hub.Core.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/Microsoft.Azure.Devices.Edge.Hub.Core.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/Microsoft.Azure.Devices.Edge.Hub.Http.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/Microsoft.Azure.Devices.Edge.Hub.Http.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/Microsoft.Azure.Devices.Routing.Core.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/Microsoft.Azure.Devices.Routing.Core.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
+++ b/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-modules/TemperatureFilter/TemperatureFilter.csproj
+++ b/edge-modules/TemperatureFilter/TemperatureFilter.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-modules/functions/binding/src/Microsoft.Azure.Devices.Edge.Functions.Binding/Microsoft.Azure.Devices.Edge.Functions.Binding.csproj
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.Devices.Edge.Functions.Binding/Microsoft.Azure.Devices.Edge.Functions.Binding.csproj
@@ -5,6 +5,7 @@
     <AssemblyName>Microsoft.Azure.Devices.Edge.Functions.BindingExtension</AssemblyName>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/Microsoft.Azure.Devices.Edge.Storage.RocksDb.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/Microsoft.Azure.Devices.Edge.Storage.RocksDb.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/Microsoft.Azure.Devices.Edge.Storage.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/Microsoft.Azure.Devices.Edge.Storage.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Microsoft.Azure.Devices.Edge.Util.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Microsoft.Azure.Devices.Edge.Util.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/Microsoft.Azure.Devices.Edge.Storage.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/Microsoft.Azure.Devices.Edge.Storage.Test.csproj
@@ -5,6 +5,7 @@
     <IsPackable>false</IsPackable>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/Microsoft.Azure.Devices.Edge.Util.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/Microsoft.Azure.Devices.Edge.Util.Test.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CodeCoverage</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
   </PropertyGroup>
 
   <!--


### PR DESCRIPTION
The SDL build is failing due to lack of high-entropy ASLR support for the dotnet binaries. This PR updates the csproj to enable ASLR support. This is off by default.