### PR TITLE
Add docker.service as systemd dependency of iotedge.service

### DIFF
--- a/edgelet/contrib/systemd/iotedge.service
+++ b/edgelet/contrib/systemd/iotedge.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Azure IoT Edge daemon
-After=network-online.target
+After=network-online.target docker.service
+Wants=docker.service
 Requires=network-online.target
 Documentation=man:iotedged(8)
 


### PR DESCRIPTION
The full issue is explained in the issue below. The gist is that on systems that don't use socket activation, the docker daemon must be up before the `iotedged`.

This tweaks the unit file for `iotedge` to declare docker as a soft dependency and start after docker. I verified that if the `docker.service` is not installed, systemd will ignore the dependency and still attempt to start `iotedged`.

Fixes #452 