### PR TITLE
Fix ARM linux package builds

### DIFF
--- a/edgelet/build/linux/centos/aarch64/package-libiothsm.sh
+++ b/edgelet/build/linux/centos/aarch64/package-libiothsm.sh
@@ -47,6 +47,6 @@ run_command()
 }
 
 mkdir -p $BUILD_DIR
-run_command "cd /$BUILD_DIR_REL && cmake -DCMAKE_SYSROOT=/toolchain//${TOOLCHAIN}/libc -DCMAKE_C_COMPILER=/toolchain/bin//${TOOLCHAIN}-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin//${TOOLCHAIN}-g++ -DCMAKE_SYSTEM_NAME=Linux -DCPACK_RPM_PACKAGE_ARCHITECTURE=aarch64 -DCPACK_PACKAGE_VERSION=\"$RPM_VERSION\" -DCPACK_RPM_PACKAGE_RELEASE=\"$RPM_RELEASE\" -DBUILD_SHARED=On -Drun_unittests=Off -Duse_emulator=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On -Duse_http=Off -DCPACK_GENERATOR=RPM /project/hsm-sys/azure-iot-hsm-c/"
+run_command "cd /$BUILD_DIR_REL && cmake -DCMAKE_SYSROOT=/toolchain//${TOOLCHAIN}/libc -DCMAKE_C_COMPILER=/toolchain/bin//${TOOLCHAIN}-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin//${TOOLCHAIN}-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCPACK_RPM_PACKAGE_ARCHITECTURE=aarch64 -DCPACK_PACKAGE_VERSION=\"$RPM_VERSION\" -DCPACK_RPM_PACKAGE_RELEASE=\"$RPM_RELEASE\" -DBUILD_SHARED=On -Drun_unittests=Off -Duse_emulator=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On -Duse_http=Off -DCPACK_GENERATOR=RPM /project/hsm-sys/azure-iot-hsm-c/"
 
 run_command "cd /$BUILD_DIR_REL && make package"

--- a/edgelet/build/linux/centos/arm32v7/package-libiothsm.sh
+++ b/edgelet/build/linux/centos/arm32v7/package-libiothsm.sh
@@ -45,6 +45,6 @@ run_command()
 }
 
 mkdir -p $BUILD_DIR
-run_command "cd /$BUILD_DIR_REL && cmake -DCMAKE_SYSROOT=/toolchain/arm-linux-gnueabihf/libc -DCMAKE_C_COMPILER=/toolchain/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCPACK_RPM_PACKAGE_ARCHITECTURE=armv7hl -DCPACK_PACKAGE_VERSION=\"$RPM_VERSION\" -DCPACK_RPM_PACKAGE_RELEASE=\"$RPM_RELEASE\" -DBUILD_SHARED=On -Drun_unittests=Off -Duse_emulator=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On -Duse_http=Off -DCPACK_GENERATOR=RPM /project/hsm-sys/azure-iot-hsm-c/"
+run_command "cd /$BUILD_DIR_REL && cmake -DCMAKE_SYSROOT=/toolchain/arm-linux-gnueabihf/libc -DCMAKE_C_COMPILER=/toolchain/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCPACK_RPM_PACKAGE_ARCHITECTURE=armv7hl -DCPACK_PACKAGE_VERSION=\"$RPM_VERSION\" -DCPACK_RPM_PACKAGE_RELEASE=\"$RPM_RELEASE\" -DBUILD_SHARED=On -Drun_unittests=Off -Duse_emulator=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On -Duse_http=Off -DCPACK_GENERATOR=RPM /project/hsm-sys/azure-iot-hsm-c/"
 
 run_command "cd /$BUILD_DIR_REL && make package"

--- a/edgelet/build/linux/debian/arm32v7/package-libiothsm.sh
+++ b/edgelet/build/linux/debian/arm32v7/package-libiothsm.sh
@@ -36,7 +36,7 @@ run_command()
 
 mkdir -p $BUILD_DIR
 
-run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/arm-linux-gnueabihf/libc -DCMAKE_C_COMPILER=/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/bin/arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=armhf -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On -Duse_http=Off /project/hsm-sys/azure-iot-hsm-c/"
+run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/arm-linux-gnueabihf/libc -DCMAKE_C_COMPILER=/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/bin/arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=armhf -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On -Duse_http=Off /project/hsm-sys/azure-iot-hsm-c/"
 
 run_command "cd /target/hsm/build && make package"
 

