### PR TITLE
Fix `Install-SD -ExistingConfig` to not complain about existing install directory

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -544,7 +544,7 @@ function Get-SecurityDaemon {
             }
         }
         else {
-            New-Item -Type Directory $EdgeInstallDirectory | Out-Null
+            New-Item -Type Directory $EdgeInstallDirectory -Force | Out-Null
             Expand-Archive $edgeArchivePath $EdgeInstallDirectory -Force
             if ($ExistingConfig) {
                 Copy-Item "$EdgeInstallDirectory\iotedged-windows\*" $EdgeInstallDirectory -Force -Recurse -Exclude 'config.yaml'


### PR DESCRIPTION
82b82ccffdaeed408b04803ea2679e9b626d15c9 added `-Force` to the
`New-Item -Type Directory $EdgeInstallDirectory` when using an expanded
iotedged-windows directory, but forgot to add it to the command when
using a ZIP file.

Fixes #789