### PR TITLE
Add support to LeafDevice for testing devices behind an HTTP proxy

### DIFF
--- a/smoke/LeafDevice/LeafDevice.cs
+++ b/smoke/LeafDevice/LeafDevice.cs
@@ -5,7 +5,6 @@ namespace LeafDevice
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Edge.Util;
 
     public class LeafDevice : Details.Details
     {
@@ -15,8 +14,8 @@ namespace LeafDevice
             string deviceId,
             string certificateFileName,
             string edgeHostName,
-            Option<UpstreamProtocolType> upstreamProtocol) :
-            base(iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, deviceId, certificateFileName, edgeHostName, upstreamProtocol)
+            bool useWebSockets) :
+            base(iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, deviceId, certificateFileName, edgeHostName, useWebSockets)
         {
         }
 

--- a/smoke/LeafDevice/LeafDevice.cs
+++ b/smoke/LeafDevice/LeafDevice.cs
@@ -5,6 +5,7 @@ namespace LeafDevice
 {
     using System;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
 
     public class LeafDevice : Details.Details
     {
@@ -13,8 +14,9 @@ namespace LeafDevice
             string eventhubCompatibleEndpointWithEntityPath,
             string deviceId,
             string certificateFileName,
-            string edgeHostName) :
-            base(iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, deviceId, certificateFileName, edgeHostName)
+            string edgeHostName,
+            Option<UpstreamProtocolType> upstreamProtocol) :
+            base(iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, deviceId, certificateFileName, edgeHostName, upstreamProtocol)
         {
         }
 

--- a/smoke/LeafDevice/LeafDevice.csproj
+++ b/smoke/LeafDevice/LeafDevice.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.0-*" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.1" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.1" />
-    <PackageReference Include="Microsoft.Azure.EventHubs" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Azure.EventHubs" Version="2.2.0" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="1.0.3" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />
     <PackageReference Include="YamlDotNet" Version="5.2.1" />

--- a/smoke/LeafDevice/Program.cs
+++ b/smoke/LeafDevice/Program.cs
@@ -5,7 +5,6 @@ namespace LeafDevice
     using System;
     using System.Threading.Tasks;
     using McMaster.Extensions.CommandLineUtils;
-    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
 
     [Command(
@@ -55,8 +54,8 @@ Defaults:
         [Option("-ed|--edge-hostname", Description = "Leaf device identifier to be registered with IoT Hub")]
         public string EdgeHostName { get; } = "";
 
-        [Option("--upstream-protocol <value>", CommandOptionType.SingleValue, Description = "Upstream protocol for IoT Hub connections.")]
-        public (bool overrideUpstreamProtocol, UpstreamProtocolType upstreamProtocol) UpstreamProtocol { get; } = (false, UpstreamProtocolType.Amqp);
+        [Option("--use-web-sockets", CommandOptionType.NoValue, Description = "Use websockets for IoT Hub connections.")]
+        public bool UseWebSockets { get; } = false;
 
         // ReSharper disable once UnusedMember.Local
         async Task<int> OnExecuteAsync()
@@ -69,18 +68,13 @@ Defaults:
                 string endpoint = this.EventHubCompatibleEndpointWithEntityPath ??
                     await SecretsHelper.GetSecretFromConfigKey("eventHubConnStrKey");
 
-                (bool overrideUpstreamProtocol, UpstreamProtocolType upstreamProtocol) = this.UpstreamProtocol;
-                Option<UpstreamProtocolType> upstreamProtocolOption = overrideUpstreamProtocol
-                    ? Option.Some(upstreamProtocol)
-                    : Option.None<UpstreamProtocolType>();
-
                 var test = new LeafDevice(
                     connectionString,
                     endpoint,
                     this.DeviceId,
                     this.CertificateFileName,
                     this.EdgeHostName,
-                    upstreamProtocolOption);
+                    this.UseWebSockets);
                 await test.RunAsync();
             }
             catch (Exception ex)
