### PR TITLE
Fix bug in Docker codegen'd client that prevents listing networks from working

### DIFF
--- a/edgelet/docker-rs/src/models/ipam.rs
+++ b/edgelet/docker-rs/src/models/ipam.rs
@@ -21,7 +21,7 @@ pub struct Ipam {
     config: Option<Vec<::std::collections::HashMap<String, String>>>,
     /// Driver-specific options, specified as a map.
     #[serde(rename = "Options", skip_serializing_if = "Option::is_none")]
-    options: Option<Vec<::std::collections::HashMap<String, String>>>,
+    options: Option<::std::collections::HashMap<String, String>>,
 }
 
 impl Ipam {
@@ -67,20 +67,20 @@ impl Ipam {
         self.config = None;
     }
 
-    pub fn set_options(&mut self, options: Vec<::std::collections::HashMap<String, String>>) {
+    pub fn set_options(&mut self, options: ::std::collections::HashMap<String, String>) {
         self.options = Some(options);
     }
 
     pub fn with_options(
         mut self,
-        options: Vec<::std::collections::HashMap<String, String>>,
+        options: ::std::collections::HashMap<String, String>,
     ) -> Self {
         self.options = Some(options);
         self
     }
 
-    pub fn options(&self) -> Option<&[::std::collections::HashMap<String, String>]> {
-        self.options.as_ref().map(AsRef::as_ref)
+    pub fn options(&self) -> Option<&::std::collections::HashMap<String, String>> {
+        self.options.as_ref()
     }
 
     pub fn reset_options(&mut self) {


### PR DESCRIPTION
The result of `NetworkApi::network_list` returns a `Network`, which contains
an `Ipam`. The swagger spec defines `Ipam::options` to be an array of objects,
but in fact it is a single object.

Compare the actual struct at
https://github.com/docker/docker-ce/blob/18.06/components/engine/api/types/network/network.go#L12
with the swagger spec at
https://github.com/docker/docker-ce/blob/18.06/components/engine/api/swagger.yaml#L1476-L1478

This meant that the result of `NetworkApi::network_list` would fail to
deserialize. Since iotedged filters the networks to only contain the one
mentioned in config.yaml, and since the `options` value is usually `null`,
this has not been noticed until now. But if the user manually creates
the network, such as with

    docker network create azure-iot-edge --subnet 172.18.0.0/16 --gateway 172.18.0.1

then the `options` key becomes a non-null object, which triggers the bug.