### PR TITLE
Remove Verify Temp Sensor.

### DIFF
--- a/smoke/IotEdgeQuickstart/Quickstart.cs
+++ b/smoke/IotEdgeQuickstart/Quickstart.cs
@@ -67,7 +67,6 @@ namespace IotEdgeQuickstart
                         await DeployToEdgeDevice();
                         if (!this.noVerify)
                         {
-                            await VerifyTempSensorIsRunning();
                             await this.VerifyDataOnIoTHub(this.verifyDataFromModule);
                         }
 

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -189,8 +189,6 @@ namespace IotEdgeQuickstart.Details
             return this.context.RegistryManager.ApplyConfigurationContentOnDeviceAsync(this.context.Device.Id, config);
         }
 
-        protected Task VerifyTempSensorIsRunning() => this.bootstrapper.VerifyModuleIsRunning("tempSensor");
-
         protected async Task VerifyDataOnIoTHub(string moduleId)
         {
             var builder = new EventHubsConnectionStringBuilder(this.eventhubCompatibleEndpointWithEntityPath);


### PR DESCRIPTION
This is not needed since we are already verifying data from a specific module.
This was forcing us for always having tempsensor on Quick Start (even with a different deployment.