### PR TITLE
Add new authenticator for clients in device scope

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxyEventIds.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxyEventIds.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         public const int ConnectivityAwareClient = EventIdStart + 600;
         public const int ServiceProxy = EventIdStart + 700;
         public const int DeviceScopeApiClient = EventIdStart + 800;
+        public const int CloudTokenAuthenticator = EventIdStart + 900;
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/CloudTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/CloudTokenAuthenticator.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
+
+    public class CloudTokenAuthenticator : IAuthenticator
+    {
+        readonly IConnectionManager connectionManager;
+
+        public CloudTokenAuthenticator(IConnectionManager connectionManager)
+        {
+            this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
+        }
+
+        public async Task<bool> AuthenticateAsync(IClientCredentials clientCredentials)
+        {
+            if (!(clientCredentials is ITokenCredentials))
+            {
+                return false;
+            }
+
+            Try<ICloudProxy> cloudProxyTry = await this.connectionManager.CreateCloudConnectionAsync(clientCredentials);
+            if (cloudProxyTry.Success)
+            {
+                try
+                {
+                    await cloudProxyTry.Value.OpenAsync();
+                    Events.AuthenticatedWithIotHub(clientCredentials.Identity);
+                    return true;
+                }
+                catch (Exception ex)
+                {
+                    Events.ErrorValidatingTokenWithIoTHub(clientCredentials.Identity, ex);
+                }
+            }
+            else
+            {
+                Events.ErrorGettingCloudProxy(clientCredentials.Identity, cloudProxyTry.Exception);
+            }
+
+            return false;
+        }
+
+
+        static class Events
+        {
+            static readonly ILogger Log = Logger.Factory.CreateLogger<CloudTokenAuthenticator>();
+            const int IdStart = CloudProxyEventIds.CloudTokenAuthenticator;
+
+            enum EventIds
+            {
+                AuthenticatedWithCloud = IdStart,
+                ErrorValidatingToken,
+                ErrorGettingCloudProxy
+            }
+
+            public static void AuthenticatedWithIotHub(IIdentity identity)
+            {
+                Log.LogDebug((int)EventIds.AuthenticatedWithCloud, $"Authenticated {identity.Id} with IotHub");
+            }
+
+            public static void ErrorValidatingTokenWithIoTHub(IIdentity identity, Exception ex)
+            {
+                Log.LogWarning((int)EventIds.ErrorValidatingToken, ex, $"Error validating token for {identity.Id} with IoTHub");
+            }
+
+            public static void ErrorGettingCloudProxy(IIdentity identity, Exception ex)
+            {
+                Log.LogWarning((int)EventIds.ErrorGettingCloudProxy, ex, $"Error getting cloud proxy for {identity.Id}");
+            }
+        }
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -1,0 +1,302 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
+{
+    using System;
+    using System.Net;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Common.Data;
+    using Microsoft.Azure.Devices.Common.Security;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
+
+    public class DeviceScopeTokenAuthenticator : IAuthenticator
+    {
+        readonly IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache;
+        readonly string iothubHostName;
+        readonly string edgeHubHostName;
+        readonly IAuthenticator underlyingAuthenticator;
+        readonly IConnectionManager connectionManager;
+
+        public DeviceScopeTokenAuthenticator(IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache,
+            string iothubHostName,
+            string edgeHubHostName,
+            IAuthenticator underlyingAuthenticator,
+            IConnectionManager connectionManager)
+        {
+            this.underlyingAuthenticator = Preconditions.CheckNotNull(underlyingAuthenticator, nameof(underlyingAuthenticator));
+            this.deviceScopeIdentitiesCache = Preconditions.CheckNotNull(deviceScopeIdentitiesCache, nameof(deviceScopeIdentitiesCache));
+            this.iothubHostName = Preconditions.CheckNonWhiteSpace(iothubHostName, nameof(iothubHostName));
+            this.edgeHubHostName = Preconditions.CheckNonWhiteSpace(edgeHubHostName, nameof(edgeHubHostName));
+            this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
+            this.deviceScopeIdentitiesCache.ServiceIdentityUpdated += this.HandleServiceIdentityUpdate;
+            this.deviceScopeIdentitiesCache.ServiceIdentityRemoved += this.HandleServiceIdentityRemove;
+        }
+
+        async void HandleServiceIdentityUpdate(object sender, ServiceIdentity serviceIdentity)
+        {
+            try
+            {
+                Events.ServiceIdentityUpdated(serviceIdentity.Id);
+                Option<IClientCredentials> clientCredentials = this.connectionManager.GetClientCredentials(serviceIdentity.Id);
+                await clientCredentials.ForEachAsync(
+                    async c =>
+                    {
+                        if (!(c is ITokenCredentials tokenCredentials) ||
+                            !await this.AuthenticateInternalAsync(tokenCredentials, serviceIdentity))
+                        {
+                            Events.ServiceIdentityUpdatedRemoving(serviceIdentity.Id);
+                            await this.connectionManager.RemoveDeviceConnection(c.Identity.Id);
+                        }
+                        else
+                        {
+                            Events.ServiceIdentityUpdatedValidated(serviceIdentity.Id);
+                        }
+                    });
+            }
+            catch (Exception ex)
+            {
+                Events.ErrorReauthenticating(ex, serviceIdentity);
+            }
+        }
+
+        async void HandleServiceIdentityRemove(object sender, string id)
+        {
+            try
+            {
+                Events.ServiceIdentityRemoved(id);
+                await this.connectionManager.RemoveDeviceConnection(id);
+            }
+            catch (Exception ex)
+            {
+                Events.ErrorRemovingConnection(ex, id);
+            }
+        }
+
+        public async Task<bool> AuthenticateAsync(IClientCredentials clientCredentials)
+        {
+            if (!(clientCredentials is ITokenCredentials tokenCredentials))
+            {
+                return false;
+            }
+
+            try
+            {
+                Option<ServiceIdentity> serviceIdentity = await this.deviceScopeIdentitiesCache.GetServiceIdentity(clientCredentials.Identity.Id);
+                return await serviceIdentity.Map(s => this.AuthenticateInternalAsync(tokenCredentials, s))
+                    .GetOrElse(() => this.underlyingAuthenticator.AuthenticateAsync(clientCredentials));
+            }
+            catch (Exception e)
+            {
+                Events.ErrorAuthenticating(e, clientCredentials);
+                return await this.underlyingAuthenticator.AuthenticateAsync(clientCredentials);
+            }
+        }
+
+        async Task<bool> AuthenticateInternalAsync(ITokenCredentials tokenCredentials, ServiceIdentity serviceIdentity)
+        {
+            SharedAccessSignature sharedAccessSignature = SharedAccessSignature.Parse(this.iothubHostName, tokenCredentials.Token);
+            bool result = this.ValidateCredentials(sharedAccessSignature, serviceIdentity, tokenCredentials.Identity);
+            if (!result && tokenCredentials.Identity is IModuleIdentity moduleIdentity && serviceIdentity.IsModule)
+            {
+                // Module can use the Device key to authenticate
+                Option<ServiceIdentity> deviceServiceIdentity = await this.deviceScopeIdentitiesCache.GetServiceIdentity(moduleIdentity.DeviceId);
+                result = await deviceServiceIdentity.Map(d => this.AuthenticateInternalAsync(tokenCredentials, d))
+                    .GetOrElse(Task.FromResult(false));
+            }
+            return result;
+        }
+
+        bool ValidateCredentials(SharedAccessSignature sharedAccessSignature, ServiceIdentity serviceIdentity, IIdentity identity) =>
+            this.ValidateTokenWithSecurityIdentity(sharedAccessSignature, serviceIdentity) &&
+            this.ValidateAudience(sharedAccessSignature.Audience, identity);
+
+        bool ValidateTokenWithSecurityIdentity(SharedAccessSignature sharedAccessSignature, ServiceIdentity serviceIdentity)
+        {
+            if (serviceIdentity.Authentication.Type != ServiceAuthenticationType.SymmetricKey)
+            {
+                Events.InvalidServiceIdentityType(serviceIdentity);
+                return false;
+            }
+
+            if (serviceIdentity.Status != ServiceIdentityStatus.Enabled)
+            {
+                Events.ServiceIdentityNotEnabled(serviceIdentity);
+                return false;
+            }
+
+            return serviceIdentity.Authentication.SymmetricKey.Map(
+                s =>
+                {
+                    var rule = new SharedAccessSignatureAuthorizationRule
+                    {
+                        PrimaryKey = s.PrimaryKey,
+                        SecondaryKey = s.SecondaryKey
+                    };
+
+                    try
+                    {
+                        sharedAccessSignature.Authenticate(rule);
+                        return true;
+                    }
+                    catch (UnauthorizedAccessException e)
+                    {
+                        Events.KeysMismatch(serviceIdentity.Id, e);
+                        return false;
+                    }
+                })
+                .GetOrElse(() => throw new InvalidOperationException($"Unable to validate token because the service identity has empty symmetric keys"));
+        }
+
+        internal bool ValidateAudience(string audience, IIdentity identity)
+        {
+            Preconditions.CheckNonWhiteSpace(audience, nameof(audience));
+            audience = WebUtility.UrlDecode(audience.Trim());
+            // The audience should be in one of the following formats -
+            // {HostName}/devices/{deviceId}/modules/{moduleId}
+            // {HostName}/devices/{deviceId}
+            string[] parts = audience.Split('/');
+            string hostName;
+            if (parts.Length == 3)
+            {
+                hostName = parts[0];
+                string deviceId = parts[2];
+                if (identity is IDeviceIdentity deviceIdentity && deviceIdentity.DeviceId != deviceId)
+                {
+                    Events.IdMismatch(audience, identity, deviceIdentity.DeviceId);
+                    return false;
+                }
+                else if(identity is IModuleIdentity moduleIdentity && moduleIdentity.DeviceId != deviceId)
+                {
+                    Events.IdMismatch(audience, identity, moduleIdentity.DeviceId);
+                    return false;
+                }
+            }
+            else if (parts.Length == 5)
+            {
+                hostName = parts[0];
+                string deviceId = parts[2];
+                string moduleId = parts[4];
+                if (!(identity is IModuleIdentity moduleIdentity))
+                {
+                    Events.InvalidAudience(audience, identity);
+                    return false;
+                }
+                else if (moduleIdentity.DeviceId != deviceId)
+                {
+                    Events.IdMismatch(audience, identity, moduleIdentity.DeviceId);
+                    return false;
+                }
+                else if (moduleIdentity.ModuleId != moduleId)
+                {
+                    Events.IdMismatch(audience, identity, moduleIdentity.ModuleId);
+                    return false;
+                }
+            }
+            else
+            {
+                Events.InvalidAudience(audience, identity);
+                return false;
+            }
+
+            if (string.IsNullOrWhiteSpace(hostName) || !(this.iothubHostName.Equals(hostName) || this.edgeHubHostName.Equals(hostName)))
+            {
+                Events.InvalidHostName(identity.Id, hostName, this.iothubHostName, this.edgeHubHostName);
+                return false;
+            }
+
+            return true;
+        }
+
+        static class Events
+        {
+            static readonly ILogger Log = Logger.Factory.CreateLogger<DeviceScopeTokenAuthenticator>();
+            const int IdStart = CloudProxyEventIds.TokenCredentialsAuthenticator;
+
+            enum EventIds
+            {
+                ErrorReauthenticating = IdStart,
+                InvalidHostName,
+                InvalidAudience,
+                IdMismatch,
+                KeysMismatch,
+                InvalidServiceIdentityType,
+                ErrorAuthenticating,
+                ErrorRemovingConnection,
+                ServiceIdentityUpdated,
+                ServiceIdentityUpdatedRemoving,
+                ServiceIdentityUpdatedValidated,
+                ServiceIdentityRemoved,
+                ServiceIdentityNotEnabled
+            }
+
+            public static void ErrorReauthenticating(Exception exception, ServiceIdentity serviceIdentity)
+            {
+                Log.LogWarning((int)EventIds.ErrorReauthenticating, exception, $"Error re-authenticating {serviceIdentity.Id} after the service identity was updated.");
+            }
+
+            public static void InvalidHostName(string id, string hostName, string iotHubHostName, string edgeHubHostName)
+            {
+                Log.LogWarning((int)EventIds.InvalidHostName, $"Error authenticating token for {id} because the audience hostname {hostName} does not match IoTHub hostname {iotHubHostName} or the EdgeHub hostname {edgeHubHostName}.");
+            }
+
+            public static void InvalidAudience(string audience, IIdentity identity)
+            {
+                Log.LogWarning((int)EventIds.InvalidAudience, $"Error authenticating token for {identity.Id} because the audience {audience} is invalid.");
+            }
+
+            public static void IdMismatch(string audience, IIdentity identity, string deviceId)
+            {
+                Log.LogWarning((int)EventIds.IdMismatch, $"Error authenticating token for {identity.Id} because the deviceId {deviceId} in the identity does not match the audience {audience}.");
+            }
+
+            public static void KeysMismatch(string id, Exception exception)
+            {
+                Log.LogWarning((int)EventIds.KeysMismatch, $"Error authenticating token for {id} because the token did not match the primary or the secondary key. Error - {exception.Message}");
+            }
+
+            public static void InvalidServiceIdentityType(ServiceIdentity serviceIdentity)
+            {
+                Log.LogWarning((int)EventIds.InvalidServiceIdentityType, $"Error authenticating token for {serviceIdentity.Id} because the service identity authentication type is unexpected - {serviceIdentity.Authentication.Type}");
+            }
+
+            public static void ErrorAuthenticating(Exception exception, IClientCredentials credentials)
+            {
+                Log.LogWarning((int)EventIds.ErrorAuthenticating, exception, $"Error authenticating credentials for {credentials.Identity.Id}");
+            }
+
+            public static void ErrorRemovingConnection(Exception exception, string id)
+            {
+                Log.LogWarning((int)EventIds.ErrorRemovingConnection, exception, $"Error removing connection for {id} after service identity was removed from device scope.");
+            }
+
+            public static void ServiceIdentityUpdated(string serviceIdentityId)
+            {
+                Log.LogDebug((int)EventIds.ServiceIdentityUpdated, $"Service identity for {serviceIdentityId} in device scope was updated.");
+            }
+
+            public static void ServiceIdentityUpdatedRemoving(string serviceIdentityId)
+            {
+                Log.LogDebug((int)EventIds.ServiceIdentityUpdatedRemoving, $"Service identity for {serviceIdentityId} in device scope was updated, dropping client connection.");
+            }
+
+            public static void ServiceIdentityUpdatedValidated(string serviceIdentityId)
+            {
+                Log.LogDebug((int)EventIds.ServiceIdentityUpdatedValidated, $"Service identity for {serviceIdentityId} in device scope was updated, client connection was re-validated.");
+            }
+
+            public static void ServiceIdentityRemoved(string id)
+            {
+                Log.LogDebug((int)EventIds.ServiceIdentityRemoved, $"Service identity for {id} in device scope was removed, dropping client connection.");
+            }
+
+            public static void ServiceIdentityNotEnabled(ServiceIdentity serviceIdentity)
+            {
+                Log.LogWarning((int)EventIds.ServiceIdentityNotEnabled, $"Error authenticating token for {serviceIdentity.Id} because the service identity is not enabled");
+            }
+        }
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public interface IDeviceScopeIdentitiesCache
+    {
+        Task<Option<ServiceIdentity>> GetServiceIdentity(string id);
+
+        Task<Option<ServiceIdentity>> GetServiceIdentity(string deviceId, string moduleId);
+
+        Task RefreshServiceIdentities(IEnumerable<string> deviceIds);
+
+        Task RefreshServiceIdentity(string deviceId);
+
+        Task RefreshServiceIdentity(string deviceId, string moduleId);
+
+        event EventHandler<ServiceIdentity> ServiceIdentityUpdated;
+
+        event EventHandler<string> ServiceIdentityRemoved;
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullAuthenticator.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+
+    public class NullAuthenticator : IAuthenticator
+    {
+        public Task<bool> AuthenticateAsync(IClientCredentials identity) => Task.FromResult(false);
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
 {
     using System.Threading.Tasks;
     using Autofac;
-    using Microsoft.Azure.Devices.Edge.Hub.CloudProxy;
+    using Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                 {
                     var connectionManager = c.Resolve<IConnectionManager>();
                     ICredentialsStore credentialsStore = await c.Resolve<Task<ICredentialsStore>>();
-                    var tokenCredentialsAuthenticator = new TokenCredentialsAuthenticator(connectionManager, credentialsStore, this.iothubHostName);
+                    var tokenCredentialsAuthenticator = new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), credentialsStore, this.iothubHostName);
                     return new Authenticator(tokenCredentialsAuthenticator, this.deviceId, connectionManager) as IAuthenticator;
                 })
                 .As<Task<IAuthenticator>>()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudTokenAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudTokenAuthenticatorTest.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class CloudTokenAuthenticatorTest
+    {
+        [Fact]
+        public async Task AuthenticateTest()
+        {
+            // Arrange
+            var deviceIdentity = Mock.Of<IDeviceIdentity>(d => d.Id == "d1" && d.DeviceId == "d1");
+            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty);
+            var cloudProxy = Mock.Of<ICloudProxy>(c => c.OpenAsync() == Task.FromResult(true));
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.CreateCloudConnectionAsync(credentials) == Task.FromResult(Try.Success(cloudProxy)));
+            IAuthenticator cloudAuthenticator = new CloudTokenAuthenticator(connectionManager);
+
+            // Act
+            bool isAuthenticated = await cloudAuthenticator.AuthenticateAsync(credentials);
+
+            // Assert
+            Assert.True(isAuthenticated);
+        }
+
+        [Fact]
+        public async Task AuthenticateFailureTest()
+        {
+            // Arrange
+            var deviceIdentity = Mock.Of<IDeviceIdentity>(d => d.Id == "d1" && d.DeviceId == "d1");
+            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty);
+            var cloudProxy = Mock.Of<ICloudProxy>();
+            Mock.Get(cloudProxy).Setup(c => c.OpenAsync()).ThrowsAsync(new Exception("Unauthorized"));
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.CreateCloudConnectionAsync(credentials) == Task.FromResult(Try.Success(cloudProxy)));
+            IAuthenticator cloudAuthenticator = new CloudTokenAuthenticator(connectionManager);
+
+            // Act
+            bool isAuthenticated = await cloudAuthenticator.AuthenticateAsync(credentials);
+
+            // Assert
+            Assert.False(isAuthenticated);
+        }
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
@@ -1,0 +1,364 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Security.Cryptography;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Common.Security;
+    using Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class DeviceScopeTokenAuthenticatorTest
+    {
+        [Fact]
+        public async Task AuthenticateTest_Device()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+            var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Enabled);
+            deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId)))
+                .ReturnsAsync(Option.Some(serviceIdentity));
+
+            IAuthenticator authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IDeviceIdentity>(d => d.DeviceId == deviceId && d.Id == deviceId);
+            string token = GetDeviceToken(iothubHostName, deviceId, key);
+            var tokenCredentials = Mock.Of<ITokenCredentials>(t => t.Identity == identity && t.Token == token);
+
+            // Act
+            bool isAuthenticated = await authenticator.AuthenticateAsync(tokenCredentials);
+
+            // Assert
+            Assert.True(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public async Task AuthenticateTest_Module()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            string moduleId = "m1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+            var serviceIdentity = new ServiceIdentity(deviceId, moduleId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Enabled);
+            deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == $"{deviceId}/{moduleId}")))
+                .ReturnsAsync(Option.Some(serviceIdentity));
+
+            IAuthenticator authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IModuleIdentity>(d => d.DeviceId == deviceId && d.ModuleId == moduleId && d.Id == $"{deviceId}/{moduleId}");
+            string token = GetDeviceToken(iothubHostName, deviceId, moduleId, key);
+            var tokenCredentials = Mock.Of<ITokenCredentials>(t => t.Identity == identity && t.Token == token);
+
+            // Act
+            bool isAuthenticated = await authenticator.AuthenticateAsync(tokenCredentials);
+
+            // Assert
+            Assert.True(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public async Task AuthenticateTest_ModuleWithDeviceToken()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            string moduleId = "m1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+            var deviceServiceIdentity = new ServiceIdentity(deviceId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Enabled);
+            var moduleServiceIdentity = new ServiceIdentity(deviceId, moduleId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey())), ServiceIdentityStatus.Enabled);
+            deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == $"{deviceId}/{moduleId}")))
+                .ReturnsAsync(Option.Some(moduleServiceIdentity));
+            deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId)))
+                .ReturnsAsync(Option.Some(deviceServiceIdentity));
+
+            IAuthenticator authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IModuleIdentity>(d => d.DeviceId == deviceId && d.ModuleId == moduleId && d.Id == $"{deviceId}/{moduleId}");
+            string token = GetDeviceToken(iothubHostName, deviceId, key);
+            var tokenCredentials = Mock.Of<ITokenCredentials>(t => t.Identity == identity && t.Token == token);
+
+            // Act
+            bool isAuthenticated = await authenticator.AuthenticateAsync(tokenCredentials);
+
+            // Assert
+            Assert.True(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public async Task AuthenticateTest_Device_ServiceIdentityNotEnabled()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+            var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Disabled);
+            deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId)))
+                .ReturnsAsync(Option.Some(serviceIdentity));
+
+            IAuthenticator authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IDeviceIdentity>(d => d.DeviceId == deviceId && d.Id == deviceId);
+            string token = GetDeviceToken(iothubHostName, deviceId, key);
+            var tokenCredentials = Mock.Of<ITokenCredentials>(t => t.Identity == identity && t.Token == token);
+
+            // Act
+            bool isAuthenticated = await authenticator.AuthenticateAsync(tokenCredentials);
+
+            // Assert
+            Assert.False(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public async Task AuthenticateTest_Device_WrongToken()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+            var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey())), ServiceIdentityStatus.Enabled);
+            deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId)))
+                .ReturnsAsync(Option.Some(serviceIdentity));
+
+            IAuthenticator authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IDeviceIdentity>(d => d.DeviceId == deviceId && d.Id == deviceId);
+            string token = GetDeviceToken(iothubHostName, deviceId, key);
+            var tokenCredentials = Mock.Of<ITokenCredentials>(t => t.Identity == identity && t.Token == token);
+
+            // Act
+            bool isAuthenticated = await authenticator.AuthenticateAsync(tokenCredentials);
+
+            // Assert
+            Assert.False(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public void ValidateAudienceTest()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+
+            var authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IDeviceIdentity>(d => d.DeviceId == deviceId && d.Id == deviceId);
+            string token = GetDeviceToken(iothubHostName, deviceId, key);
+            SharedAccessSignature sharedAccessSignature = SharedAccessSignature.Parse(iothubHostName, token);
+            string audience = sharedAccessSignature.Audience;
+
+            // Act
+            bool isAuthenticated = authenticator.ValidateAudience(audience, identity);
+
+            // Assert
+            Assert.True(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public void ValidateAudienceWithEdgeHubHostNameTest()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+
+            var authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IDeviceIdentity>(d => d.DeviceId == deviceId && d.Id == deviceId);
+            string token = GetDeviceToken(edgehubHostName, deviceId, key);
+            SharedAccessSignature sharedAccessSignature = SharedAccessSignature.Parse(edgehubHostName, token);
+            string audience = sharedAccessSignature.Audience;
+
+            // Act
+            bool isAuthenticated = authenticator.ValidateAudience(audience, identity);
+
+            // Assert
+            Assert.True(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public void InvalidAudienceTest_DeviceId()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+
+            var authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IDeviceIdentity>(d => d.DeviceId == deviceId && d.Id == deviceId);
+            string token = GetDeviceToken(edgehubHostName, "d2", key);
+            SharedAccessSignature sharedAccessSignature = SharedAccessSignature.Parse(edgehubHostName, token);
+            string audience = sharedAccessSignature.Audience;
+
+            // Act
+            bool isAuthenticated = authenticator.ValidateAudience(audience, identity);
+
+            // Assert
+            Assert.False(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public void InvalidAudienceTest_Hostname()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+
+            var authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IDeviceIdentity>(d => d.DeviceId == deviceId && d.Id == deviceId);
+            string token = GetDeviceToken("edgehub2", deviceId, key);
+            SharedAccessSignature sharedAccessSignature = SharedAccessSignature.Parse(edgehubHostName, token);
+            string audience = sharedAccessSignature.Audience;
+
+            // Act
+            bool isAuthenticated = authenticator.ValidateAudience(audience, identity);
+
+            // Assert
+            Assert.False(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public void InvalidAudienceTest_Device_Format()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+
+            var authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IDeviceIdentity>(d => d.DeviceId == deviceId && d.Id == deviceId);
+            string audience = $"{iothubHostName}/devices/{deviceId}/foo";
+
+            // Act
+            bool isAuthenticated = authenticator.ValidateAudience(audience, identity);
+
+            // Assert
+            Assert.False(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        [Fact]
+        public void InvalidAudienceTest_Module_Format()
+        {
+            // Arrange
+            string iothubHostName = "testiothub.azure-devices.net";
+            string edgehubHostName = "edgehub1";
+            string deviceId = "d1";
+            string moduleId = "m1";
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var underlyingAuthenticator = Mock.Of<IAuthenticator>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            string key = GetKey();
+
+            var authenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, iothubHostName, edgehubHostName, underlyingAuthenticator, connectionManager);
+
+            var identity = Mock.Of<IModuleIdentity>(d => d.DeviceId == deviceId && d.ModuleId == moduleId && d.Id == $"{deviceId}/{moduleId}");
+            string audience = $"{iothubHostName}/devices/{deviceId}/modules/{moduleId}/m1";
+
+            // Act
+            bool isAuthenticated = authenticator.ValidateAudience(audience, identity);
+
+            // Assert
+            Assert.False(isAuthenticated);
+            Mock.Get(underlyingAuthenticator).VerifyAll();
+        }
+
+        static string GetDeviceToken(string iothubHostName, string deviceId, string key)
+        {
+            DateTime startTime = DateTime.UtcNow;
+            string audience = WebUtility.UrlEncode($"{iothubHostName}/devices/{deviceId}");
+            string expiresOn = SasTokenHelper.BuildExpiresOn(startTime, TimeSpan.FromHours(1));
+            string data = string.Join("\n", new List<string> { audience, expiresOn });
+            string signature = Sign(data, key);
+            return SasTokenHelper.BuildSasToken(audience, signature, expiresOn);
+        }
+
+        static string GetDeviceToken(string iothubHostName, string deviceId, string moduleId, string key)
+        {
+            DateTime startTime = DateTime.UtcNow;
+            string audience = WebUtility.UrlEncode($"{iothubHostName}/devices/{deviceId}/modules/{moduleId}");
+            string expiresOn = SasTokenHelper.BuildExpiresOn(startTime, TimeSpan.FromHours(1));
+            string data = string.Join("\n", new List<string> { audience, expiresOn });
+            string signature = Sign(data, key);
+            return SasTokenHelper.BuildSasToken(audience, signature, expiresOn);
+        }
+
+        static string Sign(string requestString, string key)
+        {
+            using (var algorithm = new HMACSHA256(Convert.FromBase64String(key)))
+            {
+                return Convert.ToBase64String(algorithm.ComputeHash(Encoding.UTF8.GetBytes(requestString)));
+            }
+        }
+
+        static string GetKey() => Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()));
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/TokenCacheAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/TokenCacheAuthenticatorTest.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 {
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client.Exceptions;
+    using Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
@@ -11,7 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     using Moq;
     using Xunit;
 
-    public class TokenCredentialsAuthenticatorTest
+    public class TokenCacheAuthenticatorTest
     {
         [Unit]
         [Fact]
@@ -35,7 +36,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
             var credentials = new TokenCredentials(identity, sasToken, callerProductInfo);
 
-            var tokenCredentialsAuthenticator = new TokenCredentialsAuthenticator(connectionManager, credentialsStore.Object, iothubHostName);
+            var tokenCredentialsAuthenticator = new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), credentialsStore.Object, iothubHostName);
 
             // Act
             bool isAuthenticated = await tokenCredentialsAuthenticator.AuthenticateAsync(credentials);
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             credentialsStore.Setup(c => c.Add(It.IsAny<IClientCredentials>()))
                 .Returns(Task.CompletedTask);
 
-            var tokenCredentialsAuthenticator = new TokenCredentialsAuthenticator(connectionManager, credentialsStore.Object, iothubHostName);
+            var tokenCredentialsAuthenticator = new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), credentialsStore.Object, iothubHostName);
 
             // Act
             bool isAuthenticated = await tokenCredentialsAuthenticator.AuthenticateAsync(credentials);
@@ -108,7 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             credentialsStore.Setup(c => c.Add(It.IsAny<IClientCredentials>()))
                 .Returns(Task.CompletedTask);
 
-            var tokenCredentialsAuthenticator = new TokenCredentialsAuthenticator(connectionManager, credentialsStore.Object, iothubHostName);
+            var tokenCredentialsAuthenticator = new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), credentialsStore.Object, iothubHostName);
 
             // Act
             bool isAuthenticated = await tokenCredentialsAuthenticator.AuthenticateAsync(credentials);
