### PR TITLE
EdgeHub: Fix DeviceConnectivityManager from using stale cloud proxies

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             }
         }
 
-        async void DeviceDisconnected(object sender, IIdentity device)
+        internal async void DeviceDisconnected(object sender, IIdentity device)
         {
             try
             {
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             }
         }
 
-        async void DeviceConnected(object sender, IIdentity device)
+        internal async void DeviceConnected(object sender, IIdentity device)
         {
             try
             {
@@ -285,6 +285,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             try
             {
+                if (client.Id.Equals(this.edgeHubIdentity.Id))
+                {
+                    Events.SkipUpdatingEdgeHubIdentity(client.Id, connectionStatus);
+                    return Task.CompletedTask;
+                }
+
                 Events.UpdatingDeviceConnectionStatus(client.Id, connectionStatus);
 
                 // If a downstream device disconnects, then remove the entry from Reported properties
@@ -529,7 +535,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 ErrorParsingMethodRequest,
                 ErrorRefreshingServiceIdentities,
                 RefreshedServiceIdentities,
-                InvalidMethodRequest
+                InvalidMethodRequest,
+                SkipUpdatingEdgeHubIdentity
             }
 
             internal static void Initialized(IIdentity edgeHubIdentity)
@@ -624,6 +631,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             public static void InvalidMethodRequest(string requestName)
             {
                 Log.LogWarning((int)EventIds.InvalidMethodRequest, Invariant($"Received request for unsupported method {requestName}"));
+            }
+
+            public static void SkipUpdatingEdgeHubIdentity(string id, ConnectionStatus connectionStatus)
+            {
+                Log.LogDebug((int)EventIds.SkipUpdatingEdgeHubIdentity, Invariant($"Skipped updating connection status change to {connectionStatus} for {id}"));
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
@@ -81,19 +81,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 deviceScopeIdentitiesCache
             );
 
-            await InitEdgeHub(edgeHubConnection, connectionManager, edgeHubCredentials, edgeHub);
+            await InitEdgeHub(edgeHubConnection, connectionManager, edgeHubIdentity, edgeHub);
             connectionManager.DeviceConnected += edgeHubConnection.DeviceConnected;
             connectionManager.DeviceDisconnected += edgeHubConnection.DeviceDisconnected;
             Events.Initialized(edgeHubIdentity);
             return edgeHubConnection;
         }
 
-        static Task InitEdgeHub(EdgeHubConnection edgeHubConnection, IConnectionManager connectionManager, IClientCredentials edgeHubCredentials, IEdgeHub edgeHub)
+        static Task InitEdgeHub(EdgeHubConnection edgeHubConnection, IConnectionManager connectionManager, IIdentity edgeHubIdentity, IEdgeHub edgeHub)
         {
             IDeviceProxy deviceProxy = new EdgeHubDeviceProxy(edgeHubConnection);
-            Task addDeviceConnectionTask = connectionManager.AddDeviceConnection(edgeHubCredentials.Identity, deviceProxy);
-            Task desiredPropertyUpdatesSubscriptionTask = edgeHub.AddSubscription(edgeHubCredentials.Identity.Id, DeviceSubscription.DesiredPropertyUpdates);
-            Task methodsSubscriptionTask = edgeHub.AddSubscription(edgeHubCredentials.Identity.Id, DeviceSubscription.Methods);
+            Task addDeviceConnectionTask = connectionManager.AddDeviceConnection(edgeHubIdentity, deviceProxy);
+            Task desiredPropertyUpdatesSubscriptionTask = edgeHub.AddSubscription(edgeHubIdentity.Id, DeviceSubscription.DesiredPropertyUpdates);
+            Task methodsSubscriptionTask = edgeHub.AddSubscription(edgeHubIdentity.Id, DeviceSubscription.Methods);
             Task clearDeviceConnectionStatusesTask = edgeHubConnection.ClearDeviceConnectionStatuses();
             return Task.WhenAll(addDeviceConnectionTask, desiredPropertyUpdatesSubscriptionTask, methodsSubscriptionTask, clearDeviceConnectionStatusesTask);
         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceConnectivityManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceConnectivityManagerTest.cs
@@ -1,186 +1,196 @@
-//// Copyright (c) Microsoft. All rights reserved.
-//namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
-//{
-//    using Microsoft.Azure.Devices.Client;
-//    using Microsoft.Azure.Devices.Edge.Hub.Core;
-//    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
-//    using Microsoft.Azure.Devices.Shared;
-//    using Moq;
-//    using System;
-//    using System.Threading;
-//    using System.Threading.Tasks;
-//    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
-//    using Xunit;
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
+{
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Microsoft.Azure.Devices.Shared;
+    using Moq;
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Xunit;
 
-//    [Unit]
-//    public class DeviceConnectivityManagerTest
-//    {
-//        [Fact]
-//        public async Task NoEventsTest()
-//        {
-//            // Arrange / act            
-//            var client = new Mock<IClient>();
-//            client.SetupSequence(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
-//                .Returns(Task.CompletedTask)
-//                .Throws<TimeoutException>()
-//                .Throws<TimeoutException>()
-//                .Returns(Task.CompletedTask);
-//            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
-//            var cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
-//            deviceConnectivityManager.SetTestCloudProxy(cloudProxy);
+    [Unit]
+    public class DeviceConnectivityManagerTest
+    {
+        [Fact]
+        public async Task NoEventsTest()
+        {
+            // Arrange / act
+            var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
+            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), edgeHubIdentity);
+            var client = new Mock<IClient>();
+            client.SetupSequence(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
+                .Returns(Task.CompletedTask)
+                .Throws<TimeoutException>()
+                .Throws<TimeoutException>()
+                .Returns(Task.CompletedTask);
+            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
+            ICloudProxy cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection("d1/m1") == Task.FromResult(Option.Some(cloudProxy)));
+            deviceConnectivityManager.SetConnectionManager(connectionManager);
 
-//            bool connected = false;
-//            deviceConnectivityManager.DeviceConnected += (_, __) => connected = true;
-//            deviceConnectivityManager.DeviceDisconnected += (_, __) => connected = false;
+            bool connected = false;
+            deviceConnectivityManager.DeviceConnected += (_, __) => connected = true;
+            deviceConnectivityManager.DeviceDisconnected += (_, __) => connected = false;
 
-//            // Assert
-//            await Task.Delay(TimeSpan.FromSeconds(4));
-//            Assert.True(connected);
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(4));
+            Assert.True(connected);
 
-//            await Task.Delay(TimeSpan.FromSeconds(4));
-//            Assert.False(connected);
+            await Task.Delay(TimeSpan.FromSeconds(4));
+            Assert.False(connected);
 
-//            await Task.Delay(TimeSpan.FromSeconds(4));
-//            Assert.True(connected);
-//        }
+            await Task.Delay(TimeSpan.FromSeconds(4));
+            Assert.True(connected);
+        }
 
-//        [Fact]
-//        public async Task ConnectivityTestFailedTest()
-//        {
-//            // Arrange / act
-//            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+        [Fact]
+        public async Task ConnectivityTestFailedTest()
+        {
+            // Arrange / act
+            var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
+            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), edgeHubIdentity);
 
