### PR TITLE
EdgeHub: Fix recovering connections after connectivity is resumed over AMQP

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             {
                 client.SetProductInfo(newCredentials.ProductInfo);
             }
-
+            await client.OpenAsync();
             Events.CreateDeviceClientSuccess(transportSettings.GetTransportType(), OperationTimeoutMilliseconds, newCredentials.Identity);
             return client;
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 }
                 else
                 {
-                    Events.TokenNotUsable(iotHub, id, token);                    
+                    Events.TokenNotUsable(iotHub, id, token);
                 }
 
                 bool newTokenGetterCreated = false;
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                             Events.SafeCreateNewToken(id);
                             var taskCompletionSource = new TaskCompletionSource<string>();
                             this.tokenGetter = Option.Some(taskCompletionSource);
-                            newTokenGetterCreated = true;                            
+                            newTokenGetterCreated = true;
                             return taskCompletionSource;
                         });
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -99,7 +99,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                 AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings
                                 {
                                     Pooling = true,
-                                    MaxPoolSize = (uint)connectionPoolSize
+                                    MaxPoolSize = (uint)connectionPoolSize,
+                                    ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                                 }
                             },
                             new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
@@ -107,7 +108,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                 AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings
                                 {
                                     Pooling = true,
-                                    MaxPoolSize = (uint)connectionPoolSize
+                                    MaxPoolSize = (uint)connectionPoolSize,
+                                    ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                                 }
                             }
                         });

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
     public class CloudConnectionProvider : ICloudConnectionProvider
     {
+        // Minimum value allowed by the SDK for Connection Idle timeout for AMQP Multiplexed connections.
+        static readonly TimeSpan MinAmqpConnectionMuxIdleTimeout = TimeSpan.FromSeconds(5);
+
         static readonly IDictionary<UpstreamProtocol, TransportType> UpstreamProtocolTransportTypeMap = new Dictionary<UpstreamProtocol, TransportType>
         {
             [UpstreamProtocol.Amqp] = TransportType.Amqp_Tcp_Only,
@@ -76,7 +79,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                         {
                                             Pooling = true,
                                             MaxPoolSize = (uint)connectionPoolSize,
-                                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
+                                            ConnectionIdleTimeout = MinAmqpConnectionMuxIdleTimeout
                                         }
                                     }
                                 };
@@ -100,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                 {
                                     Pooling = true,
                                     MaxPoolSize = (uint)connectionPoolSize,
-                                    ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
+                                    ConnectionIdleTimeout = MinAmqpConnectionMuxIdleTimeout
                                 }
                             },
                             new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
@@ -109,7 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                 {
                                     Pooling = true,
                                     MaxPoolSize = (uint)connectionPoolSize,
-                                    ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
+                                    ConnectionIdleTimeout = MinAmqpConnectionMuxIdleTimeout
                                 }
                             }
                         });

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -75,7 +75,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                         AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings
                                         {
                                             Pooling = true,
-                                            MaxPoolSize = (uint)connectionPoolSize
+                                            MaxPoolSize = (uint)connectionPoolSize,
+                                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                                         }
                                     }
                                 };
@@ -110,7 +111,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                                 }
                             }
                         });
-        }        
+        }
 
         public async Task<Try<ICloudConnection>> Connect(IClientCredentials identity, Action<string, CloudConnectionStatus> connectionStatusChangedHandler)
         {
@@ -162,5 +163,5 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 Log.LogWarning((int)EventIds.CloudConnectError, exception, $"Error creating cloud connection for client {identity.Id}");
             }
         }
