### PR TITLE
EdgeHub: Make Device/Module Client operation timeout configurable

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ClientTokenCloudConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ClientTokenCloudConnection.cs
@@ -35,7 +35,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             IClientProvider clientProvider,
             ICloudListener cloudListener,
             TimeSpan idleTimeout,
-            bool closeOnIdleTimeout)
+            bool closeOnIdleTimeout,
+            TimeSpan operationTimeout)
             : base(
                 identity,
                 connectionStatusChangedHandler,
@@ -44,7 +45,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 clientProvider,
                 cloudListener,
                 idleTimeout,
-                closeOnIdleTimeout)
+                closeOnIdleTimeout,
+                operationTimeout)
         {
         }
 
@@ -56,7 +58,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             IClientProvider clientProvider,
             ICloudListener cloudListener,
             TimeSpan idleTimeout,
-            bool closeOnIdleTimeout)
+            bool closeOnIdleTimeout,
+            TimeSpan operationTimeout)
         {
             Preconditions.CheckNotNull(tokenCredentials, nameof(tokenCredentials));
             var cloudConnection = new ClientTokenCloudConnection(
@@ -67,7 +70,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 clientProvider,
                 cloudListener,
                 idleTimeout,
-                closeOnIdleTimeout);
+                closeOnIdleTimeout,
+                operationTimeout);
             ITokenProvider tokenProvider = new ClientTokenBasedTokenProvider(tokenCredentials, cloudConnection);
             ICloudProxy cloudProxy = await cloudConnection.CreateNewCloudProxyAsync(tokenProvider);
             cloudConnection.cloudProxy = Option.Some(cloudProxy);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             this.idleTimeout = idleTimeout;
             this.closeOnIdleTimeout = closeOnIdleTimeout;
             this.cloudProxy = Option.None<ICloudProxy>();
+            this.operationTimeout = operationTimeout;
         }
 
         public static async Task<CloudConnection> Create(
@@ -186,7 +187,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 string transportType = transportSettings.Length == 1
                     ? TransportName(transportSettings[0].GetTransportType())
                     : transportSettings.Select(t => TransportName(t.GetTransportType())).Join("/");
-                Log.LogInformation((int)EventIds.TransportConnected, $"Created cloud proxy for client {identity.Id} via {transportType}, with client operation timeout {timeout}.");
+                Log.LogInformation((int)EventIds.TransportConnected, $"Created cloud proxy for client {identity.Id} via {transportType}, with client operation timeout {timeout.TotalSeconds} seconds.");
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         readonly bool closeOnIdleTimeout;
         readonly ICredentialsCache credentialsCache;
         readonly IIdentity edgeHubIdentity;
+        readonly TimeSpan operationTimeout;
         Option<IEdgeHub> edgeHub;
 
         public CloudConnectionProvider(IMessageConverterProvider messageConverterProvider,
@@ -47,7 +48,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             ICredentialsCache credentialsCache,
             IIdentity edgeHubIdentity,
             TimeSpan idleTimeout,
-            bool closeOnIdleTimeout)
+            bool closeOnIdleTimeout,
+            TimeSpan operationTimeout)
         {
             Preconditions.CheckRange(connectionPoolSize, 1, nameof(connectionPoolSize));
             this.messageConverterProvider = Preconditions.CheckNotNull(messageConverterProvider, nameof(messageConverterProvider));
@@ -60,6 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             this.deviceScopeIdentitiesCache = Preconditions.CheckNotNull(deviceScopeIdentitiesCache, nameof(deviceScopeIdentitiesCache));
             this.credentialsCache = Preconditions.CheckNotNull(credentialsCache, nameof(credentialsCache));
             this.edgeHubIdentity = Preconditions.CheckNotNull(edgeHubIdentity, nameof(edgeHubIdentity));
+            this.operationTimeout = operationTimeout;
         }
 
         public void BindEdgeHub(IEdgeHub edgeHubInstance)
@@ -136,7 +139,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                         cloudListener,
                         this.edgeHubTokenProvider,
                         this.idleTimeout,
-                        this.closeOnIdleTimeout);
+                        this.closeOnIdleTimeout,
+                        this.operationTimeout);
                     Events.SuccessCreatingCloudConnection(clientCredentials.Identity);
                     return Try.Success(cc);
                 }
@@ -150,7 +154,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                         this.clientProvider,
                         cloudListener,
                         this.idleTimeout,