@@ -92,13 +86,5 @@ Defaults:
             Console.WriteLine("Success!");
             return 0;
         }
-    }
-
-    public enum UpstreamProtocolType
-    {
-        Amqp,
-        AmqpWs,
-        Mqtt,
-        MqttWs
     }
 }

--- a/smoke/LeafDevice/details/Details.cs
+++ b/smoke/LeafDevice/details/Details.cs
@@ -14,9 +14,9 @@ namespace LeafDevice.Details
     using Microsoft.Azure.EventHubs;
     using System.Net;
     using Microsoft.Azure.Devices.Edge.Util;
+    using DeviceClientTransportType = Microsoft.Azure.Devices.Client.TransportType;
     using EventHubClientTransportType = Microsoft.Azure.EventHubs.TransportType;
     using ServiceClientTransportType = Microsoft.Azure.Devices.TransportType;
-    using DeviceClientTransportType = Microsoft.Azure.Devices.Client.TransportType;
 
     public class Details
     {
@@ -37,7 +37,7 @@ namespace LeafDevice.Details
             string deviceId,
             string certificateFileName,
             string edgeHostName,
-            Option<UpstreamProtocolType> upstreamProtocol
+            bool useWebSockets
         )
         {
             this.iothubConnectionString = iothubConnectionString;
@@ -46,22 +46,17 @@ namespace LeafDevice.Details
             this.certificateFileName = certificateFileName;
             this.edgeHostName = edgeHostName;
 
-            switch (upstreamProtocol.GetOrElse(UpstreamProtocolType.Amqp))
+            if (useWebSockets)
             {
-                case UpstreamProtocolType.Amqp:
-                case UpstreamProtocolType.Mqtt:
-                    this.serviceClientTransportType = ServiceClientTransportType.Amqp;
-                    this.eventHubClientTransportType = EventHubClientTransportType.Amqp;
-                    this.deviceClientTransportType = DeviceClientTransportType.Mqtt;
-                    break;
-                case UpstreamProtocolType.AmqpWs:
-                case UpstreamProtocolType.MqttWs:
-                    this.serviceClientTransportType = ServiceClientTransportType.Amqp_WebSocket_Only;
-                    this.eventHubClientTransportType = EventHubClientTransportType.AmqpWebSockets;
-                    this.deviceClientTransportType = DeviceClientTransportType.Mqtt_WebSocket_Only;
-                    break;
-                default:
-                    throw new Exception($"Unexpected upstream protocol type {upstreamProtocol}");
+                this.serviceClientTransportType = ServiceClientTransportType.Amqp_WebSocket_Only;
+                this.eventHubClientTransportType = EventHubClientTransportType.AmqpWebSockets;
+                this.deviceClientTransportType = DeviceClientTransportType.Mqtt_WebSocket_Only;
+            }
+            else
+            {
+                this.serviceClientTransportType = ServiceClientTransportType.Amqp;
+                this.eventHubClientTransportType = EventHubClientTransportType.Amqp;
+                this.deviceClientTransportType = DeviceClientTransportType.Mqtt;
             }
         }
 

--- a/smoke/LeafDevice/details/PartitionReceiveHandler.cs
+++ b/smoke/LeafDevice/details/PartitionReceiveHandler.cs
@@ -26,6 +26,6 @@ namespace LeafDevice.Details
             return Task.CompletedTask;
         }
         public Task ProcessErrorAsync(Exception error) => throw error;
-        public int MaxBatchSize { get; } = 10;
+        public int MaxBatchSize { get; set; }
     }
 }


### PR DESCRIPTION
Similar to 1217b83104678841c27b9df7e7c60d1c7dbc0dc1 which was for Quickstart.

This change adds a new CLI parameter `--upstream-protocol` that is used to
override the transport used by IoT SDK's `DeviceClient` and `ServiceClient`
and EventHub SDK's `EventHubClient` to use websockets if necessary.