### PR TITLE
Ensure rs files have LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,9 @@
 # Auto detect text files and perform LF normalization
-*        text=auto
+*text=auto
 
 # Declare files that will always have LF line endings on checkout
 *.sh text eol=lf
+*.rs text eol=lf
 
 # Binary files to ignore and not modify
 *.pfx binary


### PR DESCRIPTION
This is being done to facilitate cargo format and clippy runs on Windows.