@@ -145,7 +146,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             credentialsStore.Setup(c => c.Add(It.IsAny<IClientCredentials>()))
                 .Returns(Task.CompletedTask);
 
-            var tokenCredentialsAuthenticator = new TokenCredentialsAuthenticator(connectionManager, credentialsStore.Object, iothubHostName);
+            var tokenCredentialsAuthenticator = new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), credentialsStore.Object, iothubHostName);
 
             // Act
             bool isAuthenticated = await tokenCredentialsAuthenticator.AuthenticateAsync(credentials);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/AuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/AuthenticatorTest.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.CloudProxy;
+    using Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
@@ -22,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public void AuthenticatorConstructorTest()
         {
             var connectionManager = Mock.Of<IConnectionManager>();
-            Assert.NotNull(new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), "your-device", connectionManager));
+            Assert.NotNull(new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), "your-device", connectionManager));
         }
 
         [Fact]
@@ -37,7 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public void AuthenticatorConstructor_NullDeviceIdTest()
         {
             var connectionManager = Mock.Of<IConnectionManager>();
-            Assert.Throws<ArgumentException>(() => new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), null, Mock.Of<IConnectionManager>()));
+            Assert.Throws<ArgumentException>(() => new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), null, Mock.Of<IConnectionManager>()));
         }
 
         [Fact]
