### PR TITLE
Remove write access (not read, execute) for BUILTIN\Users

### DIFF
--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/settings/windows.json
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/settings/windows.json
@@ -1,5 +1,5 @@
 ﻿{
-    "dockerHostUrl": "npipe://./pipe/docker_engine",
+    "dockerHostUrl": "npipe://./pipe/iotedge_moby_engine",
     "testSuite": [
         "test-config-windows-x64.json"
       ]

--- a/edgelet/contrib/config/windows/config.yaml
+++ b/edgelet/contrib/config/windows/config.yaml
@@ -163,5 +163,5 @@ homedir: "C:\\ProgramData\\iotedge"
 ###############################################################################
 
 moby_runtime:
-  uri: "npipe://./pipe/docker_engine"
+  uri: "npipe://./pipe/iotedge_moby_engine"
 #   network: "nat"

--- a/edgelet/hyper-named-pipe/src/uri.rs
+++ b/edgelet/hyper-named-pipe/src/uri.rs
@@ -159,8 +159,7 @@ mod tests {
         let uri: HyperUri = Uri::new("npipe://./pipe/boo", "/containers/json?all=true")
             .unwrap()
             .into();
-        let expected =
-            "npipe://5c5c2e5c706970655c626f6f/containers/json?all=true";
+        let expected = "npipe://5c5c2e5c706970655c626f6f/containers/json?all=true";
         assert_eq!(uri, expected.parse::<HyperUri>().unwrap());
     }
 
@@ -184,10 +183,9 @@ mod tests {
 
     #[test]
     fn uri_host() {
-        let uri: HyperUri =
-            "npipe://5c5c2e5c706970655c626f6f/containers/json?all=true"
-                .parse()
-                .unwrap();
+        let uri: HyperUri = "npipe://5c5c2e5c706970655c626f6f/containers/json?all=true"
+            .parse()
+            .unwrap();
         assert_eq!(
             &Uri::get_pipe_path_from_parts(
                 uri.scheme_part().unwrap().as_str(),

--- a/edgelet/hyper-named-pipe/src/uri.rs
+++ b/edgelet/hyper-named-pipe/src/uri.rs
@@ -160,7 +160,7 @@ mod tests {
             .unwrap()
             .into();
         let expected =
-            "npipe://5c5c2e5c706970655c646f636b65725f656e67696e65/containers/json?all=true";
+            "npipe://5c5c2e5c706970655c626f6f/containers/json?all=true";
         assert_eq!(uri, expected.parse::<HyperUri>().unwrap());
     }
 
@@ -185,7 +185,7 @@ mod tests {
     #[test]
     fn uri_host() {
         let uri: HyperUri =
-            "npipe://5c5c2e5c706970655c646f636b65725f656e67696e65/containers/json?all=true"
+            "npipe://5c5c2e5c706970655c626f6f/containers/json?all=true"
                 .parse()
                 .unwrap();
         assert_eq!(
@@ -193,7 +193,7 @@ mod tests {
                 uri.scheme_part().unwrap().as_str(),
                 uri.host().unwrap()
             ).unwrap(),
-            "\\\\.\\pipe\\docker_engine"
+            "\\\\.\\pipe\\boo"
         );
     }
 }

--- a/edgelet/hyper-named-pipe/src/uri.rs
+++ b/edgelet/hyper-named-pipe/src/uri.rs
@@ -149,14 +149,14 @@ mod tests {
 
     #[test]
     fn url_path() {
-        let url = Uri::new("npipe://./pipe/docker_engine", "/containers/json?all=true").unwrap();
+        let url = Uri::new("npipe://./pipe/boo", "/containers/json?all=true").unwrap();
         assert_eq!(url.url.path(), "/containers/json");
         assert_eq!(url.url.query(), Some("all=true"));
     }
 
     #[test]
     fn hyper_uri() {
-        let uri: HyperUri = Uri::new("npipe://./pipe/docker_engine", "/containers/json?all=true")
+        let uri: HyperUri = Uri::new("npipe://./pipe/boo", "/containers/json?all=true")
             .unwrap()
             .into();
         let expected =

--- a/edgelet/iotedged/src/config/windows/default.yaml
+++ b/edgelet/iotedged/src/config/windows/default.yaml
@@ -23,5 +23,5 @@ listen:
 homedir: "C:\\ProgramData\\iotedge"
 
 moby_runtime:
-  uri: "npipe://./pipe/docker_engine"
+  uri: "npipe://./pipe/iotedge_moby_engine"
   network: "nat"

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -872,8 +872,8 @@ function Remove-BuiltinWritePermissions([string] $Path) {
     Invoke-Native "icacls ""$Path"" /inheritance:d"
     
     $acl = Get-Acl -Path $Path
+    $write = [System.Security.AccessControl.FileSystemRights]::Write
     foreach ($access in $acl.Access) {
-        $write = [System.Security.AccessControl.FileSystemRights]::Write
         if ($access.IdentityReference.Value -eq $user -and
             $access.AccessControlType -eq 'Allow' -and
             ($access.FileSystemRights -band $write) -eq $write)


### PR DESCRIPTION
We were removing all access rights for `BUILTIN\Users`, which prevents the user from using the `iotedge` CLI unless they're running as admin. This change to the Windows installer script removes write access to install folders, but preserves read and execute access.

This change also updates the docker URL in various places to the new default (replace `docker_engine` with `iotedge_moby_engine`).