### PR TITLE
EdgeHub: Process Subscriptions on device connect event

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Concurrency;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClientProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClientProvider.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 {
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Util;
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public IEnumerable<IIdentity> GetConnectedClients() =>
             this.devices.Values
-                .Where(d => d.DeviceConnection.Map(dc => dc.IsActive).GetOrElse(false) && !d.Identity.Id.Equals($"{this.edgeDeviceId}/{this.edgeModuleId}"))
+                .Where(d => d.DeviceConnection.Map(dc => dc.IsActive).GetOrElse(false))
                 .Select(d => d.Identity);
 
         public async Task AddDeviceConnection(IIdentity identity, IDeviceProxy deviceProxy)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionReauthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionReauthenticator.cs
@@ -29,7 +29,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             ICredentialsCache credentialsCache,
             IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache,
             TimeSpan reauthenticateFrequency,
-            IIdentity edgeHubIdentity)
+            IIdentity edgeHubIdentity,
+            IDeviceConnectivityManager deviceConnectivityManager)
         {
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
             this.authenticator = Preconditions.CheckNotNull(authenticator, nameof(authenticator));
@@ -38,18 +39,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             this.deviceScopeIdentitiesCache = Preconditions.CheckNotNull(deviceScopeIdentitiesCache, nameof(deviceScopeIdentitiesCache));
             this.timer = new Timer(reauthenticateFrequency.TotalMilliseconds);
             this.timer.Elapsed += this.ReauthenticateConnections;
-            this.connectionManager.CloudConnectionEstablished += this.CloudConnectionEstablishedHandler;
+            deviceConnectivityManager.DeviceConnected += this.DeviceConnected;
             this.deviceScopeIdentitiesCache.ServiceIdentityUpdated += this.HandleServiceIdentityUpdate;
             this.deviceScopeIdentitiesCache.ServiceIdentityRemoved += this.HandleServiceIdentityRemove;
         }
 
-        void CloudConnectionEstablishedHandler(object sender, IIdentity identity)
+        void DeviceConnected(object sender, EventArgs args)
         {
-            if (this.edgeHubIdentity.Id.Equals(identity.Id))
-            {
-                Events.EdgeHubConnectionReestablished();
-                this.deviceScopeIdentitiesCache.InitiateCacheRefresh();
-            }
+            Events.EdgeHubConnectionReestablished();
+            this.deviceScopeIdentitiesCache.InitiateCacheRefresh();
         }
 
         public void Init()

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceConnectivityManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceConnectivityManager.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
 {
     using System;
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/TwinManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/TwinManager.cs
@@ -44,7 +44,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             this.actionBlock = new ActionBlock<IIdentity>(this.ProcessConnectionEstablishedForDevice);
         }
 
-        public static ITwinManager CreateTwinManager(IConnectionManager connectionManager, IMessageConverterProvider messageConverterProvider, Option<IStoreProvider> storeProvider)
+        public static ITwinManager CreateTwinManager(
+            IConnectionManager connectionManager,
+            IMessageConverterProvider messageConverterProvider,
+            Option<IStoreProvider> storeProvider)
         {
             Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
             Preconditions.CheckNotNull(messageConverterProvider, nameof(messageConverterProvider));

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -31,7 +31,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         const long MaxMessageSize = 256 * 1024; // matches IoTHub
 
         public RoutingEdgeHub(Router router, Core.IMessageConverter<IRoutingMessage> messageConverter,
-            IConnectionManager connectionManager, ITwinManager twinManager, string edgeDeviceId, IInvokeMethodHandler invokeMethodHandler)
+            IConnectionManager connectionManager, ITwinManager twinManager, string edgeDeviceId,
+            IInvokeMethodHandler invokeMethodHandler,
+            IDeviceConnectivityManager deviceConnectivityManager)
         {
             this.router = Preconditions.CheckNotNull(router, nameof(router));
             this.messageConverter = Preconditions.CheckNotNull(messageConverter, nameof(messageConverter));
@@ -39,7 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             this.twinManager = Preconditions.CheckNotNull(twinManager, nameof(twinManager));
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
             this.invokeMethodHandler = Preconditions.CheckNotNull(invokeMethodHandler, nameof(invokeMethodHandler));
-            this.connectionManager.CloudConnectionEstablished += this.CloudConnectionEstablished;
+            deviceConnectivityManager.DeviceConnected += this.DeviceConnected;
         }
 
         public Task ProcessDeviceMessage(IIdentity identity, IMessage message)