-//            var client = new Mock<IClient>();
-//            client.SetupSequence(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
-//                .Returns(Task.CompletedTask)
-//                .Throws<TimeoutException>()                
-//                .Returns(Task.CompletedTask)
-//                .Throws<TimeoutException>()
-//                .Returns(Task.CompletedTask);
-//            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
-//            var cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
-//            deviceConnectivityManager.SetTestCloudProxy(cloudProxy);
+            var client = new Mock<IClient>();
+            client.SetupSequence(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
+                .Returns(Task.CompletedTask)
+                .Throws<TimeoutException>()
+                .Returns(Task.CompletedTask)
+                .Throws<TimeoutException>()
+                .Returns(Task.CompletedTask);
+            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
+            ICloudProxy cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection("d1/m1") == Task.FromResult(Option.Some(cloudProxy)));
+            deviceConnectivityManager.SetConnectionManager(connectionManager);
 
-//            int connected = 0;
-//            int disconnected = 0;
-//            deviceConnectivityManager.DeviceConnected += (_, __) => Interlocked.Increment(ref connected);
-//            deviceConnectivityManager.DeviceDisconnected += (_, __) => Interlocked.Increment(ref disconnected);
+            int connected = 0;
+            int disconnected = 0;
+            deviceConnectivityManager.DeviceConnected += (_, __) => Interlocked.Increment(ref connected);
+            deviceConnectivityManager.DeviceDisconnected += (_, __) => Interlocked.Increment(ref disconnected);
 
