### PR TITLE
Default OptimizeForPerformance to false on arm32

### DIFF
--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -13,6 +13,6 @@ EXPOSE 5671/tcp
 EXPOSE 443/tcp
 
 USER edgehubuser
-
+ENV OptimizeForPerformance false
 CMD echo "$(date --utc +"[%Y-%m-%d %H:%M:%S %:z]"): Starting Edge Hub" && \
     exec /usr/bin/dotnet Microsoft.Azure.Devices.Edge.Hub.Service.dll

--- a/edge-hub/docker/windows/arm32v7/Dockerfile
+++ b/edge-hub/docker/windows/arm32v7/Dockerfile
@@ -14,4 +14,5 @@ EXPOSE 5671/tcp
 EXPOSE 443/tcp
 
 USER edgehubuser
+ENV OptimizeForPerformance false
 CMD ["dotnet", "Microsoft.Azure.Devices.Edge.Hub.Service.dll"]


### PR DESCRIPTION
This can still be overridden by setting the env variable in the deployment.