### PR TITLE
Generate Windows executable for E2E tests

### DIFF
--- a/scripts/windows/build/Publish-Branch.ps1
+++ b/scripts/windows/build/Publish-Branch.ps1
@@ -29,6 +29,7 @@ param (
 
 Set-StrictMode -Version "Latest"
 $ErrorActionPreference = "Stop"
+$RUNTIME_IDENTIFIER="win10-x64"
 
 <#
  # Prepare environment
@@ -133,7 +134,7 @@ $AppProjects = Get-ChildItem $BuildRepositoryLocalPath -Include $CSPROJ_PATTERN 
 foreach ($Project in $AppProjects) {
     Write-Host "Publishing Solution - $($Project.Filename)"
     $ProjectPublishPath = Join-Path $PUBLISH_FOLDER ($Project.Filename -replace @(".csproj", ""))
-    &$DOTNET_PATH publish -f netcoreapp2.1 -c $Configuration -o $ProjectPublishPath $Project.Path |
+    &$DOTNET_PATH publish -f netcoreapp2.1 -r $RUNTIME_IDENTIFIER -c $Configuration -o $ProjectPublishPath $Project.Path |
         Write-Host
     if ($LASTEXITCODE -ne 0) {
         throw "Failed publishing $($Project.Filename)."
@@ -143,7 +144,7 @@ foreach ($Project in $AppProjects) {
 foreach ($Project in (Get-ChildItem $BuildRepositoryLocalPath -Include $FUNCTION_BINDING_CSPROJ_PATTERN -Recurse)) {
     Write-Host "Publishing - $Project"
     $ProjectPublishPath = Join-Path $PUBLISH_FOLDER $Project.BaseName
-    &$DOTNET_PATH publish -f netstandard2.0 -c $Configuration -o $ProjectPublishPath $Project |
+    &$DOTNET_PATH publish -f netstandard2.0 -r $RUNTIME_IDENTIFIER -c $Configuration -o $ProjectPublishPath $Project |
         Write-Host
     if ($LASTEXITCODE -ne 0) {
         throw "Failed publishing $Project."

--- a/scripts/windows/build/Publish-Branch.ps1
+++ b/scripts/windows/build/Publish-Branch.ps1
@@ -29,7 +29,7 @@ param (
 
 Set-StrictMode -Version "Latest"
 $ErrorActionPreference = "Stop"
-$RUNTIME_IDENTIFIER="win10-x64"
+$RUNTIME_IDENTIFIER="win-x64"
 
 <#
  # Prepare environment


### PR DESCRIPTION
add runtime identifier to dotnet publish for windows in order to generate executable