### PR TITLE
EdgeHub: Token update changes

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
         {
             (string token, string audience) = ValidateAndParseMessage(this.iotHubHostName, message);
             (string deviceId, string moduleId) = ParseIds(audience);
-            IClientCredentials clientCredentials = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, string.Empty, token);
+            IClientCredentials clientCredentials = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, string.Empty, token, true);
             return clientCredentials;
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/EdgeHubSaslPlainAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/EdgeHubSaslPlainAuthenticator.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 }
 
                 // TODO: Figure out where the device client type parameter value should come from.
-                IClientCredentials deviceIdentity = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, string.Empty, password);
+                IClientCredentials deviceIdentity = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, string.Empty, password, false);
 
                 if (!await this.authenticator.AuthenticateAsync(deviceIdentity))
                 {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -195,27 +195,26 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             {
                 case CloudConnectionStatus.TokenNearExpiry:
                     Events.ProcessingTokenNearExpiryEvent(device.Identity);
-                    Option<IDeviceProxy> deviceProxy = device.DeviceConnection.Map(d => d.DeviceProxy).Filter(d => d.IsActive);
-                    if (deviceProxy.HasValue)
+                    Option<IClientCredentials> clientCredentials = await this.credentialsCache.Get(device.Identity);
+                    if (clientCredentials.HasValue)
                     {
-                        Option<IClientCredentials> token = await deviceProxy.Map(d => d.GetUpdatedIdentity())
-                            .GetOrElse(Task.FromResult(Option.None<IClientCredentials>()));
-                        if (token.HasValue)
-                        {
-                            await token.ForEachAsync(async t =>
+                        await clientCredentials.ForEachAsync(
+                            async cc =>
                             {
-                                Try<ICloudConnection> cloudConnectionTry = await device.CreateOrUpdateCloudConnection(c => this.CreateOrUpdateCloudConnection(c, t));
-                                if (!cloudConnectionTry.Success)
+                                if (cc is ITokenCredentials tokenCredentials && tokenCredentials.IsUpdatable)
                                 {
-                                    await this.RemoveDeviceConnection(device, true);
-                                    this.CloudConnectionLost?.Invoke(this, device.Identity);
+                                    Try<ICloudConnection> cloudConnectionTry = await device.CreateOrUpdateCloudConnection(c => this.CreateOrUpdateCloudConnection(c, tokenCredentials));
+                                    if (!cloudConnectionTry.Success)
+                                    {
+                                        await this.RemoveDeviceConnection(device, true);
+                                        this.CloudConnectionLost?.Invoke(this, device.Identity);
+                                    }
+                                }
+                                else
+                                {
+                                    await this.RemoveDeviceConnection(device, false);
                                 }
                             });
-                        }
-                        else
-                        {
-                            await this.RemoveDeviceConnection(device, false);
-                        }
                     }
                     else
                     {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/PersistedTokenCredentialsCache.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/PersistedTokenCredentialsCache.cs
@@ -9,11 +9,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
-    public class TokenCredentialsCache : ICredentialsCache
+    public class PersistedTokenCredentialsCache : ICredentialsCache
     {
         readonly IKeyValueStore<string, string> encryptedStore;
 
-        public TokenCredentialsCache(IKeyValueStore<string, string> encryptedStore)
+        public PersistedTokenCredentialsCache(IKeyValueStore<string, string> encryptedStore)
         {
             this.encryptedStore = Preconditions.CheckNotNull(encryptedStore, nameof(encryptedStore));
         }
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         static class Events
         {
-            static readonly ILogger Log = Logger.Factory.CreateLogger<TokenCredentialsCache>();
+            static readonly ILogger Log = Logger.Factory.CreateLogger<PersistedTokenCredentialsCache>();
             const int IdStart = HubCoreEventIds.TokenCredentialsStore;
 
             enum EventIds

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/ClientCredentialsFactory.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/ClientCredentialsFactory.cs
@@ -34,11 +34,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
             return new X509CertCredentials(identity, productInfo);
         }
 
-        public IClientCredentials GetWithSasToken(string deviceId, string moduleId, string deviceClientType, string token)
+        public IClientCredentials GetWithSasToken(string deviceId, string moduleId, string deviceClientType, string token, bool updatable)
         {
             string productInfo = string.Join(" ", this.callerProductInfo, deviceClientType).Trim();
             IIdentity identity = this.GetIdentity(deviceId, moduleId);
-            return new TokenCredentials(identity, token, productInfo);
+            return new TokenCredentials(identity, token, productInfo, updatable);
         }
 
         public IClientCredentials GetWithConnectionString(string connectionString)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/IClientCredentialsFactory.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/IClientCredentialsFactory.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
     {
         IClientCredentials GetWithX509Cert(string deviceId, string moduleId, string deviceClientType);
 
-        IClientCredentials GetWithSasToken(string deviceId, string moduleId, string deviceClientType, string token);
+        IClientCredentials GetWithSasToken(string deviceId, string moduleId, string deviceClientType, string token, bool updatable);
 
         IClientCredentials GetWithConnectionString(string connectionString);
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/ITokenCredentials.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/ITokenCredentials.cs
@@ -4,5 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
     public interface ITokenCredentials : IClientCredentials
     {
         string Token { get; }
+
+        bool IsUpdatable { get; }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/TokenCredentials.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/TokenCredentials.cs
@@ -5,17 +5,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
     public class TokenCredentials : ITokenCredentials
     {
-        public TokenCredentials(IIdentity identity, string token, string productInfo)
+        public TokenCredentials(IIdentity identity, string token, string productInfo, bool updatable)
         {
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.Token = Preconditions.CheckNonWhiteSpace(token, nameof(token));
             this.AuthenticationType = AuthenticationType.Token;
             this.ProductInfo = productInfo ?? string.Empty;
+            this.IsUpdatable = updatable;
         }
 
         public IIdentity Identity { get; }
 
         public string Token { get; }
+
+        public bool IsUpdatable { get; }
 
         public AuthenticationType AuthenticationType { get; }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/AuthenticationMiddleware.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/AuthenticationMiddleware.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
             string deviceId = clientIdParts[0];
             string moduleId = clientIdParts[1];
 
-            IClientCredentials clientCredentials = this.identityFactory.GetWithSasToken(deviceId, moduleId, string.Empty, authHeader);
+            IClientCredentials clientCredentials = this.identityFactory.GetWithSasToken(deviceId, moduleId, string.Empty, authHeader, false);
             IIdentity identity = clientCredentials.Identity;
             IAuthenticator authenticator = await this.authenticatorTask;
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 }
                 else
                 {
-                    deviceCredentials = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, deviceClientType, password);
+                    deviceCredentials = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, deviceClientType, password, false);
                 }
 
                 if (deviceCredentials == null

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     if (this.persistTokens)
                     {
                         IKeyValueStore<string, string> encryptedStore = await GetEncryptedStore(c, "CredentialsCache");
-                        return new TokenCredentialsCache(encryptedStore);
+                        return new PersistedTokenCredentialsCache(encryptedStore);
                     }
                     else
                     {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 
             var clientCredentials = Mock.Of<IClientCredentials>();
             var identityFactory = new Mock<IClientCredentialsFactory>();
-            identityFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            identityFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(clientCredentials);
 
             string iotHubHostName = "edgehubtest1.azure-devices.net";
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var identity = Mock.Of<IIdentity>(i => i.Id == "device1/mod1");
             var clientCredentials = Mock.Of<IClientCredentials>(c => c.Identity == identity);
             var clientCredentialsFactory = new Mock<IClientCredentialsFactory>();
-            clientCredentialsFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            clientCredentialsFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
                 .Returns(clientCredentials);
 
             string iotHubHostName = "edgehubtest1.azure-devices.net";

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 
             var clientCredentials = Mock.Of<IClientCredentials>();
             var identityFactory = new Mock<IClientCredentialsFactory>();
-            identityFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+            identityFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true))
                 .Returns(clientCredentials);
 
             string iotHubHostName = "edgehubtest1.azure-devices.net";
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var identity = Mock.Of<IIdentity>(i => i.Id == "device1/mod1");
             var clientCredentials = Mock.Of<IClientCredentials>(c => c.Identity == identity);
             var clientCredentialsFactory = new Mock<IClientCredentialsFactory>();
-            clientCredentialsFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()))
+            clientCredentialsFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true))
                 .Returns(clientCredentials);
 
             string iotHubHostName = "edgehubtest1.azure-devices.net";

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/EdgeHubSaslPlainAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/EdgeHubSaslPlainAuthenticatorTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             const string UserId = "dev1/modules/mod1@sas.hub1";
             const string Password = "pwd";
 
-            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password))
+            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false))
                 .Throws(new ApplicationException("Bad donut"));
 
             await Assert.ThrowsAsync<EdgeHubConnectionException>(() => saslAuthenticator.AuthenticateAsync(UserId, Password));
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             const string UserId = "dev1/modules/mod1@sas.hub1";
             const string Password = "pwd";
 
