### PR TITLE
Make sure iotedged survives a reboot in RHEL7.5 and Debian8

### DIFF
--- a/edgelet/Makefile
+++ b/edgelet/Makefile
@@ -23,7 +23,6 @@ bindir?=$(exec_prefix)/bin
 libdir?=$(exec_prefix)/lib
 sysconfdir?=/etc
 localstatedir?=/var
-runstatedir?=$(localstatedir)/run/$(PACKAGE_NAME)
 datarootdir?=$(prefix)/share
 datadir?=$(datarootdir)
 docdir?=$(datarootdir)/doc/$(PACKAGE_NAME)

--- a/edgelet/Makefile
+++ b/edgelet/Makefile
@@ -49,12 +49,13 @@ INSTALL_PROGRAM=$(INSTALL)
 MAKE=make
 MKDIR_P=mkdir -p
 SED=sed
+HOST_URI_OPTION=
 
 all:
 	VERSION=${VERSION} $(CARGO) build $(CARGOFLAGS)
 
 release:
-	VERSION=${VERSION} $(CARGO) build $(CARGOFLAGS) --release
+	$(HOST_URI_OPTION) VERSION=${VERSION} $(CARGO) build $(CARGOFLAGS) --release
 
 $(TARGET)/$(PACKAGE).tar.gz:
 	@echo Running git archive...
@@ -73,6 +74,7 @@ $(TARGET)/$(PACKAGE).tar.gz:
 
 dist: $(TARGET)/$(PACKAGE).tar.gz
 
+deb8: HOST_URI_OPTION=IOTEDGE_HOST=unix:///var/lib/iotedge/mgmt.sock
 deb8: release
 	$(INSTALL_PROGRAM) -D $(TARGET)/iotedged $(TARGET)/$(PACKAGE)/iotedged
 	$(INSTALL_PROGRAM) -D $(TARGET)/iotedge $(TARGET)/$(PACKAGE)/iotedge
@@ -107,10 +109,11 @@ deb: release
 	$(SED) "s/@version@/${DEB_VERSION}/g; s/@revision@/${DEB_REVISION}/g;" $(srcdir)/contrib/debian/changelog > $(TARGET)/$(PACKAGE)/debian/changelog
 	cd $(TARGET)/$(PACKAGE) && dpkg-buildpackage $(DPKGFLAGS)
 
+rpm: HOST_URI_OPTION=IOTEDGE_HOST=unix:///var/lib/iotedge/mgmt.sock
 rpm:
 	cp $(TARGET)/$(PACKAGE).tar.gz $(rpmbuilddir)/SOURCES/
 	$(SED) "s/@version@/${RPM_VERSION}/g; s/@release@/${RPM_RELEASE}/g;" $(srcdir)/contrib/centos/iotedge.spec > $(rpmbuilddir)/SPECS/iotedge.spec
-	rpmbuild $(RPMBUILDFLAGS) $(rpmbuilddir)/SPECS/iotedge.spec
+	$(HOST_URI_OPTION) rpmbuild $(RPMBUILDFLAGS) $(rpmbuilddir)/SPECS/iotedge.spec
 
 install: release
 	$(INSTALL_PROGRAM) -D $(TARGET)/iotedged $(DESTDIR)$(bindir)/iotedged
@@ -152,4 +155,4 @@ version:
 	@echo "rpm version:  ${RPM_VERSION}"
 	@echo "rpm release:  ${RPM_RELEASE}"
 
-.PHONY: all clean deb dist install rpm uninstall version
+.PHONY: all clean deb deb8 dist install rpm uninstall version

--- a/edgelet/Makefile
+++ b/edgelet/Makefile
@@ -125,9 +125,8 @@ install: release
 	$(GZIP) $(DESTDIR)$(man8)/iotedged.8
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(localstatedir)/lib/iotedge
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(localstatedir)/log/iotedge
-	$(INSTALL) -d -m 0755 $(DESTDIR)$(runstatedir)
-	$(INSTALL) -m 0660 /dev/null $(DESTDIR)$(runstatedir)/mgmt.sock
-	$(INSTALL) -m 0666 /dev/null $(DESTDIR)$(runstatedir)/workload.sock
+	$(INSTALL) -m 0660 /dev/null $(DESTDIR)$(localstatedir)/lib/iotedge/mgmt.sock
+	$(INSTALL) -m 0666 /dev/null $(DESTDIR)$(localstatedir)/lib/iotedge/workload.sock
 	$(INSTALL_DATA) -D $(srcdir)/contrib/docs/LICENSE $(DESTDIR)$(docdir)/LICENSE
 	$(INSTALL_DATA) -D $(srcdir)/contrib/docs/ThirdPartyNotices $(DESTDIR)$(docdir)/ThirdPartyNotices
 	$(INSTALL_DATA) -D $(srcdir)/contrib/docs/trademark $(DESTDIR)$(docdir)/trademark

--- a/edgelet/contrib/centos/iotedge.spec
+++ b/edgelet/contrib/centos/iotedge.spec
@@ -122,8 +122,8 @@ echo "==========================================================================
 %{_unitdir}/%{name}.service
 
 # sockets
-%attr(660, %{iotedge_user}, %{iotedge_group}) %{iotedge_rundir}/mgmt.sock
-%attr(666, %{iotedge_user}, %{iotedge_group}) %{iotedge_rundir}/workload.sock
+%attr(660, %{iotedge_user}, %{iotedge_group}) %{iotedge_home}/mgmt.sock
+%attr(666, %{iotedge_user}, %{iotedge_group}) %{iotedge_home}/workload.sock
 
 # dirs
 %attr(-, %{iotedge_user}, %{iotedge_group}) %dir %{iotedge_home}

