### PR TITLE
Adding One minute to time out of Edge Agent Running.

### DIFF
--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -85,7 +85,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(6)))
             {
                 string errorMessage = null;
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -85,7 +85,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(6)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10)))
             {
                 string errorMessage = null;
 


### PR DESCRIPTION
E2E Test is failing sometimes on small devices (ARM) because it times out before edgeAgent/iotedgeD is running. 

So, increasing to 1 min to check if it improve. 