### PR TITLE
EdgeHub: unify device/module apis in IDeviceScopeIdentitiesCache

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
@@ -132,67 +132,39 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             }
         }
 
-        public async Task RefreshServiceIdentity(string deviceId)
+        public async Task RefreshServiceIdentity(string id)
         {
             try
             {
-                Option<ServiceIdentity> serviceIdentity = await this.serviceProxy.GetServiceIdentity(deviceId);
+                Option<ServiceIdentity> serviceIdentity = await this.GetServiceIdentityFromService(id);
                 await serviceIdentity
                     .Map(s => this.HandleNewServiceIdentity(s))
-                    .GetOrElse(() => this.HandleNoServiceIdentity(deviceId));
+                    .GetOrElse(() => this.HandleNoServiceIdentity(id));
             }
             catch (Exception e)
             {
-                Events.ErrorRefreshingCache(e, deviceId);
+                Events.ErrorRefreshingCache(e, id);
             }
         }
 
-        public async Task RefreshServiceIdentity(string deviceId, string moduleId)
+        public async Task RefreshServiceIdentities(IEnumerable<string> ids)
         {
-            try
+            List<string> idList = Preconditions.CheckNotNull(ids, nameof(ids)).ToList();
+            foreach (string id in idList)
             {
-                Option<ServiceIdentity> serviceIdentity = await this.serviceProxy.GetServiceIdentity(deviceId, moduleId);
-                await serviceIdentity
-                    .Map(s => this.HandleNewServiceIdentity(s))
-                    .GetOrElse(() => this.HandleNoServiceIdentity($"{deviceId}/{moduleId}"));
-            }
-            catch (Exception e)
-            {
-                Events.ErrorRefreshingCache(e, $"{deviceId}/{moduleId}");
+                await this.RefreshServiceIdentity(id);
             }
         }
 
-        public async Task RefreshServiceIdentities(IEnumerable<string> deviceIds)
+        public async Task<Option<ServiceIdentity>> GetServiceIdentity(string id, bool refreshIfNotExists = false)
         {
-            List<string> deviceIdsList = Preconditions.CheckNotNull(deviceIds, nameof(deviceIds)).ToList();
-            foreach (string deviceId in deviceIdsList)
-            {
-                await this.RefreshServiceIdentity(deviceId);
-            }
-        }
-
-        public async Task<Option<ServiceIdentity>> GetServiceIdentity(string deviceId, string moduleId, bool refreshIfNotExists = false)
-        {
-            Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
-            Preconditions.CheckNonWhiteSpace(moduleId, nameof(moduleId));
-            string id = $"{deviceId}/{moduleId}";
+            Preconditions.CheckNonWhiteSpace(id, nameof(id));
             if (refreshIfNotExists && !this.serviceIdentityCache.ContainsKey(id))
             {
-                await this.RefreshServiceIdentity(deviceId, moduleId);
+                await this.RefreshServiceIdentity(id);
             }
 
             return await this.GetServiceIdentityInternal(id);
-        }
-
-        public async Task<Option<ServiceIdentity>> GetServiceIdentity(string deviceId, bool refreshIfNotExists = false)
-        {
-            Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
-            if (refreshIfNotExists && !this.serviceIdentityCache.ContainsKey(deviceId))
-            {
-                await this.RefreshServiceIdentity(deviceId);
-            }
-
-            return await this.GetServiceIdentityInternal(deviceId);
         }
 
         async Task<Option<ServiceIdentity>> GetServiceIdentityInternal(string id)
@@ -216,7 +188,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
                 // Remove device if connected
                 this.ServiceIdentityRemoved?.Invoke(this, id);
-           }
+            }
         }
 
         async Task HandleNewServiceIdentity(ServiceIdentity serviceIdentity)
@@ -255,6 +227,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     return Task.CompletedTask;
                 });
             return cache;