-//            // Assert
-//            await Task.Delay(TimeSpan.FromSeconds(15));
-//            Assert.Equal(1, connected);
-//            Assert.Equal(0, disconnected);
-//        }
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(15));
+            Assert.Equal(1, connected);
+            Assert.Equal(0, disconnected);
+        }
 
-//        [Fact]
-//        public async Task WithDownstreamEventsTest()
-//        {
-//            // Arrange / act
-//            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
-//            int connectedCallbackCount = 0;
-//            int disconnectedCallbackCount = 0;
+        [Fact]
+        public async Task WithDownstreamEventsTest()
+        {
+            // Arrange / act
+            var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
+            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), edgeHubIdentity);
 
-//            void ConnectionStatusChangedHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
-//            {
-//                if (status == ConnectionStatus.Connected && reason == ConnectionStatusChangeReason.Connection_Ok)
-//                {
-//                    Interlocked.Increment(ref connectedCallbackCount);
-//                }
-//                else if (status == ConnectionStatus.Disconnected && reason == ConnectionStatusChangeReason.No_Network)
-//                {
-//                    Interlocked.Increment(ref disconnectedCallbackCount);
-//                }
-//            }
+            int connectedCallbackCount = 0;
+            int disconnectedCallbackCount = 0;
 
-//            var device1UnderlyingClient = new Mock<IClient>();
-//            device1UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
-//                .Returns(Task.CompletedTask);
-//            var device1Client = new ConnectivityAwareClient(device1UnderlyingClient.Object, deviceConnectivityManager);
-//            device1Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
+            void ConnectionStatusChangedHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
+            {
+                if (status == ConnectionStatus.Connected && reason == ConnectionStatusChangeReason.Connection_Ok)
+                {
+                    Interlocked.Increment(ref connectedCallbackCount);
+                }
+                else if (status == ConnectionStatus.Disconnected && reason == ConnectionStatusChangeReason.No_Network)
+                {
+                    Interlocked.Increment(ref disconnectedCallbackCount);
+                }
+            }
 
-//            var device2UnderlyingClient = new Mock<IClient>();
-//            device2UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
-//                .Throws<TimeoutException>();
-//            var device2Client = new ConnectivityAwareClient(device2UnderlyingClient.Object, deviceConnectivityManager);
-//            device2Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
+            var device1UnderlyingClient = new Mock<IClient>();
+            device1UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
+                .Returns(Task.CompletedTask);
+            var device1Client = new ConnectivityAwareClient(device1UnderlyingClient.Object, deviceConnectivityManager);
+            device1Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
 
-//            var edgeHubUnderlyingClient = new Mock<IClient>();
-//            edgeHubUnderlyingClient.Setup(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
-//                .Throws<TimeoutException>();
-//            IClient edgeHubClient = new ConnectivityAwareClient(edgeHubUnderlyingClient.Object, deviceConnectivityManager);
-//            edgeHubClient.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
-//            var edgeHubCloudProxy = new CloudProxy(edgeHubClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
-//            deviceConnectivityManager.SetTestCloudProxy(edgeHubCloudProxy);
+            var device2UnderlyingClient = new Mock<IClient>();
+            device2UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
+                .Throws<TimeoutException>();
+            var device2Client = new ConnectivityAwareClient(device2UnderlyingClient.Object, deviceConnectivityManager);
+            device2Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
 
-//            bool connected = false;
-//            deviceConnectivityManager.DeviceConnected += (_, __) => connected = true;
-//            deviceConnectivityManager.DeviceDisconnected += (_, __) => connected = false;
+            var edgeHubUnderlyingClient = new Mock<IClient>();
+            edgeHubUnderlyingClient.Setup(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
+                .Throws<TimeoutException>();
+            IClient edgeHubClient = new ConnectivityAwareClient(edgeHubUnderlyingClient.Object, deviceConnectivityManager);
+            edgeHubClient.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
+            ICloudProxy cloudProxy = new CloudProxy(edgeHubClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection("d1/m1") == Task.FromResult(Option.Some(cloudProxy)));
+            deviceConnectivityManager.SetConnectionManager(connectionManager);
 
-//            // Act
-//            var cts = new CancellationTokenSource();
-//            Task t = Task.Run(
-//                async () =>
-//                {
-//                    while (!cts.IsCancellationRequested)
-//                    {
-//                        await device1Client.SendEventAsync(new Message());
-//                        if (!cts.IsCancellationRequested)
-//                        {
-//                            await Task.Delay(TimeSpan.FromSeconds(1));
-//                        }
-//                    }
-//                });
+            bool connected = false;
+            deviceConnectivityManager.DeviceConnected += (_, __) => connected = true;
+            deviceConnectivityManager.DeviceDisconnected += (_, __) => connected = false;
 
-//            await Task.Delay(TimeSpan.FromSeconds(5));
+            // Act
+            var cts = new CancellationTokenSource();
+            Task t = Task.Run(
+                async () =>
+                {
+                    while (!cts.IsCancellationRequested)
+                    {
+                        await device1Client.SendEventAsync(new Message());
+                        if (!cts.IsCancellationRequested)
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(1));
+                        }
+                    }
+                });
 
