### PR TITLE
Fix invalid DNS SAN entries

### DIFF
--- a/edgelet/edgelet-http-workload/src/server/cert/server.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/server.rs
@@ -11,7 +11,9 @@ use edgelet_core::{
 };
 use edgelet_http::route::{Handler, Parameters};
 use edgelet_http::Error as HttpError;
-use edgelet_utils::{ensure_not_empty_with_context, prepare_dns_san_entries, append_dns_san_entries};
+use edgelet_utils::{
+    append_dns_san_entries, ensure_not_empty_with_context, prepare_dns_san_entries,
+};
 use workload::models::ServerCertificateRequest;
 
 use error::{CertOperation, Error, ErrorKind};
@@ -87,7 +89,10 @@ where
                 // an alternative DNS name; we also need to add the common_name that we are using
                 // as a DNS name since the presence of a DNS name SAN will take precedence over
                 // the common name
-                let sans = vec![append_dns_san_entries(&prepare_dns_san_entries(&[&module_id]), &[common_name])];
+                let sans = vec![append_dns_san_entries(
+                    &prepare_dns_san_entries(&[&module_id]),
+                    &[common_name],
+                )];
 
                 #[cfg_attr(feature = "cargo-clippy", allow(cast_sign_loss))]
                 let props = CertificateProperties::new(

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -102,6 +102,23 @@ pub fn prepare_dns_san_entries(names: &[&str]) -> String {
         .join(", ")
 }
 
+pub fn append_dns_san_entries(sans: &str, names: &[&str]) -> String {
+    let mut dns_sans = names
+        .iter()
+        .filter_map(|name| {
+            if name.trim().is_empty() {
+                None
+            } else {
+                Some(format!("DNS:{}", name.to_lowercase()))
+            }
+        })
+        .collect::<Vec<String>>()
+        .join(", ");
+    dns_sans.push_str(", ");
+    dns_sans.push_str(sans);
+    dns_sans
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -217,7 +234,7 @@ mod tests {
         assert_eq!(
             format!("DNS:{}", expected_name),
             prepare_dns_san_entries(&[name])
-        );
+         );
 
         // 63 letters for the name and 4 more for the literal "DNS:"
         assert_eq!(63 + 4, prepare_dns_san_entries(&[name]).len());
@@ -235,5 +252,10 @@ mod tests {
             "DNS:edgehub, DNS:moo",
             prepare_dns_san_entries(&[" -edgehub -", "-----", "- moo- "])
         );
+
+        // test appending host name to sanitized label
+        let sanitized_labels = prepare_dns_san_entries(&["1edgehub", "2edgy"]);
+        assert_eq!("DNS:2019host, DNS:2020host, DNS:edgehub, DNS:edgy",
+                  append_dns_san_entries(&sanitized_labels, &["2019host", "   ", "2020host"]));
     }
 }

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -234,7 +234,7 @@ mod tests {
         assert_eq!(
             format!("DNS:{}", expected_name),
             prepare_dns_san_entries(&[name])
-         );
+        );
 
         // 63 letters for the name and 4 more for the literal "DNS:"
         assert_eq!(63 + 4, prepare_dns_san_entries(&[name]).len());
@@ -255,7 +255,9 @@ mod tests {
 
         // test appending host name to sanitized label
         let sanitized_labels = prepare_dns_san_entries(&["1edgehub", "2edgy"]);
-        assert_eq!("DNS:2019host, DNS:2020host, DNS:edgehub, DNS:edgy",
-                  append_dns_san_entries(&sanitized_labels, &["2019host", "   ", "2020host"]));
+        assert_eq!(
+            "DNS:2019host, DNS:2020host, DNS:edgehub, DNS:edgy",
+            append_dns_san_entries(&sanitized_labels, &["2019host", "   ", "2020host"])
+        );
     }
 }


### PR DESCRIPTION
Changes here fix a situation where a edge device's host name that begins with number(s) [0-9] gets sanitized. For example host name "2019edgehost" is consumed as "edgehost". This has caused problems was observed when using VMs that begin with numbers since it appears to be permitted configuration contrary to RFC 1035.

The changes involve passing the configured host name as is into the SAN entry without any modifications. The module id DNS entry continues to be sanitized.