### PR TITLE
Fix docker login in image build

### DIFF
--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -114,8 +114,12 @@ jobs:
         inputs:
           PathtoPublish: '$(Build.BinariesDirectory)/publish'
           ArtifactName: 'core-windows'
-      - powershell: '"$(registry.password)" | docker login "edgebuilds.azurecr.io" -u "$(registry.user)" --password-stdin'
-        displayName: 'Docker Login'
+      - task: Docker@1
+        displayName: docker login
+        inputs:
+          azureSubscriptionEndpoint: 'IOT_EDGE_DEV1 (5ed2dcb6-29bb-40de-a855-8c24a8260343)'
+          azureContainerRegistry: edgebuilds.azurecr.io
+          command: login
 
       # Edge Agent
       - template: templates/image-windows.yaml


### PR DESCRIPTION
Use docker vsts task to login to docker in order to fix the image build.