### PR TITLE
Use ContainerUser for windows containers

### DIFF
--- a/edge-hub/docker/windows/amd64/Dockerfile
+++ b/edge-hub/docker/windows/amd64/Dockerfile
@@ -12,9 +12,4 @@ EXPOSE 8883/tcp
 EXPOSE 5671/tcp
 EXPOSE 443/tcp
 
-USER ContainerAdministrator
-# Add an unprivileged user account for running Edge Hub
-RUN net user /add edgehubuser
-
-USER edgehubuser
 CMD ["dotnet", "Microsoft.Azure.Devices.Edge.Hub.Service.dll"]

--- a/edge-modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
@@ -8,5 +8,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER moduleuser
 CMD ["dotnet", "DirectMethodReceiver.dll"]

--- a/edge-modules/DirectMethodSender/docker/windows/amd64/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/windows/amd64/Dockerfile
@@ -7,9 +7,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER ContainerAdministrator
-# Add an unprivileged user account for running the module
-RUN net user /add moduleuser
-
-USER moduleuser
 CMD ["dotnet", "DirectMethodSender.dll"]

--- a/edge-modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
@@ -8,5 +8,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER moduleuser
 CMD ["dotnet", "DirectMethodSender.dll"]

--- a/edge-modules/MessagesAnalyzer/docker/windows/amd64/Dockerfile
+++ b/edge-modules/MessagesAnalyzer/docker/windows/amd64/Dockerfile
@@ -7,9 +7,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER ContainerAdministrator
-# Add an unprivileged user account for running the module
-RUN net user /add moduleuser
-
-USER moduleuser
 CMD ["dotnet", "MessagesAnalyzer.dll"]

--- a/edge-modules/MessagesAnalyzer/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/MessagesAnalyzer/docker/windows/arm32v7/Dockerfile
@@ -8,5 +8,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER moduleuser
 CMD ["dotnet", "MessagesAnalyzer.dll"]

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
@@ -7,9 +7,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER ContainerAdministrator
-# Add an unprivileged user account for running the module
-RUN net user /add moduleuser
-
-USER moduleuser
 CMD ["dotnet", "SimulatedTemperatureSensor.dll"]

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
@@ -8,5 +8,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER moduleuser
 CMD ["dotnet", "SimulatedTemperatureSensor.dll"]

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/base/Dockerfile
@@ -12,9 +12,8 @@ RUN curl -SL %DOTNET_DOWNLOAD_URL% --output dotnet.zip \
 USER ContainerAdministrator
 # In order to set system PATH, ContainerAdministrator must be used
 RUN setx /M PATH "%PATH%;C:\Program Files\dotnet"
-# Add an unprivileged user account for running the module
-RUN net user /add moduleuser
-USER moduleuser
+
+USER ContainerUser
  
 # Configure Kestrel web server to bind to port 80 when present
 ENV ASPNETCORE_URLS=http://+:80

--- a/edge-modules/TemperatureFilter/docker/windows/amd64/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/windows/amd64/Dockerfile
@@ -7,9 +7,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER ContainerAdministrator
-# Add an unprivileged user account for running the module
-RUN net user /add moduleuser
-
-USER moduleuser
 CMD ["dotnet", "TemperatureFilter.dll"]

--- a/edge-modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
@@ -8,5 +8,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER moduleuser
 CMD ["dotnet", "TemperatureFilter.dll"]

--- a/edge-modules/load-gen/docker/windows/amd64/Dockerfile
+++ b/edge-modules/load-gen/docker/windows/amd64/Dockerfile
@@ -7,9 +7,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER ContainerAdministrator
-# Add an unprivileged user account for running the module
-RUN net user /add moduleuser
-
-USER moduleuser
 CMD ["dotnet", "load-gen.dll"]

--- a/edge-modules/load-gen/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/load-gen/docker/windows/arm32v7/Dockerfile
@@ -8,5 +8,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER moduleuser
 CMD ["dotnet", "load-gen.dll"]


### PR DESCRIPTION
Currently we add an unprivileged user "moduleuser" for the windows containers, and run the app (edgeAgent/edgeHub, etc) as this user. This was to avoid running the container as admin. 
This is unnecessary as the containers run by default as an unprivileged user "ContainerUser". 

So remove the code to add moduleuser and run the app as moduleuser. 

This issue was also preventing windows containers from running on Microsoft IT controlled machines. 