### PR TITLE
Extend createOptions by chunking the field

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Constants.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
 
         public const string DefaultRegistryAddress = "https://index.docker.io/v1/";
 
-        public const int TwinMaxValueSize = 512;
+        public const int TwinValueMaxSize = 512;
 
         public const int TwinValueMaxChunks = 100;   // The chunks sequence number is two bytes, which allows 100 chunks [0, 100)
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Constants.cs
@@ -3,9 +3,11 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Docker
 {
     static class Constants
-    {        
+    {
         public const string EdgeAgentCreateOptionsName = "EdgeAgentCreateOptions";
 
         public const string DefaultRegistryAddress = "https://index.docker.io/v1/";
+
+        public const int TwinMaxValueSize = 512;
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Constants.cs
@@ -9,5 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
         public const string DefaultRegistryAddress = "https://index.docker.io/v1/";
 
         public const int TwinMaxValueSize = 512;
+
+        public const int TwinValueMaxChunks = 100;   // The chunks sequence number is two bytes, which allows 100 chunks [0, 100)
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerConfig.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerConfig.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                 serializer.Serialize(writer, dockerconfig.Image);
 
                 var options = JsonConvert.SerializeObject(dockerconfig.CreateOptions)
-                    .Chunks(Constants.TwinMaxValueSize)
+                    .Chunks(Constants.TwinValueMaxSize)
                     .Take(Constants.TwinValueMaxChunks)
                     .Enumerate();
                 foreach (var (i, chunk) in options)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerConfig.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerConfig.cs
@@ -14,12 +14,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
     {
         readonly CreateContainerParameters createOptions;
 
-        [JsonProperty(Required = Required.Always, PropertyName = "image")]
         public string Image { get; }
 
         // Do a serialization roundtrip to clone the createOptions
         // https://docs.docker.com/engine/api/v1.25/#operation/ContainerCreate
-        [JsonProperty(Required = Required.AllowNull, PropertyName = "createOptions")]
         public CreateContainerParameters CreateOptions => JsonConvert.DeserializeObject<CreateContainerParameters>(JsonConvert.SerializeObject(this.createOptions));
 
         public DockerConfig(string image)
@@ -27,7 +25,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
         {
         }
 
-        [JsonConstructor]
         public DockerConfig(string image, string createOptions)
         {
             this.Image = image?.Trim() ?? string.Empty;

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerConfig.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerConfig.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                 var options = obj.ChunkedValue("createOptions", true)
                     .Take(Constants.TwinValueMaxChunks)
                     .Select(token => token?.ToString() ?? string.Empty)
-                    .Join("");
+                    .Join();
 
                 return new DockerConfig(jTokenImage?.ToString(), options);
             }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerReportedConfig.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerReportedConfig.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                 serializer.Serialize(writer, dockerReportedConfig.ImageHash);
 
                 var options = JsonConvert.SerializeObject(dockerReportedConfig.CreateOptions)
-                    .Chunks(Constants.TwinMaxValueSize)
+                    .Chunks(Constants.TwinValueMaxSize)
                     .Take(Constants.TwinValueMaxChunks)
                     .Enumerate();
                 foreach (var (i, chunk) in options)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerReportedConfig.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerReportedConfig.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                 var options = obj.ChunkedValue("createOptions", true)
                     .Take(Constants.TwinValueMaxChunks)
                     .Select(token => token?.ToString() ?? string.Empty)
-                    .Join("");
+                    .Join();
 
                 return new DockerReportedConfig(jTokenImage?.ToString(), options, jTokenImageHash?.ToString());
             }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerConfigTest.cs
@@ -102,10 +102,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         [Fact]
         public void TestDeserializationError()
         {
-            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error1));
-            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error2));
-            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error3));
-            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error4));
+            var ex1 = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error1));
+            Assert.Equal("Error while parsing chunked field \"createOptions\", expected createOptions01 found createOptions02", ex1.Message);
+
+            var ex2 = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error2));
+            Assert.Equal("Error while parsing chunked field \"createOptions\", expected createOptions01 found createOptions02", ex2.Message);
+
+            var ex3 = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error3));
+            Assert.Equal("Error while parsing chunked field \"createOptions\", expected empty field number but found \"00\"", ex3.Message);
+
+            var ex4 = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error4));
+            Assert.Equal("Error while parsing chunked field \"createOptions\", expected empty field number but found \"01\"", ex4.Message);
         }
 
         [Fact]

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerConfigTest.cs
@@ -3,10 +3,14 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
 {
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
+    using global::Docker.DotNet.Models;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Newtonsoft.Json;
     using Xunit;
 
     [ExcludeFromCodeCoverage]
+    [Unit]
     public class DockerConfigTest
     {
         static readonly DockerConfig Config1 = new DockerConfig("image1:42");
@@ -14,7 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         static readonly DockerConfig Config3 = new DockerConfig("image1:42");
         static readonly DockerConfig Config4 = new DockerConfig("image1:43");
         static readonly DockerConfig ConfigWithWhitespace = new DockerConfig(" image1:42 ");
-        
+
         static readonly DockerConfig Config5 = new DockerConfig("image1:42", @"{""HostConfig"": {""PortBindings"": {""42/udp"": [{""HostPort"": ""42""}]}}}");
         static readonly DockerConfig Config6 = new DockerConfig("image1:42", @"{""Env"": [""k1=v1"", ""k2=v2""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}]}}}");
         static readonly DockerConfig Config7 = new DockerConfig("image1:42", @"{""Env"": [""k1=v1"", ""k2=v2""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}]}}}");
@@ -22,10 +26,55 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         static readonly DockerConfig Config9 = new DockerConfig("image1:42", @"{""Env"": [""k1=v1"", ""k2=v2"", ""k3=v3""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}], ""42/tcp"": [{""HostPort"": ""42""}]}}}");
 
         static readonly DockerConfig Config10 = new DockerConfig("image1:42", @"{""Env"": [""k11=v11"", ""k22=v22""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}]}}}");
-        static readonly DockerConfig Config11 = new DockerConfig("image1:42", @"{""Env"": [""k33=v33"", ""k44=v44""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}]}}}");        
+        static readonly DockerConfig Config11 = new DockerConfig("image1:42", @"{""Env"": [""k33=v33"", ""k44=v44""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}]}}}");
+
+        static readonly string Extended9 = @"
+        {
+            'image': 'image1:42',
+            'createOptions': ""{'Env': ['k1=v1', 'k2=v2', 'k3=v3'], 'HostConfig'"",
+            'createOptions01': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions02': ""3'}], '42/tcp': [{'HostPort': '42'}]}}}""
+        }";
+
+        static readonly string Extended9Order = @"
+        {
+            'image': 'image1:42',
+            'createOptions01': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions02': ""3'}], '42/tcp': [{'HostPort': '42'}]}}}"",
+            'createOptions': ""{'Env': ['k1=v1', 'k2=v2', 'k3=v3'], 'HostConfig'""
+        }";
+
+        static readonly string Extended9Error1 = @"
+        {
+            'image': 'image1:42',
+            'createOptions': ""{'Env': ['k1=v1', 'k2=v2', 'k3=v3'], 'HostConfig'"",
+            'createOptions02': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions03': ""3'}], '42/tcp': [{'HostPort': '42'}]}}}""
+        }";
+
+        static readonly string Extended9Error2 = @"
+        {
+            'image': 'image1:42',
+            'createOptions': ""{'Env': ['k1=v1', 'k2=v2', 'k3=v3'], 'HostConfig'"",
+            'createOptions02': ""3'}], '42/tcp': [{'HostPort': '42'}]}}}""
+        }";
+
+        static readonly string Extended9Error3 = @"
+        {
+            'image': 'image1:42',
+            'createOptions00': ""{'Env': ['k1=v1', 'k2=v2', 'k3=v3'], 'HostConfig'"",
+            'createOptions01': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions02': ""3'}], '42/tcp': [{'HostPort': '42'}]}}}""
+        }";
+
+        static readonly string Extended9Error4 = @"
+        {
+            'image': 'image1:42',
+            'createOptions01': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions02': ""3'}], '42/tcp': [{'HostPort': '42'}]}}}""
+        }";
 
         [Fact]