-    }    
+    }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
@@ -67,6 +67,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         {
             try
             {
+                // In offline scenario, sometimes the underlying connection has already closed and
+                // in that case calling CloseAsync throws. This needs to be fixed in the SDK, but meanwhile
+                // wrapping this.client.CloseAsync in a try/catch
                 try
                 {
                     await this.client.CloseAsync();

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
@@ -67,7 +67,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         {
             try
             {
-                await this.client.CloseAsync();
+                try
+                {
+                    await this.client.CloseAsync();
+                }
+                catch (Exception ex)
+                {
+                    Events.ErrorClosingClient(this.clientId, ex);
+                }
+
                 await (this.cloudReceiver?.CloseAsync() ?? Task.CompletedTask);
                 this.timer.Disable();
                 Events.Closed(this);
@@ -389,7 +397,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 CloudReceiverNull,
                 ErrorOpening,
                 TimedOutClosing,
-                Initialized
+                Initialized,
+                ErrorClosingClient
             }
 
             public static void Closed(CloudProxy cloudProxy)
@@ -490,6 +499,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             public static void Initialized(CloudProxy cloudProxy)
             {
                 Log.LogInformation((int)EventIds.Initialized, Invariant($"Initialized cloud proxy {cloudProxy.id} for {cloudProxy.clientId}"));
+            }
+
+            public static void ErrorClosingClient(string clientId, Exception ex)
+            {
+                Log.LogDebug((int)EventIds.ErrorClosingClient, ex, Invariant($"Error closing client for {clientId}"));
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceClientWrapper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceClientWrapper.cs
@@ -39,7 +39,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         public Task<Twin> GetTwinAsync() => this.underlyingDeviceClient.GetTwinAsync();
 
-        public Task OpenAsync() => this.underlyingDeviceClient.OpenAsync();
+        public async Task OpenAsync()
+        {
+            try
+            {
+                await this.underlyingDeviceClient.OpenAsync();
+            }
+            catch (Exception)
+            {
+                this.isActive.Set(false);
+                throw;
+            }
+        }
+
 
         public Task<Message> ReceiveAsync(TimeSpan receiveMessageTimeout) => this.underlyingDeviceClient.ReceiveAsync(receiveMessageTimeout);
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
@@ -195,14 +195,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 using (await this.sync.LockAsync())
                 {
                     Option<ICloudProxy> testClient = await this.connectionManager.GetCloudConnection(this.testClientIdentity.Id);
-                    if (testClient.HasValue)
-                    {
-                        await testClient.ForEachAsync(tc => tc.UpdateReportedPropertiesAsync(this.testMessage.Value));
-                    }
-                    else
-                    {
-                        Console.WriteLine("**** Unable to get Test Client");
-                    }
+                    await testClient.ForEachAsync(tc => tc.UpdateReportedPropertiesAsync(this.testMessage.Value));
                 }
             }
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
@@ -195,7 +195,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 using (await this.sync.LockAsync())
                 {
                     Option<ICloudProxy> testClient = await this.connectionManager.GetCloudConnection(this.testClientIdentity.Id);
-                    await testClient.ForEachAsync(tc => tc.UpdateReportedPropertiesAsync(this.testMessage.Value));
+                    if (testClient.HasValue)
+                    {
+                        await testClient.ForEachAsync(tc => tc.UpdateReportedPropertiesAsync(this.testMessage.Value));
+                    }
+                    else
+                    {
+                        Console.WriteLine("**** Unable to get Test Client");
+                    }
                 }
             }
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleClientWrapper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleClientWrapper.cs
@@ -42,7 +42,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         public Task<Twin> GetTwinAsync() => this.underlyingModuleClient.GetTwinAsync();
 
-        public Task OpenAsync() => this.underlyingModuleClient.OpenAsync();
+        public async Task OpenAsync()
+        {
+            try
+            {
+                await this.underlyingModuleClient.OpenAsync();
+            }
+            catch(Exception)
+            {
+                this.isActive.Set(false);
+                throw;
+            }
+        }
 
         public Task SendEventAsync(Message message) => this.underlyingModuleClient.SendEventAsync(message);
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/CloudTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/CloudTokenAuthenticator.cs
@@ -31,20 +31,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             Try<ICloudProxy> cloudProxyTry = await this.connectionManager.CreateCloudConnectionAsync(clientCredentials);
             if (cloudProxyTry.Success)
             {
-                try
-                {
-                    await cloudProxyTry.Value.OpenAsync();
-                    Events.AuthenticatedWithIotHub(clientCredentials.Identity);
-                    return true;
-                }
-                catch (Exception ex)
-                {
-                    Events.ErrorValidatingTokenWithIoTHub(clientCredentials.Identity, ex);
-                }
+                Events.AuthenticatedWithIotHub(clientCredentials.Identity);
+                return true;
             }
             else
             {
-                Events.ErrorGettingCloudProxy(clientCredentials.Identity, cloudProxyTry.Exception);
+                Events.ErrorValidatingTokenWithIoTHub(clientCredentials.Identity, cloudProxyTry.Exception);
             }
 
             return false;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -239,6 +239,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 case CloudConnectionStatus.Disconnected:
                     Events.InvokingCloudConnectionLostEvent(device.Identity);
                     this.CloudConnectionLost?.Invoke(this, device.Identity);
+                    await device.CloudConnection.Filter(cp => cp.IsActive).ForEachAsync(cp => cp.CloseAsync());
                     break;
 
                 case CloudConnectionStatus.ConnectionEstablished:

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -239,7 +239,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 case CloudConnectionStatus.Disconnected:
                     Events.InvokingCloudConnectionLostEvent(device.Identity);
                     this.CloudConnectionLost?.Invoke(this, device.Identity);
-                    await device.CloudConnection.Filter(cp => cp.IsActive).ForEachAsync(cp => cp.CloseAsync());
+                    await device.CloudConnection.Filter(cp => cp.IsActive).ForEachAsync(cp =>
+                    {
+                        Events.CloudConnectionLostClosingClient(device.Identity);
+                        return cp.CloseAsync();
+                    });
                     break;
 
                 case CloudConnectionStatus.ConnectionEstablished:
@@ -407,7 +411,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 ProcessingTokenNearExpiryEvent,
                 InvokingCloudConnectionLostEvent,
                 InvokingCloudConnectionEstablishedEvent,
-                HandlingConnectionStatusChangedHandler
+                HandlingConnectionStatusChangedHandler,
+                CloudConnectionLostClosingClient
             }
 
             public static void NewCloudConnection(IIdentity identity, Try<ICloudConnection> cloudConnection)
@@ -462,6 +467,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             public static void HandlingConnectionStatusChangedHandler(string deviceId, CloudConnectionStatus connectionStatus)
             {
                 Log.LogInformation((int)EventIds.HandlingConnectionStatusChangedHandler, Invariant($"Connection status for {deviceId} changed to {connectionStatus}"));
+            }
+
+            public static void CloudConnectionLostClosingClient(IIdentity identity)
+            {
+                Log.LogDebug((int)EventIds.CloudConnectionLostClosingClient, Invariant($"Cloud connection lost for {identity.Id}, closing client."));
             }
         }
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
@@ -98,7 +98,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                        AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings
                        {
                            Pooling = true,
-                           MaxPoolSize = 20
+                           MaxPoolSize = 20,
+                           ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                        }
                    },
                    new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only)
