### PR TITLE
EdgeHub: Pass in client cert auth allowed flag for MQTT Websockets

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 Log.LogInformation((int)EventIds.Established, Invariant($"Processed MQTT WebSocket request with CorrelationId {correlationId}"));
 
             public static void Exception(string correlationId, Exception ex) =>
-                Log.LogWarning((int)EventIds.Exception, ex, Invariant($"Error processing MQTT WebSocker request with CorrelationId {correlationId}"));
+                Log.LogWarning((int)EventIds.Exception, ex, Invariant($"Error processing MQTT WebSocket request with CorrelationId {correlationId}"));
         }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
         public Task ProcessWebSocketRequestAsync(WebSocket webSocket, Option<EndPoint> localEndPoint, EndPoint remoteEndPoint, string correlationId)
         {
-            var identityProvider = new DeviceIdentityProvider(this.authenticator, this.clientCredentialsFactory, true);
+            var identityProvider = new DeviceIdentityProvider(this.authenticator, this.clientCredentialsFactory, this.clientCertAuthAllowed);
             return this.ProcessWebSocketRequestAsyncInternal(identityProvider, webSocket, localEndPoint, remoteEndPoint, correlationId);
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
@@ -128,10 +128,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             }
 
             public static void Established(string correlationId) =>
-                Log.LogInformation((int)Events.EventIds.Established, Invariant($"CorrelationId {correlationId}"));
+                Log.LogInformation((int)EventIds.Established, Invariant($"Processed MQTT WebSocket request with CorrelationId {correlationId}"));
 
             public static void Exception(string correlationId, Exception ex) =>
-                Log.LogWarning((int)Events.EventIds.Exception, ex, Invariant($"CorrelationId {correlationId}"));
+                Log.LogWarning((int)EventIds.Exception, ex, Invariant($"Error processing MQTT WebSocker request with CorrelationId {correlationId}"));
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MqttWebSocketListenerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MqttWebSocketListenerTest.cs
@@ -1,15 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
 {
+    using System.Threading.Tasks;
     using DotNetty.Buffers;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.ProtocolGateway;
-    using Microsoft.Azure.Devices.ProtocolGateway.Identity;
     using Microsoft.Azure.Devices.ProtocolGateway.Messaging;
     using Microsoft.Azure.Devices.ProtocolGateway.Mqtt.Persistence;
     using Moq;
-    using System.Threading.Tasks;
     using Xunit;
 
     [Unit]


### PR DESCRIPTION
Currently this flag is hardcoded to true. This PR fixes that to pass in the configured value