### PR TITLE
Use HTTPS proxy in Edge Agent

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EnvironmentModuleClientProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EnvironmentModuleClientProvider.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
 {
     using System;
+    using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
@@ -10,17 +11,19 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
     public class EnvironmentModuleClientProvider : IModuleClientProvider
     {
         readonly Option<UpstreamProtocol> upstreamProtocol;
+        readonly Option<IWebProxy> proxy;
         readonly Option<string> productInfo;
 
-        public EnvironmentModuleClientProvider(Option<UpstreamProtocol> upstreamProtocol, Option<string> productInfo)
+        public EnvironmentModuleClientProvider(Option<UpstreamProtocol> upstreamProtocol, Option<IWebProxy> proxy, Option<string> productInfo)
         {
             this.upstreamProtocol = upstreamProtocol;
+            this.proxy = proxy;
             this.productInfo = productInfo;
         }
 
         public Task<IModuleClient> Create(
             ConnectionStatusChangesHandler statusChangedHandler,
             Func<IModuleClient, Task> initialize) =>
-            ModuleClient.Create(Option.None<string>(), this.upstreamProtocol, statusChangedHandler, initialize, this.productInfo);
+            ModuleClient.Create(Option.None<string>(), this.upstreamProtocol, statusChangedHandler, initialize, this.proxy, this.productInfo);
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClient.cs
@@ -134,7 +134,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 }
 
                 default:
+                {
                     throw new InvalidEnumArgumentException();
+                }
             }
         }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClient.cs
@@ -136,12 +136,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             Option<string> productInfo)
         {
             ITransportSettings[] settings = { TransportMap[upstreamProtocol](proxy) };
-            Events.AttemptingConnection(settings[0].GetTransportType(), proxy);
+            Events.AttemptingConnectionWithTransport(settings[0].GetTransportType());
             Client.ModuleClient deviceClient = await connectionString.Map(cs => Task.FromResult(Client.ModuleClient.CreateFromConnectionString(cs, settings)))
                 .GetOrElse(() => Client.ModuleClient.CreateFromEnvironmentAsync(settings));
             productInfo.ForEach(p => deviceClient.ProductInfo = p);
             await OpenAsync(statusChangedHandler, deviceClient);
-            Events.Connected(settings[0].GetTransportType(), proxy);
+            Events.ConnectedWithTransport(settings[0].GetTransportType());
             return deviceClient;
         }
 
@@ -187,18 +187,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 DeviceClientSetupFailed
             }
 
-            public static void AttemptingConnection(TransportType transport, Option<IWebProxy> proxy)
+            public static void AttemptingConnectionWithTransport(TransportType transport)
             {
-                string proxyMessage = string.Empty;
-                proxy.ForEach(p => proxyMessage = $" and proxy {p.ToString()}");
-                Log.LogInformation((int)EventIds.AttemptingConnect, $"Edge agent attempting to connect to IoT Hub via {transport.ToString()}{proxyMessage}...");
+                Log.LogInformation((int)EventIds.AttemptingConnect, $"Edge agent attempting to connect to IoT Hub via {transport.ToString()}...");
             }
 