-//            // Assert
-//            Assert.True(connected);
-//            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
-//            Assert.Equal(3, connectedCallbackCount);
-//            Assert.Equal(0, disconnectedCallbackCount);
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
-//            cts.Cancel();
-//            await t;
+            // Assert
+            Assert.True(connected);
+            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
+            Assert.Equal(3, connectedCallbackCount);
+            Assert.Equal(0, disconnectedCallbackCount);
 
-//            var cts2 = new CancellationTokenSource();
-//            Task t2 = Task.Run(
-//                async () =>
-//                {
-//                    while (!cts2.IsCancellationRequested)
-//                    {
-//                        try
-//                        {
-//                            await device2Client.SendEventAsync(new Message());
-//                        }
-//                        catch (TimeoutException)
-//                        {
-//                        }
-//                        if (!cts2.IsCancellationRequested)
-//                        {
-//                            await Task.Delay(TimeSpan.FromSeconds(1));
-//                        }
-//                    }
-//                });
+            cts.Cancel();
+            await t;
 
-//            await Task.Delay(TimeSpan.FromSeconds(5));
+            var cts2 = new CancellationTokenSource();
+            Task t2 = Task.Run(
+                async () =>
+                {
+                    while (!cts2.IsCancellationRequested)
+                    {
+                        try
+                        {
+                            await device2Client.SendEventAsync(new Message());
+                        }
+                        catch (TimeoutException)
+                        {
+                        }
+                        if (!cts2.IsCancellationRequested)
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(1));
+                        }
+                    }
+                });
 
-//            // Assert
-//            Assert.False(connected);
-//            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
-//            Assert.Equal(3, connectedCallbackCount);
-//            Assert.Equal(3, disconnectedCallbackCount);
+            await Task.Delay(TimeSpan.FromSeconds(5));
 
-//            cts2.Cancel();
-//            await t2;
+            // Assert
+            Assert.False(connected);
+            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
+            Assert.Equal(3, connectedCallbackCount);
+            Assert.Equal(3, disconnectedCallbackCount);
 
-//            await device1Client.SendEventAsync(new Message());
+            cts2.Cancel();
+            await t2;
 
-//            // Assert
-//            Assert.True(connected);
-//            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
-//            Assert.Equal(6, connectedCallbackCount);
-//            Assert.Equal(3, disconnectedCallbackCount);
+            await device1Client.SendEventAsync(new Message());
 
