### PR TITLE
EdgeHub: Process subscriptions from client in batch

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
@@ -185,8 +185,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             IDeviceProxy deviceProxy = new EdgeHubDeviceProxy(edgeHubConnection);
             Task addDeviceConnectionTask = connectionManager.AddDeviceConnection(edgeHubIdentity, deviceProxy);
-            Task desiredPropertyUpdatesSubscriptionTask = edgeHub.AddSubscription(edgeHubIdentity.Id, DeviceSubscription.DesiredPropertyUpdates);
-            Task methodsSubscriptionTask = edgeHub.AddSubscription(edgeHubIdentity.Id, DeviceSubscription.Methods);
+            Task desiredPropertyUpdatesSubscriptionTask = edgeHub.ProcessSubscription(edgeHubIdentity.Id, DeviceSubscription.DesiredPropertyUpdates, true);
+            Task methodsSubscriptionTask = edgeHub.ProcessSubscription(edgeHubIdentity.Id, DeviceSubscription.Methods, true);
             Task clearDeviceConnectionStatusesTask = edgeHubConnection.ClearDeviceConnectionStatuses();
             return Task.WhenAll(addDeviceConnectionTask, desiredPropertyUpdatesSubscriptionTask, methodsSubscriptionTask, clearDeviceConnectionStatusesTask);
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
@@ -185,8 +185,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             IDeviceProxy deviceProxy = new EdgeHubDeviceProxy(edgeHubConnection);
             Task addDeviceConnectionTask = connectionManager.AddDeviceConnection(edgeHubIdentity, deviceProxy);
-            Task desiredPropertyUpdatesSubscriptionTask = edgeHub.ProcessSubscription(edgeHubIdentity.Id, DeviceSubscription.DesiredPropertyUpdates, true);
-            Task methodsSubscriptionTask = edgeHub.ProcessSubscription(edgeHubIdentity.Id, DeviceSubscription.Methods, true);
+            Task desiredPropertyUpdatesSubscriptionTask = edgeHub.AddSubscription(edgeHubIdentity.Id, DeviceSubscription.DesiredPropertyUpdates);
+            Task methodsSubscriptionTask = edgeHub.AddSubscription(edgeHubIdentity.Id, DeviceSubscription.Methods);
             Task clearDeviceConnectionStatusesTask = edgeHubConnection.ClearDeviceConnectionStatuses();
             return Task.WhenAll(addDeviceConnectionTask, desiredPropertyUpdatesSubscriptionTask, methodsSubscriptionTask, clearDeviceConnectionStatusesTask);
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/HubCoreEventIds.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/HubCoreEventIds.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const int DeviceScopeIdentitiesCache = EventIdStart + 1200;
         public const int PeriodicConnectionAuthenticator = EventIdStart + 1300;
         public const int DeviceScopeAuthenticator = EventIdStart + 1400;
+        public const int SubscriptionProcessor = EventIdStart + 1500;
         const int EventIdStart = 1000;
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
@@ -32,5 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         Task AddSubscription(string id, DeviceSubscription deviceSubscription);
 
         Task RemoveSubscription(string id, DeviceSubscription deviceSubscription);
+
+        Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions);
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
@@ -29,7 +29,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         Task SendC2DMessageAsync(string id, IMessage message);
 
-        Task ProcessSubscription(string id, DeviceSubscription deviceSubscription, bool addSubscription);
+        Task AddSubscription(string id, DeviceSubscription deviceSubscription);
+
+        Task RemoveSubscription(string id, DeviceSubscription deviceSubscription);
 
         Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions);
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
@@ -29,9 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         Task SendC2DMessageAsync(string id, IMessage message);
 
-        Task AddSubscription(string id, DeviceSubscription deviceSubscription);
-
-        Task RemoveSubscription(string id, DeviceSubscription deviceSubscription);
+        Task ProcessSubscription(string id, DeviceSubscription deviceSubscription, bool addSubscription);
 
         Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions);
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ISubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ISubscriptionProcessor.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
+
+    public interface ISubscriptionProcessor
+    {
+        Task AddSubscription(string id, DeviceSubscription deviceSubscription);
+
+        Task RemoveSubscription(string id, DeviceSubscription deviceSubscription);
+
+        Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions);
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ISubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ISubscriptionProcessor.cs
@@ -7,9 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
     public interface ISubscriptionProcessor
     {
-        Task AddSubscription(string id, DeviceSubscription deviceSubscription);
-
-        Task RemoveSubscription(string id, DeviceSubscription deviceSubscription);
+        Task ProcessSubscription(string id, DeviceSubscription deviceSubscription, bool addSubscription);
 
         Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions);
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ISubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ISubscriptionProcessor.cs
@@ -7,7 +7,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
     public interface ISubscriptionProcessor
     {
-        Task ProcessSubscription(string id, DeviceSubscription deviceSubscription, bool addSubscription);
+        Task AddSubscription(string id, DeviceSubscription deviceSubscription);
+
+        Task RemoveSubscription(string id, DeviceSubscription deviceSubscription);
 
         Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions);
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
@@ -248,7 +248,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             internal static void ProcessingSubscriptions(string id, List<(DeviceSubscription, bool)> subscriptionsList)
             {
-                string subscriptions = String.Join(", ", subscriptionsList.Select(s => $"{s.Item1}"));
+                string subscriptions = string.Join(", ", subscriptionsList.Select(s => $"{s.Item1}"));
                 Log.LogInformation((int)EventIds.ProcessingSubscription, Invariant($"Processing subscriptions {subscriptions} for client {id}."));
             }
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
@@ -57,12 +57,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             {
                 if (addSubscription)
                 {
-                    //                    RoutingEdgeHub.Events.AddingSubscription(id, deviceSubscription);
                     this.connectionManager.AddSubscription(id, deviceSubscription);
                 }
                 else
                 {
-                    //                    RoutingEdgeHub.Events.RemovingSubscription(id, deviceSubscription);
                     this.connectionManager.RemoveSubscription(id, deviceSubscription);
                 }
             }
