### PR TITLE
Use smaller image for windows agent E2E test

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/test-config-windows-x64.json
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/test-config-windows-x64.json
@@ -1,13 +1,13 @@
 ﻿[
     {
-        "name": "dotnet",
+        "name": "nano",
         "version": "1.0",
-        "image": "microsoft/dotnet:2.1.302-sdk-nanoserver-1803",
+        "image": "microsoft/nanoserver:1803",
         "validator": {
             "$type": "RunCommandValidator",
             "command": "docker",
-            "args": "run --rm --link dotnet:dotnet microsoft/dotnet:2.1.302-sdk-nanoserver-1803 dotnet --version",
-            "outputEquals": "2.1.302"
+            "args": "ps -a -f name=nano --format '{{.Names}}'",
+            "outputEquals": "'nano'"
         }
     }
 ]


### PR DESCRIPTION
The current windows test uses a mult-Gb image to test.

This updates the test image to be as small as possible (nanoserver base image).