### PR TITLE
Map Dotnetty Timeout to Timeout exception

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ExceptionMapper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ExceptionMapper.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
+{
+    using System;
+    using DotNetty.Transport.Channels;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public static class ExceptionMapper
+    {
+        public static Exception GetEdgeException(this Exception sdkException, string operation)
+        {
+            Preconditions.CheckNonWhiteSpace(operation, nameof(operation));
+            if (sdkException != null)
+            {
+                if (sdkException is ConnectTimeoutException connectTimeoutException)
+                {
+                    return new TimeoutException($"Operation {operation} timed out", connectTimeoutException);
+                }
+            }
+
+            return sdkException;
+        }
+    }
+}


### PR DESCRIPTION
When using MQTT with EdgeHub, we need to treat DotNetty Timeout exception as a retryable exception. So mapping it to the normal timeout exception.