--- a/edgelet/build/linux/debian8/aarch64/package-libiothsm.sh
+++ b/edgelet/build/linux/debian8/aarch64/package-libiothsm.sh
@@ -35,7 +35,7 @@ run_command()
 }
 
 mkdir -p $BUILD_DIR
-run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/aarch64-linux-gnu/libc -DCMAKE_C_COMPILER=/toolchain/bin/aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
+run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/aarch64-linux-gnu/libc -DCMAKE_C_COMPILER=/toolchain/bin/aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
 
 run_command "cd /target/hsm/build && make package"
 

--- a/edgelet/build/linux/debian8/arm32v7/package-libiothsm.sh
+++ b/edgelet/build/linux/debian8/arm32v7/package-libiothsm.sh
@@ -35,7 +35,7 @@ run_command()
 }
 
 mkdir -p $BUILD_DIR
-run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/arm-linux-gnueabihf/libc -DCMAKE_C_COMPILER=/toolchain/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=armhf -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
+run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/arm-linux-gnueabihf/libc -DCMAKE_C_COMPILER=/toolchain/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=armhf -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
 
 run_command "cd /target/hsm/build && make package"
 

--- a/edgelet/build/linux/debian9/aarch64/package-libiothsm.sh
+++ b/edgelet/build/linux/debian9/aarch64/package-libiothsm.sh
@@ -35,7 +35,7 @@ run_command()
 }
 
 mkdir -p $BUILD_DIR
-run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/aarch64-linux-gnu/libc -DCMAKE_C_COMPILER=/toolchain/bin/aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
+run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/aarch64-linux-gnu/libc -DCMAKE_C_COMPILER=/toolchain/bin/aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
 
 run_command "cd /target/hsm/build && make package"
 

--- a/edgelet/build/linux/debian9/arm32v7/package-libiothsm.sh
+++ b/edgelet/build/linux/debian9/arm32v7/package-libiothsm.sh
@@ -35,7 +35,7 @@ run_command()
 }
 
 mkdir -p $BUILD_DIR
-run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/arm-linux-gnueabihf/libc -DCMAKE_C_COMPILER=/toolchain/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=armhf -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
+run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/arm-linux-gnueabihf/libc -DCMAKE_C_COMPILER=/toolchain/bin/arm-linux-gnueabihf-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/arm-linux-gnueabihf-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=armhf -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
 
 run_command "cd /target/hsm/build && make package"
 

--- a/edgelet/build/linux/ubuntu16.04/aarch64/package-libiothsm.sh
+++ b/edgelet/build/linux/ubuntu16.04/aarch64/package-libiothsm.sh
@@ -35,7 +35,7 @@ run_command()
 }
 
 mkdir -p $BUILD_DIR
-run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/aarch64-linux-gnu/libc -DCMAKE_C_COMPILER=/toolchain/bin/aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
+run_command "cd /target/hsm/build && cmake -DCMAKE_SYSROOT=/toolchain/aarch64-linux-gnu/libc -DCMAKE_C_COMPILER=/toolchain/bin/aarch64-linux-gnu-gcc -DCMAKE_CXX_COMPILER=/toolchain/bin/aarch64-linux-gnu-g++ -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCPACK_DEBIAN_PACKAGE_ARCHITECTURE=arm64 -DCPACK_PACKAGE_VERSION=\"$VERSION\" -DBUILD_SHARED=On -Drun_unittests=On -Duse_emulator=Off -Duse_http=Off -DCMAKE_BUILD_TYPE=Release -Duse_default_uuid=On /project/hsm-sys/azure-iot-hsm-c/"
 
 run_command "cd /target/hsm/build && make package"
 


### PR DESCRIPTION
* Per CMake documentation for cross compile builds, we need to define two variables, the target OS via variable CMAKE_SYSTEM_NAME and the target OS version via variable CMAKE_SYSTEM_VERSION. Link: https://cmake.org/cmake/help/v3.4/variable/CMAKE_SYSTEM_VERSION.html

* The issue was that CMAKE_SYSTEM_NAME was defined however CMAKE_SYSTEM_VERSION was not. The fix put in place ensures that CMAKE_SYSTEM_VERSION is defined. The CMAKE_SYSTEM_NAME for linux builds is "Linux" by default and the value for CMAKE_SYSTEM_VERSION was chosen to be 1. 
**Note:** This specific configuration was observed several other cross compile projects including the Azure IoT C SDK.

