### PR TITLE
Verify Twin in E2E test script

### DIFF
--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -187,22 +187,22 @@ Function PrepareTestFromArtifacts
         {
             "DirectMethodAmqp"
             {
-                Write-Host "Copy deployment file from $DirectMethodModuleToModuleDeploymentArtifactsFilePath"
-                Copy-Item $DirectMethodModuleToModuleDeploymentArtifactsFilePath -Destination $DeploymentWorkingFilePath -Force
+                Write-Host "Copy deployment file from $DirectMethodModuleToModuleDeploymentArtifactFilePath"
+                Copy-Item $DirectMethodModuleToModuleDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
                 (Get-Content $DeploymentWorkingFilePath).replace('<UpstreamProtocol>','Amqp') | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<ClientTransportType>','Amqp_Tcp_Only') | Set-Content $DeploymentWorkingFilePath
             }
             "DirectMethodMqtt"
             {
-                Write-Host "Copy deployment file from $DirectMethodModuleToModuleDeploymentArtifactsFilePath"
-                Copy-Item $DirectMethodModuleToModuleDeploymentArtifactsFilePath -Destination $DeploymentWorkingFilePath -Force
+                Write-Host "Copy deployment file from $DirectMethodModuleToModuleDeploymentArtifactFilePath"
+                Copy-Item $DirectMethodModuleToModuleDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
                 (Get-Content $DeploymentWorkingFilePath).replace('<UpstreamProtocol>','Mqtt') | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<ClientTransportType>','Mqtt_Tcp_Only') | Set-Content $DeploymentWorkingFilePath
             }
             "TempFilter"
             {
-                Write-Host "Copy deployment file from $ModuleToModuleDeploymentArtifactsFilePath"
-                Copy-Item $ModuleToModuleDeploymentArtifactsFilePath -Destination $DeploymentWorkingFilePath -Force
+                Write-Host "Copy deployment file from $ModuleToModuleDeploymentArtifactFilePath"
+                Copy-Item $ModuleToModuleDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
             }
         }
 
@@ -449,7 +449,8 @@ Function RunTempSensorTest
         -r `"edgebuilds.azurecr.io`" ``
         -u `"$ContainerRegistryUsername`" ``
         -p `"$ContainerRegistryPassword`" --optimize_for_performance true ``
-        -t `"${ReleaseArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`""
+        -t `"${ReleaseArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
+        -tw `"$TwinTestFileArtifactFilePath`""
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
     $testExitCode = $lastExitCode
@@ -537,6 +538,11 @@ Function ValidateE2ETestParameters
         (Join-Path $IoTEdgeQuickstartArtifactFolder "*"),
         $InstallationScriptPath)
 
+    If (($TestName -eq "DirectMethodAmqp") -Or ($TestName -eq "DirectMethodMqtt"))
+    {
+        $validatingItems += $DirectMethodModuleToModuleDeploymentArtifactFilePath
+    }
+
     If (($TestName -eq "QuickstartCerts") -Or ($TestName -eq "TransparentGateway"))
     {
         $validatingItems += (Join-Path $LeafDeviceArtifactFolder "*")
@@ -544,12 +550,12 @@ Function ValidateE2ETestParameters
 
     If ($TestName -eq "TempFilter")
     {
-        $validatingItems += $ModuleToModuleDeploymentArtifactsFilePath
+        $validatingItems += $ModuleToModuleDeploymentArtifactFilePath
     }
 
-    If (($TestName -eq "DirectMethodAmqp") -Or ($TestName -eq "DirectMethodMqtt"))
+    If ($TestName -eq "TempSensor")
     {
-        $validatingItems += $DirectMethodModuleToModuleDeploymentArtifactsFilePath
+        $validatingItems += $TwinTestFileArtifactFilePath
     }
 
     If ($TestName -eq "TransparentGateway")
@@ -579,14 +585,17 @@ $E2ETestFolder = (Resolve-Path $E2ETestFolder).Path
 $InstallationScriptPath = Join-Path $E2ETestFolder "artifacts\core-windows\scripts\windows\setup\IotEdgeSecurityDaemon.ps1"
 $ModuleToModuleDeploymentFilename = "module_to_module_deployment.template.json"
 $DirectMethodModuleToModuleDeploymentFilename = "dm_module_to_module_deployment.json"
+$TwinTestFilename = "twin_test_tempSensor.json"
 
 $IoTEdgeQuickstartArtifactFolder = Join-Path $E2ETestFolder "artifacts\core-windows\IoTEdgeQuickstart\$Architecture"
 $LeafDeviceArtifactFolder = Join-Path $E2ETestFolder "artifacts\core-windows\LeafDevice\$Architecture"
 $IoTEdgedArtifactFolder = Join-Path $E2ETestFolder "artifacts\iotedged-windows"
 $PackagesArtifactFolder = Join-Path $E2ETestFolder "artifacts\packages"
 $DeploymentFilesFolder = Join-Path $E2ETestFolder "artifacts\core-windows\e2e_deployment_files"
-$ModuleToModuleDeploymentArtifactsFilePath = Join-Path $DeploymentFilesFolder $ModuleToModuleDeploymentFilename
-$DirectMethodModuleToModuleDeploymentArtifactsFilePath = Join-Path $DeploymentFilesFolder $DirectMethodModuleToModuleDeploymentFilename
+$TestFileFolder = Join-Path $E2ETestFolder "artifacts\core-windows\e2e_test_files"
+$ModuleToModuleDeploymentArtifactFilePath = Join-Path $DeploymentFilesFolder $ModuleToModuleDeploymentFilename
+$TwinTestFileArtifactFilePath = Join-Path $TestFileFolder $TwinTestFilename
+$DirectMethodModuleToModuleDeploymentArtifactFilePath = Join-Path $DeploymentFilesFolder $DirectMethodModuleToModuleDeploymentFilename
 
 $TestWorkingFolder = Join-Path $E2ETestFolder "working"
 $QuickstartWorkingFolder = (Join-Path $TestWorkingFolder "quickstart")

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -344,6 +344,7 @@ namespace IotEdgeQuickstart.Details
             await this.TwinTestFileName.ForEachAsync(
                 async fileName =>
                 {
+                    Console.WriteLine($"VerifyTwinAsync for {fileName} started.");
                     string twinTestJson = File.ReadAllText(fileName);
 
                     var twinTest = JsonConvert.DeserializeObject<TwinTestConfiguration>(twinTestJson);
@@ -376,6 +377,8 @@ namespace IotEdgeQuickstart.Details
                             await Retry.Do(Func, IsValid, null, retryInterval, cts.Token);
                         }
                     }
+
+                    Console.WriteLine($"VerifyTwinAsync for {fileName} completed.");
                 });
         }
 


### PR DESCRIPTION
1. Add -tw option to run TempSensor test for verify Twin in E2E test script.
2. rename $ModuleToModuleDeploymentArtifactFilePath and $DirectMethodModuleToModuleDeploymentArtifactFilePath variable.