-        [Unit]
         public void TestEquality()
         {
             Assert.Equal(Config1, Config1);
@@ -41,6 +90,34 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             Assert.False(Config1.Equals((object)null));
             Assert.False(Config1.Equals(new object()));
             Assert.Equal(Config1, ConfigWithWhitespace);
+        }
+
+        [Fact]
+        public void TestDeserialization()
+        {
+            Assert.Equal(Config9, JsonConvert.DeserializeObject<DockerConfig>(Extended9));
+            Assert.Equal(Config9, JsonConvert.DeserializeObject<DockerConfig>(Extended9Order));
+        }
+
+        [Fact]
+        public void TestDeserializationError()
+        {
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error1));
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error2));
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error3));
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerConfig>(Extended9Error4));
+        }
+
+        [Fact]
+        public void TestSerialization()
+        {
+            var createOptions = @"{""Env"": [""k1=v1"", ""k2=v2"", ""k3=v3""], ""HostConfig"": {""PortBindings"": {""43/udp"": [" +
+                string.Join(", ", Enumerable.Repeat(@"{""HostPort"": ""43""}", 50)) +
+                @"], ""42/tcp"": [{""HostPort"": ""42""}]}}}";
+            var config = new DockerConfig("image1:42", createOptions);
+            var json = JsonConvert.SerializeObject(config);
+            var expected = "{\"image\":\"image1:42\",\"createOptions\":\"{\\\"Env\\\":[\\\"k1=v1\\\",\\\"k2=v2\\\",\\\"k3=v3\\\"],\\\"HostConfig\\\":{\\\"PortBindings\\\":{\\\"43/udp\\\":[{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostP\",\"createOptions01\":\"ort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"}],\\\"42/tcp\\\":[{\\\"HostPort\\\":\\\"42\\\"}]}}}\"}";
+            Assert.Equal(expected, json);
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerReportedConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerReportedConfigTest.cs
@@ -3,10 +3,13 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
 {
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Newtonsoft.Json;
     using Xunit;
 
     [ExcludeFromCodeCoverage]
+    [Unit]
     public class DockerReportedConfigTest
     {
         static readonly DockerReportedConfig Config1 = new DockerReportedConfig("image1:42", @"{""HostConfig"": {""PortBindings"": {""42/udp"": [{""HostPort"": ""42""}]}}}", "sha256:foo");
@@ -15,14 +18,93 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         static readonly DockerReportedConfig Config4 = new DockerReportedConfig("image1:43", @"{""Env"": [""k1=v1"", ""k2=v2""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}]}}}", "sha256:foo");
         static readonly DockerReportedConfig Config5 = new DockerReportedConfig("image1:43", @"{""Env"": [""k1=v1"", ""k2=v2""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}]}}}", "sha256:foosha");
 
+        static readonly string Extended5 = @"
+        {
+            'image': 'image1:43',
+            'imageHash': 'sha256:foosha',
+            'createOptions': ""{'Env': ['k1=v1', 'k2=v2'], 'HostConfig'"",
+            'createOptions01': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions02': ""3'}]}}}""
+        }";
+
+        static readonly string Extended5Order = @"
+        {
+            'image': 'image1:43',
+            'imageHash': 'sha256:foosha',
+            'createOptions01': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions02': ""3'}]}}}"",
+            'createOptions': ""{'Env': ['k1=v1', 'k2=v2'], 'HostConfig'""
+        }";
+
+        static readonly string Extended5Error1 = @"
+        {
+            'image': 'image1:43',
+            'imageHash': 'sha256:foosha',
+            'createOptions': ""{'Env': ['k1=v1', 'k2=v2'], 'HostConfig'"",
+            'createOptions02': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions03': ""3'}]}}}""
+        }";
+
+        static readonly string Extended5Error2 = @"
+        {
+            'image': 'image1:43',
+            'imageHash': 'sha256:foosha',
+            'createOptions': ""{'Env': ['k1=v1', 'k2=v2'], 'HostConfig'"",
+            'createOptions02': ""3'}]}}}""
+        }";
+
+        static readonly string Extended5Error3 = @"
+        {
+            'image': 'image1:43',
+            'imageHash': 'sha256:foosha',
+            'createOptions00': ""{'Env': ['k1=v1', 'k2=v2'], 'HostConfig'"",
+            'createOptions01': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions02': ""3'}]}}}""
+        }";
+
+        static readonly string Extended5Error4 = @"
+        {
+            'image': 'image1:43',
+            'imageHash': 'sha256:foosha',
+            'createOptions01': "": {'PortBindings': {'43/udp': [{'HostPort': '4"",
+            'createOptions02': ""3'}]}}}""
+        }";
+
         [Fact]
-        [Unit]
         public void TestEquality()
         {
             Assert.NotEqual(Config1, Config2);
             Assert.Equal(Config2, Config3);
             Assert.NotEqual(Config3, Config4);
             Assert.NotEqual(Config4, Config5);
+        }
+
+        [Fact]
+        public void TestDeserialization()
+        {
+            Assert.Equal(Config5, JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5));
+            Assert.Equal(Config5, JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Order));
+        }
+
+        [Fact]
+        public void TestDeserializationError()
+        {
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error1));
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error2));
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error3));
+            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error4));
+        }
+
+        [Fact]
+        public void TestSerialization()
+        {
+            var createOptions = @"{""Env"": [""k1=v1"", ""k2=v2"", ""k3=v3""], ""HostConfig"": {""PortBindings"": {""43/udp"": [" +
+                string.Join(", ", Enumerable.Repeat(@"{""HostPort"": ""43""}", 50)) +
+                @"], ""42/tcp"": [{""HostPort"": ""42""}]}}}";
+            var config = new DockerReportedConfig("image1:42", createOptions, "sha256:foosha");
+            var json = JsonConvert.SerializeObject(config);
+            var expected = "{\"image\":\"image1:42\",\"imageHash\":\"sha256:foosha\",\"createOptions\":\"{\\\"Env\\\":[\\\"k1=v1\\\",\\\"k2=v2\\\",\\\"k3=v3\\\"],\\\"HostConfig\\\":{\\\"PortBindings\\\":{\\\"43/udp\\\":[{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostP\",\"createOptions01\":\"ort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"},{\\\"HostPort\\\":\\\"43\\\"}],\\\"42/tcp\\\":[{\\\"HostPort\\\":\\\"42\\\"}]}}}\"}";
+            Assert.Equal(expected, json);
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerReportedConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerReportedConfigTest.cs
@@ -89,10 +89,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         [Fact]
         public void TestDeserializationError()
         {
-            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error1));
-            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error2));
-            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error3));
-            Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error4));
+            var ex1 = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error1));
+            Assert.Equal("Error while parsing chunked field \"createOptions\", expected createOptions01 found createOptions02", ex1.Message);
+
+            var ex2 = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error2));
+            Assert.Equal("Error while parsing chunked field \"createOptions\", expected createOptions01 found createOptions02", ex2.Message);
+
+            var ex3 = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error3));
+            Assert.Equal("Error while parsing chunked field \"createOptions\", expected empty field number but found \"00\"", ex3.Message);
+
+            var ex4 = Assert.Throws<JsonSerializationException>(() => JsonConvert.DeserializeObject<DockerReportedConfig>(Extended5Error4));
+            Assert.Equal("Error while parsing chunked field \"createOptions\", expected empty field number but found \"01\"", ex4.Message);
         }
 
         [Fact]

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Util
 {
     using System;
+    using System.Collections;
     using System.Collections.Generic;
     using System.Linq;
     using System.Text.RegularExpressions;
@@ -266,7 +267,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 }
             }
 
