### PR TITLE
EdgeAgent: Allow EdgeAgent to process crashed modules when offline

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
@@ -163,6 +163,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                     if (deploymentConfig != DeploymentConfig.Empty)
                     {
                         ModuleSet desiredModuleSet = deploymentConfig.GetModuleSet();
+                        // TODO - Update this logic to create identities only when needed, in the Command factory, instead of creating all the identities
+                        // up front here. That will allow handling the case when only the state of the system has changed (say one module crashes), and
+                        // no new identities need to be created. This will simplify the logic to allow EdgeAgent to work when offline.
                         IImmutableDictionary<string, IModuleIdentity> identities = await this.moduleIdentityLifecycleManager.GetModuleIdentitiesAsync(desiredModuleSet, current);
                         Plan plan = await this.planner.PlanAsync(desiredModuleSet, current, deploymentConfig.Runtime, identities);
                         if (!plan.IsEmpty)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
@@ -166,6 +166,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                         // TODO - Update this logic to create identities only when needed, in the Command factory, instead of creating all the identities
                         // up front here. That will allow handling the case when only the state of the system has changed (say one module crashes), and
                         // no new identities need to be created. This will simplify the logic to allow EdgeAgent to work when offline.
+                        // But that required ModuleSet.Diff to be updated to include modules updated by deployment, and modules updated by state change. 
                         IImmutableDictionary<string, IModuleIdentity> identities = await this.moduleIdentityLifecycleManager.GetModuleIdentitiesAsync(desiredModuleSet, current);
                         Plan plan = await this.planner.PlanAsync(desiredModuleSet, current, deploymentConfig.Runtime, identities);
                         if (!plan.IsEmpty)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/AgentEventIds.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/AgentEventIds.cs
@@ -20,5 +20,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         public const int RetryingServiceClient = EventIdStart + 1300;
         public const int OrderedRetryPlanRunner = EventIdStart + 1400;
         public const int ModuleManagementHttpClient = EventIdStart + 1500;
+        public const int ModuleIdentityLifecycleManager = EventIdStart + 1600;
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/serde/TypeSpecificSerDe.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/serde/TypeSpecificSerDe.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Serde
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
-    using Newtonsoft.Json.Serialization;
 
     /// <summary>
     /// SerDe for objects with types that depend on the "type" property 
@@ -30,7 +29,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Serde
 
             this.jsonSerializerSettings = new JsonSerializerSettings
             {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 Converters = new List<JsonConverter>
                 {
                     new TypeSpecificJsonConverter(deserializerTypesMap)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/ModuleIdentityLifecycleManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/ModuleIdentityLifecycleManager.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
     using Microsoft.Azure.Devices.Edge.Agent.Core;
     using Microsoft.Azure.Devices.Edge.Agent.Edgelet.GeneratedCode;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
 
     public class ModuleIdentityLifecycleManager : IModuleIdentityLifecycleManager
     {
@@ -37,8 +38,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
                 IImmutableDictionary<string, IModuleIdentity> moduleIdentities = await this.GetModuleIdentitiesAsync(diff);
                 return moduleIdentities;
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                Events.ErrorGettingModuleIdentities(ex);
                 return ImmutableDictionary<string, IModuleIdentity>.Empty;
             }
         }
@@ -87,5 +89,21 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
 
         IModuleIdentity GetModuleIdentity(Identity identity) =>
             this.identityProviderServiceBuilder.Create(identity.ModuleId, identity.GenerationId, this.workloadUri.ToString());
+
+        static class Events
+        {
+            static readonly ILogger Log = Logger.Factory.CreateLogger<ModuleIdentityLifecycleManager>();
+            const int IdStart = AgentEventIds.ModuleIdentityLifecycleManager;
+
+            enum EventIds
+            {
+                ErrorGettingModuleIdentities = IdStart,
+            }
+
+            public static void ErrorGettingModuleIdentities(Exception ex)
+            {
+                Log.LogDebug((int)EventIds.ErrorGettingModuleIdentities, ex, "Error getting module identities.");
+            }
+        }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/ModuleIdentityLifecycleManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/ModuleIdentityLifecycleManager.cs
@@ -32,6 +32,19 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
                 return ImmutableDictionary<string, IModuleIdentity>.Empty;
             }
 
+            try
+            {
+                IImmutableDictionary<string, IModuleIdentity> moduleIdentities = await this.GetModuleIdentitiesAsync(diff);
+                return moduleIdentities;
+            }
+            catch (Exception)
+            {
+                return ImmutableDictionary<string, IModuleIdentity>.Empty;
+            }
+        }
+
+        async Task<IImmutableDictionary<string, IModuleIdentity>> GetModuleIdentitiesAsync(Diff diff)
+        {
             IList<string> updatedModuleNames = diff.Updated.Select(m => ModuleIdentityHelper.GetModuleIdentityName(m.Name)).ToList();
             IEnumerable<string> removedModuleNames = diff.Removed.Select(m => ModuleIdentityHelper.GetModuleIdentityName(m));
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -223,8 +223,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             {
                 baseStoragePath = Path.GetTempPath();
             }
+
             string storagePath = Path.Combine(baseStoragePath, EdgeAgentStorageFolder);
-            Directory.CreateDirectory(storagePath);
+            if (!Directory.Exists(storagePath))
+            {
+                Directory.CreateDirectory(storagePath);
+            }
+
             return storagePath;
         }
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleIdentityLifecycleManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleIdentityLifecycleManagerTest.cs
@@ -49,42 +49,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
             Mock.Get(identityManager).Setup(m => m.GetIdentities()).ThrowsAsync(new InvalidOperationException());
             var moduleIdentityLifecycleManager = new ModuleIdentityLifecycleManager(identityManager, ModuleIdentityProviderServiceBuilder, EdgeletUri);
             var envVar = new Dictionary<string, EnvVal>();