@@ -73,7 +71,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         internal async Task ProcessSubscription(string id, Option<ICloudProxy> cloudProxy, DeviceSubscription deviceSubscription, bool addSubscription)
         {
-            //RoutingEdgeHub.Events.ProcessingSubscription(id, deviceSubscription);
             switch (deviceSubscription)
             {
                 case DeviceSubscription.C2D:

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
@@ -48,20 +48,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             deviceConnectivityManager.DeviceConnected += this.DeviceConnected;
         }
 
-        public Task ProcessSubscription(string id, DeviceSubscription deviceSubscription, bool addSubscription)
+        public Task AddSubscription(string id, DeviceSubscription deviceSubscription)
         {
-            if (addSubscription)
-            {
-                Events.AddingSubscription(id, deviceSubscription);
-                this.connectionManager.AddSubscription(id, deviceSubscription);
-            }
-            else
-            {
-                Events.RemovingSubscription(id, deviceSubscription);
-                this.connectionManager.RemoveSubscription(id, deviceSubscription);
-            }
+            Events.AddingSubscription(id, deviceSubscription);
+            this.connectionManager.AddSubscription(id, deviceSubscription);
+            this.AddToPendingSubscriptions(id, new List<(DeviceSubscription, bool)> { (deviceSubscription, true) });
+            return Task.CompletedTask;
+        }
 
-            this.AddToPendingSubscriptions(id, new List<(DeviceSubscription, bool)> { (deviceSubscription, addSubscription) });
+        public Task RemoveSubscription(string id, DeviceSubscription deviceSubscription)
+        {
+            Events.RemovingSubscription(id, deviceSubscription);
+            this.connectionManager.RemoveSubscription(id, deviceSubscription);
+            this.AddToPendingSubscriptions(id, new List<(DeviceSubscription, bool)> { (deviceSubscription, false) });
             return Task.CompletedTask;
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
@@ -31,19 +31,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             deviceConnectivityManager.DeviceConnected += this.DeviceConnected;
         }
 
-        public Task AddSubscription(string id, DeviceSubscription deviceSubscription)
+        public Task ProcessSubscription(string id, DeviceSubscription deviceSubscription, bool addSubscription)
         {
-            Events.AddingSubscription(id, deviceSubscription);
-            this.connectionManager.AddSubscription(id, deviceSubscription);
-            this.AddToPendingSubscriptions(id, new List<(DeviceSubscription, bool)> { (deviceSubscription, true) });
-            return Task.CompletedTask;
-        }
+            if (addSubscription)
+            {
+                Events.AddingSubscription(id, deviceSubscription);
+                this.connectionManager.AddSubscription(id, deviceSubscription);
+            }
+            else
+            {
+                Events.RemovingSubscription(id, deviceSubscription);
+                this.connectionManager.RemoveSubscription(id, deviceSubscription);
+            }
 
-        public Task RemoveSubscription(string id, DeviceSubscription deviceSubscription)
-        {
-            Events.RemovingSubscription(id, deviceSubscription);
-            this.connectionManager.RemoveSubscription(id, deviceSubscription);
-            this.AddToPendingSubscriptions(id, new List<(DeviceSubscription, bool)> { (deviceSubscription, false) });
+            this.AddToPendingSubscriptions(id, new List<(DeviceSubscription, bool)> { (deviceSubscription, addSubscription) });
             return Task.CompletedTask;
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Threading.Tasks.Dataflow;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public interface ISubscriptionProcessor
+    {
+        Task AddSubscription(string id, DeviceSubscription deviceSubscription);
+
+        Task RemoveSubscription(string id, DeviceSubscription deviceSubscription);
+
+        Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions);
+    }
+
+    public class SubscriptionProcessor
+    {
+        readonly IConnectionManager connectionManager;
+        readonly ConcurrentDictionary<string, ConcurrentQueue<(DeviceSubscription, bool)>> subscriptionsToProcess;
+        readonly ActionBlock<string> processSubscriptionsBlock;
+        readonly IInvokeMethodHandler invokeMethodHandler;
+
+        public SubscriptionProcessor(IConnectionManager connectionManager, IInvokeMethodHandler invokeMethodHandler)
+        {
+            this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
+            this.invokeMethodHandler = Preconditions.CheckNotNull(invokeMethodHandler, nameof(invokeMethodHandler));
+            this.subscriptionsToProcess = new ConcurrentDictionary<string, ConcurrentQueue<(DeviceSubscription, bool)>>();
+            this.processSubscriptionsBlock = new ActionBlock<string>(this.ProcessSubscriptions);
+        }
+
+        public Task AddSubscription(string id, DeviceSubscription deviceSubscription)
+        {
+            this.connectionManager.AddSubscription(id, deviceSubscription);
+            this.AddSubscriptionsToProcess(id, new List<(DeviceSubscription, bool)> { (deviceSubscription, true) });
+            return Task.CompletedTask;
+        }
+
+        public Task RemoveSubscription(string id, DeviceSubscription deviceSubscription)
+        {
+            this.connectionManager.RemoveSubscription(id, deviceSubscription);
+            this.AddSubscriptionsToProcess(id, new List<(DeviceSubscription, bool)> { (deviceSubscription, false) });
+            return Task.CompletedTask;
+        }
+
+        public Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions)
+        {
+            Preconditions.CheckNonWhiteSpace(id, nameof(id));
+            List<(DeviceSubscription, bool)> subscriptionsList = Preconditions.CheckNotNull(subscriptions, nameof(subscriptions)).ToList();
+
+            foreach ((DeviceSubscription deviceSubscription, bool addSubscription) in subscriptionsList)
+            {
+                if (addSubscription)
+                {
+                    //                    RoutingEdgeHub.Events.AddingSubscription(id, deviceSubscription);
+                    this.connectionManager.AddSubscription(id, deviceSubscription);
+                }
+                else
+                {
+                    //                    RoutingEdgeHub.Events.RemovingSubscription(id, deviceSubscription);
+                    this.connectionManager.RemoveSubscription(id, deviceSubscription);
+                }
+            }
+
+            this.AddSubscriptionsToProcess(id, subscriptionsList);
+            return Task.CompletedTask;
+        }
+
+        internal async Task ProcessSubscription(string id, Option<ICloudProxy> cloudProxy, DeviceSubscription deviceSubscription, bool addSubscription)
+        {
+            //RoutingEdgeHub.Events.ProcessingSubscription(id, deviceSubscription);
+            switch (deviceSubscription)
+            {
+                case DeviceSubscription.C2D:
+                    if (addSubscription)
+                    {
+                        cloudProxy.ForEach(c => c.StartListening());
+                    }
+
+                    break;
+
+                case DeviceSubscription.DesiredPropertyUpdates:
+                    await cloudProxy.ForEachAsync(c => addSubscription ? c.SetupDesiredPropertyUpdatesAsync() : c.RemoveDesiredPropertyUpdatesAsync());
+                    break;
+
+                case DeviceSubscription.Methods:
+                    if (addSubscription)
+                    {
+                        await cloudProxy.ForEachAsync(c => c.SetupCallMethodAsync());
+                        await this.invokeMethodHandler.ProcessInvokeMethodSubscription(id);
+                    }
+                    else
+                    {
+                        await cloudProxy.ForEachAsync(c => c.RemoveCallMethodAsync());
+                    }
+
+                    break;
+
+                case DeviceSubscription.ModuleMessages:
+                case DeviceSubscription.TwinResponse:
+                case DeviceSubscription.Unknown:
+                    // No Action required
+                    break;
+            }
+        }
+
+        async Task ProcessSubscriptions(string id)
+        {
+            ConcurrentQueue<(DeviceSubscription, bool)> clientSubscriptionsQueue = this.GetClientSubscriptionsQueue(id);
+            if (!clientSubscriptionsQueue.IsEmpty)
+            {
+                Option<ICloudProxy> cloudProxy = await this.connectionManager.GetCloudConnection(id);
+                while (clientSubscriptionsQueue.TryDequeue(out (DeviceSubscription deviceSubscription, bool addSubscription) result))
+                {
+                    await this.ProcessSubscription(id, cloudProxy, result.deviceSubscription, result.addSubscription);
+                }
+            }
+        }
+
+        void AddSubscriptionsToProcess(string id, List<(DeviceSubscription, bool)> subscriptions)
+        {
+            ConcurrentQueue<(DeviceSubscription, bool)> clientSubscriptionsQueue = this.GetClientSubscriptionsQueue(id);
+            subscriptions.ForEach(s => clientSubscriptionsQueue.Enqueue(s));
+            this.processSubscriptionsBlock.Post(id);
+        }
+
+        ConcurrentQueue<(DeviceSubscription, bool)> GetClientSubscriptionsQueue(string id)
+            => this.subscriptionsToProcess.GetOrAdd(id, new ConcurrentQueue<(DeviceSubscription, bool)>());
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -110,9 +110,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
             }
         }
 
-        public Task AddSubscription(DeviceSubscription subscription) => this.edgeHub.AddSubscription(this.Identity.Id, subscription);
+        public Task AddSubscription(DeviceSubscription subscription)
+            => this.edgeHub.AddSubscription(this.Identity.Id, subscription);
 
-        public Task RemoveSubscription(DeviceSubscription subscription) => this.edgeHub.RemoveSubscription(this.Identity.Id, subscription);
+        public Task RemoveSubscription(DeviceSubscription subscription)
+            => this.edgeHub.RemoveSubscription(this.Identity.Id, subscription);
 
         public async Task AddDesiredPropertyUpdatesSubscription(string correlationId)
         {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -111,14 +111,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
         }
 
         public Task AddSubscription(DeviceSubscription subscription)
-            => this.edgeHub.AddSubscription(this.Identity.Id, subscription);
+            => this.edgeHub.ProcessSubscription(this.Identity.Id, subscription, true);
 
         public Task RemoveSubscription(DeviceSubscription subscription)
