### PR TITLE
EdgeHub: Fix CbsNode to handle multiple tokens

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading;
@@ -35,9 +36,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
         readonly IAuthenticator authenticator;
         readonly string iotHubHostName;
         readonly ICredentialsCache credentialsCache;
+        readonly ConcurrentDictionary<string, CredentialsInfo> clientCredentialsMap = new ConcurrentDictionary<string, CredentialsInfo>();
         bool disposed;
-        AmqpAuthentication amqpAuthentication;
-        Task<AmqpAuthentication> authenticationUpdateTask;
+
         ISendingAmqpLink sendingLink;
         IReceivingAmqpLink receivingLink;
         int deliveryCount;
@@ -48,10 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             this.iotHubHostName = iotHubHostName;
             this.authenticator = authenticator;
             this.credentialsCache = credentialsCache;
-            this.authenticationUpdateTask = Task.FromResult(AmqpAuthentication.Unauthenticated);
         }
-
-        public Task<AmqpAuthentication> GetAmqpAuthentication() => this.authenticationUpdateTask;
 
         public void RegisterLink(IAmqpLink link)
         {
@@ -73,34 +71,97 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             Events.LinkRegistered(link);
         }
 
-        void OnMessageReceived(AmqpMessage message)
+        // TODO: Temporary implementation - just get the first credentials and return it. 
+        public async Task<AmqpAuthentication> GetAmqpAuthentication()
         {
-            Events.NewTokenReceived();
-            this.authenticationUpdateTask = this.UpdateAmqpAuthentication(message);
+            if (!this.clientCredentialsMap.Any())
+            {
+                throw new InvalidOperationException("No valid credentials found");
+            }
+
+            KeyValuePair<string, CredentialsInfo> creds = this.clientCredentialsMap.First();
+            if (!creds.Value.IsAuthenticated)
+            {
+                creds.Value.IsAuthenticated = await this.authenticator.AuthenticateAsync(creds.Value.ClientCredentials);
+            }
+            return new AmqpAuthentication(creds.Value.IsAuthenticated, Option.Some(creds.Value.ClientCredentials));
         }
 