@@ -214,16 +216,28 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             }
         }
 
-        async void CloudConnectionEstablished(object sender, IIdentity identity)
+        async void DeviceConnected(object sender, EventArgs eventArgs)
         {
+            Events.DeviceConnectedProcessingSubscriptions();
             try
             {
-                Events.ProcessingSubscriptions(identity);
-                await this.ProcessSubscriptions(identity.Id);
+                IEnumerable<IIdentity> connectedClients = this.connectionManager.GetConnectedClients();
+                foreach (IIdentity identity in connectedClients)
+                {
+                    try
+                    {
+                        Events.ProcessingSubscriptions(identity);
+                        await this.ProcessSubscriptions(identity.Id);
+                    }
+                    catch (Exception e)
+                    {
+                        Events.ErrorProcessingSubscriptions(e, identity);
+                    }
+                }
             }
             catch (Exception e)
             {
-                Events.ErrorProcessingSubscriptions(e, identity);
+                Events.ErrorProcessingSubscriptions(e);
             }
         }
 
@@ -386,6 +400,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             public static void ProcessingSubscription(string id, DeviceSubscription deviceSubscription)
             {
                 Log.LogInformation((int)EventIds.ProcessingSubscription, Invariant($"Processing subscription {deviceSubscription} for client {id}."));
+            }
+
+            internal static void DeviceConnectedProcessingSubscriptions()
+            {
+                Log.LogInformation((int)EventIds.ProcessingSubscription, Invariant($"Device connected to cloud, processing subscriptions for connected clients."));
+            }
+
+            internal static void ErrorProcessingSubscriptions(Exception e)
+            {
+                Log.LogWarning((int)EventIds.ProcessingSubscription, e, Invariant($"Error processing subscriptions for connected clients."));
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             Events.DeviceConnectedProcessingSubscriptions();
             try
             {
-                IEnumerable<IIdentity> connectedClients = this.connectionManager.GetConnectedClients();
+                IEnumerable<IIdentity> connectedClients = this.connectionManager.GetConnectedClients().ToList();
                 foreach (IIdentity identity in connectedClients)
                 {
                     try

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -262,6 +262,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     var authenticatorTask = c.Resolve<Task<IAuthenticator>>();
                     var credentialsCacheTask = c.Resolve<Task<ICredentialsCache>>();
                     var deviceScopeIdentitiesCacheTask = c.Resolve<Task<IDeviceScopeIdentitiesCache>>();
+                    var deviceConnectivityManager = c.Resolve<IDeviceConnectivityManager>();
                     IConnectionManager connectionManager = await connectionManagerTask;
                     IAuthenticator authenticator = await authenticatorTask;
                     ICredentialsCache credentialsCache = await credentialsCacheTask;
@@ -272,7 +273,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         credentialsCache,
                         deviceScopeIdentitiesCache,
                         TimeSpan.FromMinutes(5),
-                        edgeHubCredentials.Identity); 
+                        edgeHubCredentials.Identity,
+                        deviceConnectivityManager); 
                     return connectionReauthenticator;
                 })
                 .As<Task<ConnectionReauthenticator>>()

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -375,12 +375,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         var twinManagerTask = c.Resolve<Task<ITwinManager>>();
                         var invokeMethodHandlerTask = c.Resolve<Task<IInvokeMethodHandler>>();
                         var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();
