### PR TITLE
Update Windows images to RS5

### DIFF
--- a/edge-agent/docker/windows/amd64/Dockerfile
+++ b/edge-agent/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.2-runtime-nanoserver-1803
+ARG base_tag=2.1.6-runtime-nanoserver-1809
 FROM microsoft/dotnet:${base_tag}
 
 USER ContainerAdministrator

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/test-config-windows-x64.json
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/test-config-windows-x64.json
@@ -2,7 +2,7 @@
     {
         "name": "nano",
         "version": "1.0",
-        "image": "microsoft/nanoserver:1803",
+        "image": "microsoft/nanoserver:1809",
         "validator": {
             "$type": "RunCommandValidator",
             "command": "docker",

--- a/edge-hub/docker/windows/amd64/Dockerfile
+++ b/edge-hub/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.2-runtime-nanoserver-1803
+ARG base_tag=2.1.6-runtime-nanoserver-1809
 FROM microsoft/dotnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
+++ b/edge-modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.2-runtime-nanoserver-1803
+ARG base_tag=2.1.6-runtime-nanoserver-1809
 FROM microsoft/dotnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodSender/docker/windows/amd64/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.2-runtime-nanoserver-1803
+ARG base_tag=2.1.6-runtime-nanoserver-1809
 FROM microsoft/dotnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MessagesAnalyzer/docker/windows/amd64/Dockerfile
+++ b/edge-modules/MessagesAnalyzer/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.0-runtime-nanoserver-1803
+ARG base_tag=2.1.6-runtime-nanoserver-1809
 FROM microsoft/dotnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.2-runtime-nanoserver-1803
+ARG base_tag=2.1.6-runtime-nanoserver-1809
 FROM microsoft/dotnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TemperatureFilter/docker/windows/amd64/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.2-runtime-nanoserver-1803
+ARG base_tag=2.1.6-runtime-nanoserver-1809
 FROM microsoft/dotnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/functions/samples/docker/windows/amd64/Dockerfile
+++ b/edge-modules/functions/samples/docker/windows/amd64/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
 
-FROM mcr.microsoft.com/azure-functions/dotnet:2.0-nanoserver-1803
+FROM mcr.microsoft.com/azure-functions/dotnet:2.0-nanoserver-1809
 
 COPY . /approot

--- a/edge-modules/load-gen/docker/windows/amd64/Dockerfile
+++ b/edge-modules/load-gen/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.2-runtime-nanoserver-1803
+ARG base_tag=2.1.6-runtime-nanoserver-1809
 FROM microsoft/dotnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -33,7 +33,7 @@ use iotedge::*;
 #[cfg(unix)]
 const MGMT_URI: &str = "unix:///var/run/iotedge/mgmt.sock";
 #[cfg(windows)]
-const MGMT_URI: &str = "http://localhost:15580";
+const MGMT_URI: &str = "unix:///C:/ProgramData/iotedge/mgmt/sock";
 
 fn main() {
     if let Err(ref error) = run() {

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -539,6 +539,9 @@ function Install-Services {
         }
     }
 
+    # Set service to restart after 1s if it fails
+    Invoke-Native "sc.exe failure ""$EdgeServiceName"" actions= restart/1000 reset= 0"
+
     Start-Service $EdgeServiceName
 
     Write-HostGreen 'Initialized the IoT Edge service.'

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -440,7 +440,7 @@ function Remove-SecurityDaemonResources {
     }
     elseif ($cmdErr.FullyQualifiedErrorId -ne 'PathNotFound,Microsoft.PowerShell.Commands.RemoveItemCommand') {
         Write-Verbose "$cmdErr"
-        Write-HostRed "Could not delete install directory '$MobyInstallDirectory'. Please reboot " +
+        Write-HostRed ("Could not delete install directory '$MobyInstallDirectory'. Please reboot " +
             'your device and run `Uninstall-SecurityDaemon` again with `-Force`.')
         $success = $false
     }

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -335,9 +335,9 @@ function Get-SecurityDaemon {
             New-Item $Path -ItemType Directory -Force | Out-Null
             $rule = New-Object -TypeName System.Security.AccessControl.FileSystemAccessRule(`
                 'NT AUTHORITY\Authenticated Users', 'Modify', 'ObjectInherit', 'InheritOnly', 'Allow')
-            $acl = [System.IO.Directory]::GetAccessControl($path)
+            $acl = Get-Acl -Path $path
             $acl.AddAccessRule($rule)
-            [System.IO.Directory]::SetAccessControl($path, $acl)
+            Set-Acl -Path $path -AclObject $acl
         }
 
         New-Item -Type Directory $EdgeEventLogInstallDirectory -ErrorAction SilentlyContinue -ErrorVariable cmdErr | Out-Null

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -277,7 +277,7 @@ function Test-AgentRegistryArgs {
             else {
                 'Parameters ''Username'' and ''Password'' must be used together. Please specify both (or neither for anonymous access).'
             }
-        Write-HostRed $Message
+        Write-HostRed $message
     }
     return $valid
 }

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -16,7 +16,7 @@ Set-Variable Windows1809 -Value 17763 -Option Constant
 Set-Variable MinBuildForLinuxContainers -Value $Windows1607
 Set-Variable SupportedBuildsForWindowsContainers -Value @($Windows1809)
 
-Set-Variable DockerServiceName -Value 'docker' -Option Constant
+Set-Variable DockerServiceName -Value 'com.docker.service' -Option Constant
 
 Set-Variable EdgeInstallDirectory -Value 'C:\ProgramData\iotedge' -Option Constant
 Set-Variable EdgeEventLogName -Value 'iotedged' -Option Constant

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -192,6 +192,10 @@ function Uninstall-SecurityDaemon {
     Stop-IotEdgeContainers
     $success = Remove-SecurityDaemonResources
     Reset-SystemPath
+
+    [System.Environment]::SetEnvironmentVariable('IOTEDGE_HOST', $null, [System.EnvironmentVariableTarget]::Machine)
+    Remove-Item Env:\IOTEDGE_HOST -ErrorAction SilentlyContinue
+
     Remove-FirewallExceptions
 
     if ($success) {
@@ -681,7 +685,7 @@ function Set-GatewayAddress {
         "  workload_uri: 'http://${gatewayAddress}:15581'")
     $configurationYaml = $configurationYaml -replace $selectionRegex, ($replacementContent -join "`n")
 
-    [Environment]::SetEnvironmentVariable('IOTEDGE_HOST', "http://${gatewayAddress}:15580", [System.EnvironmentVariableTarget]::Machine)
+    [System.Environment]::SetEnvironmentVariable('IOTEDGE_HOST', "http://${gatewayAddress}:15580", [System.EnvironmentVariableTarget]::Machine)
     $env:IOTEDGE_HOST = "http://${gatewayAddress}:15580"
 
     $configurationYaml | Set-Content "$EdgeInstallDirectory\config.yaml" -Force

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -460,7 +460,7 @@ function Remove-SecurityDaemonResources {
 
     if (Test-Path $MobyDataRootDirectory) {
         try {
-            # Removing $MobyDataRootDirectory is tricky. Windows base images contain files owned by TrustedInstaller, etc
+            # Removing `$MobyDataRootDirectory` is tricky. Windows base images contain files owned by TrustedInstaller, etc
             # Deleting them is a three-step process:
             #
             # 1. Take ownership of all files
@@ -469,8 +469,10 @@ function Remove-SecurityDaemonResources {
             # 2. Reset their ACLs so that they inherit from their container
             Invoke-Native "icacls ""$MobyDataRootDirectory"" /reset /t /l /q /c"
 
-            # 3. Use cmd's `rd` rather than `Remove-Item` since the latter gets tripped up by reparse points, etc
-            Invoke-Native "rd /s /q ""$MobyDataRootDirectory"""
+            # 3. Use cmd's `rd` rather than `Remove-Item` since the latter gets tripped up by reparse points, etc.
+            #    Prepend the path with `\\?\` since the layer directories have long names, so the paths usually exceed 260 characters,
+            #    and IoT Core's filesystem doesn't seem to automatically use (or even have) short names
+            Invoke-Native "rd /s /q ""\\?\$MobyDataRootDirectory"""
 
             Write-Verbose "Deleted Moby data root directory '$MobyDataRootDirectory'"
         }

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -460,6 +460,8 @@ function Remove-SecurityDaemonResources {
 
     if (Test-Path $MobyDataRootDirectory) {
         try {
+            Write-Host "Deleting Moby data root directory '$MobyDataRootDirectory'..."
+
             # Removing `$MobyDataRootDirectory` is tricky. Windows base images contain files owned by TrustedInstaller, etc
             # Deleting them is a three-step process:
             #

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -866,21 +866,19 @@ function Write-HostRed {
     Write-Host -ForegroundColor Red @args
 }
 
-function Remove-Permissions {
-    $Path = $args
-    $User = 'BUILTIN\Users'
-    Write-HostGreen "Remove $User permission to $Path"
+function Remove-Permissions([string] $Path) {
+    $user = 'BUILTIN\Users'
+    Write-Verbose  "Remove $User permission to $Path"
+    Invoke-Native "icacls ""$Path"" /inheritance:d"
     
-    # Remove inherited Write permission for BUILTIN\Users
-    icacls $Path /inheritance:d | Out-Null
-    $Acl = [System.IO.Directory]::GetAccessControl($Path)
-    foreach ($access in $Acl.Access) { 
-        if ($access.IdentityReference.Value -eq $User)  
+    $acl = Get-Acl -Path $Path
+    foreach ($access in $acl.Access) { 
+        if ($access.IdentityReference.Value -eq $user)  
         { 
-            $Acl.RemoveAccessRule($access) | Out-Null
+            $acl.RemoveAccessRule($access) | Out-Null
         }
     } 
-    [System.IO.Directory]::SetAccessControl($Path, $Acl)  
+    Set-Acl -Path $Path -AclObject $acl
 }
 
 Export-ModuleMember -Function Install-SecurityDaemon, Uninstall-SecurityDaemon

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -868,7 +868,7 @@ function Write-HostRed {
 
 function Remove-Permissions([string] $Path) {
     $user = 'BUILTIN\Users'
-    Write-Verbose  "Remove $User permission to $Path"
+    Write-Verbose  "Remove $user permission to $Path"
     Invoke-Native "icacls ""$Path"" /inheritance:d"
     
     $acl = Get-Acl -Path $Path


### PR DESCRIPTION
Update the Dockerfiles to point to the RS5 nanoserver base image.

This change also makes some minor tweaks to the Windows installer script in preparation for turning on UDS/RS5:
- If an archive folder is passed rather than a ZIP file, create the iotedge directory first before trying to copy to it. Not sure why this wasn't failing before, maybe the build job that uses this feature is pre-creating the folder.
- When creating the parent directory for the UNIX domain socket files, pipe to null so that the `Get-SecurityDaemon` function _only_ returns the intended boolean value.
- During uninstall, if the event log component directory doesn't exist (e.g., because it was already deleted), ensure `Remove-SecurityDaemonResources` still returns `$true` so that the user sees a satisfying completion message ("Successfully uninstalled IoT Edge.") at the end.
- Print some more errors when the -Verbose switch is specified.
- During uninstall, remove the `IOTEDGE_HOST` system environment variable.
- Use PowerShell's `Get-Acl` and `Set-Acl` instead of .NET Core's `[System.IO.Directory]::GetAccessControl` and `[System.IO.Directory]::SetAccessControl` (which Windows IoT Core doesn't have).
- Set up the service to automatically restart when it fails.