@@ -106,7 +107,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                        AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings
                        {
                            Pooling = true,
-                           MaxPoolSize = 20
+                           MaxPoolSize = 20,
+                           ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                        }
                    }
                }
@@ -123,7 +125,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings
                         {
                             Pooling = true,
-                            MaxPoolSize = 30
+                            MaxPoolSize = 30,
+                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                         }
                     }
                 }
@@ -140,7 +143,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         AmqpConnectionPoolSettings = new AmqpConnectionPoolSettings
                         {
                             Pooling = true,
-                            MaxPoolSize = 50
+                            MaxPoolSize = 50,
+                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                         }
                     }
                 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -170,6 +170,27 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             cloudProxy.StartListening();
         }
 
+        [Fact]
+        public async Task TestCloseThrows()
+        {
+            // Arrange
+            var messageConverterProvider = Mock.Of<IMessageConverterProvider>();
+            string clientId = "d1";
+            var cloudListener = Mock.Of<ICloudListener>();
+            TimeSpan idleTimeout = TimeSpan.FromSeconds(60);
+            Action<string, CloudConnectionStatus> connectionStatusChangedHandler = (s, status) => { };
+            var client = new Mock<IClient>();
+            client.Setup(c => c.CloseAsync()).ThrowsAsync(new InvalidOperationException());
+            var cloudProxy = new CloudProxy(client.Object, messageConverterProvider, clientId, connectionStatusChangedHandler, cloudListener, idleTimeout, false);
+
+            // Act
+            bool result = await cloudProxy.CloseAsync();
+
+            // Assert.
+            Assert.True(result);
+            client.VerifyAll();
+        }
+
         Task<ICloudProxy> GetCloudProxyWithConnectionStringKey(string connectionStringConfigKey) =>
             GetCloudProxyWithConnectionStringKey(connectionStringConfigKey, Mock.Of<IEdgeHub>());
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudTokenAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudTokenAuthenticatorTest.cs
@@ -42,9 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             // Arrange
             var deviceIdentity = Mock.Of<IDeviceIdentity>(d => d.Id == "d1" && d.DeviceId == "d1");
             IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty);