-            System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
@@ -218,19 +218,19 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 foreach (var (num, kv) in tokens)
                 {
                     var strNum = this.regex.Match(kv.Key).Groups["num"].Value;
-                    Validate(strNum, num);
+                    this.Validate(strNum, num);
                     yield return kv.Value;
                 }
             }
 
-            static void Validate(string strNum, uint expectedNum)
+            void Validate(string strNum, uint expectedNum)
             {
                 // The zero-th item should have an empty num
                 if (expectedNum == 0)
                 {
                     if (strNum != string.Empty)
                     {
-                        throw new JsonSerializationException(string.Format("Expected empty field number but found \"{0}\"", strNum));
+                        throw new JsonSerializationException(string.Format("Error while parsing chunked field \"{0}\", expected empty field number but found \"{1}\"", this.name, strNum));
                     }
                 }
                 else
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
                     if (expectedNum != tokenNum)
                     {
-                        throw new JsonSerializationException(string.Format("Error while parsing chunked field, expected {0} found {1}", expectedNum, tokenNum));
+                        throw new JsonSerializationException(string.Format("Error while parsing chunked field \"{0}\", expected {0}{1:D2} found {0}{2}", this.name, expectedNum, strNum));
                     }
                 }
             }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
@@ -179,8 +179,27 @@ namespace Microsoft.Azure.Devices.Edge.Util
             return token;
         }
 
