### PR TITLE
docker login fix for image build

### DIFF
--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -116,7 +116,7 @@ jobs:
           ArtifactName: 'core-windows'
       - script: echo $(registry.password)|docker login "edgebuilds.azurecr.io" -u "$(registry.user)" --password-stdin
         displayName: Docker login
-        
+
       # Edge Agent
       - template: templates/image-windows.yaml
         parameters:

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -115,7 +115,7 @@ jobs:
           PathtoPublish: '$(Build.BinariesDirectory)/publish'
           ArtifactName: 'core-windows'
       - script: echo $(registry.password)|docker login "edgebuilds.azurecr.io" -u "$(registry.user)" --password-stdin
-        displayName: Docker login
+        displayName: Docker Login
 
       # Edge Agent
       - template: templates/image-windows.yaml

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -114,9 +114,9 @@ jobs:
         inputs:
           PathtoPublish: '$(Build.BinariesDirectory)/publish'
           ArtifactName: 'core-windows'
-      - powershell: '"$(registry.password)" | docker login "edgebuilds.azurecr.io" -u "$(registry.user)" --password-stdin'
-        displayName: 'Docker Login'
-
+      - script: echo $(registry.password)|docker login "edgebuilds.azurecr.io" -u "$(registry.user)" --password-stdin
+        displayName: Docker login
+        
       # Edge Agent
       - template: templates/image-windows.yaml
         parameters:


### PR DESCRIPTION
PowerShell to run docker login failed with unauthorized 401 error, which seems password can't pass successfully to docker login command.  Use cmd instead to run docker login to fix image build.