### PR TITLE
hsm ctest conditional compilation applied to full file

### DIFF
--- a/edgelet/Cross.toml
+++ b/edgelet/Cross.toml
@@ -2,6 +2,7 @@
 passthrough = [
     "BUILD_SOURCEVERSION",
     "VERSION",
+    "IOTEDGE_HOMEDIR",
 ]
 
 [target.armv7-unknown-linux-gnueabihf]

--- a/edgelet/build/linux/cross-test.sh
+++ b/edgelet/build/linux/cross-test.sh
@@ -60,7 +60,7 @@ process_args()
 process_args "$@"
 
 if [[ -z ${RELEASE} ]]; then
-    cd "$PROJECT_ROOT" && cross test --all --target "$TOOLCHAIN"
+    cd "$PROJECT_ROOT" && IOTEDGE_HOMEDIR=/tmp cross test --all --target "$TOOLCHAIN"
 else
-    cd "$PROJECT_ROOT" && cross test --all --release --target "$TOOLCHAIN"
+    cd "$PROJECT_ROOT" && IOTEDGE_HOMEDIR=/tmp cross test --all --release --target "$TOOLCHAIN"
 fi

--- a/edgelet/hsm-sys/tests/hsm_ctest.rs
+++ b/edgelet/hsm-sys/tests/hsm_ctest.rs
@@ -1,11 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(unused_extern_crates, warnings)]
+#![deny(warnings)]
 // Remove this when clippy stops warning about old-style `allow()`,
 // which can only be silenced by enabling a feature and thus requires nightly
 //
 // Ref: https://github.com/rust-lang-nursery/rust-clippy/issues/3159#issuecomment-420530386
-#![allow(renamed_and_removed_lints)]
+// Allow unused imports and unused external crates because ctest application is not invoked on arm targets
+#![allow(renamed_and_removed_lints, unused_imports, unused_extern_crates)]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
 
 extern crate num_cpus;

--- a/edgelet/hsm-sys/tests/hsm_ctest.rs
+++ b/edgelet/hsm-sys/tests/hsm_ctest.rs
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-#![deny(warnings)]
+#![deny(unused_extern_crates, warnings)]
 // Remove this when clippy stops warning about old-style `allow()`,
 // which can only be silenced by enabling a feature and thus requires nightly
 //
 // Ref: https://github.com/rust-lang-nursery/rust-clippy/issues/3159#issuecomment-420530386
-// Allow unused imports and unused external crates because ctest application is not invoked on arm targets
-#![allow(renamed_and_removed_lints, unused_imports, unused_extern_crates)]
+#![allow(renamed_and_removed_lints)]
 #![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
+//Skip ARM(cross-compile) until I figure out how to run ctest on this.
+#![cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 
 extern crate num_cpus;
 
@@ -15,8 +16,6 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 
-//Skip ARM(cross-compile) until I figure out how to run ctest on this.
-#[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]
 #[test]
 fn run_ctest() {
     // Run iot-hsm-c tests


### PR DESCRIPTION
- Move conditional compilation to include imports because ctest application is not invoked on arm targets and imports were unused
- Pass IOTEDGE_HOMEDIR to cross tests