### PR TITLE
Reduce time of windows check in build

### DIFF
--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -39,7 +39,7 @@ phases:
         displayName: Install
         inputs:
           filePath: scripts/windows/setup/Install-Prerequisites.ps1
-          arguments: -DotnetSdkUrl $(NetCorePackageUriWindows)
+          arguments: -DotnetSdkUrl $(NetCorePackageUriWindows) -Dotnet -Nuget
       - task: PowerShell@2
         displayName: Build
         inputs:


### PR DESCRIPTION
…uget.

We don't need code coverage tool for now or python. So removing these dependencies.