@@ -45,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public void AuthenticatorConstructor_EmptyDeviceIdTest()
         {
             var connectionManager = Mock.Of<IConnectionManager>();
-            Assert.Throws<ArgumentException>(() => new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), string.Empty, Mock.Of<IConnectionManager>()));
+            Assert.Throws<ArgumentException>(() => new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), string.Empty, Mock.Of<IConnectionManager>()));
         }
 
         [Fact]
@@ -60,7 +61,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Mock.Get(connectionManager).Setup(cm => cm.AddDeviceConnection(It.IsAny<IClientCredentials>())).Returns(Task.CompletedTask);
             Mock.Get(cloudProxy).Setup(cp => cp.IsActive).Returns(true);
 
-            var authenticator = new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
+            var authenticator = new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
             Assert.Equal(true, await authenticator.AuthenticateAsync(clientCredentials));
             Mock.Get(connectionManager).Verify();
         }
@@ -77,7 +78,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Mock.Get(connectionManager).Setup(cm => cm.AddDeviceConnection(It.IsAny<IClientCredentials>())).Returns(Task.CompletedTask);
             Mock.Get(cloudProxy).Setup(cp => cp.IsActive).Returns(false);
 
-            var authenticator = new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
+            var authenticator = new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
             Assert.Equal(false, await authenticator.AuthenticateAsync(clientCredentials));
             Mock.Get(connectionManager).Verify(c => c.AddDeviceConnection(It.IsAny<IClientCredentials>()), Times.Never);
         }
