### PR TITLE
Update Edge Hub E2E config test for service change

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -310,6 +310,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     {
                         ["properties.desired"] = desiredProperties
 
+                    },
+                    ["$edgeAgent"] = new Dictionary<string, object>
+                    {
+                        ["properties.desired"] = new object()
                     }
                 }
             };
@@ -343,6 +347,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     {
                         ["properties.desired"] = desiredProperties
 
+                    },
+                    ["$edgeAgent"] = new Dictionary<string, object>
+                    {
+                        ["properties.desired"] = new object()
                     }
                 }
             };


### PR DESCRIPTION
The service now expects a `$edgeAgent` key in an edge configuration. This caused an exception the EdgeHubConnection tests when submitting a configuration to the registry manager.

This updates the test add an empty object for `$edgeAgent`.