### PR TITLE
Add support to obtain trust bundle from iotedged or an input file

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             public const string WorkloadUri = "IOTEDGE_WORKLOADURI";
             public const string EdgeHubDevServerCertificateFile = "EdgeHubDevServerCertificateFile";
             public const string EdgeHubDevServerPrivateKeyFile = "EdgeHubDevServerPrivateKeyFile";
+            public const string EdgeHubDevTrustBundleFile = "EdgeHubDevTrustBundleFile";
+            public const string EdgeHubClientCertAuthEnabled = "ClientCertAuthEnabled";
         }
 
         public const int CertificateValidityDays = 90;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
     {
         readonly IConfigurationRoot configuration;
         readonly X509Certificate2 serverCertificate;
+        readonly IList<X509Certificate2> trustBundle;
 
         readonly string iotHubHostname;
         readonly string edgeDeviceId;
@@ -31,10 +32,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         readonly Option<string> connectionString;
         readonly VersionInfo versionInfo;
 
-        public DependencyManager(IConfigurationRoot configuration, X509Certificate2 serverCertificate)
+        public DependencyManager(IConfigurationRoot configuration, X509Certificate2 serverCertificate, IList<X509Certificate2> trustBundle)
         {
             this.configuration = Preconditions.CheckNotNull(configuration, nameof(configuration));
             this.serverCertificate = Preconditions.CheckNotNull(serverCertificate, nameof(serverCertificate));
+            this.trustBundle = Preconditions.CheckNotNull(trustBundle, nameof(trustBundle));
 
             string edgeHubConnectionString = this.configuration.GetValue<string>(Constants.ConfigKey.IotHubConnectionString);
             if (!string.IsNullOrWhiteSpace(edgeHubConnectionString))
@@ -168,7 +170,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     storeAndForward.storagePath,
                     workloadUri,
                     scopeCacheRefreshRate,
-                    cacheTokens));
+                    cacheTokens,
+                    this.trustBundle));
         }
 
         internal static Option<UpstreamProtocol> GetUpstreamProtocol(IConfigurationRoot configuration) =>
@@ -178,7 +181,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
         (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) GetStoreAndForwardConfiguration()
         {
-            int defaultTtl = -1;            
+            int defaultTtl = -1;
             bool usePersistentStorage = this.configuration.GetValue<bool>("usePersistentStorage");
             int timeToLiveSecs = defaultTtl;
             string storagePath = this.GetStoragePath();

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
@@ -19,10 +19,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
         public IList<X509Certificate2> CertificateChain { get; }
 
-        EdgeHubCertificates(X509Certificate2 serverCertificate, IList<X509Certificate2> certificateChain)
+        public IList<X509Certificate2> TrustBundle { get; }
+
+        EdgeHubCertificates(X509Certificate2 serverCertificate, IList<X509Certificate2> certificateChain, IList<X509Certificate2> trustBundle)
         {
             this.ServerCertificate = Preconditions.CheckNotNull(serverCertificate, nameof(serverCertificate));
             this.CertificateChain = Preconditions.CheckNotNull(certificateChain, nameof(certificateChain));
+            this.TrustBundle = Preconditions.CheckNotNull(trustBundle, nameof(trustBundle));
         }
 
         public static async Task<EdgeHubCertificates> LoadAsync(IConfigurationRoot configuration)
@@ -31,6 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             EdgeHubCertificates result;
             string edgeHubDevCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerCertificateFile);
             string edgeHubDevPrivateKeyPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerPrivateKeyFile);
+            string edgeHubDevTrustBundlePath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevTrustBundleFile);
             string edgeHubDockerCertPFXPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCertificateFile);
             string edgeHubDockerCaChainCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCAChainCertificateFile);
             string edgeHubConnectionString = configuration.GetValue<string>(Constants.ConfigKey.IotHubConnectionString);
@@ -48,17 +52,27 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 DateTime expiration = DateTime.UtcNow.AddDays(Constants.CertificateValidityDays);
                 certificates = await CertificateHelper.GetServerCertificatesFromEdgelet(workloadUri, Constants.WorkloadApiVersion, moduleId, generationId, edgeHubHostname, expiration);
                 InstallCertificates(certificates.CertificateChain);