--- a/edgelet/contrib/centos/iotedge.spec
+++ b/edgelet/contrib/centos/iotedge.spec
@@ -2,7 +2,6 @@
 %define iotedge_group %{iotedge_user}
 %define iotedge_home %{_localstatedir}/lib/iotedge
 %define iotedge_logdir %{_localstatedir}/log/iotedge
-%define iotedge_rundir %{_localstatedir}/run/iotedge
 %define iotedge_confdir %{_sysconfdir}/iotedge
 %define iotedge_datadir %{_datadir}/iotedge
 
@@ -128,7 +127,6 @@ echo "==========================================================================
 # dirs
 %attr(-, %{iotedge_user}, %{iotedge_group}) %dir %{iotedge_home}
 %attr(-, %{iotedge_user}, %{iotedge_group}) %dir %{iotedge_logdir}
-%attr(-, %{iotedge_user}, %{iotedge_group}) %dir %{iotedge_rundir}
 
 %doc %{_docdir}/%{name}/LICENSE.gz
 %doc %{_docdir}/%{name}/ThirdPartyNotices.gz

--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -107,8 +107,8 @@ hostname: "<ADD HOSTNAME HERE>"
 ###############################################################################
 
 connect:
-  management_uri: "unix:///var/run/iotedge/mgmt.sock"
-  workload_uri: "unix:///var/run/iotedge/workload.sock"
+  management_uri: "unix:///var/lib/iotedge/mgmt.sock"
+  workload_uri: "unix:///var/lib/iotedge/workload.sock"
 
 ###############################################################################
 # Listen settings
@@ -132,8 +132,8 @@ connect:
 ###############################################################################
 
 listen:
-  management_uri: "unix:///var/run/iotedge/mgmt.sock"
-  workload_uri: "unix:///var/run/iotedge/workload.sock"
+  management_uri: "unix:///var/lib/iotedge/mgmt.sock"
+  workload_uri: "unix:///var/lib/iotedge/workload.sock"
 
 ###############################################################################
 # Home Directory

--- a/edgelet/contrib/debian8/postinst
+++ b/edgelet/contrib/debian8/postinst
@@ -16,15 +16,12 @@ case "$1" in
             chmod 400 /etc/iotedge/config.yaml
 
             # Do this for debian systems which don't support FDNAMES
-            if [ ! -d  /var/lib/iotedge/ ]; then
-                touch /var/lib/iotedge/mgmt.sock
-                touch /var/lib/iotedge/workload.sock
-                chown ${USER}:${GROUP} /var/lib/iotedge/
-                chown ${USER}:${GROUP} /var/lib/iotedge/mgmt.sock
-                chown ${USER}:${GROUP} /var/lib/iotedge/workload.sock
-                chmod 660 /var/lib/iotedge/mgmt.sock
-                chmod 666 /var/lib/iotedge/workload.sock
-            fi
+            touch /var/lib/iotedge/mgmt.sock
+            touch /var/lib/iotedge/workload.sock
+            chown ${USER}:${GROUP} /var/lib/iotedge/mgmt.sock
+            chown ${USER}:${GROUP} /var/lib/iotedge/workload.sock
+            chmod 660 /var/lib/iotedge/mgmt.sock
+            chmod 666 /var/lib/iotedge/workload.sock
         fi
 
         # Set the hostname

--- a/edgelet/contrib/debian8/postinst
+++ b/edgelet/contrib/debian8/postinst
@@ -16,16 +16,14 @@ case "$1" in
             chmod 400 /etc/iotedge/config.yaml
 
             # Do this for debian systems which don't support FDNAMES
-            if [ ! -d  /var/run/iotedge/ ]; then
-                mkdir /var/run/iotedge/
-                touch /var/run/iotedge/mgmt.sock
-                touch /var/run/iotedge/workload.sock
-                chown ${USER}:${GROUP} /var/run/iotedge/
-                chown ${USER}:${GROUP} /var/run/iotedge/mgmt.sock
-                chown ${USER}:${GROUP} /var/run/iotedge/workload.sock
-                chmod 755 /var/run/iotedge/
-                chmod 660 /var/run/iotedge/mgmt.sock
-                chmod 666 /var/run/iotedge/workload.sock
+            if [ ! -d  /var/lib/iotedge/ ]; then
+                touch /var/lib/iotedge/mgmt.sock
+                touch /var/lib/iotedge/workload.sock
+                chown ${USER}:${GROUP} /var/lib/iotedge/
+                chown ${USER}:${GROUP} /var/lib/iotedge/mgmt.sock
+                chown ${USER}:${GROUP} /var/lib/iotedge/workload.sock
+                chmod 660 /var/lib/iotedge/mgmt.sock
+                chmod 666 /var/lib/iotedge/workload.sock
             fi
         fi
 

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -47,6 +47,7 @@ fn main() {
 
 fn run() -> Result<(), Error> {
     let mut core = Core::new()?;
+    let default_uri = option_env!("IOTEDGE_HOST").unwrap_or(MGMT_URI);
 
     let matches = App::new(crate_name!())
         .version(edgelet_core::version())
@@ -61,7 +62,7 @@ fn run() -> Result<(), Error> {
                 .value_name("HOST")
                 .global(true)
                 .env("IOTEDGE_HOST")
-                .default_value(MGMT_URI),
+                .default_value(default_uri),
         ).subcommand(SubCommand::with_name("list").about("List modules"))
         .subcommand(
             SubCommand::with_name("restart")


### PR DESCRIPTION
On systems where systemd is not new enough to support socket files
and fdnames, we need to create the socket files in a directory which
will survive across a reboot and is owned by iotedge.  Using
/var/lib/iotedge fits that bill.