### PR TITLE
EdgeHub: For thumbprint auth, only validate cert expiry

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeCertificateAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeCertificateAuthenticator.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
+
 namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
 {
     using System;
@@ -17,12 +18,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
 
         public DeviceScopeCertificateAuthenticator(
             IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache,
-            string iothubHostName,
             IAuthenticator underlyingAuthenticator,
             IList<X509Certificate2> trustBundle,
             bool syncServiceIdentityOnFailure)
-            :
-            base(deviceScopeIdentitiesCache, underlyingAuthenticator, false, syncServiceIdentityOnFailure)
+            : base(deviceScopeIdentitiesCache, underlyingAuthenticator, false, syncServiceIdentityOnFailure)
         {
             this.trustBundle = Preconditions.CheckNotNull(trustBundle, nameof(trustBundle));
         }
@@ -52,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             }
             else if (serviceIdentity.Authentication.Type == ServiceAuthenticationType.CertificateAuthority)
             {
-                result = this.ValidateCaAuth(serviceIdentity, certificateCredentials);                
+                result = this.ValidateCaAuth(serviceIdentity, certificateCredentials);
             }
             else
             {
@@ -71,7 +70,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
                 return false;
             }
 
-            if (!CertificateHelper.ValidateClientCert(certificateCredentials.ClientCertificate,
+            if (!CertificateHelper.ValidateClientCert(
+                certificateCredentials.ClientCertificate,
                 certificateCredentials.ClientCertificateChain,
                 Option.Some(this.trustBundle),
                 Events.Log))
@@ -89,6 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
                 && !serviceIdentity.Authentication.X509Thumbprint.HasValue)
             {
                 Events.ThumbprintServiceIdentityInvalid(serviceIdentity);
+                return false;
             }
 
             X509ThumbprintAuthentication x509ThumbprintAuthentication =
@@ -104,6 +105,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             if (!CertificateHelper.ValidateCertificateThumbprint(certificateCredentials.ClientCertificate, thumbprints))
             {
                 Events.ThumbprintMismatch(serviceIdentity.Id);
+                return false;
             }
 
             return true;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     var credentialsCacheTask = c.Resolve<Task<ICredentialsCache>>();
                     // by default regardless of how the authenticationMode, X.509 certificate validation will always be scoped
                     deviceScopeIdentitiesCache = await c.Resolve<Task<IDeviceScopeIdentitiesCache>>();
-                    certificateAuthenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, new NullAuthenticator(), this.trustBundle, true);
+                    certificateAuthenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, new NullAuthenticator(), this.trustBundle, true);
                     switch (this.authenticationMode)
                     {
                         case AuthenticationMode.Cloud:

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeCertificateAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeCertificateAuthenticatorTest.cs
@@ -21,8 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     [Unit]
     public class DeviceScopeCertificateAuthenticatorTest
     {
-        string iothubHostName = "testiothub.azure-devices.net";
-        IAuthenticator underlyingAuthenticator = new NullAuthenticator();
+        static IAuthenticator UnderlyingAuthenticator = new NullAuthenticator();
 
         [Fact]
         public void DeviceScopeCertificateAuthenticatorNullArgumentsThrows()
@@ -30,12 +29,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
             IList<X509Certificate2> trustBundle = new List<X509Certificate2>();
 
-            Assert.Throws<ArgumentNullException>(() => new DeviceScopeCertificateAuthenticator(null, iothubHostName, underlyingAuthenticator, trustBundle, true));
-            Assert.Throws<ArgumentException>(() => new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, null, underlyingAuthenticator, trustBundle, true));
-            Assert.Throws<ArgumentException>(() => new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, "", underlyingAuthenticator, trustBundle, true));
-            Assert.Throws<ArgumentException>(() => new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, "   ", underlyingAuthenticator, trustBundle, true));
-            Assert.Throws<ArgumentNullException>(() => new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, iothubHostName, null, trustBundle, true));
-            Assert.Throws<ArgumentNullException>(() => new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, iothubHostName, underlyingAuthenticator, null, true));
+            Assert.Throws<ArgumentNullException>(() => new DeviceScopeCertificateAuthenticator(null, UnderlyingAuthenticator, trustBundle, true));
+            Assert.Throws<ArgumentNullException>(() => new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, null, trustBundle, true));
+            Assert.Throws<ArgumentNullException>(() => new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, UnderlyingAuthenticator, null, true));
         }
 
         [Fact]
