### PR TITLE
Change default Auth mode to CloudAndScope

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
@@ -70,6 +70,6 @@
   "Metrics": {
     "MetricsStoreType": "influxdb"
   },
-  "AuthenticationMode": "Cloud",
+  "AuthenticationMode": "CloudAndScope",
   "DeviceScopeCacheRefreshRateSecs": 3600
 }


### PR DESCRIPTION
Change default Auth mode to CloudAndScope to enable scope for customers by default. This should improve scenarios like Method invocations for most of our customers, even if they are not interested in offline behavior.