### PR TITLE
EdgeHub: Fix updating message store endpoints when routes are updated

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
 
         public async Task RemoveEndpoint(string endpointId)
         {
-            if (this.endpointSequentialStores.TryGetValue(endpointId, out ISequentialStore<MessageRef> sequentialStore))
+            if (this.endpointSequentialStores.TryRemove(endpointId, out ISequentialStore<MessageRef> sequentialStore))
             {
                 await this.storeProvider.RemoveStore(sequentialStore);
                 Events.SequentialStoreRemoved(endpointId);
@@ -109,11 +109,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
                     return offset;
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
                 // If adding the message to the SequentialStore throws, then remove the message from the EntityStore as well, so that there is no leak.
                 await this.messageEntityStore.Remove(edgeMessageId);
-                throw;
+                throw e;
             }
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
@@ -109,11 +109,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
                     return offset;
                 }
             }
-            catch (Exception e)
+            catch (Exception)
             {
                 // If adding the message to the SequentialStore throws, then remove the message from the EntityStore as well, so that there is no leak.
                 await this.messageEntityStore.Remove(edgeMessageId);
-                throw e;
+                throw;
             }
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutorFactory.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutorFactory.cs
@@ -25,15 +25,15 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
 
         public Task<IEndpointExecutor> CreateAsync(Endpoint endpoint, ICheckpointer checkpointer) => this.CreateAsync(endpoint, checkpointer, this.config);
 
-        public Task<IEndpointExecutor> CreateAsync(Endpoint endpoint, ICheckpointer checkpointer, EndpointExecutorConfig endpointExecutorConfig)
+        public async Task<IEndpointExecutor> CreateAsync(Endpoint endpoint, ICheckpointer checkpointer, EndpointExecutorConfig endpointExecutorConfig)
         {
             Preconditions.CheckNotNull(endpoint, nameof(endpoint));
             Preconditions.CheckNotNull(checkpointer, nameof(checkpointer));
             Preconditions.CheckNotNull(endpointExecutorConfig, nameof(endpointExecutorConfig));
 
-            this.messageStore.AddEndpoint(endpoint.Id);
+            await this.messageStore.AddEndpoint(endpoint.Id);
             IEndpointExecutor endpointExecutor = new StoringAsyncEndpointExecutor(endpoint, checkpointer, endpointExecutorConfig, this.options, this.messageStore);
-            return Task.FromResult(endpointExecutor);
+            return endpointExecutor;
         }
     }    
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
@@ -202,6 +202,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
                 Assert.Equal(0, batch.Count());
             }
         }
+
+        //[Fact]
+        //public async Task MessageStoreAddRemoveEndpointTest()
+        //{
+
+        //}
         
         IMessage GetMessage(int i)
         {


### PR DESCRIPTION
When routes are added/removed, we need to add/remove corresponding Sequential stores for them. 
This PR fixes a bug where when a route is removed, the sequential store reference in the message store is not updated correctly.
This fixes https://github.com/Azure/iotedge/issues/359