@@ -94,7 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Mock.Get(connectionManager).Setup(cm => cm.AddDeviceConnection(It.IsAny<IClientCredentials>())).Returns(Task.CompletedTask);
             Mock.Get(cloudProxy).Setup(cp => cp.IsActive).Returns(true);
 
-            var authenticator = new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
+            var authenticator = new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
             Assert.Equal(false, await authenticator.AuthenticateAsync(clientCredentials));
             Mock.Get(connectionManager).Verify(c => c.AddDeviceConnection(It.IsAny<IClientCredentials>()), Times.Never);
         }
@@ -106,7 +107,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connectionManager = Mock.Of<IConnectionManager>();
             var clientCredentials = Mock.Of<IClientCredentials>(c => c.Identity == Mock.Of<IModuleIdentity>(i => i.DeviceId == "my-device"));
 
-            var authenticator = new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
+            var authenticator = new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
             Assert.Equal(false, await authenticator.AuthenticateAsync(clientCredentials));
         }
 
@@ -116,7 +117,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             var connectionManager = Mock.Of<IConnectionManager>();
 
-            var authenticator = new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
+            var authenticator = new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), "your-device", connectionManager);
             await Assert.ThrowsAsync<ArgumentNullException>(() => authenticator.AuthenticateAsync(null));
         }
 
@@ -129,7 +130,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 c.Identity == Mock.Of<IModuleIdentity>(i => i.DeviceId == "my-device")
                 && c.AuthenticationType == AuthenticationType.X509Cert);
 
-            var authenticator = new Authenticator(new TokenCredentialsAuthenticator(connectionManager, new NullCredentialsStore(), TestIotHub), "my-device", connectionManager);
+            var authenticator = new Authenticator(new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager), new NullCredentialsStore(), TestIotHub), "my-device", connectionManager);
             Assert.Equal(true, await authenticator.AuthenticateAsync(clientCredentials));
         }
     }


### PR DESCRIPTION
Added a new authenticator to authenticate incoming connections based on stored service identities in the device scope of the edge device. 