### PR TITLE
Adding build script that matches our documentation on github.

### DIFF
--- a/scripts/windows/buildBranch.bat
+++ b/scripts/windows/buildBranch.bat
@@ -1,0 +1,2 @@
+@echo off
+powershell -command ".\build\Publish-Branch.ps1"


### PR DESCRIPTION
When the build scripts were updated, we didn't match the documentation to the new build scripts. By adding this simple bat file back, the dev documentation is accurate again. 