### PR TITLE
EdgeHub: Prevent modules on downstream devices from invoking methods

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Authenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Authenticator.cs
@@ -39,16 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             Preconditions.CheckNotNull(clientCredentials);
 
-            bool isAuthenticated = false;
-            // If 'identity' represents an Edge module then its device id MUST match the authenticator's
-            // 'edgeDeviceId'. In other words the authenticator for one edge device cannot authenticate
-            // modules belonging to a different edge device.
-            if (clientCredentials.Identity is IModuleIdentity moduleIdentity && !moduleIdentity.DeviceId.Equals(this.edgeDeviceId, StringComparison.OrdinalIgnoreCase))
-            {
-                Events.InvalidDeviceId(moduleIdentity, this.edgeDeviceId);
-                isAuthenticated = false;
-            }
-
+            bool isAuthenticated;
             if (clientCredentials.AuthenticationType == AuthenticationType.X509Cert)
             {
                 // If we reach here, we have validated the client cert. Validation is done in

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/AuthenticationMiddleware.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/AuthenticationMiddleware.cs
@@ -22,17 +22,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
         readonly Task<IAuthenticator> authenticatorTask;
         readonly IClientCredentialsFactory identityFactory;
         readonly string iotHubName;
+        readonly string edgeDeviceId;
 
         public AuthenticationMiddleware(
             RequestDelegate next,
             Task<IAuthenticator> authenticatorTask,
             IClientCredentialsFactory identityFactory,
-            string iotHubName)
+            string iotHubName,
+            string edgeDeviceId)
         {
             this.next = next;
             this.authenticatorTask = Preconditions.CheckNotNull(authenticatorTask, nameof(authenticatorTask));
             this.identityFactory = Preconditions.CheckNotNull(identityFactory, nameof(identityFactory));
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
+            this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
         }
 
         public async Task Invoke(HttpContext context)
@@ -113,6 +116,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
             IClientCredentials clientCredentials = this.identityFactory.GetWithSasToken(deviceId, moduleId, string.Empty, authHeader);
             IIdentity identity = clientCredentials.Identity;
             IAuthenticator authenticator = await this.authenticatorTask;
+
+            // A downstream module cannot invoke a method on a device by connecting to EdgeHub
+            if (deviceId != this.edgeDeviceId)
+            {
+                return LogAndReturnFailure($"Module {moduleId} on device {deviceId} cannot invoke methods. Only modules on IoT Edge device {this.edgeDeviceId} can invoke methods.");
+            }
+
             if (!await authenticator.AuthenticateAsync(clientCredentials))
             {
                 return LogAndReturnFailure($"Unable to authenticate device with Id {identity.Id}");
@@ -175,9 +185,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
 
     public static class AuthenticationMiddlewareExtensions
     {
-        public static IApplicationBuilder UseAuthenticationMiddleware(this IApplicationBuilder builder, string iotHubName)
+        public static IApplicationBuilder UseAuthenticationMiddleware(this IApplicationBuilder builder, string iotHubName, string edgeDeviceId)
         {
-            return builder.UseMiddleware<AuthenticationMiddleware>(iotHubName);
+            return builder.UseMiddleware<AuthenticationMiddleware>(iotHubName, edgeDeviceId);
         }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
             app.UseWebSockets();
             app.UseWebSocketHandlingMiddleware(webSocketListenerRegistry);
-            app.UseAuthenticationMiddleware(this.iotHubHostname);
+            app.UseAuthenticationMiddleware(this.iotHubHostname, this.edgeDeviceId);
             app.UseMvc();
         }
 


### PR DESCRIPTION
Now IoThub allows non IoT devices to have modules. EdgeHub also allows modules on downstream devices to connect. However, we don't want to allow those modules to invoke methods on other modules/devices for security reasons. This PR blocks that.