### PR TITLE
EdgeHub: Add unit tests for PUT/DELETE operations in AMQP for Twin subscriptions

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/TwinReceivingLinkHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/TwinReceivingLinkHandler.cs
@@ -22,7 +22,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
         public const string TwinPut = "PUT";
         public const string TwinDelete = "DELETE";
 
-        public TwinReceivingLinkHandler(IReceivingAmqpLink link, Uri requestUri, IDictionary<string, string> boundVariables,
+        public TwinReceivingLinkHandler(IReceivingAmqpLink link,
+            Uri requestUri,
+            IDictionary<string, string> boundVariables,
             IMessageConverter<AmqpMessage> messageConverter)
             : base(link, requestUri, boundVariables, messageConverter)
         {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/TwinReceivingLinkHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/TwinReceivingLinkHandlerTest.cs
@@ -1,0 +1,91 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Amqp;
+    using Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class TwinReceivingLinkHandlerTest
+    {
+        [Fact]
+        public async Task ProcessPutOperationMessageTest()
+        {
+            // Arrange
+            string receivedCorrelationId = null;
+            var deviceListener = new Mock<IDeviceListener>();
+            deviceListener.Setup(d => d.AddDesiredPropertyUpdatesSubscription(It.IsAny<string>()))
+                .Callback<string>(c => receivedCorrelationId = c)
+                .Returns(Task.CompletedTask);
+            var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object)
+                && c.GetAmqpAuthentication() == Task.FromResult(new AmqpAuthentication(true, Option.Some(Mock.Of<IClientCredentials>()))));
+            var amqpConnection = Mock.Of<IAmqpConnection>(c => c.FindExtension<IConnectionHandler>() == connectionHandler);
+            var amqpSession = Mock.Of<IAmqpSession>(s => s.Connection == amqpConnection);
+            var receivingLink = Mock.Of<IReceivingAmqpLink>(l => l.Session == amqpSession && l.IsReceiver && l.Settings == new AmqpLinkSettings() && l.State == AmqpObjectState.Opened);
+
+            var requestUri = new Uri("amqps://foo.bar/devices/d1/twin");
+            var boundVariables = new Dictionary<string, string> { { "deviceid", "d1" } };
+            var messageConverter = Mock.Of<IMessageConverter<AmqpMessage>>();
+            var twinReceivingLinkHandler = new TwinReceivingLinkHandler(receivingLink, requestUri, boundVariables, messageConverter);
+
+            string correlationId = Guid.NewGuid().ToString();
+            AmqpMessage amqpMessage = AmqpMessage.Create();
+            amqpMessage.MessageAnnotations.Map["operation"] = "PUT";
+            amqpMessage.Properties.CorrelationId = correlationId;
+
+            // Act
+            await twinReceivingLinkHandler.OpenAsync(TimeSpan.FromSeconds(60));
+            await twinReceivingLinkHandler.ProcessMessageAsync(amqpMessage);
+
+            // Assert
+            Assert.NotNull(receivedCorrelationId);
+            Assert.Equal(correlationId, receivedCorrelationId);
+            deviceListener.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ProcessDeleteOperationMessageTest()
+        {
+            // Arrange
+            string receivedCorrelationId = null;
+            var deviceListener = new Mock<IDeviceListener>();
+            deviceListener.Setup(d => d.RemoveDesiredPropertyUpdatesSubscription(It.IsAny<string>()))
+                .Callback<string>(c => receivedCorrelationId = c)
+                .Returns(Task.CompletedTask);
+            var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object)
+                && c.GetAmqpAuthentication() == Task.FromResult(new AmqpAuthentication(true, Option.Some(Mock.Of<IClientCredentials>()))));
+            var amqpConnection = Mock.Of<IAmqpConnection>(c => c.FindExtension<IConnectionHandler>() == connectionHandler);
+            var amqpSession = Mock.Of<IAmqpSession>(s => s.Connection == amqpConnection);
+            var receivingLink = Mock.Of<IReceivingAmqpLink>(l => l.Session == amqpSession && l.IsReceiver && l.Settings == new AmqpLinkSettings() && l.State == AmqpObjectState.Opened);
+
+            var requestUri = new Uri("amqps://foo.bar/devices/d1/twin");
+            var boundVariables = new Dictionary<string, string> { { "deviceid", "d1" } };
+            var messageConverter = Mock.Of<IMessageConverter<AmqpMessage>>();
+            var twinReceivingLinkHandler = new TwinReceivingLinkHandler(receivingLink, requestUri, boundVariables, messageConverter);
+
+            string correlationId = Guid.NewGuid().ToString();
+            AmqpMessage amqpMessage = AmqpMessage.Create();
+            amqpMessage.MessageAnnotations.Map["operation"] = "DELETE";
+            amqpMessage.Properties.CorrelationId = correlationId;
+
+            // Act
+            await twinReceivingLinkHandler.OpenAsync(TimeSpan.FromSeconds(60));
+            await twinReceivingLinkHandler.ProcessMessageAsync(amqpMessage);
+
+            // Assert
+            Assert.NotNull(receivedCorrelationId);
+            Assert.Equal(correlationId, receivedCorrelationId);
+            deviceListener.VerifyAll();
+        }
+    }
+}


### PR DESCRIPTION
Add unit tests for PUT / DELETE operations supported by Twins receiving link to add/remove subscriptions for twin desired properties.