-            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password))
+            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false))
                 .Returns(clientCredentials);
             Mock.Get(authenticator).Setup(a => a.AuthenticateAsync(clientCredentials))
                 .ReturnsAsync(false);
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             const string UserId = "dev1/modules/mod1@sas.hub1";
             const string Password = "pwd";
 
-            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password))
+            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false))
                 .Returns(clientCredentials);
             Mock.Get(authenticator).Setup(a => a.AuthenticateAsync(clientCredentials))
                 .ReturnsAsync(true);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(10));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty);
+                return new TokenCredentials(identity, token, string.Empty, false);
             }
 
             IClient client = GetMockDeviceClient();
@@ -118,14 +118,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(3));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty);
+                return new TokenCredentials(identity, token, string.Empty, false);
             }
 
             IClientCredentials GetClientCredentialsWithNonExpiringToken()
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(10));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty);
+                return new TokenCredentials(identity, token, string.Empty, false);
             }
 
             IAuthenticationMethod authenticationMethod = null;
@@ -178,14 +178,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(3));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty);
+                return new TokenCredentials(identity, token, string.Empty, false);
             }
 
             IClientCredentials GetClientCredentialsWithNonExpiringToken()
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(10));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty);
+                return new TokenCredentials(identity, token, string.Empty, false);
             }
 
             IAuthenticationMethod authenticationMethod = null;
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             {
                 string token = TokenHelper.CreateSasToken(hostname, DateTime.UtcNow.AddSeconds(tokenExpiryDuration.TotalSeconds));
                 var identity = new DeviceIdentity(hostname, deviceId);
-                return new TokenCredentials(identity, token, string.Empty);
+                return new TokenCredentials(identity, token, string.Empty, false);
             }
 
             IDeviceProxy GetMockDeviceProxy()