-            => this.edgeHub.RemoveSubscription(this.Identity.Id, subscription);
+            => this.edgeHub.ProcessSubscription(this.Identity.Id, subscription, false);
 
         public async Task AddDesiredPropertyUpdatesSubscription(string correlationId)
         {
-            await this.edgeHub.AddSubscription(this.Identity.Id, DeviceSubscription.DesiredPropertyUpdates);
+            await this.edgeHub.ProcessSubscription(this.Identity.Id, DeviceSubscription.DesiredPropertyUpdates, true);
             if (!string.IsNullOrWhiteSpace(correlationId))
             {
                 IMessage responseMessage = new EdgeMessage.Builder(new byte[0])
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
 
         public async Task RemoveDesiredPropertyUpdatesSubscription(string correlationId)
         {
-            await this.edgeHub.RemoveSubscription(this.Identity.Id, DeviceSubscription.DesiredPropertyUpdates);
+            await this.edgeHub.ProcessSubscription(this.Identity.Id, DeviceSubscription.DesiredPropertyUpdates, false);
             if (!string.IsNullOrWhiteSpace(correlationId))
             {
                 IMessage responseMessage = new EdgeMessage.Builder(new byte[0])

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -111,14 +111,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
         }
 
         public Task AddSubscription(DeviceSubscription subscription)
-            => this.edgeHub.ProcessSubscription(this.Identity.Id, subscription, true);
+            => this.edgeHub.AddSubscription(this.Identity.Id, subscription);
 
         public Task RemoveSubscription(DeviceSubscription subscription)
-            => this.edgeHub.ProcessSubscription(this.Identity.Id, subscription, false);
+            => this.edgeHub.RemoveSubscription(this.Identity.Id, subscription);
 
         public async Task AddDesiredPropertyUpdatesSubscription(string correlationId)
         {
-            await this.edgeHub.ProcessSubscription(this.Identity.Id, DeviceSubscription.DesiredPropertyUpdates, true);
+            await this.edgeHub.AddSubscription(this.Identity.Id, DeviceSubscription.DesiredPropertyUpdates);
             if (!string.IsNullOrWhiteSpace(correlationId))
             {
                 IMessage responseMessage = new EdgeMessage.Builder(new byte[0])
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
 
         public async Task RemoveDesiredPropertyUpdatesSubscription(string correlationId)
         {
-            await this.edgeHub.ProcessSubscription(this.Identity.Id, DeviceSubscription.DesiredPropertyUpdates, false);
+            await this.edgeHub.RemoveSubscription(this.Identity.Id, DeviceSubscription.DesiredPropertyUpdates);
             if (!string.IsNullOrWhiteSpace(correlationId))
             {
                 IMessage responseMessage = new EdgeMessage.Builder(new byte[0])

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -123,8 +123,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             return this.twinManager.UpdateDesiredPropertiesAsync(id, twinCollection);
         }
 
-        public Task ProcessSubscription(string id, DeviceSubscription deviceSubscription, bool addSubscription)
-            => this.subscriptionProcessor.ProcessSubscription(id, deviceSubscription, addSubscription);
+        public Task AddSubscription(string id, DeviceSubscription deviceSubscription)
+            => this.subscriptionProcessor.AddSubscription(id, deviceSubscription);
+
+        public Task RemoveSubscription(string id, DeviceSubscription deviceSubscription)
+            => this.subscriptionProcessor.RemoveSubscription(id, deviceSubscription);
 
         public Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions)
             => this.subscriptionProcessor.ProcessSubscriptions(id, subscriptions);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             ITwinManager twinManager,
             string edgeDeviceId,
             IInvokeMethodHandler invokeMethodHandler,
-            IDeviceConnectivityManager deviceConnectivityManager,
             ISubscriptionProcessor subscriptionProcessor)
         {
             this.router = Preconditions.CheckNotNull(router, nameof(router));
@@ -48,7 +47,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             this.twinManager = Preconditions.CheckNotNull(twinManager, nameof(twinManager));
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
             this.invokeMethodHandler = Preconditions.CheckNotNull(invokeMethodHandler, nameof(invokeMethodHandler));
-            deviceConnectivityManager.DeviceConnected += this.DeviceConnected;
             this.subscriptionProcessor = Preconditions.CheckNotNull(subscriptionProcessor, nameof(subscriptionProcessor));
         }
 
@@ -126,22 +124,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         }
 
         public Task AddSubscription(string id, DeviceSubscription deviceSubscription)
-        {
-            Events.AddingSubscription(id, deviceSubscription);
-            return this.subscriptionProcessor.AddSubscription(id, deviceSubscription);
-        }
+            => this.subscriptionProcessor.AddSubscription(id, deviceSubscription);
 
         public Task RemoveSubscription(string id, DeviceSubscription deviceSubscription)
-        {
-            Events.RemovingSubscription(id, deviceSubscription);
-            return this.subscriptionProcessor.RemoveSubscription(id, deviceSubscription);
-        }
+            => this.subscriptionProcessor.RemoveSubscription(id, deviceSubscription);
 
         public Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions)
-        {
-            Preconditions.CheckNonWhiteSpace(id, nameof(id));
-            return this.subscriptionProcessor.ProcessSubscriptions(id, Preconditions.CheckNotNull(subscriptions, nameof(subscriptions)));
-        }
+            => this.subscriptionProcessor.ProcessSubscriptions(id, subscriptions);
 
         public void Dispose()
         {
@@ -169,44 +158,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             }
         }
 
-        internal async Task ProcessSubscription(string id, Option<ICloudProxy> cloudProxy, DeviceSubscription deviceSubscription, bool addSubscription)
-        {
-            Events.ProcessingSubscription(id, deviceSubscription);
-            switch (deviceSubscription)
-            {
-                case DeviceSubscription.C2D:
-                    if (addSubscription)
-                    {
-                        cloudProxy.ForEach(c => c.StartListening());
-                    }
-
-                    break;
-
-                case DeviceSubscription.DesiredPropertyUpdates:
-                    await cloudProxy.ForEachAsync(c => addSubscription ? c.SetupDesiredPropertyUpdatesAsync() : c.RemoveDesiredPropertyUpdatesAsync());
-                    break;
-
-                case DeviceSubscription.Methods:
-                    if (addSubscription)
-                    {
-                        await cloudProxy.ForEachAsync(c => c.SetupCallMethodAsync());
-                        await this.invokeMethodHandler.ProcessInvokeMethodSubscription(id);
-                    }
-                    else
-                    {
-                        await cloudProxy.ForEachAsync(c => c.RemoveCallMethodAsync());
-                    }
-
-                    break;
-
-                case DeviceSubscription.ModuleMessages:
-                case DeviceSubscription.TwinResponse:
-                case DeviceSubscription.Unknown:
-                    // No Action required
-                    break;
-            }
-        }
-
         static void ValidateMessageSize(IRoutingMessage messageToBeValidated)
         {
             long messageSize = messageToBeValidated.Size();
@@ -230,45 +181,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             return routingMessage;
         }
 
-        async void DeviceConnected(object sender, EventArgs eventArgs)
-        {
-            Events.DeviceConnectedProcessingSubscriptions();
-            try
-            {
-                IEnumerable<IIdentity> connectedClients = this.connectionManager.GetConnectedClients().ToList();
-                foreach (IIdentity identity in connectedClients)
-                {
-                    try
-                    {
-                        Events.ProcessingSubscriptions(identity);
-                        await this.ProcessSubscriptions(identity.Id);
-                    }
-                    catch (Exception e)
-                    {
-                        Events.ErrorProcessingSubscriptions(e, identity);
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                Events.ErrorProcessingSubscriptions(e);
-            }
-        }
-
-        async Task ProcessSubscriptions(string id)
-        {
-            Option<ICloudProxy> cloudProxy = await this.connectionManager.GetCloudConnection(id);
-            Option<IReadOnlyDictionary<DeviceSubscription, bool>> subscriptions = this.connectionManager.GetSubscriptions(id);
-            await subscriptions.ForEachAsync(
-                async s =>
-                {
-                    foreach (KeyValuePair<DeviceSubscription, bool> subscription in s)
-                    {
-                        await this.ProcessSubscription(id, cloudProxy, subscription.Key, subscription.Value);
-                    }
-                });
-        }
-
         static class Events
         {
             const int IdStart = HubCoreEventIds.RoutingEdgeHub;
@@ -280,14 +192,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 MessageReceived = 1501,
                 ReportedPropertiesUpdateReceived = 1502,
                 DesiredPropertiesUpdateReceived = 1503,
-                DeviceConnectionNotFound,
-                ErrorProcessingSubscriptions,
-                ErrorRemovingSubscription,
-                ErrorAddingSubscription,
-                AddingSubscription,
-                RemovingSubscription,
-                ProcessingSubscriptions,
-                ProcessingSubscription
+                DeviceConnectionNotFound
             }
 
             public static void MethodCallReceived(string fromId, string toId, string correlationId)
@@ -298,62 +203,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             public static void UnableToSendC2DMessageNoDeviceConnection(string id)
             {
                 Log.LogWarning((int)EventIds.DeviceConnectionNotFound, Invariant($"Unable to send C2D message to device {id} as an active device connection was not found."));
-            }
-
-            public static void ErrorProcessingSubscriptions(Exception ex, IIdentity identity)
-            {
-                if (ex.HasTimeoutException())
-                {
-                    Log.LogDebug((int)EventIds.ErrorProcessingSubscriptions, ex, Invariant($"Timed out while processing subscriptions for client {identity.Id}. Will try again when connected."));
-                }
-                else
-                {
-                    Log.LogWarning((int)EventIds.ErrorProcessingSubscriptions, ex, Invariant($"Error processing subscriptions for client {identity.Id}."));
-                }
-            }
-
-            public static void ErrorRemovingSubscription(Exception ex, string id, DeviceSubscription subscription)
-            {
-                if (ex.HasTimeoutException())
-                {
-                    Log.LogDebug((int)EventIds.ErrorAddingSubscription, ex, Invariant($"Timed out while removing subscription {subscription} for client {id}. Will try again when connected."));
-                }
-                else
-                {
-                    Log.LogWarning((int)EventIds.ErrorRemovingSubscription, ex, Invariant($"Error removing subscription {subscription} for client {id}."));
-                }
-            }
-
-            public static void ErrorAddingSubscription(Exception ex, string id, DeviceSubscription subscription)
-            {
-                if (ex.HasTimeoutException())
-                {
-                    Log.LogDebug((int)EventIds.ErrorAddingSubscription, ex, Invariant($"Timed out while adding subscription {subscription} for client {id}. Will try again when connected."));
-                }
-                else
-                {
-                    Log.LogDebug((int)EventIds.ErrorAddingSubscription, ex, Invariant($"Error adding subscription {subscription} for client {id}."));
-                }
-            }
-
-            public static void AddingSubscription(string id, DeviceSubscription subscription)
-            {
-                Log.LogDebug((int)EventIds.AddingSubscription, Invariant($"Adding subscription {subscription} for client {id}."));
-            }
-
-            public static void RemovingSubscription(string id, DeviceSubscription subscription)
-            {
-                Log.LogDebug((int)EventIds.RemovingSubscription, Invariant($"Removing subscription {subscription} for client {id}."));
-            }
-
-            public static void ProcessingSubscriptions(IIdentity identity)
-            {
-                Log.LogInformation((int)EventIds.ProcessingSubscriptions, Invariant($"Processing subscriptions for client {identity.Id}."));
-            }
-
-            public static void ProcessingSubscription(string id, DeviceSubscription deviceSubscription)
-            {
-                Log.LogInformation((int)EventIds.ProcessingSubscription, Invariant($"Processing subscription {deviceSubscription} for client {id}."));
             }
 
             public static void MessagesReceived(IIdentity identity, IList<IMessage> messages)
@@ -402,16 +251,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             {
                 Log.LogDebug((int)EventIds.DesiredPropertiesUpdateReceived, Invariant($"Desired properties update message received for {id ?? string.Empty}"));
             }
-
-            internal static void DeviceConnectedProcessingSubscriptions()
-            {
-                Log.LogInformation((int)EventIds.ProcessingSubscription, Invariant($"Device connected to cloud, processing subscriptions for connected clients."));
-            }
-
-            internal static void ErrorProcessingSubscriptions(Exception e)
-            {
-                Log.LogWarning((int)EventIds.ProcessingSubscription, e, Invariant($"Error processing subscriptions for connected clients."));
-            }
         }
 
         static class Metrics
@@ -435,7 +274,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
 
             public static IDisposable MessageLatency(IIdentity identity) => Util.Metrics.Latency(GetTags(identity), EdgeHubMessageLatencyOptions);
 
-            internal static MetricTags GetTags(IIdentity identity)
+            static MetricTags GetTags(IIdentity identity)
             {
                 return new MetricTags("Id", identity.Id);
             }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -129,55 +129,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         {
             Events.AddingSubscription(id, deviceSubscription);
             return this.subscriptionProcessor.AddSubscription(id, deviceSubscription);
-            //try
-            //{
-            //    Option<ICloudProxy> cloudProxy = await this.connectionManager.GetCloudConnection(id);
-            //    await this.ProcessSubscription(id, cloudProxy, deviceSubscription, true);
-            //}
-            //catch (Exception e)
-            //{
-            //    Events.ErrorAddingSubscription(e, id, deviceSubscription);
-            //}
         }
 
-        public async Task RemoveSubscription(string id, DeviceSubscription deviceSubscription)
+        public Task RemoveSubscription(string id, DeviceSubscription deviceSubscription)
         {
             Events.RemovingSubscription(id, deviceSubscription);
-            this.connectionManager.RemoveSubscription(id, deviceSubscription);
-            try
-            {
-                Option<ICloudProxy> cloudProxy = await this.connectionManager.GetCloudConnection(id);
-                await this.ProcessSubscription(id, cloudProxy, deviceSubscription, false);
-            }
-            catch (Exception e)
-            {
-                Events.ErrorRemovingSubscription(e, id, deviceSubscription);
-            }
+            return this.subscriptionProcessor.RemoveSubscription(id, deviceSubscription);
         }
 
         public Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions)
         {
             Preconditions.CheckNonWhiteSpace(id, nameof(id));
-            Preconditions.CheckNotNull(subscriptions, nameof(subscriptions));
-            return this.subscriptionProcessor.ProcessSubscriptions(id, subscriptions);
-            //Option<ICloudProxy> cloudProxy = await this.connectionManager.GetCloudConnection(id);
-            //foreach (KeyValuePair<DeviceSubscription, bool> item in subscriptions)
-            //{
-            //    DeviceSubscription deviceSubscription = item.Key;
-            //    bool addSubscription = item.Value;
-            //    if (addSubscription)
-            //    {
-            //        Events.AddingSubscription(id, deviceSubscription);
-            //        this.connectionManager.AddSubscription(id, deviceSubscription);
-            //    }
-            //    else
-            //    {
-            //        Events.RemovingSubscription(id, deviceSubscription);
-            //        this.connectionManager.RemoveSubscription(id, deviceSubscription);
-            //    }
-
-            //    await this.ProcessSubscription(id, cloudProxy, deviceSubscription, addSubscription);
-            //}
+            return this.subscriptionProcessor.ProcessSubscriptions(id, Preconditions.CheckNotNull(subscriptions, nameof(subscriptions)));
         }
 
         public void Dispose()

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -123,11 +123,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             return this.twinManager.UpdateDesiredPropertiesAsync(id, twinCollection);
         }
 
