### PR TITLE
Fix AMQP for C SDK

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Constants.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Constants.cs
@@ -34,5 +34,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
         public const string MessageAnnotationsConnectionModuleId = "iothub-connection-module-id";
         public const string WebSocketSubProtocol = "AMQPWSB10";
         public const string WebSocketListenerName = WebSocketSubProtocol +"-listener";
+        public const string ServiceBusCbsSaslMechanismName = "MSSBCBS";
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/settings/AmqpSettingsProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/settings/AmqpSettingsProvider.cs
@@ -53,7 +53,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Settings
                 //       needs (i.e. old clients that are still using EXTERNAL for CBS).
                 // saslProvider.AddHandler(new SaslExternalHandler());
 
-                saslProvider.AddHandler(new SaslAnonymousHandler()); // CBS for other clients
+                // CBS 
+                saslProvider.AddHandler(new SaslAnonymousHandler());
+
+                // CBS - used by some SDKs like C
+                saslProvider.AddHandler(new SaslAnonymousHandler(Constants.ServiceBusCbsSaslMechanismName));
 
                 // This handler implements SAS key based auth.
                 saslProvider.AddHandler(new SaslPlainHandler(new EdgeHubSaslPlainAuthenticator(authenticator, identityFactory, iotHubHostName)));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/AmqpSettingsProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/AmqpSettingsProviderTest.cs
@@ -3,6 +3,9 @@
 namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 {
     using System;
+    using Microsoft.Azure.Amqp;
+    using Microsoft.Azure.Amqp.Sasl;
+    using Microsoft.Azure.Amqp.Transport;
     using Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers;
     using Microsoft.Azure.Devices.Edge.Hub.Amqp.Settings;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
@@ -11,10 +14,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
     using Moq;
     using Xunit;
 
+    [Unit]
     public class AmqpSettingsProviderTest
     {
-        [Fact]
-        [Unit]
+        [Fact]        
         public void TestInvalidInputsForGetDefaultAmqpSettings()
         {
             const string IotHubHostName = "restaurantatendofuniverse.azure-devices.net";
@@ -28,6 +31,41 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Assert.Throws<ArgumentNullException>(() => AmqpSettingsProvider.GetDefaultAmqpSettings(IotHubHostName, authenticator.Object, null, linkHandlerProvider, connectionProvider, new NullCredentialsCache()));
 
             Assert.NotNull(AmqpSettingsProvider.GetDefaultAmqpSettings(IotHubHostName, authenticator.Object, identityFactory.Object, linkHandlerProvider, connectionProvider, new NullCredentialsCache()));
+        }
+
+        [Fact]
+        public void ValidateSettingsTest()
+        {
+            // Arrange
+            string iotHubHostName = "foo.azure-devices.net";
+            var authenticator = Mock.Of<IAuthenticator>();
+            var identityFactory = Mock.Of<IClientCredentialsFactory>();
+            var linkHandlerProvider = Mock.Of<ILinkHandlerProvider>();
+            var connectionProvider = Mock.Of<IConnectionProvider>();
+
+            // Act
+            AmqpSettings settings = AmqpSettingsProvider.GetDefaultAmqpSettings(iotHubHostName, authenticator, identityFactory, linkHandlerProvider, connectionProvider, new NullCredentialsCache());
+
+            // Assert
+            Assert.NotNull(settings);
+            Assert.Equal(2, settings.TransportProviders.Count);
+
+            var saslTransportProvider = settings.GetTransportProvider<SaslTransportProvider>();
+            Assert.NotNull(saslTransportProvider);
+
+            SaslHandler anonHandler = saslTransportProvider.GetHandler("ANONYMOUS", false);
+            Assert.NotNull(anonHandler);
+
+            SaslHandler plainHandler = saslTransportProvider.GetHandler("PLAIN", false);
+            Assert.NotNull(plainHandler);
+
+            SaslHandler cbsHandler = saslTransportProvider.GetHandler(Amqp.Constants.ServiceBusCbsSaslMechanismName, false);
+            Assert.NotNull(cbsHandler);
+
+            var amqpTransportProvider = settings.GetTransportProvider<AmqpTransportProvider>();
+            Assert.NotNull(amqpTransportProvider);
+
+            Assert.Equal(Amqp.Constants.AmqpVersion100, amqpTransportProvider.Versions[0]);
         }
     }
 }


### PR DESCRIPTION
C SDK uses CBS Auth with Anon auth with a different mechanism name (MSSBCBS) than the C# SDK, I suppose for legacy reasons. So adding that the EdgeHub as well. 