### PR TITLE
EdgeHub: Logs to identify messages received

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -59,7 +59,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
 
         public Task ProcessDeviceMessageBatch(IIdentity identity, IEnumerable<IMessage> messages)
         {
-            IList<IMessage> messagesList = Preconditions.CheckNotNull(messages, nameof(messages)).ToList();
+            Preconditions.CheckNotNull(messages, nameof(messages));
+            IList<IMessage> messagesList = messages as IList<IMessage> ?? messages.ToList();
             Events.MessagesReceived(identity, messagesList);
             Metrics.MessageCount(identity, messagesList.Count);
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -421,36 +421,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             {
                 Log.LogWarning((int)EventIds.ProcessingSubscription, e, Invariant($"Error processing subscriptions for connected clients."));
             }
-            
-            public static void MessagesReceived(IIdentity identity, IEnumerable<IMessage> messages)
+
+            public static void MessagesReceived(IIdentity identity, IList<IMessage> messages)
             {
                 if (Logger.GetLogLevel() <= LogEventLevel.Debug)
                 {
-                    if (messages.Count > 1)
+                    string messageIdsString = messages
+                        .Select(m => m.SystemProperties.TryGetValue(SystemProperties.MessageId, out string messageId) ? messageId : string.Empty)
+                        .Where(m => !string.IsNullOrWhiteSpace(m))
+                        .Join(", ");
+
+                    if (!string.IsNullOrWhiteSpace(messageIdsString))
                     {
-                        IEnumerable<string> messageIds = messages
-                            .Select(m => m.SystemProperties.TryGetValue(SystemProperties.MessageId, out string messageId) ? messageId : string.Empty)
-                            .Where(m => !string.IsNullOrWhiteSpace(m));
-                        string messageIdsString = string.Join(", ", messageIds);
-                        if (!string.IsNullOrWhiteSpace(messageIdsString))
-                        {
-                            Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received messages from {identity.Id} with message Ids [{messageIdsString}]"));
-                        }
-                        else
-                        {
-                            Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received {messages.Count} messages from {identity.Id}"));
-                        }
+                        Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received {messages.Count} messages from {identity.Id} with message Ids [{messageIdsString}]"));
                     }
-                    else if (messages.Count == 1)
+                    else
                     {
-                        if (messages[0].SystemProperties.TryGetValue(SystemProperties.MessageId, out string messageId))
-                        {
-                            Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received message from {identity.Id} with message Id {messageId}"));
-                        }
-                        else
-                        {
-                            Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received message from {identity.Id}"));
-                        }
+                        Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received {messages.Count} messages from {identity.Id}"));
                     }
                 }
             }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -433,11 +433,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
 
                     if (!string.IsNullOrWhiteSpace(messageIdsString))
                     {
-                        Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received {messages.Count} messages from {identity.Id} with message Ids [{messageIdsString}]"));
+                        Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received {messages.Count} message(s) from {identity.Id} with message Id(s) [{messageIdsString}]"));
                     }
                     else
                     {
-                        Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received {messages.Count} messages from {identity.Id}"));
+                        Log.LogDebug((int)EventIds.MessageReceived, Invariant($"Received {messages.Count} message(s) from {identity.Id}"));
                     }
                 }
             }


### PR DESCRIPTION
Currently we don't log messageId of the received messages. The message logs are also slightly different for MQTT/AMQP. So adding a unified log when messages are received. It also logs the MessageId of the received message, if one exists.