-        public Task AddSubscription(string id, DeviceSubscription deviceSubscription)
-            => this.subscriptionProcessor.AddSubscription(id, deviceSubscription);
-
-        public Task RemoveSubscription(string id, DeviceSubscription deviceSubscription)
-            => this.subscriptionProcessor.RemoveSubscription(id, deviceSubscription);
+        public Task ProcessSubscription(string id, DeviceSubscription deviceSubscription, bool addSubscription)
+            => this.subscriptionProcessor.ProcessSubscription(id, deviceSubscription, addSubscription);
 
         public Task ProcessSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions)
             => this.subscriptionProcessor.ProcessSubscriptions(id, subscriptions);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -457,7 +457,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         var routerTask = c.Resolve<Task<Router>>();
                         var twinManagerTask = c.Resolve<Task<ITwinManager>>();
                         var invokeMethodHandlerTask = c.Resolve<Task<IInvokeMethodHandler>>();
-                        var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();                        
+                        var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();
                         var subscriptionProcessorTask = c.Resolve<Task<ISubscriptionProcessor>>();
                         Router router = await routerTask;
                         ITwinManager twinManager = await twinManagerTask;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
     using Microsoft.Azure.Devices.Routing.Core.Checkpointers;
     using Microsoft.Azure.Devices.Routing.Core.Endpoints;
     using Microsoft.Azure.Devices.Shared;
-    using Microsoft.Extensions.Logging;
     using IRoutingMessage = Microsoft.Azure.Devices.Routing.Core.IMessage;
     using Message = Microsoft.Azure.Devices.Client.Message;
 
@@ -442,9 +441,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     {
                         var invokeMethodHandlerTask = c.Resolve<Task<IInvokeMethodHandler>>();
                         var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();
+                        var deviceConnectivityManager = c.Resolve<IDeviceConnectivityManager>();
                         IConnectionManager connectionManager = await connectionManagerTask;
                         IInvokeMethodHandler invokeMethodHandler = await invokeMethodHandlerTask;
-                        return new SubscriptionProcessor(connectionManager, invokeMethodHandler) as ISubscriptionProcessor;
+                        return new SubscriptionProcessor(connectionManager, invokeMethodHandler, deviceConnectivityManager) as ISubscriptionProcessor;
                     })
                 .As<Task<ISubscriptionProcessor>>()
                 .SingleInstance();
@@ -457,8 +457,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         var routerTask = c.Resolve<Task<Router>>();
                         var twinManagerTask = c.Resolve<Task<ITwinManager>>();
                         var invokeMethodHandlerTask = c.Resolve<Task<IInvokeMethodHandler>>();
-                        var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();
-                        var deviceConnectivityManager = c.Resolve<IDeviceConnectivityManager>();
+                        var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();                        
                         var subscriptionProcessorTask = c.Resolve<Task<ISubscriptionProcessor>>();
                         Router router = await routerTask;
                         ITwinManager twinManager = await twinManagerTask;
@@ -472,7 +471,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                             twinManager,
                             this.edgeDeviceId,
                             invokeMethodHandler,
-                            deviceConnectivityManager,
                             subscriptionProcessor);
                         return hub;
                     })

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             // Arrange
             var edgeHub = new Mock<IEdgeHub>();
-            edgeHub.Setup(e => e.ProcessSubscription("d1", DeviceSubscription.DesiredPropertyUpdates, true)).Returns(Task.CompletedTask);
+            edgeHub.Setup(e => e.AddSubscription("d1", DeviceSubscription.DesiredPropertyUpdates)).Returns(Task.CompletedTask);
             var connMgr = Mock.Of<IConnectionManager>();
             var identity = Mock.Of<IDeviceIdentity>(i => i.Id == "d1");
             var deviceProxy = new Mock<IDeviceProxy>();
@@ -295,7 +295,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             // Arrange
             var edgeHub = new Mock<IEdgeHub>();
-            edgeHub.Setup(e => e.ProcessSubscription("d1", DeviceSubscription.DesiredPropertyUpdates, false)).Returns(Task.CompletedTask);
+            edgeHub.Setup(e => e.RemoveSubscription("d1", DeviceSubscription.DesiredPropertyUpdates))
+                .Returns(Task.CompletedTask);
             var connMgr = Mock.Of<IConnectionManager>();
             var identity = Mock.Of<IDeviceIdentity>(i => i.Id == "d1");
             var deviceProxy = new Mock<IDeviceProxy>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             // Arrange
             var edgeHub = new Mock<IEdgeHub>();
-            edgeHub.Setup(e => e.AddSubscription("d1", DeviceSubscription.DesiredPropertyUpdates)).Returns(Task.CompletedTask);
+            edgeHub.Setup(e => e.ProcessSubscription("d1", DeviceSubscription.DesiredPropertyUpdates, true)).Returns(Task.CompletedTask);
             var connMgr = Mock.Of<IConnectionManager>();
             var identity = Mock.Of<IDeviceIdentity>(i => i.Id == "d1");
             var deviceProxy = new Mock<IDeviceProxy>();
@@ -295,7 +295,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             // Arrange
             var edgeHub = new Mock<IEdgeHub>();