@@ -44,7 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
             IList<X509Certificate2> trustBundle = new List<X509Certificate2>();
             IClientCredentials clientCredentials = Mock.Of<IClientCredentials>();
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, UnderlyingAuthenticator, trustBundle, true);
 
             Assert.False(await authenticator.AuthenticateAsync(clientCredentials));
         }
@@ -73,7 +69,39 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(new X509ThumbprintAuthentication(primaryCertificate.Thumbprint, secondaryCertificate.Thumbprint)),
                                                       ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
+            deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
+
+            // Assert
+            Assert.True(await authenticator.AuthenticateAsync(primaryCredentials));
+            Assert.True(await authenticator.AuthenticateAsync(secondaryCredentials));
+        }
+
+        [Fact]
+        public async Task AuthenticateAsyncWithDeviceThumbprintX509InScopeCacheSucceedsWithCACert()
+        {
+            string deviceId = "d1";
+            var primaryCertificate = TestCertificateHelper.GenerateSelfSignedCert("primo", true);
+            var primaryClientCertChain = new List<X509Certificate2>() { primaryCertificate };
+            var secondaryCertificate = TestCertificateHelper.GenerateSelfSignedCert("secondo", true);
+            var secondaryClientCertChain = new List<X509Certificate2>() { secondaryCertificate };
+
+            var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
+            IList<X509Certificate2> trustBundle = new List<X509Certificate2>();
+            var primaryCredentials = Mock.Of<ICertificateCredentials>(c =>
+                c.Identity == Mock.Of<IDeviceIdentity>(i => i.DeviceId == deviceId && i.Id == deviceId)
+                    && c.AuthenticationType == AuthenticationType.X509Cert
+                    && c.ClientCertificate == primaryCertificate && c.ClientCertificateChain == primaryClientCertChain);
+
+            var secondaryCredentials = Mock.Of<ICertificateCredentials>(c =>
+                c.Identity == Mock.Of<IDeviceIdentity>(i => i.DeviceId == deviceId && i.Id == deviceId)
+                    && c.AuthenticationType == AuthenticationType.X509Cert
+                    && c.ClientCertificate == secondaryCertificate && c.ClientCertificateChain == secondaryClientCertChain);
+
+            var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
+                                                      new ServiceAuthentication(new X509ThumbprintAuthentication(primaryCertificate.Thumbprint, secondaryCertificate.Thumbprint)),
+                                                      ServiceIdentityStatus.Enabled);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
             // Assert
@@ -105,7 +133,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(new X509ThumbprintAuthentication("7A57E1E55", "DECAF")),
                                                       ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
             // Assert
@@ -138,7 +166,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity = new ServiceIdentity("some_other_device", "1234", new string[0],
                                                       new ServiceAuthentication(new X509ThumbprintAuthentication(primaryCertificate.Thumbprint, secondaryCertificate.Thumbprint)),
                                                       ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == "some_other_device"), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
             // Assert
@@ -171,7 +199,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Enabled);
 
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
             // Assert
@@ -197,7 +225,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 
@@ -224,7 +252,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(someOtherDeviceId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == someOtherDeviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 
@@ -250,7 +278,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 
@@ -277,7 +305,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 
@@ -304,7 +332,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 
@@ -330,7 +358,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 
@@ -356,7 +384,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 
@@ -383,7 +411,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(deviceId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 
@@ -418,7 +446,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity = new ServiceIdentity(deviceId, moduleId, "1234", new string[0],
                                                       new ServiceAuthentication(new X509ThumbprintAuthentication(primaryCertificate.Thumbprint, secondaryCertificate.Thumbprint)),
                                                       ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == identity), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
             // Assert
@@ -448,7 +476,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
             var serviceIdentity = new ServiceIdentity(deviceId, moduleId, "1234", new string[0],
                                                       new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, iothubHostName, underlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == identity), false)).ReturnsAsync(Option.Some(serviceIdentity));
 
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -205,19 +205,9 @@ namespace Microsoft.Azure.Devices.Edge.Util
             Preconditions.CheckNotNull(certificate);
             Preconditions.CheckNotNull(certificateChain);
             Preconditions.CheckNotNull(trustedCACerts);
