### PR TITLE
Fix clippy lints from clippy's stable channel.

### DIFF
--- a/edgelet/dps/src/registration.rs
+++ b/edgelet/dps/src/registration.rs
@@ -519,7 +519,6 @@ mod tests {
             Some(op) => {
                 assert_eq!(op.operation_id(), "something");
                 assert_eq!(op.status().unwrap(), "assigning");
-                ()
             }
             None => panic!("Unexpected"),
         });
@@ -682,12 +681,9 @@ mod tests {
             key,
             3,
         );
-        let task = dps_operation.map(|result| {
-            match result {
-                Some(r) => assert_eq!(*r.registration_id(), "reg".to_string()),
-                None => panic!("Expected registration id"),
-            }
-            ()
+        let task = dps_operation.map(|result| match result {
+            Some(r) => assert_eq!(*r.registration_id(), "reg".to_string()),
+            None => panic!("Expected registration id"),
         });
         tokio::runtime::current_thread::Runtime::new()
             .unwrap()
@@ -728,12 +724,9 @@ mod tests {
             key,
             3,
         );
-        let task = dps_operation.map(|result| {
-            match result {
-                Some(_) => panic!("Shouldn't have passed because every attempt failed"),
-                None => assert_eq!(true, true),
-            }
-            ()
+        let task = dps_operation.map(|result| match result {
+            Some(_) => panic!("Shouldn't have passed because every attempt failed"),
+            None => assert_eq!(true, true),
         });
 
         tokio::runtime::current_thread::Runtime::new()
@@ -776,7 +769,6 @@ mod tests {
         let task = dps_operation.map(|result| match result {
             Some(op) => {
                 assert_eq!(*op.registration_id(), "reg".to_string());
-                ()
             }
             None => panic!("Unexpected"),
         });

--- a/edgelet/edgelet-core/src/watchdog.rs
+++ b/edgelet/edgelet-core/src/watchdog.rs
@@ -183,11 +183,7 @@ where
 {
     runtime
         .list()
-        .map(move |m| {
-            m.into_iter()
-                .filter_map(move |m| if m.name() == name { Some(m) } else { None })
-                .next()
-        })
+        .map(move |m| m.into_iter().find(move |m| m.name() == name))
         .map_err(|e| Error::from(e.context(ErrorKind::ModuleRuntime)))
 }
 

--- a/edgelet/edgelet-http-mgmt/src/client/module.rs
+++ b/edgelet/edgelet-http-mgmt/src/client/module.rs
@@ -255,7 +255,7 @@ impl ModuleRuntime for ModuleClient {
             .list_modules(&API_VERSION.to_string())
             .map(|list| {
                 list.modules()
-                    .into_iter()
+                    .iter()
                     .cloned()
                     .map(|m| {
                         let type_ = m.type_().clone();

--- a/edgelet/edgelet-http-mgmt/src/server/module/mod.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/mod.rs
@@ -45,7 +45,7 @@ where
     let name = spec.name().to_string();
     let type_ = spec.type_().to_string();
     let env = spec.config().env().map_or_else(HashMap::new, |vars| {
-        vars.into_iter()
+        vars.iter()
             .map(|var| (var.key().clone(), var.value().clone()))
             .collect()
     });

--- a/edgelet/edgelet-utils/src/ser_de.rs
+++ b/edgelet/edgelet-utils/src/ser_de.rs
@@ -77,7 +77,7 @@ where
     S: Serializer,
     T: BuildHasher,
 {
-    let sorted_map: BTreeMap<_, _> = x.into_iter().collect();
+    let sorted_map: BTreeMap<_, _> = x.iter().collect();
     sorted_map.serialize(serializer)
 }
 

--- a/edgelet/iotedged/src/signal.rs
+++ b/edgelet/iotedged/src/signal.rs
@@ -21,7 +21,7 @@ mod imp {
     use super::ShutdownSignal;
 
     pub(super) fn shutdown() -> ShutdownSignal {
-        let signals = [SIGINT, SIGTERM].into_iter().map(|&sig| {
+        let signals = [SIGINT, SIGTERM].iter().map(|&sig| {
             Signal::new(sig)
                 .flatten_stream()
                 .into_future()


### PR DESCRIPTION
Ran clippy from the stable channel (_clippy 0.0.212 (b2601be 2018-11-27_) and fixed the errors and warnings it gave.
