### PR TITLE
Add support to Quickstart for testing devices behind an HTTP proxy.

### DIFF
--- a/smoke/IotEdgeQuickstart/IotEdgeQuickstart.csproj
+++ b/smoke/IotEdgeQuickstart/IotEdgeQuickstart.csproj
@@ -23,7 +23,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.0-*" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.1" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.1" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />
     <PackageReference Include="YamlDotNet" Version="4.3.2" />

--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -135,7 +135,7 @@ Defaults:
         public (bool useProxy, string proxyUrl) Proxy { get; } = (false, string.Empty);
 
         [Option("--upstream-protocol <value>", CommandOptionType.SingleValue, Description = "Upstream protocol for IoT Hub connections.")]
-        public (bool overrideUpstreamProtocol, string upstreamProtocol) UpstreamProtocol { get; } = (false, string.Empty);
+        public (bool overrideUpstreamProtocol, UpstreamProtocolType upstreamProtocol) UpstreamProtocol { get; } = (false, UpstreamProtocolType.Amqp);
 
         // ReSharper disable once UnusedMember.Local
         async Task<int> OnExecuteAsync()
@@ -176,10 +176,10 @@ Defaults:
                                     ? Option.Some(string.IsNullOrEmpty(hostname) ? new HttpUris() : new HttpUris(hostname))
                                     : Option.None<HttpUris>();
 
-                                (bool overrideUpstreamProtocol, string upstreamProtocol) = this.UpstreamProtocol;
-                                Option<string> upstreamProtocolOption = overrideUpstreamProtocol
-                                    ? Option.Maybe(upstreamProtocol)
-                                    : Option.None<string>();
+                                (bool overrideUpstreamProtocol, UpstreamProtocolType upstreamProtocol) = this.UpstreamProtocol;
+                                Option<UpstreamProtocolType> upstreamProtocolOption = overrideUpstreamProtocol
+                                    ? Option.Some(upstreamProtocol)
+                                    : Option.None<UpstreamProtocolType>();
 
                                 bootstrapper = new IotedgedLinux(this.BootstrapperArchivePath, credentials, uris, proxy, upstreamProtocolOption);
                             }
@@ -207,6 +207,7 @@ Defaults:
                     credentials,
                     connectionString,
                     endpoint,
+                    this.UpstreamProtocol.Item2,
                     tag,
                     this.DeviceId,
                     this.EdgeHostname,
@@ -264,5 +265,13 @@ Defaults:
     {
         Info,
         Debug
+    }
+
+    public enum UpstreamProtocolType
+    {
+        Amqp,
+        AmqpWs,
+        Mqtt,
+        MqttWs
     }
 }

--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -27,6 +27,7 @@ Environment Variables:
   --registry                registryAddress
   --tag                     imageTag
   --username                registryUser
+  --proxy                   https_proxy
 
 Defaults:
   All options to this command have defaults. If an option is not specified and
@@ -55,6 +56,7 @@ Defaults:
   --deployment               deployment json file
   --runtime-log-level        debug
   --clean_up_existing_device false
+  --proxy                    No proxy is used
 "
         )]
     [HelpOption]
@@ -129,6 +131,12 @@ Defaults:
         [Option("--clean_up_existing_device <true/false>", CommandOptionType.SingleValue, Description = "Clean up existing device on success.")]
         public bool CleanUpExistingDeviceOnSuccess { get; } = false;
 