-                result = new EdgeHubCertificates(certificates.ServerCertificate, certificates.CertificateChain?.ToList());
+                IEnumerable<X509Certificate2> trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(workloadUri, Constants.WorkloadApiVersion, moduleId, generationId);
+
+                result = new EdgeHubCertificates(certificates.ServerCertificate,
+                                                 certificates.CertificateChain?.ToList(),
+                                                 trustBundle?.ToList());
             }
             else if (!string.IsNullOrEmpty(edgeHubDevCertPath) &&
-                     !string.IsNullOrEmpty(edgeHubDevPrivateKeyPath))
+                     !string.IsNullOrEmpty(edgeHubDevPrivateKeyPath) &&
+                     !string.IsNullOrEmpty(edgeHubDevTrustBundlePath))
             {
                 // If no connection string was set and we use iotedged workload style certificates for development
                 (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
 
                 certificates = CertificateHelper.GetServerCertificateAndChainFromFile(edgeHubDevCertPath, edgeHubDevPrivateKeyPath);
                 InstallCertificates(certificates.CertificateChain);
-                result = new EdgeHubCertificates(certificates.ServerCertificate, certificates.CertificateChain?.ToList());
+
+                IEnumerable<X509Certificate2> trustBundle = CertificateHelper.ParseTrustedBundleFromFile(edgeHubDevTrustBundlePath);
+
+                result = new EdgeHubCertificates(certificates.ServerCertificate,
+                                                 certificates.CertificateChain?.ToList(),
+                                                 trustBundle?.ToList());
             }
             else if (!string.IsNullOrEmpty(edgeHubDockerCertPFXPath) &&
                      !string.IsNullOrEmpty(edgeHubDockerCaChainCertPath))
@@ -66,7 +80,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 // If no connection string was set and we use iotedge devdiv style certificates for development
                 List<X509Certificate2> certificateChain = CertificateHelper.GetServerCACertificatesFromFile(edgeHubDockerCaChainCertPath)?.ToList();
                 InstallCertificates(certificateChain);
-                result = new EdgeHubCertificates(new X509Certificate2(edgeHubDockerCertPFXPath), certificateChain);
+                result = new EdgeHubCertificates(new X509Certificate2(edgeHubDockerCertPFXPath), certificateChain, new List<X509Certificate2>());
             }
             else
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             }
 
             EdgeHubCertificates certificates = await EdgeHubCertificates.LoadAsync(configuration).ConfigureAwait(false);
-            Hosting hosting = Hosting.Initialize(configuration, certificates.ServerCertificate, new DependencyManager(configuration, certificates.ServerCertificate));
+            Hosting hosting = Hosting.Initialize(configuration, certificates.ServerCertificate, new DependencyManager(configuration, certificates.ServerCertificate, certificates.TrustBundle));
             IContainer container = hosting.Container;
 
             ILogger logger = container.Resolve<ILoggerFactory>().CreateLogger("EdgeHub");

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
     using System;
     using System.Collections.Generic;
     using System.Net;
+    using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using Autofac;
     using Microsoft.Azure.Devices.Edge.Hub.CloudProxy;
@@ -32,6 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly TimeSpan scopeCacheRefreshRate;
         readonly Option<string> workloadUri;
         readonly bool persistTokens;
