### PR TITLE
Add PartOf to the iotedged socket units

### DIFF
--- a/edgelet/contrib/systemd/debian/iotedge.mgmt.socket
+++ b/edgelet/contrib/systemd/debian/iotedge.mgmt.socket
@@ -1,6 +1,7 @@
 [Unit]
 Description=Azure IoT Edge daemon management socket
 Documentation=man:iotedged(8)
+PartOf=iotedge.service
 
 [Socket]
 ListenStream=/var/run/iotedge/mgmt.sock

--- a/edgelet/contrib/systemd/debian/iotedge.socket
+++ b/edgelet/contrib/systemd/debian/iotedge.socket
@@ -1,6 +1,7 @@
 [Unit]
 Description=Azure IoT Edge daemon workload socket
 Documentation=man:iotedged(8)
+PartOf=iotedge.service
 
 [Socket]
 ListenStream=/var/run/iotedge/workload.sock


### PR DESCRIPTION
This prevents the socket activation from restarting the `iotedged` service if it was explicitly stopped with `systemctl stop iotedge`.

Fixes #398 