+        [Option("--proxy <value>", CommandOptionType.SingleValue, Description = "Proxy for IoT Hub connections.")]
+        public (bool useProxy, string proxyUrl) Proxy { get; } = (false, string.Empty);
+
+        [Option("--upstream-protocol <value>", CommandOptionType.SingleValue, Description = "Upstream protocol for IoT Hub connections.")]
+        public (bool overrideUpstreamProtocol, string upstreamProtocol) UpstreamProtocol { get; } = (false, string.Empty);
+
         // ReSharper disable once UnusedMember.Local
         async Task<int> OnExecuteAsync()
         {
@@ -152,9 +160,14 @@ Defaults:
                 {
                     case BootstrapperType.Iotedged:
                         {
+                            (bool useProxy, string proxyUrl) = this.Proxy;
+                            Option<string> proxy = useProxy
+                                ? Option.Some(proxyUrl)
+                                : Option.Maybe(Environment.GetEnvironmentVariable("https_proxy"));
+
                             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                             {
-                                bootstrapper = new IotedgedWindows(this.BootstrapperArchivePath, credentials);
+                                bootstrapper = new IotedgedWindows(this.BootstrapperArchivePath, credentials, proxy);
                             }
                             else
                             {
@@ -162,7 +175,13 @@ Defaults:
                                 Option<HttpUris> uris = useHttp
                                     ? Option.Some(string.IsNullOrEmpty(hostname) ? new HttpUris() : new HttpUris(hostname))
                                     : Option.None<HttpUris>();
-                                bootstrapper = new IotedgedLinux(this.BootstrapperArchivePath, credentials, uris);
+
+                                (bool overrideUpstreamProtocol, string upstreamProtocol) = this.UpstreamProtocol;
+                                Option<string> upstreamProtocolOption = overrideUpstreamProtocol
+                                    ? Option.Maybe(upstreamProtocol)
+                                    : Option.None<string>();
+
+                                bootstrapper = new IotedgedLinux(this.BootstrapperArchivePath, credentials, uris, proxy, upstreamProtocolOption);
                             }
                         }
                         break;

--- a/smoke/IotEdgeQuickstart/Quickstart.cs
+++ b/smoke/IotEdgeQuickstart/Quickstart.cs
@@ -20,6 +20,7 @@ namespace IotEdgeQuickstart
             Option<RegistryCredentials> credentials,
             string iothubConnectionString,
             string eventhubCompatibleEndpointWithEntityPath,
+            UpstreamProtocolType upstreamProtocol,
             string imageTag,
             string deviceId,
             string hostname,
@@ -34,7 +35,7 @@ namespace IotEdgeQuickstart
             bool optimizedForPerformance,
             LogLevel runtimeLogLevel,
             bool cleanUpExistingDeviceOnSuccess) :
-            base(bootstrapper, credentials, iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, imageTag, deviceId, hostname, deploymentFileName, deviceCaCert, deviceCaPk, deviceCaCerts, optimizedForPerformance, runtimeLogLevel, cleanUpExistingDeviceOnSuccess)
+            base(bootstrapper, credentials, iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, upstreamProtocol, imageTag, deviceId, hostname, deploymentFileName, deviceCaCert, deviceCaPk, deviceCaCerts, optimizedForPerformance, runtimeLogLevel, cleanUpExistingDeviceOnSuccess)
         {
             this.leaveRunning = leaveRunning;
             this.noDeployment = noDeployment;

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -207,7 +207,7 @@ namespace IotEdgeQuickstart.Details
                 EventHubPartitionKeyResolver.ResolveToPartition(
                     this.context.Device.Id,
                     (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
-                DateTime.Now);
+                EventPosition.FromEnd());
 
             var result = new TaskCompletionSource<bool>();
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(3)))

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -227,7 +227,6 @@ namespace IotEdgeQuickstart.Details
             EventHubClient eventHubClient =
                 EventHubClient.CreateFromConnectionString(builder.ToString());
 
