### PR TITLE
EdgeHub: Fix MessageStore initial offset after restart

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/CheckpointStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/CheckpointStore.cs
@@ -15,14 +15,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
     {
         readonly IEntityStore<string, CheckpointEntity> underlyingStore;
 
-        CheckpointStore(IEntityStore<string, CheckpointEntity> underlyingStore)
+        internal CheckpointStore(IEntityStore<string, CheckpointEntity> underlyingStore)
         {
             this.underlyingStore = underlyingStore;
         }
 
         public static CheckpointStore Create(IStoreProvider storeProvider)
         {
-            IEntityStore<string, CheckpointEntity> underlyingStore = Preconditions.CheckNotNull(storeProvider, nameof(storeProvider)).GetEntityStore<string, CheckpointEntity>(Constants.CheckpointStorePartitionKey);
+            IEntityStore<string, CheckpointEntity> underlyingStore = Preconditions.CheckNotNull(storeProvider, nameof(storeProvider))
+                .GetEntityStore<string, CheckpointEntity>(Constants.CheckpointStorePartitionKey);
             return new CheckpointStore(underlyingStore);
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
@@ -55,7 +55,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
 
         public async Task AddEndpoint(string endpointId)
         {
-            ISequentialStore<MessageRef> sequentialStore = await this.storeProvider.GetSequentialStore<MessageRef>(endpointId);
+            CheckpointData checkpointData = await this.checkpointStore.GetCheckpointDataAsync(endpointId, CancellationToken.None);
+            ISequentialStore<MessageRef> sequentialStore = await this.storeProvider.GetSequentialStore<MessageRef>(endpointId, checkpointData.Offset + 1);
             if (this.endpointSequentialStores.TryAdd(endpointId, sequentialStore))
             {
                 Events.SequentialStoreAdded(endpointId);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
@@ -17,10 +17,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
     [Integration]
     public class MessageStoreTest
     {
-        [Fact]
-        public async Task BasicTest()
+        [Theory]
+        [InlineData(0)]
+        [InlineData(10150)]
+        [InlineData(-1)]
+        public async Task BasicTest(long initialCheckpointOffset)
         {
-            (IMessageStore messageStore, ICheckpointStore checkpointStore) result = await this.GetMessageStore();
+            (IMessageStore messageStore, ICheckpointStore checkpointStore) result = await this.GetMessageStore(initialCheckpointOffset);
             using (IMessageStore messageStore = result.messageStore)
             {
                 for (int i = 0; i < 10000; i++)
@@ -28,12 +31,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
                     if (i % 2 == 0)
                     {
                         long offset = await messageStore.Add("module1", this.GetMessage(i));
-                        Assert.Equal(i / 2, offset);
+                        Assert.Equal(initialCheckpointOffset + 1 + i / 2, offset);
                     }
                     else
                     {
                         long offset = await messageStore.Add("module2", this.GetMessage(i));
-                        Assert.Equal(i / 2, offset);
+                        Assert.Equal(initialCheckpointOffset + 1 + i / 2, offset);
                     }
                 }
 
@@ -279,6 +282,25 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
             ICheckpointStore checkpointStore = CheckpointStore.Create(storeProvider);
+            IMessageStore messageStore = new MessageStore(storeProvider, checkpointStore, TimeSpan.FromSeconds(ttlSecs));
+            await messageStore.AddEndpoint("module1");
+            await messageStore.AddEndpoint("module2");
+            return (messageStore, checkpointStore);
+        }
+
+        async Task<(IMessageStore, ICheckpointStore)> GetMessageStore(long initialCheckpointOffset, int ttlSecs = 300)
+        {
+            var dbStoreProvider = new InMemoryDbStoreProvider();
+            IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
+            
+            IEntityStore<string, CheckpointStore.CheckpointEntity> checkpointUnderlyingStore = storeProvider.GetEntityStore<string, CheckpointStore.CheckpointEntity>($"Checkpoint{Guid.NewGuid().ToString()}");
+            if (initialCheckpointOffset >= 0)
+            {
+                await checkpointUnderlyingStore.Put("module1", new CheckpointStore.CheckpointEntity(initialCheckpointOffset, null, null));
+                await checkpointUnderlyingStore.Put("module2", new CheckpointStore.CheckpointEntity(initialCheckpointOffset, null, null));
+            }
+
+            ICheckpointStore checkpointStore = new CheckpointStore(checkpointUnderlyingStore);
             IMessageStore messageStore = new MessageStore(storeProvider, checkpointStore, TimeSpan.FromSeconds(ttlSecs));
             await messageStore.AddEndpoint("module1");
             await messageStore.AddEndpoint("module2");

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/IStoreProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/IStoreProvider.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 {
     using System;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
 
     /// <summary>
     /// Provides stores that are higher level abstractions over the underlying key/value stores.
@@ -13,6 +14,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName);
 
         Task<ISequentialStore<T>> GetSequentialStore<T>(string entityName);
+
+        Task<ISequentialStore<T>> GetSequentialStore<T>(string entityName, long defaultHeadOffset);
 
         Task RemoveStore<T>(ISequentialStore<T> sequentialStore);
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/StoreProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/StoreProvider.cs
@@ -38,6 +38,13 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             return sequentialStore;
         }
 
+        public async Task<ISequentialStore<T>> GetSequentialStore<T>(string entityName, long defaultHeadOffset)
+        {
+            IEntityStore<byte[], T> underlyingStore = this.GetEntityStore<byte[], T>(entityName);
+            ISequentialStore<T> sequentialStore = await SequentialStore<T>.Create(underlyingStore, defaultHeadOffset);
+            return sequentialStore;
+        }
+
         public Task RemoveStore<T>(ISequentialStore<T> sequentialStore)
         {
             this.dbStoreProvider.RemoveDbStore(sequentialStore.EntityName);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/StoreUtils.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/StoreUtils.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.Azure.Devices.Edge.Util;
 
     public static class StoreUtils
@@ -13,6 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             Preconditions.CheckNotNull(key, nameof(key));
             if (BitConverter.IsLittleEndian)
             {
+                key = key.ToArray();
                 Array.Reverse(key);
             }
 
@@ -26,6 +28,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             byte[] bytes = BitConverter.GetBytes(offset);
             if (BitConverter.IsLittleEndian)
             {
+                bytes = bytes.ToArray();
                 Array.Reverse(bytes);
             }
 

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTestBase.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTestBase.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
+
 namespace Microsoft.Azure.Devices.Edge.Storage.Test
 {
     using System;
@@ -6,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Storage;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Xunit;
 
@@ -17,7 +19,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
         [Fact]
         public async Task CreateTest()
         {
-            IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>("testEntity");
+            IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>($"testEntity{Guid.NewGuid().ToString()}");
             ISequentialStore<Item> sequentialStore = await SequentialStore<Item>.Create(entityStore);
             long offset = await sequentialStore.Append(new Item { Prop1 = 10 });
             Assert.Equal(0, offset);
@@ -28,47 +30,84 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
         }
 
         [Fact]
-        public async Task BasicTest()
-        {            
-            ISequentialStore<Item> sequentialStore = await this.GetSequentialStore("basicTest");
+        public async Task CreateWithOffsetTest()
+        {
+            IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>($"testEntity{Guid.NewGuid().ToString()}");
+            ISequentialStore<Item> sequentialStore = await SequentialStore<Item>.Create(entityStore, 10150);
+            long offset = await sequentialStore.Append(new Item { Prop1 = 10 });
+            Assert.Equal(10150, offset);
+
+            sequentialStore = await SequentialStore<Item>.Create(entityStore);
+            for (int i = 0; i < 10; i++)
+            {
+                offset = await sequentialStore.Append(new Item { Prop1 = 20 });
+                Assert.Equal(10151 + i, offset);
+            }
+
+            sequentialStore = await SequentialStore<Item>.Create(entityStore);
+            offset = await sequentialStore.Append(new Item { Prop1 = 20 });
+            Assert.Equal(10162, offset);
+
+            IList<(long, Item)> batch = (await sequentialStore.GetBatch(0, 100)).ToList();
+            Assert.Equal(12, batch.Count);
+            long expectedOffset = 10150;
+            foreach ((long itemOffset, Item _) in batch)
+            {
+                Assert.Equal(itemOffset, expectedOffset++);
+            }
+        }
+
+        [Theory]
+        [MemberData(nameof(GetDefaultHeadOffset))]
+        public async Task BasicTest(Option<long> defaultHeadOffset)
+        {
+            string entityId = $"basicTest{Guid.NewGuid().ToString()}";
+            ISequentialStore<Item> sequentialStore = await this.GetSequentialStore(entityId, defaultHeadOffset);
+            long startOffset = defaultHeadOffset.GetOrElse(0);
             var tasks = new List<Task>();
             for (int i = 0; i < 10; i++)
             {
                 int i1 = i;
-                tasks.Add(Task.Run(async () =>
-                {
-                    for (int j = 0; j < 1000; j++)
-                    {
-                        long offset = await sequentialStore.Append(new Item { Prop1 = i1 * 10 + j });
-                        Assert.True(offset <= 10000);
-                    }
-                }));
+                tasks.Add(
+                    Task.Run(
+                        async () =>
+                        {
+                            for (int j = 0; j < 1000; j++)
+                            {
+                                long offset = await sequentialStore.Append(new Item { Prop1 = i1 * 10 + j });
+                                Assert.True(offset <= 10000 + startOffset);
+                            }
+                        }));
             }
+
             await Task.WhenAll(tasks);
 
-            IEnumerable<(long offset, Item item)> batch = await sequentialStore.GetBatch(0, 10000);
+            IEnumerable<(long offset, Item item)> batch = await sequentialStore.GetBatch(startOffset, 10000);
             IEnumerable<(long offset, Item item)> batchItems = batch as IList<(long offset, Item item)> ?? batch.ToList();
             Assert.Equal(10000, batchItems.Count());
-            int counter = 0;
+            long counter = startOffset;
             foreach ((long offset, Item item) batchItem in batchItems)
             {
                 Assert.Equal(counter++, batchItem.offset);
             }
         }
 
-        [Fact]
-        public async Task RemoveTest()
+        [Theory]
+        [MemberData(nameof(GetDefaultHeadOffset))]
+        public async Task RemoveTest(Option<long> defaultHeadOffset)
         {
-            ISequentialStore<Item> sequentialStore = await this.GetSequentialStore("removeTestEntity");
+            string entityId = $"removeTestEntity{Guid.NewGuid().ToString()}";
+            long startOffset = defaultHeadOffset.GetOrElse(0);
+            ISequentialStore<Item> sequentialStore = await this.GetSequentialStore(entityId, defaultHeadOffset);
             for (int i = 0; i < 10; i++)
             {
                 long offset = await sequentialStore.Append(new Item { Prop1 = i });
-                Assert.Equal(i, offset);
+                Assert.Equal(i + startOffset, offset);
             }
 
-            List<(long offset, Item item)> batch = (await sequentialStore.GetBatch(0, 100)).ToList();
+            List<(long offset, Item item)> batch = (await sequentialStore.GetBatch(startOffset, 100)).ToList();
             Assert.Equal(10, batch.Count);
-            int counter = 0;
+            long counter = startOffset;
             foreach ((long offset, Item item) batchItem in batch)
             {
                 Assert.Equal(counter++, batchItem.offset);
@@ -76,50 +115,52 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
 
             await sequentialStore.RemoveFirst((offset, item) => Task.FromResult(item.Prop1 == 0));
 
-            batch = (await sequentialStore.GetBatch(0, 100)).ToList();
+            batch = (await sequentialStore.GetBatch(startOffset, 100)).ToList();
             Assert.Equal(9, batch.Count);
-            counter = 1;
+            counter = startOffset + 1;
             foreach ((long offset, Item item) batchItem in batch)
             {
                 Assert.Equal(counter++, batchItem.offset);
             }
 
-            batch = (await sequentialStore.GetBatch(1, 100)).ToList();
+            batch = (await sequentialStore.GetBatch(startOffset + 1, 100)).ToList();
             Assert.Equal(9, batch.Count);
-            counter = 1;
+            counter = startOffset + 1;
             foreach ((long offset, Item item) batchItem in batch)
             {
                 Assert.Equal(counter++, batchItem.offset);
             }
 
             await sequentialStore.RemoveFirst((offset, item) => Task.FromResult(item.Prop1 == 0));
-            batch = (await sequentialStore.GetBatch(1, 100)).ToList();
+            batch = (await sequentialStore.GetBatch(startOffset + 1, 100)).ToList();
             Assert.Equal(9, batch.Count);
-            counter = 1;
+            counter = startOffset + 1;
             foreach ((long offset, Item item) batchItem in batch)
             {
                 Assert.Equal(counter++, batchItem.offset);
             }
 
             await sequentialStore.RemoveFirst((offset, item) => Task.FromResult(item.Prop1 == 1));
-            batch = (await sequentialStore.GetBatch(2, 100)).ToList();
+            batch = (await sequentialStore.GetBatch(startOffset + 2, 100)).ToList();
             Assert.Equal(8, batch.Count);
-            counter = 2;
+            counter = startOffset + 2;
             foreach ((long offset, Item item) batchItem in batch)
             {
                 Assert.Equal(counter++, batchItem.offset);
             }
         }
 
-        [Fact]
-        public async Task GetBatchTest()
+        [Theory]
+        [MemberData(nameof(GetDefaultHeadOffset))]
+        public async Task GetBatchTest(Option<long> defaultHeadOffset)
         {
             // Arrange
-            
-            ISequentialStore<Item> sequentialStore = await this.GetSequentialStore("invalidGetBatch");
+            string entityId = $"invalidGetBatch{Guid.NewGuid().ToString()}";
+            long startOffset = defaultHeadOffset.GetOrElse(0);
+            ISequentialStore<Item> sequentialStore = await this.GetSequentialStore(entityId, defaultHeadOffset);
 
             // Try to get the batch, should return empty batch. 
-            List<(long, Item)> batch = (await sequentialStore.GetBatch(0, 10)).ToList();
+            List<(long, Item)> batch = (await sequentialStore.GetBatch(startOffset, 10)).ToList();
             Assert.NotNull(batch);
             Assert.Equal(0, batch.Count);
 
@@ -127,7 +168,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
             for (int i = 0; i < 10; i++)
             {
                 long offset = await sequentialStore.Append(new Item { Prop1 = i });
-                Assert.Equal(i, offset);
+                Assert.Equal(i + startOffset, offset);
             }
 
             for (int i = 0; i < 4; i++)
@@ -138,34 +179,42 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
             // Try to get with starting offset <= 4, should return remaining elements - 4 - 9. 
             for (int i = 0; i <= 4; i++)
             {
-                batch = (await sequentialStore.GetBatch(i, 10)).ToList();
+                batch = (await sequentialStore.GetBatch(i + startOffset, 10)).ToList();
                 Assert.NotNull(batch);
                 Assert.Equal(10 - 4, batch.Count);
-                Assert.Equal(4, batch[0].Item1);
+                Assert.Equal(4 + startOffset, batch[0].Item1);
             }
 
             // Try to get with starting offset between 5 and 9, should return a valid batch. 
             for (int i = 5; i < 10; i++)
             {
-                batch = (await sequentialStore.GetBatch(i, 10)).ToList();
+                batch = (await sequentialStore.GetBatch(i + startOffset, 10)).ToList();
                 Assert.NotNull(batch);
                 Assert.Equal(10 - i, batch.Count);
-                Assert.Equal(i, batch[0].Item1);
+                Assert.Equal(i + startOffset, batch[0].Item1);
             }
 
             // Try to get with starting offset > 10, should return empty batch
             for (int i = 10; i < 14; i++)
             {
-                batch = (await sequentialStore.GetBatch(i, 10)).ToList();
+                batch = (await sequentialStore.GetBatch(i + startOffset, 10)).ToList();
                 Assert.NotNull(batch);
                 Assert.Equal(0, batch.Count);
-            }            
+            }
         }
 
-        async Task<ISequentialStore<Item>> GetSequentialStore(string entityName)
+        static IEnumerable<object[]> GetDefaultHeadOffset()
+        {
+            yield return new object[] { Option.None<long>() };
+            yield return new object[] { Option.Some((long)1500) };
+        }
+
+        async Task<ISequentialStore<Item>> GetSequentialStore(string entityName, Option<long> defaultHeadOffset)
         {
             IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>(entityName);
-            ISequentialStore<Item> sequentialStore = await SequentialStore<Item>.Create(entityStore);
+            ISequentialStore<Item> sequentialStore = await defaultHeadOffset
+                .Map(d => SequentialStore<Item>.Create(entityStore, d))
+                .GetOrElse(() => SequentialStore<Item>.Create(entityStore));
             return sequentialStore;
         }
 

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTestBase.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTestBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
 
             sequentialStore = await SequentialStore<Item>.Create(entityStore);
             offset = await sequentialStore.Append(new Item { Prop1 = 20 });
-            Assert.Equal(10162, offset);
+            Assert.Equal(10161, offset);
 
             IList<(long, Item)> batch = (await sequentialStore.GetBatch(0, 100)).ToList();
             Assert.Equal(12, batch.Count);

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/StoreUtilsTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/StoreUtilsTest.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 
 namespace Microsoft.Azure.Devices.Edge.Storage.Test
 {
+    using System.Linq;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Xunit;
@@ -18,6 +19,19 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
                 long offset2 = StoreUtils.GetOffsetFromKey(key);
                 Assert.Equal(offset, offset2);
             }
-        }        
+        }
+
+        [Fact]
+        public void TestOperation()
+        {
+            long offset = 1000;
+            byte[] key = StoreUtils.GetKeyFromOffset(offset);
+            byte[] obtainedKey = key.ToArray();
+            Assert.Equal(key, obtainedKey);
+
+            long obtainedOffset = StoreUtils.GetOffsetFromKey(key);
+            Assert.Equal(offset, obtainedOffset);
+            Assert.Equal(key, obtainedKey);
+        }
     }
 }


### PR DESCRIPTION
EdgeHub Message store contains queues for each endpoint. 3 pointer values are maintained - head, tail, and checkpoint (where the last processed pointer was).
Of these head and tail are computed from the queue, and checkpoint is persisted. 
However, in a situation where all messages are processed and cleaned up, the queue will be empty and checkpointer will be pointing to the last processed value (say 1600). 
If at this point the EdgeHub is restarted, the initialized values will be -
head =0, tail = -1 and checkpoint = 1600. 
This PR fixes the issue, so that the initialization values are - 
head = 1600, tail = 1599, checkpoint = 1600. 