### PR TITLE
Remove OpenCover

### DIFF
--- a/scripts/windows/setup/Install-Prerequisites.ps1
+++ b/scripts/windows/setup/Install-Prerequisites.ps1
@@ -45,7 +45,7 @@ if (-not $BuildRepositoryLocalPath) {
     $BuildRepositoryLocalPath = DefaultBuildRepositoryLocalPath
 }
 
-$All = -not $Dotnet -and -not $Python -and -not $Nuget -and -not $Coverage
+$All = -not $Dotnet -and -not $Python -and -not $Nuget
 
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/scripts/windows/setup/Install-Prerequisites.ps1
+++ b/scripts/windows/setup/Install-Prerequisites.ps1
@@ -25,8 +25,7 @@ param (
 
     [Switch]$Dotnet,
     [Switch]$Python,
-    [Switch]$Nuget,
-    [Switch]$Coverage
+    [Switch]$Nuget
 )
 
 Set-StrictMode -Version "Latest"
@@ -103,17 +102,6 @@ if ($Python -or $All) {
     $PythonMsi = Join-Path $PythonInstallPath "python.msi"
     (New-Object System.Net.WebClient).DownloadFile($PythonUrl, $PythonMsi)
     cmd /c start /wait msiexec /passive /package $PythonMsi 
-}
-
-<#
- # Install code coverage tools
- #>
-
-if ($Coverage -or $All) {
-    $NugetConfig = Join-Path $BuildRepositoryLocalPath "nuget.config"
-    &$NugetExe install OpenCover -version 4.6.519 -OutputDirectory $BuildRepositoryLocalPath -ConfigFile $NugetConfig
-    &$NugetExe install OpenCoverToCoberturaConverter -version 0.2.6 -OutputDirectory $BuildRepositoryLocalPath -ConfigFile $NugetConfig
-    &$NugetExe install ReportGenerator  -version 2.5.6 -OutputDirectory $BuildRepositoryLocalPath -ConfigFile $NugetConfig
 }
 
 Write-Host "Done!"

--- a/scripts/windows/test/Test-Branch.ps1
+++ b/scripts/windows/test/Test-Branch.ps1
@@ -44,19 +44,6 @@ $TEST_PROJ_PATTERN = "Microsoft.Azure*test.csproj"
 $LOGGER_ARG = "trx;LogFileName=result.trx"
 
 $DOTNET_PATH = [IO.Path]::Combine($AgentWorkFolder, "dotnet", "dotnet.exe")
-$OPENCOVER = [IO.Path]::Combine($BuildRepositoryLocalPath, "OpenCover.4.6.519", "tools", "OpenCover.Console.exe")
-$CODE_COVERAGE = Join-Path $BuildBinariesDirectory "code-coverage.xml"
-$OPENCOVER_COBERTURA_CONVERTER = [IO.Path]::Combine(
-    $BuildRepositoryLocalPath,
-    "OpenCoverToCoberturaConverter.0.2.6.0",
-    "tools",
-    "OpenCoverToCoberturaConverter.exe")
-$REPORT_GENERATOR = [IO.Path]::Combine(
-    $BuildRepositoryLocalPath,
-    "ReportGenerator.2.5.6",
-    "tools",
-    "ReportGenerator.exe"
-)
 
 if (-not (Test-Path $DOTNET_PATH -PathType Leaf)) {
     throw "$DOTNET_PATH not found."
@@ -77,38 +64,10 @@ Write-Host "Running tests in all test projects with filter '$Filter'."
 $Success = $True
 foreach ($Project in (Get-ChildItem $BuildRepositoryLocalPath -Include $TEST_PROJ_PATTERN -Recurse)) {
     Write-Host "Running tests for $Project."
-    if (Test-Path $OPENCOVER -PathType "Leaf") {
-		Write-Host "Run command: $OPENCOVER -register:user -target:$DOTNET_PATH -targetargs:'$BaseTestCommand $Project' -skipautoprops -hideskipped:All -oldstyle -output:$CODE_COVERAGE -mergeoutput:$CODE_COVERAGE -returntargetcode ..."
-        &$OPENCOVER `
-            -register:user `
-            -target:$DOTNET_PATH `
-            -targetargs:"$BaseTestCommand $Project" `
-            -skipautoprops `
-            -hideskipped:All `
-            -oldstyle `
-            -output:$CODE_COVERAGE `
-            -mergeoutput:$CODE_COVERAGE `
-            -returntargetcode `
-			-filter:"+[*]* -[Moq*]* -[App.Metrics.Reporting*]*"
-    }
-    else {
-		Write-Host "Run command: '" + $DOTNET_PATH + "' " + $BaseTestCommand " -o " + $BuildBinariesDirectory + " " + $Project
-        Invoke-Expression "&`"$DOTNET_PATH`" $BaseTestCommand -o $BuildBinariesDirectory $Project"
-    }
+	Write-Host "Run command: '" + $DOTNET_PATH + "' " + $BaseTestCommand " -o " + $BuildBinariesDirectory + " " + $Project
+    Invoke-Expression "&`"$DOTNET_PATH`" $BaseTestCommand -o $BuildBinariesDirectory $Project"
 
     $Success = $Success -and $LASTEXITCODE -eq 0
-}
-
-<#
- # Process results
- #>
-
-if (Test-Path $OPENCOVER_COBERTURA_CONVERTER -PathType "Leaf") {
-    &$OPENCOVER_COBERTURA_CONVERTER -sources:. -input:$CODE_COVERAGE -output:(Join-Path $BuildBinariesDirectory "CoberturaCoverage.xml")
-}
-
-if (Test-Path $REPORT_GENERATOR -PathType "Leaf") {
-    &$REPORT_GENERATOR -reporttypes:MHtml -reports:$CODE_COVERAGE -targetdir:(Join-Path $BuildBinariesDirectory "report")
 }
 
 if (-not $Success) {


### PR DESCRIPTION
OpenCover randomly cause CI to fail; since no coverage data is published, there is no benefit to run OpenCover during CI build.  Remove it now and it should be replaced by VS Code coverage feature later.

Passed CI build for this PR
https://msazure.visualstudio.com/One/_build/results?buildId=19043223&_a=summary