+        /// <summary>
+        /// Returns an ordered iterator of JTokens for a chunked field.
+        /// The field must use a sequence number suffix, excluding zero.
+        /// For example, createOptions, createOptions01, createOptions02, etc.
+        /// The iterator assumes that these fields are string sortable.
+        /// </summary>
+        /// <param name="self">The JObject</param>
+        /// <param name="name">The base name of the field. For example, createOptions</param>
+        /// <returns></returns>
         public static IEnumerable<JToken> ChunkedValue(this JObject self, string name) => new ChunkedProperty(self, name);
 
+        /// <summary>
+        /// Returns an ordered iterator of JTokens for a chunked field.
+        /// The field must use a sequence number suffix, excluding zero.
+        /// For example, createOptions, createOptions01, createOptions02, etc.
+        /// The iterator assumes that these fields are string sortable.
+        /// </summary>
+        /// <param name="self">The JObject</param>
+        /// <param name="name">The base name of the field. For example, createOptions</param>
+        /// <param name="ignoreCase">If true, ignore case of the field name</param>
+        /// <returns></returns>
         public static IEnumerable<JToken> ChunkedValue(this JObject self, string name, bool ignoreCase) => new ChunkedProperty(self, name, ignoreCase);
 
         class ChunkedProperty : IEnumerable<JToken>

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/LinqEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/LinqEx.cs
@@ -60,6 +60,24 @@ namespace Microsoft.Azure.Devices.Edge.Util
             IEnumerable<string> second,
             Func<string, string> keySelector
         ) => first.Except(second, new StringKeyComparer(keySelector));