-        async Task<AmqpAuthentication> UpdateAmqpAuthentication(AmqpMessage message)
+        public async Task<bool> AuthenticateAsync(string id)
+        {
+            try
+            {
+                if (this.clientCredentialsMap.TryGetValue(id, out CredentialsInfo credentialsInfo))
+                {
+                    if (credentialsInfo.IsAuthenticated)
+                    {
+                        return true;
+                    }
+                    else
+                    {
+                        bool isAuthenticated = await this.authenticator.AuthenticateAsync(credentialsInfo.ClientCredentials);
+                        if (isAuthenticated)
+                        {
+                            credentialsInfo.IsAuthenticated = true;
+                        }
+
+                        return isAuthenticated;
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            catch (Exception e)
+            {
+                Events.ErrorAuthenticatingIdentity(id, e);
+                return false;
+            }
+        }
+
+        public Option<IIdentity> GetIdentity(string id)
+        {
+            if (this.clientCredentialsMap.TryGetValue(id, out CredentialsInfo credentialsInfo))
+            {
+                return Option.Some(credentialsInfo.ClientCredentials.Identity);
+            }
+
+            return Option.None<IIdentity>();
+        }
+
+        async void OnMessageReceived(AmqpMessage message)
+        {
+            Events.NewTokenReceived();
+            try
+            {
+                await this.HandleTokenUpdate(message);
+            }
+            catch (Exception ex)
+            {
+                Events.ErrorHandlingTokenUpdate(ex);
+            }
+        }
+
+        async Task HandleTokenUpdate(AmqpMessage message)
         {
             using (await this.identitySyncLock.LockAsync())
             {
                 try
                 {
-                    (AmqpAuthentication amqpAuth, AmqpResponseStatusCode statusCode, string description) = await this.UpdateCbsToken(message);
+                    (AmqpResponseStatusCode statusCode, string description) = await this.UpdateCbsToken(message);
                     await this.SendResponseAsync(message, statusCode, description);
-                    this.amqpAuthentication = amqpAuth;
-                    return this.amqpAuthentication;
                 }
                 catch (Exception e)
                 {
                     await this.SendResponseAsync(message, AmqpResponseStatusCode.InternalServerError, e.Message);
                     Events.ErrorUpdatingToken(e);
-                    return AmqpAuthentication.Unauthenticated;
                 }
             }
         }
 
         // Note: This method accesses this.amqpAuthentication, and should be invoked only within this.identitySyncLock
-        internal async Task<(AmqpAuthentication, AmqpResponseStatusCode, string)> UpdateCbsToken(AmqpMessage message)
+        internal async Task<(AmqpResponseStatusCode, string)> UpdateCbsToken(AmqpMessage message)
         {
             IClientCredentials identity;
             try
@@ -110,21 +171,28 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             catch (Exception e) when (!ExceptionEx.IsFatal(e))
             {
                 Events.ErrorGettingIdentity(e);
-                return (AmqpAuthentication.Unauthenticated, AmqpResponseStatusCode.BadRequest, e.Message);
+                return (AmqpResponseStatusCode.BadRequest, e.Message);
             }
 
-            if ((this.amqpAuthentication == null || !this.amqpAuthentication.IsAuthenticated)
-                && !await this.authenticator.AuthenticateAsync(identity))
+            if (!this.clientCredentialsMap.TryGetValue(identity.Identity.Id, out CredentialsInfo credentialsInfo))
             {
-                Events.ErrorAuthenticatingIdentity(identity.Identity);
-                return (AmqpAuthentication.Unauthenticated, AmqpResponseStatusCode.BadRequest, $"Unable to authenticate {identity.Identity.Id}");
+                this.clientCredentialsMap[identity.Identity.Id] = new CredentialsInfo(identity);
             }
             else
             {
-                Events.CbsTokenUpdated(identity.Identity);
-                await this.credentialsCache.Add(identity);
-                return (new AmqpAuthentication(true, Option.Some(identity)), AmqpResponseStatusCode.OK, AmqpResponseStatusCode.OK.ToString());
+                credentialsInfo.ClientCredentials = identity;
+                if (credentialsInfo.IsAuthenticated)
+                {
+                    await this.credentialsCache.Add(identity);
+                    Events.CbsTokenUpdated(identity.Identity);
+                }
+                else
+                {
+                    Events.CbsTokenNotUpdated(identity.Identity);
+                }
             }
+
+            return (AmqpResponseStatusCode.OK, AmqpResponseStatusCode.OK.ToString());
         }
 
         internal IClientCredentials GetClientCredentials(AmqpMessage message)
@@ -236,6 +304,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             }
         }
 
+        /// <summary>
+        /// This type is deliberately mutable because of the use case. 
+        /// </summary>
+        class CredentialsInfo
+        {
+            public CredentialsInfo(IClientCredentials clientCredentials)
+            {
+                this.ClientCredentials = clientCredentials;
+                this.IsAuthenticated = false;
+            }
+
+            public IClientCredentials ClientCredentials { get; set; }
+
+            public bool IsAuthenticated { get; set; }
+        }
+
         static class Events
         {
             static readonly ILogger Log = Logger.Factory.CreateLogger<CbsNode>();
@@ -248,7 +332,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 ErrorUpdatingToken,
                 ErrorGettingIdentity,
                 TokenUpdated,
-                ErrorSendingResponse
+                ErrorSendingResponse,
+                ErrorHandlingTokenUpdate,
+                CbsTokenNotUpdated
             }
 
             public static void LinkRegistered(IAmqpLink link)
@@ -271,9 +357,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 Log.LogWarning((int)EventIds.ErrorGettingIdentity, exception, "Error getting identity from the token received on the Cbs link");
             }
 