@@ -471,7 +471,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         {
             string token = TokenHelper.CreateSasToken(hostname);
             var identity = new DeviceIdentity(hostname, deviceId);
-            return new TokenCredentials(identity, token, string.Empty);
+            return new TokenCredentials(identity, token, string.Empty, false);
         }
 
         [Fact]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionTest.cs
@@ -374,10 +374,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             ICloudConnectionProvider cloudConnectionProvider = new CloudConnectionProvider(messageConverterProvider, 1, deviceClientProvider.Object, Option.None<UpstreamProtocol>(), TokenProvider, DeviceScopeIdentitiesCache, TimeSpan.FromMinutes(60), true);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
-            var credentialsCache = Mock.Of<ICredentialsCache>();
+            var credentialsCache = new CredentialsCache(new NullCredentialsCache());
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache);
 
             IClientCredentials clientCredentials1 = GetClientCredentials(TimeSpan.FromSeconds(10));
+            await credentialsCache.Add(clientCredentials1);
             Try<ICloudProxy> cloudProxyTry1 = await connectionManager.CreateCloudConnectionAsync(clientCredentials1);
             Assert.True(cloudProxyTry1.Success);
 
@@ -392,6 +393,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.False(tokenGetter.IsCompleted);
 
             IClientCredentials clientCredentials2 = GetClientCredentials(TimeSpan.FromMinutes(2));
+            await credentialsCache.Add(clientCredentials2);
             Try<ICloudProxy> cloudProxyTry2 = await connectionManager.CreateCloudConnectionAsync(clientCredentials2);
             Assert.True(cloudProxyTry2.Success);
 
@@ -402,6 +404,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.False(tokenGetter.IsCompleted);
 
             IClientCredentials clientCredentials3 = GetClientCredentials(TimeSpan.FromMinutes(10));