+                        var deviceConnectivityManager = c.Resolve<IDeviceConnectivityManager>();
                         Router router = await routerTask;
                         ITwinManager twinManager = await twinManagerTask;
                         IConnectionManager connectionManager = await connectionManagerTask;
                         IInvokeMethodHandler invokeMethodHandler = await invokeMethodHandlerTask;
                         IEdgeHub hub = new RoutingEdgeHub(router, routingMessageConverter,
-                            connectionManager, twinManager, this.edgeDeviceId, invokeMethodHandler);
+                            connectionManager, twinManager, this.edgeDeviceId, invokeMethodHandler, deviceConnectivityManager);
                         return hub;
                     })
                 .As<Task<IEdgeHub>>()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ConnectivityAwareClientTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ConnectivityAwareClientTest.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     using DotNetty.Transport.Channels;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -635,7 +635,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // Assert
             Assert.NotNull(connectedClients);
             List<IIdentity> connectedClientsList = connectedClients.ToList();
-            Assert.Equal(10, connectedClientsList.Count);
+            Assert.Equal(11, connectedClientsList.Count);
+            Assert.True(connectedClientsList.Any(c => c.Id.Equals($"{EdgeDeviceId}/{EdgeModuleId}")));
 
             for (int i = 0; i < 10; i++)
             {
@@ -654,7 +655,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // Assert
             Assert.NotNull(connectedClients);
             connectedClientsList = connectedClients.ToList();
-            Assert.Equal(5, connectedClientsList.Count);
+            Assert.Equal(6, connectedClientsList.Count);
+            Assert.True(connectedClientsList.Any(c => c.Id.Equals($"{EdgeDeviceId}/{EdgeModuleId}")));
 
             for (int i = 5; i < 10; i++)
             {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionReauthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionReauthenticatorTest.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
             var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
             var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             TimeSpan reauthFrequency = TimeSpan.FromSeconds(3);
 
             var deviceIdentity = new DeviceIdentity(IoTHubHostName, "d2");
@@ -49,7 +50,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             authenticator.Setup(a => a.ReauthenticateAsync(moduleCredentials)).ReturnsAsync(true);
 
             // Act
-            var connectionReauthenticator = new ConnectionReauthenticator(connectionManager.Object, authenticator.Object, credentialsStore.Object, deviceScopeIdentitiesCache, reauthFrequency, edgeHubIdentity);
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache,
+                reauthFrequency,
+                edgeHubIdentity,
+                deviceConnectivityManager);
             connectionReauthenticator.Init();
 
             // Assert            
@@ -70,6 +78,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
             var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
             var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             TimeSpan reauthFrequency = TimeSpan.FromSeconds(3);
 
             var deviceIdentity = new DeviceIdentity(IoTHubHostName, "d1");
@@ -92,7 +101,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             authenticator.Setup(a => a.ReauthenticateAsync(moduleCredentials)).ReturnsAsync(false);
 
             // Act
-            var connectionReauthenticator = new ConnectionReauthenticator(connectionManager.Object, authenticator.Object, credentialsStore.Object, deviceScopeIdentitiesCache, reauthFrequency, Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"));
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache,
+                reauthFrequency,
+                Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"),
+                deviceConnectivityManager);
             connectionReauthenticator.Init();
 
             // Assert            
@@ -114,6 +130,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
             var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
             var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             TimeSpan reauthFrequency = TimeSpan.FromSeconds(5);
 
             var deviceIdentity = new DeviceIdentity(IoTHubHostName, "d1");
@@ -139,7 +156,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .ReturnsAsync(true);
 
             // Act
-            var connectionReauthenticator = new ConnectionReauthenticator(connectionManager.Object, authenticator.Object, credentialsStore.Object, deviceScopeIdentitiesCache, reauthFrequency, Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"));
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache,
+                reauthFrequency,
+                Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"),
+                deviceConnectivityManager);
             connectionReauthenticator.Init();
 
             // Assert            
@@ -161,13 +185,21 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
             var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
             var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>(MockBehavior.Strict);
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             TimeSpan reauthFrequency = TimeSpan.FromSeconds(3);
 
             connectionManager.Setup(c => c.RemoveDeviceConnection("d1")).Returns(Task.CompletedTask);
             connectionManager.Setup(c => c.RemoveDeviceConnection("d1/m1")).Returns(Task.CompletedTask);
 
             // Act
-            var connectionReauthenticator = new ConnectionReauthenticator(connectionManager.Object, authenticator.Object, credentialsStore.Object, deviceScopeIdentitiesCache.Object, reauthFrequency, Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"));
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache.Object,
+                reauthFrequency,
+                Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"),
+                deviceConnectivityManager);
             deviceScopeIdentitiesCache.Raise(d => d.ServiceIdentityRemoved += null, null, "d1");
             deviceScopeIdentitiesCache.Raise(d => d.ServiceIdentityRemoved += null, null, "d1/m1");
 
@@ -189,13 +221,21 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
             var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
             var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>(MockBehavior.Strict);
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             TimeSpan reauthFrequency = TimeSpan.FromSeconds(3);
             var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "d2/$edgeHub");
 
             connectionManager.Setup(c => c.RemoveDeviceConnection("d2/$edgeHub")).Returns(Task.CompletedTask);
 
             // Act
