### PR TITLE
Add key usage extensions to certificates

### DIFF
--- a/edgelet/hsm-sys/azure-iot-hsm-c/src/edge_pki_openssl.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/src/edge_pki_openssl.c
@@ -842,12 +842,12 @@ static int set_key_usage
     }
     else if (cert_type == CERTIFICATE_TYPE_CLIENT)
     {
-        usage = "critical, nonRepudiation, digitalSignature, keyEncipherment";
+        usage = "critical, nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment";
         ext_usage = "clientAuth";
     }
     else
     {
-        usage = "critical, digitalSignature, keyEncipherment, dataEncipherment";
+        usage = "critical, nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment, keyAgreement";
         ext_usage = "serverAuth";
     }
 

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
@@ -162,11 +162,7 @@ MOCKABLE_FUNCTION(, const char*, get_locality, CERT_PROPS_HANDLE, handle);
 MOCKABLE_FUNCTION(, const char*, get_organization_name, CERT_PROPS_HANDLE, handle);
 MOCKABLE_FUNCTION(, const char*, get_organization_unit, CERT_PROPS_HANDLE, handle);
 MOCKABLE_FUNCTION(, CERTIFICATE_TYPE, get_certificate_type, CERT_PROPS_HANDLE, handle);
-
-// #define LHASH_OF(type) struct lhash_st_##type
-//struct lhash_st_CONF_VALUE;
-//LHASH_OF(CONF_VALUE);
-MOCKABLE_FUNCTION(, X509_EXTENSION*, X509V3_EXT_conf_nid, LHASH_OF(CONF_VALUE)*, conf, X509V3_CTX*, ctx, int, ext_nid, const char*, value);
+MOCKABLE_FUNCTION(, X509_EXTENSION*, mocked_X509V3_EXT_conf_nid, struct lhash_st_CONF_VALUE*, conf, X509V3_CTX*, ctx, int, ext_nid, char*, value);
 MOCKABLE_FUNCTION(, int, X509_add_ext, X509*, x, X509_EXTENSION*, ex, int, loc);
 MOCKABLE_FUNCTION(, void, X509_EXTENSION_free, X509_EXTENSION*, ex);
 
@@ -258,7 +254,7 @@ static TEST_MUTEX_HANDLE g_dllByDll;
 #define TEST_CERT_PROPS_HANDLE (CERT_PROPS_HANDLE)0x2029
 #define TEST_WRITE_PRIVATE_KEY_FD (int)0x2030
 #define TEST_WRITE_CERTIFICATE_FD (int)0x2031
-
+#define TEST_NID_EXTENSION (X509_EXTENSION*)0x2032
 #define TEST_UTC_TIME_FROM_ASN1 1000
 #define VALID_ASN1_TIME_STRING_UTC_FORMAT 0x17
 #define VALID_ASN1_TIME_STRING_UTC_LEN    13
@@ -1049,6 +1045,36 @@ static CERTIFICATE_TYPE test_hook_get_certificate_type(CERT_PROPS_HANDLE handle)
     return TEST_PROPS_CERT_TYPE;
 }
 
+static X509_EXTENSION* test_hook_mocked_X509V3_EXT_conf_nid
+(
+    struct lhash_st_CONF_VALUE *conf,
+    X509V3_CTX *ctx,
+    int ext_nid,
+    char *value
+)
+{
+    (void)conf;
+    (void)ctx;
+    (void)ext_nid;
+    (void)value;
+
+    return TEST_NID_EXTENSION;
+}
+
+static int test_hook_X509_add_ext(X509* x, X509_EXTENSION* ex, int loc)
+{
+    (void)x;
+    (void)ex;
+    (void)loc;
+
+    return 1;
+}
+
+static void test_hook_X509_EXTENSION_free(X509_EXTENSION* ex)
+{
+    (void)ex;
+}
+
 //#############################################################################
 // Test helpers
 //#############################################################################
@@ -1383,6 +1409,68 @@ static void test_helper_cert_create_with_subject
 
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_free(&TEST_NON_CA_BASIC_CONSTRAINTS));
         ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+    }
+
+    if (cert_type == CERTIFICATE_TYPE_CA)
+    {
+        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, digitalSignature, cRLSign, keyCertSign"));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
+        i++;
+    }
+    else if (cert_type == CERTIFICATE_TYPE_CLIENT)
+    {
+        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, nonRepudiation, digitalSignature, keyEncipherment"));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
+        i++;
+
+        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_ext_key_usage, "clientAuth"));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
+        i++;
+    }
+    else
+    {
+        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, digitalSignature, keyEncipherment, dataEncipherment"));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
+        i++;
+
+        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_ext_key_usage, "serverAuth"));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
+        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        i++;
+
+        STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
         i++;
     }
 