+            await credentialsCache.Add(clientCredentials3);
             Try<ICloudProxy> cloudProxyTry3 = await connectionManager.CreateCloudConnectionAsync(clientCredentials3);
             Assert.True(cloudProxyTry3.Success);
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudTokenAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudTokenAuthenticatorTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         {
             // Arrange
             var deviceIdentity = Mock.Of<IDeviceIdentity>(d => d.Id == "d1" && d.DeviceId == "d1");
-            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty);
+            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty, false);
             var cloudProxy = Mock.Of<ICloudProxy>(c => c.OpenAsync() == Task.FromResult(true));
             var connectionManager = Mock.Of<IConnectionManager>(c => c.CreateCloudConnectionAsync(credentials) == Task.FromResult(Try.Success(cloudProxy)));
             IAuthenticator cloudAuthenticator = new CloudTokenAuthenticator(connectionManager, IotHubHostName);
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         {
             // Arrange
             var deviceIdentity = Mock.Of<IDeviceIdentity>(d => d.Id == "d1" && d.DeviceId == "d1");
-            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty);
+            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty, false);
             var connectionManager = Mock.Of<IConnectionManager>(c => c.CreateCloudConnectionAsync(credentials) == Task.FromResult(Try<ICloudProxy>.Failure(new TimeoutException())));
             IAuthenticator cloudAuthenticator = new CloudTokenAuthenticator(connectionManager, IotHubHostName);
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/TokenCacheAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/TokenCacheAuthenticatorTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, false);
 
             var tokenCredentialsAuthenticator = new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager, iothubHostName), credentialsStore.Object, iothubHostName);
 
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, false);
 
             var storedTokenCredentials = Mock.Of<ITokenCredentials>(c => c.Token == sasToken);
             var credentialsStore = new Mock<ICredentialsCache>();
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, false);
 
             string sasToken2 = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId") + "a";
             var storedTokenCredentials = Mock.Of<ITokenCredentials>(c => c.Token == sasToken2);
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId", expired: true);
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, false);
 
             var storedTokenCredentials = Mock.Of<ITokenCredentials>(c => c.Token == sasToken);
             var credentialsStore = new Mock<ICredentialsCache>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -111,10 +111,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string iotHubHostName = "iotHubName";
             string edgeDeviceId = "edge";
             string edgeDeviceConnStr = "dummyConnStr";
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module1"), "xyz", DummyProductInfo);
-            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module2"), "xyz", DummyProductInfo);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module1"), "xyz", DummyProductInfo, false);
+            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module2"), "xyz", DummyProductInfo, false);
             var edgeDeviceCredentials = new SharedKeyCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), edgeDeviceConnStr, "abc");
-            var device1Credentials = new TokenCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), "pqr", DummyProductInfo);
+            var device1Credentials = new TokenCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), "pqr", DummyProductInfo, false);
 
             var cloudConnectionProvider = Mock.Of<ICloudConnectionProvider>();
             Mock.Get(cloudConnectionProvider)
@@ -215,8 +215,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string module2Id = "module2";
             string iotHubHostName = "iotHub";
 
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, module1Id), DummyToken, DummyProductInfo);
-            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, module2Id), DummyToken, DummyProductInfo);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, module1Id), DummyToken, DummyProductInfo, false);
+            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, module2Id), DummyToken, DummyProductInfo, false);
 
             var cloudProxyMock1 = Mock.Of<ICloudProxy>();
             var cloudConnectionMock1 = Mock.Of<ICloudConnection>(cp => cp.IsActive && cp.CloudProxy == Option.Some(cloudProxyMock1));
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             string device = "device1";
             var identity = new DeviceIdentity("iotHub", device);
-            var deviceCredentials = new TokenCredentials(identity, "dummyToken", DummyProductInfo);
+            var deviceCredentials = new TokenCredentials(identity, "dummyToken", DummyProductInfo, false);
 
             Action<string, CloudConnectionStatus> callback = null;
             var cloudProxy = Mock.Of<ICloudProxy>(c => c.IsActive);
@@ -333,8 +333,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             string device = "device1";
             var deviceIdentity = new DeviceIdentity("iotHub", device);
-            IClientCredentials deviceCredentials = new TokenCredentials(deviceIdentity, "dummyToken", DummyProductInfo);
-            IClientCredentials updatedDeviceCredentials = new TokenCredentials(deviceIdentity, "dummyToken", DummyProductInfo);
+            IClientCredentials deviceCredentials = new TokenCredentials(deviceIdentity, "dummyToken", DummyProductInfo, false);
+            IClientCredentials updatedDeviceCredentials = new TokenCredentials(deviceIdentity, "dummyToken", DummyProductInfo, false);
 
             Action<string, CloudConnectionStatus> callback = null;
             var cloudProxy = Mock.Of<ICloudProxy>(c => c.IsActive);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             var connectionManager = Mock.Of<IConnectionManager>();
             var edgeHub = Mock.Of<IEdgeHub>();
-            var moduleCredentials = new TokenCredentials(new ModuleIdentity("hub", "device", "module"), "token", "productInfo");
+            var moduleCredentials = new TokenCredentials(new ModuleIdentity("hub", "device", "module"), "token", "productInfo", false);
 
             var connectionProvider = new ConnectionProvider(connectionManager, edgeHub);
             Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/IdentityFactoryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/IdentityFactoryTest.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // device test
             string deviceId = "device1";
             string deviceClientType = "customDeviceClient1";
