### PR TITLE
EdgeHub: Update logs when failing to parse token

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -221,7 +221,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
 
             public static void ErrorParsingToken(IIdentity identity, Exception exception)
             {
-                Log.LogWarning((int)EventIds.ErrorParsingToken, exception, $"Error authenticating token for {identity.Id} because the token could not be parsed");
+                Log.LogInformation((int)EventIds.ErrorParsingToken, $"Error authenticating token for {identity.Id} because the token is expired or could not be parsed");
+                Log.LogDebug((int)EventIds.ErrorParsingToken, exception, $"Error parsing token for {identity.Id}");
             }
         }
     }


### PR DESCRIPTION
Log the exception when parsing a client token fails only in debug mode. This is to avoid exceptions show up in EdgeHub logs during normal operations.

Fixes #676 