-//        }
-//    }
-//}
+            // Assert
+            Assert.True(connected);
+            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
+            Assert.Equal(6, connectedCallbackCount);
+            Assert.Equal(3, disconnectedCallbackCount);
+
+        }
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceConnectivityManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceConnectivityManagerTest.cs
@@ -1,189 +1,186 @@
-// Copyright (c) Microsoft. All rights reserved.
-namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
-{
-    using Microsoft.Azure.Devices.Client;
-    using Microsoft.Azure.Devices.Edge.Hub.Core;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
-    using Microsoft.Azure.Devices.Shared;
-    using Moq;
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
-    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
-    using Xunit;
+//// Copyright (c) Microsoft. All rights reserved.
+//namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
+//{
+//    using Microsoft.Azure.Devices.Client;
+//    using Microsoft.Azure.Devices.Edge.Hub.Core;
+//    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+//    using Microsoft.Azure.Devices.Shared;
+//    using Moq;
+//    using System;
+//    using System.Threading;
+//    using System.Threading.Tasks;
+//    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
+//    using Xunit;
 
-    [Unit]
-    public class DeviceConnectivityManagerTest
-    {
-        [Fact]
-        public async Task NoEventsTest()
-        {
-            // Arrange / act
-            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+//    [Unit]
+//    public class DeviceConnectivityManagerTest
+//    {
+//        [Fact]
+//        public async Task NoEventsTest()
+//        {
+//            // Arrange / act            
+//            var client = new Mock<IClient>();
+//            client.SetupSequence(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
+//                .Returns(Task.CompletedTask)
+//                .Throws<TimeoutException>()
+//                .Throws<TimeoutException>()
+//                .Returns(Task.CompletedTask);
+//            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
+//            var cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
+//            deviceConnectivityManager.SetTestCloudProxy(cloudProxy);
 
-            var client = new Mock<IClient>();
-            client.SetupSequence(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
-                .Returns(Task.CompletedTask)
-                .Throws<TimeoutException>()
-                .Throws<TimeoutException>()
-                .Returns(Task.CompletedTask);
-            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager, Mock.Of<IIdentity>(i => i.Id == "d1/m1"));
-            var cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
-            deviceConnectivityManager.SetTestCloudProxy(cloudProxy);
+//            bool connected = false;
+//            deviceConnectivityManager.DeviceConnected += (_, __) => connected = true;
+//            deviceConnectivityManager.DeviceDisconnected += (_, __) => connected = false;
 
-            bool connected = false;
-            deviceConnectivityManager.DeviceConnected += (_, __) => connected = true;
-            deviceConnectivityManager.DeviceDisconnected += (_, __) => connected = false;
+//            // Assert
+//            await Task.Delay(TimeSpan.FromSeconds(4));
+//            Assert.True(connected);
 
-            // Assert
-            await Task.Delay(TimeSpan.FromSeconds(4));
-            Assert.True(connected);
+//            await Task.Delay(TimeSpan.FromSeconds(4));
+//            Assert.False(connected);
 
-            await Task.Delay(TimeSpan.FromSeconds(4));
-            Assert.False(connected);
+//            await Task.Delay(TimeSpan.FromSeconds(4));
+//            Assert.True(connected);
+//        }
 
-            await Task.Delay(TimeSpan.FromSeconds(4));
-            Assert.True(connected);
-        }
+//        [Fact]
+//        public async Task ConnectivityTestFailedTest()
+//        {
+//            // Arrange / act
+//            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
 
-        [Fact]
-        public async Task ConnectivityTestFailedTest()
-        {
-            // Arrange / act
-            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3));
+//            var client = new Mock<IClient>();
+//            client.SetupSequence(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
+//                .Returns(Task.CompletedTask)
+//                .Throws<TimeoutException>()                
+//                .Returns(Task.CompletedTask)
+//                .Throws<TimeoutException>()
+//                .Returns(Task.CompletedTask);
+//            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
+//            var cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
+//            deviceConnectivityManager.SetTestCloudProxy(cloudProxy);
 
-            var client = new Mock<IClient>();
-            client.SetupSequence(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
-                .Returns(Task.CompletedTask)
-                .Throws<TimeoutException>()                
-                .Returns(Task.CompletedTask)
-                .Throws<TimeoutException>()
-                .Returns(Task.CompletedTask);
-            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager, Mock.Of<IIdentity>(i => i.Id == "d1/m1"));
-            var cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
-            deviceConnectivityManager.SetTestCloudProxy(cloudProxy);
+//            int connected = 0;
+//            int disconnected = 0;
+//            deviceConnectivityManager.DeviceConnected += (_, __) => Interlocked.Increment(ref connected);
+//            deviceConnectivityManager.DeviceDisconnected += (_, __) => Interlocked.Increment(ref disconnected);
 
-            int connected = 0;
-            int disconnected = 0;
-            deviceConnectivityManager.DeviceConnected += (_, __) => Interlocked.Increment(ref connected);
-            deviceConnectivityManager.DeviceDisconnected += (_, __) => Interlocked.Increment(ref disconnected);
+//            // Assert
+//            await Task.Delay(TimeSpan.FromSeconds(15));
+//            Assert.Equal(1, connected);
+//            Assert.Equal(0, disconnected);
+//        }
 
-            // Assert
-            await Task.Delay(TimeSpan.FromSeconds(15));
-            Assert.Equal(1, connected);
-            Assert.Equal(0, disconnected);
-        }
+//        [Fact]
+//        public async Task WithDownstreamEventsTest()
+//        {
+//            // Arrange / act
+//            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
+//            int connectedCallbackCount = 0;
+//            int disconnectedCallbackCount = 0;
 
