### PR TITLE
MqttEventsProcessorThreadCount parameter for E2E tests

### DIFF
--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -199,6 +199,11 @@ Function PrepareTestFromArtifacts
                 Copy-Item $DirectMethodModuleToModuleDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
                 (Get-Content $DeploymentWorkingFilePath).replace('<UpstreamProtocol>','Mqtt') | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<ClientTransportType>','Mqtt_Tcp_Only') | Set-Content $DeploymentWorkingFilePath
+
+                If ($Architecture -eq "arm32v7")
+                {
+                    (Get-Content $DeploymentWorkingFilePath).replace('<MqttEventsProcessorThreadCount>','1') | Set-Content $DeploymentWorkingFilePath
+                }
             }
             "TempFilter"
             {


### PR DESCRIPTION
Update to handle MqttEventsProcessorThreadCount parameter in deployment file for Windows E2E tests