### PR TITLE
Add an option to Clean Up Devices (even if it already exists) on QuickStart

### DIFF
--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -126,7 +126,7 @@ Defaults:
         [Option("--trusted_ca_certs", Description = "path to a file containing all the trusted CA")]
         public string DeviceCaCerts { get; } = "";
 
-        [Option("--clean_up_existing_device", CommandOptionType.NoValue, Description = "Clean up existing device on success.")]
+        [Option("--clean_up_existing_device <true/false>", CommandOptionType.SingleValue, Description = "Clean up existing device on success.")]
         public bool CleanUpExistingDeviceOnSuccess { get; } = false;
 
         // ReSharper disable once UnusedMember.Local

--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -54,6 +54,7 @@ Defaults:
   --verify-data-from-module  tempSensor
   --deployment               deployment json file
   --runtime-log-level        debug
+  --clean_up_existing_device false
 "
         )]
     [HelpOption]
@@ -124,6 +125,9 @@ Defaults:
 
         [Option("--trusted_ca_certs", Description = "path to a file containing all the trusted CA")]
         public string DeviceCaCerts { get; } = "";
+
+        [Option("--clean_up_existing_device", Description = "Clean up existing device on success.")]
+        public bool CleanUpExistingDeviceOnSuccess { get; } = false;
 
         // ReSharper disable once UnusedMember.Local
         async Task<int> OnExecuteAsync()
@@ -196,7 +200,8 @@ Defaults:
                     this.DeviceCaPk,
                     this.DeviceCaCerts,
                     this.OptimizeForPerformance,
-                    this.RuntimeLogLevel);
+                    this.RuntimeLogLevel,
+                    this.CleanUpExistingDeviceOnSuccess);
                 await test.RunAsync();
             }
             catch (Exception ex)

--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -126,7 +126,7 @@ Defaults:
         [Option("--trusted_ca_certs", Description = "path to a file containing all the trusted CA")]
         public string DeviceCaCerts { get; } = "";
 
-        [Option("--clean_up_existing_device", Description = "Clean up existing device on success.")]
+        [Option("--clean_up_existing_device", CommandOptionType.NoValue, Description = "Clean up existing device on success.")]
         public bool CleanUpExistingDeviceOnSuccess { get; } = false;
 
         // ReSharper disable once UnusedMember.Local

--- a/smoke/IotEdgeQuickstart/Quickstart.cs
+++ b/smoke/IotEdgeQuickstart/Quickstart.cs
@@ -32,8 +32,9 @@ namespace IotEdgeQuickstart
             string deviceCaPk,
             string deviceCaCerts,
             bool optimizedForPerformance,
-            LogLevel runtimeLogLevel) :
-            base(bootstrapper, credentials, iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, imageTag, deviceId, hostname, deploymentFileName, deviceCaCert, deviceCaPk, deviceCaCerts, optimizedForPerformance, runtimeLogLevel)
+            LogLevel runtimeLogLevel,
+            bool cleanUpExistingDeviceOnSuccess) :
+            base(bootstrapper, credentials, iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, imageTag, deviceId, hostname, deploymentFileName, deviceCaCert, deviceCaPk, deviceCaCerts, optimizedForPerformance, runtimeLogLevel, cleanUpExistingDeviceOnSuccess)
         {
             this.leaveRunning = leaveRunning;
             this.noDeployment = noDeployment;

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -83,6 +83,7 @@ namespace IotEdgeQuickstart.Details
             if (device != null)
             {
                 Console.WriteLine($"Device '{device.Id}' already registered on IoT hub '{builder.HostName}'");
+                Console.WriteLine($"Clean up Existing device? {this.cleanUpExistingDeviceOnSuccess}");
 
                 this.context = new DeviceContext
                 {
@@ -266,6 +267,7 @@ namespace IotEdgeQuickstart.Details
 
         protected void KeepEdgeDeviceIdentity()
         {
+            Console.WriteLine("Keeping Edge Device Identity.");
             if (this.context != null)
             {
                 this.context.RemoveDevice = false;
@@ -282,6 +284,7 @@ namespace IotEdgeQuickstart.Details
 
                 if (remove)
                 {
+                    Console.WriteLine($"Trying to remove device from Registry. Device Id: {device.Id}");
                     return this.context.RegistryManager.RemoveDeviceAsync(device);
                 }
             }

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -31,6 +31,7 @@ namespace IotEdgeQuickstart.Details
         readonly string deviceCaCerts;
         readonly bool optimizedForPerformance;
         readonly LogLevel runtimeLogLevel;
+        readonly bool cleanUpExistingDeviceOnSuccess; 
 
         DeviceContext context;
 
@@ -47,7 +48,8 @@ namespace IotEdgeQuickstart.Details
             string deviceCaPk,
             string deviceCaCerts,
             bool optimizedForPerformance,
-            LogLevel runtimeLogLevel
+            LogLevel runtimeLogLevel,
+            bool cleanUpExistingDeviceOnSuccess
             )
         {
             this.bootstrapper = bootstrapper;
@@ -63,6 +65,7 @@ namespace IotEdgeQuickstart.Details
             this.deviceCaCerts = deviceCaCerts;
             this.optimizedForPerformance = optimizedForPerformance;
             this.runtimeLogLevel = runtimeLogLevel;
+            this.cleanUpExistingDeviceOnSuccess = cleanUpExistingDeviceOnSuccess;
         }
 
         protected Task VerifyEdgeIsNotAlreadyActive() => this.bootstrapper.VerifyNotActive();
@@ -86,7 +89,7 @@ namespace IotEdgeQuickstart.Details
                     Device = device,
                     IotHubConnectionString = this.iothubConnectionString,
                     RegistryManager = rm,
-                    RemoveDevice = false
+                    RemoveDevice = this.cleanUpExistingDeviceOnSuccess
                 };
             }
             else


### PR DESCRIPTION
This will give the option to delete existing devices (On Success). 
Before we were just deleting devices if it was created by Quick Start. This made some devices to leak (For example the devices created on Leaf Device test, which has 2 separate tasks, 1 for setup and 1 for test execution.