### PR TITLE
EdgeHub: Handle receiving messages with invalid topic

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                                         {
                                             Events.InvalidMessage(ex);
                                             invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.InvalidInput));
-                                            sendFailureDetails = new SendFailureDetails(FailureKind.InvalidInput, new InvalidOperationException("Message does not contain client identity"));
+                                            sendFailureDetails = new SendFailureDetails(FailureKind.InvalidInput, ex);
                                         }
 
                                         if (failed.Count > 0)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
@@ -73,45 +73,58 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
 
                 IMessage message = this.cloudEndpoint.messageConverter.ToMessage(routingMessage);
 
-                Util.Option<ICloudProxy> cloudProxy = await this.GetCloudProxy(routingMessage);
-                if (!cloudProxy.HasValue)
+                Util.Option<string> identity = this.GetIdentity(routingMessage);
+                if (!identity.HasValue)
                 {
-                    sendFailureDetails = new SendFailureDetails(FailureKind.Transient, new EdgeHubConnectionException("IoT Hub is not connected"));
-                    failed.Add(routingMessage);
+                    Events.InvalidMessageNoIdentity();
+                    invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.None));
                 }
                 else
                 {
-                    await cloudProxy.ForEachAsync(async cp =>
-                    {
-                        try
+                    await identity.ForEachAsync(
+                        async id =>
                         {
-                            string id = this.GetIdentity(routingMessage).Expect(() => new InvalidOperationException("Could not retrieve identity of message"));
-                            using (Metrics.CloudLatency(id))
+                            Util.Option<ICloudProxy> cloudProxy = await this.cloudEndpoint.cloudProxyGetterFunc(id);
+                            if (!cloudProxy.HasValue)
                             {
-                                await cp.SendMessageAsync(message);
-                            }
-                            succeeded.Add(routingMessage);
-                            Metrics.MessageCount(id);
-                        }
-                        catch (Exception ex)
-                        {
-                            if (IsRetryable(ex))
-                            {
+                                Events.IoTHubNotConnected(id);
+                                sendFailureDetails = new SendFailureDetails(FailureKind.Transient, new EdgeHubConnectionException("IoT Hub is not connected"));
                                 failed.Add(routingMessage);
                             }
                             else
                             {
-                                Events.InvalidMessage(ex);
-                                invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.None));
-                            }
+                                await cloudProxy.ForEachAsync(async cp =>
+                                {
+                                    try
+                                    {
+                                        using (Metrics.CloudLatency(id))
+                                        {
+                                            await cp.SendMessageAsync(message);
+                                        }
+                                        succeeded.Add(routingMessage);
+                                        Metrics.MessageCount(id);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        if (IsRetryable(ex))
+                                        {
+                                            failed.Add(routingMessage);
+                                        }
+                                        else
+                                        {
+                                            Events.InvalidMessage(ex);
+                                            invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.None));
+                                        }
 
-                            if (failed.Count > 0)
-                            {
-                                Events.RetryingMessage(routingMessage, ex);
-                                sendFailureDetails = new SendFailureDetails(FailureKind.Transient, new EdgeHubIOException($"Error sending messages to IotHub for device {this.cloudEndpoint.Id}"));
+                                        if (failed.Count > 0)
+                                        {
+                                            Events.RetryingMessage(routingMessage, ex);
+                                            sendFailureDetails = new SendFailureDetails(FailureKind.Transient, new EdgeHubIOException($"Error sending messages to IotHub for device {this.cloudEndpoint.Id}"));
+                                        }
+                                    }
+                                });
                             }
-                        }
-                    });
+                        });
                 }
 
                 return new SinkResult<IRoutingMessage>(succeeded, failed, invalid, sendFailureDetails);
@@ -169,21 +182,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 return Option.None<string>();
             }
 
-            Task<Util.Option<ICloudProxy>> GetCloudProxy(IRoutingMessage routingMessage)
-            {
-                return this.GetIdentity(routingMessage).Map(
-                    async id =>
-                    {
-                        Util.Option<ICloudProxy> cloudProxy = await this.cloudEndpoint.cloudProxyGetterFunc(id);
-                        if (!cloudProxy.HasValue)
-                        {
-                            Events.IoTHubNotConnected(id);
-                        }
-                        return cloudProxy;
-                    })
-                    .GetOrElse(() => Task.FromResult(Option.None<ICloudProxy>()));
-            }
-
             static bool IsRetryable(Exception ex) => ex != null && RetryableExceptions.Contains(ex.GetType());
         }
 
@@ -203,7 +201,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 RateUnit = TimeUnit.Seconds
             };
 
-            internal static MetricTags GetTags(string id)
+            static MetricTags GetTags(string id)
             {
                 return new MetricTags("DeviceId", id);
             }
@@ -224,7 +222,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 IoTHubNotConnected,
                 RetryingMessages,
                 InvalidMessage,
-                ProcessingMessages
+                ProcessingMessages,
+                InvalidMessageNoIdentity
             }
 
             public static void DeviceIdNotFound(IRoutingMessage routingMessage)
@@ -232,7 +231,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 string message = routingMessage.SystemProperties.TryGetValue(SystemProperties.MessageId, out string messageId)
                     ? Invariant($"Message with MessageId {messageId} does not contain a device Id.")
                     : "Received message does not contain a device Id";
-                Log.LogError((int)EventIds.DeviceIdNotFound, message);
+                Log.LogWarning((int)EventIds.DeviceIdNotFound, message);
             }
 
             internal static void IoTHubNotConnected(string id)
