### PR TITLE
Update checkin builds with directory paths

### DIFF
--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -3,6 +3,9 @@ pr:
   branches:
     include:
       - master
+  paths:
+    exclude:
+      - edgelet/*
 jobs:
 
 ################################################################################

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -33,7 +33,7 @@ jobs:
     displayName: Linux arm32v7
     pool:
       vmImage: 'ubuntu-16.04'
-    env:
+    variables:
       IOTEDGE_HOMEDIR: /tmp
     steps:
       - bash: 'echo "##vso[task.setvariable variable=PATH;]$HOME/.cargo/bin:$PATH"'

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -45,10 +45,10 @@ jobs:
         displayName: Install Rust
       - script: 'cargo install --git https://github.com/myagley/cross.git --branch set-path'
         displayName: 'Install cross (fork with docker fix)'
-      - script: 'cross build --toolchain armv7-unknown-linux-gnueabihf'
+      - script: 'cross build --target armv7-unknown-linux-gnueabihf'
         displayName: armv7-unknown-linux-gnueabihf build
         workingDirectory: $(Build.SourcesDirectory)/edgelet
-      - script: 'cross test --toolchain armv7-unknown-linux-gnueabihf'
+      - script: 'cross test --target armv7-unknown-linux-gnueabihf'
         displayName: armv7-unknown-linux-gnueabihf test
         workingDirectory: $(Build.SourcesDirectory)/edgelet
 

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -3,6 +3,10 @@ pr:
   branches:
     include:
       - master
+  paths:
+    include:
+      - builds/*
+      - edgelet/*
 jobs:
 
 ################################################################################
@@ -14,51 +18,39 @@ jobs:
     steps:
       - script: echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
         displayName: Set env variables
-      - task: Bash@3
+      - bash: edgelet/build/linux/install.sh
         displayName: Install Rust
-        inputs:
-          filePath: edgelet/build/linux/install.sh
-      - task: Bash@3
+      - bash: edgelet/build/linux/check-submodules.sh
         displayName: Check submodules
-        inputs:
-          filePath: edgelet/build/linux/check-submodules.sh
-      - task: Bash@3
+      - bash: edgelet/build/linux/build.sh
         displayName: Build
-        inputs:
-          filePath: edgelet/build/linux/build.sh
-      - task: Bash@3
+      - bash: edgelet/build/linux/test.sh
         displayName: Test
-        inputs:
-          filePath: edgelet/build/linux/test.sh
 
-# ################################################################################
-  # - job: linux_arm32v7
-# ################################################################################
-    # displayName: Linux arm32v7
-    # queue:
-      # name: Hosted Linux Preview
-    # steps:
-      # - script: |
-          # echo "##vso[task.setvariable variable=RUSTUP_HOME;]$VSTS_WORK/rustup"
-          # echo "##vso[task.setvariable variable=CARGO_HOME;]$VSTS_WORK/cargo"
-          # echo "##vso[task.setvariable variable=PATH;]$VSTS_WORK/cargo/bin:$PATH"
-        # displayName: Modify path
-      # - task: Bash@3
-        # displayName: Install Rust
-        # inputs:
-          # filePath: edgelet/build/linux/install.sh
-      # - script: cargo install --git https://github.com/myagley/cross.git --branch set-path
-        # displayName: Install cross (fork with docker fix)
-      # - task: Bash@3
-        # displayName: armv7-unknown-linux-gnueabihf build
-        # inputs:
-          # filePath: edgelet/build/linux/cross.sh
-          # arguments: --toolchain armv7-unknown-linux-gnueabihf
-      # - task: Bash@3
-        # displayName: armv7-unknown-linux-gnueabihf test
-        # inputs:
-          # filePath: edgelet/build/linux/cross-test.sh
-          # arguments: --toolchain armv7-unknown-linux-gnueabihf
+################################################################################
+  - job: linux_arm32v7
+################################################################################
+    displayName: Linux arm32v7
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - bash: 'echo "##vso[task.setvariable variable=PATH;]$HOME/.cargo/bin:$PATH"'
+        displayName: Modify path
+      - bash: |
+          BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+          VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
+          echo "##vso[task.setvariable variable=VERSION;]$VERSION"
+        displayName: Set Version
+      - script: edgelet/build/linux/install.sh
+        displayName: Install Rust
+      - script: 'cargo install --git https://github.com/myagley/cross.git --branch set-path'
+        displayName: 'Install cross (fork with docker fix)'
+      - script: 'cross build --toolchain armv7-unknown-linux-gnueabihf'
+        displayName: armv7-unknown-linux-gnueabihf build
+        workingDirectory: $(Build.SourcesDirectory)/edgelet
+      - script: 'cross test --toolchain armv7-unknown-linux-gnueabihf'
+        displayName: armv7-unknown-linux-gnueabihf test
+        workingDirectory: $(Build.SourcesDirectory)/edgelet
 
 ################################################################################
   - job: windows_amd64
@@ -69,18 +61,12 @@ jobs:
     steps:
       - powershell: Write-Host ("##vso[task.setvariable variable=NO_VALGRIND;]true")
         displayName: Set env variables
-      - task: PowerShell@2
+      - powershell: edgelet/build/windows/install.ps1
         displayName: Install Rust
-        inputs:
-          filePath: edgelet/build/windows/install.ps1
-      - task: PowerShell@2
+      - powershell: edgelet/build/windows/build.ps1
         displayName: Build
-        inputs:
-          filePath: edgelet/build/windows/build.ps1
-      - task: PowerShell@2
+      - powershell: edgelet/build/windows/test.ps1
         displayName: Test
-        inputs:
-          filePath: edgelet/build/windows/test.ps1
 
 ################################################################################
   - job: style_check
@@ -89,18 +75,11 @@ jobs:
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
-      - script: |
-          echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
+      - script: echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
         displayName: Set env variables
-      - task: Bash@3
+      - bash: edgelet/build/linux/install.sh
         displayName: Install Rust
-        inputs:
-          filePath: edgelet/build/linux/install.sh
-      - task: Bash@3
+      - bash: edgelet/build/linux/format.sh
         displayName: Format Code
-        inputs:
-          filePath: edgelet/build/linux/format.sh
-      - task: Bash@3
+      - bash: edgelet/build/linux/clippy.sh
         displayName: Clippy
-        inputs:
-          filePath: edgelet/build/linux/clippy.sh

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -33,6 +33,8 @@ jobs:
     displayName: Linux arm32v7
     pool:
       vmImage: 'ubuntu-16.04'
+    env:
+      IOTEDGE_HOMEDIR: /tmp
     steps:
       - bash: 'echo "##vso[task.setvariable variable=PATH;]$HOME/.cargo/bin:$PATH"'
         displayName: Modify path

--- a/builds/checkin/libiothsm.yaml
+++ b/builds/checkin/libiothsm.yaml
@@ -3,6 +3,10 @@ pr:
   branches:
     include:
       - master
+  paths:
+    include:
+      - builds/*
+      - edgelet/*
 jobs:
 
 ################################################################################
@@ -12,10 +16,8 @@ jobs:
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
-      - task: Bash@3
+      - bash: edgelet/build/linux/install.sh
         displayName: Install dependencies
-        inputs:
-          filePath: edgelet/build/linux/install.sh
       - task: CMake@1
         displayName: Setup
         inputs:
@@ -35,10 +37,8 @@ jobs:
     pool:
       vmImage: 'vs2017-win2016'
     steps:
-      - task: PowerShell@2
+      - powershell: edgelet/build/windows/install.ps1
         displayName: Install
-        inputs:
-          filePath: edgelet/build/windows/install.ps1
       - task: CMake@1
         displayName: Setup
         inputs:


### PR DESCRIPTION
* Will only run checkin job based on what files have changed. (look at `paths.includes/excludes`)
* Simplifies some of the yaml
* Reinstates arm32 checkin build for edgelet