-            var connectionReauthenticator = new ConnectionReauthenticator(connectionManager.Object, authenticator.Object, credentialsStore.Object, deviceScopeIdentitiesCache.Object, reauthFrequency, edgeHubIdentity);
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache.Object,
+                reauthFrequency,
+                edgeHubIdentity,
+                deviceConnectivityManager);
             deviceScopeIdentitiesCache.Raise(d => d.ServiceIdentityRemoved += null, null, "d2/$edgeHub");
 
             // Assert            
@@ -214,6 +254,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
             var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
             var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>(MockBehavior.Strict);
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             TimeSpan reauthFrequency = TimeSpan.FromSeconds(3);
 
             var deviceIdentity = new DeviceIdentity(IoTHubHostName, "d1");
@@ -240,7 +281,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var moduleServiceIdentity = new ServiceIdentity("d1/m1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
 
             // Act
-            var connectionReauthenticator = new ConnectionReauthenticator(connectionManager.Object, authenticator.Object, credentialsStore.Object, deviceScopeIdentitiesCache.Object, reauthFrequency, Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"));
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache.Object,
+                reauthFrequency,
+                Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"),
+                deviceConnectivityManager);
             deviceScopeIdentitiesCache.Raise(d => d.ServiceIdentityUpdated += null, null, deviceServiceIdentity);
             deviceScopeIdentitiesCache.Raise(d => d.ServiceIdentityUpdated += null, null, moduleServiceIdentity);
 
@@ -262,6 +310,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
             var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
             var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>(MockBehavior.Strict);
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             TimeSpan reauthFrequency = TimeSpan.FromSeconds(3);
 
             var deviceIdentity = new DeviceIdentity(IoTHubHostName, "d1");
@@ -288,7 +337,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var moduleServiceIdentity = new ServiceIdentity("d1/m1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
 
             // Act
-            var connectionReauthenticator = new ConnectionReauthenticator(connectionManager.Object, authenticator.Object, credentialsStore.Object, deviceScopeIdentitiesCache.Object, reauthFrequency, Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"));
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache.Object,
+                reauthFrequency,
+                Mock.Of<IIdentity>(e => e.Id == "ed/$edgeHub"),
+                deviceConnectivityManager);
             deviceScopeIdentitiesCache.Raise(d => d.ServiceIdentityUpdated += null, null, deviceServiceIdentity);
             deviceScopeIdentitiesCache.Raise(d => d.ServiceIdentityUpdated += null, null, moduleServiceIdentity);
 
@@ -311,6 +367,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
             var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
             var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>(MockBehavior.Strict);
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             TimeSpan reauthFrequency = TimeSpan.FromSeconds(3);
 
             var edgeHubIdentity = new ModuleIdentity(IoTHubHostName, "d1", "$edgeHub");
@@ -326,7 +383,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var edgeHubServiceIdentity = new ServiceIdentity("d1/$edgeHub", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
 
             // Act
-            var connectionReauthenticator = new ConnectionReauthenticator(connectionManager.Object, authenticator.Object, credentialsStore.Object, deviceScopeIdentitiesCache.Object, reauthFrequency, Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"));
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache.Object,
+                reauthFrequency,
+                Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"),
+                deviceConnectivityManager);
             deviceScopeIdentitiesCache.Raise(d => d.ServiceIdentityUpdated += null, null, edgeHubServiceIdentity);
 
             // Assert            
@@ -336,6 +400,34 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             connectionManager.Verify(c => c.GetDeviceConnection("d1/$edgeHub"), Times.Never);
             authenticator.Verify(a => a.ReauthenticateAsync(edgeHubCredentials), Times.Never);
             credentialsStore.Verify(c => c.Get(edgeHubIdentity), Times.Never);
+            deviceScopeIdentitiesCache.VerifyAll();
+        }
+
+        [Fact]
+        public void DeviceScopeIdentitiesCacheOnDeviceConnectedEvent()
+        {
+            // Arrange
+            var connectionManager = new Mock<IConnectionManager>(MockBehavior.Strict);
+            var authenticator = new Mock<IAuthenticator>(MockBehavior.Strict);
+            var credentialsStore = new Mock<ICredentialsCache>(MockBehavior.Strict);
+            var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>(MockBehavior.Strict);
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
+            TimeSpan reauthFrequency = TimeSpan.FromHours(1);
+            var connectionReauthenticator = new ConnectionReauthenticator(
+                connectionManager.Object,
+                authenticator.Object,
+                credentialsStore.Object,
+                deviceScopeIdentitiesCache.Object,
+                reauthFrequency,
+                Mock.Of<IIdentity>(i => i.Id == "d1/$edgeHub"),
+                deviceConnectivityManager);
+
+            deviceScopeIdentitiesCache.Setup(d => d.InitiateCacheRefresh());
+
+            // Act
+            Mock.Get(deviceConnectivityManager).Raise(d => d.DeviceConnected += null, new EventArgs());
+
+            // Assert
             deviceScopeIdentitiesCache.VerifyAll();
         }
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
+
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 {
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
@@ -10,10 +15,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
     using Microsoft.Azure.Devices.Routing.Core;
     using Microsoft.Azure.Devices.Routing.Core.MessageSources;
     using Moq;
-    using System;
-    using System.Collections.Generic;
-    using System.Net;
-    using System.Threading.Tasks;
     using Xunit;
     using IMessage = Microsoft.Azure.Devices.Routing.Core.IMessage;
     using Message = Microsoft.Azure.Devices.Edge.Hub.Core.EdgeMessage;
@@ -57,7 +58,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             var twinManager = Mock.Of<ITwinManager>();
 
             // Test Scenario
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", Mock.Of<IInvokeMethodHandler>());
+            var routingEdgeHub = new RoutingEdgeHub(
+                router,
+                messageConverter,
+                connectionManager,
+                twinManager,
+                "testEdgeDevice",
+                Mock.Of<IInvokeMethodHandler>(),
+                Mock.Of<IDeviceConnectivityManager>());
             var identity = new Mock<IIdentity>();
             identity.SetupGet(id => id.Id).Returns("something");
             EdgeMessage[] messages = { new Message.Builder(new byte[0]).Build() };
@@ -104,7 +112,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             Message badMessage = new Message.Builder(new byte[300 * 1024]).Build();
 
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", Mock.Of<IInvokeMethodHandler>());
+            var routingEdgeHub = new RoutingEdgeHub(
+                router,
+                messageConverter,
+                connectionManager,
+                twinManager,
+                "testEdgeDevice",
+                Mock.Of<IInvokeMethodHandler>(),
+                Mock.Of<IDeviceConnectivityManager>());
 
             await Assert.ThrowsAsync<EdgeHubMessageTooLargeException>(() => routingEdgeHub.ProcessDeviceMessage(identity.Object, badMessage));
 
@@ -148,14 +163,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             var twinManager = new Mock<ITwinManager>();
             var message = Mock.Of<Core.IMessage>();
             twinManager.Setup(t => t.GetTwinAsync(It.IsAny<string>())).Returns(Task.FromResult(message));
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager.Object, "testEdgeDevice", Mock.Of<IInvokeMethodHandler>());
+            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager.Object, "testEdgeDevice", Mock.Of<IInvokeMethodHandler>(), Mock.Of<IDeviceConnectivityManager>());
 
             Core.IMessage received = await routingEdgeHub.GetTwinAsync("*");
             twinManager.Verify(x => x.GetTwinAsync("*"), Times.Once);
 
             Assert.Equal(message, received);
         }