+        }
+
+        Task<Option<ServiceIdentity>> GetServiceIdentityFromService(string id)
+        {
+            // If it is a module id, it will have the format "deviceId/moduleId"
+            string[] parts = id.Split('/');
+            if (parts.Length == 2)
+            {
+                return this.serviceProxy.GetServiceIdentity(parts[0], parts[1]);
+            }
+            else
+            {
+                return this.serviceProxy.GetServiceIdentity(id);
+            }
         }
 
         public void Dispose()

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             return cache;
         }
 
-        Task<Option<ServiceIdentity>> GetServiceIdentityFromService(string id)
+        internal Task<Option<ServiceIdentity>> GetServiceIdentityFromService(string id)
         {
             // If it is a module id, it will have the format "deviceId/moduleId"
             string[] parts = id.Split('/');

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
@@ -12,15 +12,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     {
         Task<Option<ServiceIdentity>> GetServiceIdentity(string id, bool refreshIfNotExists = false);
 
-        Task<Option<ServiceIdentity>> GetServiceIdentity(string deviceId, string moduleId, bool refreshIfNotExists = false);
-        
         void InitiateCacheRefresh();
 
-        Task RefreshServiceIdentities(IEnumerable<string> deviceIds);
+        Task RefreshServiceIdentities(IEnumerable<string> ids);
 
-        Task RefreshServiceIdentity(string deviceId);
-
-        Task RefreshServiceIdentity(string deviceId, string moduleId);
+        Task RefreshServiceIdentity(string id);
 
         event EventHandler<ServiceIdentity> ServiceIdentityUpdated;
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
@@ -42,8 +42,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m1");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
         }
 
         [Fact]
@@ -52,11 +52,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // Arrange            
             var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
             var serviceAuthentication = new ServiceAuthentication(ServiceAuthenticationType.None);
-            var si1 = new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-            var si2 = new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-
-            var si3 = new ServiceIdentity("d3", "5678", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-            var si4 = new ServiceIdentity("d2", "m4", "9898", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si1 = () => new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si2 = () => new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si3 = () => new ServiceIdentity("d3", "5678", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si4 = () => new ServiceIdentity("d2", "m4", "9898", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
 
             var iterator1 = new Mock<IServiceIdentitiesIterator>();
             iterator1.SetupSequence(i => i.HasNext)
@@ -67,14 +66,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2
+                        si1(),
+                        si2()
                     })
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si3,
-                        si4
+                        si3(),
+                        si4()
                     });
 
             var iterator2 = new Mock<IServiceIdentitiesIterator>();
@@ -85,9 +84,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2,
-                        si3
+                        si1(),
+                        si2(),
+                        si3()
                     });
 
             var serviceProxy = new Mock<IServiceProxy>();
@@ -110,10 +109,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m4");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
-            CompareServiceIdentities(si4, receivedServiceIdentity4);
+            Assert.True(si1().Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2().Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3().Equals(receivedServiceIdentity3.OrDefault()));
+            Assert.True(si4().Equals(receivedServiceIdentity4.OrDefault()));
 
             Assert.Equal(0, updatedIdentities.Count);
             Assert.Equal(0, removedIdentities.Count);
@@ -127,9 +126,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m4");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
+            Assert.True(si1().Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2().Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3().Equals(receivedServiceIdentity3.OrDefault()));
             Assert.False(receivedServiceIdentity4.HasValue);
 
             Assert.Equal(0, updatedIdentities.Count);
@@ -143,11 +142,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // Arrange            
             var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
             var serviceAuthentication = new ServiceAuthentication(ServiceAuthenticationType.None);
-            var si1 = new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-            var si2 = new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-
-            var si3 = new ServiceIdentity("d3", "5678", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
-            var si4 = new ServiceIdentity("d2", "m4", "9898", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si1 = () => new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si2 = () => new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si3 = () => new ServiceIdentity("d3", "5678", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
+            Func<ServiceIdentity> si4 = () => new ServiceIdentity("d2", "m4", "9898", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
 
             var iterator1 = new Mock<IServiceIdentitiesIterator>();
             iterator1.SetupSequence(i => i.HasNext)
@@ -158,14 +156,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2
+                        si1(),
+                        si2()
                     })
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si3,
-                        si4
+                        si3(),
+                        si4()
                     });
 
             var iterator2 = new Mock<IServiceIdentitiesIterator>();