+        readonly IList<X509Certificate2> trustBundle;
 
         public CommonModule(
             string productInfo,
@@ -47,7 +49,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             string storagePath,
             Option<string> workloadUri,
             TimeSpan scopeCacheRefreshRate,
-            bool persistTokens)
+            bool persistTokens,
+            IList<X509Certificate2> trustBundle)
         {
             this.productInfo = productInfo;
             this.iothubHostName = Preconditions.CheckNonWhiteSpace(iothubHostName, nameof(iothubHostName));
@@ -63,6 +66,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.scopeCacheRefreshRate = scopeCacheRefreshRate;
             this.workloadUri = workloadUri;
             this.persistTokens = persistTokens;
+            this.trustBundle = Preconditions.CheckNotNull(trustBundle, nameof(trustBundle));
         }
 
         protected override void Load(ContainerBuilder builder)

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -24,11 +24,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
     {
         readonly IConfigurationRoot configuration;
         readonly X509Certificate2 serverCertificate;
+        readonly IList<X509Certificate2> trustBundle;
 
-        public DependencyManager(IConfigurationRoot configuration, X509Certificate2 serverCertificate)
+        public DependencyManager(IConfigurationRoot configuration, X509Certificate2 serverCertificate, IList<X509Certificate2> trustBundle)
         {
             this.configuration = configuration;
             this.serverCertificate = serverCertificate;
+            this.trustBundle = trustBundle;
         }
 
         public void Register(ContainerBuilder builder)
@@ -72,7 +74,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     string.Empty,
                     Option.None<string>(),
                     TimeSpan.FromHours(1),
-                    false));
+                    false,
+                    this.trustBundle));
 
             builder.RegisterModule(
                 new RoutingModule(

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/ProtocolHeadFixture.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/ProtocolHeadFixture.cs
@@ -59,6 +59,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 string certificateValue = await SecretsHelper.GetSecret("IotHubMqttHeadCert");
                 byte[] cert = Convert.FromBase64String(certificateValue);
                 var certificate = new X509Certificate2(cert);
+                // TODO for now this is empty as will suffice for SAS X.509 thumprint auth but we will need other CA certs for X.509 CA validation
+                var trustBundle = new List<X509Certificate2>();
 
                 string edgeDeviceConnectionString = await SecretsHelper.GetSecretFromConfigKey("edgeCapableDeviceConnStrKey");
 
@@ -66,7 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 await ConnectToIotHub(edgeDeviceConnectionString);
 
                 ConfigHelper.TestConfig[Service.Constants.ConfigKey.IotHubConnectionString] = edgeDeviceConnectionString;
-                Hosting hosting = Hosting.Initialize(ConfigHelper.TestConfig, certificate, new DependencyManager(ConfigHelper.TestConfig, certificate));
+                Hosting hosting = Hosting.Initialize(ConfigHelper.TestConfig, certificate, new DependencyManager(ConfigHelper.TestConfig, certificate, trustBundle));
                 this.container = hosting.Container;
 
                 // CloudConnectionProvider and RoutingEdgeHub have a circular dependency. So set the

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
     using Microsoft.Azure.Devices.Edge.Util.Edged;
     using Microsoft.Azure.Devices.Edge.Util.Edged.GeneratedCode;
     using Microsoft.Extensions.Logging;
+    using Org.BouncyCastle.Crypto;
     using Org.BouncyCastle.Crypto.Parameters;
     using Org.BouncyCastle.OpenSsl;
     using Org.BouncyCastle.Pkcs;
@@ -208,6 +209,12 @@ namespace Microsoft.Azure.Devices.Edge.Util
             return ParseCertificateResponse(response);
         }
 
+        public static async Task<IEnumerable<X509Certificate2>> GetTrustBundleFromEdgelet(Uri workloadUri, string workloadApiVersion, string moduleId, string moduleGenerationId)
+        {
+            TrustBundleResponse response = await new WorkloadClient(workloadUri, workloadApiVersion, moduleId, moduleGenerationId).GetTrustBundleAsync();
+            return ParseTrustBundleResponse(response);
+        }
+
         public static (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) GetServerCertificateAndChainFromFile(string serverWithChainFilePath, string serverPrivateKeyFilePath)
         {
             string cert, privateKey;
@@ -258,6 +265,33 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 .ToList(); // Re-add the certificate end-marker which was removed by split
         }
 
+        public static IEnumerable<X509Certificate2> ParseTrustedBundleFromFile(string trustBundleFilePath)
+        {
+            string certs;
+
+            if (string.IsNullOrWhiteSpace(trustBundleFilePath) || !File.Exists(trustBundleFilePath))
+            {
+                throw new ArgumentException($"'{trustBundleFilePath}' is not a path to a trust bundle certificates file");
+            }
+
+            using (var sr = new StreamReader(trustBundleFilePath))
+            {
+                certs = sr.ReadToEnd();
+            }
+
+            return ParseTrustedBundleCerts(certs);
+        }
+
+        internal static IEnumerable<X509Certificate2> ParseTrustBundleResponse(TrustBundleResponse response)
+        {
+            return ParseTrustedBundleCerts(response.Certificate);
+        }
+
+        internal static IEnumerable<X509Certificate2> ParseTrustedBundleCerts(string trustedCACerts)
+        {
+            return GetCertificatesFromPem(ParsePemCerts(trustedCACerts));
+        }
+
         internal static (X509Certificate2, IEnumerable<X509Certificate2>) ParseCertificateResponse(CertificateResponse response)
         {
             return ParseCertificateAndKey(response.Certificate, response.PrivateKey.Bytes);
@@ -288,6 +322,10 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 if (certObject is Org.BouncyCastle.X509.X509Certificate x509Cert)
                 {
                     chain.Add(new X509CertificateEntry(x509Cert));
+                }
+                if (certObject is AsymmetricCipherKeyPair)
+                {
+                    certObject = ((AsymmetricCipherKeyPair)certObject).Private;
                 }
                 if (certObject is RsaPrivateCrtKeyParameters)
                 {

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/WorkloadClient.cs
@@ -44,6 +44,16 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged
             }
         }
 
+        public async Task<TrustBundleResponse> GetTrustBundleAsync()
+        {
+            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.workloadUri))
+            {
+                var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.workloadUri) };
+                TrustBundleResponse result = await this.Execute(() => edgeletHttpClient.TrustBundleAsync(this.apiVersion), "TrustBundleAsync");
+                return result;
+            }
+        }
+
         public async Task<string> EncryptAsync(string initializationVector, string plainText)
         {
             var request = new EncryptRequest

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/certificate/CertificateHelperTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/certificate/CertificateHelperTest.cs
@@ -114,6 +114,60 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Certificate
         }
 
         [Fact]