-            edgeHub.Setup(e => e.RemoveSubscription("d1", DeviceSubscription.DesiredPropertyUpdates)).Returns(Task.CompletedTask);
+            edgeHub.Setup(e => e.ProcessSubscription("d1", DeviceSubscription.DesiredPropertyUpdates, false)).Returns(Task.CompletedTask);
             var connMgr = Mock.Of<IConnectionManager>();
             var identity = Mock.Of<IDeviceIdentity>(i => i.Id == "d1");
             var deviceProxy = new Mock<IDeviceProxy>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.C2D, true);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.C2D);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.C2D, false);
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.C2D);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.DesiredPropertyUpdates, true);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.DesiredPropertyUpdates, false);
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Methods, true);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Methods);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Methods, false);
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.Methods);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -165,10 +165,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.C2D, true);
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.DesiredPropertyUpdates, true);
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Methods, true);
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.TwinResponse, true);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.C2D);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Methods);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.TwinResponse);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -186,9 +186,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.ModuleMessages, true);
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.TwinResponse, true);
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Unknown, true);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.ModuleMessages);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.TwinResponse);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Unknown);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -199,9 +199,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.ModuleMessages, false);
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.TwinResponse, false);
-            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Unknown, false);
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.ModuleMessages);
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.TwinResponse);
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.Unknown);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(deviceId, DeviceSubscription.Methods, true);
+            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(deviceId, DeviceSubscription.Methods, true);
+            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(deviceId, DeviceSubscription.Methods, true);
+            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.ProcessSubscription(deviceId, DeviceSubscription.Methods, true);
+            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
@@ -1,0 +1,374 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Microsoft.Azure.Devices.Routing.Core;
+    using Microsoft.Azure.Devices.Routing.Core.MessageSources;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class SubscriptionProcessorTest
+    {
+        public static SubscriptionProcessor GetSubscriptionProcessor(IConnectionManager connectionManager = null)
+        {
+            // Arrange
+            connectionManager = connectionManager ?? Mock.Of<IConnectionManager>();
+            var subscriptionProcessor = new SubscriptionProcessor(
+                connectionManager,
+                Mock.Of<IInvokeMethodHandler>(),
+                Mock.Of<IDeviceConnectivityManager>());
+            return subscriptionProcessor;
+        }
+
+        [Fact]
+        public async Task ProcessC2DSubscriptionTest()
+        {
+            // Arrange
+            string id = "d1";
+            var cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            cloudProxy.Setup(c => c.StartListening());
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.C2D);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+
+            cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.C2D);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ProcessDesiredPropertiesSubscriptionTest()
+        {
+            // Arrange
+            string id = "d1";
+            var cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            cloudProxy.Setup(c => c.SetupDesiredPropertyUpdatesAsync());
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+
+            cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            cloudProxy.Setup(c => c.RemoveDesiredPropertyUpdatesAsync());
+            connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ProcessMethodsSubscriptionTest()
+        {
+            // Arrange
+            string id = "d1";
+            var cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            cloudProxy.Setup(c => c.SetupCallMethodAsync());
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Methods);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+
+            cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            cloudProxy.Setup(c => c.RemoveCallMethodAsync());
+            connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.Methods);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ProcessMultipleSubscriptionsTest()
+        {
+            // Arrange
+            string id = "d1";
+            var cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            cloudProxy.Setup(c => c.SetupCallMethodAsync());
+            cloudProxy.Setup(c => c.RemoveDesiredPropertyUpdatesAsync());
+            cloudProxy.Setup(c => c.StartListening());
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.ProcessSubscriptions(
+                id,
+                new[]
+                {
+                    (DeviceSubscription.C2D, true),
+                    (DeviceSubscription.DesiredPropertyUpdates, false),
+                    (DeviceSubscription.Methods, true),
+                    (DeviceSubscription.TwinResponse, true)
+                });
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ProcessMultipleSubscriptionCallsTest()
+        {
+            // Arrange
+            string id = "d1";
+
+            async Task<Option<ICloudProxy>> DummyProxyGetter()
+            {
+                await Task.Delay(TimeSpan.FromSeconds(3));
+                throw new TimeoutException();
+            }
+
+            var cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            var connectionManager = new Mock<IConnectionManager>(MockBehavior.Strict);
+            connectionManager.Setup(c => c.AddSubscription(id, It.IsAny<DeviceSubscription>()));
+            connectionManager.Setup(c => c.GetCloudConnection(id))
+                .Returns(DummyProxyGetter);
+            SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.C2D);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Methods);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.TwinResponse);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+            connectionManager.Verify(c => c.GetCloudConnection(id), Times.Once);
+        }
+
+        [Fact]
+        public async Task ProcessNoOpSubscriptionTest()
+        {
+            // Arrange
+            string id = "d1";
+            var cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            var connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.ModuleMessages);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.TwinResponse);
+            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Unknown);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+
+            cloudProxy = new Mock<ICloudProxy>(MockBehavior.Strict);
+            connectionManager = Mock.Of<IConnectionManager>(c => c.GetCloudConnection(id) == Task.FromResult(Option.Some(cloudProxy.Object)));
+            subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
+
+            // Act
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.ModuleMessages);
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.TwinResponse);
+            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.Unknown);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+        }
+
+        [Fact]
+        public async Task AddSubscriptionHandlesExceptionTest()
+        {
+            // Arrange
+            string deviceId = "d1";
+            var cloudProxy = new Mock<ICloudProxy>();
+            cloudProxy.Setup(c => c.SetupCallMethodAsync())
+                .ThrowsAsync(new InvalidOperationException());
+
+            var connectionManager = new Mock<IConnectionManager>();
+            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
+            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
+            var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+            connectionManager.VerifyAll();
+        }
+
+        [Fact]
+        public async Task AddSubscriptionTimesOutTest()
+        {
+            // Arrange
+            string deviceId = "d1";
+            var cloudProxy = new Mock<ICloudProxy>();
+            cloudProxy.Setup(c => c.SetupCallMethodAsync())
+                .ThrowsAsync(new TimeoutException());
+
+            var connectionManager = new Mock<IConnectionManager>();
+            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
+            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
+            var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+            connectionManager.VerifyAll();
+        }
+
+        [Fact]
+        public async Task RemoveSubscriptionHandlesExceptionTest()
+        {
+            // Arrange
+            string deviceId = "d1";
+            var cloudProxy = new Mock<ICloudProxy>();
+            cloudProxy.Setup(c => c.SetupCallMethodAsync())
+                .ThrowsAsync(new InvalidOperationException());
+
+            var connectionManager = new Mock<IConnectionManager>();
+            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
+            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
+            var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+            connectionManager.VerifyAll();
+        }
+
+        [Fact]
+        public async Task RemoveSubscriptionTimesOutTest()
+        {
+            // Arrange
+            string deviceId = "d1";
+            var cloudProxy = new Mock<ICloudProxy>();
+            cloudProxy.Setup(c => c.SetupCallMethodAsync())
+                .ThrowsAsync(new TimeoutException());
+
+            var connectionManager = new Mock<IConnectionManager>();
+            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
+            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
+            var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
+
+            // Act
+            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(5));
+            cloudProxy.VerifyAll();
+            connectionManager.VerifyAll();
+        }
+
+        [Fact]
+        public async Task ProcessSubscriptionsOnDeviceConnected()
+        {
+            // Arrange
+            string d1 = "d1";
+            var deviceIdentity = Mock.Of<IIdentity>(d => d.Id == d1);
+            string m1 = "d2/m1";
+            var moduleIdentity = Mock.Of<IIdentity>(m => m.Id == m1);
+
+            var connectedClients = new List<IIdentity>
+            {
+                deviceIdentity,
+                moduleIdentity
+            };
+
+            IReadOnlyDictionary<DeviceSubscription, bool> device1Subscriptions = new Dictionary<DeviceSubscription, bool>()
+            {
+                [DeviceSubscription.Methods] = true,
+                [DeviceSubscription.DesiredPropertyUpdates] = true
+            };
+
+            IReadOnlyDictionary<DeviceSubscription, bool> module1Subscriptions = new Dictionary<DeviceSubscription, bool>()
+            {
+                [DeviceSubscription.Methods] = true,
+                [DeviceSubscription.ModuleMessages] = true
+            };
+
+            var device1CloudProxy = Mock.Of<ICloudProxy>(
+                dc => dc.SetupDesiredPropertyUpdatesAsync() == Task.CompletedTask
+                      && dc.SetupCallMethodAsync() == Task.CompletedTask);
+            Mock.Get(device1CloudProxy).SetupGet(d => d.IsActive).Returns(true);
+            var module1CloudProxy = Mock.Of<ICloudProxy>(mc => mc.SetupCallMethodAsync() == Task.CompletedTask && mc.IsActive);
+
+            var invokeMethodHandler = Mock.Of<IInvokeMethodHandler>(
+                m =>
+                    m.ProcessInvokeMethodSubscription(d1) == Task.CompletedTask
+                    && m.ProcessInvokeMethodSubscription(m1) == Task.CompletedTask);
+
+            var connectionManager = Mock.Of<IConnectionManager>(
+                c =>
+                    c.GetConnectedClients() == connectedClients
+                    && c.GetSubscriptions(d1) == Option.Some(device1Subscriptions)
+                    && c.GetSubscriptions(m1) == Option.Some(module1Subscriptions)
+                    && c.GetCloudConnection(d1) == Task.FromResult(Option.Some(device1CloudProxy))
+                    && c.GetCloudConnection(m1) == Task.FromResult(Option.Some(module1CloudProxy)));
+
+            var endpoint = new Mock<Endpoint>("myId");
+            var endpointExecutor = Mock.Of<IEndpointExecutor>();
+            Mock.Get(endpointExecutor).SetupGet(ee => ee.Endpoint).Returns(() => endpoint.Object);
+            var endpointExecutorFactory = Mock.Of<IEndpointExecutorFactory>();
+            Mock.Get(endpointExecutorFactory).Setup(eef => eef.CreateAsync(It.IsAny<Endpoint>())).ReturnsAsync(endpointExecutor);
+            var endpoints = new HashSet<Endpoint> { endpoint.Object };
+            var route = new Route("myRoute", "true", "myIotHub", TelemetryMessageSource.Instance, endpoints);
+            var routerConfig = new RouterConfig(new[] { route });
+            Router router = await Router.CreateAsync("myRouter", "myIotHub", routerConfig, endpointExecutorFactory);
+
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
+
+            var subscriptionProcessor = new SubscriptionProcessor(connectionManager, invokeMethodHandler, deviceConnectivityManager);
+
+            // Act
+            Mock.Get(deviceConnectivityManager).Raise(d => d.DeviceConnected += null, new EventArgs());
+
+            // Assert
+            Mock.Get(device1CloudProxy).Verify(d => d.SetupDesiredPropertyUpdatesAsync(), Times.Once);
+            Mock.Get(device1CloudProxy).Verify(d => d.SetupCallMethodAsync(), Times.Once);
+            Mock.Get(module1CloudProxy).Verify(m => m.SetupCallMethodAsync(), Times.Once);
+            Mock.Get(invokeMethodHandler).VerifyAll();
+            Mock.Get(connectionManager).VerifyAll();
+        }
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.C2D);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.C2D, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.C2D);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.C2D, false);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.DesiredPropertyUpdates, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.DesiredPropertyUpdates, false);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Methods);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Methods, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.Methods);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Methods, false);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -165,10 +165,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.C2D);
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.DesiredPropertyUpdates);
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Methods);
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.TwinResponse);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.C2D, true);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.DesiredPropertyUpdates, true);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Methods, true);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.TwinResponse, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -186,9 +186,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             SubscriptionProcessor subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.ModuleMessages);
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.TwinResponse);
-            await subscriptionProcessor.AddSubscription(id, DeviceSubscription.Unknown);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.ModuleMessages, true);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.TwinResponse, true);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Unknown, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -199,9 +199,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             subscriptionProcessor = GetSubscriptionProcessor(connectionManager);
 
             // Act
