### PR TITLE
Use timer for cert renewal

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/CertificateRenewal.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/CertificateRenewal.cs
@@ -23,20 +23,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         {
             Preconditions.CheckNotNull(certificates, nameof(certificates));
             this.logger = Preconditions.CheckNotNull(logger, nameof(logger));
+            this.cts = new CancellationTokenSource();
 
             TimeSpan timeToExpire = certificates.ServerCertificate.NotAfter - DateTime.UtcNow;
             if (timeToExpire > TimeBuffer)
             {
                 var renewAfter = timeToExpire - TimeBuffer;
                 logger.LogInformation("Scheduling server certificate renewal for {0}.", DateTime.UtcNow.Add(renewAfter).ToString("o"));
-                this.cts = new CancellationTokenSource();
                 this.timer = new Timer(this.Callback, null, renewAfter, Timeout.InfiniteTimeSpan);
             }
             else
             {
-                this.cts = new CancellationTokenSource();
-                this.timer = new Timer(this.Callback, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
                 logger.LogWarning("Server certificate is expired ({0}). Not scheduling renewal.", timeToExpire.ToString("c"));
+                this.timer = new Timer(this.Callback, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
             }
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/CertificateRenewal.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/CertificateRenewal.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
     public class CertificateRenewal : IDisposable
     {
         readonly static TimeSpan TimeBuffer = TimeSpan.FromMinutes(5);
+        readonly ILogger logger;
+        readonly Timer timer;
         readonly CancellationTokenSource cts;
 
         /// <summary>
@@ -20,19 +22,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         public CertificateRenewal(EdgeHubCertificates certificates, ILogger logger)
         {
             Preconditions.CheckNotNull(certificates, nameof(certificates));
-            Preconditions.CheckNotNull(logger, nameof(logger));
+            this.logger = Preconditions.CheckNotNull(logger, nameof(logger));
 
             TimeSpan timeToExpire = certificates.ServerCertificate.NotAfter - DateTime.UtcNow;
             if (timeToExpire > TimeBuffer)
             {
                 var renewAfter = timeToExpire - TimeBuffer;
                 logger.LogInformation("Scheduling server certificate renewal for {0}.", DateTime.UtcNow.Add(renewAfter).ToString("o"));
-                this.cts = new CancellationTokenSource(renewAfter);
-                this.cts.Token.Register(l => ((ILogger)l).LogInformation("Restarting process to perform server certificate renewal."), logger);
+                this.cts = new CancellationTokenSource();
+                this.timer = new Timer(this.Callback, null, renewAfter, Timeout.InfiniteTimeSpan);
             }
             else
             {
                 this.cts = new CancellationTokenSource();
+                this.timer = new Timer(this.Callback, null, Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
                 logger.LogWarning("Server certificate is expired ({0}). Not scheduling renewal.", timeToExpire.ToString("c"));
             }
         }
@@ -43,12 +46,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             GC.SuppressFinalize(this);
         }
 
+        void Callback(object _state)
+        {
+            this.logger.LogInformation("Restarting process to perform server certificate renewal.");
+            this.cts.Cancel();
+        }
+
         protected virtual void Dispose(bool disposing)
         {
             if (disposing)
             {
                 try
                 {
+                    this.timer.Dispose();
                     this.cts.Dispose();
                 }
                 catch (OperationCanceledException)


### PR DESCRIPTION
The `CancellationTokenSource` can only accepts delays up to `Int32.MaxValue` milliseconds (~24 days).
The implementation is updated to use a Timer instead which can use `Int64.MaxValue` milliseconds.

This previous change broke the E2E tests because the cert used has expiration greater than 24 days.