-        [Fact]
-        public async Task WithDownstreamEventsTest()
-        {
-            // Arrange / act
-            var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(10), TimeSpan.FromSeconds(10));
-            int connectedCallbackCount = 0;
-            int disconnectedCallbackCount = 0;
+//            void ConnectionStatusChangedHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
+//            {
+//                if (status == ConnectionStatus.Connected && reason == ConnectionStatusChangeReason.Connection_Ok)
+//                {
+//                    Interlocked.Increment(ref connectedCallbackCount);
+//                }
+//                else if (status == ConnectionStatus.Disconnected && reason == ConnectionStatusChangeReason.No_Network)
+//                {
+//                    Interlocked.Increment(ref disconnectedCallbackCount);
+//                }
+//            }
 
-            void ConnectionStatusChangedHandler(ConnectionStatus status, ConnectionStatusChangeReason reason)
-            {
-                if (status == ConnectionStatus.Connected && reason == ConnectionStatusChangeReason.Connection_Ok)
-                {
-                    Interlocked.Increment(ref connectedCallbackCount);
-                }
-                else if (status == ConnectionStatus.Disconnected && reason == ConnectionStatusChangeReason.No_Network)
-                {
-                    Interlocked.Increment(ref disconnectedCallbackCount);
-                }
-            }
+//            var device1UnderlyingClient = new Mock<IClient>();
+//            device1UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
+//                .Returns(Task.CompletedTask);
+//            var device1Client = new ConnectivityAwareClient(device1UnderlyingClient.Object, deviceConnectivityManager);
+//            device1Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
 
-            var device1UnderlyingClient = new Mock<IClient>();
-            device1UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
-                .Returns(Task.CompletedTask);
-            var device1Client = new ConnectivityAwareClient(device1UnderlyingClient.Object, deviceConnectivityManager, Mock.Of<IIdentity>(i => i.Id == "d1/m1"));
-            device1Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
+//            var device2UnderlyingClient = new Mock<IClient>();
+//            device2UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
+//                .Throws<TimeoutException>();
+//            var device2Client = new ConnectivityAwareClient(device2UnderlyingClient.Object, deviceConnectivityManager);
+//            device2Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
 
-            var device2UnderlyingClient = new Mock<IClient>();
-            device2UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
-                .Throws<TimeoutException>();
-            var device2Client = new ConnectivityAwareClient(device2UnderlyingClient.Object, deviceConnectivityManager, Mock.Of<IIdentity>(i => i.Id == "d1/m1"));
-            device2Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
+//            var edgeHubUnderlyingClient = new Mock<IClient>();
+//            edgeHubUnderlyingClient.Setup(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
+//                .Throws<TimeoutException>();
+//            IClient edgeHubClient = new ConnectivityAwareClient(edgeHubUnderlyingClient.Object, deviceConnectivityManager);
+//            edgeHubClient.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
+//            var edgeHubCloudProxy = new CloudProxy(edgeHubClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
+//            deviceConnectivityManager.SetTestCloudProxy(edgeHubCloudProxy);
 
