### PR TITLE
EdgeAgent: Fix should restart logic when clock is off

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/RestartPolicyManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/RestartPolicyManager.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
     using Microsoft.Extensions.Logging;
 
     public class RestartPolicyManager : IRestartPolicyManager
-    {        
+    {
         const int MaxCoolOffPeriodSecs = 300; // 5 mins
         readonly int maxRestartCount;
         readonly int coolOffTimeUnitInSeconds;
@@ -70,8 +70,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                 TimeSpan coolOffPeriod = this.GetCoolOffPeriod(module.RestartCount);
                 TimeSpan elapsedTime = DateTime.UtcNow - module.LastExitTimeUtc;
 
-                bool shouldRestart = elapsedTime > coolOffPeriod;
-                if(!shouldRestart)
+                bool shouldRestart = elapsedTime > TimeSpan.Zero ? elapsedTime > coolOffPeriod : true;
+                if (!shouldRestart)
                 {
                     Events.ScheduledModule(module, elapsedTime, coolOffPeriod);
                 }
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         }
 
         internal TimeSpan GetCoolOffPeriod(int restartCount) =>
-            TimeSpan.FromSeconds(Math.Min(this.coolOffTimeUnitInSeconds * Math.Pow(2, restartCount), MaxCoolOffPeriodSecs));        
+            TimeSpan.FromSeconds(Math.Min(this.coolOffTimeUnitInSeconds * Math.Pow(2, restartCount), MaxCoolOffPeriodSecs));
 
         public IEnumerable<IRuntimeModule> ApplyRestartPolicy(IEnumerable<IRuntimeModule> modules) =>
             modules.Where(module => this.ShouldRestart(module));
@@ -102,7 +102,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         public static void ScheduledModule(IRuntimeModule module, TimeSpan elapsedTime, TimeSpan coolOffPeriod)
         {
             TimeSpan timeLeft = coolOffPeriod - elapsedTime;
-            Log.LogInformation((int)EventIds.ScheduledModule,
+            Log.LogInformation(
+                (int)EventIds.ScheduledModule,
                 $"Module '{module.Name}' scheduled to restart after {coolOffPeriod.Humanize()} ({timeLeft.Humanize()} left).");
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/RestartPolicyManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/RestartPolicyManager.cs
@@ -70,6 +70,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                 TimeSpan coolOffPeriod = this.GetCoolOffPeriod(module.RestartCount);
                 TimeSpan elapsedTime = DateTime.UtcNow - module.LastExitTimeUtc;
 
+                // LastExitTime can be greater thatn UtcNow if the clock is off, so check if the elapsed time is > 0
                 bool shouldRestart = elapsedTime > TimeSpan.Zero ? elapsedTime > coolOffPeriod : true;
                 if (!shouldRestart)
                 {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/RestartPolicyManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/RestartPolicyManagerTest.cs
@@ -657,6 +657,25 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             Assert.True(apply ? count == 1 : count == 0);
         }
 
+        [Unit]
+        [Fact]
+        public void TestApplyRestartPolicyWithWrongUtcTime()
+        {
+            // Arrange
+            var restartPolicy = RestartPolicy.Always;
+            var runtimeStatus = ModuleStatus.Backoff;
+            int restartCount = 5;
+            DateTime lastExitTime = DateTime.UtcNow.Add(TimeSpan.FromHours(1));
+            var manager = new RestartPolicyManager(MaxRestartCount, CoolOffTimeUnitInSeconds);
+            Mock<IRuntimeModule> module = CreateMockRuntimeModule(restartPolicy, runtimeStatus, restartCount, lastExitTime);
+
+            // Act
+            IEnumerable<IRuntimeModule> result = manager.ApplyRestartPolicy(new[] { module.Object });
+
+            // Assert
+            Assert.Equal(1, result.Count());
+        }
+
         [Fact]
         [Unit]
         public void TestApplyRestartPolicyWithUnknownRuntimeStatus()


### PR DESCRIPTION
Sometimes the EA clock is off, which results in incorrect time computations. This affects the module restart logic in EdgeAgent, causing some modules to not restart when failed for a long time. 
This PR fixes that so that if the clock is off, then the module is restarted right away.