-                        this.closeOnIdleTimeout);
+                        this.closeOnIdleTimeout,
+                        this.operationTimeout);
                     Events.SuccessCreatingCloudConnection(clientCredentials.Identity);
                     return Try.Success(cc);
                 }
@@ -188,7 +193,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                             cloudListener,
                             this.edgeHubTokenProvider,
                             this.idleTimeout,
-                            this.closeOnIdleTimeout);
+                            this.closeOnIdleTimeout,
+                            this.operationTimeout);
                         Events.SuccessCreatingCloudConnection(identity);
                         return Try.Success(cc);
                     })

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -117,6 +117,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             int cloudConnectionIdleTimeoutSecs = this.configuration.GetValue("CloudConnectionIdleTimeoutSecs", 3600);
             TimeSpan cloudConnectionIdleTimeout = TimeSpan.FromSeconds(cloudConnectionIdleTimeoutSecs);
             bool closeCloudConnectionOnIdleTimeout = this.configuration.GetValue("CloseCloudConnectionOnIdleTimeout", true);
+            int cloudOperationTimeoutSecs = this.configuration.GetValue("CloudOperationTimeoutSecs", 20);
+            TimeSpan cloudOperationTimeout = TimeSpan.FromSeconds(cloudOperationTimeoutSecs); 
 
             builder.RegisterModule(
                 new RoutingModule(
@@ -134,7 +136,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     connectivityCheckFrequency,
                     maxConnectedClients,
                     cloudConnectionIdleTimeout,
-                    closeCloudConnectionOnIdleTimeout));
+                    closeCloudConnectionOnIdleTimeout,
+                    cloudOperationTimeout));
         }
 
         void RegisterCommonModule(ContainerBuilder builder, bool optimizeForPerformance, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly int maxConnectedClients;
         readonly TimeSpan cloudConnectionIdleTimeout;
         readonly bool closeCloudConnectionOnIdleTimeout;
+        readonly TimeSpan operationTimeout;
 
         public RoutingModule(string iotHubName,
             string edgeDeviceId,
@@ -56,7 +57,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             TimeSpan connectivityCheckFrequency,
             int maxConnectedClients,
             TimeSpan cloudConnectionIdleTimeout,
-            bool closeCloudConnectionOnIdleTimeout)
+            bool closeCloudConnectionOnIdleTimeout,
+            TimeSpan operationTimeout)
         {
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
@@ -73,6 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.maxConnectedClients = Preconditions.CheckRange(maxConnectedClients, 1);
             this.cloudConnectionIdleTimeout = cloudConnectionIdleTimeout;
             this.closeCloudConnectionOnIdleTimeout = closeCloudConnectionOnIdleTimeout;
+            this.operationTimeout = operationTimeout;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -184,7 +187,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         credentialsCache,
                         edgeHubCredentials.Identity,
                         this.cloudConnectionIdleTimeout,
-                        this.closeCloudConnectionOnIdleTimeout);
+                        this.closeCloudConnectionOnIdleTimeout,
+                        this.operationTimeout);
                     return cloudConnectionProvider;
                 })
                 .As<Task<ICloudConnectionProvider>>()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     public class ClientTokenCloudConnectionTest
     {
         static readonly ITokenProvider TokenProvider = Mock.Of<ITokenProvider>();
-        static readonly IDeviceScopeIdentitiesCache DeviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();        
+        static readonly IDeviceScopeIdentitiesCache DeviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
 
         [Unit]
         [Fact]
@@ -40,7 +40,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 clientProvider,
                 Mock.Of<ICloudListener>(),
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             Option<ICloudProxy> cloudProxy1 = cloudConnection.CloudProxy;
             Assert.True(cloudProxy1.HasValue);
             Assert.True(cloudProxy1.OrDefault().IsActive);
@@ -74,7 +75,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 deviceClientProvider.Object,
                 Mock.Of<ICloudListener>(),
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
 
             Option<ICloudProxy> cloudProxy1 = cloudConnection.CloudProxy;
             Assert.True(cloudProxy1.HasValue);
@@ -116,7 +118,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 deviceClientProvider.Object,
                 Mock.Of<ICloudListener>(),
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
 
             Option<ICloudProxy> cloudProxy = cloudConnection.CloudProxy;
             Assert.True(cloudProxy.HasValue);
@@ -163,8 +166,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 clientProvider,
                 Mock.Of<ICloudListener>(),
                 TimeSpan.FromMinutes(60),
-                true);
-            
+                true,
+                TimeSpan.FromSeconds(20));
+
             Option<ICloudProxy> cloudProxy1 = cloudConnection.CloudProxy;
             Assert.True(cloudProxy1.HasValue);
             Assert.True(cloudProxy1.OrDefault().IsActive);
