### PR TITLE
Increase timeout for Docker tests

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
 
     public class RuntimeInfoProviderTest
     {
-        static readonly TimeSpan Timeout = TimeSpan.FromSeconds(45);
+        static readonly TimeSpan Timeout = TimeSpan.FromSeconds(300);
         static readonly IDockerClient Client = DockerHelper.Client;
         static readonly IEntityStore<string, ModuleState> RestartStateStore = new Mock<IEntityStore<string, ModuleState>>().Object;
         static readonly IRestartPolicyManager RestartManager = new Mock<IRestartPolicyManager>().Object;

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/commands/CreateCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/commands/CreateCommandTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test.Commands
     {
         static readonly IDictionary<string, EnvVal> EnvVars = new Dictionary<string, EnvVal>();
 
-        readonly TimeSpan defaultTimeout = TimeSpan.FromSeconds(30);
+        readonly TimeSpan defaultTimeout = TimeSpan.FromSeconds(300);
 
         [Fact]
         [Integration]


### PR DESCRIPTION
The tests in these suites pull images and start containers under these timeouts, so 30 / 45s wasn't enough and the tests would time out and fail. I raised them to 120s but they would still fail sometimes. Five minutes appears to be enough.