### PR TITLE
EdgeHub: Update GetDeviceListenerAsync to take IIdentity instead of IClientCredentials

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ConnectionHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ConnectionHandler.cs
@@ -79,13 +79,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                             throw new InvalidOperationException("Connection not authenticated");
                         }
 
-                        IClientCredentials identity = amqpAuth.ClientCredentials.Expect(() => new InvalidOperationException("Authenticated connection should have a valid identity"));
-                        this.deviceListener = await this.connectionProvider.GetDeviceListenerAsync(identity);
-                        var deviceProxy = new DeviceProxy(this, identity.Identity);
+                        IClientCredentials clientCredentials = amqpAuth.ClientCredentials.Expect(() => new InvalidOperationException("Authenticated connection should have a valid identity"));
+                        this.deviceListener = await this.connectionProvider.GetDeviceListenerAsync(clientCredentials.Identity);
+                        var deviceProxy = new DeviceProxy(this, clientCredentials.Identity);
                         this.deviceListener.BindDeviceProxy(deviceProxy);
                         this.amqpAuthentication = amqpAuth;
                         this.isInitialized = true;
-                        Events.InitializedConnectionHandler(identity.Identity);
+                        Events.InitializedConnectionHandler(clientCredentials.Identity);
                     }
                 }
             }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
@@ -18,10 +18,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             this.edgeHub = Preconditions.CheckNotNull(edgeHub, nameof(edgeHub));
         }
 
-        public Task<IDeviceListener> GetDeviceListenerAsync(IClientCredentials clientCredentials)
+        public Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity)
         {
-            Preconditions.CheckNotNull(clientCredentials, nameof(clientCredentials));
-            IDeviceListener deviceListener = new DeviceMessageHandler(clientCredentials.Identity, this.edgeHub, this.connectionManager);
+            IDeviceListener deviceListener = new DeviceMessageHandler(Preconditions.CheckNotNull(identity, nameof(identity)), this.edgeHub, this.connectionManager);
             return Task.FromResult(deviceListener);
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IConnectionProvider.cs
@@ -9,6 +9,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
     public interface IConnectionProvider : IDisposable
     {
-        Task<IDeviceListener> GetDeviceListenerAsync(IClientCredentials clientCredentials);
+        Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity);
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttConnectionProvider.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 throw new AuthenticationException("Invalid identity object received");
             }
 
-            IDeviceListener deviceListener = await this.connectionProvider.GetDeviceListenerAsync(protocolGatewayIdentity.ClientCredentials);
+            IDeviceListener deviceListener = await this.connectionProvider.GetDeviceListenerAsync(protocolGatewayIdentity.ClientCredentials.Identity);
             IMessagingServiceClient messagingServiceClient = new MessagingServiceClient(deviceListener, this.pgMessageConverter, this.byteBufferConverter);
             IMessagingBridge messagingBridge = new SingleClientMessagingBridge(deviceidentity, messagingServiceClient);
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/ConnectionHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/ConnectionHandlerTest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials.Identity) == Task.FromResult(deviceListener));
 
             var amqpAuthentication = new AmqpAuthentication(true, Option.Some(clientCredentials));
             var cbsNode = Mock.Of<ICbsNode>(c => c.GetAmqpAuthentication() == Task.FromResult(amqpAuthentication));
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                 Assert.Equal(deviceListener, deviceListeners[0]);
             }
             Assert.NotNull(deviceProxy);
-            Mock.Get(connectionProvider).Verify(c => c.GetDeviceListenerAsync(It.IsAny<IClientCredentials>()), Times.AtMostOnce);
+            Mock.Get(connectionProvider).Verify(c => c.GetDeviceListenerAsync(It.IsAny<IIdentity>()), Times.AtMostOnce);
             Mock.Get(deviceListener).Verify(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()), Times.AtMostOnce);
         }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var deviceListener = Mock.Of<IDeviceListener>();
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()));
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials.Identity) == Task.FromResult(deviceListener));
 
             var amqpAuthentication = new AmqpAuthentication(true, Option.Some(clientCredentials));
             var cbsNode = Mock.Of<ICbsNode>(c => c.GetAmqpAuthentication() == Task.FromResult(amqpAuthentication));
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             }
             Assert.True(amqpAuthentications[0].IsAuthenticated);
             Assert.Equal(identity, amqpAuthentications[0].ClientCredentials.OrDefault().Identity);
-            Mock.Get(connectionProvider).Verify(c => c.GetDeviceListenerAsync(It.IsAny<IClientCredentials>()), Times.AtMostOnce);
+            Mock.Get(connectionProvider).Verify(c => c.GetDeviceListenerAsync(It.IsAny<IIdentity>()), Times.AtMostOnce);
             Mock.Get(cbsNode).Verify(d => d.GetAmqpAuthentication(), Times.AtMostOnce);
         }
 
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials.Identity) == Task.FromResult(deviceListener));
 
             var amqpAuthentication = new AmqpAuthentication(true, Option.Some(clientCredentials));
             var cbsNode = Mock.Of<ICbsNode>(c => c.GetAmqpAuthentication() == Task.FromResult(amqpAuthentication));
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials.Identity) == Task.FromResult(deviceListener));
 
             var amqpAuthentication = new AmqpAuthentication(true, Option.Some(clientCredentials));
             var cbsNode = Mock.Of<ICbsNode>(c => c.GetAmqpAuthentication() == Task.FromResult(amqpAuthentication));
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials.Identity) == Task.FromResult(deviceListener));
 
             var amqpAuthentication = new AmqpAuthentication(true, Option.Some(clientCredentials));
             var cbsNode = Mock.Of<ICbsNode>(c => c.GetAmqpAuthentication() == Task.FromResult(amqpAuthentication));
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials.Identity) == Task.FromResult(deviceListener));
 
             var amqpAuthentication = new AmqpAuthentication(true, Option.Some(clientCredentials));
             var cbsNode = Mock.Of<ICbsNode>(c => c.GetAmqpAuthentication() == Task.FromResult(amqpAuthentication));
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             deviceListener.Setup(d => d.CloseAsync()).Returns(Task.CompletedTask);
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
             var clientCredentials = Mock.Of<IClientCredentials>(c => c.Identity == identity);
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials) == Task.FromResult(deviceListener.Object));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(clientCredentials.Identity) == Task.FromResult(deviceListener.Object));
             deviceListener.Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()));
 
             var amqpAuthentication = new AmqpAuthentication(true, Option.Some(clientCredentials));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
@@ -4,9 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
-    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
-    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Xunit;
@@ -50,7 +48,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var moduleCredentials = new TokenCredentials(new ModuleIdentity("hub", "device", "module"), "token", "productInfo", false);
 
             var connectionProvider = new ConnectionProvider(connectionManager, edgeHub);
-            Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials));
+            Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity));
         }
 
         [Fact]
@@ -62,7 +60,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var moduleCredentials = new X509CertCredentials(new ModuleIdentity("hub", "device", "module"), string.Empty);
 
             var connectionProvider = new ConnectionProvider(connectionManager, edgeHub);
-            Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials));
+            Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity));
         }
 
         [Fact]


### PR DESCRIPTION
Precursor to the Amqp Multiplexing + refactoring changes