-            public static void Connected(TransportType transport, Option<IWebProxy> proxy)
+            public static void ConnectedWithTransport(TransportType transport)
             {
-                string proxyMessage = string.Empty;
-                proxy.ForEach(p => proxyMessage = $" and proxy {p.ToString()}");
-                Log.LogInformation((int)EventIds.Connected, $"Edge agent connected to IoT Hub via {transport.ToString()}{proxyMessage}.");
+                Log.LogInformation((int)EventIds.Connected, $"Edge agent connected to IoT Hub via {transport.ToString()}.");
             }
 
             public static void DeviceClientCreated()

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClientProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClientProvider.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
 {
     using System;
+    using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
@@ -11,18 +12,20 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
     {
         readonly string edgeAgentConnectionString;
         readonly Option<UpstreamProtocol> upstreamProtocol;
+        readonly Option<IWebProxy> proxy;
         readonly Option<string> productInfo;
 
-        public ModuleClientProvider(string edgeAgentConnectionString, Option<UpstreamProtocol> upstreamProtocol, Option<string> productInfo)
+        public ModuleClientProvider(string edgeAgentConnectionString, Option<UpstreamProtocol> upstreamProtocol, Option<IWebProxy> proxy, Option<string> productInfo)
         {
             this.edgeAgentConnectionString = Preconditions.CheckNonWhiteSpace(edgeAgentConnectionString, nameof(edgeAgentConnectionString));
             this.upstreamProtocol = upstreamProtocol;
+            this.proxy = proxy;
             this.productInfo = productInfo;
         }
 
         public Task<IModuleClient> Create(
             ConnectionStatusChangesHandler statusChangedHandler,
             Func<IModuleClient, Task> initialize) =>
-            ModuleClient.Create(Option.Some(this.edgeAgentConnectionString), this.upstreamProtocol, statusChangedHandler, initialize, this.productInfo);
+            ModuleClient.Create(Option.Some(this.edgeAgentConnectionString), this.upstreamProtocol, statusChangedHandler, initialize, this.proxy, this.productInfo);
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Autofac;
@@ -99,13 +100,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 builder.RegisterModule(new LoggingModule(dockerLoggingDriver, dockerLoggingOptions));
                 Option<string> productInfo = versionInfo != VersionInfo.Empty ? Option.Some(versionInfo.ToString()) : Option.None<string>();
                 Option<UpstreamProtocol> upstreamProtocol = configuration.GetValue<string>(Constants.UpstreamProtocolKey).ToUpstreamProtocol();
+                Option<IWebProxy> proxy = ParseProxy(configuration.GetValue<string>("https_proxy"));
                 switch (mode.ToLowerInvariant())
                 {
                     case Constants.DockerMode:
                         var dockerUri = new Uri(configuration.GetValue<string>("DockerUri"));
                         string deviceConnectionString = configuration.GetValue<string>("DeviceConnectionString");
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath));
-                        builder.RegisterModule(new DockerModule(deviceConnectionString, edgeDeviceHostName, dockerUri, dockerAuthConfig, upstreamProtocol, productInfo));
+                        builder.RegisterModule(new DockerModule(deviceConnectionString, edgeDeviceHostName, dockerUri, dockerAuthConfig, upstreamProtocol, proxy, productInfo));
                         break;
 
                     case Constants.IotedgedMode:
@@ -116,7 +118,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         string moduleId = configuration.GetValue(Constants.ModuleIdVariableName, Constants.EdgeAgentModuleIdentityName);
                         string moduleGenerationId = configuration.GetValue<string>(Constants.EdgeletModuleGenerationIdVariableName);
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), moduleId, Option.Some(moduleGenerationId)));
-                        builder.RegisterModule(new EdgeletModule(iothubHostname, edgeDeviceHostName, deviceId, new Uri(managementUri), new Uri(workloadUri), dockerAuthConfig, upstreamProtocol, productInfo));
+                        builder.RegisterModule(new EdgeletModule(iothubHostname, edgeDeviceHostName, deviceId, new Uri(managementUri), new Uri(workloadUri), dockerAuthConfig, upstreamProtocol, proxy, productInfo));
                         break;
 
                     default:
@@ -215,6 +217,36 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             {
                 logger.LogError(AgentEventIds.Agent, ex, "Error on shutdown");
                 return Task.CompletedTask;
+            }
+        }
+
+        static Option<IWebProxy> ParseProxy(string proxyUri)
+        {
+            if (string.IsNullOrWhiteSpace(proxyUri))
+            {
+                return Option.None<IWebProxy>();
+            }
+
+            var uri = new Uri(proxyUri);
+            if (string.IsNullOrEmpty(uri.UserInfo))
+            {
+                return Option.Some<IWebProxy>(new WebProxy(uri));
+            }
+            else
+            {
+                string[] parts = uri.UserInfo.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                var credentials = new NetworkCredential
+                {
+                    UserName = Uri.UnescapeDataString(parts[0])
+                };
+                if (parts.Length > 1)
+                {
+                    credentials.Password = Uri.UnescapeDataString(parts[1]);
+                }
+
+                var proxy = new WebProxy(uri);
+                proxy.Credentials = credentials;
+                return Option.Some<IWebProxy>(proxy);
             }
         }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -254,9 +254,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
 
                     // log the proxy URI without the password
                     int pos = uri.ToString().IndexOf(uri.UserInfo, StringComparison.InvariantCulture);