@@ -229,7 +233,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 clientProvider,
                 Mock.Of<ICloudListener>(),
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
 
             Option<ICloudProxy> cloudProxy1 = cloudConnection.CloudProxy;
             Assert.True(cloudProxy1.HasValue);
@@ -295,11 +300,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                     .Callback<ConnectionStatusChangesHandler>(c => connectionStatusChangesHandler = c);
 
                 deviceClient.Setup(dc => dc.OpenAsync())
-                    .Callback(() =>
-                    {
-                        Assert.NotNull(connectionStatusChangesHandler);
-                        connectionStatusChangesHandler.Invoke(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
-                    })
+                    .Callback(
+                        () =>
+                        {
+                            Assert.NotNull(connectionStatusChangesHandler);
+                            connectionStatusChangesHandler.Invoke(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+                        })
                     .Returns(Task.CompletedTask);
                 return deviceClient.Object;
             }
@@ -328,7 +334,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 deviceClientProvider.Object,
                 Mock.Of<ICloudListener>(),
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
 
             Assert.Equal(receivedConnectedStatusCount, 1);
             Option<ICloudProxy> cloudProxy1 = cloudConnection.CloudProxy;
@@ -387,13 +394,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                     .Callback<ConnectionStatusChangesHandler>(c => connectionStatusChangesHandler = c);
 
                 deviceClient.Setup(dc => dc.OpenAsync())
-                    .Callback(() =>
-                    {
-                        int currentCount = receivedConnectedStatusCount;
-                        Assert.NotNull(connectionStatusChangesHandler);
-                        connectionStatusChangesHandler.Invoke(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
-                        Assert.Equal(receivedConnectedStatusCount, currentCount);
-                    })
+                    .Callback(
+                        () =>
+                        {
+                            int currentCount = receivedConnectedStatusCount;
+                            Assert.NotNull(connectionStatusChangesHandler);
+                            connectionStatusChangesHandler.Invoke(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
+                            Assert.Equal(receivedConnectedStatusCount, currentCount);
+                        })
                     .Returns(Task.CompletedTask);
                 return deviceClient.Object;
             }
@@ -407,9 +415,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var messageConverterProvider = Mock.Of<IMessageConverterProvider>();
 
             var credentialsCache = Mock.Of<ICredentialsCache>();
-            ICloudConnectionProvider cloudConnectionProvider = new CloudConnectionProvider(messageConverterProvider, 1, deviceClientProvider.Object, Option.None<UpstreamProtocol>(), TokenProvider, DeviceScopeIdentitiesCache, credentialsCache,
+            ICloudConnectionProvider cloudConnectionProvider = new CloudConnectionProvider(
+                messageConverterProvider,
+                1,
+                deviceClientProvider.Object,
+                Option.None<UpstreamProtocol>(),
+                TokenProvider,
+                DeviceScopeIdentitiesCache,
+                credentialsCache,
                 Mock.Of<IIdentity>(i => i.Id == $"{deviceId}/$edgeHub"),
-                TimeSpan.FromMinutes(60), true);
+                TimeSpan.FromMinutes(60),
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, Mock.Of<ICredentialsCache>(), new IdentityProvider(hostname));
 
@@ -467,7 +484,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             return deviceClient.Object;
         }
 
-        static ITokenCredentials GetMockClientCredentialsWithToken(string hostname = "dummy.azure-devices.net",
+        static ITokenCredentials GetMockClientCredentialsWithToken(
+            string hostname = "dummy.azure-devices.net",
             string deviceId = "device1")
         {
             string token = TokenHelper.CreateSasToken(hostname);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
@@ -44,7 +44,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 CredentialsCache,
                 EdgeHubIdentity,
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(edgeHub);
             var deviceIdentity = Mock.Of<IDeviceIdentity>(m => m.Id == "d1");
             string token = TokenHelper.CreateSasToken(IotHubHostName, DateTime.UtcNow.AddMinutes(10));
@@ -84,7 +85,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 CredentialsCache,
                 EdgeHubIdentity,
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(edgeHub);
             var deviceIdentity = Mock.Of<IDeviceIdentity>(m => m.Id == "d1");
             string token = TokenHelper.CreateSasToken(IotHubHostName, DateTime.UtcNow.AddMinutes(10));
@@ -120,7 +122,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 CredentialsCache,
                 EdgeHubIdentity,
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             // Act
@@ -159,7 +162,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 credentialsCache.Object,
                 EdgeHubIdentity,
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             // Act
@@ -198,7 +202,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 credentialsCache.Object,
                 EdgeHubIdentity,
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             // Act

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionTest.cs
@@ -34,7 +34,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 Mock.Of<ICloudListener>(),
                 tokenProvider,
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
 
             Option<ICloudProxy> cloudProxy1 = cloudConnection.CloudProxy;
             Assert.True(cloudProxy1.HasValue);
@@ -68,7 +69,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 Mock.Of<ICloudListener>(),
                 tokenProvider,
                 TimeSpan.FromMinutes(60),
-                true));
+                true,
+                TimeSpan.FromSeconds(20)));
         }
 
         static IClientProvider GetMockDeviceClientProviderWithKey()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -240,7 +240,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 credentialsCache,
                 Mock.Of<IIdentity>(),
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(edgeHub);
             var deviceIdentity = Mock.Of<IDeviceIdentity>(m => m.Id == ConnectionStringHelper.GetDeviceId(deviceConnectionString));
             var clientCredentials = new SharedKeyCredentials(deviceIdentity, deviceConnectionString, string.Empty);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
