### PR TITLE
Update C shared utils and UTPM submodules

### DIFF
--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ut/certificate_info_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ut/certificate_info_ut.c
@@ -376,8 +376,8 @@ BEGIN_TEST_SUITE(certificate_info_ut)
         //assert
         ASSERT_IS_NOT_NULL(cert_handle);
         ASSERT_IS_NULL(pk);
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pk_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(int, PRIVATE_KEY_UNKNOWN, pk_type, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_UNKNOWN, pk_type, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(cert_handle);
@@ -395,10 +395,10 @@ BEGIN_TEST_SUITE(certificate_info_ut)
 
         //assert
         ASSERT_IS_NOT_NULL(cert_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, TEST_PRIVATE_KEY_LEN, pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_PRIVATE_KEY_LEN, pk_size, "Line:" TOSTRING(__LINE__));
         int cmp = memcmp(pk, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LEN);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(int, PRIVATE_KEY_PAYLOAD, pk_type, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_PAYLOAD, pk_type, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(cert_handle);
@@ -416,10 +416,10 @@ BEGIN_TEST_SUITE(certificate_info_ut)
 
         //assert
         ASSERT_IS_NOT_NULL(cert_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, TEST_PRIVATE_KEY_LEN, pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_PRIVATE_KEY_LEN, pk_size, "Line:" TOSTRING(__LINE__));
         int cmp = memcmp(pk, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LEN);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(int, PRIVATE_KEY_REFERENCE, pk_type, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_REFERENCE, pk_type, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(cert_handle);
@@ -563,7 +563,7 @@ BEGIN_TEST_SUITE(certificate_info_ut)
             CERT_INFO_HANDLE cert_handle = certificate_info_create(TEST_RSA_CERT_WIN_EOL, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LEN, PRIVATE_KEY_PAYLOAD);
 
             //assert
-            ASSERT_IS_NULL_WITH_MSG(cert_handle, tmp_msg);
+            ASSERT_IS_NULL(cert_handle, tmp_msg);
         }
 
         //cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_int/edge_hsm_crypto_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_int/edge_hsm_crypto_int.c
@@ -96,7 +96,7 @@ static CERT_PROPS_HANDLE test_helper_create_certificate_props
 )
 {
     CERT_PROPS_HANDLE cert_props_handle = cert_properties_create();
-    ASSERT_IS_NOT_NULL_WITH_MSG(cert_props_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" TOSTRING(__LINE__));
     set_validity_seconds(cert_props_handle, validity);
     set_common_name(cert_props_handle, common_name);
     set_country_name(cert_props_handle, "US");
@@ -128,7 +128,7 @@ static void test_helper_generate_pki_certificate
                                            cert_file,
                                            issuer_private_key_file,
                                            issuer_cert_file);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 }
 
 static void test_helper_generate_self_signed
@@ -147,7 +147,7 @@ static void test_helper_generate_self_signed
                                                       private_key_file,
                                                       cert_file,
                                                       key_props);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 }
 
 static void test_helper_prepare_transparent_gateway_certs(void)
@@ -228,9 +228,9 @@ static void test_helper_prepare_transparent_gateway_certs(void)
     const char *trusted_files[1] = { NULL };
     trusted_files[0] = int_ca_2_path;
     char* trusted_ca_certs = concat_files_to_cstring(trusted_files, sizeof(trusted_files)/sizeof(trusted_files[0]));