-                    int end = pos + uri.UserInfo.Length;
-                    int begin = end - parts[1].Length;
-                    logger.LogInformation($"Detected proxy {uri.ToString().Remove(begin, end)}");
+                    int begin = pos + parts[0].Length;
+                    int count = parts[1].Length + 1;
+                    logger.LogInformation($"Detected proxy {uri.ToString().Remove(begin, count)}");
                 }
 
                 var proxy = new WebProxy(uri)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 builder.RegisterModule(new LoggingModule(dockerLoggingDriver, dockerLoggingOptions));
                 Option<string> productInfo = versionInfo != VersionInfo.Empty ? Option.Some(versionInfo.ToString()) : Option.None<string>();
                 Option<UpstreamProtocol> upstreamProtocol = configuration.GetValue<string>(Constants.UpstreamProtocolKey).ToUpstreamProtocol();
-                Option<IWebProxy> proxy = ParseProxy(configuration.GetValue<string>("https_proxy"));
+                Option<IWebProxy> proxy = ParseProxy(configuration.GetValue<string>("https_proxy"), logger);
                 switch (mode.ToLowerInvariant())
                 {
                     case Constants.DockerMode:
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             }
         }
 
-        static Option<IWebProxy> ParseProxy(string proxyUri)
+        static Option<IWebProxy> ParseProxy(string proxyUri, ILogger logger)
         {
             if (string.IsNullOrWhiteSpace(proxyUri))
             {
@@ -230,22 +230,40 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             var uri = new Uri(proxyUri);
             if (string.IsNullOrEmpty(uri.UserInfo))
             {
+                // http://proxyserver:1234
+                logger.LogInformation($"Detected proxy {uri}");
                 return Option.Some<IWebProxy>(new WebProxy(uri));
             }
             else
             {
-                string[] parts = uri.UserInfo.Split(':', StringSplitOptions.RemoveEmptyEntries);
+                string[] parts = uri.UserInfo.Split(':');
                 var credentials = new NetworkCredential
                 {
                     UserName = Uri.UnescapeDataString(parts[0])
                 };
-                if (parts.Length > 1)
+
+                if (parts.Length == 1)
                 {
+                    // http://user@proxyserver:1234
+                    logger.LogInformation($"Detected proxy {uri}");
+                }
+                else
+                {
+                    // http://user:password@proxyserver:1234
                     credentials.Password = Uri.UnescapeDataString(parts[1]);
+
+                    // log the proxy URI without the password
+                    int pos = uri.ToString().IndexOf(uri.UserInfo, StringComparison.InvariantCulture);
+                    int end = pos + uri.UserInfo.Length;
+                    int begin = end - parts[1].Length;
+                    logger.LogInformation($"Detected proxy {uri.ToString().Remove(begin, end)}");
                 }
 
-                var proxy = new WebProxy(uri);
-                proxy.Credentials = credentials;
+                var proxy = new WebProxy(uri)
+                {
+                    Credentials = credentials
+                };
+
                 return Option.Some<IWebProxy>(proxy);
             }
         }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DockerModule.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Threading.Tasks;
     using Autofac;
     using Core;
@@ -23,6 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly Uri dockerHostname;
         readonly IEnumerable<AuthConfig> dockerAuthConfig;
         readonly Option<UpstreamProtocol> upstreamProtocol;
+        readonly Option<IWebProxy> proxy;
         readonly Option<string> productInfo;
 
         public DockerModule(
@@ -31,6 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             Uri dockerHostname,
             IEnumerable<AuthConfig> dockerAuthConfig,
             Option<UpstreamProtocol> upstreamProtocol,
+            Option<IWebProxy> proxy,
             Option<string> productInfo)
         {
             this.edgeDeviceConnectionString = Preconditions.CheckNonWhiteSpace(edgeDeviceConnectionString, nameof(edgeDeviceConnectionString));
@@ -41,6 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.dockerHostname = Preconditions.CheckNotNull(dockerHostname, nameof(dockerHostname));
             this.dockerAuthConfig = Preconditions.CheckNotNull(dockerAuthConfig, nameof(dockerAuthConfig));
             this.upstreamProtocol = Preconditions.CheckNotNull(upstreamProtocol, nameof(upstreamProtocol));
+            this.proxy = Preconditions.CheckNotNull(proxy, nameof(proxy));
             this.productInfo = productInfo;
         }
 
@@ -48,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         {
             // IDeviceClientProvider
             string edgeAgentConnectionString = $"{this.edgeDeviceConnectionString};{Constants.ModuleIdKey}={Constants.EdgeAgentModuleIdentityName}";
-            builder.Register(c => new ModuleClientProvider(edgeAgentConnectionString, this.upstreamProtocol, this.productInfo))
+            builder.Register(c => new ModuleClientProvider(edgeAgentConnectionString, this.upstreamProtocol, this.proxy, this.productInfo))
                 .As<IModuleClientProvider>()
                 .SingleInstance();
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
 {
     using System;
     using System.Collections.Generic;
+    using System.Net;
     using System.Threading.Tasks;
     using Autofac;
     using global::Docker.DotNet.Models;
@@ -30,6 +31,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly Uri workloadUri;
         readonly IEnumerable<AuthConfig> dockerAuthConfig;
         readonly Option<UpstreamProtocol> upstreamProtocol;
+        readonly Option<IWebProxy> proxy;
         readonly Option<string> productInfo;
 
         public EdgeletModule(
@@ -40,6 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             Uri workloadUri,
             IEnumerable<AuthConfig> dockerAuthConfig,
             Option<UpstreamProtocol> upstreamProtocol,
+            Option<IWebProxy> proxy,
             Option<string> productInfo)
         {
             this.iotHubHostName = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
@@ -49,13 +52,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.workloadUri = Preconditions.CheckNotNull(workloadUri, nameof(workloadUri));
             this.dockerAuthConfig = Preconditions.CheckNotNull(dockerAuthConfig, nameof(dockerAuthConfig));
             this.upstreamProtocol = Preconditions.CheckNotNull(upstreamProtocol, nameof(upstreamProtocol));
+            this.proxy = Preconditions.CheckNotNull(proxy, nameof(proxy));
             this.productInfo = productInfo;
         }
 
         protected override void Load(ContainerBuilder builder)
         {
             // IModuleClientProvider
-            builder.Register(c => new EnvironmentModuleClientProvider(this.upstreamProtocol, this.productInfo))
+            builder.Register(c => new EnvironmentModuleClientProvider(this.upstreamProtocol, this.proxy, this.productInfo))
                 .As<IModuleClientProvider>()
                 .SingleInstance();
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Common.Exceptions;
@@ -384,7 +385,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 await SetAgentDesiredProperties(registryManager, edgeDeviceId);
 
                 string edgeAgentConnectionString = $"HostName={iotHubConnectionStringBuilder.HostName};DeviceId={edgeDeviceId};ModuleId=$edgeAgent;SharedAccessKey={edgeDevice.Authentication.SymmetricKey.PrimaryKey}";
-                IModuleClientProvider moduleClientProvider = new ModuleClientProvider(edgeAgentConnectionString, Option.None<UpstreamProtocol>(), Option.None<string>());
+                IModuleClientProvider moduleClientProvider = new ModuleClientProvider(edgeAgentConnectionString, Option.None<UpstreamProtocol>(), Option.None<IWebProxy>(), Option.None<string>());
 
                 var moduleDeserializerTypes = new Dictionary<string, Type>
                 {
@@ -501,7 +502,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 await Task.Delay(TimeSpan.FromMinutes(7));
 
                 string edgeAgentConnectionString = $"HostName={iotHubConnectionStringBuilder.HostName};DeviceId={edgeDeviceId};ModuleId=$edgeAgent;SharedAccessKey={edgeDevice.Authentication.SymmetricKey.PrimaryKey}";
-                IModuleClientProvider moduleClientProvider = new ModuleClientProvider(edgeAgentConnectionString, Option.None<UpstreamProtocol>(), Option.None<string>());
+                IModuleClientProvider moduleClientProvider = new ModuleClientProvider(edgeAgentConnectionString, Option.None<UpstreamProtocol>(), Option.None<IWebProxy>(), Option.None<string>());
 
                 var moduleDeserializerTypes = new Dictionary<string, Type>
                 {
@@ -1030,7 +1031,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 await SetAgentDesiredProperties(registryManager, edgeDeviceId);
 
                 string edgeAgentConnectionString = $"HostName={iotHubConnectionStringBuilder.HostName};DeviceId={edgeDeviceId};ModuleId=$edgeAgent;SharedAccessKey={edgeDevice.Authentication.SymmetricKey.PrimaryKey}";
-                IModuleClientProvider moduleClientProvider = new ModuleClientProvider(edgeAgentConnectionString, Option.None<UpstreamProtocol>(), Option.None<string>());
+                IModuleClientProvider moduleClientProvider = new ModuleClientProvider(edgeAgentConnectionString, Option.None<UpstreamProtocol>(), Option.None<IWebProxy>(), Option.None<string>());
 
                 var moduleDeserializerTypes = new Dictionary<string, Type>
                 {
@@ -1119,7 +1120,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 await SetAgentDesiredProperties(registryManager, edgeDeviceId);
 
                 string edgeAgentConnectionString = $"HostName={iotHubConnectionStringBuilder.HostName};DeviceId={edgeDeviceId};ModuleId=$edgeAgent;SharedAccessKey={edgeDevice.Authentication.SymmetricKey.PrimaryKey}";
-                IModuleClientProvider moduleClientProvider = new ModuleClientProvider(edgeAgentConnectionString, Option.None<UpstreamProtocol>(), Option.None<string>());
+                IModuleClientProvider moduleClientProvider = new ModuleClientProvider(edgeAgentConnectionString, Option.None<UpstreamProtocol>(), Option.None<IWebProxy>(), Option.None<string>());
 
                 var moduleDeserializerTypes = new Dictionary<string, Type>
                 {

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Proxy.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Proxy.cs
@@ -41,13 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 {
                     // http://user:password@proxyserver:1234
                     credentials.Password = Uri.UnescapeDataString(parts[1]);
-
-                    // log the proxy URI but hide the password
-                    string uriStr = uri.ToString();
-                    int user = uriStr.IndexOf(uri.UserInfo, StringComparison.Ordinal);
-                    int password = user + parts[0].Length + 1;
-                    int suffix = password + parts[1].Length;
-                    logger.LogInformation($"Detected proxy {uriStr.Substring(0, password)}****{uriStr.Substring(suffix)}");
+                    logger.LogInformation($"Detected proxy {uri.ToString().Replace($":{parts[1]}@", ":****@")}");
                 }
 
                 var proxy = new WebProxy(uri)

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Proxy.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Proxy.cs
@@ -40,11 +40,12 @@ namespace Microsoft.Azure.Devices.Edge.Util
                     // http://user:password@proxyserver:1234
                     credentials.Password = Uri.UnescapeDataString(parts[1]);
 
-                    // log the proxy URI without the password
-                    int pos = uri.ToString().IndexOf(uri.UserInfo, StringComparison.InvariantCulture);
-                    int begin = pos + parts[0].Length;
-                    int count = parts[1].Length + 1;
-                    logger.LogInformation($"Detected proxy {uri.ToString().Remove(begin, count)}");
+                    // log the proxy URI but hide the password
+                    string uriStr = uri.ToString();
+                    int user = uriStr.IndexOf(uri.UserInfo, StringComparison.Ordinal);
+                    int password = user + parts[0].Length + 1;
+                    int suffix = password + parts[1].Length;
+                    logger.LogInformation($"Detected proxy {uriStr.Substring(0, password)}****{uriStr.Substring(suffix)}");
                 }
 
                 var proxy = new WebProxy(uri)

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Proxy.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Proxy.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Devices.Edge.Util
     {
         public static Option<IWebProxy> Parse(string proxyUri, ILogger logger)
         {
+            Preconditions.CheckNotNull(logger, nameof(logger));
+
             if (string.IsNullOrWhiteSpace(proxyUri))
             {
                 return Option.None<IWebProxy>();

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Proxy.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Proxy.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+    using System.Net;
+    using Microsoft.Extensions.Logging;
+
+    public static class Proxy
+    {
+        public static Option<IWebProxy> Parse(string proxyUri, ILogger logger)
+        {
+            if (string.IsNullOrWhiteSpace(proxyUri))
+            {
+                return Option.None<IWebProxy>();
+            }
+
+            var uri = new Uri(proxyUri);
+            if (string.IsNullOrEmpty(uri.UserInfo))
+            {
+                // http://proxyserver:1234
+                logger.LogInformation($"Detected proxy {uri}");
+                return Option.Some<IWebProxy>(new WebProxy(uri));
+            }
+            else
+            {
+                string[] parts = uri.UserInfo.Split(':');
+                var credentials = new NetworkCredential
+                {
+                    UserName = Uri.UnescapeDataString(parts[0])
+                };
+
+                if (parts.Length == 1)
+                {
+                    // http://user@proxyserver:1234
+                    logger.LogInformation($"Detected proxy {uri}");
+                }
+                else
+                {
+                    // http://user:password@proxyserver:1234
+                    credentials.Password = Uri.UnescapeDataString(parts[1]);
+
+                    // log the proxy URI without the password
+                    int pos = uri.ToString().IndexOf(uri.UserInfo, StringComparison.InvariantCulture);
+                    int begin = pos + parts[0].Length;
+                    int count = parts[1].Length + 1;
+                    logger.LogInformation($"Detected proxy {uri.ToString().Remove(begin, count)}");
+                }
+
+                var proxy = new WebProxy(uri)
+                {
+                    Credentials = credentials
+                };
+
+                return Option.Some<IWebProxy>(proxy);
+            }
+        }
+    }
+}

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/ProxyTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/ProxyTest.cs
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Util.Test
+{
+    using System;
+    using System.Net;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class ProxyTest
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData(" \t ")]
+        public void ParseReturnsNone(string uri)
+        {
+            var logger = Mock.Of<ILogger>();
+            Assert.Equal(Option.None<IWebProxy>(), Proxy.Parse(uri, logger));
+        }
+
+        [Theory]
+        [InlineData("http://proxyserver:1234", null, null)]
+        [InlineData("http://user@proxyserver:1234", "user", "")]
+        [InlineData("http://user:password@proxyserver:1234", "user", "password")]
+        public void ParseReturnsSome(string uri, string expectedUsername, string expectedPassword)
+        {
+            var logger = Mock.Of<ILogger>();
+            Option<IWebProxy> proxy = Proxy.Parse(uri, logger);
+            Assert.True(proxy.HasValue);
+            proxy.ForEach(
+                p =>
+                {
+                    Assert.Equal(new Uri(uri), p.GetProxy(new Uri("https://whatever")));
+                    NetworkCredential credential = p.Credentials?.GetCredential(new Uri("http://whatever"), string.Empty);
+                    Assert.Equal(expectedUsername, credential?.UserName);
+                    Assert.Equal(expectedPassword, credential?.Password);
+                });
+        }
+
+        [Fact]
+        public void ParseThrowsOnBadUri()
+        {
+            var logger = Mock.Of<ILogger>();
+            Assert.Throws<UriFormatException>(() => Proxy.Parse("http://proxyserver:xyz", logger));
+        }
+    }
+}

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/ProxyTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/ProxyTest.cs
@@ -48,5 +48,11 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             var logger = Mock.Of<ILogger>();
             Assert.Throws<UriFormatException>(() => Proxy.Parse("http://proxyserver:xyz", logger));
         }
+
+        [Fact]
+        public void ParseThrowsOnNullLogger()
+        {
+            Assert.Throws<ArgumentNullException>(() => Proxy.Parse("http://proxyserver:1234", null));
+        }
     }
 }


### PR DESCRIPTION
In Linux, .NET Core recognizes and honors the `https_proxy` environment variable when it is present in a module like Edge Agent or Edge Hub. The behavior is different in Windows, however, where the default WinInet proxy settings are used (as set via the Control Panel, or Internet Explorer) and `https_proxy` is ignored. This is especially a problem in RS5 nanoserver containers, which don't even expose the WinInet proxy settings.

The fix is to look for the environment variable ourselves, create a `WebProxy` object, and attach it to the `ITransportSettings` object that we pass into the SDK's `ModuleClient`. We technically only have to do this for Windows, but we'll do it for all platforms, for consistency.

This PR includes the change for Edge Agent. Edge Hub will come next.

~~_I've tested this on Windows. I still need to test on Linux..._~~
I've tested on Windows and Linux in a proxy (squid) environment.