+        public void ParseTrustedBundleFromFileRaisesExceptionWithInvalidTBFile()
+        {
+            string testFile = Path.GetRandomFileName();
+            Assert.Throws<ArgumentException>(() => CertificateHelper.ParseTrustedBundleFromFile(null));
+            Assert.Throws<ArgumentException>(() => CertificateHelper.ParseTrustedBundleFromFile(""));
+            Assert.Throws<ArgumentException>(() => CertificateHelper.ParseTrustedBundleFromFile("   "));
+            Assert.Throws<ArgumentException>(() => CertificateHelper.ParseTrustedBundleFromFile(testFile));
+        }
+
+        [Fact]
+        public void ParseTrustBundleEmptyResponseReturnsEmptyList()
+        {
+            var response = new TrustBundleResponse()
+            {
+                Certificate = "  ",
+            };
+            //Assert.Throws<InvalidOperationException>(() => CertificateHelper.ParseTrustBundleResponse(response));
+            IEnumerable<X509Certificate2> certs = CertificateHelper.ParseTrustBundleResponse(response);
+            Assert.Equal(certs.Count(), 0);
+        }
+
+        [Fact]
+        public void ParseTrustBundleInvalidResponseReturnsEmptyList()
+        {
+            var response = new TrustBundleResponse()
+            {
+                Certificate = "somewhere over the rainbow",
+            };
+            IEnumerable<X509Certificate2> certs = CertificateHelper.ParseTrustBundleResponse(response);
+            Assert.Equal(certs.Count(), 0);
+        }
+
+        [Fact]
+        public void ParseTrustBundleResponseWithOneCertReturnsNonEmptyList()
+        {
+            var response = new TrustBundleResponse()
+            {
+                Certificate = $"{TestCertificateHelper.CertificatePem}\n",
+            };
+            IEnumerable<X509Certificate2> certs = CertificateHelper.ParseTrustBundleResponse(response);
+            Assert.Equal(certs.Count(), 1);
+        }
+
+        public void ParseTrustBundleResponseWithMultipleCertReturnsNonEmptyList()
+        {
+            var response = new TrustBundleResponse()
+            {
+                Certificate = $"{TestCertificateHelper.CertificatePem}\n{TestCertificateHelper.CertificatePem}",
+            };
+            IEnumerable<X509Certificate2> certs = CertificateHelper.ParseTrustBundleResponse(response);
+            Assert.Equal(certs.Count(), 2);
+        }
+
+        [Fact]
         public void ParseCertificatesSingleShouldReturnCetificate()
         {
             IList<string> pemCerts = CertificateHelper.ParsePemCerts(TestCertificateHelper.CertificatePem);

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/certificate/CertificateHelperTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/certificate/CertificateHelperTest.cs
@@ -157,6 +157,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Certificate
             Assert.Equal(certs.Count(), 1);
         }
 
+        [Fact]
         public void ParseTrustBundleResponseWithMultipleCertReturnsNonEmptyList()
         {
             var response = new TrustBundleResponse()


### PR DESCRIPTION
Add functionality along with tests in the Edge Hub to obtain the trust bundle either from the iotedged or an input file to facilitate development. The trust bundle is not really used here rather this is being staged for additional upcoming features.