-
 
         [Fact]
         public async Task UpdateDesiredPropertiesForwardsToTwinManager()
@@ -186,7 +200,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             var message = Mock.Of<Core.IMessage>();
             Core.IMessage received = new Message.Builder(new byte[0]).Build();
             twinManager.Setup(t => t.UpdateDesiredPropertiesAsync(It.IsAny<string>(), It.IsAny<Core.IMessage>())).Callback<string, Core.IMessage>((s, m) => received = message).Returns(Task.CompletedTask);
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager.Object, "testEdgeDevice", Mock.Of<IInvokeMethodHandler>());
+            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager.Object, "testEdgeDevice", Mock.Of<IInvokeMethodHandler>(), Mock.Of<IDeviceConnectivityManager>());
 
             await routingEdgeHub.UpdateDesiredPropertiesAsync("*", message);
             twinManager.Verify(x => x.UpdateDesiredPropertiesAsync("*", message), Times.Once);
@@ -218,15 +232,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Router router = await Router.CreateAsync("myRouter", "myIotHub", routerConfig, endpointExecutorFactory);
 
             // Create mock message converter to generate a message with source matching the route
-            var messageConverter = Mock.Of<Core.IMessageConverter<IMessage>>();            
+            var messageConverter = Mock.Of<Core.IMessageConverter<IMessage>>();
 
             // Mock of twin manager
             var twinManager = Mock.Of<ITwinManager>();
