### PR TITLE
EdgeHub: Fix ServiceIdentity class equality comparison

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/service/ServiceAuthentication.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/service/ServiceAuthentication.cs
@@ -2,11 +2,13 @@
 
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service
 {
+    using System;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
 
-    public class ServiceAuthentication
+    public class ServiceAuthentication : IEquatable<ServiceAuthentication>
+
     {
         public ServiceAuthentication(SymmetricKeyAuthentication symmetricKeyAuthentication)
             : this(ServiceAuthenticationType.SymmetricKey, Preconditions.CheckNotNull(symmetricKeyAuthentication, nameof(symmetricKeyAuthentication)), null)
@@ -44,5 +46,36 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service
         [JsonProperty("x509Thumbprint")]
         [JsonConverter(typeof(OptionConverter<X509ThumbprintAuthentication>))]
         public Option<X509ThumbprintAuthentication> X509Thumbprint { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return Equals((ServiceAuthentication)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = (int)this.Type;
+                hashCode = (hashCode * 397) ^ this.SymmetricKey.GetHashCode();
+                hashCode = (hashCode * 397) ^ this.X509Thumbprint.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public bool Equals(ServiceAuthentication other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return this.Type == other.Type && this.SymmetricKey.Equals(other.SymmetricKey) && this.X509Thumbprint.Equals(other.X509Thumbprint);
+        }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/service/ServiceIdentity.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/service/ServiceIdentity.cs
@@ -2,12 +2,14 @@
 
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service
 {
+    using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
 
-    public class ServiceIdentity
+    public class ServiceIdentity : IEquatable<ServiceIdentity>
     {
         public ServiceIdentity(
             string deviceId,
@@ -61,5 +63,46 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service
 
         [JsonProperty("generationId")]
         public string GenerationId { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return this.Equals((ServiceIdentity)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = (this.Id != null ? this.Id.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (this.DeviceId != null ? this.DeviceId.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ this.ModuleId.GetHashCode();
+                hashCode = (hashCode * 397) ^ (this.Capabilities != null ? this.Capabilities.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (this.Authentication != null ? this.Authentication.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (int)this.Status;
+                hashCode = (hashCode * 397) ^ (this.GenerationId != null ? this.GenerationId.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
+
+        public bool Equals(ServiceIdentity other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return string.Equals(this.Id, other.Id)
+                && string.Equals(this.DeviceId, other.DeviceId)
+                && this.ModuleId.Equals(other.ModuleId)
+                && this.Capabilities.SequenceEqual(other.Capabilities)
+                && Equals(this.Authentication, other.Authentication)
+                && this.Status == other.Status
+                && string.Equals(this.GenerationId, other.GenerationId);
+        }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/service/SymmetricKeyAuthentication.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/service/SymmetricKeyAuthentication.cs
@@ -2,10 +2,12 @@
 
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service
 {
+    using System;
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
 
-    public class SymmetricKeyAuthentication
+    public class SymmetricKeyAuthentication : IEquatable<SymmetricKeyAuthentication>
+
     {
         [JsonConstructor]
         public SymmetricKeyAuthentication(string primaryKey, string secondaryKey)
@@ -19,5 +21,33 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service
 
         [JsonProperty("secondaryKey")]
         public string SecondaryKey { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return this.Equals((SymmetricKeyAuthentication)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((this.PrimaryKey != null ? this.PrimaryKey.GetHashCode() : 0) * 397) ^ (this.SecondaryKey != null ? this.SecondaryKey.GetHashCode() : 0);
+            }
+        }
+
+        public bool Equals(SymmetricKeyAuthentication other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return string.Equals(this.PrimaryKey, other.PrimaryKey) && string.Equals(this.SecondaryKey, other.SecondaryKey);
+        }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/service/X509ThumbprintAuthentication.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/service/X509ThumbprintAuthentication.cs
@@ -2,10 +2,11 @@
 
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service
 {
+    using System;
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
 
-    public class X509ThumbprintAuthentication
+    public class X509ThumbprintAuthentication : IEquatable<X509ThumbprintAuthentication>
     {
         [JsonConstructor]
         public X509ThumbprintAuthentication(string primaryThumbprint, string secondaryThumbprint)
@@ -19,5 +20,33 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service
 
         [JsonProperty("secondaryThumbprint")]
         public string SecondaryThumbprint { get; }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return this.Equals((X509ThumbprintAuthentication)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return ((this.PrimaryThumbprint != null ? this.PrimaryThumbprint.GetHashCode() : 0) * 397) ^ (this.SecondaryThumbprint != null ? this.SecondaryThumbprint.GetHashCode() : 0);
+            }
+        }
+
+        public bool Equals(X509ThumbprintAuthentication other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return string.Equals(this.PrimaryThumbprint, other.PrimaryThumbprint) && string.Equals(this.SecondaryThumbprint, other.SecondaryThumbprint);
+        }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2", "m1");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
         }
 
         [Fact]
@@ -52,11 +52,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // Arrange            
             var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
             var serviceAuthentication = new ServiceAuthentication(ServiceAuthenticationType.None);
-            var si1 = new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-            var si2 = new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-
-            var si3 = new ServiceIdentity("d3", "5678", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-            var si4 = new ServiceIdentity("d2", "m4", "9898", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si1 = () => new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si2 = () => new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si3 = () => new ServiceIdentity("d3", "5678", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si4 = () => new ServiceIdentity("d2", "m4", "9898", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
 
             var iterator1 = new Mock<IServiceIdentitiesIterator>();
             iterator1.SetupSequence(i => i.HasNext)
@@ -67,14 +66,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2
+                        si1(),
+                        si2()
                     })
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si3,
-                        si4
+                        si3(),
+                        si4()
                     });
 
             var iterator2 = new Mock<IServiceIdentitiesIterator>();
@@ -85,9 +84,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2,
-                        si3
+                        si1(),
+                        si2(),
+                        si3()
                     });
 
             var serviceProxy = new Mock<IServiceProxy>();
@@ -110,10 +109,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2", "m4");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
-            CompareServiceIdentities(si4, receivedServiceIdentity4);
+            Assert.True(si1().Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2().Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3().Equals(receivedServiceIdentity3.OrDefault()));
+            Assert.True(si4().Equals(receivedServiceIdentity4.OrDefault()));
 
             Assert.Equal(0, updatedIdentities.Count);
             Assert.Equal(0, removedIdentities.Count);
@@ -127,9 +126,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2", "m4");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
+            Assert.True(si1().Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2().Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3().Equals(receivedServiceIdentity3.OrDefault()));
             Assert.False(receivedServiceIdentity4.HasValue);
 
             Assert.Equal(0, updatedIdentities.Count);
@@ -143,11 +142,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // Arrange            
             var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
             var serviceAuthentication = new ServiceAuthentication(ServiceAuthenticationType.None);
-            var si1 = new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-            var si2 = new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-
-            var si3 = new ServiceIdentity("d3", "5678", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-            var si4 = new ServiceIdentity("d2", "m4", "9898", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si1 = () => new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si2 = () => new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si3 = () => new ServiceIdentity("d3", "5678", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si4 = () => new ServiceIdentity("d2", "m4", "9898", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
 
             var iterator1 = new Mock<IServiceIdentitiesIterator>();
             iterator1.SetupSequence(i => i.HasNext)
@@ -158,14 +156,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2
+                        si1(),
+                        si2()
                     })
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si3,
-                        si4
+                        si3(),
+                        si4()
                     });
 
             var iterator2 = new Mock<IServiceIdentitiesIterator>();
@@ -176,9 +174,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2,
-                        si3
+                        si1(),
+                        si2(),
+                        si3()
                     });
 
             var iterator3 = new Mock<IServiceIdentitiesIterator>();
@@ -189,8 +187,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2
+                        si1(),
+                        si2()
                     });
 
             var iterator4 = new Mock<IServiceIdentitiesIterator>();
@@ -201,8 +199,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si3,
-                        si4
+                        si3(),
+                        si4()
                     });
 
             var serviceProxy = new Mock<IServiceProxy>();
@@ -228,10 +226,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2", "m4");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
-            CompareServiceIdentities(si4, receivedServiceIdentity4);
+            Assert.True(si1().Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2().Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3().Equals(receivedServiceIdentity3.OrDefault()));
+            Assert.True(si4().Equals(receivedServiceIdentity4.OrDefault()));
 
             Assert.Equal(0, updatedIdentities.Count);
             Assert.Equal(0, removedIdentities.Count);
@@ -250,8 +248,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2", "m4");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1().Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2().Equals(receivedServiceIdentity2.OrDefault()));
             Assert.False(receivedServiceIdentity3.HasValue);
             Assert.False(receivedServiceIdentity4.HasValue);
 
@@ -268,8 +266,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2", "m4");
 
             // Assert
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
-            CompareServiceIdentities(si4, receivedServiceIdentity4);
+            Assert.True(si3().Equals(receivedServiceIdentity3.OrDefault()));
+            Assert.True(si4().Equals(receivedServiceIdentity4.OrDefault()));
             Assert.False(receivedServiceIdentity1.HasValue);
             Assert.False(receivedServiceIdentity2.HasValue);
 
@@ -323,8 +321,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
 
             // Update the identities
             await deviceScopeIdentitiesCache.RefreshServiceIdentity("d1");
@@ -334,7 +332,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2");
 
             // Assert
-            CompareServiceIdentities(si1_updated, receivedServiceIdentity1);
+            Assert.True(si1_updated.Equals(receivedServiceIdentity1.OrDefault()));
             Assert.False(receivedServiceIdentity2.HasValue);
             Assert.Equal(1, removedIdentities.Count);
             Assert.Equal("d2", removedIdentities[0]);
@@ -386,17 +384,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
 
             // Update the identities
-            await deviceScopeIdentitiesCache.RefreshServiceIdentities(new string[] { "d1", "d2" });
+            await deviceScopeIdentitiesCache.RefreshServiceIdentities(new [] { "d1", "d2" });
 
             receivedServiceIdentity1 = await deviceScopeIdentitiesCache.GetServiceIdentity("d1");
             receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2");
 
             // Assert
-            CompareServiceIdentities(si1_updated, receivedServiceIdentity1);
+            Assert.True(si1_updated.Equals(receivedServiceIdentity1.OrDefault()));
             Assert.False(receivedServiceIdentity2.HasValue);
             Assert.Equal(1, removedIdentities.Count);
             Assert.Equal("d2", removedIdentities[0]);
@@ -448,8 +446,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2", "m2");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
 
             // Update the identities
             await deviceScopeIdentitiesCache.RefreshServiceIdentity("d1", "m1");
@@ -459,7 +457,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2", "m2");
 
             // Assert
-            CompareServiceIdentities(si1_updated, receivedServiceIdentity1);
+            Assert.True(si1_updated.Equals(receivedServiceIdentity1.OrDefault()));
             Assert.False(receivedServiceIdentity2.HasValue);
             Assert.Equal(1, removedIdentities.Count);
             Assert.Equal("d2/m2", removedIdentities[0]);
@@ -515,8 +513,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity("d3");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
             Assert.False(receivedServiceIdentity3.HasValue);
 
             // Get the identities with refresh
@@ -525,9 +523,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity("d3", true);
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3.Equals(receivedServiceIdentity3.OrDefault()));
             Assert.Equal(0, removedIdentities.Count);
             Assert.Equal(0, updatedIdentities.Count);
         }
@@ -580,8 +578,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity("d3", "m3");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
             Assert.False(receivedServiceIdentity3.HasValue);
 
             // Get the identities with refresh
@@ -590,9 +588,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity("d3", "m3", true);
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3.Equals(receivedServiceIdentity3.OrDefault()));
             Assert.Equal(0, removedIdentities.Count);
             Assert.Equal(0, updatedIdentities.Count);
         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ServiceIdentityTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ServiceIdentityTest.cs
@@ -1,0 +1,206 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Xunit;
+
+    [Unit]
+    public class ServiceIdentityTest
+    {
+        [Theory]
+        [MemberData(nameof(GetEqualityTestData))]
+        public void EqualityTest(ServiceIdentity identity1, ServiceIdentity identity2, bool areEqual)
+        {
+            // Act
+            bool result = identity1.Equals(identity2);
+
+            // Assert
+            Assert.Equal(areEqual, result);
+        }
+
+        static IEnumerable<object[]> GetEqualityTestData()
+        {
+            // Device identities - Equal
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                true
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>{"123", "iotEdge"}, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string>{"123", "iotEdge"}, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                true
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(new SymmetricKeyAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(new SymmetricKeyAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                true
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(new X509ThumbprintAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(new X509ThumbprintAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                true
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.None), ServiceIdentityStatus.Disabled),
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.None), ServiceIdentityStatus.Disabled),
+                true
+            };
+
+            // Module identities - Equal
+            yield return new object[]
+{
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                true
+};
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>{"123", "iotEdge"}, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>{"123", "iotEdge"}, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                true
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(new SymmetricKeyAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(new SymmetricKeyAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                true
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(new X509ThumbprintAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(new X509ThumbprintAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                true
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.None), ServiceIdentityStatus.Disabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.None), ServiceIdentityStatus.Disabled),
+                true
+            };
+
+            // Device identities - Not Equal
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d2", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1235", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string> { "123" }, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string> { "123" }, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string> { "234" }, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(new SymmetricKeyAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(new X509ThumbprintAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(new SymmetricKeyAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Disabled),
+                false
+            };
+
+            // Module identities - Not Equal
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d2", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m2", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1235", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string> { "123" }, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string> { "123" }, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string> { "234" }, new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(new SymmetricKeyAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(new X509ThumbprintAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(new SymmetricKeyAuthentication("k1", "k2")), ServiceIdentityStatus.Enabled),
+                false
+            };
+
+            yield return new object[]
+            {
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled),
+                new ServiceIdentity("d1", "m1", "1234", new List<string>(), new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Disabled),
+                false
+            };
+        }
+    }
+}


### PR DESCRIPTION
ServiceIdentity types were using reference for equality which gives wrong results. So implementing IEquatable for all ServiceIdentity types. 