+
+
+        /// <summary>
+        /// Converts an IEnumerable<typeparamref name="T"/> into an IEnumerable<(uint, typeparamref name="T")/>.
+        /// The uint provides the current count of items.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="self"></param>
+        /// <returns></returns>
+        public static IEnumerable<(uint, T)> Enumerate<T>(this IEnumerable<T> self)
+        {
+            uint num = 0;
+            foreach (var item in self)
+            {
+                yield return (num, item);
+                num += 1;
+            }
+        }
     }
 
     internal class StringKeyComparer : IEqualityComparer<string>

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/StringEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/StringEx.cs
@@ -7,6 +7,13 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
     public static class StringEx
     {
+        /// <summary>
+        /// Adds an extension method to string that returns an iterator
+        /// of strings of a specific length.
+        /// </summary>
+        /// <param name="self"></param>
+        /// <param name="size"></param>
+        /// <returns></returns>
         public static IEnumerable<string> Chunks(this string self, int size)
         {
             Preconditions.CheckNotNull(self, nameof(self));
@@ -19,8 +26,19 @@ namespace Microsoft.Azure.Devices.Edge.Util
             }
         }
 
+        /// <summary>
+        /// Adds an extension method to make string.Join more ergonomic
+        /// </summary>
+        /// <param name="strings"></param>
+        /// <returns></returns>
         public static string Join(this IEnumerable<string> strings) => strings.Join("");
 