-            var edgeHubUnderlyingClient = new Mock<IClient>();
-            edgeHubUnderlyingClient.Setup(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
-                .Throws<TimeoutException>();
-            IClient edgeHubClient = new ConnectivityAwareClient(edgeHubUnderlyingClient.Object, deviceConnectivityManager, Mock.Of<IIdentity>(i => i.Id == "d1/m1"));
-            edgeHubClient.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
-            var edgeHubCloudProxy = new CloudProxy(edgeHubClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
-            deviceConnectivityManager.SetTestCloudProxy(edgeHubCloudProxy);
+//            bool connected = false;
+//            deviceConnectivityManager.DeviceConnected += (_, __) => connected = true;
+//            deviceConnectivityManager.DeviceDisconnected += (_, __) => connected = false;
 
-            bool connected = false;
-            deviceConnectivityManager.DeviceConnected += (_, __) => connected = true;
-            deviceConnectivityManager.DeviceDisconnected += (_, __) => connected = false;
+//            // Act
+//            var cts = new CancellationTokenSource();
+//            Task t = Task.Run(
+//                async () =>
+//                {
+//                    while (!cts.IsCancellationRequested)
+//                    {
+//                        await device1Client.SendEventAsync(new Message());
+//                        if (!cts.IsCancellationRequested)
+//                        {
+//                            await Task.Delay(TimeSpan.FromSeconds(1));
+//                        }
+//                    }
+//                });
 
-            // Act
-            var cts = new CancellationTokenSource();
-            Task t = Task.Run(
-                async () =>
-                {
-                    while (!cts.IsCancellationRequested)
-                    {
-                        await device1Client.SendEventAsync(new Message());
-                        if (!cts.IsCancellationRequested)
-                        {
-                            await Task.Delay(TimeSpan.FromSeconds(1));
-                        }
-                    }
-                });
+//            await Task.Delay(TimeSpan.FromSeconds(5));
 
-            await Task.Delay(TimeSpan.FromSeconds(5));
+//            // Assert
+//            Assert.True(connected);
+//            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
+//            Assert.Equal(3, connectedCallbackCount);
+//            Assert.Equal(0, disconnectedCallbackCount);
 
-            // Assert
-            Assert.True(connected);
-            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
-            Assert.Equal(3, connectedCallbackCount);
-            Assert.Equal(0, disconnectedCallbackCount);
+//            cts.Cancel();
+//            await t;
 
-            cts.Cancel();
-            await t;
+//            var cts2 = new CancellationTokenSource();
+//            Task t2 = Task.Run(
+//                async () =>
+//                {
+//                    while (!cts2.IsCancellationRequested)
+//                    {
+//                        try
+//                        {
+//                            await device2Client.SendEventAsync(new Message());
+//                        }
+//                        catch (TimeoutException)
+//                        {
+//                        }
+//                        if (!cts2.IsCancellationRequested)
+//                        {
+//                            await Task.Delay(TimeSpan.FromSeconds(1));
+//                        }
+//                    }
+//                });
 
-            var cts2 = new CancellationTokenSource();
-            Task t2 = Task.Run(
-                async () =>
-                {
-                    while (!cts2.IsCancellationRequested)
-                    {
-                        try
-                        {
-                            await device2Client.SendEventAsync(new Message());
-                        }
-                        catch (TimeoutException)
-                        {
-                        }
-                        if (!cts2.IsCancellationRequested)
-                        {
-                            await Task.Delay(TimeSpan.FromSeconds(1));
-                        }
-                    }
-                });
+//            await Task.Delay(TimeSpan.FromSeconds(5));
 
-            await Task.Delay(TimeSpan.FromSeconds(5));
+//            // Assert
+//            Assert.False(connected);
+//            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
+//            Assert.Equal(3, connectedCallbackCount);
+//            Assert.Equal(3, disconnectedCallbackCount);
 
-            // Assert
-            Assert.False(connected);
-            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
-            Assert.Equal(3, connectedCallbackCount);
-            Assert.Equal(3, disconnectedCallbackCount);
+//            cts2.Cancel();
+//            await t2;
 
-            cts2.Cancel();
-            await t2;
+//            await device1Client.SendEventAsync(new Message());
 
-            await device1Client.SendEventAsync(new Message());
+//            // Assert
+//            Assert.True(connected);
+//            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
+//            Assert.Equal(6, connectedCallbackCount);
+//            Assert.Equal(3, disconnectedCallbackCount);
 
-            // Assert
-            Assert.True(connected);
-            edgeHubUnderlyingClient.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
-            Assert.Equal(6, connectedCallbackCount);
-            Assert.Equal(3, disconnectedCallbackCount);
-
-        }
-    }
-}
+//        }
+//    }
+//}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceConnectivityManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceConnectivityManagerTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         public async Task NoEventsTest()
         {
             // Arrange / act
+            var deviceIdentity = Mock.Of<IIdentity>(i => i.Id == "d2");
             var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
             var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), edgeHubIdentity);
             var client = new Mock<IClient>();
@@ -29,7 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 .Throws<TimeoutException>()
                 .Throws<TimeoutException>()
                 .Returns(Task.CompletedTask);
-            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
+            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager, deviceIdentity);
             ICloudProxy cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
             var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection("d1/m1") == Task.FromResult(Option.Some(cloudProxy)));
             deviceConnectivityManager.SetConnectionManager(connectionManager);
@@ -53,6 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         public async Task ConnectivityTestFailedTest()
         {
             // Arrange / act
+            var deviceIdentity = Mock.Of<IIdentity>(i => i.Id == "d2");
             var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
             var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), edgeHubIdentity);
 
@@ -63,7 +65,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 .Returns(Task.CompletedTask)
                 .Throws<TimeoutException>()
                 .Returns(Task.CompletedTask);
-            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager);
+            IClient connectivityAwareClient = new ConnectivityAwareClient(client.Object, deviceConnectivityManager, deviceIdentity);
             ICloudProxy cloudProxy = new CloudProxy(connectivityAwareClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
             var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection("d1/m1") == Task.FromResult(Option.Some(cloudProxy)));
             deviceConnectivityManager.SetConnectionManager(connectionManager);
