### PR TITLE
Handle username/proxy in proxy auth

### DIFF
--- a/edgelet/edgelet-http/src/error.rs
+++ b/edgelet/edgelet-http/src/error.rs
@@ -68,7 +68,7 @@ pub enum ErrorKind {
     #[cfg(unix)]
     #[fail(display = "Syscall for socket failed.")]
     Nix,
-    #[fail(display = "UTF-8 coversion error.")]
+    #[fail(display = "UTF-8 conversion error.")]
     Utf8,
     #[fail(display = "Error creating HTTP header")]
     TypedHeaders,

--- a/edgelet/edgelet-http/src/error.rs
+++ b/edgelet/edgelet-http/src/error.rs
@@ -4,6 +4,7 @@ use std::fmt::{self, Display};
 use std::io;
 use std::num::ParseIntError;
 use std::str;
+use std::str::Utf8Error;
 
 use edgelet_core::{Error as CoreError, ErrorKind as CoreErrorKind};
 use failure::{Backtrace, Context, Fail};
@@ -17,6 +18,7 @@ use hyper_tls::Error as HyperTlsError;
 use nix::Error as NixError;
 use serde_json::Error as SerdeError;
 use systemd::Error as SystemdError;
+use typed_headers::Error as TypedHeadersError;
 use url::ParseError;
 
 use edgelet_utils::Error as UtilsError;
@@ -66,6 +68,10 @@ pub enum ErrorKind {
     #[cfg(unix)]
     #[fail(display = "Syscall for socket failed.")]
     Nix,
+    #[fail(display = "UTF-8 coversion error.")]
+    Utf8,
+    #[fail(display = "Error creating HTTP header")]
+    TypedHeaders,
 }
 
 impl Fail for Error {
@@ -251,6 +257,22 @@ impl From<HyperTlsError> for Error {
     fn from(error: HyperTlsError) -> Error {
         Error {
             inner: error.context(ErrorKind::HyperTls),
+        }
+    }
+}
+
+impl From<Utf8Error> for Error {
+    fn from(error: Utf8Error) -> Error {
+        Error {
+            inner: error.context(ErrorKind::Utf8),
+        }
+    }
+}
+
+impl From<TypedHeadersError> for Error {
+    fn from(error: TypedHeadersError) -> Error {
+        Error {
+            inner: error.context(ErrorKind::TypedHeaders),
         }
     }
 }

--- a/edgelet/edgelet-http/src/util/proxy.rs
+++ b/edgelet/edgelet-http/src/util/proxy.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn can_create_client_with_proxy() {
-        let uri = "irrelevant".parse::<Uri>().unwrap();
+        let uri = "http://example.com".parse::<Uri>().unwrap();
         let client = MaybeProxyClient::new(Some(uri)).unwrap();
         assert!(client.has_proxy() && !client.is_null());
     }


### PR DESCRIPTION
username/password specified via the `HTTPS_PROXY` uri are not being added as Authorization headers for proxied requests. The proxy lib has a call `set_authorization` which is supposed to be used to set the username/password.