### PR TITLE
EdgeHub: Fix registering DevicesScopeIdentitiesCache

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceScopeIdentitiesCache.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public class NullDeviceScopeIdentitiesCache : IDeviceScopeIdentitiesCache
+    {
+        public Task<Option<ServiceIdentity>> GetServiceIdentity(string id) => Task.FromResult(Option.None<ServiceIdentity>());
+
+        public Task<Option<ServiceIdentity>> GetServiceIdentity(string deviceId, string moduleId) => Task.FromResult(Option.None<ServiceIdentity>());
+
+        public Task RefreshServiceIdentities(IEnumerable<string> deviceIds) => Task.CompletedTask;
+
+        public Task RefreshServiceIdentity(string deviceId) => Task.CompletedTask;
+
+        public Task RefreshServiceIdentity(string deviceId, string moduleId) => Task.CompletedTask;
+
+        public event EventHandler<ServiceIdentity> ServiceIdentityUpdated { add { } remove { } }
+
+        public event EventHandler<string> ServiceIdentityRemoved { add { } remove { } }
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
@@ -70,6 +70,6 @@
   "Metrics": {
     "MetricsStoreType": "influxdb"
   },
-  "AuthenticationMode": "CloudAndScope",
-  "DeviceScopeCacheRefreshRateSecs":  3600 
+  "AuthenticationMode": "Cloud",
+  "DeviceScopeCacheRefreshRateSecs": 3600
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -80,8 +80,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                             .GetOrElse(
                                 () =>
                                 {
-                                    string edgeHubGenerationId = this.edgeHubGenerationId.Expect(() => new Exception("Generation ID missing"));
-                                    return new HttpHsmSignatureProvider(this.edgeHubModuleId, edgeHubGenerationId, string.Empty, string.Empty) as ISignatureProvider;
+                                    string edgeHubGenerationId = this.edgeHubGenerationId.Expect(() => new InvalidOperationException("Generation ID missing"));
+                                    string workloadUri = this.workloadUri.Expect(() => new InvalidOperationException("workloadUri is missing"));
+                                    return new HttpHsmSignatureProvider(this.edgeHubModuleId, edgeHubGenerationId, workloadUri, Service.Constants.WorkloadApiVersion) as ISignatureProvider;
                                 });
                         return signatureProvider;
                     })

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/HttpHsmSignatureProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/HttpHsmSignatureProvider.cs
@@ -28,20 +28,11 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged
             new ExponentialBackoff(retryCount: 3, minBackoff: TimeSpan.FromSeconds(2), maxBackoff: TimeSpan.FromSeconds(30), deltaBackoff: TimeSpan.FromSeconds(3));
 
         public HttpHsmSignatureProvider(string moduleId, string generationId, string providerUri, string apiVersion)
-        {
-            if (string.IsNullOrEmpty(providerUri))
-            {
-                throw new ArgumentNullException(nameof(providerUri));
-            }
-            if (string.IsNullOrEmpty(apiVersion))
-            {
-                throw new ArgumentNullException(nameof(apiVersion));
-            }
-
-            this.providerUri = new Uri(providerUri);
-            this.apiVersion = apiVersion;
-            this.moduleId = moduleId;
-            this.generationId = generationId;
+        {            
+            this.providerUri = new Uri(Preconditions.CheckNotNull(providerUri, nameof(providerUri)));
+            this.apiVersion = Preconditions.CheckNonWhiteSpace(apiVersion, nameof(apiVersion));
+            this.moduleId = Preconditions.CheckNonWhiteSpace(moduleId, nameof(moduleId));
+            this.generationId = Preconditions.CheckNonWhiteSpace(generationId, nameof(generationId));
         }
 
         public async Task<string> SignAsync(string data)


### PR DESCRIPTION
Add DeviceScopeIdentitesCache only if authentication using DeviceScope is enabled. 
Change the default to not using DeviceScope
This fixes the EdgeHub (that got broken in one of the previous merges)