### PR TITLE
Adding LeafDevice tool for transparent Gateway E2E Test.

### DIFF
--- a/Microsoft.Azure.Devices.Edge.sln
+++ b/Microsoft.Azure.Devices.Edge.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27130.2027
+VisualStudioVersion = 15.0.27130.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "agent", "agent", "{EC8E6AC9-7AD8-4749-88F3-5D0CDD52D7B0}"
 	ProjectSection(SolutionItems) = preProject
@@ -165,6 +165,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "load-gen", "edge-modules\load-gen\load-gen.csproj", "{54771470-860C-4853-9318-6DB4EA76B595}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagesAnalyzer", "edge-modules\MessagesAnalyzer\MessagesAnalyzer.csproj", "{047DC795-A159-4BFF-AC0F-4DCE51A79C2C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LeafDevice", "smoke\LeafDevice\LeafDevice.csproj", "{C5CBC493-96A4-4628-A952-8C7B9EEF1441}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -407,6 +409,12 @@ Global
 		{047DC795-A159-4BFF-AC0F-4DCE51A79C2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{047DC795-A159-4BFF-AC0F-4DCE51A79C2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{047DC795-A159-4BFF-AC0F-4DCE51A79C2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C5CBC493-96A4-4628-A952-8C7B9EEF1441}.CodeCoverage|Any CPU.ActiveCfg = CodeCoverage|Any CPU
+		{C5CBC493-96A4-4628-A952-8C7B9EEF1441}.CodeCoverage|Any CPU.Build.0 = CodeCoverage|Any CPU
+		{C5CBC493-96A4-4628-A952-8C7B9EEF1441}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C5CBC493-96A4-4628-A952-8C7B9EEF1441}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C5CBC493-96A4-4628-A952-8C7B9EEF1441}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C5CBC493-96A4-4628-A952-8C7B9EEF1441}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -469,6 +477,7 @@ Global
 		{79E573DB-A6A8-4F6F-B5A0-DA2258EB82E6} = {F5E37327-3AA9-4CC2-9FE3-B28271ADB5E3}
 		{54771470-860C-4853-9318-6DB4EA76B595} = {578D5330-2F72-44C6-9DB5-C93B3F42C473}
 		{047DC795-A159-4BFF-AC0F-4DCE51A79C2C} = {578D5330-2F72-44C6-9DB5-C93B3F42C473}
+		{C5CBC493-96A4-4628-A952-8C7B9EEF1441} = {871A0862-7480-49C3-ACEB-9A60E9CE5B61}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D71830F5-3AF5-46B4-8A9E-1DCE4F2253AC}

--- a/smoke/LeafDevice/LeafDevice.cs
+++ b/smoke/LeafDevice/LeafDevice.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// ReSharper disable ArrangeThisQualifier
+namespace LeafDevice
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class LeafDevice : Details.Details
+    {
+        public LeafDevice(
+            string iothubConnectionString,
+            string eventhubCompatibleEndpointWithEntityPath,
+            string deviceId,
+            string certificateFileName,
+            string edgeHostName) :
+            base(iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, deviceId, certificateFileName, edgeHostName)
+        {
+        }
+
+        public async Task RunAsync()
+        {
+            // This test assumes that there is an edge deployment running as transparent gateway.
+            try
+            {
+                await this.InstallCaCertificate();
+                await GetOrCreateDeviceIdentity();
+                await ConnectToEdgeAndSendData();
+                await this.VerifyDataOnIoTHub();
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("** Oops, there was a problem.");
+                KeepDeviceIdentity();
+                throw;
+            }
+            finally
+            {
+                // only remove the identity if we created it; if it already existed in IoT Hub then leave it alone
+                await MaybeDeleteDeviceIdentity();
+            }
+        }
+    }
+}

