### PR TITLE
Fix DI registration for EdgeHub

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/AmqpModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/AmqpModule.cs
@@ -71,9 +71,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     var transportSettings = c.Resolve<ITransportSettings>();
                     var transportListenerProvider = c.Resolve<ITransportListenerProvider>();
                     var linkHandlerProvider = c.Resolve<ILinkHandlerProvider>();
-                    ICredentialsCache credentialsCache = await c.Resolve<Task<ICredentialsCache>>();
-                    IAuthenticator authenticator = await c.Resolve<Task<IAuthenticator>>();
-                    IConnectionProvider connectionProvider = await c.Resolve<Task<IConnectionProvider>>();
+                    var credentialsCacheTask = c.Resolve<Task<ICredentialsCache>>();
+                    var authenticatorTask = c.Resolve<Task<IAuthenticator>>();
+                    var connectionProviderTask = c.Resolve<Task<IConnectionProvider>>();
+                    ICredentialsCache credentialsCache = await credentialsCacheTask;
+                    IAuthenticator authenticator = await authenticatorTask;
+                    IConnectionProvider connectionProvider = await connectionProviderTask;
                     AmqpSettings amqpSettings = AmqpSettingsProvider.GetDefaultAmqpSettings(
                         this.iotHubHostName,
                         authenticator,
@@ -81,6 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         linkHandlerProvider,
                         connectionProvider,
                         credentialsCache);
+
                     return new AmqpProtocolHead(
                         transportSettings,
                         amqpSettings,

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     if (this.usePersistentStorage)
                     {
                         // Create partitions for messages and twins
-                        var partitionsList = new List<string> { Core.Constants.MessageStorePartitionKey, Core.Constants.TwinStorePartitionKey, Core.Constants.CheckpointStorePartitionKey };
+                        var partitionsList = new List<string> { Constants.MessageStorePartitionKey, Constants.TwinStorePartitionKey, Core.Constants.CheckpointStorePartitionKey };
                         try
                         {
                             IDbStoreProvider dbStoreprovider = Storage.RocksDb.DbStoreProvider.Create(c.Resolve<Storage.RocksDb.IRocksDbOptionsProvider>(),
@@ -196,6 +196,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         return deviceScopeIdentitiesCache;
                     })
                 .As<Task<IDeviceScopeIdentitiesCache>>()
+                .AutoActivate()
                 .SingleInstance();
 
             // Task<ICredentialsCache>
@@ -300,8 +301,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
 
         static async Task<IKeyValueStore<string, string>> GetEncryptedStore(IComponentContext context, string entityName)
         {
-            Option<IEncryptionProvider> encryptionProvider = await context.Resolve<Task<Option<IEncryptionProvider>>>();
             var storeProvider = context.Resolve<IStoreProvider>();
+            Option<IEncryptionProvider> encryptionProvider = await context.Resolve<Task<Option<IEncryptionProvider>>>();
             IKeyValueStore<string, string> encryptedStore = encryptionProvider
                 .Map(
                     e =>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -418,9 +418,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         var edgeHubCredentials = c.ResolveNamed<IClientCredentials>("EdgeHubCredentials");
                         var twinCollectionMessageConverter = c.Resolve<Core.IMessageConverter<TwinCollection>>();
                         var twinMessageConverter = c.Resolve<Core.IMessageConverter<Twin>>();
-                        ITwinManager twinManager = await c.Resolve<Task<ITwinManager>>();
-                        ICloudProxy cloudProxy = await c.ResolveNamed<Task<ICloudProxy>>("EdgeHubCloudProxy");
-                        IEdgeHub edgeHub = await c.Resolve<Task<IEdgeHub>>();
+                        var twinManagerTask = c.Resolve<Task<ITwinManager>>();
+                        var cloudProxyTask = c.ResolveNamed<Task<ICloudProxy>>("EdgeHubCloudProxy");
+                        var edgeHubTask = c.Resolve<Task<IEdgeHub>>();
+                        ITwinManager twinManager = await twinManagerTask;
+                        ICloudProxy cloudProxy = await cloudProxyTask;
+                        IEdgeHub edgeHub = await edgeHubTask;
                         IConnectionManager connectionManager = await c.Resolve<Task<IConnectionManager>>();
                         IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await c.Resolve<Task<IDeviceScopeIdentitiesCache>>();
                         IConfigSource edgeHubConnection = await EdgeHubConnection.Create(
@@ -449,8 +452,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             builder.Register(
                 async c =>
                 {
-                    IConnectionManager connectionManager = await c.Resolve<Task<IConnectionManager>>();
-                    IEdgeHub edgeHub = await c.Resolve<Task<IEdgeHub>>();
+                    var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();
+                    var edgeHubTask = c.Resolve<Task<IEdgeHub>>();
+                    IConnectionManager connectionManager = await connectionManagerTask;
+                    IEdgeHub edgeHub = await edgeHubTask;
                     IConnectionProvider connectionProvider = new ConnectionProvider(connectionManager, edgeHub);
                     return connectionProvider;
                 })


### PR DESCRIPTION
When registering types for EdgeHub, if any types are registered as tasks, when resolving them, all the resolutions need to be done before the awaits. Otherwise autofac sometimes throws an exception saying that the context has been closed already. This exception seems to be non-deterministic. So fixing it everywhere to make it reliable and uniform.