### PR TITLE
Fix windows CI docker image to use 1803

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/test-config-windows-x64.json
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/test-config-windows-x64.json
@@ -2,11 +2,11 @@
     {
         "name": "dotnet",
         "version": "1.0",
-        "image": "microsoft/dotnet:2.0.6-sdk-2.1.101-nanoserver-1709",
+        "image": "microsoft/dotnet:2.1.302-sdk-nanoserver-1803",
         "validator": {
             "$type": "RunCommandValidator",
             "command": "docker",
-            "args": "run --rm --link dotnet:dotnet microsoft/dotnet:2.1.302-sdk-nanoserver-1709 dotnet --version",
+            "args": "run --rm --link dotnet:dotnet microsoft/dotnet:2.1.302-sdk-nanoserver-1803 dotnet --version",
             "outputEquals": "2.1.302"
         }
     }


### PR DESCRIPTION
Updates the docker image used for the windows CI to use an 1803 image. This should fix the failing `AgentStartsUpModules` test.