### PR TITLE
Don't stop updating modules until new one pulled

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/planners/HealthRestartPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/planners/HealthRestartPlannerTest.cs
@@ -123,7 +123,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
 
             var updateExecutionList = new List<TestRecordType>
             {
-                new TestRecordType(TestCommandType.TestStop, desiredModule),
                 new TestRecordType(TestCommandType.TestUpdate, desiredModule),
                 new TestRecordType(TestCommandType.TestStart, desiredModule),
             };
@@ -219,7 +218,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
             IEnumerable<TestRecordType> expectedExecutionList = data.SelectMany(
                 d => new[]
                 {
-                    new TestRecordType(TestCommandType.TestStop, d.UpdatedModule),
                     new TestRecordType(TestCommandType.TestUpdate, d.UpdatedModule),
                     new TestRecordType(TestCommandType.TestStart, d.UpdatedModule)
                 });
@@ -273,7 +271,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 .SelectMany(
                     d => new[]
                     {
-                        new TestRecordType(TestCommandType.TestStop, d.UpdatedModule),
                         new TestRecordType(TestCommandType.TestUpdate, d.UpdatedModule),
                         new TestRecordType(TestCommandType.TestStart, d.UpdatedModule)
                     })


### PR DESCRIPTION
This change modifies the behavior of the Agent Core HealthRestartPlanner
to delay the stopping of containers which are to be replaced until the
replacement has been pulled.

The HealthRestartPlanner no longer creates a stop task for modules which
are to be updated initially, and instead defers the stopping of the
current module to the GroupCommand created by
DockerCommandFactory::UpdateAsync.  UpdateAsync first pulls the new
container, then stops and removes the current container.  The new
Container is the created, and started in the usual way.

fixes #641