### PR TITLE
Fix Simulated Temp Sensor to send 500 messages at a time by default

### DIFF
--- a/edge-modules/SimulatedTemperatureSensor/config/appsettings.json
+++ b/edge-modules/SimulatedTemperatureSensor/config/appsettings.json
@@ -1,6 +1,7 @@
 ﻿{
   "EdgeHubConnectionString": "<YourConnectionString>",
   "MessageDelay": "00:00:05",
+  "MessageCount": 500,
   "machineTempMin": 21,
   "machineTempMax": 100,
   "machinePressureMin": 1,

--- a/edge-modules/SimulatedTemperatureSensor/src/Program.cs
+++ b/edge-modules/SimulatedTemperatureSensor/src/Program.cs
@@ -5,9 +5,7 @@ namespace SimulatedTemperatureSensor
     using System;
     using System.Globalization;
     using System.IO;
-    using System.Linq.Expressions;
     using System.Net;
-    using System.Runtime.Loader;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -80,7 +78,7 @@ namespace SimulatedTemperatureSensor
 
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler)
                 = ShutdownHandler.Init(TimeSpan.FromSeconds(5), null);
-            await SendEvents(moduleClient, messageDelay, sendForever, messageCount, sim, cts);            
+            await SendEvents(moduleClient, messageDelay, sendForever, messageCount, sim, cts);
             await cts.Token.WhenCanceled();
             completed.Set();
             handler.ForEach(h => GC.KeepAlive(h));
@@ -98,7 +96,7 @@ namespace SimulatedTemperatureSensor
                     case TransportType.Mqtt_WebSocket_Only:
                         return new ITransportSettings[] { new MqttTransportSettings(transportType) };
                     default:
-                        return new ITransportSettings[]{new AmqpTransportSettings(transportType)};
+                        return new ITransportSettings[] { new AmqpTransportSettings(transportType) };
                 }
             }
             ITransportSettings[] settings = GetTransportSettings();


### PR DESCRIPTION
People trying out IoTEdge using the Free tier IoTHub run out of quota very quickly because the simulated temperature sensor continues to send messages. So this fix is to change that to send 500 messages at a time, by default. This should be enough for trying it out, and can be changed using an environment variable, if they want to send more/less messages. 