-    ASSERT_IS_NOT_NULL_WITH_MSG(trusted_ca_certs, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(trusted_ca_certs, "Line:" TOSTRING(__LINE__));
     status = write_cstring_to_file(trusted_ca_path, trusted_ca_certs);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     // cleanup
     free(trusted_ca_certs);
@@ -245,53 +245,53 @@ static void test_helper_setup_homedir(void)
     int status;
 
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
     printf("IoT Edge home dir set to %s\n", TEST_IOTEDGE_HOMEDIR);
 
     STRING_HANDLE BASE_TG_CERTS_PATH = STRING_construct(TEST_IOTEDGE_HOMEDIR);
-    ASSERT_IS_NOT_NULL_WITH_MSG(BASE_TG_CERTS_PATH, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(BASE_TG_CERTS_PATH, "Line:" TOSTRING(__LINE__));
     status = STRING_concat(BASE_TG_CERTS_PATH, SLASH);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     VALID_DEVICE_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(VALID_DEVICE_CA_PATH, "device_ca_cert.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     VALID_DEVICE_PK_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(VALID_DEVICE_PK_PATH, "device_pk_cert.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     VALID_TRUSTED_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(VALID_TRUSTED_CA_PATH, "trusted_ca_certs.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     ROOT_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(ROOT_CA_PATH, "root_ca_cert.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     ROOT_PK_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(ROOT_PK_PATH, "root_ca_pk.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     INT_1_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(INT_1_CA_PATH, "int_1_ca_cert.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     INT_1_PK_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(INT_1_PK_PATH, "int_1_ca_pk.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     INT_2_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(INT_2_CA_PATH, "int_2_ca_cert.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     INT_2_PK_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(INT_2_PK_PATH, "int_2_ca_pk.pem");
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     test_helper_prepare_transparent_gateway_certs();
 
@@ -351,10 +351,10 @@ static HSM_CLIENT_HANDLE test_helper_crypto_init(void)
 {
     int status;
     status = hsm_client_crypto_init();
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
     HSM_CLIENT_HANDLE result = interface->hsm_client_crypto_create();
-    ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     return result;
 }
 
@@ -368,7 +368,7 @@ static void test_helper_crypto_deinit(HSM_CLIENT_HANDLE hsm_handle)
 static CERT_PROPS_HANDLE test_helper_create_ca_cert_properties(void)
 {
     CERT_PROPS_HANDLE certificate_props = cert_properties_create();
-    ASSERT_IS_NOT_NULL_WITH_MSG(certificate_props, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(certificate_props, "Line:" TOSTRING(__LINE__));
     set_common_name(certificate_props, TEST_CA_COMMON_NAME);
     set_validity_seconds(certificate_props, 3600);
     set_alias(certificate_props, TEST_CA_ALIAS);
@@ -380,7 +380,7 @@ static CERT_PROPS_HANDLE test_helper_create_ca_cert_properties(void)
 static CERT_PROPS_HANDLE test_helper_create_server_cert_properties(void)
 {
     CERT_PROPS_HANDLE certificate_props = cert_properties_create();
-    ASSERT_IS_NOT_NULL_WITH_MSG(certificate_props, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(certificate_props, "Line:" TOSTRING(__LINE__));
     set_common_name(certificate_props, TEST_SERVER_COMMON_NAME);
     set_validity_seconds(certificate_props, 3600);
     set_alias(certificate_props, TEST_SERVER_ALIAS);
@@ -392,7 +392,7 @@ static CERT_PROPS_HANDLE test_helper_create_server_cert_properties(void)
 static CERT_PROPS_HANDLE test_helper_create_client_cert_properties(void)
 {
     CERT_PROPS_HANDLE certificate_props = cert_properties_create();
-    ASSERT_IS_NOT_NULL_WITH_MSG(certificate_props, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(certificate_props, "Line:" TOSTRING(__LINE__));
     set_common_name(certificate_props, TEST_CLIENT_COMMON_NAME);
     set_validity_seconds(certificate_props, 3600);
     set_alias(certificate_props, TEST_CLIENT_ALIAS);
@@ -461,8 +461,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         int result = interface->hsm_client_get_random_bytes(hsm_handle, output_buffer, sizeof(output_buffer));
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, memcmp(unexpected_buffer, output_buffer, sizeof(unexpected_buffer)), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, sizeof(unexpected_buffer)), "Line:" TOSTRING(__LINE__));
 
         //cleanup
         test_helper_crypto_deinit(hsm_handle);
@@ -479,7 +479,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
@@ -496,23 +496,23 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_server_cert_properties();
 
         // act
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
         const char *certificate = certificate_info_get_certificate(result);
         const char *chain_certificate = certificate_info_get_chain(result);
         const void* private_key = certificate_info_get_private_key(result, &pk_size);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(chain_certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(private_key, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(private_key, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
@@ -537,7 +537,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
@@ -555,7 +555,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         set_validity_seconds(ca_certificate_props, 3600);
         CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_server_cert_properties();
         set_validity_seconds(certificate_props, 3600 * 2);
 
@@ -563,19 +563,19 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
         const char *certificate = certificate_info_get_certificate(result);
         const char *chain_certificate = certificate_info_get_chain(result);
         const void* private_key = certificate_info_get_private_key(result, &pk_size);
         int64_t expiration_time = certificate_info_get_valid_to(result);
         int64_t issuer_expiration_time = certificate_info_get_valid_to(ca_cert_info);
-        ASSERT_IS_TRUE_WITH_MSG((expiration_time <= issuer_expiration_time), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((expiration_time <= issuer_expiration_time), "Line:" TOSTRING(__LINE__));
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(chain_certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(private_key, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(private_key, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
@@ -596,7 +596,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         set_validity_seconds(ca_certificate_props, 3600 * 2);
         CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_server_cert_properties();
         set_validity_seconds(certificate_props, 3600);
 
@@ -604,19 +604,19 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
         const char *certificate = certificate_info_get_certificate(result);
         const char *chain_certificate = certificate_info_get_chain(result);
         const void* private_key = certificate_info_get_private_key(result, &pk_size);
         int64_t expiration_time = certificate_info_get_valid_to(result);
         int64_t issuer_expiration_time = certificate_info_get_valid_to(ca_cert_info);
-        ASSERT_IS_TRUE_WITH_MSG((expiration_time < issuer_expiration_time), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((expiration_time < issuer_expiration_time), "Line:" TOSTRING(__LINE__));
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(chain_certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(private_key, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(private_key, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
@@ -635,31 +635,31 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_client_cert_properties();
 
         // act, assert multiple calls to create certificate only creates if not created
         CERT_INFO_HANDLE result_first, result_second;
         result_first = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(result_first, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result_first, "Line:" TOSTRING(__LINE__));
         result_second = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(result_second, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result_second, "Line:" TOSTRING(__LINE__));
         const char *first_certificate = certificate_info_get_certificate(result_first);
         const char *second_certificate = certificate_info_get_certificate(result_second);
         size_t first_len = strlen(first_certificate);
         size_t second_len = strlen(second_certificate);
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, first_len, second_len, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, first_len, second_len, "Line:" TOSTRING(__LINE__));
         int cmp_result = memcmp(first_certificate, second_certificate, first_len);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
 
         // destroy the certificate in the HSM and create a new one and test if different from prior call
         certificate_info_destroy(result_second);
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
         result_second = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(result_second, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result_second, "Line:" TOSTRING(__LINE__));
         second_certificate = certificate_info_get_certificate(result_second);
         cmp_result = memcmp(first_certificate, second_certificate, first_len);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
@@ -694,14 +694,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_client_cert_properties();
 
         // act
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
@@ -722,14 +722,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
 
         // act
         CERT_INFO_HANDLE result = interface->hsm_client_get_trust_bundle(hsm_handle);
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
 
         // assert
         const char *certificate = certificate_info_get_certificate(result);
         const void *private_key = certificate_info_get_private_key(result, &pk_size);
-        ASSERT_IS_NOT_NULL_WITH_MSG(certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(private_key, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(private_key, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pk_size, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         certificate_info_destroy(result);
@@ -745,13 +745,13 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
 
         // act, assert
         status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         test_helper_crypto_deinit(hsm_handle);
@@ -771,24 +771,24 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
 
         // act, assert
         status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = interface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(ciphertext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(size_t, 0, ciphertext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ciphertext_result.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(size_t, 0, ciphertext_result.size, "Line:" TOSTRING(__LINE__));
         status = memcmp(TEST_PLAINTEXT, ciphertext_result.buffer, TEST_PLAINTEXT_SIZE);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = interface->hsm_client_decrypt_data(hsm_handle, &id, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, TEST_PLAINTEXT_SIZE, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_PLAINTEXT_SIZE, plaintext_result.size, "Line:" TOSTRING(__LINE__));
         status = memcmp(TEST_PLAINTEXT, plaintext_result.buffer, TEST_PLAINTEXT_SIZE);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(plaintext_result.buffer);
@@ -809,22 +809,22 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         SIZED_BUFFER ciphertext_result_2 = { NULL, 0 };
 
         status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = interface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result_1);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // act, assert
         status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = interface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result_2);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, ciphertext_result_1.size, ciphertext_result_2.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ciphertext_result_1.size, ciphertext_result_2.size, "Line:" TOSTRING(__LINE__));
         status = memcmp(ciphertext_result_1.buffer, ciphertext_result_2.buffer, ciphertext_result_1.size);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result_1.buffer);
@@ -839,15 +839,15 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
         const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
         status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // act
         status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         test_helper_crypto_deinit(hsm_handle);
     }
@@ -866,13 +866,13 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
 
         // act, assert
         CERT_INFO_HANDLE result = interface->hsm_client_get_trust_bundle(hsm_handle);
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
         const char *certificate = certificate_info_get_certificate(result);
-        ASSERT_IS_NOT_NULL_WITH_MSG(certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
         char *expected_trust_bundle = read_file_into_cstring(trusted_ca_path, NULL);
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, strlen(certificate), strlen(expected_trust_bundle), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, strlen(certificate), strlen(expected_trust_bundle), "Line:" TOSTRING(__LINE__));
         int cmp = memcmp(certificate, expected_trust_bundle, strlen(certificate));
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(expected_trust_bundle);
@@ -898,13 +898,13 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
 
         // act, assert
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
         const char *chain_certificate = certificate_info_get_chain(result);
-        ASSERT_IS_NOT_NULL_WITH_MSG(chain_certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
         char *expected_chain_certificate = read_file_into_cstring(device_ca_path, NULL);
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, strlen(expected_chain_certificate), strlen(chain_certificate), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, strlen(expected_chain_certificate), strlen(chain_certificate), "Line:" TOSTRING(__LINE__));
         int cmp = memcmp(expected_chain_certificate, chain_certificate, strlen(chain_certificate));
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(expected_chain_certificate);
@@ -925,14 +925,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         set_validity_seconds(ca_certificate_props, 1);
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
 
         // act
         ThreadAPI_Sleep(2000);
         CERT_INFO_HANDLE temp_info_handle = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
 
         // assert
-        ASSERT_IS_NULL_WITH_MSG(temp_info_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(temp_info_handle, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
@@ -957,13 +957,13 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
 
         // act, assert
         CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
         const char *chain_certificate = certificate_info_get_chain(result);
-        ASSERT_IS_NOT_NULL_WITH_MSG(chain_certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
         char *expected_chain_certificate = read_file_into_cstring(device_ca_path, NULL);
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, strlen(expected_chain_certificate), strlen(chain_certificate), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, strlen(expected_chain_certificate), strlen(chain_certificate), "Line:" TOSTRING(__LINE__));
         int cmp = memcmp(expected_chain_certificate, chain_certificate, strlen(chain_certificate));
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(expected_chain_certificate);
@@ -993,43 +993,43 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         hsm_test_util_unsetenv(ENV_DEVICE_PK_PATH);
         hsm_test_util_unsetenv(ENV_TRUSTED_CA_CERTS_PATH);
         status = hsm_client_crypto_init();
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         hsm_test_util_unsetenv(ENV_DEVICE_CA_PATH);
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_unsetenv(ENV_TRUSTED_CA_CERTS_PATH);
         status = hsm_client_crypto_init();
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         hsm_test_util_setenv(ENV_DEVICE_CA_PATH, device_ca_path);
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_unsetenv(ENV_TRUSTED_CA_CERTS_PATH);
         status = hsm_client_crypto_init();
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         hsm_test_util_unsetenv(ENV_DEVICE_CA_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_PK_PATH);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         status = hsm_client_crypto_init();
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         hsm_test_util_setenv(ENV_DEVICE_CA_PATH, device_ca_path);
         hsm_test_util_unsetenv(ENV_DEVICE_PK_PATH);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         status = hsm_client_crypto_init();
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         hsm_test_util_unsetenv(ENV_DEVICE_CA_PATH);
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         status = hsm_client_crypto_init();
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         hsm_test_util_setenv(ENV_DEVICE_CA_PATH, INVALID_PATH);
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, INVALID_PATH);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, INVALID_PATH);
         status = hsm_client_crypto_init();
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         hsm_test_util_unsetenv(ENV_DEVICE_CA_PATH);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_ut/edge_hsm_crypto_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_ut/edge_hsm_crypto_ut.c
@@ -537,8 +537,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_crypto_init();
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -570,7 +570,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 status = hsm_client_crypto_init();
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -592,8 +592,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_crypto_init();
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -614,7 +614,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_crypto_deinit();
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
         }
@@ -640,8 +640,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_crypto_init();
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -659,19 +659,19 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             const HSM_CLIENT_CRYPTO_INTERFACE* result = hsm_client_crypto_interface();
 
             // assert
-            ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_crypto_create, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_crypto_destroy, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_get_random_bytes, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_create_master_encryption_key, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_destroy_master_encryption_key, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_create_certificate, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_destroy_certificate, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_encrypt_data, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_decrypt_data, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_get_trust_bundle, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_free_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_crypto_create, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_crypto_destroy, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_get_random_bytes, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_create_master_encryption_key, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_destroy_master_encryption_key, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_create_certificate, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_destroy_certificate, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_encrypt_data, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_decrypt_data, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_get_trust_bundle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_free_buffer, "Line:" TOSTRING(__LINE__));
 
             //cleanup
         }
@@ -692,8 +692,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
 
             // assert
-            ASSERT_IS_NULL_WITH_MSG(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -705,7 +705,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -718,8 +718,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
 
             // assert
-            ASSERT_IS_NOT_NULL_WITH_MSG(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -738,7 +738,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
 
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -758,7 +758,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
 
                 // assert
-                ASSERT_IS_NULL_WITH_MSG(hsm_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -782,7 +782,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_crypto_destroy(NULL);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -801,7 +801,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_crypto_destroy(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -813,7 +813,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -827,8 +827,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_crypto_destroy(hsm_handle);
 
             // assert
-            ASSERT_IS_NOT_NULL_WITH_MSG(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -853,11 +853,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_get_random_bytes(TEST_HSM_CLIENT_HANDLE, test_output, sizeof(test_output));
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
             for (int idx = 0; idx < (int)sizeof(test_output); idx++)
             {
-                ASSERT_ARE_EQUAL_WITH_MSG(char, test_input[idx], test_output[idx], "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(char, test_input[idx], test_output[idx], "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -869,7 +869,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -880,17 +880,17 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
 
             // act, assert
             status = hsm_client_get_random_bytes(NULL, test_output, sizeof(test_output));
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             for (int idx = 0; idx < (int)sizeof(test_output); idx++)
             {
-                ASSERT_ARE_EQUAL_WITH_MSG(char, test_input[idx], test_output[idx], "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(char, test_input[idx], test_output[idx], "Line:" TOSTRING(__LINE__));
             }
 
             status = hsm_client_get_random_bytes(hsm_handle, NULL, sizeof(test_output));
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             status = hsm_client_get_random_bytes(hsm_handle, test_output, 0);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -906,7 +906,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -919,8 +919,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = interface->hsm_client_get_random_bytes(hsm_handle, test_output, sizeof(test_output));
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             // if this test fails it implies that the call to hsm_client_get_random_bytes
             // never updated the buffer and yet returned a success OR
@@ -928,7 +928,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             // exactly what the test_input was setup with
             // P(test failure) = P('r') * P('a') * P('n') * P('d') = ((1/256) ^ 4) == very small
             int cmp = memcmp(test_input, test_output, sizeof(test_input));
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -953,8 +953,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_create_master_encryption_key(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -965,14 +965,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE_MASTER_ENCRYPTION_KEY hsm_client_create_master_encryption_key;
             hsm_client_create_master_encryption_key = interface->hsm_client_create_master_encryption_key;
 
             // act, assert
             status = hsm_client_create_master_encryption_key(NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -986,7 +986,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -996,7 +996,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
 
             // act, assert
             status = hsm_client_create_master_encryption_key(hsm_handle);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1022,8 +1022,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_destroy_master_encryption_key(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -1034,14 +1034,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_DESTROY_MASTER_ENCRYPTION_KEY hsm_client_destroy_master_encryption_key;
             hsm_client_destroy_master_encryption_key = interface->hsm_client_destroy_master_encryption_key;
 
             // act, assert
             status = hsm_client_destroy_master_encryption_key(NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1055,7 +1055,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -1065,7 +1065,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
 
             // act, assert
             status = hsm_client_destroy_master_encryption_key(hsm_handle);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1089,8 +1089,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_create_certificate(TEST_HSM_CLIENT_HANDLE, TEST_CERT_PROPS_HANDLE);
 
             // assert
-            ASSERT_IS_NULL_WITH_MSG(cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -1101,7 +1101,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = interface->hsm_client_create_certificate;
             CERT_INFO_HANDLE cert_info_handle;
@@ -1109,11 +1109,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
 
             // act, assert
             cert_info_handle = hsm_client_create_certificate(NULL, TEST_CERT_PROPS_HANDLE);
-            ASSERT_IS_NULL_WITH_MSG(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
 
             // act, assert
             cert_info_handle = hsm_client_create_certificate(TEST_HSM_CLIENT_HANDLE, NULL);
-            ASSERT_IS_NULL_WITH_MSG(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1128,7 +1128,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -1146,8 +1146,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_create_certificate(hsm_handle, TEST_CERT_PROPS_HANDLE);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(void_ptr, TEST_CERT_INFO_HANDLE, cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(void_ptr, TEST_CERT_INFO_HANDLE, cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1165,7 +1165,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -1190,7 +1190,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 cert_info_handle = hsm_client_create_certificate(hsm_handle, TEST_CERT_PROPS_HANDLE);
 
                 // assert
-                ASSERT_IS_NULL_WITH_MSG(cert_info_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1216,8 +1216,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_get_trust_bundle(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_IS_NULL_WITH_MSG(cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -1228,7 +1228,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = interface->hsm_client_get_trust_bundle;
             CERT_INFO_HANDLE cert_info_handle;
@@ -1236,7 +1236,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
 
             // act, assert
             cert_info_handle = hsm_client_get_trust_bundle(NULL);
-            ASSERT_IS_NULL_WITH_MSG(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1251,7 +1251,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -1266,8 +1266,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_get_trust_bundle(hsm_handle);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(void_ptr, TEST_TRUST_BUNDLE_CERT_INFO_HANDLE, cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(void_ptr, TEST_TRUST_BUNDLE_CERT_INFO_HANDLE, cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1285,7 +1285,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -1307,7 +1307,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 cert_info_handle = hsm_client_get_trust_bundle(hsm_handle);
 
                 // assert
-                ASSERT_IS_NULL_WITH_MSG(cert_info_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1332,7 +1332,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_destroy_certificate(TEST_HSM_CLIENT_HANDLE, TEST_ALIAS_STRING);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -1343,14 +1343,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = interface->hsm_client_destroy_certificate;
             umock_c_reset_all_calls();
 
             // act, assert
             hsm_client_destroy_certificate(TEST_HSM_CLIENT_HANDLE, NULL);
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1364,14 +1364,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = interface->hsm_client_destroy_certificate;
             umock_c_reset_all_calls();
 
             // act, assert
             hsm_client_destroy_certificate(NULL, TEST_ALIAS_STRING);
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1386,7 +1386,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -1400,7 +1400,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_destroy_certificate(hsm_handle, TEST_ALIAS_STRING);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1418,7 +1418,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
             HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
@@ -1439,7 +1439,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 hsm_client_destroy_certificate(hsm_handle, TEST_ALIAS_STRING);
 
                 // assert
-                ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_key_intf_sas_ut/edge_hsm_key_intf_sas_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_key_intf_sas_ut/edge_hsm_key_intf_sas_ut.c
@@ -94,7 +94,7 @@ static unsigned char* test_hook_BUFFER_u_char(BUFFER_HANDLE handle)
     {
         result = TEST_DERIVED_DIGEST_DATA;
     }
-    ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     return result;
 }
 
@@ -109,7 +109,7 @@ static size_t test_hook_BUFFER_length(BUFFER_HANDLE handle)
     {
         result = sizeof(TEST_DERIVED_DIGEST_DATA);
     }
-    ASSERT_ARE_NOT_EQUAL_WITH_MSG(size_t, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_NOT_EQUAL(size_t, 0, result, "Line:" TOSTRING(__LINE__));
     return result;
 }
 
@@ -137,13 +137,13 @@ static HMACSHA256_RESULT test_hook_HMACSHA256_ComputeHash
 static KEY_HANDLE test_helper_create_key(const unsigned char* key, size_t key_len)
 {
     KEY_HANDLE key_handle = create_sas_key(key, key_len);
-    ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
     return key_handle;
 }
 
 static void test_helper_destroy_key(KEY_HANDLE key_handle)
 {
-    ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
     const HSM_CLIENT_KEY_INTERFACE* key_if = hsm_client_key_interface();
     key_if->hsm_client_key_destroy(key_handle);
 }
@@ -220,12 +220,12 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             const HSM_CLIENT_KEY_INTERFACE* key_if = hsm_client_key_interface();
 
             // assert
-            ASSERT_IS_NOT_NULL_WITH_MSG(key_if, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(key_if->hsm_client_key_sign, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(key_if->hsm_client_key_derive_and_sign, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(key_if->hsm_client_key_encrypt, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(key_if->hsm_client_key_decrypt, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(key_if->hsm_client_key_destroy, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_sign, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_derive_and_sign, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_encrypt, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_decrypt, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_destroy, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -240,8 +240,8 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             KEY_HANDLE key_handle = create_sas_key(TEST_KEY_DATA, sizeof(TEST_KEY_DATA));
 
             // assert
-            ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             // cleanup
             test_helper_destroy_key(key_handle);
@@ -266,7 +266,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
                 KEY_HANDLE key_handle = create_sas_key(TEST_KEY_DATA, sizeof(TEST_KEY_DATA));
 
                 // assert
-                ASSERT_IS_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -280,9 +280,9 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
 
             // act, assert
             key_handle = create_sas_key(TEST_KEY_DATA, 0);
-            ASSERT_IS_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
             key_handle = create_sas_key(NULL, sizeof(TEST_KEY_DATA));
-            ASSERT_IS_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -297,7 +297,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             key_if->hsm_client_key_destroy(key_handle);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -316,7 +316,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             key_if->hsm_client_key_destroy(key_handle);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -334,35 +334,35 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
 
             // act, assert
             status = key_if->hsm_client_key_sign(NULL, data_to_be_signed, data_len, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_sign(key_handle, NULL, data_len, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, 0, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, data_len, NULL, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, data_len, &digest, NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             test_helper_destroy_key(key_handle);
@@ -392,11 +392,11 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, data_len, &digest, &digest_size);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, sizeof(TEST_DIGEST_DATA), digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, sizeof(TEST_DIGEST_DATA), digest_size, "Line:" TOSTRING(__LINE__));
             status = memcmp(TEST_DIGEST_DATA, digest, sizeof(TEST_DIGEST_DATA));
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             test_hook_gballoc_free(digest);
@@ -437,7 +437,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
                 status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, data_len, &digest, &digest_size);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -460,49 +460,49 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
 
             // act, assert
             status = key_if->hsm_client_key_derive_and_sign(NULL, data_to_be_signed, data_len, identity, identity_size, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, NULL, data_len, identity, identity_size, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, 0, identity, identity_size, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, NULL, identity_size, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, 0, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, identity_size, NULL, &digest_size);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, identity_size, &digest, NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             test_helper_destroy_key(key_handle);
@@ -542,12 +542,12 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, identity_size, &digest, &digest_size);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             status = memcmp(TEST_DERIVED_DIGEST_DATA, digest, sizeof(TEST_DERIVED_DIGEST_DATA));
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, sizeof(TEST_DERIVED_DIGEST_DATA), digest_size, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, sizeof(TEST_DERIVED_DIGEST_DATA), digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
             // cleanup
             test_hook_gballoc_free(digest);
             test_helper_destroy_key(key_handle);
@@ -611,7 +611,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
                     status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, identity_size, &digest, &digest_size);
 
                     // assert
-                    ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                    ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
                 }
             }
 

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_sas_auth_int/edge_hsm_sas_auth_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_sas_auth_int/edge_hsm_sas_auth_int.c
@@ -45,8 +45,8 @@ static TEST_MUTEX_HANDLE g_dllByDll;
 static void test_helper_setup_homedir(void)
 {
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
@@ -69,10 +69,10 @@ static HSM_CLIENT_HANDLE tpm_provision(void)
 {
     int status;
     status = hsm_client_tpm_init();
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
     HSM_CLIENT_HANDLE result = interface->hsm_client_tpm_create();
-    ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     return result;
 }
 
@@ -85,7 +85,7 @@ static void tpm_activate_key
 {
     const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
     int status = interface->hsm_client_activate_identity_key(hsm_handle, key, key_size);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 }
 
 static int tpm_sign
@@ -116,9 +116,9 @@ static int tpm_sign
                                                                      &digest,
                                                                      &digest_size);
     }
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     status = BUFFER_build(hash, digest, digest_size);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     free(digest);
     return status;
 }
@@ -133,11 +133,11 @@ static void tpm_deprovision(HSM_CLIENT_HANDLE hsm_handle)
 static BUFFER_HANDLE test_helper_base64_converter(const char* input)
 {
     BUFFER_HANDLE result = Base64_Decoder(input);
-    ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     size_t out_len = BUFFER_length(result);
-    ASSERT_ARE_NOT_EQUAL_WITH_MSG(size_t, 0, out_len, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_NOT_EQUAL(size_t, 0, out_len, "Line:" TOSTRING(__LINE__));
     unsigned char* out_buffer = BUFFER_u_char(result);
-    ASSERT_IS_NOT_NULL_WITH_MSG(out_buffer, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(out_buffer, "Line:" TOSTRING(__LINE__));
     return result;
 }
 
@@ -150,10 +150,10 @@ static BUFFER_HANDLE test_helper_compute_hmac
 {
     int status;
     BUFFER_HANDLE result = BUFFER_new();
-    ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     status = HMACSHA256_ComputeHash(BUFFER_u_char(key_handle), BUFFER_length(key_handle),
                                     input, input_size, result);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, (int)HMACSHA256_OK, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, (int)HMACSHA256_OK, status, "Line:" TOSTRING(__LINE__));
     return result;
 }
 
@@ -289,7 +289,7 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
 
         // act
         BUFFER_HANDLE test_output_digest = BUFFER_new();
-        ASSERT_IS_NOT_NULL_WITH_MSG(test_output_digest, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" TOSTRING(__LINE__));
         HSM_CLIENT_HANDLE hsm_handle = test_helper_init_tpm_and_activate_key(decoded_key);
         tpm_sign(hsm_handle, NULL, 0, test_data_to_be_signed,
                  test_data_to_be_signed_size, test_output_digest);
@@ -338,7 +338,7 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
 
         // act
         BUFFER_HANDLE test_output_digest = BUFFER_new();
-        ASSERT_IS_NOT_NULL_WITH_MSG(test_output_digest, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" TOSTRING(__LINE__));
         HSM_CLIENT_HANDLE hsm_handle = test_helper_init_tpm_and_activate_key(decoded_key);
         tpm_sign(hsm_handle, (unsigned char*)primary_fqmid, strlen(primary_fqmid),
                  test_data_to_be_signed, test_data_to_be_signed_size, test_output_digest);
@@ -383,9 +383,9 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
 
         // act
         BUFFER_HANDLE test_output_primary_key_buf = BUFFER_new();
-        ASSERT_IS_NOT_NULL_WITH_MSG(test_output_primary_key_buf, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_primary_key_buf, "Line:" TOSTRING(__LINE__));
         BUFFER_HANDLE test_output_secondary_key_buf = BUFFER_new();
-        ASSERT_IS_NOT_NULL_WITH_MSG(test_output_secondary_key_buf, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_secondary_key_buf, "Line:" TOSTRING(__LINE__));
 
         HSM_CLIENT_HANDLE hsm_handle = test_helper_init_tpm_and_activate_key(decoded_key);
         tpm_sign(hsm_handle, NULL, 0, (unsigned char*)primary_fqmid, strlen(primary_fqmid), test_output_primary_key_buf);
@@ -434,7 +434,7 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
         HSM_CLIENT_HANDLE hsm_handle = tpm_provision();
         tpm_activate_key(hsm_handle, BUFFER_u_char(decoded_key), BUFFER_length(decoded_key));
         STRING_HANDLE token = tpm_construct_sas_token(hsm_handle, NULL, 0, hostname, device_id, expiry_time);
-        ASSERT_IS_NOT_NULL_WITH_MSG(token, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(token, "Line:" TOSTRING(__LINE__));
         printf("TPM Generated Token: [%s]\n", STRING_c_str(token));
 
         // cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_int/edge_hsm_store_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_int/edge_hsm_store_int.c
@@ -46,8 +46,8 @@ static TEST_MUTEX_HANDLE g_dllByDll;
 static void test_helper_setup_homedir(void)
 {
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
@@ -76,7 +76,7 @@ static CERT_PROPS_HANDLE test_helper_create_certificate_props
 )
 {
     CERT_PROPS_HANDLE cert_props_handle = cert_properties_create();
-    ASSERT_IS_NOT_NULL_WITH_MSG(cert_props_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" TOSTRING(__LINE__));
     set_validity_seconds(cert_props_handle, validity);
     set_common_name(cert_props_handle, common_name);
     set_country_name(cert_props_handle, "US");
@@ -93,11 +93,11 @@ static CERT_PROPS_HANDLE test_helper_create_certificate_props
 static BUFFER_HANDLE test_helper_base64_converter(const char* input)
 {
     BUFFER_HANDLE result = Base64_Decoder(input);
-    ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     size_t out_len = BUFFER_length(result);
-    ASSERT_ARE_NOT_EQUAL_WITH_MSG(size_t, 0, out_len, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_NOT_EQUAL(size_t, 0, out_len, "Line:" TOSTRING(__LINE__));
     unsigned char* out_buffer = BUFFER_u_char(result);
-    ASSERT_IS_NOT_NULL_WITH_MSG(out_buffer, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(out_buffer, "Line:" TOSTRING(__LINE__));
     return result;
 }
 
@@ -110,10 +110,10 @@ static BUFFER_HANDLE test_helper_compute_hmac
 {
     int status;
     BUFFER_HANDLE result = BUFFER_new();
-    ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     status = HMACSHA256_ComputeHash(BUFFER_u_char(key_handle), BUFFER_length(key_handle),
                                     input, input_size, result);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, (int)HMACSHA256_OK, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, (int)HMACSHA256_OK, status, "Line:" TOSTRING(__LINE__));
     return result;
 }
 
@@ -136,7 +136,7 @@ static void test_helper_sas_key_sign
     KEY_HANDLE key_handle = store_if->hsm_client_store_open_key(store_handle,
                                                                 HSM_KEY_SAS,
                                                                 key_name);
-    ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
     if (derived_identity != NULL)
     {
         status = key_if->hsm_client_key_derive_and_sign(key_handle,
@@ -155,12 +155,12 @@ static void test_helper_sas_key_sign
                                              &digest,
                                              &digest_size);
     }
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     status = BUFFER_build(hash, digest, digest_size);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     free(digest);
     status = store_if->hsm_client_store_close_key(store_handle, key_handle);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 }
 
 
@@ -202,68 +202,68 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
     {
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(open_close_smoke)
     {
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(insert_remove_sas_key_smoke)
     {
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_remove_key(store_handle, HSM_KEY_SAS, "bad_sas_key_name");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_insert_sas_key(store_handle, "my_sas_key", (unsigned char*)"ABCD", 5);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_insert_sas_key(store_handle, "my_sas_key", (unsigned char*)"1234", 5);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_remove_key(store_handle, HSM_KEY_SAS, "my_sas_key");
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(insert_overwrite_sign_remove_sas_key_smoke)
@@ -281,24 +281,24 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
                                                                       test_data_to_be_signed_size);
 
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
 
         // act
         BUFFER_HANDLE test_output_digest = BUFFER_new();
-        ASSERT_IS_NOT_NULL_WITH_MSG(test_output_digest, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_insert_sas_key(store_handle, "my_sas_key", (unsigned char*)"ABCD", 5);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
         result = store_if->hsm_client_store_insert_sas_key(store_handle, "my_sas_key",
                                                            BUFFER_u_char(decoded_key),
                                                            BUFFER_length(decoded_key));
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         test_helper_sas_key_sign(store_handle,
                                  "my_sas_key",
@@ -320,9 +320,9 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
         BUFFER_delete(test_expected_digest);
         BUFFER_delete(decoded_key);
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(insert_default_trusted_ca_cert_smoke)
@@ -330,27 +330,27 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
         // arrange
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
 
         // act
         CERT_INFO_HANDLE cert_info = store_if->hsm_client_store_get_pki_trusted_certs(store_handle);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(cert_info, "Line:" TOSTRING(__LINE__));
         // todo validate cert props
 
         // cleanup
         certificate_info_destroy(cert_info);
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(insert_generated_cert_smoke)
@@ -358,16 +358,16 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
         // arrange
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL_WITH_MSG(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_remove_pki_cert(store_handle, "my_test_alias");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         CERT_PROPS_HANDLE cert_props = test_helper_create_certificate_props("test_cn",
                                                                             "my_test_alias",
@@ -376,25 +376,25 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
                                                                             3600);
         // act, assert
         CERT_INFO_HANDLE cert_info = store_if->hsm_client_store_get_pki_cert(store_handle, "my_test_alias");
-        ASSERT_IS_NULL_WITH_MSG(cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(cert_info, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create_pki_cert(store_handle, cert_props);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         cert_info = store_if->hsm_client_store_get_pki_cert(store_handle, "my_test_alias");
-        ASSERT_IS_NOT_NULL_WITH_MSG(cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(cert_info, "Line:" TOSTRING(__LINE__));
         // todo validate cert props
 
         result = store_if->hsm_client_store_remove_pki_cert(store_handle, "my_test_alias");
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         cert_properties_destroy(cert_props);
         certificate_info_destroy(cert_info);
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
     }
 
 END_TEST_SUITE(edge_hsm_store_int_tests)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_ut/edge_hsm_store_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_ut/edge_hsm_store_ut.c
@@ -316,10 +316,10 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // act, assert
         result = store_if->hsm_client_store_create(NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create("");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -332,10 +332,10 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // act, assert
         result = store_if->hsm_client_store_destroy(NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_destroy("");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -370,7 +370,7 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // assert
         ASSERT_IS_NOT_NULL(result);
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(result);
@@ -391,7 +391,7 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // assert
         ASSERT_IS_NOT_NULL(handle_2);
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(handle_2);
@@ -436,11 +436,11 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // act, assert
         result = store_if->hsm_client_store_close(NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
 
         result = store_if->hsm_client_store_close(TEST_STORE_HANDLE);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -462,8 +462,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         result = store_if->hsm_client_store_close(handle);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -485,8 +485,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         result = store_if->hsm_client_store_close(handle);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -507,8 +507,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         int result = store_if->hsm_client_store_close(handle_2);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(handle_1);
@@ -525,7 +525,7 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         handle_2 = store_if->hsm_client_store_open(TEST_STORE_NAME);
         ASSERT_IS_NOT_NULL(handle_2);
         int result = store_if->hsm_client_store_close(handle_2);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
         umock_c_reset_all_calls();
 
         call_stack_helper_store_close(0);
@@ -534,8 +534,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         result = store_if->hsm_client_store_close(handle_1);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -553,23 +553,23 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(NULL, TEST_SAS_KEY_NAME_1, TEST_SAS_KEY_VALUE_1, strlen(TEST_SAS_KEY_VALUE_1) + 1);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(handle, NULL, TEST_SAS_KEY_VALUE_1, strlen(TEST_SAS_KEY_VALUE_1) + 1);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(handle, "", TEST_SAS_KEY_VALUE_1, strlen(TEST_SAS_KEY_VALUE_1) + 1);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(handle, TEST_SAS_KEY_NAME_1, NULL, strlen(TEST_SAS_KEY_VALUE_1) + 1);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(handle, TEST_SAS_KEY_NAME_1, TEST_SAS_KEY_VALUE_1, 0);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(handle);
@@ -603,8 +603,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         result = store_if->hsm_client_store_insert_sas_key(handle, TEST_SAS_KEY_NAME_1, TEST_SAS_KEY_VALUE_1, strlen(TEST_SAS_KEY_VALUE_1) + 1);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(handle);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_tpm_ut/edge_hsm_tpm_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_tpm_ut/edge_hsm_tpm_ut.c
@@ -482,8 +482,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_tpm_store_init();
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_store_deinit();
@@ -515,7 +515,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 status = hsm_client_tpm_store_init();
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -537,8 +537,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_tpm_store_init();
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_store_deinit();
@@ -558,7 +558,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             hsm_client_tpm_store_deinit();
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
         }
@@ -584,8 +584,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_tpm_store_init();
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_store_deinit();
@@ -603,15 +603,15 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             const HSM_CLIENT_TPM_INTERFACE* result = hsm_client_tpm_store_interface();
 
             // assert
-            ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_tpm_create, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_tpm_destroy, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_activate_identity_key, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_get_ek, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_get_srk, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_sign_with_identity, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(result->hsm_client_derive_and_sign_with_identity, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_tpm_create, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_tpm_destroy, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_activate_identity_key, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_get_ek, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_get_srk, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_sign_with_identity, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_derive_and_sign_with_identity, "Line:" TOSTRING(__LINE__));
 
             //cleanup
         }
@@ -631,8 +631,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
 
             // assert
-            ASSERT_IS_NULL_WITH_MSG(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -644,7 +644,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             //arrange
             int status;
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -657,8 +657,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
 
             // assert
-            ASSERT_IS_NOT_NULL_WITH_MSG(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -677,7 +677,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
 
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -697,7 +697,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
 
                 // assert
-                ASSERT_IS_NULL_WITH_MSG(hsm_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -719,7 +719,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             hsm_client_tpm_destroy(NULL);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -736,7 +736,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             hsm_client_tpm_destroy(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -748,7 +748,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             //arrange
             int status;
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -762,8 +762,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             hsm_client_tpm_destroy(hsm_handle);
 
             // assert
-            ASSERT_IS_NOT_NULL_WITH_MSG(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_store_deinit();
@@ -778,7 +778,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             //arrange
             int status;
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -788,11 +788,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
 
             // act, assert
             status = hsm_client_activate_identity_key(NULL, test_input, sizeof(test_input));
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             status = hsm_client_activate_identity_key(hsm_handle, NULL, sizeof(test_input));
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             status = hsm_client_activate_identity_key(hsm_handle, test_input, 0);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -808,7 +808,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             //arrange
             int status;
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -823,8 +823,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_activate_identity_key(hsm_handle, test_input, sizeof(test_input));
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -843,7 +843,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
 
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -865,7 +865,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 status = hsm_client_activate_identity_key(hsm_handle, test_input, sizeof(test_input));
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -892,10 +892,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_get_ek(TEST_HSM_CLIENT_HANDLE, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -906,7 +906,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -920,10 +920,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_get_ek(hsm_handle, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -938,7 +938,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -949,21 +949,21 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
 
             // act, assert
             status = hsm_client_get_ek(NULL, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = (unsigned char*)0x5000;
             test_output_len = 10;
             status = hsm_client_get_ek(hsm_handle, NULL, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = (unsigned char*)0x5000;
             test_output_len = 10;
             status = hsm_client_get_ek(hsm_handle, &test_output_buffer, NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -988,10 +988,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_get_srk(TEST_HSM_CLIENT_HANDLE, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -1002,7 +1002,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -1016,10 +1016,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_get_srk(hsm_handle, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1034,7 +1034,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -1045,21 +1045,21 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
 
             // act, assert
             status = hsm_client_get_srk(NULL, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_get_srk(hsm_handle, NULL, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_get_srk(hsm_handle, &test_output_buffer, NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1085,11 +1085,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_sign_with_identity(TEST_HSM_CLIENT_HANDLE, test_input, sizeof(test_input), &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -1100,7 +1100,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -1112,35 +1112,35 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
 
             // act, assert
             status = hsm_client_sign_with_identity(NULL, test_input, sizeof(test_input), &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_sign_with_identity(hsm_handle, NULL, sizeof(test_input), &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_sign_with_identity(hsm_handle, test_input, 0, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_sign_with_identity(hsm_handle, test_input, sizeof(test_input), NULL, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_sign_with_identity(hsm_handle, test_input, sizeof(test_input), &test_output_buffer, NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1155,7 +1155,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -1174,8 +1174,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_sign_with_identity(hsm_handle, test_input, sizeof(test_input), &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1192,7 +1192,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             int test_result = umock_c_negative_tests_init();
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -1218,7 +1218,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 status = hsm_client_sign_with_identity(hsm_handle, test_input, sizeof(test_input), &test_output_buffer, &test_output_len);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1247,10 +1247,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_derive_and_sign_with_identity(TEST_HSM_CLIENT_HANDLE, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
         }
 
         /**
@@ -1261,7 +1261,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -1276,49 +1276,49 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(NULL, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, NULL, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, 0, TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), NULL, identity_size, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, 0, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, NULL, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE_WITH_MSG((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1333,7 +1333,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -1354,8 +1354,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1372,7 +1372,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             int test_result = umock_c_negative_tests_init();
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
             HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
             HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
@@ -1400,7 +1400,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
 
             //cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_util_int/edge_hsm_util_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_util_int/edge_hsm_util_int.c
@@ -66,8 +66,8 @@ static char* TEST_TEMP_DIR_GUID = NULL;
 static void test_helper_setup_testdir(void)
 {
     TEST_TEMP_DIR = hsm_test_util_create_temp_dir(&TEST_TEMP_DIR_GUID);
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_TEMP_DIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_TEMP_DIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_TEMP_DIR_GUID, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_TEMP_DIR, "Line:" TOSTRING(__LINE__));
     printf("Temp dir created: [%s]\r\n", TEST_TEMP_DIR);
 }
 
@@ -128,9 +128,9 @@ static char* prepare_file_path(const char* base_dir, const char* file_name)
 {
     size_t path_size = get_max_file_path_size();
     char *file_path = calloc(path_size, 1);
-    ASSERT_IS_NOT_NULL_WITH_MSG(file_path, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(file_path, "Line:" TOSTRING(__LINE__));
     int status = snprintf(file_path, path_size, "%s%s", base_dir, file_name);
-    ASSERT_IS_TRUE_WITH_MSG(((status > 0) || (status < (int)path_size)), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < (int)path_size)), "Line:" TOSTRING(__LINE__));
 
     return file_path;
 }
@@ -215,8 +215,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -235,8 +235,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -252,7 +252,7 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // assert
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -267,7 +267,7 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // assert
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -282,13 +282,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             output_size = 100;
             output_string = (unsigned char *)read_file_into_cstring(NULL, &output_size);
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
 
             // act, assert
             output_size = 100;
             output_string = (unsigned char *)read_file_into_cstring("", &output_size);
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -306,8 +306,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_buffer);
             int cmp_result = memcmp(expected_buffer, output_buffer, expected_buffer_size);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_buffer_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_buffer_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_buffer);
@@ -326,8 +326,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_buffer);
             int cmp_result = memcmp(expected_buffer, output_buffer, expected_buffer_size);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_buffer_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_buffer_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_buffer);
@@ -343,13 +343,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             output_size = 100;
             output_buffer = read_file_into_buffer(NULL, &output_size);
             ASSERT_IS_NULL(output_buffer);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
 
             // act, assert
             output_size = 100;
             output_buffer = read_file_into_buffer("", &output_size);
             ASSERT_IS_NULL(output_buffer);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -364,7 +364,7 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // assert
             ASSERT_IS_NULL(output_buffer);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -379,7 +379,7 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // assert
             ASSERT_IS_NULL(output_buffer);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -420,8 +420,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -444,8 +444,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -469,8 +469,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -494,8 +494,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -526,13 +526,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             result = is_directory_valid(NULL);
-            ASSERT_IS_FALSE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
 
             result = is_directory_valid("");
-            ASSERT_IS_FALSE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
 
             result = is_directory_valid("some_bad_dir");
-            ASSERT_IS_FALSE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -543,10 +543,10 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             bool result;
             // act, assert
             result = is_directory_valid(".");
-            ASSERT_IS_TRUE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE(result, "Line:" TOSTRING(__LINE__));
 
             result = is_directory_valid("..");
-            ASSERT_IS_TRUE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE(result, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -558,13 +558,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             result = is_file_valid(NULL);
-            ASSERT_IS_FALSE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
 
             result = is_file_valid("");
-            ASSERT_IS_FALSE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
 
             result = is_file_valid(TEST_FILE_BAD);
-            ASSERT_IS_FALSE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -576,10 +576,10 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             result = is_file_valid(TEST_FILE_ALPHA);
-            ASSERT_IS_TRUE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE(result, "Line:" TOSTRING(__LINE__));
 
             result = is_file_valid(TEST_FILE_NUMERIC);
-            ASSERT_IS_TRUE_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE(result, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -598,11 +598,11 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             char *output_string = read_file_into_cstring(TEST_WRITE_FILE, &output_size);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -616,13 +616,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             output = write_cstring_to_file(NULL, "abcd");
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
 
             output = write_cstring_to_file("", "abcd");
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
 
             output = write_cstring_to_file(TEST_WRITE_FILE, NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -641,9 +641,9 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             char *output_string = read_file_into_cstring(TEST_WRITE_FILE, &output_size);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -655,18 +655,18 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             const char *input_string = "abcd";
 
             int status = write_cstring_to_file(TEST_WRITE_FILE_FOR_DELETE, input_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
             // act
             int output = delete_file(TEST_WRITE_FILE_FOR_DELETE);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
             size_t output_size = 10;
             char *output_string = read_file_into_cstring(TEST_WRITE_FILE_FOR_DELETE, &output_size);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -678,10 +678,10 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             output = delete_file(NULL);
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
 
             output = delete_file("");
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -695,11 +695,11 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // act
             status = hsm_get_env(NULL,&output);
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             // act
             status = hsm_get_env("TEST_ENV_1",NULL);
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             // cleanup
         }
 
@@ -715,9 +715,9 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             status = hsm_get_env("TEST_ENV_1", &output);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, input_data, output, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, strlen(input_data), strlen(output), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, input_data, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, strlen(input_data), strlen(output), "Line:" TOSTRING(__LINE__));
 
             // cleanup
             free(output);
@@ -730,8 +730,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             status = hsm_get_env("TEST_ENV_1", &output);
 
             // assert
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL_WITH_MSG(output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(output, "Line:" TOSTRING(__LINE__));
 
             // cleanup
         }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_common_ut/edge_openssl_common_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_common_ut/edge_openssl_common_ut.c
@@ -148,7 +148,7 @@ BEGIN_TEST_SUITE(edge_openssl_common_ut)
         initialize_openssl();
 
         // assert 1
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         umock_c_reset_all_calls();
 
@@ -156,7 +156,7 @@ BEGIN_TEST_SUITE(edge_openssl_common_ut)
         initialize_openssl();
 
         // assert 2
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_int/edge_openssl_enc_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_int/edge_openssl_enc_int.c
@@ -103,8 +103,8 @@ size_t TEST_CIPHER_SIZE = sizeof(TEST_CIPHER);
 static void test_helper_setup_homedir(void)
 {
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
@@ -162,7 +162,7 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -171,19 +171,19 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
 
         // act, assert (encrypt)
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, (TEST_STRING_SIZE + TEST_CIPHERTEXT_HEADER_SIZE), ciphertext_result.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char, TEST_VERSION, ciphertext_result.buffer[0], "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, (TEST_STRING_SIZE + TEST_CIPHERTEXT_HEADER_SIZE), ciphertext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char, TEST_VERSION, ciphertext_result.buffer[0], "Line:" TOSTRING(__LINE__));
         status = memcmp(ciphertext_result.buffer + TEST_TAG_OFFSET, TEST_TAG, TEST_TAG_SIZE);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = memcmp(ciphertext_result.buffer + TEST_CIPHERTEXT_OFFSET, TEST_CIPHER, TEST_CIPHER_SIZE);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // act, assert (decrypt)
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = memcmp(plaintext_result.buffer, TEST_STRING, TEST_STRING_SIZE);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -196,7 +196,7 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER id2 = {TEST_ID_2, TEST_ID_2_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
@@ -204,13 +204,13 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // act
         status = key_decrypt(key_handle, &id2, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -222,22 +222,22 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         // corrupt tag bits
         ciphertext_result.buffer[TEST_TAG_OFFSET] ^= 1;
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -249,22 +249,22 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         // corrupt data bit
         ciphertext_result.buffer[TEST_CIPHERTEXT_OFFSET] ^= 1;
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -276,7 +276,7 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         unsigned char data[] = {'a'};
         size_t data_size = sizeof(data);
@@ -289,8 +289,8 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, (TEST_CIPHERTEXT_HEADER_SIZE + data_size), ciphertext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, (TEST_CIPHERTEXT_HEADER_SIZE + data_size), ciphertext_result.size, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -302,7 +302,7 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         unsigned char data[] = {'a'};
         size_t data_size = sizeof(data);
@@ -311,16 +311,16 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, data_size, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, data_size, plaintext_result.size, "Line:" TOSTRING(__LINE__));
         status = memcmp(data, plaintext_result.buffer, plaintext_result.size);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(plaintext_result.buffer);
@@ -333,11 +333,11 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         size_t data_size = 2048;
         unsigned char *data = malloc(data_size);
-        ASSERT_IS_NOT_NULL_WITH_MSG(data, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(data, "Line:" TOSTRING(__LINE__));
         memset(data, 0xDE, data_size);
         SIZED_BUFFER plaintext = {data, data_size};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -348,8 +348,8 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, TEST_CIPHERTEXT_HEADER_SIZE + data_size, ciphertext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_HEADER_SIZE + data_size, ciphertext_result.size, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -362,27 +362,27 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         size_t data_size = 2048;
         unsigned char *data = malloc(data_size);
-        ASSERT_IS_NOT_NULL_WITH_MSG(data, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(data, "Line:" TOSTRING(__LINE__));
         memset(data, 0xDE, data_size);
         SIZED_BUFFER plaintext = {data, data_size};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, data_size, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, data_size, plaintext_result.size, "Line:" TOSTRING(__LINE__));
         status = memcmp(data, plaintext_result.buffer, plaintext_result.size);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(plaintext_result.buffer);
@@ -396,23 +396,23 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV_LARGE, TEST_IV_LARGE_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, TEST_STRING_SIZE, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_STRING_SIZE, plaintext_result.size, "Line:" TOSTRING(__LINE__));
         status = memcmp(TEST_STRING, plaintext_result.buffer, plaintext_result.size);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(plaintext_result.buffer);
@@ -425,14 +425,14 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV_LARGE, TEST_IV_LARGE_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         // corrupt one bit in the iv
         iv.buffer[iv.size - 1] ^= 1;
 
@@ -440,9 +440,9 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -460,17 +460,17 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         status = generate_encryption_key(&key1, &key1_size);
 
         // assert 1
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, ENCRYPTION_KEY_SIZE, key1_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key1_size, "Line:" TOSTRING(__LINE__));
 
         // act 2
         status = generate_encryption_key(&key2, &key2_size);
 
         // assert 2
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, ENCRYPTION_KEY_SIZE, key2_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key2_size, "Line:" TOSTRING(__LINE__));
         status = memcmp(key1, key2, ENCRYPTION_KEY_SIZE);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(key1);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_ut/edge_openssl_enc_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_ut/edge_openssl_enc_ut.c
@@ -431,13 +431,13 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         // act, assert
         key_size = 10;
         status = generate_encryption_key(NULL, &key_size);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, key_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, key_size, "Line:" TOSTRING(__LINE__));
 
         key = (unsigned char*)0x1000;
         status = generate_encryption_key(&key, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(key, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -461,10 +461,10 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         status = generate_encryption_key(&key, &key_size);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(key, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, ENCRYPTION_KEY_SIZE, key_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
         gballoc_free(key);
@@ -501,9 +501,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
                status = generate_encryption_key(&key, &key_size);
 
                // assert
-               ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-               ASSERT_IS_NULL_WITH_MSG(key, "Line:" TOSTRING(__LINE__));
-               ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, key_size, "Line:" TOSTRING(__LINE__));
+               ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+               ASSERT_IS_NULL(key, "Line:" TOSTRING(__LINE__));
+               ASSERT_ARE_EQUAL(size_t, 0, key_size, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -523,16 +523,16 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
 
         // act, assert
         key_handle = create_encryption_key(NULL, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
 
         key_handle = create_encryption_key(key, 0);
-        ASSERT_IS_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
 
         key_handle = create_encryption_key(key, ENCRYPTION_KEY_SIZE - 1);
-        ASSERT_IS_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
 
         key_handle = create_encryption_key(key, ENCRYPTION_KEY_SIZE + 1);
-        ASSERT_IS_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -553,8 +553,8 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
 
         // assert
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(key_handle);
@@ -586,7 +586,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
             key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
 
             // assert
-            ASSERT_IS_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         }
 
         //cleanup
@@ -601,7 +601,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         umock_c_reset_all_calls();
 
         EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
@@ -611,7 +611,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         key_destroy(key_handle);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -623,7 +623,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     TEST_FUNCTION(key_encrypt_invalid_params)
     {
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER pt = {TEST_PLAINTEXT, TEST_PLAINTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -637,69 +637,69 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         // act, assert
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, NULL, &pt, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &inv1, &pt, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &inv2, &pt, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, NULL, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &inv1, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         inv_pt_size.size = 0;
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &inv_pt_size, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         inv_pt_size.size = INT_MAX - TEST_CIPHERTEXT_HEADER_SIZE + 1;
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &inv_pt_size, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &pt, NULL, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &pt, &inv1, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &pt, &inv2, &ct);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &pt, &iv, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(key_handle);
@@ -713,7 +713,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER pt = {TEST_PLAINTEXT, TEST_PLAINTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -727,10 +727,10 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         status = key_encrypt(key_handle, &id, &pt, &iv, &ct);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, TEST_CIPHERTEXT_HEADER_SIZE+TEST_PLAINTEXT_SIZE, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_HEADER_SIZE+TEST_PLAINTEXT_SIZE, ct.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(ct.buffer);
@@ -747,7 +747,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         int test_result = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, test_result);
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER pt = {TEST_PLAINTEXT, TEST_PLAINTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -767,9 +767,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
                 int status = key_encrypt(key_handle, &id, &pt, &iv, &ct);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-                ASSERT_IS_NULL_WITH_MSG(ct.buffer, "Line:" TOSTRING(__LINE__));
-                ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -785,7 +785,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     TEST_FUNCTION(key_decrypt_invalid_params)
     {
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER ct = {TEST_CIPHERTEXT, TEST_CIPHERTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -800,97 +800,97 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         // act, assert
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, NULL, &ct, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &inv1, &ct, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &inv2, &ct, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, NULL, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv1, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         inv_ct_size.size = 0;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_size, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         inv_ct_size.size = TEST_CIPHERTEXT_HEADER_SIZE - 1;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_size, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         inv_ct_size.size = TEST_CIPHERTEXT_HEADER_SIZE;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_size, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         inv_ct_size.size = ((size_t)INT_MAX + 1);
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_size, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         inv_ct_version.buffer[0] = 0;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_version, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         inv_ct_version.buffer[0] = 2;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_version, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &ct, NULL, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &ct, &inv1, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &ct, &inv2, &pt);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &ct, &iv, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(key_handle);
@@ -904,7 +904,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER ct = {TEST_CIPHERTEXT, TEST_CIPHERTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -918,10 +918,10 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         status = key_decrypt(key_handle, &id, &ct, &iv, &pt);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, TEST_CIPHERTEXT_SIZE-TEST_CIPHERTEXT_HEADER_SIZE, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_SIZE-TEST_CIPHERTEXT_HEADER_SIZE, pt.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
         free(pt.buffer);
@@ -938,7 +938,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         int test_result = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, test_result);
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER ct = {TEST_CIPHERTEXT, TEST_CIPHERTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -958,9 +958,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
                 int status = key_decrypt(key_handle, &id, &ct, &iv, &pt);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-                ASSERT_IS_NULL_WITH_MSG(pt.buffer, "Line:" TOSTRING(__LINE__));
-                ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -977,7 +977,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         unsigned char TBS[] = "data";
         unsigned char *output = (unsigned char*)0x1000;
         size_t output_size = 1234;
@@ -986,9 +986,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         int status = key_sign(key_handle, TBS, sizeof(TBS), &output, &output_size);
 
         // arrange
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(output, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(output, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         key_destroy(key_handle);
@@ -1002,7 +1002,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
         unsigned char TBS[] = "data";
         unsigned char *output = (unsigned char*)0x1000;
         size_t output_size = 1234;
@@ -1013,9 +1013,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
                                          &output, &output_size);
 
         // arrange
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL_WITH_MSG(output, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(output, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         key_destroy(key_handle);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_int/edge_openssl_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_int/edge_openssl_int.c
@@ -128,8 +128,8 @@ static void test_helper_setup_temp_dir(char **pp_temp_dir, char **pp_temp_dir_gu
 {
     char *temp_dir, *guid;
     temp_dir = hsm_test_util_create_temp_dir(&guid);
-    ASSERT_IS_NOT_NULL_WITH_MSG(guid, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(temp_dir, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(guid, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(temp_dir, "Line:" TOSTRING(__LINE__));
     printf("Temp dir created: [%s]\r\n", temp_dir);
     *pp_temp_dir = temp_dir;
     *pp_temp_dir_guid = guid;
@@ -137,13 +137,13 @@ static void test_helper_setup_temp_dir(char **pp_temp_dir, char **pp_temp_dir_gu
 
 static void test_helper_teardown_temp_dir(char **pp_temp_dir, char **pp_temp_dir_guid)
 {
-    ASSERT_IS_NOT_NULL_WITH_MSG(pp_temp_dir, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(pp_temp_dir_guid, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(pp_temp_dir, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(pp_temp_dir_guid, "Line:" TOSTRING(__LINE__));
 
     char *temp_dir = *pp_temp_dir;
     char *guid = *pp_temp_dir_guid;
-    ASSERT_IS_NOT_NULL_WITH_MSG(temp_dir, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(guid, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(temp_dir, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(guid, "Line:" TOSTRING(__LINE__));
 
     hsm_test_util_delete_dir(guid);
     free(temp_dir);
@@ -156,9 +156,9 @@ static char* prepare_file_path(const char* base_dir, const char* file_name)
 {
     size_t path_size = get_max_file_path_size();
     char *file_path = calloc(path_size, 1);
-    ASSERT_IS_NOT_NULL_WITH_MSG(file_path, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(file_path, "Line:" TOSTRING(__LINE__));
     int status = snprintf(file_path, path_size, "%s%s", base_dir, file_name);
-    ASSERT_IS_TRUE_WITH_MSG(((status > 0) || (status < (int)path_size)), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < (int)path_size)), "Line:" TOSTRING(__LINE__));
 
     return file_path;
 }
@@ -180,7 +180,7 @@ static CERT_PROPS_HANDLE test_helper_create_certificate_props
 )
 {
     CERT_PROPS_HANDLE cert_props_handle = cert_properties_create();
-    ASSERT_IS_NOT_NULL_WITH_MSG(cert_props_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" TOSTRING(__LINE__));
     set_validity_seconds(cert_props_handle, validity);
     set_common_name(cert_props_handle, common_name);
     set_country_name(cert_props_handle, "US");
@@ -212,7 +212,7 @@ static void test_helper_generate_pki_certificate
                                            cert_file,
                                            issuer_private_key_file,
                                            issuer_cert_file);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 }
 
 static void test_helper_generate_self_signed
@@ -231,7 +231,7 @@ static void test_helper_generate_self_signed
                                                       private_key_file,
                                                       cert_file,
                                                       key_props);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 }
 
 void test_helper_server_chain_validator(const PKI_KEY_PROPS *key_props)
@@ -286,21 +286,21 @@ void test_helper_server_chain_validator(const PKI_KEY_PROPS *key_props)
     // assert
     bool cert_verified = false;
     int status = verify_certificate(TEST_CA_CERT_RSA_FILE_2, TEST_CA_PK_RSA_FILE_2, TEST_CA_CERT_RSA_FILE_1, &cert_verified);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_TRUE_WITH_MSG(cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(cert_verified, "Line:" TOSTRING(__LINE__));
     cert_verified = false;
     status = verify_certificate(TEST_SERVER_CERT_RSA_FILE_3, TEST_SERVER_PK_RSA_FILE_3, TEST_CA_CERT_RSA_FILE_2, &cert_verified);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_TRUE_WITH_MSG(cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(cert_verified, "Line:" TOSTRING(__LINE__));
     cert_verified = false;
     status = verify_certificate(TEST_SERVER_CERT_RSA_FILE_3, TEST_SERVER_PK_RSA_FILE_3, TEST_SERVER_CERT_RSA_FILE_3, &cert_verified);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_TRUE_WITH_MSG(cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(cert_verified, "Line:" TOSTRING(__LINE__));
     cert_verified = false;
     status = verify_certificate(TEST_SERVER_CERT_RSA_FILE_3, TEST_SERVER_PK_RSA_FILE_3, TEST_CA_CERT_RSA_FILE_1, &cert_verified);
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_FALSE_WITH_MSG(cert_verified, "Line:" TOSTRING(__LINE__));
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_FALSE(cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, cert_verified, "Line:" TOSTRING(__LINE__));
 
     // cleanup
     delete_file(TEST_SERVER_PK_RSA_FILE_3);
@@ -317,11 +317,11 @@ void test_helper_server_chain_validator(const PKI_KEY_PROPS *key_props)
 static X509* test_helper_load_certificate_file(const char* cert_file_name)
 {
     BIO* cert_file = BIO_new_file(cert_file_name, "r");
-    ASSERT_IS_NOT_NULL_WITH_MSG(cert_file, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cert_file, "Line:" TOSTRING(__LINE__));
     X509* x509_cert = PEM_read_bio_X509(cert_file, NULL, NULL, NULL);
     // make sure the file is closed before asserting below
     BIO_free_all(cert_file);
-    ASSERT_IS_NOT_NULL_WITH_MSG(x509_cert, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(x509_cert, "Line:" TOSTRING(__LINE__));
     return x509_cert;
 }
 
@@ -347,7 +347,7 @@ static void test_helper_validate_extension
     STACK_OF(X509_EXTENSION) *ext_list = cert_inf->extensions;
 #endif
 
-    ASSERT_IS_TRUE_WITH_MSG((sk_X509_EXTENSION_num(ext_list) > 0), "Found zero extensions");
+    ASSERT_IS_TRUE((sk_X509_EXTENSION_num(ext_list) > 0), "Found zero extensions");
 
     for (int ext_idx=0; ext_idx < sk_X509_EXTENSION_num(ext_list); ext_idx++)
     {
@@ -357,15 +357,15 @@ static void test_helper_validate_extension
         X509_EXTENSION *ext;
 
         ext = sk_X509_EXTENSION_value(ext_list, ext_idx);
-        ASSERT_IS_NOT_NULL_WITH_MSG(ext, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ext, "Line:" TOSTRING(__LINE__));
 
         obj = X509_EXTENSION_get_object(ext);
-        ASSERT_IS_NOT_NULL_WITH_MSG(obj, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(obj, "Line:" TOSTRING(__LINE__));
 
         memset(output_buffer, 0, MAX_X509_EXT_SIZE);
         sz = i2t_ASN1_OBJECT(output_buffer, MAX_X509_EXT_SIZE, obj);
         // if size is larger use the call twice first to get size and then allocate or increase MAX_X509_EXT_SIZE
-        ASSERT_IS_FALSE_WITH_MSG((sz > MAX_X509_EXT_SIZE), "Unexpected buffer size");
+        ASSERT_IS_FALSE((sz > MAX_X509_EXT_SIZE), "Unexpected buffer size");
 
         if (strcmp(ext_name, output_buffer) == 0)
         {
@@ -375,14 +375,14 @@ static void test_helper_validate_extension
             printf("\r\nTesting Extension Contents: [%s]\r\n", output_buffer);
 
             BIO *mem_bio = BIO_new(BIO_s_mem());
-            ASSERT_IS_NOT_NULL_WITH_MSG(mem_bio, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(mem_bio, "Line:" TOSTRING(__LINE__));
             // print the extension contents into the mem_bio
             X509V3_EXT_print(mem_bio, ext, 0, 0);
             sz = BIO_get_mem_data(mem_bio, &memst);
-            ASSERT_IS_TRUE_WITH_MSG((sz > 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL_WITH_MSG(memst, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((sz > 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(memst, "Line:" TOSTRING(__LINE__));
             char *output_str = calloc(sz + 1, 1);
-            ASSERT_IS_NOT_NULL_WITH_MSG(output_str, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(output_str, "Line:" TOSTRING(__LINE__));
             memcpy(output_str, memst, sz);
             printf("\r\n Obtained Extension value from cert. Size:[%ld] Data:[%s]", sz, output_str);
             for (size_t idx = 0; idx < num_expted_vals; idx++)
@@ -402,8 +402,8 @@ static void test_helper_validate_extension
         }
     }
 
-    ASSERT_ARE_EQUAL_WITH_MSG(size_t, expected_num_ext_name_entries, nid_match,  "NID match count failed");
-    ASSERT_ARE_EQUAL_WITH_MSG(size_t, num_expted_vals, match_count,  "Match count failed");
+    ASSERT_ARE_EQUAL(size_t, expected_num_ext_name_entries, nid_match,  "NID match count failed");
+    ASSERT_ARE_EQUAL(size_t, num_expted_vals, match_count,  "Match count failed");
 }
 
 static void test_helper_validate_all_x509_extensions
@@ -422,7 +422,7 @@ static void test_helper_validate_all_x509_extensions
     bool test_path_len = false;
 
     CERTIFICATE_TYPE cert_type = get_certificate_type(handle);
-    ASSERT_ARE_NOT_EQUAL_WITH_MSG(size_t, CERTIFICATE_TYPE_UNKNOWN, cert_type, "Unknown cert type not supported");
+    ASSERT_ARE_NOT_EQUAL(size_t, CERTIFICATE_TYPE_UNKNOWN, cert_type, "Unknown cert type not supported");
 
     // setup common extension expected values such as basic constraints and SAN entries
     idx = 0;
@@ -443,7 +443,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_key_usage_vals_size = 2;
         expected_key_usage_vals = calloc(expected_key_usage_vals_size, sizeof(SIZED_BUFFER));
-        ASSERT_IS_NOT_NULL_WITH_MSG(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_DIG_SIG;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_KEY_CERT_SIGN;
 
@@ -456,7 +456,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_key_usage_vals_size = 4;
         expected_key_usage_vals = calloc(expected_key_usage_vals_size, sizeof(void*));
-        ASSERT_IS_NOT_NULL_WITH_MSG(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_DIG_SIG;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_NON_REPUDIATION;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_KEY_ENCIPHER;
@@ -465,7 +465,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_ext_key_usage_vals_size = 1;
         expected_ext_key_usage_vals = calloc(expected_ext_key_usage_vals_size, sizeof(void*));
-        ASSERT_IS_NOT_NULL_WITH_MSG(expected_ext_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_ext_key_usage_vals, "Line:" TOSTRING(__LINE__));
         expected_ext_key_usage_vals[idx++] = TEST_X509_KEY_EXT_USAGE_CLIENT_AUTH;
     }
     else
@@ -473,7 +473,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_key_usage_vals_size = 5;
         expected_key_usage_vals = calloc(expected_key_usage_vals_size, sizeof(void*));
-        ASSERT_IS_NOT_NULL_WITH_MSG(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_DIG_SIG;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_NON_REPUDIATION;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_KEY_ENCIPHER;
@@ -483,7 +483,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_ext_key_usage_vals_size = 1;
         expected_ext_key_usage_vals = calloc(expected_ext_key_usage_vals_size, sizeof(SIZED_BUFFER));
-        ASSERT_IS_NOT_NULL_WITH_MSG(expected_ext_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_ext_key_usage_vals, "Line:" TOSTRING(__LINE__));
         expected_ext_key_usage_vals[idx++] = TEST_X509_KEY_EXT_USAGE_SERVER_AUTH;
     }
     X509* cert = test_helper_load_certificate_file(cert_file_path);
@@ -540,13 +540,13 @@ void test_helper_x509_ext_validator(const PKI_KEY_PROPS *key_props)
     const char* server_san_list[] = {"URI:edgetest://server/test1", "DNS:test.contoso.com"};
     const char* client_san_list[] = {"URI:edgetest://client/test2", "email:test@contoso.com"};
     status = set_san_entries(ca_root_handle, ca_san_list, sizeof(ca_san_list)/sizeof(ca_san_list[0]));
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     status = set_san_entries(int_ca_root_handle, int_ca_san_list, sizeof(int_ca_san_list)/sizeof(int_ca_san_list[0]));
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     status = set_san_entries(server_root_handle, server_san_list, sizeof(server_san_list)/sizeof(server_san_list[0]));
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     status = set_san_entries(client_root_handle, client_san_list, sizeof(client_san_list)/sizeof(client_san_list[0]));
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
     // act
     test_helper_generate_self_signed(ca_root_handle,
@@ -762,7 +762,7 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
                                                           TEST_SERVER_CERT_RSA_FILE_1,
                                                           &key_props);
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
 
         // cleanup
         cert_properties_destroy(cert_props_handle);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
@@ -698,7 +698,7 @@ static void* test_hook_read_file_into_buffer
     size_t test_data_len = strlen(TEST_ISSUER_CERT_DATA);
     size_t test_data_size = test_data_len + 1;
     void *data = test_hook_gballoc_malloc(test_data_size);
-    ASSERT_IS_NOT_NULL_WITH_MSG(data, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(data, "Line:" TOSTRING(__LINE__));
     memset(data, 0, test_data_size);
     memcpy(data, TEST_ISSUER_CERT_DATA, test_data_len);
     if (output_buffer_size) *output_buffer_size = test_data_size;
@@ -1151,7 +1151,7 @@ static char *test_helper_strdup(const char *s)
     size_t len = strlen(s);
     size_t size = len + 1;
     char *result = test_hook_gballoc_malloc(size);
-    ASSERT_IS_NOT_NULL_WITH_MSG(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     memset(result, 0, size);
     strcpy(result, s);
     return result;
@@ -1162,35 +1162,35 @@ void test_helper_generate_rsa_key(int key_len, size_t *index, char *failed_funct
     size_t i = *index;
 
     EXPECTED_CALL(EVP_PKEY_new());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(BN_new());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(BN_set_word(TEST_BIGNUM, RSA_F4));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(RSA_new());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(RSA_generate_key_ex(TEST_RSA, key_len, TEST_BIGNUM, NULL));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_PKEY_set1_RSA(TEST_EVP_KEY, TEST_RSA));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(RSA_free(TEST_RSA));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(BN_free(TEST_BIGNUM));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     *index = i;
@@ -1203,59 +1203,59 @@ void test_helper_generate_ecc_key(bool is_self_signed, size_t *index, char *fail
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(EVP_PKEY_get1_EC_KEY(TEST_ISSUER_PUB_KEY));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(EC_KEY_get0_group(TEST_EC_PUB_KEY));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(EC_GROUP_get_curve_name(TEST_PUB_GROUP));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(OBJ_nid2sn(TEST_CURVE_NAME_ID));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(EVP_PKEY_bits(TEST_ISSUER_PUB_KEY));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
     // generate_ecc_key
     STRICT_EXPECTED_CALL(OBJ_txt2nid(TEST_CURVE_NAME));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(EC_KEY_new_by_curve_name(TEST_ECC_GROUP));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EC_KEY_set_asn1_flag(TEST_EC_KEY, OPENSSL_EC_NAMED_CURVE));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(EC_KEY_generate_key(TEST_EC_KEY));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(EVP_PKEY_new());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_PKEY_set1_EC_KEY(TEST_EVP_KEY, TEST_EC_KEY));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EC_KEY_free(TEST_EC_KEY));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(EC_KEY_free(TEST_EC_PUB_KEY));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
@@ -1289,53 +1289,53 @@ static void test_helper_cert_create_with_subject
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(initialize_openssl());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(get_validity_seconds(TEST_CERT_PROPS_HANDLE));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(get_common_name(TEST_CERT_PROPS_HANDLE));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(get_certificate_type(TEST_CERT_PROPS_HANDLE)).SetReturn(cert_type);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(BIO_new_file(TEST_ISSUER_CERT_FILE, "r"));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(PEM_read_bio_X509(TEST_BIO, NULL, NULL, NULL)).SetReturn(TEST_ISSUER_X509);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(BIO_new_file(TEST_ISSUER_KEY_FILE, "r"));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(PEM_read_bio_PrivateKey(TEST_BIO, NULL, NULL, NULL)).SetReturn(TEST_ISSUER_EVP_KEY);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_get_pubkey(TEST_ISSUER_X509)).SetReturn(TEST_ISSUER_PUB_KEY);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(EVP_PKEY_base_id(TEST_ISSUER_PUB_KEY)).SetReturn(key_type);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
@@ -1351,134 +1351,134 @@ static void test_helper_cert_create_with_subject
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(EVP_PKEY_free(TEST_ISSUER_PUB_KEY));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
     if (test_helper_is_windows())
     {
         STRICT_EXPECTED_CALL(BIO_new_file(TEST_KEY_FILE, "w")).SetReturn(TEST_BIO_WRITE_KEY);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     else
     {
         STRICT_EXPECTED_CALL(mocked_OPEN(TEST_KEY_FILE, EXPECTED_CREATE_FLAGS, EXPECTED_MODE_FLAGS)).SetReturn(TEST_WRITE_PRIVATE_KEY_FD);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BIO_new_fd(TEST_WRITE_PRIVATE_KEY_FD, 0)).SetReturn(TEST_BIO_WRITE_KEY);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     STRICT_EXPECTED_CALL(PEM_write_bio_PrivateKey(TEST_BIO_WRITE_KEY, TEST_EVP_KEY, NULL, NULL, 0, NULL, NULL));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO_WRITE_KEY));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if (!test_helper_is_windows())
     {
         STRICT_EXPECTED_CALL(mocked_CLOSE(TEST_WRITE_PRIVATE_KEY_FD));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(X509_new());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_set_version(TEST_X509, 0x2));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_get_serialNumber(TEST_X509));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(ASN1_INTEGER_set(TEST_ASN1_SERIAL_NUM, TEST_SERIAL_NUMBER));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_set_pubkey(TEST_X509, TEST_EVP_KEY));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(mocked_X509_get_notBefore(TEST_X509));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_gmtime_adj(&TEST_ASN1_TIME_BEFORE, 0));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(mocked_X509_get_notAfter(TEST_ISSUER_X509));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(get_utc_time_from_asn_string(TEST_ASN1_TIME_AFTER.data, VALID_ASN1_TIME_STRING_UTC_LEN));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     STRICT_EXPECTED_CALL(mocked_X509_get_notAfter(TEST_X509));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_gmtime_adj(&TEST_ASN1_TIME_AFTER, TEST_UTC_TIME_FROM_ASN1));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     if (cert_type == CERTIFICATE_TYPE_CA)
     {
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_new()).SetReturn(&TEST_CA_BASIC_CONSTRAINTS);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(ASN1_INTEGER_new());
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(ASN1_INTEGER_set(TEST_ASN1_INTEGER, TEST_PATH_LEN_CA));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(X509_add1_ext_i2d(TEST_X509, NID_basic_constraints, &TEST_CA_BASIC_CONSTRAINTS, 1, X509V3_ADD_DEFAULT));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_free(&TEST_CA_BASIC_CONSTRAINTS));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
     else
     {
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_new()).SetReturn(&TEST_NON_CA_BASIC_CONSTRAINTS);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(X509_add1_ext_i2d(TEST_X509, NID_basic_constraints, &TEST_NON_CA_BASIC_CONSTRAINTS, 0, X509V3_ADD_DEFAULT));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_free(&TEST_NON_CA_BASIC_CONSTRAINTS));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
     if (cert_type == CERTIFICATE_TYPE_CA)
     {
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, digitalSignature, keyCertSign"));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1487,22 +1487,22 @@ static void test_helper_cert_create_with_subject
     else if (cert_type == CERTIFICATE_TYPE_CLIENT)
     {
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment"));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
         i++;
 
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_ext_key_usage, "clientAuth"));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1511,22 +1511,22 @@ static void test_helper_cert_create_with_subject
     else
     {
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment, keyAgreement"));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
         i++;
 
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_ext_key_usage, "serverAuth"));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1539,11 +1539,11 @@ static void test_helper_cert_create_with_subject
     for (size_t san_idx = 0; san_idx < TEST_NUM_SAN_ENTRIES; san_idx++)
     {
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_subject_alt_name, (char*)TEST_SAN_ENTRIES[san_idx]));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1556,7 +1556,7 @@ static void test_helper_cert_create_with_subject
         issuer_subject = TEST_X509_SUBJECT_ISSUER_NAME;
 
         STRICT_EXPECTED_CALL(X509_get_subject_name(TEST_ISSUER_X509)).SetReturn(issuer_subject);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     else
@@ -1565,128 +1565,128 @@ static void test_helper_cert_create_with_subject
     }
 
     STRICT_EXPECTED_CALL(X509_get_subject_name(TEST_X509));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     const char *country = TEST_PROPS_COUNTRY_NAME_DEFLT;
     if (set_return_subject != NULL) country = set_return_subject->country_name;
     STRICT_EXPECTED_CALL(get_country_name(TEST_CERT_PROPS_HANDLE)).SetReturn(country);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (country == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_countryName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (country != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "C", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     const char *state = TEST_PROPS_STATE_NAME_DEFLT;
     if (set_return_subject != NULL) state = set_return_subject->state_name;
     STRICT_EXPECTED_CALL(get_state_name(TEST_CERT_PROPS_HANDLE)).SetReturn(state);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (state == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_stateOrProvinceName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (state != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "ST", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     const char *locality = TEST_PROPS_LOCALITY_NAME_DEFLT;
     if (set_return_subject != NULL) locality = set_return_subject->locality_name;
     STRICT_EXPECTED_CALL(get_locality(TEST_CERT_PROPS_HANDLE)).SetReturn(locality);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (locality == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_localityName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (locality != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "L", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     const char *organization = TEST_PROPS_ORG_NAME_DEFLT;
     if (set_return_subject != NULL) organization = set_return_subject->organization_name;
     STRICT_EXPECTED_CALL(get_organization_name(TEST_CERT_PROPS_HANDLE)).SetReturn(organization);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (organization == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_organizationName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (organization != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "O", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     const char *organization_unit = TEST_PROPS_ORG_UNIT_NAME_DEFLT;
     if (set_return_subject != NULL) organization_unit = set_return_subject->organization_unit_name;
     STRICT_EXPECTED_CALL(get_organization_unit(TEST_CERT_PROPS_HANDLE)).SetReturn(organization_unit);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (organization_unit == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_organizationalUnitName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (organization_unit != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "OU", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "CN", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_set_issuer_name(TEST_X509, issuer_subject));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     // subject key identifier
     STRICT_EXPECTED_CALL(X509V3_set_ctx(IGNORED_PTR_ARG, NULL, TEST_X509, NULL, NULL, 0));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, IGNORED_PTR_ARG, NID_subject_key_identifier, "hash"));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1696,108 +1696,108 @@ static void test_helper_cert_create_with_subject
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(X509V3_set_ctx(IGNORED_PTR_ARG, TEST_ISSUER_X509, TEST_X509, NULL, NULL, 0));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
     else
     {
         STRICT_EXPECTED_CALL(X509V3_set_ctx(IGNORED_PTR_ARG, TEST_X509, TEST_X509, NULL, NULL, 0));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, IGNORED_PTR_ARG, NID_authority_key_identifier, "issuer:always,keyid:always"));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
     i++;
 
     EXPECTED_CALL(EVP_sha256());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(X509_sign(TEST_X509, TEST_ISSUER_EVP_KEY, TEST_EVP_SHA256_MD));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     else
     {
         STRICT_EXPECTED_CALL(X509_sign(TEST_X509, TEST_EVP_KEY, TEST_EVP_SHA256_MD));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (test_helper_is_windows())
     {
         STRICT_EXPECTED_CALL(BIO_new_file(TEST_CERT_FILE, "w")).SetReturn(TEST_BIO_WRITE_CERT);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     else
     {
         STRICT_EXPECTED_CALL(mocked_OPEN(TEST_CERT_FILE, EXPECTED_CREATE_FLAGS, EXPECTED_MODE_FLAGS)).SetReturn(TEST_WRITE_CERTIFICATE_FD);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BIO_new_fd(TEST_WRITE_CERTIFICATE_FD, 0)).SetReturn(TEST_BIO_WRITE_CERT);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     STRICT_EXPECTED_CALL(PEM_write_bio_X509(TEST_BIO_WRITE_CERT, TEST_X509));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(read_file_into_buffer(TEST_ISSUER_CERT_FILE, IGNORED_PTR_ARG));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         int cert_data_size = (int)(strlen(TEST_ISSUER_CERT_DATA)) + 1;
         STRICT_EXPECTED_CALL(BIO_write(TEST_BIO_WRITE_CERT, IGNORED_PTR_ARG, cert_data_size)).SetReturn(cert_data_size);
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO_WRITE_CERT));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if (!test_helper_is_windows())
     {
         STRICT_EXPECTED_CALL(mocked_CLOSE(TEST_WRITE_CERTIFICATE_FD));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(X509_free(TEST_X509));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(EVP_PKEY_free(TEST_EVP_KEY));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(X509_free(TEST_ISSUER_X509));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(EVP_PKEY_free(TEST_ISSUER_EVP_KEY));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 }
@@ -1828,15 +1828,15 @@ static void test_helper_load_cert_file
     size_t i = *index;
 
     STRICT_EXPECTED_CALL(BIO_new_file(file, "r"));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(PEM_read_bio_X509(TEST_BIO, NULL, NULL, NULL)).SetReturn(set_return);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     *index = i;
@@ -1854,57 +1854,57 @@ static void test_helper_verify_certificate
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(initialize_openssl());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(read_file_into_cstring(params->cert_file, NULL));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(read_file_into_cstring(params->issuer_cert_file, NULL));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_new());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(X509_LOOKUP_file());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_add_lookup(TEST_X509_STORE, TEST_X509_LOOKUP_METHOD_FILE)).SetReturn(TEST_X509_LOOKUP_LOAD_FILE);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_LOOKUP_ctrl(TEST_X509_LOOKUP_LOAD_FILE, IGNORED_NUM_ARG, params->issuer_cert_file, X509_FILETYPE_PEM, NULL));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(X509_LOOKUP_hash_dir());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_add_lookup(TEST_X509_STORE, TEST_X509_LOOKUP_METHOD_HASH)).SetReturn(TEST_X509_LOOKUP_LOAD_HASH);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_LOOKUP_ctrl(TEST_X509_LOOKUP_LOAD_HASH, IGNORED_NUM_ARG, NULL, X509_FILETYPE_DEFAULT, NULL));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     test_helper_load_cert_file(TEST_CERT_FILE, TEST_X509, &i, failed_function_list, failed_function_size);
 
     STRICT_EXPECTED_CALL(X509_STORE_CTX_new());
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     unsigned long policy = X509_V_FLAG_X509_STRICT |
@@ -1912,53 +1912,53 @@ static void test_helper_verify_certificate
                            X509_V_FLAG_POLICY_CHECK;
 
     STRICT_EXPECTED_CALL(X509_STORE_set_flags(TEST_X509_STORE, policy));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_CTX_init(TEST_STORE_CTXT, TEST_X509_STORE, TEST_X509, 0));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     ASN1_TIME *asn1_time = (params->force_set_asn1_time != NULL) ? params->force_set_asn1_time : &TEST_ASN1_TIME_AFTER;
     STRICT_EXPECTED_CALL(mocked_X509_get_notAfter(TEST_X509)).SetReturn(asn1_time);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(get_utc_time_from_asn_string(asn1_time->data, VALID_ASN1_TIME_STRING_UTC_LEN));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     int skid_nid_lookup = params->skid_set ? 1 : -1;
     STRICT_EXPECTED_CALL(X509_get_ext_by_NID(TEST_X509, NID_subject_key_identifier, -1)).SetReturn(skid_nid_lookup);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     int return_value = (params->force_set_verify_return_value)?1:0;
     STRICT_EXPECTED_CALL(X509_verify_cert(TEST_STORE_CTXT)).SetReturn(return_value);
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     if(!params->force_set_verify_return_value)
     {
         STRICT_EXPECTED_CALL(X509_STORE_CTX_get_error(TEST_STORE_CTXT));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_verify_cert_error_string(TEST_ERROR_CODE));
-        ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(X509_STORE_CTX_free(TEST_STORE_CTXT));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_free(TEST_X509));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_free(TEST_X509_STORE));
-    ASSERT_IS_TRUE_WITH_MSG((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 }
 
@@ -2250,22 +2250,22 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
 
         // act, assert
         status = generate_pki_cert_and_key(NULL, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, NULL, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, NULL, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, NULL, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, -1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2285,7 +2285,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2305,7 +2305,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2325,7 +2325,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2345,7 +2345,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2368,8 +2368,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2401,7 +2401,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -2427,8 +2427,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2460,7 +2460,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -2486,8 +2486,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2519,7 +2519,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -2545,8 +2545,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2578,7 +2578,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -2604,8 +2604,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2637,7 +2637,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -2663,8 +2663,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2696,7 +2696,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -2716,22 +2716,22 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
 
         // act, assert
         status = generate_pki_cert_and_key_with_props(NULL, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, NULL, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, NULL, &TEST_VALID_KEY_PROPS_RSA);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &INVALID_KEY_PROPS);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, -1, TEST_KEY_FILE, TEST_CERT_FILE, &INVALID_KEY_PROPS);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2751,7 +2751,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, -1, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2771,7 +2771,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2791,7 +2791,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2811,7 +2811,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, -1, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2833,8 +2833,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2867,7 +2867,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -2892,8 +2892,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2926,7 +2926,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -2951,8 +2951,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2985,7 +2985,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -3010,8 +3010,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3044,7 +3044,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -3069,8 +3069,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3103,7 +3103,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -3128,8 +3128,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3162,7 +3162,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             }
         }
 
@@ -3183,21 +3183,21 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         // act, assert
         verify_status = true;
         status = verify_certificate(NULL, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
 
         verify_status = true;
         status = verify_certificate(TEST_CERT_FILE, NULL, TEST_ISSUER_CERT_FILE, &verify_status);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
 
         verify_status = true;
         status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, NULL, &verify_status);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
 
         status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3228,9 +3228,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_TRUE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3254,9 +3254,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_BAD_CHAIN_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3287,9 +3287,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3320,8 +3320,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3352,8 +3352,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3395,8 +3395,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-                ASSERT_IS_FALSE_WITH_MSG(verify_status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
             }
         }
 

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_certificate_props_ut/hsm_certificate_props_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_certificate_props_ut/hsm_certificate_props_ut.c
@@ -759,21 +759,21 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // invalid handle
         status = set_validity_seconds(NULL, test_validity_value);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 1, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 1, status, "Line:" TOSTRING(__LINE__));
         validity = get_validity_seconds(NULL);
-        ASSERT_ARE_EQUAL_WITH_MSG(uint64_t, 0, validity, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(uint64_t, 0, validity, "Line:" TOSTRING(__LINE__));
 
         // invalid input data
         status = set_validity_seconds(props_handle, 0);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         validity = get_validity_seconds(props_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(uint64_t, 0, validity, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(uint64_t, 0, validity, "Line:" TOSTRING(__LINE__));
 
         // valid input data
         status = set_validity_seconds(props_handle, test_validity_value);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         validity = get_validity_seconds(props_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(uint64_t, test_validity_value, validity, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(uint64_t, test_validity_value, validity, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -796,35 +796,35 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_state_name(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid handle
         status = set_common_name(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_common_name(NULL);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_common_name(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_common_name(props_handle, TEST_STRING_65);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_common_name(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_common_name(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // valid input data
         status = set_common_name(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_common_name(props_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid input for get_common_name
         status = set_common_name(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_common_name(NULL);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -847,29 +847,29 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_state_name(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid handle
         status = set_state_name(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_state_name(NULL);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_state_name(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_state_name(props_handle, TEST_STRING_129);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_state_name(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_state_name(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // valid input data
         status = set_state_name(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_state_name(props_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -892,29 +892,29 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_locality(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid handle
         status = set_locality(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_locality(NULL);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_locality(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_locality(props_handle, TEST_STRING_129);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_locality(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_locality(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // valid input data
         status = set_locality(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_locality(props_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -937,29 +937,29 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_organization_name(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid handle
         status = set_organization_name(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_organization_name(NULL);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_organization_name(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_organization_name(props_handle, TEST_STRING_65);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_organization_name(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_organization_name(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // valid input data
         status = set_organization_name(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_organization_name(props_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -982,29 +982,29 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_organization_unit(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid handle
         status = set_organization_unit(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_organization_unit(NULL);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_organization_unit(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_organization_unit(props_handle, TEST_STRING_65);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         status = set_organization_unit(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_organization_unit(props_handle);
-        ASSERT_IS_NULL_WITH_MSG(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
 
         // valid input data
         status = set_organization_unit(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         test_output_string = get_organization_unit(props_handle);
-        ASSERT_ARE_EQUAL_WITH_MSG(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -1024,12 +1024,12 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // act 1, assert
         test_output = get_san_entries(NULL, &num_entries);
-        ASSERT_IS_NULL_WITH_MSG(test_output, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
 
         // act 2, assert
         test_output = get_san_entries(props_handle, NULL);
-        ASSERT_IS_NULL_WITH_MSG(test_output, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -1051,8 +1051,8 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
         test_output = get_san_entries(props_handle, &num_entries);
 
         // assert
-        ASSERT_IS_NULL_WITH_MSG(test_output, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -1082,11 +1082,11 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // act 1, assert
         status = set_san_entries(props_handle, san_list_1, san_list_size_1);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         num_entries = 10;
         test_output = get_san_entries(props_handle, &num_entries);
-        ASSERT_IS_NOT_NULL_WITH_MSG(test_output, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, san_list_size_1, num_entries, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, san_list_size_1, num_entries, "Line:" TOSTRING(__LINE__));
         num_matched = 0;
         for (size_t i = 0; i < san_list_size_1; i++)
         {
@@ -1099,15 +1099,15 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
                 }
             }
         }
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, san_list_size_1, num_matched, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, san_list_size_1, num_matched, "Line:" TOSTRING(__LINE__));
 
         // act 2, assert
         status = set_san_entries(props_handle, san_list_2, san_list_size_2);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         num_entries = 10;
         test_output = get_san_entries(props_handle, &num_entries);
-        ASSERT_IS_NOT_NULL_WITH_MSG(test_output, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, san_list_size_2, num_entries, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, san_list_size_2, num_entries, "Line:" TOSTRING(__LINE__));
         num_matched = 0;
         for (size_t i = 0; i < san_list_size_2; i++)
         {
@@ -1120,7 +1120,7 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
                 }
             }
         }
-        ASSERT_ARE_EQUAL_WITH_MSG(size_t, san_list_size_2, num_matched, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, san_list_size_2, num_matched, "Line:" TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -1164,10 +1164,10 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
             int status = set_san_entries(props_handle, san_list, num_san_entries);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
             test_output = get_san_entries(props_handle, &num_entries);
-            ASSERT_IS_NULL_WITH_MSG(test_output, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
         }
 
         //cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
@@ -76,7 +76,7 @@ static TPM_HANDLE my_TSS_CreatePersistentKey(TSS_DEVICE* tpm_device, TPM_HANDLE 
     (void)sess;
     (void)hierarchy;
     (void)inPub;
-    
+
     (*outPub).publicArea.unique.rsa.t.size = g_rsa_size;
     return (TPM_HANDLE)0x1;
 }
@@ -102,7 +102,7 @@ static int my_mallocAndStrcpy_s(char** destination, const char* source)
     return 0;
 }
 
-static int my_perform_sign_with_key( const unsigned char* key, size_t key_len, 
+static int my_perform_sign_with_key( const unsigned char* key, size_t key_len,
                                      const unsigned char* data_to_be_signed, size_t data_to_be_signed_size,
                                      unsigned char** digest, size_t* digest_size)
 {
@@ -223,7 +223,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
 
         REGISTER_GLOBAL_MOCK_HOOK(Base64_Encode_Bytes, my_Base64_Encode_Bytes);
         REGISTER_GLOBAL_MOCK_FAIL_RETURN(Base64_Encode_Bytes, NULL);
-        
+
         REGISTER_GLOBAL_MOCK_HOOK(gballoc_malloc, my_gballoc_malloc);
         REGISTER_GLOBAL_MOCK_FAIL_RETURN(gballoc_malloc, NULL);
         REGISTER_GLOBAL_MOCK_HOOK(gballoc_free, my_gballoc_free);
@@ -402,7 +402,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             HSM_CLIENT_HANDLE sec_handle = tpm_if->hsm_client_tpm_create();
 
             //assert
-            ASSERT_IS_NULL_WITH_MSG(sec_handle, tmp_msg);
+            ASSERT_IS_NULL(sec_handle, tmp_msg);
         }
 
         //cleanup
@@ -511,7 +511,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             int import_res = tpm_if->hsm_client_activate_identity_key(sec_handle, TEST_IMPORT_KEY, TEST_KEY_SIZE);
 
             //assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, import_res, tmp_msg);
+            ASSERT_ARE_NOT_EQUAL(int, 0, import_res, tmp_msg);
         }
         //cleanup
         tpm_if->hsm_client_tpm_destroy(sec_handle);
@@ -607,7 +607,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             int result = tpm_if->hsm_client_get_ek(sec_handle, &key, &key_len);
 
             //assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, tmp_msg);
+            ASSERT_ARE_NOT_EQUAL(int, 0, result, tmp_msg);
         }
         //cleanup
         tpm_if->hsm_client_tpm_destroy(sec_handle);
@@ -708,7 +708,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             int result = tpm_if->hsm_client_get_srk(sec_handle, &key, &key_len);
 
             //assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, tmp_msg);
+            ASSERT_ARE_NOT_EQUAL(int, 0, result, tmp_msg);
         }
 
         //cleanup
@@ -870,7 +870,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             int result = tpm_if->hsm_client_sign_with_identity(NULL, TEST_BUFFER, TEST_BUFFER_SIZE, &key, &key_len);
 
             //assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, tmp_msg);
+            ASSERT_ARE_NOT_EQUAL(int, 0, result, tmp_msg);
         }
 
         //cleanup
@@ -911,7 +911,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
 
         //act
         const HSM_CLIENT_TPM_INTERFACE* tpm_if = hsm_client_tpm_device_interface();
-        int result = tpm_if->hsm_client_derive_and_sign_with_identity(NULL, TEST_BUFFER, TEST_BUFFER_SIZE, 
+        int result = tpm_if->hsm_client_derive_and_sign_with_identity(NULL, TEST_BUFFER, TEST_BUFFER_SIZE,
                 IDENTITY_BUFFER, IDENTITY_BUFFER_SIZE, &key, &key_len);
 
         //assert
@@ -932,7 +932,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         umock_c_reset_all_calls();
 
         //act
-        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, NULL, TEST_BUFFER_SIZE, 
+        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, NULL, TEST_BUFFER_SIZE,
                 IDENTITY_BUFFER, IDENTITY_BUFFER_SIZE, &key, &key_len);
 
         //assert
@@ -954,7 +954,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         umock_c_reset_all_calls();
 
         //act
-        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, 0, 
+        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, 0,
                 IDENTITY_BUFFER, IDENTITY_BUFFER_SIZE, &key, &key_len);
 
         //assert
@@ -976,7 +976,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         umock_c_reset_all_calls();
 
         //act
-        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, TEST_BUFFER_SIZE, 
+        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, TEST_BUFFER_SIZE,
                 NULL, IDENTITY_BUFFER_SIZE, &key, &key_len);
 
         //assert
@@ -1019,7 +1019,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         umock_c_reset_all_calls();
 
         //act
-        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, TEST_BUFFER_SIZE, 
+        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, TEST_BUFFER_SIZE,
                 IDENTITY_BUFFER, IDENTITY_BUFFER_SIZE, NULL, &key_len);
 
         //assert
@@ -1040,7 +1040,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         umock_c_reset_all_calls();
 
         //act
-        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, TEST_BUFFER_SIZE, 
+        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, TEST_BUFFER_SIZE,
                 IDENTITY_BUFFER, IDENTITY_BUFFER_SIZE, &key, NULL);
 
         //assert
@@ -1078,11 +1078,11 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             sprintf(tmp_msg, "hsm_client_derive_and_sign_with_identity failure in test %zu/%zu", index, count);
 
             //act
-            int result = tpm_if->hsm_client_derive_and_sign_with_identity(NULL, TEST_BUFFER, TEST_BUFFER_SIZE, 
+            int result = tpm_if->hsm_client_derive_and_sign_with_identity(NULL, TEST_BUFFER, TEST_BUFFER_SIZE,
                     IDENTITY_BUFFER, IDENTITY_BUFFER_SIZE, &key, &key_len);
 
             //assert
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, 0, result, tmp_msg);
+            ASSERT_ARE_NOT_EQUAL(int, 0, result, tmp_msg);
         }
 
         //cleanup
@@ -1104,7 +1104,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         STRICT_EXPECTED_CALL(perform_sign_with_key(IGNORED_PTR_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
 
         //act
-        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, TEST_BUFFER_SIZE, 
+        int result = tpm_if->hsm_client_derive_and_sign_with_identity(sec_handle, TEST_BUFFER, TEST_BUFFER_SIZE,
                 IDENTITY_BUFFER, IDENTITY_BUFFER_SIZE, &key, &key_len);
 
         //assert
@@ -1128,7 +1128,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
         // cleanup
     }
-    
+
     TEST_FUNCTION(hsm_client_tpm_free_buffer_frees_something)
     {
         // arrange

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_tpm_select_ut/hspm_client_tpm_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_tpm_select_ut/hspm_client_tpm_ut.c
@@ -47,8 +47,8 @@ extern const char* const ENV_TPM_SELECT;
 static void test_helper_setup_homedir(void)
 {
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL_WITH_MSG(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
@@ -70,7 +70,7 @@ static void test_helper_teardown_homedir(void)
 const HSM_CLIENT_TPM_INTERFACE * init_get_if_deinit(void)
 {
     int status;
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
     const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
     hsm_client_tpm_deinit();
     return interface;
@@ -122,15 +122,15 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
                                                "false", "FALSE", "False" };
         int array_size = sizeof(user_says_no)/sizeof(user_says_no[0]);
         int status = hsm_test_util_unsetenv(ENV_TPM_SELECT);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         const HSM_CLIENT_TPM_INTERFACE * no_tpm =  init_get_if_deinit();
         // act
         // assert
         for(int no = 0; no < array_size; no++)
         {
             int status = hsm_test_util_setenv(ENV_TPM_SELECT, user_says_no[no]);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL_WITH_MSG(const HSM_CLIENT_TPM_INTERFACE *,
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(const HSM_CLIENT_TPM_INTERFACE *,
                                       no_tpm, init_get_if_deinit(),
                                       "Line:" TOSTRING(__LINE__));
         }
@@ -147,15 +147,15 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
                                                 "plugh" };
         int array_size = sizeof(user_says_yes)/sizeof(user_says_yes[0]);
         int status = hsm_test_util_unsetenv(ENV_TPM_SELECT);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
         const HSM_CLIENT_TPM_INTERFACE * no_tpm =  init_get_if_deinit();
         // act
         // assert
         for(int yes = 0; yes < array_size; yes++)
         {
             int status = hsm_test_util_setenv(ENV_TPM_SELECT, user_says_yes[yes]);
-            ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_NOT_EQUAL_WITH_MSG(const HSM_CLIENT_TPM_INTERFACE *,
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(const HSM_CLIENT_TPM_INTERFACE *,
                                           no_tpm, init_get_if_deinit(),
                                           "Line:" TOSTRING(__LINE__));
         }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/test_utils/test_utils.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/test_utils/test_utils.c
@@ -36,11 +36,11 @@ static char* get_temp_base_dir(void)
 
 #if (defined __WINDOWS__ || defined _WIN32 || defined _WIN64 || defined _Windows)
     DWORD count = GetTempPathA(MAX_FILE_NAME_SIZE, result);
-    ASSERT_IS_TRUE_WITH_MSG(count < MAX_FILE_NAME_SIZE, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(count < MAX_FILE_NAME_SIZE, "TestUtil Line:" TOSTRING(__LINE__));
 #else
     strcpy_s(result, MAX_FILE_NAME_SIZE, "/tmp/");
 #endif
-    ASSERT_ARE_NOT_EQUAL_WITH_MSG(size_t, 0, strlen(result), "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_NOT_EQUAL(size_t, 0, strlen(result), "TestUtil Line:" TOSTRING(__LINE__));
 
     return result;
 }
@@ -87,9 +87,9 @@ char *create_temp_dir_path(const char *dir_guid)
 
     tmp_dir = get_temp_base_dir();
     dir_path = calloc(MAX_FILE_NAME_SIZE, 1);
-    ASSERT_IS_NOT_NULL_WITH_MSG(dir_path, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(dir_path, "TestUtil Line:" TOSTRING(__LINE__));
     status = snprintf(dir_path, MAX_FILE_NAME_SIZE, "%shsm_test_%s", tmp_dir, dir_guid);
-    ASSERT_IS_TRUE_WITH_MSG(((status > 0) || (status < MAX_FILE_NAME_SIZE)), "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < MAX_FILE_NAME_SIZE)), "TestUtil Line:" TOSTRING(__LINE__));
     free(tmp_dir);
 
     return dir_path;
@@ -100,17 +100,17 @@ char* hsm_test_util_create_temp_dir(char **dir_guid)
     char *dir_path, *guid;
     int status, attempt = 0, dir_made = 0;
 
-    ASSERT_IS_NOT_NULL_WITH_MSG(dir_guid, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(dir_guid, "TestUtil Line:" TOSTRING(__LINE__));
     guid = (char*)malloc(UID_SIZE);
-    ASSERT_IS_NOT_NULL_WITH_MSG(guid, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(guid, "TestUtil Line:" TOSTRING(__LINE__));
     do
     {
         memset(guid, 0, UID_SIZE);
         status = UniqueId_Generate(guid, UID_SIZE);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, UNIQUEID_OK, status, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, UNIQUEID_OK, status, "TestUtil Line:" TOSTRING(__LINE__));
         dir_path = create_temp_dir_path(guid);
         status = make_test_dir(dir_path);
-        ASSERT_ARE_NOT_EQUAL_WITH_MSG(int, CREATE_DIR_ERROR, status, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, CREATE_DIR_ERROR, status, "TestUtil Line:" TOSTRING(__LINE__));
         if (status == CREATE_DIR_EXISTS)
         {
             free(dir_path);
@@ -123,7 +123,7 @@ char* hsm_test_util_create_temp_dir(char **dir_guid)
         }
     } while (++attempt < MAX_ATTEMPTS);
 
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 1, dir_made, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 1, dir_made, "TestUtil Line:" TOSTRING(__LINE__));
 
     *dir_guid = guid;
 
@@ -134,7 +134,7 @@ void hsm_test_util_delete_dir(const char *dir_guid)
 {
     int status;
 
-    ASSERT_IS_NOT_NULL_WITH_MSG(dir_guid, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(dir_guid, "TestUtil Line:" TOSTRING(__LINE__));
     char *dir_path = create_temp_dir_path(dir_guid);
     printf("Deleting temp directory '%s'.\r\n", dir_path);
 
@@ -153,14 +153,14 @@ void hsm_test_util_delete_dir(const char *dir_guid)
     const char *cmd_prefix = "rm -fr ";
     size_t cmd_size = strlen(cmd_prefix) + MAX_FILE_NAME_SIZE + 1;
     char *cmd = calloc(cmd_size, 1);
-    ASSERT_IS_NOT_NULL_WITH_MSG(cmd, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cmd, "TestUtil Line:" TOSTRING(__LINE__));
     status = snprintf(cmd, cmd_size, "%s%s", cmd_prefix, dir_path);
-    ASSERT_IS_TRUE_WITH_MSG(((status > 0) || (status < (int)cmd_size)), "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < (int)cmd_size)), "TestUtil Line:" TOSTRING(__LINE__));
     printf("Deleting directory using command '%s'.\r\n", cmd);
     status = system(cmd);
     free(cmd);
 #endif
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
     free(dir_path);
 }
 
@@ -171,12 +171,12 @@ void hsm_test_util_setenv(const char *key, const char *value)
     #else
         int status = setenv(key, value, 1);
     #endif
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
     const char *retrieved_value = getenv(key);
     if (retrieved_value != NULL)
     {
         int cmp = strcmp(retrieved_value, value);
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, cmp, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "TestUtil Line:" TOSTRING(__LINE__));
     }
 }
 
@@ -184,15 +184,15 @@ void hsm_test_util_unsetenv(const char *key)
 {
     #if defined __WINDOWS__ || defined _WIN32 || defined _WIN64 || defined _Windows
         STRING_HANDLE key_handle = STRING_construct(key);
-        ASSERT_IS_NOT_NULL_WITH_MSG(key_handle, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "TestUtil Line:" TOSTRING(__LINE__));
         int ret_val = STRING_concat(key_handle, "=");
-        ASSERT_ARE_EQUAL_WITH_MSG(int, 0, ret_val, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, ret_val, "TestUtil Line:" TOSTRING(__LINE__));
         errno_t status = _putenv(STRING_c_str(key_handle));
         STRING_delete(key_handle);
     #else
         int status = unsetenv(key);
     #endif
-    ASSERT_ARE_EQUAL_WITH_MSG(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
     const char *retrieved_value = getenv(key);
-    ASSERT_IS_NULL_WITH_MSG(retrieved_value, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NULL(retrieved_value, "TestUtil Line:" TOSTRING(__LINE__));
 }


### PR DESCRIPTION
As part of the submodule update, the ctest macros ASSERT_ARE_EQUAL_WITH_MSG and its variants were removed. The code changes here are relegated to test files only and are essentially a bulk search replace operation.