-            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.ModuleMessages);
-            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.TwinResponse);
-            await subscriptionProcessor.RemoveSubscription(id, DeviceSubscription.Unknown);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.ModuleMessages, false);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.TwinResponse, false);
+            await subscriptionProcessor.ProcessSubscription(id, DeviceSubscription.Unknown, false);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
+            await subscriptionProcessor.ProcessSubscription(deviceId, DeviceSubscription.Methods, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -246,7 +246,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
+            await subscriptionProcessor.ProcessSubscription(deviceId, DeviceSubscription.Methods, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
+            await subscriptionProcessor.ProcessSubscription(deviceId, DeviceSubscription.Methods, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var subscriptionProcessor = GetSubscriptionProcessor(connectionManager.Object);
 
             // Act
-            await subscriptionProcessor.AddSubscription(deviceId, DeviceSubscription.Methods);
+            await subscriptionProcessor.ProcessSubscription(deviceId, DeviceSubscription.Methods, true);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(5));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 });
 
             // Assert
-            await Task.Delay(TimeSpan.FromSeconds(5));
+            await Task.Delay(TimeSpan.FromSeconds(30));
             cloudProxy.VerifyAll();
         }
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Assert.False(responseTask.IsCompleted);
 
             // Act
-            await routingEdgeHub.ProcessSubscription(identity.Id, DeviceSubscription.Methods, true);
+            await routingEdgeHub.AddSubscription(identity.Id, DeviceSubscription.Methods);
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert
@@ -455,7 +455,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Assert.False(responseTask.IsCompleted);
 
             // Act
-            await routingEdgeHub.ProcessSubscription(identity.Id, DeviceSubscription.Methods, true);
+            await routingEdgeHub.AddSubscription(identity.Id, DeviceSubscription.Methods);
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -370,7 +370,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Assert.False(responseTask.IsCompleted);
 
             // Act
-            await routingEdgeHub.AddSubscription(identity.Id, DeviceSubscription.Methods);
+            await routingEdgeHub.ProcessSubscription(identity.Id, DeviceSubscription.Methods, true);
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert
@@ -455,7 +455,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Assert.False(responseTask.IsCompleted);
 
             // Act
-            await routingEdgeHub.AddSubscription(identity.Id, DeviceSubscription.Methods);
+            await routingEdgeHub.ProcessSubscription(identity.Id, DeviceSubscription.Methods, true);
             await Task.Delay(TimeSpan.FromSeconds(5));
 
             // Assert

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -269,6 +269,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
+            var subscriptionProcessor = new SubscriptionProcessor(connectionManager, invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
+
             // RoutingEdgeHub
             var routingEdgeHub = new RoutingEdgeHub(
                 router,
@@ -277,7 +279,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 twinManager,
                 "testEdgeDevice",
                 invokeMethodHandler,
-                Mock.Of<ISubscriptionProcessor>());
+                subscriptionProcessor);
 
             var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
             var methodRequest = new DirectMethodRequest("device1/module1", "shutdown", null, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10));
@@ -423,6 +425,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             var connectionManager = new ConnectionManager(cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), new IdentityProvider("myIotHub"));
 
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
+            var subscriptionProcessor = new SubscriptionProcessor(connectionManager, invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
 
             // RoutingEdgeHub
             var routingEdgeHub = new RoutingEdgeHub(
@@ -432,7 +435,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 twinManager,
                 "testEdgeDevice",
                 invokeMethodHandler,
-                Mock.Of<ISubscriptionProcessor>());
+                subscriptionProcessor);
 
             var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -525,7 +525,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Assert.True(clientMessage3.SystemProperties.ContainsKey(SystemProperties.EdgeMessageId));
         }
 
-
         static async Task<RoutingEdgeHub> GetTestEdgeHub(IConnectionManager connectionManager = null)
         {
             // Arrange

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 twinManager,
                 "testEdgeDevice",
                 Mock.Of<IInvokeMethodHandler>(),
-                Mock.Of<IDeviceConnectivityManager>());
+                Mock.Of<ISubscriptionProcessor>());
             var identity = new Mock<IIdentity>();
             identity.SetupGet(id => id.Id).Returns("something");
             EdgeMessage[] messages = { new EdgeMessage.Builder(new byte[0]).Build() };
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 twinManager,
                 "testEdgeDevice",
                 Mock.Of<IInvokeMethodHandler>(),
-                Mock.Of<IDeviceConnectivityManager>());
+                Mock.Of<ISubscriptionProcessor>());
 
             await Assert.ThrowsAsync<EdgeHubMessageTooLargeException>(() => routingEdgeHub.ProcessDeviceMessage(identity.Object, badMessage));
 
@@ -165,7 +165,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             var twinManager = new Mock<ITwinManager>();
             var message = Mock.Of<IMessage>();
             twinManager.Setup(t => t.GetTwinAsync(It.IsAny<string>())).Returns(Task.FromResult(message));
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager.Object, "testEdgeDevice", Mock.Of<IInvokeMethodHandler>(), Mock.Of<IDeviceConnectivityManager>());
+            var routingEdgeHub = new RoutingEdgeHub(
+                router,
+                messageConverter,
+                connectionManager,
+                twinManager.Object,
+                "testEdgeDevice",
+                Mock.Of<IInvokeMethodHandler>(),
+                Mock.Of<ISubscriptionProcessor>());
 
             IMessage received = await routingEdgeHub.GetTwinAsync("*");
             twinManager.Verify(x => x.GetTwinAsync("*"), Times.Once);
@@ -202,7 +209,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             var message = Mock.Of<IMessage>();
             IMessage received = new EdgeMessage.Builder(new byte[0]).Build();
             twinManager.Setup(t => t.UpdateDesiredPropertiesAsync(It.IsAny<string>(), It.IsAny<IMessage>())).Callback<string, IMessage>((s, m) => received = message).Returns(Task.CompletedTask);
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager.Object, "testEdgeDevice", Mock.Of<IInvokeMethodHandler>(), Mock.Of<IDeviceConnectivityManager>());
+            var routingEdgeHub = new RoutingEdgeHub(
+                router,
+                messageConverter,
+                connectionManager,
+                twinManager.Object,
+                "testEdgeDevice",
+                Mock.Of<IInvokeMethodHandler>(),
+                Mock.Of<ISubscriptionProcessor>());
 
             await routingEdgeHub.UpdateDesiredPropertiesAsync("*", message);
             twinManager.Verify(x => x.UpdateDesiredPropertiesAsync("*", message), Times.Once);
@@ -256,7 +270,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
             // RoutingEdgeHub
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
+            var routingEdgeHub = new RoutingEdgeHub(
+                router,
+                messageConverter,
+                connectionManager,
+                twinManager,
+                "testEdgeDevice",
+                invokeMethodHandler,
+                Mock.Of<ISubscriptionProcessor>());
 
             var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
             var methodRequest = new DirectMethodRequest("device1/module1", "shutdown", null, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10));