+
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 {
     using System;
@@ -28,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task DeviceConnectionTest()
         {
             var cloudProviderMock = new Mock<ICloudConnectionProvider>();
-            var credentialsManager = Mock.Of<ICredentialsCache>();            
+            var credentialsManager = Mock.Of<ICredentialsCache>();
             IConnectionManager connectionManager = new ConnectionManager(cloudProviderMock.Object, credentialsManager, GetIdentityProvider());
 
             var deviceProxyMock1 = new Mock<IDeviceProxy>();
@@ -176,8 +177,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var credentialsManager = Mock.Of<ICredentialsCache>();
             var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "edgeDevice/$edgeHub");
-            var cloudConnectionProvider = new CloudConnectionProvider(messageConverterProvider, 1, deviceClientProvider.Object, Option.None<UpstreamProtocol>(), Mock.Of<ITokenProvider>(), Mock.Of<IDeviceScopeIdentitiesCache>(), credentialsManager, edgeHubIdentity,
-                TimeSpan.FromMinutes(60), true);
+            var cloudConnectionProvider = new CloudConnectionProvider(
+                messageConverterProvider,
+                1,
+                deviceClientProvider.Object,
+                Option.None<UpstreamProtocol>(),
+                Mock.Of<ITokenProvider>(),
+                Mock.Of<IDeviceScopeIdentitiesCache>(),
+                credentialsManager,
+                edgeHubIdentity,
+                TimeSpan.FromMinutes(60),
+                true,
+                TimeSpan.FromSeconds(20));
 
             cloudConnectionProvider.BindEdgeHub(edgeHub.Object);
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsManager, GetIdentityProvider());
@@ -261,7 +272,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var module1Credentials = new TokenCredentials(new ModuleIdentity("iotHub", edgeDeviceId, module1Id), "token", DummyProductInfo, false);
 
-
             IClient client1 = GetDeviceClient();
             IClient client2 = GetDeviceClient();
             var messageConverterProvider = Mock.Of<IMessageConverterProvider>();
@@ -272,8 +282,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var credentialsCache = Mock.Of<ICredentialsCache>();
             var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "edgeDevice/$edgeHub");
-            var cloudConnectionProvider = new CloudConnectionProvider(messageConverterProvider, 1, deviceClientProvider.Object,
-                Option.None<UpstreamProtocol>(), Mock.Of<ITokenProvider>(), Mock.Of<IDeviceScopeIdentitiesCache>(), credentialsCache, edgeHubIdentity, TimeSpan.FromMinutes(60), true);
+            var cloudConnectionProvider = new CloudConnectionProvider(
+                messageConverterProvider,
+                1,
+                deviceClientProvider.Object,
+                Option.None<UpstreamProtocol>(),
+                Mock.Of<ITokenProvider>(),
+                Mock.Of<IDeviceScopeIdentitiesCache>(),
+                credentialsCache,
+                edgeHubIdentity,
+                TimeSpan.FromMinutes(60),
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider());
 
@@ -388,8 +408,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var credentialsCache = Mock.Of<ICredentialsCache>();
             var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "edgeDevice/$edgeHub");
