### PR TITLE
EdgeHub: Resync service identity if client request cannot be authenticated

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -175,23 +175,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
 
             enum EventIds
             {
-                ErrorReauthenticating = IdStart,
-                InvalidHostName,
+                InvalidHostName = IdStart,
                 InvalidAudience,
                 IdMismatch,
                 KeysMismatch,
                 InvalidServiceIdentityType,
-                ErrorAuthenticating,
                 ServiceIdentityNotEnabled,
                 TokenExpired,
-                ErrorParsingToken,
-                ServiceIdentityNotFound,
-                AuthenticatedInScope
-            }
-
-            public static void ErrorReauthenticating(Exception exception, ServiceIdentity serviceIdentity)
-            {
-                Log.LogWarning((int)EventIds.ErrorReauthenticating, exception, $"Error re-authenticating {serviceIdentity.Id} after the service identity was updated.");
+                ErrorParsingToken
             }
 
             public static void InvalidHostName(string id, string hostName, string iotHubHostName, string edgeHubHostName)
@@ -219,11 +210,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
                 Log.LogWarning((int)EventIds.InvalidServiceIdentityType, $"Error authenticating token for {serviceIdentity.Id} because the service identity authentication type is unexpected - {serviceIdentity.Authentication.Type}");
             }
 
-            public static void ErrorAuthenticating(Exception exception, IClientCredentials credentials)
-            {
-                Log.LogWarning((int)EventIds.ErrorAuthenticating, exception, $"Error authenticating credentials for {credentials.Identity.Id}");
-            }
-
             public static void ServiceIdentityNotEnabled(ServiceIdentity serviceIdentity)
             {
                 Log.LogWarning((int)EventIds.ServiceIdentityNotEnabled, $"Error authenticating token for {serviceIdentity.Id} because the service identity is not enabled");
@@ -237,23 +223,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             public static void ErrorParsingToken(IIdentity identity, Exception exception)
             {
                 Log.LogWarning((int)EventIds.ErrorParsingToken, exception, $"Error authenticating token for {identity.Id} because the token could not be parsed");
-            }
-
-            public static void ServiceIdentityNotFound(IIdentity identity)
-            {
-                Log.LogDebug((int)EventIds.ServiceIdentityNotFound, $"Service identity for {identity.Id} not found. Using underlying authenticator to authenticate");
-            }
-
-            public static void AuthenticatedInScope(IIdentity identity, bool isAuthenticated)
-            {
-                string authenticated = isAuthenticated ? "authenticated" : "not authenticated";
-                Log.LogInformation((int)EventIds.AuthenticatedInScope, $"Client {identity.Id} in device scope {authenticated} locally.");
-            }
-
-            public static void ReauthenticatedInScope(IIdentity identity, bool isAuthenticated)
-            {
-                string authenticated = isAuthenticated ? "reauthenticated" : "not reauthenticated";
-                Log.LogDebug((int)EventIds.AuthenticatedInScope, $"Client {identity.Id} in device scope {authenticated} locally.");
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -109,16 +109,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
         async Task<(bool isAuthenticated, bool serviceIdentityFound)> AuthenticateWithServiceIdentity(IIdentity clientIdentity, string serviceIdentityId, SharedAccessSignature sharedAccessSignature)
         {
             Option<ServiceIdentity> serviceIdentity = await this.deviceScopeIdentitiesCache.GetServiceIdentity(serviceIdentityId);
-            (bool isAuthenticated, bool valueFound) = serviceIdentity.Map(s => (this.ValidateCredentials(sharedAccessSignature, s, clientIdentity), true)).GetOrElse((false, false));
+            (bool isAuthenticated, bool serviceIdentityFound) = serviceIdentity.Map(s => (this.ValidateCredentials(sharedAccessSignature, s, clientIdentity), true)).GetOrElse((false, false));
 
             if (!isAuthenticated)
             {
                 await this.deviceScopeIdentitiesCache.RefreshServiceIdentity(serviceIdentityId);
                 serviceIdentity = await this.deviceScopeIdentitiesCache.GetServiceIdentity(serviceIdentityId);
-                (isAuthenticated, valueFound) = serviceIdentity.Map(s => (this.ValidateCredentials(sharedAccessSignature, s, clientIdentity), true)).GetOrElse((false, false));
+                (isAuthenticated, serviceIdentityFound) = serviceIdentity.Map(s => (this.ValidateCredentials(sharedAccessSignature, s, clientIdentity), true)).GetOrElse((false, false));
             }
 
-            return (isAuthenticated, valueFound);
+            return (isAuthenticated, serviceIdentityFound);
         }
 
         bool TryGetSharedAccessSignature(string token, IIdentity identity, out SharedAccessSignature sharedAccessSignature)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
@@ -1,0 +1,200 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
+
+    public abstract class DeviceScopeAuthenticator<T> : IAuthenticator
+        where T : IClientCredentials
+    {
+        readonly IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache;
+        readonly IAuthenticator underlyingAuthenticator;
+        readonly bool allowDeviceAuthForModule;
+        readonly bool syncServiceIdentityOnFailure;
+
+        protected DeviceScopeAuthenticator(
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache,
+            IAuthenticator underlyingAuthenticator,
+            bool allowDeviceAuthForModule,
+            bool syncServiceIdentityOnFailure)
+        {
+            this.underlyingAuthenticator = Preconditions.CheckNotNull(underlyingAuthenticator, nameof(underlyingAuthenticator));
+            this.deviceScopeIdentitiesCache = Preconditions.CheckNotNull(deviceScopeIdentitiesCache, nameof(deviceScopeIdentitiesCache));
+            this.allowDeviceAuthForModule = allowDeviceAuthForModule;
+            this.syncServiceIdentityOnFailure = syncServiceIdentityOnFailure;
+        }
+
+        public async Task<bool> AuthenticateAsync(IClientCredentials clientCredentials)
+        {
+            if (!(clientCredentials is T tCredentials))
+            {
+                return false;
+            }
+
+            (bool isAuthenticated, bool shouldFallback) = await this.AuthenticateInternalAsync(tCredentials);
+            Events.AuthenticatedInScope(clientCredentials.Identity, isAuthenticated);
+            if (!isAuthenticated && shouldFallback)
+            {
+                isAuthenticated = await this.underlyingAuthenticator.AuthenticateAsync(clientCredentials);
+            }
+
+            return isAuthenticated;
+        }
+
+        public async Task<bool> ReauthenticateAsync(IClientCredentials clientCredentials)
+        {
+            if (!(clientCredentials is T tCredentials))
+            {
+                return false;
+            }
+
+            (bool isAuthenticated, bool shouldFallback) = await this.AuthenticateInternalAsync(tCredentials);
+            Events.ReauthenticatedInScope(clientCredentials.Identity, isAuthenticated);
+            if (!isAuthenticated && shouldFallback)
+            {
+                isAuthenticated = await this.underlyingAuthenticator.ReauthenticateAsync(clientCredentials);
+            }
+
+            return isAuthenticated;
+        }
+
+        protected abstract bool AreInputCredentialsValid(T credentials);
+
+        protected abstract bool ValidateWithServiceIdentity(ServiceIdentity serviceIdentity, T credentials);
+
+        async Task<(bool isAuthenticated, bool shouldFallback)> AuthenticateInternalAsync(T tCredentials)
+        {
+            try
+            {
+                if (!this.AreInputCredentialsValid(tCredentials))
+                {
+                    return (false, false);
+                }
+
+                (bool isAuthenticated, bool valueFound) = await this.AuthenticateWithServiceIdentity(tCredentials, tCredentials.Identity.Id);
+                if (!isAuthenticated && this.allowDeviceAuthForModule && tCredentials.Identity is IModuleIdentity moduleIdentity)
+                {
+                    // Module can use the Device key to authenticate
+                    (isAuthenticated, valueFound) = await this.AuthenticateWithServiceIdentity(tCredentials, moduleIdentity.DeviceId);
+                }
+
+                return (isAuthenticated, !valueFound);
+            }
+            catch (Exception e)
+            {
+                Events.ErrorAuthenticating(e, tCredentials);
+                return (false, true);
+            }
+        }
+
+        async Task<(bool isAuthenticated, bool serviceIdentityFound)> AuthenticateWithServiceIdentity(T credentials, string serviceIdentityId)
+        {
+            Option<ServiceIdentity> serviceIdentity = await this.deviceScopeIdentitiesCache.GetServiceIdentity(serviceIdentityId);
+            (bool isAuthenticated, bool serviceIdentityFound) = serviceIdentity.Map(s => (this.ValidateWithServiceIdentity(s, credentials), true)).GetOrElse((false, false));
+
+            if (!isAuthenticated && (!serviceIdentityFound || this.syncServiceIdentityOnFailure))
+            {
+                await this.deviceScopeIdentitiesCache.RefreshServiceIdentity(serviceIdentityId);
+                serviceIdentity = await this.deviceScopeIdentitiesCache.GetServiceIdentity(serviceIdentityId);
+                (isAuthenticated, serviceIdentityFound) = serviceIdentity.Map(s => (this.ValidateWithServiceIdentity(s, credentials), true)).GetOrElse((false, false));
+            }
+
+            return (isAuthenticated, serviceIdentityFound);
+        }
+
+        static class Events
+        {
+            static readonly ILogger Log = Logger.Factory.CreateLogger<DeviceScopeAuthenticator<T>>();
+            const int IdStart = HubCoreEventIds.DeviceScopeAuthenticator;
+
+            enum EventIds
+            {
+                ErrorReauthenticating = IdStart,
+                InvalidHostName,
+                InvalidAudience,
+                IdMismatch,
+                KeysMismatch,
+                InvalidServiceIdentityType,
+                ErrorAuthenticating,
+                ServiceIdentityNotEnabled,
+                TokenExpired,
+                ErrorParsingToken,
+                ServiceIdentityNotFound,
+                AuthenticatedInScope
+            }
+
+            public static void ErrorReauthenticating(Exception exception, ServiceIdentity serviceIdentity)
+            {
+                Log.LogWarning((int)EventIds.ErrorReauthenticating, exception, $"Error re-authenticating {serviceIdentity.Id} after the service identity was updated.");
+            }
+
+            public static void InvalidHostName(string id, string hostName, string iotHubHostName, string edgeHubHostName)
+            {
+                Log.LogWarning((int)EventIds.InvalidHostName, $"Error authenticating token for {id} because the audience hostname {hostName} does not match IoTHub hostname {iotHubHostName} or the EdgeHub hostname {edgeHubHostName}.");
+            }
+
+            public static void InvalidAudience(string audience, IIdentity identity)
+            {
+                Log.LogWarning((int)EventIds.InvalidAudience, $"Error authenticating token for {identity.Id} because the audience {audience} is invalid.");
+            }
+
+            public static void IdMismatch(string audience, IIdentity identity, string deviceId)
+            {
+                Log.LogWarning((int)EventIds.IdMismatch, $"Error authenticating token for {identity.Id} because the deviceId {deviceId} in the identity does not match the audience {audience}.");
+            }
+
+            public static void KeysMismatch(string id, Exception exception)
+            {
+                Log.LogWarning((int)EventIds.KeysMismatch, $"Error authenticating token for {id} because the token did not match the primary or the secondary key. Error - {exception.Message}");
+            }
+
+            public static void InvalidServiceIdentityType(ServiceIdentity serviceIdentity)
+            {
+                Log.LogWarning((int)EventIds.InvalidServiceIdentityType, $"Error authenticating token for {serviceIdentity.Id} because the service identity authentication type is unexpected - {serviceIdentity.Authentication.Type}");
+            }
+
+            public static void ErrorAuthenticating(Exception exception, IClientCredentials credentials)
+            {
+                Log.LogWarning((int)EventIds.ErrorAuthenticating, exception, $"Error authenticating credentials for {credentials.Identity.Id}");
+            }
+
+            public static void ServiceIdentityNotEnabled(ServiceIdentity serviceIdentity)
+            {
+                Log.LogWarning((int)EventIds.ServiceIdentityNotEnabled, $"Error authenticating token for {serviceIdentity.Id} because the service identity is not enabled");
+            }
+
+            public static void TokenExpired(IIdentity identity)
+            {
+                Log.LogWarning((int)EventIds.TokenExpired, $"Error authenticating token for {identity.Id} because the token has expired.");
+            }
+
+            public static void ErrorParsingToken(IIdentity identity, Exception exception)
+            {
+                Log.LogWarning((int)EventIds.ErrorParsingToken, exception, $"Error authenticating token for {identity.Id} because the token could not be parsed");
+            }
+
+            public static void ServiceIdentityNotFound(IIdentity identity)
+            {
+                Log.LogDebug((int)EventIds.ServiceIdentityNotFound, $"Service identity for {identity.Id} not found. Using underlying authenticator to authenticate");
+            }
+
+            public static void AuthenticatedInScope(IIdentity identity, bool isAuthenticated)
+            {
+                string authenticated = isAuthenticated ? "authenticated" : "not authenticated";
+                Log.LogInformation((int)EventIds.AuthenticatedInScope, $"Client {identity.Id} in device scope {authenticated} locally.");
+            }
+
+            public static void ReauthenticatedInScope(IIdentity identity, bool isAuthenticated)
+            {
+                string authenticated = isAuthenticated ? "reauthenticated" : "not reauthenticated";
+                Log.LogDebug((int)EventIds.AuthenticatedInScope, $"Client {identity.Id} in device scope {authenticated} locally.");
+            }
+        }
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
@@ -88,6 +88,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     (isAuthenticated, valueFound) = await this.AuthenticateWithServiceIdentity(tCredentials, moduleIdentity.DeviceId, syncServiceIdentity);
                 }
 
+                // In the return value, the first flag indicates if the authentication succeeded.
+                // The second flag indicates whether the authenticator should fall back to the underlying authenticator. This is done if
+                // the ServiceIdentity was not found (which means the device/module is not in scope).
                 return (isAuthenticated, !valueFound);
             }
             catch (Exception e)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/HubCoreEventIds.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/HubCoreEventIds.cs
@@ -18,5 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 	    public const int InvokeMethodHandler = EventIdStart + 1100;
 	    public const int DeviceScopeIdentitiesCache = EventIdStart + 1200;
 	    public const int PeriodicConnectionAuthenticator = EventIdStart + 1300;
+	    public const int DeviceScopeAuthenticator = EventIdStart + 1400;
+
 	}
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -232,14 +232,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
 
                         case AuthenticationMode.Scope:
                             deviceScopeIdentitiesCache = await c.Resolve<Task<IDeviceScopeIdentitiesCache>>();
-                            tokenAuthenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, this.edgeDeviceHostName, new NullAuthenticator());
+                            tokenAuthenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, this.edgeDeviceHostName, new NullAuthenticator(), true, true);
                             break;
 
                         default:                            
                             var deviceScopeIdentitiesCacheTask = c.Resolve<Task<IDeviceScopeIdentitiesCache>>();
                             IAuthenticator cloudTokenAuthenticator = await this.GetCloudTokenAuthenticator(c);
                             deviceScopeIdentitiesCache = await deviceScopeIdentitiesCacheTask;
-                            tokenAuthenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, this.edgeDeviceHostName, cloudTokenAuthenticator);
+                            tokenAuthenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, this.edgeDeviceHostName, cloudTokenAuthenticator, true, true);
                             break;
                     }
 


### PR DESCRIPTION
Currently, EdgeHub pulls service identities of devices/modules in scope and caches them locally. This cache is re-synced every hour (configurable). 
If during this time, the client key was updated in IoTHub, the subsequent authentication will fail for the client if the client tried to connect to EdgeHub. To prevent this, if the authentication of an identity in scope fails locally, try to resync the identity with IoTHub and authenticate again. 