@@ -330,7 +351,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
             // RoutingEdgeHub
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
+            var routingEdgeHub = new RoutingEdgeHub(
+                router,
+                messageConverter,
+                connectionManager,
+                twinManager,
+                "testEdgeDevice",
+                invokeMethodHandler,
+                Mock.Of<ISubscriptionProcessor>());
 
             var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
 
@@ -397,7 +425,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
             // RoutingEdgeHub
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, "testEdgeDevice", invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
+            var routingEdgeHub = new RoutingEdgeHub(
+                router,
+                messageConverter,
+                connectionManager,
+                twinManager,
+                "testEdgeDevice",
+                invokeMethodHandler,
+                Mock.Of<ISubscriptionProcessor>());
 
             var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
@@ -461,7 +496,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             string edgeDeviceId = "testEdgeDevice";
             // Test Scenario
-            var routingEdgeHub = new RoutingEdgeHub(router, messageConverter, connectionManager, twinManager, edgeDeviceId, Mock.Of<IInvokeMethodHandler>(), Mock.Of<IDeviceConnectivityManager>());
+            var routingEdgeHub = new RoutingEdgeHub(
+                router,
+                messageConverter,
+                connectionManager,
+                twinManager,
+                edgeDeviceId,
+                Mock.Of<IInvokeMethodHandler>(),
+                Mock.Of<ISubscriptionProcessor>());
 
             Message clientMessage1 = new EdgeMessage.Builder(new byte[0]).Build();
             clientMessage1.SystemProperties[SystemProperties.ConnectionDeviceId] = edgeDeviceId;
@@ -483,316 +525,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Assert.True(clientMessage3.SystemProperties.ContainsKey(SystemProperties.EdgeMessageId));
         }
 
-        [Fact]
-        public async Task ProcessC2DSubscriptionTest()
-        {
-            // Arrange
-            string id = "d1";
-            RoutingEdgeHub edgeHub = await GetTestEdgeHub();
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.StartListening());
-
-            // Act
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.C2D, true);
-
-            // Assert
-            cloudProxy.VerifyAll();
-
-            // Arrange
-            cloudProxy = new Mock<ICloudProxy>();
-
-            // Act
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.C2D, false);
-
-            // Assert
-            cloudProxy.VerifyAll();
-        }
-
-        [Fact]
-        public async Task ProcessDesiredPropertiesSubscriptionTest()
-        {
-            // Arrange
-            string id = "d1";
-            RoutingEdgeHub edgeHub = await GetTestEdgeHub();
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.SetupDesiredPropertyUpdatesAsync())
-                .Returns(Task.CompletedTask);
-
-            // Act
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.DesiredPropertyUpdates, true);
-
-            // Assert
-            cloudProxy.VerifyAll();
-
-            // Arrange
-            cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.RemoveDesiredPropertyUpdatesAsync())
-                .Returns(Task.CompletedTask);
-
-            // Act
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.DesiredPropertyUpdates, false);
-
-            // Assert
-            cloudProxy.VerifyAll();
-        }
-
-        [Fact]
-        public async Task ProcessMethodsSubscriptionTest()
-        {
-            // Arrange
-            string id = "d1";
-            RoutingEdgeHub edgeHub = await GetTestEdgeHub();
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.SetupCallMethodAsync())
-                .Returns(Task.CompletedTask);
-
-            // Act
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.Methods, true);
-
-            // Assert
-            cloudProxy.VerifyAll();
-
-            // Arrange
-            cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.RemoveCallMethodAsync())
-                .Returns(Task.CompletedTask);
-
-            // Act
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.Methods, false);
-
-            // Assert
-            cloudProxy.VerifyAll();
-        }
-
-        [Fact]
-        public async Task ProcessNoOpSubscriptionTest()
-        {
-            // Arrange
-            string id = "d1";
-            RoutingEdgeHub edgeHub = await GetTestEdgeHub();
-            var cloudProxy = new Mock<ICloudProxy>();
-
-            // Act
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.ModuleMessages, true);
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.ModuleMessages, false);
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.TwinResponse, true);
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.TwinResponse, false);
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.Unknown, true);
-            await edgeHub.ProcessSubscription(id, Option.Some(cloudProxy.Object), DeviceSubscription.Unknown, false);
-
-            // Assert
-            cloudProxy.VerifyAll();
-        }
-
-        [Fact]
-        public async Task AddSubscriptionTest()
-        {
-            // Arrange
-            string deviceId = "d1";
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.SetupCallMethodAsync())
-                .Returns(Task.CompletedTask);
-
-            var connectionManager = new Mock<IConnectionManager>();
-            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
-            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
-
-            // Act
-            await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
-
-            // Assert
-            cloudProxy.VerifyAll();
-            connectionManager.VerifyAll();
-        }
-
-        [Fact]
-        public async Task AddSubscriptionHandlesExceptionTest()
-        {
-            // Arrange
-            string deviceId = "d1";
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.SetupCallMethodAsync())
-                .ThrowsAsync(new InvalidOperationException());
-
-            var connectionManager = new Mock<IConnectionManager>();
-            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
-            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
-
-            // Act
-            await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
-
-            // Assert
-            cloudProxy.VerifyAll();
-            connectionManager.VerifyAll();
-        }
-
-        [Fact]
-        public async Task AddSubscriptionTimesOutTest()
-        {
-            // Arrange
-            string deviceId = "d1";
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.SetupCallMethodAsync())
-                .ThrowsAsync(new TimeoutException());
-
-            var connectionManager = new Mock<IConnectionManager>();
-            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
-            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
-
-            // Act
-            await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
-
-            // Assert
-            cloudProxy.VerifyAll();
-            connectionManager.VerifyAll();
-        }
-
-        [Fact]
-        public async Task RemoveSubscriptionTest()
-        {
-            // Arrange
-            string deviceId = "d1";
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.SetupCallMethodAsync())
-                .Returns(Task.CompletedTask);
-
-            var connectionManager = new Mock<IConnectionManager>();
-            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
-            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
-
-            // Act
-            await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
-
-            // Assert
-            cloudProxy.VerifyAll();
-            connectionManager.VerifyAll();
-        }
-
-        [Fact]
-        public async Task RemoveSubscriptionHandlesExceptionTest()
-        {
-            // Arrange
-            string deviceId = "d1";
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.SetupCallMethodAsync())
-                .ThrowsAsync(new InvalidOperationException());
-
-            var connectionManager = new Mock<IConnectionManager>();
-            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
-            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
-
-            // Act
-            await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
-
-            // Assert
-            cloudProxy.VerifyAll();
-            connectionManager.VerifyAll();
-        }
-
-        [Fact]
-        public async Task RemoveSubscriptionTimesOutTest()
-        {
-            // Arrange
-            string deviceId = "d1";
-            var cloudProxy = new Mock<ICloudProxy>();
-            cloudProxy.Setup(c => c.SetupCallMethodAsync())
-                .ThrowsAsync(new TimeoutException());
-
-            var connectionManager = new Mock<IConnectionManager>();
-            connectionManager.Setup(c => c.AddSubscription(deviceId, DeviceSubscription.Methods));
-            connectionManager.Setup(c => c.GetCloudConnection(deviceId)).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            IEdgeHub edgeHub = await GetTestEdgeHub(connectionManager.Object);
-
-            // Act
-            await edgeHub.AddSubscription(deviceId, DeviceSubscription.Methods);
-
-            // Assert
-            cloudProxy.VerifyAll();
-            connectionManager.VerifyAll();
-        }
-
-        [Fact]
-        public async Task ProcessSubscriptionsOnDeviceConnected()
-        {
-            // Arrange
-            string d1 = "d1";
-            var deviceIdentity = Mock.Of<IIdentity>(d => d.Id == d1);
-            string m1 = "d2/m1";
-            var moduleIdentity = Mock.Of<IIdentity>(m => m.Id == m1);
-
-            var connectedClients = new List<IIdentity>
-            {
-                deviceIdentity,
-                moduleIdentity
-            };
-
-            IReadOnlyDictionary<DeviceSubscription, bool> device1Subscriptions = new Dictionary<DeviceSubscription, bool>()
-            {
-                [DeviceSubscription.Methods] = true,
-                [DeviceSubscription.DesiredPropertyUpdates] = true
-            };
-
-            IReadOnlyDictionary<DeviceSubscription, bool> module1Subscriptions = new Dictionary<DeviceSubscription, bool>()
-            {
-                [DeviceSubscription.Methods] = true,
-                [DeviceSubscription.ModuleMessages] = true
-            };
-
-            var device1CloudProxy = Mock.Of<ICloudProxy>(
-                dc => dc.SetupDesiredPropertyUpdatesAsync() == Task.CompletedTask
-                      && dc.SetupCallMethodAsync() == Task.CompletedTask);
-            Mock.Get(device1CloudProxy).SetupGet(d => d.IsActive).Returns(true);
-            var module1CloudProxy = Mock.Of<ICloudProxy>(mc => mc.SetupCallMethodAsync() == Task.CompletedTask && mc.IsActive);
-
-            var invokeMethodHandler = Mock.Of<IInvokeMethodHandler>(
-                m =>
-                    m.ProcessInvokeMethodSubscription(d1) == Task.CompletedTask
-                    && m.ProcessInvokeMethodSubscription(m1) == Task.CompletedTask);
-
-            var connectionManager = Mock.Of<IConnectionManager>(
-                c =>
-                    c.GetConnectedClients() == connectedClients
-                    && c.GetSubscriptions(d1) == Option.Some(device1Subscriptions)
-                    && c.GetSubscriptions(m1) == Option.Some(module1Subscriptions)
-                    && c.GetCloudConnection(d1) == Task.FromResult(Option.Some(device1CloudProxy))
-                    && c.GetCloudConnection(m1) == Task.FromResult(Option.Some(module1CloudProxy)));
-
-            var endpoint = new Mock<Endpoint>("myId");
-            var endpointExecutor = Mock.Of<IEndpointExecutor>();
-            Mock.Get(endpointExecutor).SetupGet(ee => ee.Endpoint).Returns(() => endpoint.Object);
-            var endpointExecutorFactory = Mock.Of<IEndpointExecutorFactory>();
-            Mock.Get(endpointExecutorFactory).Setup(eef => eef.CreateAsync(It.IsAny<Endpoint>())).ReturnsAsync(endpointExecutor);
-            var endpoints = new HashSet<Endpoint> { endpoint.Object };
-            var route = new Route("myRoute", "true", "myIotHub", TelemetryMessageSource.Instance, endpoints);
-            var routerConfig = new RouterConfig(new[] { route });
-            Router router = await Router.CreateAsync("myRouter", "myIotHub", routerConfig, endpointExecutorFactory);
-
-            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-
-            var edgeHub = new RoutingEdgeHub(
-                router,
-                Mock.Of<Core.IMessageConverter<Devices.Routing.Core.IMessage>>(),
-                connectionManager,
-                Mock.Of<ITwinManager>(),
-                "ed1",
-                invokeMethodHandler,
-                deviceConnectivityManager);
-
-            // Act
-            Mock.Get(deviceConnectivityManager).Raise(d => d.DeviceConnected += null, new EventArgs());
-
-            // Assert
-            Mock.Get(device1CloudProxy).Verify(d => d.SetupDesiredPropertyUpdatesAsync(), Times.Once);
-            Mock.Get(device1CloudProxy).Verify(d => d.SetupCallMethodAsync(), Times.Once);
-            Mock.Get(module1CloudProxy).Verify(m => m.SetupCallMethodAsync(), Times.Once);
-            Mock.Get(invokeMethodHandler).VerifyAll();
-            Mock.Get(connectionManager).VerifyAll();
-        }
 
         static async Task<RoutingEdgeHub> GetTestEdgeHub(IConnectionManager connectionManager = null)
         {
@@ -818,7 +550,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 Mock.Of<ITwinManager>(),
                 "ed1",
                 Mock.Of<IInvokeMethodHandler>(),
-                Mock.Of<IDeviceConnectivityManager>());
+                Mock.Of<ISubscriptionProcessor>());
             return edgeHub;
         }
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -440,7 +440,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             IEndpointExecutorFactory endpointExecutorFactory = new StoringAsyncEndpointExecutorFactory(endpointExecutorConfig, new AsyncEndpointExecutorOptions(1, TimeSpan.FromMilliseconds(10)), messageStore);
             Router router = await Router.CreateAsync(Guid.NewGuid().ToString(), iotHubName, routerConfig, endpointExecutorFactory);
             ITwinManager twinManager = new TwinManager(connectionManager, new TwinCollectionMessageConverter(), new TwinMessageConverter(), Option.None<IEntityStore<string, TwinInfo>>());
