### PR TITLE
EdgeAgent: Do not use CamelCase property name resolver

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/serde/TypeSpecificSerDe.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/serde/TypeSpecificSerDe.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Serde
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
-    using Newtonsoft.Json.Serialization;
 
     /// <summary>
     /// SerDe for objects with types that depend on the "type" property 
@@ -30,11 +29,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Serde
 
             this.jsonSerializerSettings = new JsonSerializerSettings
             {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
                 Converters = new List<JsonConverter>
                 {
                     new TypeSpecificJsonConverter(deserializerTypesMap)
-                },
+                }
             };
         }
 


### PR DESCRIPTION
Avoid using CamelCase property name resolver in EdgeAgent. 

Working on adding some tests and some refactoring. Sending this out to expedite checking in and testing e2e. 