### PR TITLE
EdgeHub: Synchronize cloud proxy creation

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -367,7 +367,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                                 {
                                     using (await this.cloudConnectionLock.LockAsync())
                                     {
-
                                         return await this.CloudConnection.Filter(cp => cp.IsActive)
                                             .Map(c => Task.FromResult(Try.Success(c)))
                                             .GetOrElse(async () =>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     .Map(c => Task.FromResult(Try.Success(c)))
                     .GetOrElse(async () =>
                     {
-                        return await this.cloudConnectionCreateTask.Filter(c => c.IsCompleted)
+                        return await this.cloudConnectionCreateTask.Filter(c => !c.IsCompleted)
                             .GetOrElse(
                                 async () =>
                                 {
@@ -361,7 +361,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                                             .Map(c => Task.FromResult(Try.Success(c)))
                                             .GetOrElse(async () =>
                                             {
-                                                return await this.cloudConnectionCreateTask.Filter(c => c.IsCompleted)
+                                                return await this.cloudConnectionCreateTask.Filter(c => !c.IsCompleted)
                                                     .GetOrElse(
                                                         async () =>
                                                         {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -347,16 +347,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             {
                 Preconditions.CheckNotNull(cloudConnectionCreator, nameof(cloudConnectionCreator));
 
-                async Task<Try<ICloudConnection>> CloudConnectionCreator()
-                {
-                    Try<ICloudConnection> cloudConnection = await cloudConnectionCreator(this);
-                    if (cloudConnection.Success)
-                    {
-                        this.CloudConnection = Option.Some(cloudConnection.Value);
-                    }
-                    return cloudConnection;
-                }
-
                 return await this.CloudConnection.Filter(cp => cp.IsActive)
                     .Map(c => Task.FromResult(Try.Success(c)))
                     .GetOrElse(async () =>
@@ -375,10 +365,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                                                     .GetOrElse(
                                                         async () =>
                                                         {
-                                                            Task<Try<ICloudConnection>> createTask = CloudConnectionCreator();
+                                                            Task<Try<ICloudConnection>> createTask = cloudConnectionCreator(this);
                                                             this.cloudConnectionCreateTask = Option.Some(createTask);
                                                             Try<ICloudConnection> cloudConnectionResult = await createTask;
-                                                            this.cloudConnectionCreateTask = Option.None<Task<Try<ICloudConnection>>>();
+                                                            this.CloudConnection = cloudConnectionResult.Ok();
                                                             return cloudConnectionResult;
                                                         });
                                             });

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -81,9 +81,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var deviceCredentials2 = Mock.Of<ITokenCredentials>(c => c.Identity == Mock.Of<IIdentity>(d => d.Id == "Device2"));
 
             string edgeDeviceId = "edgeDevice";
-            string module1Id = "module1";
-            string token = TokenHelper.CreateSasToken(IotHubHostName);
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(IotHubHostName, edgeDeviceId, module1Id), token, DummyProductInfo, true);
             IClient client1 = GetDeviceClient();
             IClient client2 = GetDeviceClient();
             var messageConverterProvider = Mock.Of<IMessageConverterProvider>();
@@ -104,7 +101,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 credentialsCache,
                 new ModuleIdentity(IotHubHostName, edgeDeviceId, "$edgeHub"),
                 TimeSpan.FromMinutes(60),
-                true);
+                true,
+                TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
 
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider());
@@ -821,7 +819,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                credentialsCache,
                new ModuleIdentity(IotHubHostName, edgeDeviceId, "$edgeHub"),
                TimeSpan.FromMinutes(60),
-               true);
+               true,
+               TimeSpan.FromSeconds(20));
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider());
 


### PR DESCRIPTION
If multiple operations need the cloudProxy for a client when one does not exist, then each operation attempts to create a new CloudProxy, if the previous operations fail. This happens typically when the device is offline. 
Because of this, each operation gets backed up because of the DeviceClient operation timeout.

With this change, if multiple components request a cloudProxy, if one is being created, then the same task is returned. This way, all operations wait only for 1 timeout period. 

The use case for this is to speed up EdgeHub startup when offline. EdgeHub does a bunch of operations on startup (subscribe to methods, desired properties, update reported properties, etc). With this change, these operations get parallelized and EdgeHub starts faster when offline.