### PR TITLE
Moved hostname section to top of configuration file

### DIFF
--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -1,4 +1,20 @@
 ###############################################################################
+# Edge device hostname
+###############################################################################
+#
+# Configures the environment variable 'IOTEDGE_GATEWAYHOSTNAME' injected into
+# modules. Regardless of case the hostname is specified below, a lower case
+# value is used to configure the Edge Hub server hostname as well as the
+# environment variable specified above.
+#
+# It is important to note that when connecting downstream devices to the
+# Edge Hub that the lower case value of this hostname be used in the
+# 'GatewayHostName' field of the device's connection string URI.
+###############################################################################
+
+hostname: "<ADD HOSTNAME HERE>"
+
+###############################################################################
 #                      IoT Edge Daemon configuration
 ###############################################################################
 #
@@ -73,22 +89,6 @@ agent:
   config:
     image: "mcr.microsoft.com/azureiotedge-agent:1.0"
     auth: {}
-
-###############################################################################
-# Edge device hostname
-###############################################################################
-#
-# Configures the environment variable 'IOTEDGE_GATEWAYHOSTNAME' injected into
-# modules. Regardless of case the hostname is specified below, a lower case
-# value is used to configure the Edge Hub server hostname as well as the
-# environment variable specified above.
-#
-# It is important to note that when connecting downstream devices to the
-# Edge Hub that the lower case value of this hostname be used in the
-# 'GatewayHostName' field of the device's connection string URI.
-###############################################################################
-
-hostname: "<ADD HOSTNAME HERE>"
 
 ###############################################################################
 # Connect settings

--- a/edgelet/contrib/config/linux/debian/config.yaml
+++ b/edgelet/contrib/config/linux/debian/config.yaml
@@ -1,4 +1,20 @@
 ###############################################################################
+# Edge device hostname
+###############################################################################
+#
+# Configures the environment variable 'IOTEDGE_GATEWAYHOSTNAME' injected into
+# modules. Regardless of case the hostname is specified below, a lower case
+# value is used to configure the Edge Hub server hostname as well as the
+# environment variable specified above.
+#
+# It is important to note that when connecting downstream devices to the
+# Edge Hub that the lower case value of this hostname be used in the
+# 'GatewayHostName' field of the device's connection string URI.
+###############################################################################
+
+hostname: "<ADD HOSTNAME HERE>"
+
+###############################################################################
 #                      IoT Edge Daemon configuration
 ###############################################################################
 #
@@ -73,22 +89,6 @@ agent:
   config:
     image: "mcr.microsoft.com/azureiotedge-agent:1.0"
     auth: {}
-
-###############################################################################
-# Edge device hostname
-###############################################################################
-#
-# Configures the environment variable 'IOTEDGE_GATEWAYHOSTNAME' injected into
-# modules. Regardless of case the hostname is specified below, a lower case
-# value is used to configure the Edge Hub server hostname as well as the
-# environment variable specified above.
-#
-# It is important to note that when connecting downstream devices to the
-# Edge Hub that the lower case value of this hostname be used in the
-# 'GatewayHostName' field of the device's connection string URI.
-###############################################################################
-
-hostname: "<ADD HOSTNAME HERE>"
 
 ###############################################################################
 # Connect settings

--- a/edgelet/contrib/config/windows/config.yaml
+++ b/edgelet/contrib/config/windows/config.yaml
@@ -1,4 +1,20 @@
 ###############################################################################
+# Edge device hostname
+###############################################################################
+#
+# Configures the environment variable 'IOTEDGE_GATEWAYHOSTNAME' injected into
+# modules. Regardless of case the hostname is specified below, a lower case
+# value is used to configure the Edge Hub server hostname as well as the
+# environment variable specified above.
+#
+# It is important to note that when connecting downstream devices to the
+# Edge Hub that the lower case value of this hostname be used in the
+# 'GatewayHostName' field of the device's connection string URI.
+###############################################################################
+
+hostname: "<ADD HOSTNAME HERE>"
+
+###############################################################################
 #                      IoT Edge Daemon configuration
 ###############################################################################
 #
@@ -73,22 +89,6 @@ agent:
   config:
     image: "mcr.microsoft.com/azureiotedge-agent:1.0"
     auth: {}
-
-###############################################################################
-# Edge device hostname
-###############################################################################
-#
-# Configures the environment variable 'IOTEDGE_GATEWAYHOSTNAME' injected into
-# modules. Regardless of case the hostname is specified below, a lower case
-# value is used to configure the Edge Hub server hostname as well as the
-# environment variable specified above.
-#
-# It is important to note that when connecting downstream devices to the
-# Edge Hub that the lower case value of this hostname be used in the
-# 'GatewayHostName' field of the device's connection string URI.
-###############################################################################
-
-hostname: "<ADD HOSTNAME HERE>"
 
 ###############################################################################
 # Connect settings


### PR DESCRIPTION
Hi,

When debugging configuration files, it is pretty annoying to scroll down to find, which "hostname" or device a configuration belongs to, instead of leaving it at the top of the configuration.

/Henrik