### PR TITLE
EdgeHub: Fix Mqtt message address parsing

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessageAddressConverterTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessageAddressConverterTest.cs
@@ -528,5 +528,50 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Assert.Equal("bee", message2.Properties["b"]);
             Assert.Equal("dee", message2.Properties["d"]);
         }
+
+        [Fact]
+        public void TestTryParseAddressWithTailingSlashOptionalWithMultipleMatches()
+        {
+            IList<string> input = new List<string>
+            {
+                "a/{b}/c/{d}/{e}/",
+                "a/{b}/c/{d}/",
+                "a/{b}/c/",
+                "a/{b}/c/{d}/{e}",
+                "a/{b}/c/{d}",
+                "a/{b}/c"
+            };
+            var config = new MessageAddressConversionConfiguration(
+                input,
+                DontCareOutput
+            );
+            var converter = new MessageAddressConverter(config);
+
+            string address = "a/bee/c/";
+            ProtocolGatewayMessage message = new ProtocolGatewayMessage.Builder(Payload, address)
+                .Build();
+            bool status = converter.TryParseProtocolMessagePropsFromAddress(message);
+            Assert.True(status);
+            Assert.Equal(1, message.Properties.Count);
+            Assert.Equal("bee", message.Properties["b"]);
+
+            string address2 = "a/bee/c/dee/";
+            ProtocolGatewayMessage message2 = new ProtocolGatewayMessage.Builder(Payload, address2)
+                .Build();
+            bool status2 = converter.TryParseProtocolMessagePropsFromAddress(message2);
+            Assert.True(status2);
+            Assert.Equal(2, message2.Properties.Count);
+            Assert.Equal("bee", message2.Properties["b"]);
+            Assert.Equal("dee", message2.Properties["d"]);
+
+            string address3 = "a/bee/c/dee";
+            ProtocolGatewayMessage message3 = new ProtocolGatewayMessage.Builder(Payload, address3)
+                .Build();
+            bool status3 = converter.TryParseProtocolMessagePropsFromAddress(message3);
+            Assert.True(status2);
+            Assert.Equal(2, message2.Properties.Count);
+            Assert.Equal("bee", message2.Properties["b"]);
+            Assert.Equal("dee", message2.Properties["d"]);
+        }
     }
 }


### PR DESCRIPTION
Issue: Because of the handling of an optional trailing '/', a message address can sometimes match 2 templates. For example, a message address - a/foo/b/ matches both the following templates 
"a/{p1}/b/" and "a/{p1}/b/{p2}, with the value of p2 in the second case being "".

Fix: 
If there are multiple matches, then select the first match. Because of this, the order of the input templates matter (I confirmed they are in the right order).

Eventually we should move away form this and to a model based on Regex matching, where we won't have this problem. But that is a much bigger change, so will put it on our backlog.