-            
+
             // DeviceListener
             var identity = Mock.Of<IModuleIdentity>(m => m.DeviceId == "device1" && m.ModuleId == "module1" && m.Id == "device1/module1");
             var clientCredentials = Mock.Of<IClientCredentials>(c => c.Identity == identity);
-            var cloudProxy = new Mock<ICloudProxy>();            
+            var cloudProxy = new Mock<ICloudProxy>();
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
             underlyingDeviceProxy.Setup(d => d.InvokeMethodAsync(It.IsAny<DirectMethodRequest>())).ReturnsAsync(default(DirectMethodResponse));
             underlyingDeviceProxy.SetupGet(d => d.IsActive).Returns(true);
@@ -242,15 +256,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
             // RoutingEdgeHub
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler);
+            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);            
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
             var methodRequest = new DirectMethodRequest("device1/module1", "shutdown", null, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10));
 
             // Act
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
             await deviceMessageHandler.AddSubscription(DeviceSubscription.Methods);
-            Task<DirectMethodResponse> responseTask = routingEdgeHub.InvokeMethodAsync(identity.Id, methodRequest);                        
+            Task<DirectMethodResponse> responseTask = routingEdgeHub.InvokeMethodAsync(identity.Id, methodRequest);
 
             // Assert
             Assert.False(responseTask.IsCompleted);
@@ -318,12 +332,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
             // RoutingEdgeHub
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler);
+            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
 
             var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
 
             // Act
-            deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);            
+            deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
             Task<DirectMethodResponse> responseTask = routingEdgeHub.InvokeMethodAsync(identity.Id, methodRequest);
 
             // Assert
@@ -387,7 +401,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
             // RoutingEdgeHub
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler);
+            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
 
             var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
@@ -451,7 +465,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             string edgeDeviceId = "testEdgeDevice";
             // Test Scenario
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, edgeDeviceId, Mock.Of<IInvokeMethodHandler>());
+            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, edgeDeviceId, Mock.Of<IInvokeMethodHandler>(), Mock.Of<IDeviceConnectivityManager>());
 
             Message clientMessage1 = new Message.Builder(new byte[0]).Build();
             clientMessage1.SystemProperties[Core.SystemProperties.ConnectionDeviceId] = edgeDeviceId;
@@ -490,7 +504,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             // Arrange
             cloudProxy = new Mock<ICloudProxy>();
-            
+
             // Act
             await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.C2D, false);
 
@@ -561,7 +575,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             string id = "d1";
             RoutingEdgeHub edgeHub = await GetTestEdgeHub();
             var cloudProxy = new Mock<ICloudProxy>();