-            var cloudProxy = Mock.Of<ICloudProxy>();
-            Mock.Get(cloudProxy).Setup(c => c.OpenAsync()).ThrowsAsync(new Exception("Unauthorized"));
-            var connectionManager = Mock.Of<IConnectionManager>(c => c.CreateCloudConnectionAsync(credentials) == Task.FromResult(Try.Success(cloudProxy)));
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.CreateCloudConnectionAsync(credentials) == Task.FromResult(Try<ICloudProxy>.Failure(new TimeoutException())));
             IAuthenticator cloudAuthenticator = new CloudTokenAuthenticator(connectionManager, IotHubHostName);
 
             // Act

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/TokenCacheAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/TokenCacheAuthenticatorTest.cs
@@ -88,12 +88,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         public async Task NotAuthenticatedTest()
         {
             // Arrange
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.OpenAsync())
-                .Throws(new UnauthorizedException("Not authorized"));
             var connectionManager = Mock.Of<IConnectionManager>(
                 c =>
-                    c.CreateCloudConnectionAsync(It.IsAny<IClientCredentials>()) == Task.FromResult(Try.Success(cloudProxy.Object)));
+                    c.CreateCloudConnectionAsync(It.IsAny<IClientCredentials>()) == Task.FromResult(Try<ICloudProxy>.Failure(new UnauthorizedException("Not authorized"))));
 
             string iothubHostName = "iothub1.azure.net";
             string callerProductInfo = "productInfo";
@@ -118,7 +115,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.False(isAuthenticated);
             Mock.Verify(credentialsStore);
             Mock.Verify(Mock.Get(connectionManager));
-            cloudProxy.VerifyAll();
         }
 
         [Unit]
@@ -126,12 +122,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         public async Task CacheTokenExpiredNotAuthenticatedTest()
         {
             // Arrange
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.OpenAsync())
-                .Throws(new UnauthorizedException("Not authorized"));
             var connectionManager = Mock.Of<IConnectionManager>(
                 c =>
-                    c.CreateCloudConnectionAsync(It.IsAny<IClientCredentials>()) == Task.FromResult(Try.Success(cloudProxy.Object)));
+                    c.CreateCloudConnectionAsync(It.IsAny<IClientCredentials>()) == Task.FromResult(Try<ICloudProxy>.Failure(new UnauthorizedException("Not authorized"))));
 
             string iothubHostName = "iothub1.azure.net";
             string callerProductInfo = "productInfo";
@@ -155,7 +148,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.False(isAuthenticated);
             Mock.Verify(credentialsStore);
             Mock.Verify(Mock.Get(connectionManager));
-            cloudProxy.VerifyAll();
         }
     }
 }


### PR DESCRIPTION
EdgeHub uses AMQP Multiplexing when connecting to IoTHub. So when a new link is requested, the same underlying connection is used. Similarly when the link is closed/recovered, the same underlying connection is used.
This was causing problems when the device went offline and came back online - the system tried to use the same underlying connection, and kept timing out.
To fix this, we close all the deviceClient instances when the device goes offline. This causes the underlying connection to be closed as well. Then when the connectivity is restored, a new connection is created and operations can resume.