@@ -266,6 +265,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             public static void ProcessingMessages(ICollection<IRoutingMessage> routingMessages)
             {
                 Log.LogDebug((int)EventIds.ProcessingMessages, Invariant($"Sending {routingMessages.Count} message(s) upstream."));
+            }
+
+            public static void InvalidMessageNoIdentity()
+            {
+                Log.LogWarning((int)EventIds.InvalidMessageNoIdentity, "Cannot process message with no identity, discarding it.");
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
@@ -77,7 +77,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 if (!identity.HasValue)
                 {
                     Events.InvalidMessageNoIdentity();
-                    invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.None));
+                    invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.InvalidInput));
+                    sendFailureDetails = new SendFailureDetails(FailureKind.InvalidInput, new InvalidOperationException("Message does not contain client identity"));
                 }
                 else
                 {
@@ -113,7 +114,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                                         else
                                         {
                                             Events.InvalidMessage(ex);
-                                            invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.None));
+                                            invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.InvalidInput));
+                                            sendFailureDetails = new SendFailureDetails(FailureKind.InvalidInput, new InvalidOperationException("Message does not contain client identity"));
                                         }
 
                                         if (failed.Count > 0)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
@@ -22,8 +22,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
         public IMessage ToMessage(IProtocolGatewayMessage sourceMessage)
         {
-            // TODO: should reject messages which are not matched ( PassThroughUnmatchedMessages)
-            this.addressConvertor.TryParseProtocolMessagePropsFromAddress(sourceMessage);
+            if(!this.addressConvertor.TryParseProtocolMessagePropsFromAddress(sourceMessage))
+            {
+                throw new InvalidOperationException("Topic name could not be matched against any of the configured routes.");
+            }
 
             byte[] payloadBytes = this.byteBufferConverter.ToByteArray(sourceMessage.Payload);
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/FailureKind.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/FailureKind.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Devices.Routing.Core
         Unauthorized = 3,
         Throttled = 4,
         Timeout = 5,
+        InvalidInput = 6,
 
         // Service Bus
         MaxMessageSizeExceeded = 20,

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudEndpointTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudEndpointTest.cs
@@ -110,8 +110,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             IProcessor cloudMessageProcessor = cloudEndpoint.CreateProcessor();
             ISinkResult<IRoutingMessage> sinkResult = await cloudMessageProcessor.ProcessAsync(routingMessage, CancellationToken.None);
-            Assert.Equal(FailureKind.Transient, sinkResult.SendFailureDetails.OrDefault().FailureKind);
-            Assert.Equal(typeof(EdgeHubConnectionException), sinkResult.SendFailureDetails.OrDefault().RawException.GetType());
+            Assert.Equal(FailureKind.InvalidInput, sinkResult.SendFailureDetails.OrDefault().FailureKind);
+            Assert.Equal(typeof(InvalidOperationException), sinkResult.SendFailureDetails.OrDefault().RawException.GetType());
+            Assert.Equal(1, sinkResult.InvalidDetailsList.Count);
+            Assert.Equal(0, sinkResult.Failed.Count);
+            Assert.Equal(0, sinkResult.Succeeded.Count);
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
@@ -108,8 +108,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
         [Fact]
         public async Task SendAsyncForwardsMessagesToTheDeviceListener()
         {
-            Messages m = MakeMessages();
+            Messages m = MakeMessages("devices/d1/messages/events/");
             Mock<IDeviceListener> listener = MakeDeviceListenerSpy();
+            m.Expected.SystemProperties[Core.SystemProperties.ConnectionDeviceId] = "d1";
 
             var client = new MessagingServiceClient(listener.Object, ProtocolGatewayMessageConverter.Value, ByteBufferConverter);
             await client.SendAsync(m.Source);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/ProtocolGatewayMessageConverterTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/ProtocolGatewayMessageConverterTest.cs
@@ -326,5 +326,34 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Assert.Equal("fromModule1", pgMessage.Properties["$.cmid"]);
             Assert.False(pgMessage.Properties.ContainsKey("$.on"));
         }
+
+        [Fact]
+        public void TestToMessage_NoTopicMatch()
+        {
+            var outputTemplates = new Dictionary<string, string>
+            {
+                ["Dummy"] = ""
+            };
+            var inputTemplates = new List<string>
+            {
+                "devices/{deviceId}/messages/events/{params}/",
+                "devices/{deviceId}/messages/events/"
+            };
+            var config = new MessageAddressConversionConfiguration(
+                inputTemplates,
+                outputTemplates
+            );
+            var converter = new MessageAddressConverter(config);
+            var properties = new Dictionary<string, string>();
+            var protocolGatewayMessage = Mock.Of<IProtocolGatewayMessage>(
+                m =>
+                    m.Address == @"devices/Device_6/messages/eve/%24.cid=Corrid1&%24.mid=MessageId1&Foo=Bar&Prop2=Value2&Prop3=Value3/" &&
+                    m.Payload.Equals(Payload) &&
+                    m.Properties == properties
+            );
+
+            var protocolGatewayMessageConverter = new ProtocolGatewayMessageConverter(converter, ByteBufferConverter);
+            Assert.Throws<InvalidOperationException>(() => protocolGatewayMessageConverter.ToMessage(protocolGatewayMessage));
+        }
     }
 }


### PR DESCRIPTION
- In ProtocolGatewayMessageConverter, throw if the input message topic does not match any of the expected topics. This is same as what IoTHub does
- In CloudEndpoint, if a message does not have device Id (somehow), then mark the message as invalid, instead of a transient failure, so that it will not be retried.

Fixes #615 