### PR TITLE
EdgeHub: Bind IEdgeHub instance to CloudConnectionProvider

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -99,6 +99,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 logger.LogWarning("Unable to find intermediate certificates.");
             }
 
+            // EdgeHub and CloudConnectionProvider have a circular dependency. So need to Bind the EdgeHub to the CloudConnectionProvider.
+            IEdgeHub edgeHub = await container.Resolve<Task<IEdgeHub>>();
+            var cloudConnectionProvider = container.Resolve<ICloudConnectionProvider>();
+            cloudConnectionProvider.BindEdgeHub(edgeHub);
+
             // EdgeHub cloud proxy and DeviceConnectivityManager have a circular dependency,
             // so the cloud proxy has to be set on the DeviceConnectivityManager after both have been initialized.
             var deviceConnectivityManager = container.Resolve<IDeviceConnectivityManager>();


### PR DESCRIPTION
Bind EdgeHub instance to CloudConnectionProvider to enable to start properly again.