### PR TITLE
Ensure socket files get deleted when iotedged starts on Windows

### DIFF
--- a/edgelet/edgelet-http/src/unix.rs
+++ b/edgelet/edgelet-http/src/unix.rs
@@ -20,7 +20,7 @@ pub fn listener<P: AsRef<Path>>(path: P) -> Result<Incoming, Error> {
     let listener = if socket_file_exists(path.as_ref()) {
         // get the previous file's metadata
         #[cfg(unix)]
-        let metadata = get_metadata(path)?;
+        let metadata = get_metadata(path.as_ref())?;
 
         debug!("unlinking {}...", path.as_ref().display());
         fs::remove_file(&path)
@@ -48,14 +48,10 @@ pub fn listener<P: AsRef<Path>>(path: P) -> Result<Incoming, Error> {
 }
 
 #[cfg(unix)]
-fn get_metadata<P: AsRef<Path>>(path: P) -> Result<Metadata, Error> {
-    let metadata = fs::metadata(&path)
-        .with_context(|_| ErrorKind::Path(path.as_ref().display().to_string()))?;
-    debug!(
-        "read metadata {:?} for {}",
-        metadata,
-        path.as_ref().display()
-    );
+fn get_metadata(path: &Path) -> Result<fs::Metadata, Error> {
+    let metadata =
+        fs::metadata(path).with_context(|_| ErrorKind::Path(path.display().to_string()))?;
+    debug!("read metadata {:?} for {}", metadata, path.display());
     Ok(metadata)
 }
 

--- a/edgelet/edgelet-http/src/util/connector.rs
+++ b/edgelet/edgelet-http/src/util/connector.rs
@@ -14,7 +14,6 @@
 //! HTTP and Unix sockets respectively.
 
 use std::io;
-use std::path::Path;
 
 use failure::ResultExt;
 use futures::{future, Future};
@@ -30,7 +29,7 @@ use hyperlocal_windows::{UnixConnector, Uri as HyperlocalUri};
 use url::{ParseError, Url};
 
 use error::{Error, ErrorKind, InvalidUrlReason};
-use util::StreamSelector;
+use util::{socket_file_exists, StreamSelector};
 use UrlExt;
 
 const UNIX_SCHEME: &str = "unix";
@@ -43,18 +42,6 @@ pub enum UrlConnector {
     #[cfg(windows)]
     Pipe(PipeConnector),
     Unix(UnixConnector),
-}
-
-fn socket_file_exists(path: &Path) -> bool {
-    if cfg!(windows) {
-        use std::fs;
-        // Unix domain socket files in Windows are reparse points, so path.exists()
-        // (which calls fs::metadata(path)) won't work. Use fs::symlink_metadata()
-        // instead.
-        fs::symlink_metadata(path).is_ok()
-    } else {
-        path.exists()
-    }
 }
 
 impl UrlConnector {

--- a/edgelet/edgelet-http/src/util/mod.rs
+++ b/edgelet/edgelet-http/src/util/mod.rs
@@ -5,6 +5,7 @@ use std::io::{self, Read, Write};
 use std::net::SocketAddr;
 #[cfg(unix)]
 use std::os::unix::net::SocketAddr as UnixSocketAddr;
+use std::path::Path;
 
 use bytes::{Buf, BufMut};
 use edgelet_core::pid::Pid;
@@ -140,6 +141,18 @@ impl fmt::Display for IncomingSocketAddr {
                 }
             }
         }
+    }
+}
+
+pub fn socket_file_exists(path: &Path) -> bool {
+    if cfg!(windows) {
+        use std::fs;
+        // Unix domain socket files in Windows are reparse points, so path.exists()
+        // (which calls fs::metadata(path)) won't work. Use fs::symlink_metadata()
+        // instead.
+        fs::symlink_metadata(path).is_ok()
+    } else {
+        path.exists()
     }
 }
 


### PR DESCRIPTION
We already do this elsewhere in the code; we just needed to do it here as well.

Before iotedged fires up an endpoint, it deletes the UNIX domain socket file associated with that endpoint, if it exists. But in Windows, the logic to check whether the file exists always returns false because it's not doing the special steps required to check for the existence of a file _with a reparse point_, which is what a domain socket file is. For reasons I don't understand yet, this isn't a problem if a client has connected to the socket. But if the server binds the socket and then closes the connection, and no client ever connects, then an attempt to bind again will fail.

The fix is to call `fs::symlink_metadata` on Windows, rather than `std::path::Path::exists`. Also, we don't need the result of `fs::metadata` in Windows and it fails in this scenario (in fact, `Path::exists` is just a wrapper around `fs::metadata`), so only call it in Linux.