-            Preconditions.CheckNotNull(logger);
 
-            DateTime currentTime = DateTime.Now;
-
-            if (certificate.NotAfter < currentTime)
+            if (!ValidateCertExpiry(certificate, logger))
             {
-                logger.LogWarning($"Certificate with subject: {certificate.Subject} has expired on UTC time: {certificate.NotAfter.ToString("MM-dd-yyyy H:mm:ss")}");
-                return false;
-            }
-
-            if (certificate.NotBefore > currentTime)
-            {
-                logger.LogWarning($"Certificate with subject: {certificate.Subject} is not valid until UTC time: {certificate.NotBefore.ToString("MM-dd-yyyy H:mm:ss")}");
                 return false;
             }
 
@@ -227,15 +217,34 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 return false;
             }
 
-            bool result = false;
-            Option<string> errors = Option.None<string>();
-            (result, errors) = ValidateCert(certificate, certificateChain, trustedCACerts);
+            (bool result, Option<string> errors) = ValidateCert(certificate, certificateChain, trustedCACerts);
             if (errors.HasValue)
             {
                 errors.ForEach(v => logger.LogWarning(v));
             }
 
             return result;
+        }
+
+        public static bool ValidateCertExpiry(X509Certificate2 certificate, ILogger logger)
+        {
+            Preconditions.CheckNotNull(certificate);
+
+            DateTime currentTime = DateTime.Now;
+
+            if (certificate.NotAfter < currentTime)
+            {
+                logger?.LogWarning($"Certificate with subject: {certificate.Subject} has expired on UTC time: {certificate.NotAfter.ToString("MM-dd-yyyy H:mm:ss")}");
+                return false;
+            }
+
+            if (certificate.NotBefore > currentTime)
+            {
+                logger?.LogWarning($"Certificate with subject: {certificate.Subject} is not valid until UTC time: {certificate.NotBefore.ToString("MM-dd-yyyy H:mm:ss")}");
+                return false;
+            }
+
+            return true;
         }
 
         public static void InstallCerts(StoreName name, StoreLocation location, IEnumerable<X509Certificate2> certs)

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -213,14 +213,14 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
             if (IsCACertificate(certificate))
             {
-                logger.LogWarning($"Certificate with subject: {certificate.Subject} was found to be a CA certificate, this is not permitted per the authentication policy");
+                logger?.LogWarning($"Certificate with subject: {certificate.Subject} was found to be a CA certificate, this is not permitted per the authentication policy");
                 return false;
             }
 
             (bool result, Option<string> errors) = ValidateCert(certificate, certificateChain, trustedCACerts);
             if (errors.HasValue)
             {
-                errors.ForEach(v => logger.LogWarning(v));
+                errors.ForEach(v => logger?.LogWarning(v));
             }
 
             return result;

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/certificate/CertificateHelperTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/certificate/CertificateHelperTest.cs
@@ -69,9 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Certificate
             Assert.Throws<ArgumentNullException>(() =>
             CertificateHelper.ValidateClientCert(null, new List<X509Certificate2>(), trustedCACerts, Logger.Factory.CreateLogger("something")));
             Assert.Throws<ArgumentNullException>(() =>
-            CertificateHelper.ValidateClientCert(new X509Certificate2(), null, trustedCACerts, Logger.Factory.CreateLogger("something")));
-            Assert.Throws<ArgumentNullException>(() =>
-            CertificateHelper.ValidateClientCert(new X509Certificate2(), new List<X509Certificate2>(), trustedCACerts, null));
+            CertificateHelper.ValidateClientCert(new X509Certificate2(), null, trustedCACerts, Logger.Factory.CreateLogger("something")));            
         }
 
         [Fact]


### PR DESCRIPTION
For Thumbprint Auth, IoTHub validates only if the cert is not expired and if the thumbprints match. Other checks like if the Cert is CA cert is done only for CA Cert auth. To fixing the checks for Thumbprint auth. 