+        /// <summary>
+        /// Adds an extension method to make string.Join more ergonomic
+        /// </summary>
+        /// <param name="strings"></param>
+        /// <param name="separator"></param>
+        /// <returns></returns>
         public static string Join(this IEnumerable<string> strings, string separator) => string.Join(separator, strings);
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/StringEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/StringEx.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+    using System.Collections.Generic;
+
+    public static class StringEx
+    {
+        public static IEnumerable<string> Chunks(this string self, int size)
+        {
+            Preconditions.CheckNotNull(self, nameof(self));
+            Preconditions.CheckRange(size, 0, nameof(size));
+
+            var length = self.Length;
+            for (int i = 0; i < length; i += size)
+            {
+                yield return self.Substring(i, Math.Min(size, length - i));
+            }
+        }
+
+        public static string Join(this IEnumerable<string> strings) => strings.Join("");
+
+        public static string Join(this IEnumerable<string> strings, string separator) => string.Join(separator, strings);
+    }
+}

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/LinqExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/LinqExTest.cs
@@ -129,5 +129,19 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 "k3=v32"
             }));
         }
+
+        [Fact]
+        [Unit]
+        public void EnumerateTest()
+        {
+            var strings = new List<string> { "zero", "one", "two" };
+            var expected = new List<(uint, string)>
+            {
+                {  (0, "zero") },
+                {  (1, "one") },
+                {  (2, "two") },
+            };
+            Assert.Equal(expected, strings.Enumerate().ToList());
+        }
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/StringExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/StringExTest.cs
@@ -2,6 +2,7 @@
 
 namespace Microsoft.Azure.Devices.Edge.Util.Test
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
@@ -24,6 +25,13 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             var str = "aaabb";
             var expected = new List<string> { "aaa", "bb" };
             Assert.Equal(expected, str.Chunks(3).ToList());
+        }
+
+        [Fact]
+        public void ErrorTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => StringEx.Chunks(null, 3).ToList());
+            Assert.Throws<ArgumentOutOfRangeException>(() => "test".Chunks(-1).ToList());
         }
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/StringExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/StringExTest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Util.Test
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Xunit;
+
+    [Unit]
+    public class StringExTest
+    {
+        [Fact]
+        public void EvenChunksTest()
+        {
+            var str = "aaabbb";
+            var expected = new List<string> { "aaa", "bbb" };
+            Assert.Equal(expected, str.Chunks(3).ToList());
+        }
+
+        [Fact]
+        public void UnevenChunksTest()
+        {
+            var str = "aaabb";
+            var expected = new List<string> { "aaa", "bb" };
+            Assert.Equal(expected, str.Chunks(3).ToList());
+        }
+    }
+}


### PR DESCRIPTION
**Question**
The proposal is listed below. The only item not implemented is the limit on number of chunks. It's currently limited to 100, which gives the full range of two-byte sequence numbers. Does this need to be implemented in the runtime?

# Extending `createOptions` Length
The `createOptions` field in the Edge Agent's twin is part of a module's Docker configuration.
It is an optional field and is used to customize the settings of the Docker container.
Due to the value length limit in the twin, it is restricted to 512 bytes.
Customers have recently been running into this restriction and would like the ability to provide longer `createOptions` on IoT Edge.

## Background
The `createOptions` field allows container's settings to be customized.
For instance, `createOptions` allows a container's mounts, network, port bindings, devices, etc. to be specified.

It is a JSON object with a specific schema.
The schema for this configuration is defined by the Docker Engine, and the IoT Edge runtime cannot modify it.

Due to the lack of arrays in the device twin and the restriction on the depth of objects, this JSON object is stringified and placed into each `module` object of the Edge Agent twin as a field named `createOptions`.

Here is an example of the Edge Agent twin including example `createOptions`.

```json
{
    "systemModules": {
        "edgeAgent": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-agent:1.0.1",
                "createOptions": "{}"
            },
            "env": {
                "RuntimeLogLevel": {
                    "value": "Debug"
                }
            }
        },
        "edgeHub": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-hub:1.0.1",
                "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}],\"5671/tcp\":[{\"HostPort\":\"5671\"}]}}}"
            },
            "status": "running",
            "restartPolicy": "always"
        }
    },
    "modules": {
        "tempsensor": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0.1",
                "createOptions": "{}"
            },
            "version": "1.0",
            "status": "running",
            "restartPolicy": "always"
        }
    }
}
```

