### PR TITLE
EdgeHub: Fix startup when offline

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -156,11 +156,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             }
             catch (Exception e)
             {
-                Events.ErrorAddingSubscription(e, id, deviceSubscription);
-                if (!e.HasTimeoutException())
-                {
-                    throw;
-                }
+                Events.ErrorAddingSubscription(e, id, deviceSubscription);                
             }
         }
 
@@ -175,11 +171,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             }
             catch (Exception e)
             {
-                Events.ErrorRemovingSubscription(e, id, deviceSubscription);
-                if (!(e is TimeoutException))
-                {
-                    throw;
-                }
+                Events.ErrorRemovingSubscription(e, id, deviceSubscription);                
             }
         }
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ConnectivityAwareClientTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ConnectivityAwareClientTest.cs
@@ -46,21 +46,50 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         }
 
         [Theory]
-        [InlineData(typeof(ConnectTimeoutException), typeof(TimeoutException))]
-        [InlineData(typeof(TimeoutException), typeof(TimeoutException))]
-        [InlineData(typeof(IotHubException), typeof(IotHubException))]
-        [InlineData(typeof(InvalidOperationException), typeof(InvalidOperationException))]
-        public async Task TestExceptionTest(Type thrownException, Type expectedException)
+        [InlineData(typeof(ConnectTimeoutException), typeof(TimeoutException), true)]
+        [InlineData(typeof(TimeoutException), typeof(TimeoutException), true)]
+        [InlineData(typeof(IotHubException), typeof(IotHubException), false)]
+        [InlineData(typeof(InvalidOperationException), typeof(InvalidOperationException), false)]
+        public async Task TestExceptionTest(Type thrownException, Type expectedException, bool isTimeout)
         {
             // Arrange
             var client = new Mock<IClient>();
             client.Setup(c => c.SendEventAsync(It.IsAny<Message>())).ThrowsAsync(Activator.CreateInstance(thrownException, "msg str") as Exception);
-            var deviceConnectivityManager = new DeviceConnectivityManager();
-            var connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
+            var deviceConnectivityManager = new Mock<IDeviceConnectivityManager>();
+            deviceConnectivityManager.Setup(d => d.CallTimedOut());
+            var connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager.Object);
             var message = new Message();
 
             // Act / Assert
             await Assert.ThrowsAsync(expectedException, () => connectivityAwareClient.SendEventAsync(message));
+            if (isTimeout)
+            {
+                deviceConnectivityManager.Verify(d => d.CallTimedOut(), Times.Once);
+            }
+            else
+            {
+                deviceConnectivityManager.Verify(d => d.CallTimedOut(), Times.Never);
+            }
+        }
+
+        [Theory]
+        [InlineData(typeof(ConnectTimeoutException), typeof(TimeoutException))]
+        [InlineData(typeof(TimeoutException), typeof(TimeoutException))]
+        [InlineData(typeof(IotHubException), typeof(IotHubException))]
+        [InlineData(typeof(InvalidOperationException), typeof(InvalidOperationException))]
+        public async Task TestExceptionInSetDesiredPropertyUpdateCallbackTest(Type thrownException, Type expectedException)
+        {
+            // Arrange
+            var client = new Mock<IClient>();
+            client.Setup(c => c.SetDesiredPropertyUpdateCallbackAsync(It.IsAny<DesiredPropertyUpdateCallback>(), It.IsAny<object>())).ThrowsAsync(Activator.CreateInstance(thrownException, "msg str") as Exception);
+            var deviceConnectivityManager = new Mock<IDeviceConnectivityManager>();
+            deviceConnectivityManager.Setup(d => d.CallTimedOut());
+            var connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager.Object);
+            DesiredPropertyUpdateCallback callback = (_, __) => Task.CompletedTask;
+
+            // Act / Assert
+            await Assert.ThrowsAsync(expectedException, () => connectivityAwareClient.SetDesiredPropertyUpdateCallbackAsync(callback, null));
+            deviceConnectivityManager.Verify(d => d.CallTimedOut(), Times.Never);
         }
 
         class DeviceConnectivityManager : IDeviceConnectivityManager

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -596,7 +596,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
         }
 
         [Fact]
-        public async Task AddSubscriptionThrowsTest()
+        public async Task AddSubscriptionHandlesExceptionTest()
         {
             // Arrange
             string deviceId = "d1";
@@ -610,7 +610,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
 
             // Act
-            await Assert.ThrowsAsync<InvalidOperationException>(() => edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods));
+            await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
 
             // Assert
             cloudProxy.VerifyAll();
@@ -663,7 +663,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
         }
 
         [Fact]
-        public async Task RemoveSubscriptionThrowsTest()
+        public async Task RemoveSubscriptionHandlesExceptionTest()
         {
             // Arrange
             string deviceId = "d1";
@@ -677,7 +677,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
 
             // Act
-            await Assert.ThrowsAsync<InvalidOperationException>(() => edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods));
+            await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
 
             // Assert
             cloudProxy.VerifyAll();


### PR DESCRIPTION
EdgeHubConnection sets up some subscriptions. This can throw exceptions if the device is offline. So swallow these exceptions instead of throwing.

The change in ConnectivityAwareClient is to make sure all calls go through InvokeFunc so that all calls get logging and error mapping, even if the call is not used to determine whether the device is online or not.