### PR TITLE
Add ability to list modules from workload HTTP endpoint

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "edgelet-core 0.1.0",
  "edgelet-http 0.1.0",
+ "edgelet-http-mgmt 0.1.0",
  "edgelet-test-utils 0.1.0",
  "edgelet-utils 0.1.0",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -435,6 +436,7 @@ dependencies = [
  "http 0.1.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "workload 0.1.0",
 ]

--- a/edgelet/edgelet-http-mgmt/src/lib.rs
+++ b/edgelet/edgelet-http-mgmt/src/lib.rs
@@ -45,6 +45,7 @@ mod server;
 
 pub use client::ModuleClient;
 pub use error::{Error, ErrorKind};
+pub use server::ListModules;
 pub use server::ManagementService;
 
 pub trait IntoResponse {

--- a/edgelet/edgelet-http-mgmt/src/server/mod.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/mod.rs
@@ -19,7 +19,7 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 
 use self::identity::*;
-use self::module::*;
+pub use self::module::*;
 use self::system_info::*;
 
 use IntoResponse;

--- a/edgelet/edgelet-http-workload/Cargo.toml
+++ b/edgelet/edgelet-http-workload/Cargo.toml
@@ -13,10 +13,12 @@ futures = "0.1"
 http = "0.1"
 hyper = "0.12"
 log = "0.4"
+serde = "1.0"
 serde_json = "1.0"
 
 edgelet-core = { path = "../edgelet-core" }
 edgelet-http = { path = "../edgelet-http" }
+edgelet-http-mgmt = { path = "../edgelet-http-mgmt" }
 edgelet-utils = { path = "../edgelet-utils" }
 workload = { path = "../workload" }
 

--- a/edgelet/edgelet-http-workload/src/lib.rs
+++ b/edgelet/edgelet-http-workload/src/lib.rs
@@ -12,6 +12,7 @@ extern crate chrono;
 extern crate edgelet_core;
 #[macro_use]
 extern crate edgelet_http;
+extern crate edgelet_http_mgmt;
 #[cfg(test)]
 extern crate edgelet_test_utils;
 #[macro_use]
@@ -24,6 +25,7 @@ extern crate http;
 extern crate hyper;
 #[macro_use]
 extern crate log;
+extern crate serde;
 extern crate serde_json;
 extern crate workload;
 

--- a/edgelet/edgelet-http-workload/src/server/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/mod.rs
@@ -14,10 +14,12 @@ use edgelet_core::{
 };
 use edgelet_http::authorization::Authorization;
 use edgelet_http::route::*;
+use edgelet_http_mgmt::ListModules;
 use failure;
 use futures::{future, Future};
 use hyper::service::{NewService, Service};
 use hyper::{Body, Error as HyperError, Request, Response};
+use serde::Serialize;
 
 use self::cert::{IdentityCertHandler, ServerCertHandler};
 use self::decrypt::DecryptHandler;
@@ -43,10 +45,12 @@ impl WorkloadService {
         H: 'static + CreateCertificate + Decrypt + Encrypt + GetTrustBundle + Clone + Send + Sync,
         M: 'static + ModuleRuntime + Clone + Send + Sync,
         M::Error: Into<CoreError>,
+        <M::Module as Module>::Config: Serialize,
         <M::Module as Module>::Error: Into<CoreError>,
         M::Logs: Into<Body>,
     {
         let router = router!(
+            get    "/modules" => Authorization::new(ListModules::new(runtime.clone()), Policy::Caller, runtime.clone()),
             post   "/modules/(?P<name>[^/]+)/genid/(?P<genid>[^/]+)/sign" => Authorization::new(SignHandler::new(key_store.clone()), Policy::Caller, runtime.clone()),
             post   "/modules/(?P<name>[^/]+)/genid/(?P<genid>[^/]+)/decrypt" => Authorization::new(DecryptHandler::new(hsm.clone()), Policy::Caller, runtime.clone()),
             post   "/modules/(?P<name>[^/]+)/genid/(?P<genid>[^/]+)/encrypt" => Authorization::new(EncryptHandler::new(hsm.clone()), Policy::Caller, runtime.clone()),


### PR DESCRIPTION
This change enables any module to request a list of currently running modules from `iotedged` via the workload HTTP endpoint. This helps modules discover what other modules are running in case they need to implement logic that is contingent upon other specific modules being present or in order to be able to verify inter-module calls.