### PR TITLE
EdgeHub: UpdateMethodRequestValidator to allow payloads up to 128k

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/MethodRequest.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/MethodRequest.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
+
 namespace Microsoft.Azure.Devices.Edge.Hub.Http
 {
     using System;
@@ -9,25 +10,35 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http
     public class MethodRequest
     {
         const int DeviceMethodDefaultResponseTimeoutInSeconds = 30;
-
+        const int DeviceMethodDefaultConnectTimeoutInSeconds = 0;
         byte[] payloadBytes;
 
-        public MethodRequest()
+        [JsonConstructor]
+        public MethodRequest(string methodName, JRaw payload)
+            : this(methodName, payload, DeviceMethodDefaultResponseTimeoutInSeconds, DeviceMethodDefaultConnectTimeoutInSeconds)
         {
-            this.ResponseTimeoutInSeconds = DeviceMethodDefaultResponseTimeoutInSeconds;
+        }
+
+        [JsonConstructor]
+        public MethodRequest(string methodName, JRaw payload, int? responseTimeoutInSeconds, int? connectTimeoutInSeconds)
+        {
+            this.MethodName = methodName;
+            this.Payload = payload;
+            this.ResponseTimeoutInSeconds = responseTimeoutInSeconds ?? DeviceMethodDefaultResponseTimeoutInSeconds;
+            this.ConnectTimeoutInSeconds = connectTimeoutInSeconds ?? DeviceMethodDefaultConnectTimeoutInSeconds;
         }
 
         [JsonProperty("methodName", Required = Required.Always)]
-        public string MethodName { get; set; }
+        public string MethodName { get; }
 
         [JsonProperty("payload")]
-        public JRaw Payload { get; set; }
+        public JRaw Payload { get; }
 
         [JsonProperty("responseTimeoutInSeconds")]
-        internal int ResponseTimeoutInSeconds { get; set; }
+        internal int ResponseTimeoutInSeconds { get; }
 
         [JsonProperty("connectTimeoutInSeconds")]
-        internal int ConnectTimeoutInSeconds { get; set; }
+        internal int ConnectTimeoutInSeconds { get; }
 
         [JsonIgnore]
         public TimeSpan ResponseTimeout => TimeSpan.FromSeconds(this.ResponseTimeoutInSeconds);
@@ -45,6 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http
                     // TODO - Should we allow only UTF8 or other encodings as well? Need to check what IoTHub does.
                     this.payloadBytes = Encoding.UTF8.GetBytes((string)this.Payload);
                 }
+
                 return this.payloadBytes;
             }
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/MethodRequestValidator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/MethodRequestValidator.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Hub.Http
 {
     using Microsoft.Azure.Devices.Edge.Hub.Core;
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http
         static readonly TimeSpan DeviceMethodMinResponseTimeout = TimeSpan.FromSeconds(5);
         static readonly TimeSpan DeviceMethodMaxDispatchTimeout = TimeSpan.FromMinutes(5);
         const int DeviceMethodNameMaxLength = 100;
-        const int PayloadMaxSizeBytes = 8 * 1024; // 8kb
+        const int PayloadMaxSizeBytes = 128 * 1024; // 8kb
 
         public void Validate(MethodRequest methodRequest)
         {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/MethodRequestValidator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/MethodRequestValidator.cs
@@ -11,7 +11,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http
         static readonly TimeSpan DeviceMethodMinResponseTimeout = TimeSpan.FromSeconds(5);
         static readonly TimeSpan DeviceMethodMaxDispatchTimeout = TimeSpan.FromMinutes(5);
         const int DeviceMethodNameMaxLength = 100;
-        const int PayloadMaxSizeBytes = 128 * 1024; // 8kb
+        const int PayloadMaxSizeBytes = 128 * 1024; // 128kb
 
         public void Validate(MethodRequest methodRequest)
         {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/MethodRequestValidatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/MethodRequestValidatorTest.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Xunit;
+
+    [Unit]
+    public class MethodRequestValidatorTest
+    {
+        [Theory]
+        [MemberData(nameof(GetInvalidData))]
+        public void ValidateRequestTest(MethodRequest request, Exception expectedException)
+        {
+
+        }
+
+        static IEnumerable<object[]> GetInvalidData()
+        {
+            yield return new object[0];// { new MethodRequest() }
+        }
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/MethodRequestValidatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/MethodRequestValidatorTest.cs
@@ -14,14 +14,35 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
     public class MethodRequestValidatorTest
     {
         [Theory]
+        [MemberData(nameof(GetValidData))]
+        public void ValidateRequestTest(MethodRequest request)
+        {
+            // Arrange
+            IValidator<MethodRequest> methodRequestValidator = new MethodRequestValidator();
+
+            // Act / Assert
+            methodRequestValidator.Validate(request);
+        }
+
+
+        [Theory]
         [MemberData(nameof(GetInvalidData))]
-        public void ValidateRequestTest(MethodRequest request, Type expectedExceptionType)
+        public void ValidateInvalidRequestTest(MethodRequest request, Type expectedExceptionType)
         {
             // Arrange
             IValidator<MethodRequest> methodRequestValidator = new MethodRequestValidator();
 
             // Act / Assert
             Assert.Throws(expectedExceptionType, () => methodRequestValidator.Validate(request));
+        }
+
+        static IEnumerable<object[]> GetValidData()
+        {
+            yield return new object[] { new MethodRequest("poke", new JRaw("{\"prop\":\"val\"}"), 5, 30) };
+
+            yield return new object[] { new MethodRequest("poke", new JRaw("{\"prop\":\"val\"}"), 300, 300) };
+
+            yield return new object[] { new MethodRequest(new string('1', 100), new JRaw("{\"prop\":\"val\"}"), 300, 300) };
         }
 
         static IEnumerable<object[]> GetInvalidData()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/MethodRequestValidatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/MethodRequestValidatorTest.cs
@@ -4,7 +4,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
 {
     using System;
     using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using Xunit;
 
     [Unit]
@@ -12,14 +15,58 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
     {
         [Theory]
         [MemberData(nameof(GetInvalidData))]
-        public void ValidateRequestTest(MethodRequest request, Exception expectedException)
+        public void ValidateRequestTest(MethodRequest request, Type expectedExceptionType)
         {
+            // Arrange
+            IValidator<MethodRequest> methodRequestValidator = new MethodRequestValidator();
 
+            // Act / Assert
+            Assert.Throws(expectedExceptionType, () => methodRequestValidator.Validate(request));
         }
 
         static IEnumerable<object[]> GetInvalidData()
         {
-            yield return new object[0];// { new MethodRequest() }
+            yield return new object[] { new MethodRequest("poke", new JRaw("{\"prop\":\"val\"}"), 3, 30), typeof(ArgumentOutOfRangeException) };
+
+            yield return new object[] { new MethodRequest("poke", new JRaw("{\"prop\":\"val\"}"), 302, 30), typeof(ArgumentOutOfRangeException) };
+
+            yield return new object[] { new MethodRequest("poke", new JRaw("{\"prop\":\"val\"}"), 30, 302), typeof(ArgumentOutOfRangeException) };
+
+            yield return new object[] { new MethodRequest("poke", new JRaw("{\"prop\":\"val\"}"), 30, -1), typeof(ArgumentOutOfRangeException) };
+
+            yield return new object[] { new MethodRequest(null, new JRaw("{\"prop\":\"val\"}"), 30, 30), typeof(ArgumentException) };
+
+            yield return new object[] { new MethodRequest("", new JRaw("{\"prop\":\"val\"}"), 30, 30), typeof(ArgumentException) };
+
+            yield return new object[] { new MethodRequest(new string('1', 102), new JRaw("{\"prop\":\"val\"}"), 30, 30), typeof(ArgumentException) };
+
+            TestClass testObj = null;
+            for (int i = 0; i < 1000; i++)
+            {
+                testObj = new TestClass(new string('1', 100), new string('2', 100), testObj);
+            }
+
+            var jraw = new JRaw(JsonConvert.SerializeObject(testObj));
+            yield return new object[] { new MethodRequest("poke", jraw, 30, 30), typeof(ArgumentException) };
+        }
+
+        class TestClass
+        {
+            [JsonProperty("prop1")]
+            public string Prop1 { get; }
+
+            [JsonProperty("prop2")]
+            public string Prop2 { get; }
+
+            [JsonProperty("obj")]
+            public TestClass NestedObj { get; }
+
+            public TestClass(string prop1, string prop2, TestClass obj)
+            {
+                this.Prop1 = prop1;
+                this.Prop2 = prop2;
+                this.NestedObj = obj;
+            }
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             string command = "showdown";
             string payload = "{ \"prop1\" : \"value1\" }";
 
-            var methodRequest = new MethodRequest { MethodName = command, Payload = new JRaw(payload) };
+            var methodRequest = new MethodRequest(command, new JRaw(payload));
             IActionResult actionResult = await testController.InvokeDeviceMethodAsync(toDeviceId, methodRequest);
 
             Assert.NotNull(actionResult);
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             edgeHub.Setup(e => e.InvokeMethodAsync(It.Is<string>(i => i == identity.Id), It.IsAny<DirectMethodRequest>()))
                 .ReturnsAsync(directMethodResponse);
 
-            var validator = new Mock<IValidator<Http.MethodRequest>>();
-            validator.Setup(v => v.Validate(It.IsAny<Http.MethodRequest>()));
+            var validator = new Mock<IValidator<MethodRequest>>();
+            validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
 
             var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object);
             testController.OnActionExecuting(actionExecutingContext);
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             string command = "showdown";
             string payload = "{ \"prop1\" : \"value1\" }";
 
-            var methodRequest = new Http.MethodRequest { MethodName = command, Payload = new JRaw(payload) };
+            var methodRequest = new MethodRequest( command, new JRaw(payload));
             IActionResult actionResult = await testController.InvokeModuleMethodAsync(WebUtility.UrlEncode(toDeviceId), WebUtility.UrlEncode(toModuleId), methodRequest);
 
             Assert.NotNull(actionResult);
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             string command = "showdown";
             string payload = "{ \"prop1\" : \"value1\" }";
 
-            var methodRequest = new MethodRequest { MethodName = command, Payload = new JRaw(payload) };
+            var methodRequest = new MethodRequest(command, new JRaw(payload));
             IActionResult actionResult = await testController.InvokeDeviceMethodAsync(toDeviceId, methodRequest);
 
             Assert.NotNull(actionResult);
@@ -140,8 +140,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             edgeHub.Setup(e => e.InvokeMethodAsync(It.Is<string>(i => i == identity.Id), It.IsAny<DirectMethodRequest>()))
                 .ReturnsAsync(directMethodResponse);
 
-            var validator = new Mock<IValidator<Http.MethodRequest>>();
-            validator.Setup(v => v.Validate(It.IsAny<Http.MethodRequest>()));
+            var validator = new Mock<IValidator<MethodRequest>>();
+            validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
 
             var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object);
             testController.OnActionExecuting(actionExecutingContext);
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             string command = "showdown";
             string payload = "{ \"prop1\" : \"value1\" }";
 
-            var methodRequest = new Http.MethodRequest { MethodName = command, Payload = new JRaw(payload) };
+            var methodRequest = new MethodRequest(command, new JRaw(payload));
             IActionResult actionResult = await testController.InvokeModuleMethodAsync(WebUtility.UrlEncode(toDeviceId), WebUtility.UrlEncode(toModuleId), methodRequest);
 
             Assert.NotNull(actionResult);
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             string command = "showdown";
             string payload = "{ \"prop1\" : \"value1\" }";
 
-            var methodRequest = new MethodRequest { MethodName = command, Payload = new JRaw(payload) };
+            var methodRequest = new MethodRequest(command, new JRaw(payload));
             IActionResult actionResult = await testController.InvokeDeviceMethodAsync(toDeviceId, methodRequest);
 
             Assert.NotNull(actionResult);


### PR DESCRIPTION
Updated MethodRequestValidator to allow payloads up to 128k
Also Added unit tests for MethodRequestValidator.

Fixes #616 