### PR TITLE
EdgeHub: Get credentials on token near expiry from DeviceProxy

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
             public static void NewTokenReceived()
             {
-                Log.LogDebug((int)EventIds.TokenReceived, "New token received on the Cbs link");
+                Log.LogInformation((int)EventIds.TokenReceived, "New token received on the Cbs link");
             }
 
             public static void ErrorUpdatingToken(Exception exception)
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
             public static void CbsTokenUpdated(IIdentity identity)
             {
-                Log.LogDebug((int)EventIds.TokenUpdated, $"Token updated for {identity.Id}");
+                Log.LogInformation((int)EventIds.TokenUpdated, $"Token updated for {identity.Id}");
             }
 
             public static void ErrorSendingResponse(Exception exception)


### PR DESCRIPTION
When a token for a cloud connection for a device not in scope is near expiry, we get a fresh token from the one sent over CBS for AMQP, or by dropping the connection for MQTT. 
If we get the token from the credentials manager, then it always returns the token it has. Because of this, the cloud connection never gets the updated token for the MQTT case. 

This change reverts the ConnectionManager to get the token from the DeviceProxy in the protocol head layer, instead of the credentials manager, as the Device Proxy is aware of the expected behavior in each case (no new token vs updated token over CBS).
Note - this affects only Cloud authentication, not Scope authentication.