### PR TITLE
Fix NRE in TwinManager

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/TwinManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/TwinManager.cs
@@ -110,7 +110,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 async (store) =>
                 {
                     TwinInfo twinInfo = await this.GetTwinInfoWithStoreSupportAsync(id);
-                    return this.twinConverter.ToMessage(twinInfo.Twin);
+                    return twinInfo.Twin != null
+                        ? this.twinConverter.ToMessage(twinInfo.Twin)
+                        : throw new InvalidOperationException($"Error getting twin for device {id}. Twin is null.");
                 },
                 async () =>
                 {
@@ -321,9 +323,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     return Task.CompletedTask;
                 },
                 () => throw new InvalidOperationException($"Error getting twin for device {id}", e));
-            return twinInfo.Twin != null
-                ? twinInfo
-                : throw new InvalidOperationException($"Error getting twin for device {id}", e);
+            return twinInfo;
         }
 
         async Task UpdateReportedPropertiesWhenTwinStoreHasTwinAsync(string id, TwinCollection reported, bool cloudVerified)

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -59,6 +59,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 var identityFactory = new ClientCredentialsFactory(iothubHostName);
                 string edgeHubConnectionString = $"{deviceConnStr};ModuleId={EdgeHubModuleId}";
                 IClientCredentials edgeHubCredentials = identityFactory.GetWithConnectionString(edgeHubConnectionString);
+                Mock.Get(credentialsCache)
+                    .Setup(c => c.Get(edgeHubCredentials.Identity))
+                    .ReturnsAsync(Option.Some(edgeHubCredentials));
                 Assert.NotNull(edgeHubCredentials);
                 Assert.NotNull(edgeHubCredentials.Identity);
 
@@ -78,6 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 Router router = await Router.CreateAsync(Guid.NewGuid().ToString(), iothubHostName, routerConfig, endpointExecutorFactory);
                 IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
                 IEdgeHub edgeHub = new RoutingEdgeHub(router, new RoutingMessageConverter(), connectionManager, twinManager, edgeDeviceId, invokeMethodHandler);
+                cloudConnectionProvider.BindEdgeHub(edgeHub);
 
                 var versionInfo = new VersionInfo("v1", "b1", "c1");
 


### PR DESCRIPTION
An NRE is possible in the TwinManager under the following sequence of events:
1. Device is offline
2. Send reported property patch for a device before ever calling get twin
3. Call get twin

`null` is used as a placeholder in the TwinManager when a reported property update is made with no twin. A get twin on this identity results in `null` being returned, which violates assumptions in the rest of the codebase.

This was found via a failing CI test. The test case needed to be adjusted as well because of the changes for extended offline.