-            
+
             // Act
             await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.ModuleMessages, true);
             await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.ModuleMessages, false);
@@ -571,7 +585,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.Unknown, false);
 
             // Assert
-            cloudProxy.VerifyAll();            
+            cloudProxy.VerifyAll();
         }
 
         [Fact]
@@ -587,7 +601,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
             connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
             IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
-            
+
             // Act
             await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
 
@@ -639,7 +653,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             cloudProxy.VerifyAll();
             connectionManager.VerifyAll();
         }
-
 
         [Fact]
         public async Task RemoveSubscriptionTest()
@@ -707,6 +720,81 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             connectionManager.VerifyAll();
         }
 
+        [Fact]
+        public async Task ProcessSubscriptionsOnDeviceConnected()
+        {
+            // Arrange
+            string d1 = "d1";
+            var deviceIdentity = Mock.Of<IIdentity>(d => d.Id == d1);
+            string m1 = "d2/m1";
+            var moduleIdentity = Mock.Of<IIdentity>(m => m.Id == m1);
+
+            var connectedClients = new List<IIdentity>
+            {
+                deviceIdentity,
+                moduleIdentity
+            };
+            
+            IReadOnlyDictionary<DeviceSubscription, bool> device1Subscriptions = new Dictionary<DeviceSubscription, bool>()
+            {
+                [DeviceSubscription.Methods] = true,
+                [DeviceSubscription.DesiredPropertyUpdates] = true
+            };
+
+            IReadOnlyDictionary<DeviceSubscription, bool> module1Subscriptions = new Dictionary<DeviceSubscription, bool>()
+            {
+                [DeviceSubscription.Methods] = true,
+                [DeviceSubscription.ModuleMessages] = true
+            };
+
+            var device1CloudProxy = Mock.Of<ICloudProxy>(dc => dc.SetupDesiredPropertyUpdatesAsync() == Task.CompletedTask
+                && dc.SetupCallMethodAsync() == Task.CompletedTask);
+            Mock.Get(device1CloudProxy).SetupGet(d => d.IsActive).Returns(true);
+            var module1CloudProxy = Mock.Of<ICloudProxy>(mc => mc.SetupCallMethodAsync() == Task.CompletedTask && mc.IsActive);
+
+            var invokeMethodHandler = Mock.Of<IInvokeMethodHandler>(m =>
+                m.ProcessInvokeMethodSubscription(d1) == Task.CompletedTask
+                && m.ProcessInvokeMethodSubscription(m1) == Task.CompletedTask);
+
+            var connectionManager = Mock.Of<IConnectionManager>(c =>
+                c.GetConnectedClients() == connectedClients
+                && c.GetSubscriptions(d1) == Option.Some(device1Subscriptions)
+                && c.GetSubscriptions(m1) == Option.Some(module1Subscriptions)
+                && c.GetCloudConnection(d1) == Task.FromResult(Option.Some(device1CloudProxy))
+                && c.GetCloudConnection(m1) == Task.FromResult(Option.Some(module1CloudProxy)));
+
+            var endpoint = new Mock<Endpoint>("myId");
+            var endpointExecutor = Mock.Of<IEndpointExecutor>();
+            Mock.Get(endpointExecutor).SetupGet(ee => ee.Endpoint).Returns(() => endpoint.Object);
+            var endpointExecutorFactory = Mock.Of<IEndpointExecutorFactory>();
+            Mock.Get(endpointExecutorFactory).Setup(eef => eef.CreateAsync(It.IsAny<Endpoint>())).ReturnsAsync(endpointExecutor);
+            var endpoints = new HashSet<Endpoint> { endpoint.Object };
+            var route = new Route("myRoute", "true", "myIotHub", TelemetryMessageSource.Instance, endpoints);
+            var routerConfig = new RouterConfig(new[] { route });
+            Router router = await Router.CreateAsync("myRouter", "myIotHub", routerConfig, endpointExecutorFactory);
+
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
+
+            var edgeHub = new RoutingEdgeHub(
+                router,
+                Mock.Of<Core.IMessageConverter<IMessage>>(),
+                connectionManager,
+                Mock.Of<ITwinManager>(),
+                "ed1",
+                invokeMethodHandler,
+                deviceConnectivityManager);
+
+            // Act
+            Mock.Get(deviceConnectivityManager).Raise(d => d.DeviceConnected += null, new EventArgs());
+
+            // Assert
+            Mock.Get(device1CloudProxy).Verify(d => d.SetupDesiredPropertyUpdatesAsync(), Times.Once);
+            Mock.Get(device1CloudProxy).Verify(d => d.SetupCallMethodAsync(), Times.Once);
+            Mock.Get(module1CloudProxy).Verify(m => m.SetupCallMethodAsync(), Times.Once);
+            Mock.Get(invokeMethodHandler).VerifyAll();
+            Mock.Get(connectionManager).VerifyAll();
+        }
+
         static async Task<RoutingEdgeHub> GetTestEdgeHub(IConnectionManager connectionManager = null)
         {
             // Arrange
@@ -724,8 +812,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             // Create a router
             var routerConfig = new RouterConfig(new[] { route });
             Router router = await Router.CreateAsync("myRouter", "myIotHub", routerConfig, endpointExecutorFactory);
-            var edgeHub = new RoutingEdgeHub(router, Mock.Of<Core.IMessageConverter<IMessage>>(),
-                connectionManager, Mock.Of<ITwinManager>(), "ed1", Mock.Of<IInvokeMethodHandler>());
+            var edgeHub = new RoutingEdgeHub(
+                router,
+                Mock.Of<Core.IMessageConverter<IMessage>>(),
+                connectionManager,
+                Mock.Of<ITwinManager>(),
+                "ed1",
+                Mock.Of<IInvokeMethodHandler>(),
+                Mock.Of<IDeviceConnectivityManager>());
             return edgeHub;
         }
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IEndpointExecutorFactory endpointExecutorFactory = new StoringAsyncEndpointExecutorFactory(endpointExecutorConfig, new AsyncEndpointExecutorOptions(1, TimeSpan.FromMilliseconds(10)), messageStore);
             Router router = await Router.CreateAsync(Guid.NewGuid().ToString(), iotHubName, routerConfig, endpointExecutorFactory);
             ITwinManager twinManager = new TwinManager(connectionManager, new TwinCollectionMessageConverter(), new TwinMessageConverter(), Option.None<IEntityStore<string, TwinInfo>>());