@@ -1996,6 +2084,14 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
 
         REGISTER_GLOBAL_MOCK_HOOK(get_certificate_type, test_hook_get_certificate_type);
         REGISTER_GLOBAL_MOCK_FAIL_RETURN(get_certificate_type, CERTIFICATE_TYPE_UNKNOWN);
+
+        REGISTER_GLOBAL_MOCK_HOOK(mocked_X509V3_EXT_conf_nid, test_hook_mocked_X509V3_EXT_conf_nid);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(mocked_X509V3_EXT_conf_nid, NULL);
+
+        REGISTER_GLOBAL_MOCK_HOOK(X509_add_ext, test_hook_X509_add_ext);
+        REGISTER_GLOBAL_MOCK_FAIL_RETURN(X509_add_ext, 0);
+
+        REGISTER_GLOBAL_MOCK_HOOK(X509_EXTENSION_free, test_hook_X509_EXTENSION_free);
     }
 
     TEST_SUITE_CLEANUP(TestClassCleanup)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
@@ -1427,7 +1427,7 @@ static void test_helper_cert_create_with_subject
     }
     else if (cert_type == CERTIFICATE_TYPE_CLIENT)
     {
-        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, nonRepudiation, digitalSignature, keyEncipherment"));
+        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment"));
         ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
@@ -1451,7 +1451,7 @@ static void test_helper_cert_create_with_subject
     }
     else
     {
-        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, digitalSignature, keyEncipherment, dataEncipherment"));
+        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment, keyAgreement"));
         ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
@@ -163,6 +163,13 @@ MOCKABLE_FUNCTION(, const char*, get_organization_name, CERT_PROPS_HANDLE, handl
 MOCKABLE_FUNCTION(, const char*, get_organization_unit, CERT_PROPS_HANDLE, handle);
 MOCKABLE_FUNCTION(, CERTIFICATE_TYPE, get_certificate_type, CERT_PROPS_HANDLE, handle);
 
+// #define LHASH_OF(type) struct lhash_st_##type
+//struct lhash_st_CONF_VALUE;
+//LHASH_OF(CONF_VALUE);
+MOCKABLE_FUNCTION(, X509_EXTENSION*, X509V3_EXT_conf_nid, LHASH_OF(CONF_VALUE)*, conf, X509V3_CTX*, ctx, int, ext_nid, const char*, value);
+MOCKABLE_FUNCTION(, int, X509_add_ext, X509*, x, X509_EXTENSION*, ex, int, loc);
+MOCKABLE_FUNCTION(, void, X509_EXTENSION_free, X509_EXTENSION*, ex);
+
 #undef ENABLE_MOCKS
 
 //#############################################################################

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
@@ -1414,7 +1414,7 @@ static void test_helper_cert_create_with_subject
 
     if (cert_type == CERTIFICATE_TYPE_CA)
     {
-        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, digitalSignature, cRLSign, keyCertSign"));
+        STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, digitalSignature, keyCertSign"));
         ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/pki_mocked.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/pki_mocked.c
@@ -25,12 +25,16 @@ MOCKABLE_FUNCTION(, ASN1_TIME*, mocked_X509_get_notAfter, X509*, x509_cert);
 MOCKABLE_FUNCTION(, int, mocked_OPEN, const char*, path, int, flags, MODE_T, mode);
 MOCKABLE_FUNCTION(, int, mocked_CLOSE, int, fd);
 
+struct lhash_st_CONF_VALUE;
+MOCKABLE_FUNCTION(, X509_EXTENSION*, mocked_X509V3_EXT_conf_nid, struct lhash_st_CONF_VALUE*, conf, X509V3_CTX*, ctx, int, ext_nid, char*, value);
+
+#define X509V3_EXT_conf_nid_HELPER(conf, ctx, nid, value) mocked_X509V3_EXT_conf_nid((conf), (ctx), (nid), (value))
+
 #undef X509_get_notBefore
 #undef X509_get_notAfter
 #define X509_get_notBefore mocked_X509_get_notBefore
 #define X509_get_notAfter  mocked_X509_get_notAfter
 
-#undef OPEN_HELPER
 #undef CLOSE_HELPER
 #if defined __WINDOWS__ || defined _WIN32 || defined _WIN64 || defined _Windows
     #define OPEN_HELPER(fname) mocked_OPEN((fname), _O_CREAT|_O_WRONLY|_O_TRUNC, _S_IREAD|_S_IWRITE)


### PR DESCRIPTION
Key usage determines what the certificate keys should be able to perform. More about this can be found here: https://www.ibm.com/support/knowledgecenter/en/SSKTMJ_9.0.1/admin/conf_keyusageextensionsandextendedkeyusage_r.html.

By adding these usage extensions, we further harden the Edge related certificate generation.