### PR TITLE
More Windows installer improvements

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -94,7 +94,7 @@ function Install-SecurityDaemon {
         #
         # If set to Linux, a separate installation of Docker for Windows is expected.
         #
-        # If set to Windows, the Moby Engine will be installed automatically.
+        # If set to Windows, the Moby Engine will be installed automatically. This will not affect any existing installation of Docker for Windows.
         [ContainerOs] $ContainerOs = 'Linux',
 
         # Proxy URI used for all Invoke-WebRequest calls. To specify other proxy-related options like -ProxyCredential, see -InvokeWebRequestParameters

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -769,8 +769,6 @@ function Uninstall-Services {
     }
 }
 
-# The daemon listens using UDS by default, so these firewall rules are no longer created.
-# However Uninstall-SecurityDaemon still calls this to remove rules created by old installs.
 function Remove-FirewallExceptions {
     Remove-NetFirewallRule -DisplayName 'iotedged allow inbound 15580,15581' -ErrorAction SilentlyContinue -ErrorVariable cmdErr
     Write-Verbose "$(if ($?) { 'Removed firewall exceptions' } else { $cmdErr })"

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -175,6 +175,21 @@ function Install-SecurityDaemon {
             [System.Net.ServicePointManager]::SecurityProtocol -bor [System.Net.SecurityProtocolType]::Tls12
     }
 
+    if ($ExistingConfig -and (-not (Test-Path "$EdgeInstallDirectory\config.yaml"))) {
+        Write-HostRed
+        Write-HostRed "$EdgeInstallDirectory\config.yaml was not found."
+        return
+    }
+
+    if ((-not $ExistingConfig) -and (Test-Path "$EdgeInstallDirectory\config.yaml")) {
+        Write-HostRed
+        Write-HostRed "$EdgeInstallDirectory\config.yaml already exists."
+        Write-HostRed (
+            'Delete it using `Uninstall-SecurityDaemon -Force -DeleteConfig` and then re-run `Install-SecurityDaemon`, ' +
+            'or run `Install-SecurityDaemon -ExistingConfig` to use the existing config.yaml')
+        return
+    }
+
     # Download
     Get-SecurityDaemon
     Get-VcRuntime
@@ -182,12 +197,6 @@ function Install-SecurityDaemon {
     # config.yaml
     if ($ExistingConfig) {
         Write-HostGreen 'Using existing config.yaml'
-
-        if (-not (Test-Path "$EdgeInstallDirectory\config.yaml")) {
-            Write-HostRed
-            Write-HostRed "$EdgeInstallDirectory\config.yaml was not found."
-            return
-        }
     }
     else {
         Write-Host 'Generating config.yaml...'

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -387,9 +387,7 @@ function Get-SecurityDaemon {
                     -Delete ([ref] $deleteMobyEngineArchive)
             Expand-Archive $mobyEngineArchivePath $MobyInstallDirectory -Force
 
-            if (-not (Test-Path $MobyDataRootDirectory)) {
-                New-Item -Type Directory $MobyDataRootDirectory | Out-Null
-            }
+            New-Item -Type Directory $MobyDataRootDirectory -Force | Out-Null
             Remove-BuiltinWritePermissions $MobyDataRootDirectory
 
             if (-not ($SkipMobyCli)) {
@@ -424,9 +422,7 @@ function Get-SecurityDaemon {
         }
 
         if ((Get-Item $edgeArchivePath).PSIsContainer) {
-            if (-not (Test-Path $EdgeInstallDirectory)) {
-                New-Item -Type Directory $EdgeInstallDirectory | Out-Null
-            }
+            New-Item -Type Directory $EdgeInstallDirectory -Force | Out-Null
             if ($ExistingConfig) {
                 Copy-Item "$edgeArchivePath\*" $EdgeInstallDirectory -Force -Recurse -Exclude 'config.yaml'
             }

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -241,7 +241,6 @@ function Uninstall-SecurityDaemon {
     $ContainerOs = Get-ContainerOs
 
     Uninstall-Services
-    Remove-IotEdgeContainers
     $success = Remove-SecurityDaemonResources
     Reset-SystemPath
 
@@ -742,6 +741,8 @@ function Uninstall-Services {
             Write-Verbose 'Removed IoT Edge service subkey from the registry'
         }
     }
+
+    Remove-IotEdgeContainers
 
     if (Get-Service $MobyServiceName -ErrorAction SilentlyContinue) {
         Stop-Service -NoWait -ErrorAction SilentlyContinue -ErrorVariable cmdErr $MobyServiceName

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -282,7 +282,7 @@ namespace IotEdgeQuickstart.Details
             {
                 await Process.RunAsync(
                     "powershell",
-                    $". {this.scriptDir}\\IotEdgeSecurityDaemon.ps1; Uninstall-SecurityDaemon",
+                    $". {this.scriptDir}\\IotEdgeSecurityDaemon.ps1; Uninstall-SecurityDaemon -DeleteConfig -DeleteMobyDataRoot",
                     cts.Token);
             }
         }


### PR DESCRIPTION
- `Uninstall-SecurityDaemon` now defaults to leaving config.yaml and
  Moby data root, unless new flags `-DeleteConfig` and `-DeleteMobyDataRoot`
  are specified.

- `Uninstall-SecurityDaemon` now deletes the edge containers instead of just
  stopping them, to ensure that they're deleted even if the Moby data root
  isn't.

- `Install-SecurityDaemon` now has a new flag `-ExistingConfig` that can be
  set to use an existing config.yaml, instead of generating a new one via
  `-Manual` or `-Dps`

- Fixed a bug in `Uninstall-SecurityDaemon` where it incorrectly parsed the
  result of `docker inspect`.