### PR TITLE
Don't re-authenticate EdgeHub identity

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionReauthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionReauthenticator.cs
@@ -68,6 +68,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 {
                     try
                     {
+                        if (this.IsEdgeHubIdentity(identity.Id))
+                        {
+                            continue;
+                        }
+
                         Option<IClientCredentials> clientCredentials = await this.credentialsCache.Get(identity);
                         bool result = await clientCredentials
                             .Map(
@@ -106,6 +111,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             try
             {
                 Events.ServiceIdentityUpdated(serviceIdentity.Id);
+                if (this.IsEdgeHubIdentity(serviceIdentity.Id))
+                {
+                    return;
+                }
+
                 Option<IDeviceProxy> deviceProxy = this.connectionManager.GetDeviceConnection(serviceIdentity.Id);
                 if (deviceProxy.HasValue)
                 {
@@ -143,6 +153,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             try
             {
+                if (this.IsEdgeHubIdentity(id))
+                {
+                    return;
+                }
+
                 Events.ServiceIdentityRemoved(id);
                 await this.connectionManager.RemoveDeviceConnection(id);
             }
@@ -151,6 +166,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 Events.ErrorRemovingConnection(ex, id);
             }
         }
+
+        bool IsEdgeHubIdentity(string id) => this.edgeHubIdentity.Id.Equals(id);
 
         static class Events
         {
@@ -206,22 +223,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public static void ServiceIdentityUpdated(string serviceIdentityId)
             {
-                Log.LogDebug((int)EventIds.ServiceIdentityUpdated, $"Service identity for {serviceIdentityId} in device scope was updated.");
+                Log.LogInformation((int)EventIds.ServiceIdentityUpdated, $"Service identity for {serviceIdentityId} in device scope was updated.");
             }
 
             public static void ServiceIdentityUpdatedRemoving(string serviceIdentityId)
             {
-                Log.LogDebug((int)EventIds.ServiceIdentityUpdatedRemoving, $"Service identity for {serviceIdentityId} in device scope was updated, dropping client connection.");
+                Log.LogInformation((int)EventIds.ServiceIdentityUpdatedRemoving, $"Service identity for {serviceIdentityId} in device scope was updated, dropping client connection.");
             }
 
             public static void ServiceIdentityUpdatedValidated(string serviceIdentityId)
             {
-                Log.LogDebug((int)EventIds.ServiceIdentityUpdatedValidated, $"Service identity for {serviceIdentityId} in device scope was updated, client connection was re-validated.");
+                Log.LogInformation((int)EventIds.ServiceIdentityUpdatedValidated, $"Service identity for {serviceIdentityId} in device scope was updated, client connection was re-validated.");
             }
 
             public static void ServiceIdentityRemoved(string id)
             {
-                Log.LogDebug((int)EventIds.ServiceIdentityRemoved, $"Service identity for {id} in device scope was removed, dropping client connection.");
+                Log.LogInformation((int)EventIds.ServiceIdentityRemoved, $"Service identity for {id} in device scope was removed, dropping client connection.");
             }
 
             public static void DeviceNotConnected(string id)
@@ -236,12 +253,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public static void ReauthenticatingClients()
             {
-                Log.LogDebug((int)EventIds.ReauthenticatingClients, $"Reauthenticating connected clients");
+                Log.LogDebug((int)EventIds.ReauthenticatingClients, "Reauthenticating connected clients");
             }
 
             public static void EdgeHubConnectionReestablished()
             {
-                Log.LogDebug((int)EventIds.EdgeHubConnectionReestablished, $"EdgeHub cloud connection established, refreshing device scope cache.");
+                Log.LogDebug((int)EventIds.EdgeHubConnectionReestablished, "EdgeHub cloud connection established, refreshing device scope cache.");
             }
         }
 


### PR DESCRIPTION
Add code to not re-authenticate EdgeHub identity. 
While this should never happen, and if it does, reauthenticate should succeed. However, if it does fail reauthentication (as happened in my testing because of invalid config), EdgeHub does not have resiliency to recreate the device side connection