### PR TITLE
Clean up and fix build

### DIFF
--- a/edge-agent/docker/windows/arm32v7/Dockerfile
+++ b/edge-agent/docker/windows/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-FROM azureiotedge/azureiotedge-agent-base:${base_tag}
+ARG registry
+FROM ${registry}/azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-agent/docker/windows/arm32v7/Dockerfile
+++ b/edge-agent/docker/windows/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-ARG registry
-FROM ${registry}/azureiotedge/azureiotedge-agent-base:${base_tag}
+ARG base_registry
+FROM ${base_registry}/azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-hub/docker/windows/arm32v7/Dockerfile
+++ b/edge-hub/docker/windows/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-ARG registry
-FROM ${registry}/azureiotedge/azureiotedge-hub-base:${base_tag}
+ARG base_registry
+FROM ${base_registry}/azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-hub/docker/windows/arm32v7/Dockerfile
+++ b/edge-hub/docker/windows/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-FROM azureiotedge/azureiotedge-hub-base:${base_tag}
+ARG registry
+FROM ${registry}/azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+ARG registry
+FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-ARG registry
-FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
+ARG base_registry
+FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+ARG registry
+FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-ARG registry
-FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
+ARG base_registry
+FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/MessagesAnalyzer/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/MessagesAnalyzer/docker/windows/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+ARG registry
+FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/MessagesAnalyzer/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/MessagesAnalyzer/docker/windows/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-ARG registry
-FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
+ARG base_registry
+FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+ARG registry
+FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-ARG registry
-FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
+ARG base_registry
+FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/TemperatureFilter/TemperatureFilter.csproj
+++ b/edge-modules/TemperatureFilter/TemperatureFilter.csproj
@@ -19,6 +19,10 @@
     <OutputPath>bin\CodeCoverage</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Content Include="docker*/**/*.*" CopyToPublishDirectory="Always" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.1" />
@@ -31,19 +35,5 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\edge-util\src\Microsoft.Azure.Devices.Edge.Util\Microsoft.Azure.Devices.Edge.Util.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Update="docker\linux\amd64\Dockerfile">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="docker\linux\arm32v7\base\Dockerfile">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="docker\linux\arm32v7\Dockerfile">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="docker\windows\amd64\Dockerfile">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
   </ItemGroup>
 </Project>

--- a/edge-modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+ARG registry
+FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-ARG registry
-FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
+ARG base_registry
+FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/load-gen/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/load-gen/docker/windows/arm32v7/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+ARG registry
+FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/load-gen/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/load-gen/docker/windows/arm32v7/Dockerfile
@@ -1,6 +1,6 @@
 ARG base_tag=1.0.0-windows-arm32v7
-ARG registry
-FROM ${registry}/azureiotedge/azureiotedge-module-base:${base_tag}
+ARG base_registry
+FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/scripts/windows/build/Publish-Branch.ps1
+++ b/scripts/windows/build/Publish-Branch.ps1
@@ -239,29 +239,6 @@ else {
 }
 
 <#
- # Publish IoTEdgeQuickstart and LeafDevice
- #>
-
- # Subject to remove once other pipelines are updated to use the new path
-Write-Host "Publishing - IoTEdgeQuickstart x64"
-$ProjectPublishPath = Join-Path $PUBLISH_FOLDER "IoTEdgeQuickstart"
-$IoTEdgeQuickstartProjectFolder = Join-Path $BuildRepositoryLocalPath "smoke/IoTEdgeQuickstart"
-&$DOTNET_PATH publish -f netcoreapp2.1 -r "win-x64" -c $Configuration -o $ProjectPublishPath $IoTEdgeQuickstartProjectFolder |
-	Write-Host
-if ($LASTEXITCODE -ne 0) {
-	throw "Failed publishing IoTEdgeQuickstart."
-}
-
-Write-Host "Publishing - LeafDevice x64"
-$ProjectPublishPath = Join-Path $PUBLISH_FOLDER "LeafDevice"
-$LeafDeviceProjectFolder = Join-Path $BuildRepositoryLocalPath "smoke/LeafDevice"
-&$DOTNET_PATH publish -f netcoreapp2.1 -r "win-x64" -c $Configuration -o $ProjectPublishPath $LeafDeviceProjectFolder |
-	Write-Host
-if ($LASTEXITCODE -ne 0) {
-	throw "Failed publishing LeafDevice."
-}
-
-<#
  # Publish IoTEdgeQuickstart
  #>
 $IoTEdgeQuickstartProjectFolder = Join-Path $BuildRepositoryLocalPath "smoke/IoTEdgeQuickstart"

--- a/scripts/windows/build/Publish-DockerImage.ps1
+++ b/scripts/windows/build/Publish-DockerImage.ps1
@@ -82,7 +82,7 @@ if ($Registry) {
  # Build the image
  #>
 
-$BuildOptions = "--no-cache -t $Tag --file $Dockerfile --build-arg registry=$Registry"
+$BuildOptions = "--no-cache -t $Tag --file $Dockerfile --build-arg base_registry=$Registry"
 if ($BaseTag) {
     $BuildOptions += " --build-arg base_tag=$BaseTag"
 }

--- a/scripts/windows/build/Publish-DockerImage.ps1
+++ b/scripts/windows/build/Publish-DockerImage.ps1
@@ -82,7 +82,7 @@ if ($Registry) {
  # Build the image
  #>
 
-$BuildOptions = "--no-cache -t $Tag --file $Dockerfile"
+$BuildOptions = "--no-cache -t $Tag --file $Dockerfile --build-arg registry=$Registry"
 if ($BaseTag) {
     $BuildOptions += " --build-arg base_tag=$BaseTag"
 }


### PR DESCRIPTION
1. Remove to publish IotEdgeQuickStart and LeafDevice to old folder; all published files should be found in x64 and arm32v7 folder.
2. Update TemperatureFilter project to copy all docker files.
3. Update docker build to use base_registry build arg.