### PR TITLE
Add CN on a server cert as a DNS SAN entry

### DIFF
--- a/edgelet/edgelet-http-workload/src/server/cert/server.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/server.rs
@@ -551,7 +551,7 @@ mod tests {
                 assert_eq!(CertificateType::Server, *props.certificate_type());
                 let san_entries = props.san_entries().unwrap();
                 assert_eq!(1, san_entries.len());
-                assert_eq!("DNS: beeblebrox", san_entries[0]);
+                assert_eq!("DNS:beeblebrox, DNS:marvin", san_entries[0]);
                 assert!(MAX_DURATION_SEC >= *props.validity_in_secs());
                 Ok(TestCert::default()
                     .with_private_key(PrivateKey::Key(KeyBytes::Pem("Betelgeuse".to_string()))))

--- a/edgelet/edgelet-http-workload/src/server/cert/server.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/server.rs
@@ -11,7 +11,7 @@ use edgelet_core::{
 };
 use edgelet_http::route::{Handler, Parameters};
 use edgelet_http::Error as HttpError;
-use edgelet_utils::{ensure_not_empty_with_context, prepare_dns_san_entry};
+use edgelet_utils::{ensure_not_empty_with_context, prepare_dns_san_entries};
 use workload::models::ServerCertificateRequest;
 
 use error::{CertOperation, Error, ErrorKind};
@@ -52,21 +52,18 @@ where
                 Ok((name, genid))
             })
             .map(|(module_id, genid)| {
-                let alias = format!("{}{}server", module_id.to_string(), genid.to_string());
+                let module_id = module_id.to_string();
+                let alias = format!("{}{}server", module_id, genid.to_string());
 
-                // add a DNS SAN entry in the server cert that uses the module identifier as
-                // an alternative DNS name
-                let dns_san = prepare_dns_san_entry(module_id);
-
-                req.into_body().concat2().then(|body| {
+                req.into_body().concat2().then(move |body| {
                     let body =
                         body.context(ErrorKind::CertOperation(CertOperation::GetServerCert))?;
-                    Ok((alias, body, dns_san))
+                    Ok((alias, body, module_id))
                 })
             })
             .into_future()
             .flatten()
-            .and_then(move |(alias, body, dns_san)| {
+            .and_then(move |(alias, body, module_id)| {
                 let cert_req: ServerCertificateRequest =
                     serde_json::from_slice(&body).context(ErrorKind::MalformedRequestBody)?;
 
@@ -86,7 +83,12 @@ where
                 let common_name = cert_req.common_name();
                 ensure_not_empty_with_context(common_name, || ErrorKind::MalformedRequestBody)?;
 
-                let sans = vec![dns_san];
+                // add a DNS SAN entry in the server cert that uses the module identifier as
+                // an alternative DNS name; we also need to add the common_name that we are using
+                // as a DNS name since the presence of a DNS name SAN will take precedence over
+                // the common name
+                let sans = vec![prepare_dns_san_entries(&[&module_id, common_name])];
+
                 #[cfg_attr(feature = "cargo-clippy", allow(cast_sign_loss))]
                 let props = CertificateProperties::new(
                     expiration,

--- a/edgelet/edgelet-http-workload/tests/dns-san.rs
+++ b/edgelet/edgelet-http-workload/tests/dns-san.rs
@@ -314,15 +314,15 @@ fn dns_san_server() {
     runtime.spawn(server);
 
     // run a test client that uses the module id for TLS domain name
-    let client = run_echo_client(&mut service, port, MODULE_ID);
-    runtime.block_on(client).unwrap();
+    let client1 = run_echo_client(&mut service, port, MODULE_ID);
+    runtime.block_on(client1).unwrap();
 
     // run a test client that uses the CN for TLS domain name
     // NOTE: Ideally, this should be a separate test, but there's some global
     // state in the HSM C library that does not get reset between multiple
     // tests in the same run and causes the test to fail.
-    let client = run_echo_client(&mut service, port, COMMON_NAME);
-    runtime.block_on(client).unwrap();
+    let client2 = run_echo_client(&mut service, port, COMMON_NAME);
+    runtime.block_on(client2).unwrap();
 
     // cleanup
     crypto

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -70,20 +70,25 @@ pub fn prepare_cert_uri_module(hub_name: &str, device_id: &str, module_id: &str)
     )
 }
 
-pub fn prepare_dns_san_entry(name: &str) -> String {
-    // The name returned from here must conform to following rules (as per RFC 1035):
-    //  - length must be <= 63 characters
-    //  - must be all lower case alphanumeric characters or '-'
-    //  - must start with an alphabet
-    //  - must end with an alphanumeric character
+pub fn prepare_dns_san_entries(names: &[&str]) -> String {
+    names
+        .iter()
+        .map(|name| {
+            // The name returned from here must conform to following rules (as per RFC 1035):
+            //  - length must be <= 63 characters
+            //  - must be all lower case alphanumeric characters or '-'
+            //  - must start with an alphabet
+            //  - must end with an alphanumeric character
+            let name = name
+                .to_lowercase()
+                .trim_start_matches(|c| !char::is_ascii_lowercase(&c))
+                .trim_end_matches(|c| !char::is_alphanumeric(c))
+                .replace(|c| !(char::is_alphanumeric(c) || c == '-'), "");
 
-    let name = name.to_lowercase();
-    let name = name
-        .trim_start_matches(|c| !char::is_ascii_lowercase(&c))
-        .trim_end_matches(|c| !char::is_alphanumeric(c))
-        .replace(|c| !(char::is_alphanumeric(c) || c == '-'), "");
-
-    format!("DNS: {}", &name[0..cmp::min(name.len(), 63)])
+            format!("DNS:{}", &name[0..cmp::min(name.len(), 63)])
+        })
+        .collect::<Vec<String>>()
+        .join(", ")
 }
 
 #[cfg(test)]
@@ -148,24 +153,39 @@ mod tests {
 
     #[test]
     fn dns_san() {
-        assert_eq!("DNS: edgehub", prepare_dns_san_entry("edgehub"));
-        assert_eq!("DNS: edgehub", prepare_dns_san_entry("EDGEhub"));
-        assert_eq!("DNS: edgehub", prepare_dns_san_entry("$$$Edgehub"));
-        assert_eq!("DNS: edgehub", prepare_dns_san_entry("$$$Edgehub###$$$"));
-        assert_eq!("DNS: edge-hub", prepare_dns_san_entry("$$$Edge-hub###$$"));
+        assert_eq!("DNS:edgehub", prepare_dns_san_entries(&["edgehub"]));
+        assert_eq!("DNS:edgehub", prepare_dns_san_entries(&["EDGEhub"]));
+        assert_eq!("DNS:edgehub", prepare_dns_san_entries(&["$$$Edgehub"]));
         assert_eq!(
-            "DNS: edge-hub",
-            prepare_dns_san_entry("$$$Ed###ge-h$$^$ub###$$")
+            "DNS:edgehub",
+            prepare_dns_san_entries(&["$$$Edgehub###$$$"])
+        );
+        assert_eq!(
+            "DNS:edge-hub",
+            prepare_dns_san_entries(&["$$$Edge-hub###$$"])
+        );
+        assert_eq!(
+            "DNS:edge-hub",
+            prepare_dns_san_entries(&["$$$Ed###ge-h$$^$ub###$$"])
         );
 
         let name = "$eDgE##-##Hub23212$$$eDgE##-##Hub23212$$$eDgE##-##Hub23212$$$eDgE##-##Hub23212$$$eDgE##-##Hub23212$$";
         let expected_name = "edge-hub23212edge-hub23212edge-hub23212edge-hub23212edge-hub232";
         assert_eq!(
-            format!("DNS: {}", expected_name),
-            prepare_dns_san_entry(name)
+            format!("DNS:{}", expected_name),
+            prepare_dns_san_entries(&[name])
         );
 
-        // 63 letters for the name and 5 more for the literal "DNS: "
-        assert_eq!(63 + 5, prepare_dns_san_entry(name).len());
+        // 63 letters for the name and 4 more for the literal "DNS:"
+        assert_eq!(63 + 4, prepare_dns_san_entries(&[name]).len());
+
+        assert_eq!(
+            "DNS:edgehub, DNS:edgy",
+            prepare_dns_san_entries(&["edgehub", "edgy"])
+        );
+        assert_eq!(
+            "DNS:edgehub, DNS:edgy, DNS:moo",
+            prepare_dns_san_entries(&["edgehub", "edgy", "moo"])
+        );
     }
 }


### PR DESCRIPTION
When a server cert has one or more DNS SAN entries and a client uses the CN on the cert as the domain name that it uses to connect to the server, the cert validation routine (at least in .NET Core) wants to use only the DNS SAN entries for server name validation. This causes a problem in Edge because in a default configuration, modules connect to Edge Hub using the edge device host name (for which an alias name is added in the moby network that maps the device host name to the Edge Hub container). Since server certs now have the module ID as a DNS SAN entry by default, clients are no longer able to connect to Edge Hub. This change adds the CN on the cert as a second a DNS SAN entry so that clients can connect with either the CN or with the module ID.