@@ -176,9 +174,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2,
-                        si3
+                        si1(),
+                        si2(),
+                        si3()
                     });
 
             var iterator3 = new Mock<IServiceIdentitiesIterator>();
@@ -189,8 +187,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si1,
-                        si2
+                        si1(),
+                        si2()
                     });
 
             var iterator4 = new Mock<IServiceIdentitiesIterator>();
@@ -201,8 +199,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(
                     new List<ServiceIdentity>
                     {
-                        si3,
-                        si4
+                        si3(),
+                        si4()
                     });
 
             var serviceProxy = new Mock<IServiceProxy>();
@@ -228,10 +226,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m4");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
-            CompareServiceIdentities(si4, receivedServiceIdentity4);
+            Assert.True(si1().Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2().Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3().Equals(receivedServiceIdentity3.OrDefault()));
+            Assert.True(si4().Equals(receivedServiceIdentity4.OrDefault()));
 
             Assert.Equal(0, updatedIdentities.Count);
             Assert.Equal(0, removedIdentities.Count);
@@ -250,8 +248,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m4");
 
             // Assert
-            CompareServiceIdentities(si1, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1().Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2().Equals(receivedServiceIdentity2.OrDefault()));
             Assert.False(receivedServiceIdentity3.HasValue);
             Assert.False(receivedServiceIdentity4.HasValue);
 
@@ -268,8 +266,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity4 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m4");
 
             // Assert
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
-            CompareServiceIdentities(si4, receivedServiceIdentity4);
+            Assert.True(si3().Equals(receivedServiceIdentity3.OrDefault()));
+            Assert.True(si4().Equals(receivedServiceIdentity4.OrDefault()));
             Assert.False(receivedServiceIdentity1.HasValue);
             Assert.False(receivedServiceIdentity2.HasValue);
 
@@ -323,8 +321,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
 
             // Update the identities
             await deviceScopeIdentitiesCache.RefreshServiceIdentity("d1");
@@ -334,7 +332,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2");
 
             // Assert
-            CompareServiceIdentities(si1_updated, receivedServiceIdentity1);
+            Assert.True(si1_updated.Equals(receivedServiceIdentity1.OrDefault()));
             Assert.False(receivedServiceIdentity2.HasValue);
             Assert.Equal(1, removedIdentities.Count);
             Assert.Equal("d2", removedIdentities[0]);
@@ -386,17 +384,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
 
             // Update the identities
-            await deviceScopeIdentitiesCache.RefreshServiceIdentities(new string[] { "d1", "d2" });
+            await deviceScopeIdentitiesCache.RefreshServiceIdentities(new[] { "d1", "d2" });
 
             receivedServiceIdentity1 = await deviceScopeIdentitiesCache.GetServiceIdentity("d1");
             receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2");
 
             // Assert
-            CompareServiceIdentities(si1_updated, receivedServiceIdentity1);
+            Assert.True(si1_updated.Equals(receivedServiceIdentity1.OrDefault()));
             Assert.False(receivedServiceIdentity2.HasValue);
             Assert.Equal(1, removedIdentities.Count);
             Assert.Equal("d2", removedIdentities[0]);
@@ -448,8 +446,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m2");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
 
             // Update the identities
             await deviceScopeIdentitiesCache.RefreshServiceIdentity("d1/m1");
@@ -459,7 +457,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m2");
 
             // Assert
-            CompareServiceIdentities(si1_updated, receivedServiceIdentity1);
+            Assert.True(si1_updated.Equals(receivedServiceIdentity1.OrDefault()));
             Assert.False(receivedServiceIdentity2.HasValue);
             Assert.Equal(1, removedIdentities.Count);
             Assert.Equal("d2/m2", removedIdentities[0]);