Stringifying this JSON object limits its size to 512 bytes.
There are many scenarios where this limit is not enough, particularly when modules need access to hardware on the device.

Since the Edge Agent ultimately owns this schema, changes can be made to increase the effective length of the `createOptions`.

## Proposal

The `createOptions` field in the Edge Agent twin will be chunked into several fields when serializing, with each value less than or equal to the `512b` limit.
These fields will be concatenated when deserializing.

These chunks need to be ordered so that they can be concatenated properly.
However, the device twin does not currently support arrays.
To workaround this limitation, the new fields will append a sequence number to the `createOptions` fields.

To preserve backwards compatibility, the sequence number will start at 1, with the original `createOptions` field remaining unchanged, with an implicit sequence number of 0.
This allows current deployments to function correctly without any changes.
The sequence number consists of two bytes, representing zero-padded integers (`01` - `07`).
This is to allow string compare of these fields.

The sequence numbers must be provided without gaps, and with a limit of 7.
Eight `512b` chunks allows for `4kb` of space, which should be more than enough based on customer feedback.

## Example
Here is an example of a valid Edge Agent twin with extended `createOptions`:

```json
{
    "systemModules": {
        "edgeAgent": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-agent:1.0.1",
                "createOptions": "{}"
            },
            "env": {
                "RuntimeLogLevel": {
                    "value": "Debug"
                }
            }
        },
        "edgeHub": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-hub:1.0.1",
                "createOptions": "{\"HostConfig\":{\"PortBindings\"",
                "createOptions01": ":{\"8883/tcp\":[{\"HostPort\":\"88",
                "createOptions02": "83\"}],\"443/tcp\":[{\"HostPort\":",
                "createOptions03": "\"443\"}],\"5671/tcp\":[{\"HostPort\"",
                "createOptions04": ":\"5671\"}]}}}"
            },
            "status": "running",
            "restartPolicy": "always"
        }
    },
    "modules": {
        "tempsensor": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0.1",
                "createOptions": "{}"
            },
            "version": "1.0",
            "status": "running",
            "restartPolicy": "always"
        }
    }
}
```

The following example is also valid, even though the fields are listed out of order:

```json
{
    "systemModules": {
        "edgeAgent": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-agent:1.0.1",
                "createOptions": "{}"
            },
            "env": {
                "RuntimeLogLevel": {
                    "value": "Debug"
                }
            }
        },
        "edgeHub": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-hub:1.0.1",
                "createOptions": "{\"HostConfig\":{\"PortBindings\"",
                "createOptions03": "\"443\"}],\"5671/tcp\":[{\"HostPort\"",
                "createOptions02": "83\"}],\"443/tcp\":[{\"HostPort\":",
                "createOptions04": ":\"5671\"}]}}}",
                "createOptions01": ":{\"8883/tcp\":[{\"HostPort\":\"88"
            },
            "status": "running",
            "restartPolicy": "always"
        }
    },
    "modules": {
        "tempsensor": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0.1",
                "createOptions": "{}"
            },
            "version": "1.0",
            "status": "running",
            "restartPolicy": "always"
        }
    }
}
```

The following example is *invalid* because the `createOptions` fields are not contiguous:

```json
{
    "systemModules": {
        "edgeAgent": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-agent:1.0.1",
                "createOptions": "{}"
            },
            "env": {
                "RuntimeLogLevel": {
                    "value": "Debug"
                }
            }
        },
        "edgeHub": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-hub:1.0.1",
                "createOptions": "{\"HostConfig\":{\"PortBindings\"",
                "createOptions01": ":{\"8883/tcp\":[{\"HostPort\":\"88",
                "createOptions03": "83\"}],\"443/tcp\":[{\"HostPort\":",
                "createOptions04": "\"443\"}],\"5671/tcp\":[{\"HostPort\"",
                "createOptions05": ":\"5671\"}]}}}"
            },
            "status": "running",
            "restartPolicy": "always"
        }
    },
    "modules": {
        "tempsensor": {
            "type": "docker",
            "settings": {
                "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0.1",
                "createOptions": "{}"
            },
            "version": "1.0",
            "status": "running",
            "restartPolicy": "always"
        }
    }
}
```