-            const string Module1 = "module1";
-            var identity1 = new Identity
-            {
-                ModuleId = Module1,
-                ManagedBy = "IotEdge",
-                GenerationId = Guid.NewGuid().ToString()
-            };
 
-            const string Module2 = "module2";
-            var identity2 = new Identity
-            {
-                ModuleId = Module2,
-                ManagedBy = "Me",
-                GenerationId = Guid.NewGuid().ToString()
-            };
-
-            const string Module3 = "module3";
-            var identity3 = new Identity
-            {
-                ModuleId = Module3,
-                ManagedBy = Constants.ModuleIdentityEdgeManagedByValue,
-                GenerationId = Guid.NewGuid().ToString()
-            };
-
-            const string Module4 = "$edgeHub";
-            var identity4 = new Identity
-            {
-                ModuleId = Module4,
-                ManagedBy = Constants.ModuleIdentityEdgeManagedByValue,
-                GenerationId = Guid.NewGuid().ToString()
-            };
-
-            var module1 = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, envVar);
-            var module2 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, envVar);
-            var module3 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, envVar);
-            var module4 = new TestModule(Module4, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, envVar);
+            var module1 = new TestModule("mod1", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, envVar);
+            var module2 = new TestModule("mod2", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, envVar);
+            var module3 = new TestModule("mod3", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, envVar);
+            var module4 = new TestModule("$edgeHub", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, DefaultConfigurationInfo, envVar);
             ModuleSet desired = ModuleSet.Create(module1, module4);
             ModuleSet current = ModuleSet.Create(module2, module3, module4);
 
@@ -92,7 +61,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await moduleIdentityLifecycleManager.GetModuleIdentitiesAsync(desired, current);
 
             // Assert
-            Assert.True(!modulesIdentities.Any());
+            Assert.False(modulesIdentities.Any());
             Mock.Get(identityManager).Verify();
         }
 


### PR DESCRIPTION
If EdgeAgent detects a diff in desired state v/s environment, it first updates all module identities (create/delete/update), before it creates a plan for update. This is done to handle the remove logic - we want to remove the identities that are not in the deployment (so that we don't go over IoTHub's 20 module limit). 
Because of this, the Reconcile doesn't work when the Edge device is offline, even when no identity updates are needed (say when a module is stopped/failed). 

The right way to fix this would be to move the identity create/update logic to the Command factory, where the identity can be created/updated only when needed. This requires the Diff object to be updated. 

This fix works around this by returning an Empty list of identities, if it is not able to create the identities. And then the HealthRestartPlanner skips commands that need the identity, if the identity is not present. 

Note: I did not change the RestartPlanner because it doesn't distinguish between modules that are updated by deployment (new image, or new config) vs modules that are updated by state change (running to stopped, etc).