@@ -515,8 +513,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity("d3");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
             Assert.False(receivedServiceIdentity3.HasValue);
 
             // Get the identities with refresh
@@ -525,9 +523,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity("d3", true);
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3.Equals(receivedServiceIdentity3.OrDefault()));
             Assert.Equal(0, removedIdentities.Count);
             Assert.Equal(0, updatedIdentities.Count);
         }
@@ -580,8 +578,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Option<ServiceIdentity> receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity("d3/m3");
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
             Assert.False(receivedServiceIdentity3.HasValue);
 
             // Get the identities with refresh
@@ -590,32 +588,39 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity("d3/m3", true);
 
             // Assert
-            CompareServiceIdentities(si1_initial, receivedServiceIdentity1);
-            CompareServiceIdentities(si2, receivedServiceIdentity2);
-            CompareServiceIdentities(si3, receivedServiceIdentity3);
+            Assert.True(si1_initial.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.True(si2.Equals(receivedServiceIdentity2.OrDefault()));
+            Assert.True(si3.Equals(receivedServiceIdentity3.OrDefault()));
             Assert.Equal(0, removedIdentities.Count);
             Assert.Equal(0, updatedIdentities.Count);
         }
 
-        static void CompareServiceIdentities(ServiceIdentity si1, Option<ServiceIdentity> si2Option)
+        [Fact]
+        public async Task GetServiceIdentityFromServiceTest()
         {
-            if (si1 == null)
-            {
-                Assert.False(si2Option.HasValue);
-            }
-            else
-            {
-                ServiceIdentity si2 = si2Option.OrDefault();
-                Assert.Equal(si1.DeviceId, si2.DeviceId);
-                Assert.Equal(si1.GenerationId, si2.GenerationId);
-                Assert.Equal(si1.IsModule, si2.IsModule);
-                if (si1.IsModule)
-                {
-                    Assert.Equal(si1.ModuleId.OrDefault(), si2.ModuleId.OrDefault());
-                }
-                Assert.Equal(si1.Capabilities.Count(), si2.Capabilities.Count());
-                Assert.Equal(si1.Authentication.Type, si2.Authentication.Type);
-            }
+            // Arrange
+            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
+            var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
+
+            var si_device = new ServiceIdentity("d2", "1234", Enumerable.Empty<string>(), serviceAuthenticationNone, ServiceIdentityStatus.Enabled);
+            var si_module = new ServiceIdentity("d1", "m1", "1234", Enumerable.Empty<string>(), serviceAuthenticationSas, ServiceIdentityStatus.Disabled);
+
+            var serviceProxy = new Mock<IServiceProxy>();
+            serviceProxy.Setup(s => s.GetServiceIdentity("d2")).ReturnsAsync(Option.Some(si_device));
+            serviceProxy.Setup(s => s.GetServiceIdentity("d1", "m1")).ReturnsAsync(Option.Some(si_module));
+
+            DeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(serviceProxy.Object, store, TimeSpan.FromHours(1));
+
+            // Act
+            Option<ServiceIdentity> deviceServiceIdentity = await deviceScopeIdentitiesCache.GetServiceIdentityFromService("d2");
+            Option<ServiceIdentity> moduleServiceIdentity = await deviceScopeIdentitiesCache.GetServiceIdentityFromService("d1/m1");
+
+            // Assert
+            Assert.True(deviceServiceIdentity.HasValue);
+            Assert.True(si_device.Equals(deviceServiceIdentity.OrDefault()));
+            Assert.True(moduleServiceIdentity.HasValue);
+            Assert.True(si_module.Equals(moduleServiceIdentity.OrDefault()));
         }
 
         static string GetKey() => Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()));


### PR DESCRIPTION
In EdgeHub code, IIdentity.Id is used widely to identify identities. So updating IDeviceScopeIdentitiesCache api to take in the Id for either a module or a device. This fixes a small bug where the caller was passing in an id deviceId/moduleId for a module identity.