### PR TITLE
Iotedged: Encode deviceId/moduleId for IOThub operations

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -905,6 +905,7 @@ dependencies = [
  "futures 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper-tls 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.84 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/edgelet/iothubservice/Cargo.toml
+++ b/edgelet/iothubservice/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 failure = "0.1"
 futures = "0.1"
 hyper = "0.12"
+percent-encoding = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/edgelet/iothubservice/src/device.rs
+++ b/edgelet/iothubservice/src/device.rs
@@ -86,7 +86,11 @@ where
                 .client
                 .request::<Module, Module>(
                     Method::PUT,
-                    &format!("/devices/{}/modules/{}", url_encode(&self.device_id), url_encode(&module_id)),
+                    &format!(
+                        "/devices/{}/modules/{}",
+                        url_encode(&self.device_id),
+                        url_encode(&module_id)
+                    ),
                     None,
                     Some(module),
                     add_if_match,
@@ -114,17 +118,15 @@ where
                 ModuleOperationReason::EmptyModuleId,
             ))))
         } else {
-            let url = &format!("/devices/{}/modules/{}", url_encode(&self.device_id), url_encode(&module_id));
+            let url = &format!(
+                "/devices/{}/modules/{}",
+                url_encode(&self.device_id),
+                url_encode(&module_id)
+            );
             println!("URL = {}", url);
             let res = self
                 .client
-                .request::<(), Module>(
-                    Method::GET,
-                    url,
-                    None,
-                    None,
-                    false,
-                )
+                .request::<(), Module>(Method::GET, url, None, None, false)
                 .then(|module| match module {
                     Ok(Some(module)) => Ok(module),
 
@@ -181,7 +183,11 @@ where
                 .client
                 .request::<(), ()>(
                     Method::DELETE,
-                    &format!("/devices/{}/modules/{}", url_encode(&self.device_id), url_encode(&module_id)),
+                    &format!(
+                        "/devices/{}/modules/{}",
+                        url_encode(&self.device_id),
+                        url_encode(&module_id)
+                    ),
                     None,
                     None,
                     true,

--- a/edgelet/iothubservice/src/device.rs
+++ b/edgelet/iothubservice/src/device.rs
@@ -4,7 +4,7 @@ use failure::{Fail, ResultExt};
 use futures::future::{self, Either};
 use futures::Future;
 use hyper::{Method, StatusCode};
-use percent_encoding::{percent_encode, PATH_SEGMENT_ENCODE_SET};
+use percent_encoding::{percent_encode, PercentEncode, PATH_SEGMENT_ENCODE_SET};
 
 use edgelet_http::client::{Client, ClientImpl, TokenSource};
 use edgelet_http::error::ErrorKind as HttpErrorKind;
@@ -217,8 +217,8 @@ where
     }
 }
 
-fn url_encode(value: &str) -> String {
-    percent_encode(value.as_bytes(), IOTHUB_ENCODE_SET).to_string()
+fn url_encode(value: &str) -> PercentEncode<'_, IOTHUB_ENCODE_SET> {
+    percent_encode(value.as_bytes(), IOTHUB_ENCODE_SET)
 }
 
 #[cfg(test)]

--- a/edgelet/iothubservice/src/device.rs
+++ b/edgelet/iothubservice/src/device.rs
@@ -118,15 +118,19 @@ where
                 ModuleOperationReason::EmptyModuleId,
             ))))
         } else {
-            let url = &format!(
-                "/devices/{}/modules/{}",
-                url_encode(&self.device_id),
-                url_encode(&module_id)
-            );
-            println!("URL = {}", url);
             let res = self
                 .client
-                .request::<(), Module>(Method::GET, url, None, None, false)
+                .request::<(), Module>(
+                    Method::GET,
+                    &format!(
+                        "/devices/{}/modules/{}",
+                        url_encode(&self.device_id),
+                        url_encode(&module_id)
+                    ),
+                    None,
+                    None,
+                    false,
+                )
                 .then(|module| match module {
                     Ok(Some(module)) => Ok(module),
 

--- a/edgelet/iothubservice/src/device.rs
+++ b/edgelet/iothubservice/src/device.rs
@@ -653,8 +653,8 @@ mod tests {
                     .with_secondary_key("skey".to_string()),
             );
         let module = Module::default()
-            .with_device_id("d1".to_string())
-            .with_module_id("m1".to_string())
+            .with_device_id("n@m.et#st".to_string())
+            .with_module_id("$edgeAgent".to_string())
             .with_generation_id("g1".to_string())
             .with_managed_by("iotedge".to_string())
             .with_authentication(auth.clone());
@@ -662,7 +662,7 @@ mod tests {
 
         let handler = move |req: Request<Body>| {
             assert_eq!(req.method(), &Method::GET);
-            assert_eq!(req.uri().path(), "/devices/d1/modules/m1");
+            assert_eq!(req.uri().path(), "/devices/n%40m.et%23st/modules/%24edgeAgent");
             assert_eq!(None, req.headers().get(hyper::header::IF_MATCH));
 
             let mut response = Response::new(serde_json::to_string(&module).unwrap().into());
@@ -673,9 +673,9 @@ mod tests {
         };
         let client = Client::new(handler, Some(NullTokenSource), api_version, host_name).unwrap();
 
-        let device_client = DeviceClient::new(client, "d1".to_string()).unwrap();
+        let device_client = DeviceClient::new(client, "n@m.et#st".to_string()).unwrap();
         let task = device_client
-            .get_module_by_id("m1".to_string())
+            .get_module_by_id("$edgeAgent".to_string())
             .then(|module| {
                 let module = module.unwrap();
                 assert_eq!(expected_module, module);

--- a/edgelet/iothubservice/src/device.rs
+++ b/edgelet/iothubservice/src/device.rs
@@ -4,6 +4,7 @@ use failure::{Fail, ResultExt};
 use futures::future::{self, Either};
 use futures::Future;
 use hyper::{Method, StatusCode};
+use url::form_urlencoded::byte_serialize;
 
 use edgelet_http::client::{Client, ClientImpl, TokenSource};
 use edgelet_http::error::ErrorKind as HttpErrorKind;
@@ -81,7 +82,7 @@ where
                 .client
                 .request::<Module, Module>(
                     Method::PUT,
-                    &format!("/devices/{}/modules/{}", &self.device_id, module_id),
+                    &format!("/devices/{}/modules/{}", url_encode(&self.device_id), url_encode(&module_id)),
                     None,
                     Some(module),
                     add_if_match,
@@ -109,11 +110,15 @@ where
                 ModuleOperationReason::EmptyModuleId,
             ))))
         } else {
+            // let urlencodeddid : String = byte_serialize("n@m.et#st".as_bytes()).collect();
+            // //let requrl = format!("/devices/{}/modules/{}", urlencodeddid, module_id);
+            // let url = get_url("/devices/{}/modules/{}", &self.device_id, module_id);
+            // println!("Get module request URL: {}", url);
             let res = self
                 .client
                 .request::<(), Module>(
                     Method::GET,
-                    &format!("/devices/{}/modules/{}", &self.device_id, module_id),
+                    &format!("/devices/{}/modules/{}", url_encode(&self.device_id), url_encode(&module_id)),
                     None,
                     None,
                     false,
@@ -148,7 +153,7 @@ where
         self.client
             .request::<(), Vec<Module>>(
                 Method::GET,
-                &format!("/devices/{}/modules", &self.device_id),
+                &format!("/devices/{}/modules", url_encode(&self.device_id)),
                 None,
                 None,
                 false,
@@ -174,7 +179,7 @@ where
                 .client
                 .request::<(), ()>(
                     Method::DELETE,
-                    &format!("/devices/{}/modules/{}", self.device_id, module_id),
+                    &format!("/devices/{}/modules/{}", url_encode(&self.device_id), url_encode(&module_id)),
                     None,
                     None,
                     true,
@@ -198,6 +203,10 @@ where
             device_id: self.device_id.clone(),
         }
     }
+}
+
+fn url_encode(value: &str) -> String {
+    byte_serialize(value.as_bytes()).collect()
 }
 
 #[cfg(test)]

--- a/edgelet/iothubservice/src/device.rs
+++ b/edgelet/iothubservice/src/device.rs
@@ -668,7 +668,7 @@ mod tests {
 
         let handler = move |req: Request<Body>| {
             assert_eq!(req.method(), &Method::GET);
-            assert_eq!(req.uri().path(), "/devices/n%40m.et%23st/modules/%24edgeAgent");
+            assert_eq!(req.uri().path(), "/devices/n@m.et%23st/modules/$edgeAgent");
             assert_eq!(None, req.headers().get(hyper::header::IF_MATCH));
 
             let mut response = Response::new(serde_json::to_string(&module).unwrap().into());

--- a/edgelet/iothubservice/src/lib.rs
+++ b/edgelet/iothubservice/src/lib.rs
@@ -21,7 +21,6 @@ extern crate serde_json;
 extern crate tokio;
 #[cfg(test)]
 extern crate typed_headers;
-#[cfg(test)]
 extern crate url;
 
 extern crate edgelet_http;

--- a/edgelet/iothubservice/src/lib.rs
+++ b/edgelet/iothubservice/src/lib.rs
@@ -15,12 +15,15 @@ extern crate failure;
 extern crate futures;
 extern crate hyper;
 #[macro_use]
+extern crate percent_encoding;
+#[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
 #[cfg(test)]
 extern crate tokio;
 #[cfg(test)]
 extern crate typed_headers;
+#[cfg(test)]
 extern crate url;
 
 extern crate edgelet_http;


### PR DESCRIPTION
The deviceId and moduleId should be URL encoded for all the identity operations that iotedged performs. This is to allow device IDs with non alphanumeric characters to work properly.