### PR TITLE
Move enable_testing() to root directory of hsm lib.

### DIFF
--- a/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
@@ -111,6 +111,7 @@ function(prepare_edge_homedir whatIsBuilding)
 endfunction(prepare_edge_homedir)
 
 if (run_unittests)
+    enable_testing()
     set(save_ut ${run_unittests})
     set(run_unittests OFF CACHE BOOL "unittests" FORCE)
 endif(run_unittests)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/CMakeLists.txt
@@ -4,7 +4,6 @@
 include(../deps/c-shared/configs/azure_iot_build_rules.cmake)
 usePermissiveRulesForSamplesAndTests()
 
-enable_testing()
 set(save_ut ${run_unittests})
 set(run_unittests OFF CACHE BOOL "unittests" FORCE)
 add_subdirectory(../deps/c-shared/testtools/ctest c-shared/testtools/ctest)


### PR DESCRIPTION
I moved the call to enable_testing() into the "tests" directory, but ctest will not find tests at the base directory.  Moving the enable_testing() call to the base dir will fix that, and the HSM tests launched from `cargo test` will run.