--- a/smoke/LeafDevice/LeafDevice.csproj
+++ b/smoke/LeafDevice/LeafDevice.csproj
@@ -1,0 +1,37 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <Configurations>Debug;Release;CodeCoverage</Configurations>
+  </PropertyGroup>
+
+  <!--
+    Normally, the 'Debug' configuration would work for code coverage, but Microsoft.CodeCoverage currently requires '<DebugType>full</DebugType>' for .NET Core.
+    See https://github.com/Microsoft/vstest-docs/blob/06f9dc0aeb47be7204dc4e1a98c110ead3e978c7/docs/analyze.md#setup-a-project.
+    That setting seems to break the "Open Test" context menu in VS IDE, so we'll use a dedicated configuration for code coverage.
+    -->
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'CodeCoverage|AnyCPU' ">
+    <IntermediateOutputPath>obj\CodeCoverage</IntermediateOutputPath>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\CodeCoverage</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.0-*" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.1.0" />
+    <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
+    <PackageReference Include="RunProcessAsTask" Version="1.2.3" />
+    <PackageReference Include="YamlDotNet" Version="4.3.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\edge-util\test\Microsoft.Azure.Devices.Edge.Util.Test.Common\Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/smoke/LeafDevice/Program.cs
+++ b/smoke/LeafDevice/Program.cs
@@ -8,7 +8,7 @@ namespace LeafDevice
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
 
     [Command(
-        Name = "LeadDevice",
+        Name = "LeafDevice",
         Description = "An app which installs a certificate into cert store, creates a device and sends message and check if the message was received. This is to be used on a transparent Gateway setup for testing.",
         ExtendedHelpText = @"
 Environment Variables:

--- a/smoke/LeafDevice/Program.cs
+++ b/smoke/LeafDevice/Program.cs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace LeafDevice
+{
+    using System;
+    using System.Threading.Tasks;
+    using McMaster.Extensions.CommandLineUtils;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+
+    [Command(
+        Name = "LeadDevice",
+        Description = "An app which installs a certificate into cert store, creates a device and sends message and check if the message was received. This is to be used on a transparent Gateway setup for testing.",
+        ExtendedHelpText = @"
+Environment Variables:
+  Most options in this command override environment variables. In other words,
+  the value of the corresponding environment variable will be used unless the
+  option is specified on the command line.
+
+  Option                    Environment variable
+  --connection-string       iothubConnectionString
+  --eventhub-endpoint       eventhubCompatibleEndpointWithEntityPath
+ 
+Defaults:
+  All options to this command have defaults. If an option is not specified and
+  its corresponding environment variable is not defined, then the default will
+  be used.
+
+  Option                    Default value
+  --connection-string       get the value from Key Vault
+  --eventhub-endpoint       get the value from Key Vault
+  --device-id               an auto-generated unique identifier
+  --certificate             Empty String.
+  --edge-hostname           Empty String.
+"
+        )]
+    [HelpOption]
+    class Program
+    {
+        // ReSharper disable once UnusedMember.Local
+        static int Main(string[] args) => CommandLineApplication.ExecuteAsync<Program>(args).Result;
+
+        [Option("-c|--connection-string <value>", Description = "Device connection string (hub-scoped, e.g. iothubowner)")]
+        public string DeviceConnectionString { get; } = Environment.GetEnvironmentVariable("iothubConnectionString");
+
+        [Option("-e|--eventhub-endpoint <value>", Description = "Event Hub-compatible endpoint for IoT Hub, including EntityPath")]
+        public string EventHubCompatibleEndpointWithEntityPath { get; } = Environment.GetEnvironmentVariable("eventhubCompatibleEndpointWithEntityPath");
+
+        [Option("-ct|--certificate <value>", Description = "Certificate file to be installed on the machine.")]
+        public string CertificateFileName { get; } = "";
+
+        [Option("-d|--device-id", Description = "Leaf device identifier to be registered with IoT Hub")]
+        public string DeviceId { get; } = $"leaf-device--{Guid.NewGuid()}";
+
+        [Option("-ed|--edge-hostname", Description = "Leaf device identifier to be registered with IoT Hub")]
+        public string EdgeHostName { get; } = "";
+
+        // ReSharper disable once UnusedMember.Local
+        async Task<int> OnExecuteAsync()
+        {
+            try
+            {
+                string connectionString = this.DeviceConnectionString ??
+                    await SecretsHelper.GetSecretFromConfigKey("iotHubConnStrKey");
+
+                string endpoint = this.EventHubCompatibleEndpointWithEntityPath ??
+                    await SecretsHelper.GetSecretFromConfigKey("eventHubConnStrKey");
+
+                var test = new LeafDevice(
+                    connectionString,
+                    endpoint,
+                    this.DeviceId,
+                    this.CertificateFileName,
+                    this.EdgeHostName);
+                await test.RunAsync();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(ex);
+                return 1;
+            }
+
+            Console.WriteLine("Success!");
+            return 0;
+        }
+    }
+}

--- a/smoke/LeafDevice/details/Details.cs
+++ b/smoke/LeafDevice/details/Details.cs
@@ -49,7 +49,9 @@ namespace LeafDevice.Details
 
         protected async Task ConnectToEdgeAndSendData()
         {
-            string leafDeviceConnectionString = this.iothubConnectionString + $";DeviceId={this.deviceId};gatewayHostName={this.edgeHostName}";
+            Microsoft.Azure.Devices.IotHubConnectionStringBuilder builder = Microsoft.Azure.Devices.IotHubConnectionStringBuilder.Create(this.iothubConnectionString);
+            string leafDeviceConnectionString = $"HostName={builder.HostName};DeviceId={this.deviceId};SharedAccessKey={this.context.Device.Authentication.SymmetricKey.PrimaryKey};gatewayHostName={this.edgeHostName}";
+
             DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(leafDeviceConnectionString, Microsoft.Azure.Devices.Client.TransportType.Amqp);
 
             var message = new Microsoft.Azure.Devices.Client.Message(Encoding.ASCII.GetBytes($"Message from Leaf Device. MsgGUID: {this.context.MessageGuid}"));
@@ -62,6 +64,7 @@ namespace LeafDevice.Details
             RegistryManager rm = RegistryManager.CreateFromConnectionString(builder.ToString());
 
             Device device = await rm.GetDeviceAsync(this.deviceId);
+
             if (device != null)
             {
                 Console.WriteLine($"Device '{device.Id}' already registered on IoT hub '{builder.HostName}'");

--- a/smoke/LeafDevice/details/Details.cs
+++ b/smoke/LeafDevice/details/Details.cs
@@ -1,0 +1,182 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace LeafDevice.Details
+{
+    using System;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Text;
+    using Microsoft.Azure.Devices.Client;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices;
+    using Microsoft.Azure.Devices.Common;
+    using Microsoft.Azure.Devices.Shared;
+    using Microsoft.Azure.EventHubs;
+
+    public class Details
+    {
+        readonly string iothubConnectionString;
+        readonly string eventhubCompatibleEndpointWithEntityPath;
+        readonly string deviceId;
+        readonly string certificateFileName;
+        readonly string edgeHostName;
+
+        DeviceContext context;
+
+        protected Details(
+            string iothubConnectionString,
+            string eventhubCompatibleEndpointWithEntityPath,
+            string deviceId,
+            string certificateFileName,
+            string edgeHostName
+        )
+        {
+            this.iothubConnectionString = iothubConnectionString;
+            this.eventhubCompatibleEndpointWithEntityPath = eventhubCompatibleEndpointWithEntityPath;
+            this.deviceId = deviceId;
+            this.certificateFileName = certificateFileName;
+            this.edgeHostName = edgeHostName;
+        }
+
+        protected Task InstallCaCertificate()
+        {
+            var store = new X509Store(StoreName.Root, StoreLocation.CurrentUser);
+            store.Open(OpenFlags.ReadWrite);
+            store.Add(new X509Certificate2(X509Certificate.CreateFromCertFile(this.certificateFileName)));
+            store.Close();
+            return Task.CompletedTask;
+        }
+
+        protected async Task ConnectToEdgeAndSendData()
+        {
+            string leafDeviceConnectionString = this.iothubConnectionString + $";DeviceId={this.deviceId};gatewayHostName={this.edgeHostName}";
+            DeviceClient deviceClient = DeviceClient.CreateFromConnectionString(leafDeviceConnectionString, Microsoft.Azure.Devices.Client.TransportType.Mqtt);
+            var message = new Microsoft.Azure.Devices.Client.Message(Encoding.ASCII.GetBytes("Message from Leaf Device."));
+
+            await deviceClient.SendEventAsync(message);
+        }
+
+        protected async Task GetOrCreateDeviceIdentity()
+        {
+            Microsoft.Azure.Devices.IotHubConnectionStringBuilder builder = Microsoft.Azure.Devices.IotHubConnectionStringBuilder.Create(this.iothubConnectionString);
+            RegistryManager rm = RegistryManager.CreateFromConnectionString(builder.ToString());
+
+            Device device = await rm.GetDeviceAsync(this.deviceId);
+            if (device != null)
+            {
+                Console.WriteLine($"Device '{device.Id}' already registered on IoT hub '{builder.HostName}'");
+
+                this.context = new DeviceContext
+                {
+                    Device = device,
+                    IotHubConnectionString = this.iothubConnectionString,
+                    RegistryManager = rm,
+                    RemoveDevice = false
+                };
+            }
+            else
+            {
+                await this.CreateDeviceIdentity(rm);
+            }
+        }
+
+        async Task CreateDeviceIdentity(RegistryManager rm)
+        {
+            var device = new Device(this.deviceId)
+            {
+                Authentication = new AuthenticationMechanism() { Type = AuthenticationType.Sas },
+                Capabilities = new DeviceCapabilities() { IotEdge = false }
+            };
+
+            Microsoft.Azure.Devices.IotHubConnectionStringBuilder builder = Microsoft.Azure.Devices.IotHubConnectionStringBuilder.Create(this.iothubConnectionString);
+            Console.WriteLine($"Registering device '{device.Id}' on IoT hub '{builder.HostName}'");
+
+            device = await rm.AddDeviceAsync(device);
+
+            this.context = new DeviceContext
+            {
+                Device = device,
+                IotHubConnectionString = this.iothubConnectionString,
+                RegistryManager = rm,
+                RemoveDevice = true
+            };
+        }
+
+        protected async Task VerifyDataOnIoTHub()
+        {
+            var builder = new EventHubsConnectionStringBuilder(this.eventhubCompatibleEndpointWithEntityPath);
+
+            Console.WriteLine($"Receiving events from device '{this.context.Device.Id}' on Event Hub '{builder.EntityPath}'");
+
+            EventHubClient eventHubClient =
+                EventHubClient.CreateFromConnectionString(builder.ToString());
+
+            PartitionReceiver eventHubReceiver = eventHubClient.CreateReceiver(
+                "$Default",
+                EventHubPartitionKeyResolver.ResolveToPartition(
+                    this.context.Device.Id,
+                    (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
+                DateTime.Now);
+
+            var result = new TaskCompletionSource<bool>();
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))
+            {
+                using (cts.Token.Register(() => result.TrySetCanceled()))
+                {
+                    eventHubReceiver.SetReceiveHandler(
+                        new PartitionReceiveHandler(
+                            eventData =>
+                            {
+                                eventData.Properties.TryGetValue("iothub-connection-device-id", out object devId);
+
+                                if (devId != null && devId.ToString().Equals(this.context.Device.Id))
+                                {
+                                    result.TrySetResult(true);
+                                    return true;
+                                }
+
+                                return false;
+                            }));
+
+                    await result.Task;
+                }
+            }
+
+            await eventHubReceiver.CloseAsync();
+            await eventHubClient.CloseAsync();
+        }
+
+        protected void KeepDeviceIdentity()
+        {
+            if (this.context != null)
+            {
+                this.context.RemoveDevice = false;
+            }
+        }
+
+        protected Task MaybeDeleteDeviceIdentity()
+        {
+            if (this.context != null)
+            {
+                Device device = this.context.Device;
+                bool remove = this.context.RemoveDevice;
+                this.context.Device = null;
+
+                if (remove)
+                {
+                    return this.context.RegistryManager.RemoveDeviceAsync(device);
+                }
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class DeviceContext
+    {
+        public Device Device;
+        public string IotHubConnectionString;
+        public RegistryManager RegistryManager;
+        public bool RemoveDevice;
+    }
+}

--- a/smoke/LeafDevice/details/PartitionReceiveHandler.cs
+++ b/smoke/LeafDevice/details/PartitionReceiveHandler.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace LeafDevice.Details
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.EventHubs;
+
+    class PartitionReceiveHandler : IPartitionReceiveHandler
+    {
+        readonly Func<EventData, bool> onEventReceived;
+        public PartitionReceiveHandler(Func<EventData, bool> onEventReceived)
+        {
+            this.onEventReceived = onEventReceived;
+        }
+        public Task ProcessEventsAsync(IEnumerable<EventData> events)
+        {
+            if (events != null)
+            {
+                foreach (EventData @event in events)
+                {
+                    if (this.onEventReceived(@event)) break;
+                }
+            }
+            return Task.CompletedTask;
+        }
+        public Task ProcessErrorAsync(Exception error) => throw error;
+        public int MaxBatchSize { get; } = 10;
+    }
+}

--- a/smoke/LeafDevice/details/Process.cs
+++ b/smoke/LeafDevice/details/Process.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace LeafDevice.Details
+{
+    using System;
+    using System.ComponentModel;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using RunProcessAsTask;
+
+    public class Process
+    {
+        public static async Task<string[]> RunAsync(string name, string args, int timeoutSeconds = 15)
+        {
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds)))
+            {
+                return await RunAsync(name, args, cts.Token);
+            }
+        }
+
+        public static async Task<string[]> RunAsync(string name, string args, CancellationToken token)
+        {
+            var info = new ProcessStartInfo
+            {
+                FileName = name,
+                Arguments = args,
+            };
+
+            using (ProcessResults result = await ProcessEx.RunAsync(info, token))
+            {
+                if (result.ExitCode != 0)
+                {
+                    throw new Win32Exception(result.ExitCode, $"'{name}' failed with: {string.Join("\n", result.StandardError)}");
+                }
+
+                return result.StandardOutput;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This add a tool equivalent to QuickStart for leaf device. 
This tool does the following: 
1-Install Certificate based a path; 
2-Create a Leaf Device (non Edge); 
3-Connects to edge (transparent gateway) and send data; 
4-Verify message received (unique message, based on GUID on the body). 