-            IClientCredentials identityTry1 = identityFactory.GetWithSasToken(deviceId, null, deviceClientType, sasToken);
+            IClientCredentials identityTry1 = identityFactory.GetWithSasToken(deviceId, null, deviceClientType, sasToken, false);
             Assert.IsType<DeviceIdentity>(identityTry1.Identity);
             Assert.IsType<TokenCredentials>(identityTry1);
             Assert.Equal(sasToken, (identityTry1 as ITokenCredentials)?.Token);
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             deviceId = "device1";
             string moduleId = "module1";
             deviceClientType = "customDeviceClient2";
-            IClientCredentials identityTry2 = identityFactory.GetWithSasToken(deviceId, moduleId, deviceClientType, sasToken);
+            IClientCredentials identityTry2 = identityFactory.GetWithSasToken(deviceId, moduleId, deviceClientType, sasToken, false);
             Assert.IsType<ModuleIdentity>(identityTry2.Identity);
             Assert.IsType<TokenCredentials>(identityTry2);
             Assert.Equal(sasToken, (identityTry2 as ITokenCredentials)?.Token);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/PersistedTokenCredentialsCacheTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/PersistedTokenCredentialsCacheTest.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
+
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 {
     using System;

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/PersistedTokenCredentialsCacheTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/PersistedTokenCredentialsCacheTest.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     using Moq;
     using Xunit;
 
-    public class TokenCredentialsStoreTest
+    public class PersistedTokenCredentialsCacheTest
     {
         [Fact]
         [Unit]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/TokenCredentialsStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/TokenCredentialsStoreTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, false);
 
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, false);
 
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/TokenCredentialsStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/TokenCredentialsStoreTest.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, false);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, true);
 
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
             var encryptedStore = new EncryptedStore<string, string>(storeProvider.GetEntityStore<string, string>("tokenCredentials"), new NullEncryptionProvider());
-            var tokenCredentialsStore = new TokenCredentialsCache(encryptedStore);
+            var tokenCredentialsStore = new PersistedTokenCredentialsCache(encryptedStore);
 
             // Act
             await tokenCredentialsStore.Add(credentials);
@@ -38,6 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var storedTokenCredentials = storedCredentials.OrDefault() as ITokenCredentials;
             Assert.NotNull(storedTokenCredentials);
             Assert.Equal(sasToken, storedTokenCredentials.Token);
+            Assert.Equal(credentials.IsUpdatable, storedTokenCredentials.IsUpdatable);
         }
 
         [Fact]
@@ -54,7 +55,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
             var encryptedStore = new EncryptedStore<string, string>(storeProvider.GetEntityStore<string, string>("tokenCredentials"), new TestEncryptionProvider());
-            var tokenCredentialsStore = new TokenCredentialsCache(encryptedStore);
+            var tokenCredentialsStore = new PersistedTokenCredentialsCache(encryptedStore);
 
             // Act
             await tokenCredentialsStore.Add(credentials);
@@ -65,6 +66,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var storedTokenCredentials = storedCredentials.OrDefault() as ITokenCredentials;
             Assert.NotNull(storedTokenCredentials);
             Assert.Equal(sasToken, storedTokenCredentials.Token);
+            Assert.Equal(credentials.IsUpdatable, storedTokenCredentials.IsUpdatable);
         }
 
         [Fact]
@@ -79,7 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
             var encryptedStore = new EncryptedStore<string, string>(storeProvider.GetEntityStore<string, string>("tokenCredentials"), new TestEncryptionProvider());
-            var tokenCredentialsStore = new TokenCredentialsCache(encryptedStore);
+            var tokenCredentialsStore = new PersistedTokenCredentialsCache(encryptedStore);
 
             // Act
             await tokenCredentialsStore.Add(credentials);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -599,9 +599,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
         }
 
         static IClientCredentials SetupDeviceIdentity(string deviceId) =>
-            new TokenCredentials(new DeviceIdentity("iotHub", deviceId), Guid.NewGuid().ToString(), string.Empty);
+            new TokenCredentials(new DeviceIdentity("iotHub", deviceId), Guid.NewGuid().ToString(), string.Empty, false);
 
         static IClientCredentials SetupModuleCredentials(string moduleId, string deviceId) =>
-            new TokenCredentials(new ModuleIdentity("iotHub", deviceId, moduleId), Guid.NewGuid().ToString(), string.Empty);
+            new TokenCredentials(new ModuleIdentity("iotHub", deviceId, moduleId), Guid.NewGuid().ToString(), string.Empty, false);
     }
 }


### PR DESCRIPTION
EdgeHub supports token updates over CBS for AMQP. There is no such channel for MQTT. Currently, the updated tokens are obtained from the Protocol head for AMQP. 
This change is to store that information in the TokenCredentials object, so that ConnectionManager can obtain the updated credentials from the credentials cache, instead of getting it from the Protocol head. 