-            IEdgeHub edgeHub = new RoutingEdgeHub(router, routingMessageConverter, connectionManager, twinManager, edgeDeviceId, Mock.Of<IInvokeMethodHandler>(), Mock.Of<IDeviceConnectivityManager>());
+            IEdgeHub edgeHub = new RoutingEdgeHub(router, routingMessageConverter, connectionManager, twinManager, edgeDeviceId, Mock.Of<IInvokeMethodHandler>(), Mock.Of<ISubscriptionProcessor>());
             return (edgeHub, connectionManager);
         }
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 var endpointExecutorFactory = new SyncEndpointExecutorFactory(new EndpointExecutorConfig(defaultTimeout, new FixedInterval(0, TimeSpan.FromSeconds(1)), defaultTimeout, true));
                 Router router = await Router.CreateAsync(Guid.NewGuid().ToString(), iothubHostName, routerConfig, endpointExecutorFactory);
                 IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
-                IEdgeHub edgeHub = new RoutingEdgeHub(router, new RoutingMessageConverter(), connectionManager, twinManager, edgeDeviceId, invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());
+                IEdgeHub edgeHub = new RoutingEdgeHub(router, new RoutingMessageConverter(), connectionManager, twinManager, edgeDeviceId, invokeMethodHandler, Mock.Of<ISubscriptionProcessor>());
                 cloudConnectionProvider.BindEdgeHub(edgeHub);
 
                 var versionInfo = new VersionInfo("v1", "b1", "c1");

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/SessionStatePersistenceProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/SessionStatePersistenceProviderTest.cs
@@ -71,7 +71,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Task setTask = sessionProvider.SetAsync(identity, sessionState);
 
             Assert.True(setTask.IsCompleted);
-            edgeHub.Verify(x => x.AddSubscription("d1", DeviceSubscription.Methods), Times.Once);
+            IEnumerable<(DeviceSubscription, bool)> list = new List<(DeviceSubscription, bool)> { (DeviceSubscription.Methods, true) };
+            edgeHub.Verify(x => x.ProcessSubscriptions("d1", list), Times.Once);
         }
 
         [Fact]
@@ -86,7 +87,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Task setTask = sessionProvider.SetAsync(identity, sessionState);
 
             Assert.True(setTask.IsCompleted);
-            edgeHub.Verify(x => x.RemoveSubscription("d1", DeviceSubscription.Methods), Times.Once);
+            IEnumerable<(DeviceSubscription, bool)> list = new List<(DeviceSubscription, bool)> { (DeviceSubscription.Methods, false) };
+            edgeHub.Verify(x => x.ProcessSubscriptions("d1", list), Times.Once);
         }
 
         [Fact]
@@ -130,7 +132,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Task setTask = sessionProvider.SetAsync(identity, sessionState);
 
             Assert.True(setTask.IsCompleted);
-            edgeHub.Verify(x => x.AddSubscription("d1", DeviceSubscription.Methods), Times.Once);
+            IEnumerable<(DeviceSubscription, bool)> list = new List<(DeviceSubscription, bool)>
+            {
+                (DeviceSubscription.Methods, true),
+                (DeviceSubscription.TwinResponse, true)
+            };
+            edgeHub.Verify(x => x.ProcessSubscriptions("d1", list), Times.Once);
         }
 
         [Theory]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/SessionStateStoragePersistenceProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/SessionStateStoragePersistenceProviderTest.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             edgeHub.Setup(e => e.ProcessSubscriptions("d1", It.IsAny<IEnumerable<(DeviceSubscription, bool)>>()))
                 .Callback<string, IEnumerable<(DeviceSubscription, bool)>>((d, s) => receivedSubscriptions = s.ToList())
                 .Returns(Task.CompletedTask);
-                
+
             var identity = Mock.Of<IProtocolgatewayDeviceIdentity>(i => i.Id == "d1");
             var sessionProvider = new SessionStateStoragePersistenceProvider(edgeHub.Object, this.entityStore);
             var sessionState = new SessionState(false);
@@ -196,11 +196,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             List<(DeviceSubscription, bool)> receivedSubscriptions = null;
             var edgeHub = new Mock<IEdgeHub>();
             edgeHub.Setup(e => e.ProcessSubscriptions("d1", It.IsAny<IEnumerable<(DeviceSubscription, bool)>>()))
-                .Callback<string, IEnumerable<(DeviceSubscription, bool)>>((d, s) =>
-                {
-                    callbackCount++;
-                    receivedSubscriptions = s.ToList();
-                })
+                .Callback<string, IEnumerable<(DeviceSubscription, bool)>>(
+                    (d, s) =>
+                    {
+                        callbackCount++;
+                        receivedSubscriptions = s.ToList();
+                    })
                 .Returns(Task.CompletedTask);
 
             var identity = Mock.Of<IProtocolgatewayDeviceIdentity>(i => i.Id == "d1");
@@ -218,7 +219,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var expectedSubscriptions = new List<(DeviceSubscription, bool)>
             {
                 (DeviceSubscription.C2D, true),
-                (DeviceSubscription.Methods, true),                
+                (DeviceSubscription.Methods, true),
                 (DeviceSubscription.DesiredPropertyUpdates, false)
             };
             Assert.NotNull(receivedSubscriptions);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/SessionStateStoragePersistenceProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/SessionStateStoragePersistenceProviderTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Task setTask = sessionProvider.SetAsync(identity, sessionState);
 
             Assert.True(setTask.IsCompleted);
-            edgeHub.Verify(x => x.ProcessSubscription("d1", DeviceSubscription.Methods, false), Times.Once);
+            edgeHub.Verify(x => x.RemoveSubscription("d1", DeviceSubscription.Methods), Times.Once);
         }
 
         [Fact]


### PR DESCRIPTION
Currently EdgeHub processes subscriptions one at a time, and immediately after the device sends a subscription. Because of this, when the device is offline, it can take a long time for a device to connect and set its subscriptions. With this change, we group the device subscriptions in the EdgeHub, and process them together. 