-
             PartitionReceiver eventHubReceiver = eventHubClient.CreateReceiver(
                 "$Default",
                 EventHubPartitionKeyResolver.ResolveToPartition(
@@ -242,8 +241,8 @@ namespace IotEdgeQuickstart.Details
                 {
                     eventHubReceiver.SetReceiveHandler(new PartitionReceiveHandler(eventData =>
                     {
-                        eventData.Properties.TryGetValue("iothub-connection-device-id", out object devId);
-                        eventData.Properties.TryGetValue("iothub-connection-module-id", out object modId);
+                        eventData.SystemProperties.TryGetValue("iothub-connection-device-id", out object devId);
+                        eventData.SystemProperties.TryGetValue("iothub-connection-module-id", out object modId);
 
                         if (devId != null && devId.ToString().Equals(this.context.Device.Id) &&
                             modId != null && modId.ToString().Equals(moduleId))

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -64,12 +64,16 @@ namespace IotEdgeQuickstart.Details
         readonly string archivePath;
         readonly Option<RegistryCredentials> credentials;
         readonly Option<HttpUris> httpUris;
+        readonly Option<string> proxy;
+        readonly Option<string> upstreamProtocol;
 
-        public IotedgedLinux(string archivePath, Option<RegistryCredentials> credentials, Option<HttpUris> httpUris)
+        public IotedgedLinux(string archivePath, Option<RegistryCredentials> credentials, Option<HttpUris> httpUris, Option<string> proxy, Option<String> upstreamProtocol)
         {
             this.archivePath = archivePath;
             this.credentials = credentials;
             this.httpUris = httpUris;
+            this.proxy = proxy;
+            this.upstreamProtocol = upstreamProtocol;
         }
 
         public async Task VerifyNotActive()
@@ -197,6 +201,10 @@ namespace IotEdgeQuickstart.Details
                 doc.ReplaceOrAdd("certificates.device_ca_pk", deviceCaPk);
                 doc.ReplaceOrAdd("certificates.trusted_ca_certs", deviceCaCerts);
             }
+
+            this.proxy.ForEach(proxy => doc.ReplaceOrAdd("agent.env.https_proxy", proxy));
+
+            this.upstreamProtocol.ForEach(upstreamProtocol => doc.ReplaceOrAdd("agent.env.UpstreamProtocol", upstreamProtocol));
 
             string result = doc.ToString();
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -65,9 +65,9 @@ namespace IotEdgeQuickstart.Details
         readonly Option<RegistryCredentials> credentials;
         readonly Option<HttpUris> httpUris;
         readonly Option<string> proxy;
-        readonly Option<string> upstreamProtocol;
+        readonly Option<UpstreamProtocolType> upstreamProtocol;
 
-        public IotedgedLinux(string archivePath, Option<RegistryCredentials> credentials, Option<HttpUris> httpUris, Option<string> proxy, Option<String> upstreamProtocol)
+        public IotedgedLinux(string archivePath, Option<RegistryCredentials> credentials, Option<HttpUris> httpUris, Option<string> proxy, Option<UpstreamProtocolType> upstreamProtocol)
         {
             this.archivePath = archivePath;
             this.credentials = credentials;
@@ -204,7 +204,7 @@ namespace IotEdgeQuickstart.Details
 
             this.proxy.ForEach(proxy => doc.ReplaceOrAdd("agent.env.https_proxy", proxy));
 
-            this.upstreamProtocol.ForEach(upstreamProtocol => doc.ReplaceOrAdd("agent.env.UpstreamProtocol", upstreamProtocol));
+            this.upstreamProtocol.ForEach(upstreamProtocol => doc.ReplaceOrAdd("agent.env.UpstreamProtocol", upstreamProtocol.ToString()));
 
             string result = doc.ToString();
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -12,12 +12,14 @@ namespace IotEdgeQuickstart.Details
     {
         readonly string archivePath;
         readonly Option<RegistryCredentials> credentials;
+        readonly Option<string> proxy;
         string scriptDir;
 
-        public IotedgedWindows(string archivePath, Option<RegistryCredentials> credentials)
+        public IotedgedWindows(string archivePath, Option<RegistryCredentials> credentials, Option<string> proxy)
         {
             this.archivePath = archivePath;
             this.credentials = credentials;
+            this.proxy = proxy;
         }
 
         public async Task VerifyNotActive()
@@ -114,6 +116,10 @@ namespace IotEdgeQuickstart.Details
                 {
                     args += $" -Username '{c.User}' -Password (ConvertTo-SecureString '{c.Password}' -AsPlainText -Force)";
                 }
+
+                this.proxy.ForEach(proxy => {
+                    args += $" -Proxy '{proxy}'";
+                });
 
                 if (this.archivePath != null)
                 {

--- a/smoke/IotEdgeQuickstart/details/PartitionReceiveHandler.cs
+++ b/smoke/IotEdgeQuickstart/details/PartitionReceiveHandler.cs
@@ -26,6 +26,6 @@ namespace IotEdgeQuickstart.Details
             return Task.CompletedTask;
         }
         public Task ProcessErrorAsync(Exception error) => throw error;
-        public int MaxBatchSize { get; } = 10;
+        public int MaxBatchSize { get; set; }
     }
 }

--- a/smoke/IotEdgeQuickstart/e2e_deployment_files/dm_module_to_module_deployment.json
+++ b/smoke/IotEdgeQuickstart/e2e_deployment_files/dm_module_to_module_deployment.json
@@ -81,8 +81,7 @@
               "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-direct-method-receiver:<Build.BuildNumber>-linux-<Architecture>",
               "createOptions": ""
             }
-          },
-          
+          }
         }
       }
     },

--- a/smoke/IotEdgeQuickstart/e2e_deployment_files/module_to_module_deployment.template.json
+++ b/smoke/IotEdgeQuickstart/e2e_deployment_files/module_to_module_deployment.template.json
@@ -31,11 +31,11 @@
               "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-hub:<Build.BuildNumber>-linux-<Architecture>",
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
-		    "env": {
-				"OptimizeForPerformance": {
-					"value": "<OptimizeForPerformance>"
-				}
-			},
+            "env": {
+              "OptimizeForPerformance": {
+                "value": "<OptimizeForPerformance>"
+              }
+            },
             "status": "running",
             "restartPolicy": "always"
           }
@@ -65,8 +65,7 @@
               "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-temperature-filter:<Build.BuildNumber>-linux-<Architecture>",
               "createOptions": ""
             }
-          },
-          
+          }
         }
       }
     },


### PR DESCRIPTION
This change adds two new CLI parameters `--proxy` and `--upstream-protocol`.
They correspond to `agent.env.https_proxy` and `agent.env.UpstreamProtocol`
in config.yaml.

`--proxy` defaults to the `https_proxy` environment variable on the
`Quickstart` process itself, if it's set.

Also fixed JSON errors in the smoke test deployment templates that caused `jq`
to choke.