### PR TITLE
Support proxy server in Windows install script

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -30,6 +30,9 @@ function Install-SecurityDaemon {
         [ValidateSet("Linux", "Windows")]
         [String] $ContainerOs = "Linux",
 
+        # Proxy URI
+        [Uri] $Proxy,
+
         # Local path to iotedged zip file
         [String] $ArchivePath,
 
@@ -227,7 +230,8 @@ function Get-SecurityDaemon {
             Invoke-WebRequest `
                 -Uri "https://aka.ms/iotedged-windows-latest" `
                 -OutFile "$ArchivePath" `
-                -UseBasicParsing
+                -UseBasicParsing `
+                -Proxy $Proxy
             Write-Host "Downloaded security daemon." -ForegroundColor "Green"
         }
         if ((Get-Item "$ArchivePath").PSIsContainer) {
@@ -314,7 +318,8 @@ function Get-VcRuntime {
         Invoke-WebRequest `
             -Uri "https://download.microsoft.com/download/0/6/4/064F84EA-D1DB-4EAA-9A5C-CC2F0FF6A638/vc_redist.x64.exe" `
             -OutFile "$env:TEMP\vc_redist.exe" `
-            -UseBasicParsing
+            -UseBasicParsing `
+            -Proxy $Proxy
         Invoke-Native "$env:TEMP\vc_redist.exe /quiet /norestart"
         Write-Host "Downloaded vcruntime." -ForegroundColor "Green"
     }


### PR DESCRIPTION
My first attempt to add support (#324) caused errors because the -Proxy param type (String) didn't match Invoke-WebRequest's -Proxy param type (Uri). If the user didn't pass an argument for -Proxy, then the default String value was passed ('') to Invoke-WebRequest, which converted it to an empty (aka relative) Uri object. Invoke-WebRequest doesn't like relative proxy URIs. :(