### PR TITLE
Switch workload module listing authorization to anonymous

### DIFF
--- a/edgelet/edgelet-http-workload/src/server/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/mod.rs
@@ -50,7 +50,7 @@ impl WorkloadService {
         M::Logs: Into<Body>,
     {
         let router = router!(
-            get    "/modules" => Authorization::new(ListModules::new(runtime.clone()), Policy::Caller, runtime.clone()),
+            get    "/modules" => Authorization::new(ListModules::new(runtime.clone()), Policy::Anonymous, runtime.clone()),
             post   "/modules/(?P<name>[^/]+)/genid/(?P<genid>[^/]+)/sign" => Authorization::new(SignHandler::new(key_store.clone()), Policy::Caller, runtime.clone()),
             post   "/modules/(?P<name>[^/]+)/genid/(?P<genid>[^/]+)/decrypt" => Authorization::new(DecryptHandler::new(hsm.clone()), Policy::Caller, runtime.clone()),
             post   "/modules/(?P<name>[^/]+)/genid/(?P<genid>[^/]+)/encrypt" => Authorization::new(EncryptHandler::new(hsm.clone()), Policy::Caller, runtime.clone()),


### PR DESCRIPTION
This had to be done because `Policy::Caller` requires that we pass the module name as part of the URL path at which point `/modules/name` doesn't quite work for a module _listing_ API. In the management endpoint this path is used to get the details of a specific module.