-            IEdgeHub edgeHub = new RoutingEdgeHub(router, routingMessageConverter, connectionManager, twinManager, edgeDeviceId, Mock.Of<IInvokeMethodHandler>());
+            IEdgeHub edgeHub = new RoutingEdgeHub(router, routingMessageConverter, connectionManager, twinManager, edgeDeviceId, Mock.Of<IInvokeMethodHandler>(), Mock.Of<IDeviceConnectivityManager>());
             return (edgeHub, connectionManager);
         }
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 var endpointExecutorFactory = new SyncEndpointExecutorFactory(new EndpointExecutorConfig(defaultTimeout, new FixedInterval(0, TimeSpan.FromSeconds(1)), defaultTimeout, true));
                 Router router = await Router.CreateAsync(Guid.NewGuid().ToString(), iothubHostName, routerConfig, endpointExecutorFactory);
                 IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
-                IEdgeHub edgeHub = new RoutingEdgeHub(router, new RoutingMessageConverter(), connectionManager, twinManager, edgeDeviceId, invokeMethodHandler);
+                IEdgeHub edgeHub = new RoutingEdgeHub(router, new RoutingMessageConverter(), connectionManager, twinManager, edgeDeviceId, invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
                 cloudConnectionProvider.BindEdgeHub(edgeHub);
 
                 var versionInfo = new VersionInfo("v1", "b1", "c1");


### PR DESCRIPTION
EdgeHub processes subscriptions for connected clients when the device connectivity is restored. Earlier, this was done on the CloudConnectionEstablished callback, which is per cloud connection. With the latest changes, since the CloudConnection is closed when the device loses connectivity, if the client has no active upstream communication but valid subscriptions, those will never be re-processed. 
So now we handle this on the DeviceConnected event. 

Same logic for refreshing Device scope identities cache as well.