-            public static void ErrorAuthenticatingIdentity(IIdentity identity)
+            public static void ErrorAuthenticatingIdentity(string id, Exception e)
             {
-                Log.LogWarning((int)EventIds.ErrorGettingIdentity, $"Error authenticating token received on the Cbs link for {identity.Id}");
+                Log.LogWarning((int)EventIds.ErrorGettingIdentity, e, $"Error authenticating token received on the Cbs link for {id}");
             }
 
             public static void CbsTokenUpdated(IIdentity identity)
@@ -284,6 +370,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             public static void ErrorSendingResponse(Exception exception)
             {
                 Log.LogWarning((int)EventIds.ErrorSendingResponse, exception, "Error sending response message");
+            }
+
+            public static void ErrorHandlingTokenUpdate(Exception exception)
+            {
+                Log.LogWarning((int)EventIds.ErrorHandlingTokenUpdate, exception, "Error handling token update");
+            }
+
+            public static void CbsTokenNotUpdated(IIdentity identity)
+            {
+                Log.LogDebug((int)EventIds.CbsTokenNotUpdated, $"Got a new token for an unauthenticated identity {identity.Id}, not updating credentials cache");
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/IAmqpAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/IAmqpAuthenticator.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
+{
+    using System.Threading.Tasks;
+
+    interface IAmqpAuthenticator
+    {
+        Task<bool> AuthenticateAsync(string id);
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/IAmqpAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/IAmqpAuthenticator.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 {
     using System.Threading.Tasks;
 
-    interface IAmqpAuthenticator
+    public interface IAmqpAuthenticator
     {
         Task<bool> AuthenticateAsync(string id);
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ICbsNode.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ICbsNode.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
     using System;
     using System.Threading.Tasks;
 
-    public interface ICbsNode : IDisposable
+    interface ICbsNode : IAmqpAuthenticator, IDisposable
     {
         void RegisterLink(IAmqpLink link);
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ICbsNode.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ICbsNode.cs
@@ -4,7 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
     using System;
     using System.Threading.Tasks;
 
-    interface ICbsNode : IAmqpAuthenticator, IDisposable
+    public interface ICbsNode : IAmqpAuthenticator, IDisposable
     {
         void RegisterLink(IAmqpLink link);
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
@@ -181,7 +181,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var cbsNode = new CbsNode(clientCredentialsFactory.Object, iotHubHostName, authenticator.Object, new NullCredentialsCache());
 
             // Act
-            (AmqpAuthentication amqpAuthentication, AmqpResponseStatusCode statusCode, string description) = await cbsNode.UpdateCbsToken(validAmqpMessage);
+            (AmqpResponseStatusCode statusCode, string description) = await cbsNode.UpdateCbsToken(validAmqpMessage);
+
+            AmqpAuthentication amqpAuthentication = await cbsNode.GetAmqpAuthentication();
 
             // Assert
             Assert.Equal(true, amqpAuthentication.IsAuthenticated);
@@ -189,6 +191,96 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Assert.Equal(identity, amqpAuthentication.ClientCredentials.OrDefault().Identity);
             Assert.Equal(AmqpResponseStatusCode.OK, statusCode);
             Assert.Equal(AmqpResponseStatusCode.OK.ToString(), description);
+        }
+
+        [Fact]
+        public async Task HandleMultipleTokensTest()
+        {
+            // Arrange
+            string iotHubHostName = "edgehubtest1.azure-devices.net";
+
+            var amqpValue1 = new AmqpValue
+            {
+                Value = TokenHelper.CreateSasToken("edgehubtest1.azure-devices.net/devices/device1/modules/mod1")
+            };
+            AmqpMessage validAmqpMessage1 = AmqpMessage.Create(amqpValue1);
+            validAmqpMessage1.ApplicationProperties.Map[CbsConstants.PutToken.Type] = "azure-devices.net:sastoken";
+            validAmqpMessage1.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = "iothub";
+            validAmqpMessage1.ApplicationProperties.Map[CbsConstants.Operation] = CbsConstants.PutToken.OperationValue;
+
+            var identity1 = Mock.Of<IIdentity>(i => i.Id == "device1/mod1");
+            var clientCredentials1 = Mock.Of<IClientCredentials>(c => c.Identity == identity1);
+            var clientCredentialsFactory = new Mock<IClientCredentialsFactory>();
+            clientCredentialsFactory.Setup(i => i.GetWithSasToken("device1", "mod1", It.IsAny<string>(), It.IsAny<string>(), true))
+                .Returns(clientCredentials1);
+
+            var amqpValue2 = new AmqpValue
+            {
+                Value = TokenHelper.CreateSasToken("edgehubtest1.azure-devices.net/devices/device1/modules/mod2")
+            };
+            AmqpMessage validAmqpMessage2 = AmqpMessage.Create(amqpValue2);
+            validAmqpMessage2.ApplicationProperties.Map[CbsConstants.PutToken.Type] = "azure-devices.net:sastoken";
+            validAmqpMessage2.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = "iothub";
+            validAmqpMessage2.ApplicationProperties.Map[CbsConstants.Operation] = CbsConstants.PutToken.OperationValue;
+
+            var identity2 = Mock.Of<IIdentity>(i => i.Id == "device1/mod2");
+            var clientCredentials2 = Mock.Of<IClientCredentials>(c => c.Identity == identity2);
+            clientCredentialsFactory.Setup(i => i.GetWithSasToken("device1", "mod2", It.IsAny<string>(), It.IsAny<string>(), true))
+                .Returns(clientCredentials2);
+
+            var authenticator = new Mock<IAuthenticator>();
+            authenticator.Setup(a => a.AuthenticateAsync(clientCredentials1)).ReturnsAsync(true);
+            authenticator.Setup(a => a.AuthenticateAsync(clientCredentials2)).ReturnsAsync(true);
+            var cbsNode = new CbsNode(clientCredentialsFactory.Object, iotHubHostName, authenticator.Object, new NullCredentialsCache());
+
+            // Act
+            (AmqpResponseStatusCode statusCode1, string description1) = await cbsNode.UpdateCbsToken(validAmqpMessage1);                        
+
+            // Assert
+            Assert.Equal(AmqpResponseStatusCode.OK, statusCode1);
+            Assert.Equal(AmqpResponseStatusCode.OK.ToString(), description1);
+
+            // Act
+            (AmqpResponseStatusCode statusCode2, string description2) = await cbsNode.UpdateCbsToken(validAmqpMessage2);
+
+            // Assert
+            Assert.Equal(AmqpResponseStatusCode.OK, statusCode2);
+            Assert.Equal(AmqpResponseStatusCode.OK.ToString(), description2);
+
+            // Act
+            bool isAuthenticated = await cbsNode.AuthenticateAsync("device1/mod1");
+
+            // Assert
+            Assert.True(isAuthenticated);
+            authenticator.Verify(a => a.AuthenticateAsync(clientCredentials1), Times.Once);
+
+            // Act
+            isAuthenticated = await cbsNode.AuthenticateAsync("device1/mod1");
+
+            // Assert
+            Assert.True(isAuthenticated);
+            authenticator.Verify(a => a.AuthenticateAsync(clientCredentials1), Times.Once);
+
+            // Act
+            isAuthenticated = await cbsNode.AuthenticateAsync("device1/mod2");
+
+            // Assert
+            Assert.True(isAuthenticated);
+            authenticator.Verify(a => a.AuthenticateAsync(clientCredentials2), Times.Once);
+
+            // Act
+            isAuthenticated = await cbsNode.AuthenticateAsync("device1/mod2");
+
+            // Assert
+            Assert.True(isAuthenticated);
+            authenticator.Verify(a => a.AuthenticateAsync(clientCredentials2), Times.Once);
+            authenticator.Verify(a => a.AuthenticateAsync(clientCredentials1), Times.Once);
+
+            // Act
+            isAuthenticated = await cbsNode.AuthenticateAsync("device1/mod3");
+
+            // Assert
+            Assert.False(isAuthenticated);
         }
     }
 }


### PR DESCRIPTION
CbsNode currently supports credentials for only one client. This change allows CbsNode to support credentials from multiple clients, on the same connection.
This is a precursor to the change to allow multiplexing over AMQP for EdgeHub.