### PR TITLE
Update CI test filter

### DIFF
--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -5,7 +5,7 @@ trigger:
       - master
 pr: none
 variables:
-  test.filter: "Category=E2E&Category!=Stress"
+  test.filter: "Category=Integration&Category!=Stress"
 jobs:
   - job: linux
     displayName: Linux


### PR DESCRIPTION
Currently no test is run in CI build; update CI test filter from "E2E" to "Integration".