### PR TITLE
EdgeAgent: Avoid writing config to backup file every time

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/DeploymentConfigInfo.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/DeploymentConfigInfo.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
 
-    public class DeploymentConfigInfo
+    public class DeploymentConfigInfo : IEquatable<DeploymentConfigInfo>
     {
         public static DeploymentConfigInfo Empty = new DeploymentConfigInfo(-1, DeploymentConfig.Empty);
 
@@ -33,5 +33,56 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         [JsonIgnore]
         public Option<Exception> Exception { get; }
+
+        public bool Equals(DeploymentConfigInfo other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.Version == other.Version && Equals(this.DeploymentConfig, other.DeploymentConfig)
+                && this.Exception.Equals(other.Exception);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (obj is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, obj))
+            {
+                return true;
+            }
+
+            if (obj.GetType() != this.GetType())
+            {
+                return false;
+            }
+
+            return this.Equals((DeploymentConfigInfo)obj);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = this.Version.GetHashCode();
+                hashCode = (hashCode * 397) ^ (this.DeploymentConfig != null ? this.DeploymentConfig.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ this.Exception.GetHashCode();
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(DeploymentConfigInfo left, DeploymentConfigInfo right) => Equals(left, right);
+
+        public static bool operator !=(DeploymentConfigInfo left, DeploymentConfigInfo right) => !Equals(left, right);
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/SystemModules.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/SystemModules.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Agent.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Json;
+    using Newtonsoft.Json;
+
+    public class SystemModules : IEquatable<SystemModules>
+    {
+        [JsonConstructor]
+        public SystemModules(IEdgeAgentModule edgeAgent, IEdgeHubModule edgeHub)
+        {
+            this.EdgeAgent = Option.Maybe(edgeAgent);
+            this.EdgeHub = Option.Maybe(edgeHub);
+        }
+
+        public SystemModules(Option<IEdgeAgentModule> edgeAgent, Option<IEdgeHubModule> edgeHub)
+        {
+            this.EdgeAgent = edgeAgent;
+            this.EdgeHub = edgeHub;
+        }
+
+        [JsonProperty(PropertyName = "edgeHub")]
+        [JsonConverter(typeof(OptionConverter<IEdgeHubModule>))]
+        public Option<IEdgeHubModule> EdgeHub { get; }
+
+        [JsonProperty(PropertyName = "edgeAgent")]
+        [JsonConverter(typeof(OptionConverter<IEdgeAgentModule>))]
+        public Option<IEdgeAgentModule> EdgeAgent { get; }
+
+        public override bool Equals(object obj) => this.Equals(obj as SystemModules);
+
+        public bool Equals(SystemModules other)
+        {
+            return other != null &&
+                EqualityComparer<Option<IEdgeHubModule>>.Default.Equals(this.EdgeHub, other.EdgeHub) &&
+                EqualityComparer<Option<IEdgeAgentModule>>.Default.Equals(this.EdgeAgent, other.EdgeAgent);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -874519432;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Option<IEdgeHubModule>>.Default.GetHashCode(this.EdgeHub);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Option<IEdgeAgentModule>>.Default.GetHashCode(this.EdgeAgent);
+            return hashCode;
+        }
+
+        public static bool operator ==(SystemModules modules1, SystemModules modules2)
+        {
+            return EqualityComparer<SystemModules>.Default.Equals(modules1, modules2);
+        }
+
+        public static bool operator !=(SystemModules modules1, SystemModules modules2)
+        {
+            return !(modules1 == modules2);
+        }
+
+        public SystemModules Clone() => new SystemModules(this.EdgeAgent, this.EdgeHub);
+    }
+}

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigInfoTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigInfoTest.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
+{
+    public class DeploymentConfigInfoTest
+    {
+        
+    }
+}

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigInfoTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigInfoTest.cs
@@ -1,9 +1,135 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 {
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources;
+    using Xunit;
+
     public class DeploymentConfigInfoTest
     {
+        static readonly IEdgeAgentModule TestEdgeAgent1 = new TestAgentModule(
+            "edgeAgent",
+            "docker",
+            new TestConfig("microsoft/edgeAgent:1.0"),
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeAgentModule TestEdgeAgent1_1 = new TestAgentModule(
+            "edgeAgent",
+            "docker",
+            new TestConfig("microsoft/edgeAgent:1.0"),
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
         
+        static readonly IEdgeHubModule TestEdgeHub1 = new TestHubModule(
+            "edgeHub",
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:1.0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeHubModule TestEdgeHub1_1 = new TestHubModule(
+            "edgeHub",
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:1.0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
+        
+        static readonly IModule TestModule1 = new TestModule(
+            "mod1",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod1:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule1_1 = new TestModule(
+            "mod1",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod1:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
+        
+        static readonly IModule TestModule2 = new TestModule(
+            "mod2",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod2:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule2_1 = new TestModule(
+            "mod2",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod2:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
+
+        static readonly DeploymentConfig Config1 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config1_1 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1_1, TestEdgeHub1_1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1_1,
+                ["mod2"] = TestModule2_1
+            });
+
+        static readonly DeploymentConfig Config2 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1
+            });
+
+        static readonly DeploymentConfigInfo ConfigInfo1 = new DeploymentConfigInfo(            1,            Config1);
+        static readonly DeploymentConfigInfo ConfigInfo1_1 = new DeploymentConfigInfo(1, Config1_1);
+        static readonly DeploymentConfigInfo ConfigInfo2 = new DeploymentConfigInfo(1, Config2);
+        static readonly DeploymentConfigInfo ConfigInfo3 = new DeploymentConfigInfo(2, Config1_1);
+
+        [Theory]
+        [MemberData(nameof(EqualityTestData))]
+        public void TestEquality(DeploymentConfigInfo configInfo1, DeploymentConfigInfo configInfo2, bool areEqual)
+        {
+            // Act
+            bool result = configInfo1.Equals(configInfo2);
+
+            // Assert
+            Assert.Equal(areEqual, result);
+        }
+
+        static IEnumerable<object[]> EqualityTestData()
+        {
+            yield return new object[] { ConfigInfo1, ConfigInfo1_1, true };
+            yield return new object[] { ConfigInfo1, ConfigInfo2, false };
+            yield return new object[] { ConfigInfo1, ConfigInfo3, false };
+        }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigTest.cs
@@ -1,62 +1,149 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-using System.Collections.Generic;
-using Microsoft.Azure.Devices.Edge.Util.Test.Common;
-using Moq;
-using Xunit;
-
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 {
-    using System;
+    using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;
+    using Xunit;
 
     [Unit]
     public class DeploymentConfigTest
     {
-        static readonly IEdgeAgentModule TestEdgeAgent1 = new TestAgentModule("edgeAgent", "docker",
-    new TestConfig("microsoft/edgeAgent:1.0"), new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IEdgeAgentModule TestEdgeAgent1 = new TestAgentModule(
+            "edgeAgent",
+            "docker",
+            new TestConfig("microsoft/edgeAgent:1.0"),
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IEdgeAgentModule TestEdgeAgent1_1 = new TestAgentModule("edgeAgent", "docker",
-            new TestConfig("microsoft/edgeAgent:1.0"), new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IEdgeAgentModule TestEdgeAgent1_1 = new TestAgentModule(
+            "edgeAgent",
+            "docker",
+            new TestConfig("microsoft/edgeAgent:1.0"),
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IEdgeAgentModule TestEdgeAgent2 = new TestAgentModule("edgeAgent", "docker",
-            new TestConfig("microsoft/edgeAgent:2.0"), new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IEdgeAgentModule TestEdgeAgent2 = new TestAgentModule(
+            "edgeAgent",
+            "docker",
+            new TestConfig("microsoft/edgeAgent:2.0"),
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IEdgeAgentModule TestEdgeAgent3 = new TestAgentModule("edgeAgent", "rkt",
-            new TestConfig("microsoft/edgeAgent:1.0"), new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IEdgeAgentModule TestEdgeAgent3 = new TestAgentModule(
+            "edgeAgent",
+            "rkt",
+            new TestConfig("microsoft/edgeAgent:1.0"),
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IEdgeHubModule TestEdgeHub1 = new TestHubModule("edgeHub", "docker", ModuleStatus.Running,
-            new TestConfig("microsoft/edgeHub:1.0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IEdgeHubModule TestEdgeHub1 = new TestHubModule(
+            "edgeHub",
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:1.0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IEdgeHubModule TestEdgeHub1_1 = new TestHubModule("edgeHub", "docker", ModuleStatus.Running,
-            new TestConfig("microsoft/edgeHub:1.0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IEdgeHubModule TestEdgeHub1_1 = new TestHubModule(
+            "edgeHub",
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:1.0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IEdgeHubModule TestEdgeHub2 = new TestHubModule("edgeHub", "docker", ModuleStatus.Running,
-            new TestConfig("microsoft/edgeHub:2.0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IEdgeHubModule TestEdgeHub2 = new TestHubModule(
+            "edgeHub",
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:2.0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IEdgeHubModule TestEdgeHub3 = new TestHubModule("edgeHub", "rkt", ModuleStatus.Running,
-            new TestConfig("microsoft/edgeHub:1.0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IEdgeHubModule TestEdgeHub3 = new TestHubModule(
+            "edgeHub",
+            "rkt",
+            ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:1.0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IModule TestModule1 = new TestModule("mod1", string.Empty, "docker",
-            ModuleStatus.Running, new TestConfig("mod1:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IModule TestModule1 = new TestModule(
+            "mod1",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod1:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IModule TestModule1_1 = new TestModule("mod1", string.Empty, "docker",
-            ModuleStatus.Running, new TestConfig("mod1:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IModule TestModule1_1 = new TestModule(
+            "mod1",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod1:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IModule TestModule1_2 = new TestModule("mod1", string.Empty, "docker",
-            ModuleStatus.Running, new TestConfig("mod1:v2"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IModule TestModule1_2 = new TestModule(
+            "mod1",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod1:v2"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IModule TestModule1_3 = new TestModule("mod1", string.Empty, "docker",
-            ModuleStatus.Stopped, new TestConfig("mod1:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IModule TestModule1_3 = new TestModule(
+            "mod1",
+            string.Empty,
+            "docker",
+            ModuleStatus.Stopped,
+            new TestConfig("mod1:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IModule TestModule1_4 = new TestModule("mod1", string.Empty, "docker",
-            ModuleStatus.Running, new TestConfig("mod1:v0"), RestartPolicy.OnFailure, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IModule TestModule1_4 = new TestModule(
+            "mod1",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod1:v0"),
+            RestartPolicy.OnFailure,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IModule TestModule2 = new TestModule("mod2", string.Empty, "docker",
-            ModuleStatus.Running, new TestConfig("mod2:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IModule TestModule2 = new TestModule(
+            "mod2",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod2:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
-        static readonly IModule TestModule2_1 = new TestModule("mod2", string.Empty, "docker",
-            ModuleStatus.Running, new TestConfig("mod2:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+        static readonly IModule TestModule2_1 = new TestModule(
+            "mod2",
+            string.Empty,
+            "docker",
+            ModuleStatus.Running,
+            new TestConfig("mod2:v0"),
+            RestartPolicy.Always,
+            new ConfigurationInfo(),
+            new Dictionary<string, EnvVal>());
 
         static readonly DeploymentConfig Config1 = new DeploymentConfig(
             "1.0",
@@ -256,8 +343,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 
         static IEnumerable<object[]> EqualityTestData()
         {
-            yield return new object[] {Config1, Config1_1, true};
-            yield return new object[] {Config1, Config2, false};
+            yield return new object[] { Config1, Config1_1, true };
+            yield return new object[] { Config1, Config2, false };
             yield return new object[] { Config1, Config3, false };
             yield return new object[] { Config1, Config4, false };
             yield return new object[] { Config1, Config5, false };
@@ -270,7 +357,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             yield return new object[] { Config1, Config12, false };
             yield return new object[] { Config1, Config13, false };
             yield return new object[] { Config1, Config14, false };
-            yield return new object[] { Config1, Config15, false };            
+            yield return new object[] { Config1, Config15, false };
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigTest.cs
@@ -7,9 +7,212 @@ using Xunit;
 
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 {
+    using System;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources;
+
     [Unit]
     public class DeploymentConfigTest
     {
+        static readonly IEdgeAgentModule TestEdgeAgent1 = new TestAgentModule("edgeAgent", "docker",
+    new TestConfig("microsoft/edgeAgent:1.0"), new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeAgentModule TestEdgeAgent1_1 = new TestAgentModule("edgeAgent", "docker",
+            new TestConfig("microsoft/edgeAgent:1.0"), new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeAgentModule TestEdgeAgent2 = new TestAgentModule("edgeAgent", "docker",
+            new TestConfig("microsoft/edgeAgent:2.0"), new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeAgentModule TestEdgeAgent3 = new TestAgentModule("edgeAgent", "rkt",
+            new TestConfig("microsoft/edgeAgent:1.0"), new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeHubModule TestEdgeHub1 = new TestHubModule("edgeHub", "docker", ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:1.0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeHubModule TestEdgeHub1_1 = new TestHubModule("edgeHub", "docker", ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:1.0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeHubModule TestEdgeHub2 = new TestHubModule("edgeHub", "docker", ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:2.0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IEdgeHubModule TestEdgeHub3 = new TestHubModule("edgeHub", "rkt", ModuleStatus.Running,
+            new TestConfig("microsoft/edgeHub:1.0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule1 = new TestModule("mod1", string.Empty, "docker",
+            ModuleStatus.Running, new TestConfig("mod1:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule1_1 = new TestModule("mod1", string.Empty, "docker",
+            ModuleStatus.Running, new TestConfig("mod1:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule1_2 = new TestModule("mod1", string.Empty, "docker",
+            ModuleStatus.Running, new TestConfig("mod1:v2"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule1_3 = new TestModule("mod1", string.Empty, "docker",
+            ModuleStatus.Stopped, new TestConfig("mod1:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule1_4 = new TestModule("mod1", string.Empty, "docker",
+            ModuleStatus.Running, new TestConfig("mod1:v0"), RestartPolicy.OnFailure, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule2 = new TestModule("mod2", string.Empty, "docker",
+            ModuleStatus.Running, new TestConfig("mod2:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly IModule TestModule2_1 = new TestModule("mod2", string.Empty, "docker",
+            ModuleStatus.Running, new TestConfig("mod2:v0"), RestartPolicy.Always, new ConfigurationInfo(), new Dictionary<string, EnvVal>());
+
+        static readonly DeploymentConfig Config1 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config1_1 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1_1, TestEdgeHub1_1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1_1,
+                ["mod2"] = TestModule2_1
+            });
+
+        static readonly DeploymentConfig Config2 = new DeploymentConfig(
+            "2.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config3 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker1"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config4 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent2, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config5 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent3, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config6 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub2),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config7 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub3),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config8 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1_2,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config9 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1_3,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config10 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1_4,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config11 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1
+            });
+
+        static readonly DeploymentConfig Config12 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent3, null),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config13 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(null, TestEdgeHub1),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1,
+                ["mod2"] = TestModule2
+            });
+
+        static readonly DeploymentConfig Config14 = new DeploymentConfig(
+            "1.0",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent1, TestEdgeHub1),
+            new Dictionary<string, IModule>());
+
+        static readonly DeploymentConfig Config15 = new DeploymentConfig(
+            "1.1",
+            new TestRuntimeInfo("docker"),
+            new SystemModules(TestEdgeAgent3, TestEdgeHub3),
+            new Dictionary<string, IModule>
+            {
+                ["mod1"] = TestModule1_4,
+                ["mod2"] = TestModule2
+            });
+
         [Fact]
         public void BasicTest()
         {
@@ -38,6 +241,36 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             Assert.Equal(edgeAgentModule.Name, moduleSet.Modules["edgeAgent"].Name);
             Assert.Equal(modules["mod1"].Name, moduleSet.Modules["mod1"].Name);
             Assert.Equal(modules["mod2"].Name, moduleSet.Modules["mod2"].Name);
+        }
+
+        [Theory]
+        [MemberData(nameof(EqualityTestData))]
+        public void EqualityTest(DeploymentConfig config1, DeploymentConfig config2, bool areEqual)
+        {
+            // Act
+            bool result = config1.Equals(config2);
+
+            // Assert
+            Assert.Equal(areEqual, result);
+        }
+
+        static IEnumerable<object[]> EqualityTestData()
+        {
+            yield return new object[] {Config1, Config1_1, true};
+            yield return new object[] {Config1, Config2, false};
+            yield return new object[] { Config1, Config3, false };
+            yield return new object[] { Config1, Config4, false };
+            yield return new object[] { Config1, Config5, false };
+            yield return new object[] { Config1, Config6, false };
+            yield return new object[] { Config1, Config7, false };
+            yield return new object[] { Config1, Config8, false };
+            yield return new object[] { Config1, Config9, false };
+            yield return new object[] { Config1, Config10, false };
+            yield return new object[] { Config1, Config11, false };
+            yield return new object[] { Config1, Config12, false };
+            yield return new object[] { Config1, Config13, false };
+            yield return new object[] { Config1, Config14, false };
+            yield return new object[] { Config1, Config15, false };            
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/configsources/FileConfigSourceTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/configsources/FileConfigSourceTest.cs
@@ -291,9 +291,36 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources
 
         public string Type { get; }
 
-        public bool Equals(IRuntimeInfo other)
+        public bool Equals(IRuntimeInfo other) => other is TestRuntimeInfo otherRuntimeInfo
+            && this.Equals(otherRuntimeInfo);
+
+        public override bool Equals(object obj)
         {
-            throw new NotImplementedException();
+            if (ReferenceEquals(null, obj))
+                return false;
+            if (ReferenceEquals(this, obj))
+                return true;
+            if (obj.GetType() != this.GetType())
+                return false;
+            return Equals((TestRuntimeInfo)obj);
         }
+
+        public override int GetHashCode()
+        {
+            return (this.Type != null ? this.Type.GetHashCode() : 0);
+        }
+
+        public bool Equals(TestRuntimeInfo other)
+        {
+            if (ReferenceEquals(null, other))
+                return false;
+            if (ReferenceEquals(this, other))
+                return true;
+            return string.Equals(this.Type, other.Type);
+        }
+
+        public static bool operator ==(TestRuntimeInfo left, TestRuntimeInfo right) => Equals(left, right);
+
+        public static bool operator !=(TestRuntimeInfo left, TestRuntimeInfo right) => !Equals(left, right);
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/DictionaryComparer.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/DictionaryComparer.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 )
             );
 
-        public int GetHashCode(IDictionary<TKey, TValue> obj) =>
+        public int GetHashCode(IReadOnlyDictionary<TKey, TValue> obj) =>
             obj.Aggregate(17, (acc, pair) => (acc * 31 + pair.Key.GetHashCode()) * 31 + pair.Value.GetHashCode());
     }
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/DictionaryComparer.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/DictionaryComparer.cs
@@ -6,24 +6,49 @@ namespace Microsoft.Azure.Devices.Edge.Util
     using System.Collections.Generic;
     using System.Linq;
 
-    public class DictionaryComparer<TKey, TValue> : IEqualityComparer<IDictionary<TKey, TValue>> where TValue : IEquatable<TValue>
+    public class DictionaryComparer<TKey, TValue> : IEqualityComparer<IDictionary<TKey, TValue>>
+        where TValue : IEquatable<TValue>
     {
         public bool Equals(IDictionary<TKey, TValue> x, IDictionary<TKey, TValue> y) =>
-            object.ReferenceEquals(x, y) ||
-            (x == null && y == null) ||
+            ReferenceEquals(x, y) ||
             (
                 x != null &&
                 y != null &&
                 x.Keys.Count() == y.Keys.Count() &&
                 x.Keys.All(
                     key => y.ContainsKey(key) &&
-                           (
-                            (x[key] == null && y[key] == null) ||
-                            (
-                                x[key] != null &&
-                                x[key].Equals(y[key])
-                            )
-                           )
+                    (
+                        (x[key] == null && y[key] == null) ||
+                        (
+                            x[key] != null &&
+                            x[key].Equals(y[key])
+                        )
+                    )
+                )
+            );
+
+        public int GetHashCode(IDictionary<TKey, TValue> obj) =>
+            obj.Aggregate(17, (acc, pair) => (acc * 31 + pair.Key.GetHashCode()) * 31 + pair.Value.GetHashCode());
+    }
+
+    public class ReadOnlyDictionaryComparer<TKey, TValue> : IEqualityComparer<IReadOnlyDictionary<TKey, TValue>>
+        where TValue : IEquatable<TValue>
+    {
+        public bool Equals(IReadOnlyDictionary<TKey, TValue> x, IReadOnlyDictionary<TKey, TValue> y) =>
+            ReferenceEquals(x, y) ||
+            (
+                x != null &&
+                y != null &&
+                x.Keys.Count() == y.Keys.Count() &&
+                x.Keys.All(
+                    key => y.ContainsKey(key) &&
+                    (
+                        (x[key] == null && y[key] == null) ||
+                        (
+                            x[key] != null &&
+                            x[key].Equals(y[key])
+                        )
+                    )
                 )
             );
 


### PR DESCRIPTION
Currently EdgeAgent writes the config to backup file on every reconcile, which happens every 5 secs (this involves encrypting it and writing it to disk). 

This changes fixes that to encrypt/write the config to disk, only if it has changed. 