-            var cloudConnectionProvider = new CloudConnectionProvider(messageConverterProvider, 1, deviceClientProvider.Object,
-                Option.None<UpstreamProtocol>(), Mock.Of<ITokenProvider>(), Mock.Of<IDeviceScopeIdentitiesCache>(), credentialsCache, edgeHubIdentity, TimeSpan.FromMinutes(60), true);
+            var cloudConnectionProvider = new CloudConnectionProvider(
+                messageConverterProvider,
+                1,
+                deviceClientProvider.Object,
+                Option.None<UpstreamProtocol>(),
+                Mock.Of<ITokenProvider>(),
+                Mock.Of<IDeviceScopeIdentitiesCache>(),
+                credentialsCache,
+                edgeHubIdentity,
+                TimeSpan.FromMinutes(60),
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider());
 
@@ -433,8 +463,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var credentialsCache = Mock.Of<ICredentialsCache>();
             var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "edgeDevice/$edgeHub");
-            var cloudConnectionProvider = new CloudConnectionProvider(messageConverterProvider, 1, deviceClientProvider.Object, Option.None<UpstreamProtocol>(), Mock.Of<ITokenProvider>(), Mock.Of<IDeviceScopeIdentitiesCache>(), credentialsCache, edgeHubIdentity,
-                TimeSpan.FromMinutes(60), true);
+            var cloudConnectionProvider = new CloudConnectionProvider(
+                messageConverterProvider,
+                1,
+                deviceClientProvider.Object,
+                Option.None<UpstreamProtocol>(),
+                Mock.Of<ITokenProvider>(),
+                Mock.Of<IDeviceScopeIdentitiesCache>(),
+                credentialsCache,
+                edgeHubIdentity,
+                TimeSpan.FromMinutes(60),
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider());
 
@@ -705,7 +745,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 credentialsCache,
                 new ModuleIdentity(iotHub, edgeDeviceId, "$edgeHub"),
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider());
 
@@ -735,18 +776,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             cloudConnectionMock.SetupGet(dp => dp.IsActive).Returns(true);
             cloudConnectionMock.SetupGet(dp => dp.CloudProxy).Returns(Option.Some(cloudProxyMock));
             cloudConnectionMock.Setup(c => c.UpdateTokenAsync(It.IsAny<ITokenCredentials>()))
-                .Callback(() =>
-                {
-                    cloudProxyMock = GetCloudProxyMock();
-                    cloudConnectionMock.SetupGet(dp => dp.CloudProxy).Returns(Option.Some(cloudProxyMock));
-                })
+                .Callback(
+                    () =>
+                    {
+                        cloudProxyMock = GetCloudProxyMock();
+                        cloudConnectionMock.SetupGet(dp => dp.CloudProxy).Returns(Option.Some(cloudProxyMock));
+                    })
                 .ReturnsAsync(cloudProxyMock);
             cloudConnectionMock.Setup(dp => dp.CloseAsync()).Returns(Task.FromResult(true))
-                .Callback(() =>
-                {
-                    cloudConnectionMock.SetupGet(dp => dp.IsActive).Returns(false);
-                    cloudConnectionMock.SetupGet(dp => dp.CloudProxy).Returns(Option.None<ICloudProxy>());
-                });
+                .Callback(
+                    () =>
+                    {
+                        cloudConnectionMock.SetupGet(dp => dp.IsActive).Returns(false);
+                        cloudConnectionMock.SetupGet(dp => dp.CloudProxy).Returns(Option.None<ICloudProxy>());
+                    });
 
             return cloudConnectionMock.Object;
         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     TimeSpan.FromSeconds(5),
                     101,
                     TimeSpan.FromSeconds(3600),
-                    true));
+                    true,
+                    TimeSpan.FromSeconds(20)));
 
             builder.RegisterModule(new HttpModule());
             builder.RegisterModule(new MqttModule(mqttSettingsConfiguration.Object, topics, this.serverCertificate, false, false, string.Empty, false));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -68,7 +68,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 credentialsCache,
                 edgeHubCredentials.Identity,
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             var connectionManager = new ConnectionManager(cloudConnectionProvider, Mock.Of<ICredentialsCache>(), identityProvider);
 
             try


### PR DESCRIPTION
EdgeHub uses a default operation timeout of 20 secs. For some customers with slow connections, this timeout is not enough (many operations take > 20secs and then they time out). So this PR is to make the operation timeout configurable. This will allow customers to change the default operation timeout by setting the Environment variable "CloudOperationTimeoutSecs".