@@ -83,6 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         public async Task WithDownstreamEventsTest()
         {
             // Arrange / act
+            var deviceIdentity = Mock.Of<IIdentity>(i => i.Id == "d2");
             var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
             var deviceConnectivityManager = new DeviceConnectivityManager(TimeSpan.FromSeconds(3), TimeSpan.FromSeconds(3), edgeHubIdentity);
 
@@ -104,19 +107,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var device1UnderlyingClient = new Mock<IClient>();
             device1UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
                 .Returns(Task.CompletedTask);
-            var device1Client = new ConnectivityAwareClient(device1UnderlyingClient.Object, deviceConnectivityManager);
+            var device1Client = new ConnectivityAwareClient(device1UnderlyingClient.Object, deviceConnectivityManager, deviceIdentity);
             device1Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
 
             var device2UnderlyingClient = new Mock<IClient>();
             device2UnderlyingClient.Setup(c => c.SendEventAsync(It.IsAny<Message>()))
                 .Throws<TimeoutException>();
-            var device2Client = new ConnectivityAwareClient(device2UnderlyingClient.Object, deviceConnectivityManager);
+            var device2Client = new ConnectivityAwareClient(device2UnderlyingClient.Object, deviceConnectivityManager, deviceIdentity);
             device2Client.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
 
             var edgeHubUnderlyingClient = new Mock<IClient>();
             edgeHubUnderlyingClient.Setup(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()))
                 .Throws<TimeoutException>();
-            IClient edgeHubClient = new ConnectivityAwareClient(edgeHubUnderlyingClient.Object, deviceConnectivityManager);
+            IClient edgeHubClient = new ConnectivityAwareClient(edgeHubUnderlyingClient.Object, deviceConnectivityManager, deviceIdentity);
             edgeHubClient.SetConnectionStatusChangedHandler(ConnectionStatusChangedHandler);
             ICloudProxy cloudProxy = new CloudProxy(edgeHubClient, Mock.Of<IMessageConverterProvider>(), "d1/m1", null, Mock.Of<ICloudListener>(), TimeSpan.FromHours(1));
             var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection("d1/m1") == Task.FromResult(Option.Some(cloudProxy)));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Edge.Hub.CloudProxy;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
-    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Config;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
@@ -83,14 +82,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 var versionInfo = new VersionInfo("v1", "b1", "c1");
 
                 // Create Edge Hub connection
-                Try<ICloudProxy> edgeHubCloudProxy = await connectionManager.CreateCloudConnectionAsync(edgeHubCredentials);
-                Assert.True(edgeHubCloudProxy.Success);
                 EdgeHubConnection edgeHubConnection = await EdgeHubConnection.Create(
-                    edgeHubCredentials,
+                    edgeHubCredentials.Identity,
                     edgeHub,
                     twinManager,
                     connectionManager,
-                    edgeHubCloudProxy.Value,
                     routeFactory,
                     twinCollectionMessageConverter,
                     twinMessageConverter,
@@ -254,7 +250,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 Assert.Equal(versionInfo, reportedProperties.VersionInfo);
 
                 // If the edge hub restarts, clear out the connected devices in the reported properties.
-                await EdgeHubConnection.Create(edgeHubCredentials, edgeHub, twinManager, connectionManager, edgeHubCloudProxy.Value, routeFactory, twinCollectionMessageConverter, twinMessageConverter, versionInfo,
+                await EdgeHubConnection.Create(edgeHubCredentials.Identity, edgeHub, twinManager, connectionManager, routeFactory, twinCollectionMessageConverter, twinMessageConverter, versionInfo,
                     new NullDeviceScopeIdentitiesCache());
                 await Task.Delay(TimeSpan.FromMinutes(1));
                 reportedProperties = await this.GetReportedProperties(registryManager, edgeDeviceId);


### PR DESCRIPTION
EdgeHub closes inactive cloud connections. 
DeviceConnectivityManager uses EdgeHub connection to test device connectivity.
If this connection is closed because of inactivity, the DeviceConnectionManager throws. 
Fix: So instead of using the same CloudProxy, get a CloudProxy from the ConnectionManager. It will create a new CloudProxy if the previous one has been closed.

Also, when reporting connected devices in EdgeHub reported properties, don't report EdgeHub itself. 