### PR TITLE
Update cert gen script to facilitate automated testing

### DIFF
--- a/tools/CACertificates/certGen.sh
+++ b/tools/CACertificates/certGen.sh
@@ -25,9 +25,9 @@ OPENSSL_CONFIG_FILE="${CERTIFICATE_DIR}/openssl_root_ca.cnf"
 # env variable DEFAULT_VALIDITY_DAYS and set the duration in units of days
 DEFAULT_VALIDITY_DAYS=${DEFAULT_VALIDITY_DAYS:=30}
 ROOT_CA_PREFIX="azure-iot-test-only.root.ca"
-ROOT_CA_PASSWORD="1234"
+ROOT_CA_PASSWORD=${ROOT_CA_PASSWORD:="1234"}
 INTERMEDIATE_CA_PREFIX="azure-iot-test-only.intermediate"
-INTERMEDIATE_CA_PASSWORD=${ROOT_CA_PASSWORD}
+INTERMEDIATE_CA_PASSWORD="1234"
 export TESTDIR=${CERTIFICATE_DIR}
 
 ###############################################################################

--- a/tools/CACertificates/certGen.sh
+++ b/tools/CACertificates/certGen.sh
@@ -28,7 +28,7 @@ ROOT_CA_PREFIX="azure-iot-test-only.root.ca"
 ROOT_CA_PASSWORD=${ROOT_CA_PASSWORD:="1234"}
 INTERMEDIATE_CA_PREFIX="azure-iot-test-only.intermediate"
 INTERMEDIATE_CA_PASSWORD="1234"
-export TESTDIR=${CERTIFICATE_DIR}
+export CERTIFICATE_OUTPUT_DIR=${CERTIFICATE_DIR}
 
 ###############################################################################
 # Disclaimer print

--- a/tools/CACertificates/certGen.sh
+++ b/tools/CACertificates/certGen.sh
@@ -28,7 +28,7 @@ ROOT_CA_PREFIX="azure-iot-test-only.root.ca"
 ROOT_CA_PASSWORD="1234"
 INTERMEDIATE_CA_PREFIX="azure-iot-test-only.intermediate"
 INTERMEDIATE_CA_PASSWORD=${ROOT_CA_PASSWORD}
-
+export TESTDIR=${CERTIFICATE_DIR}
 
 ###############################################################################
 # Disclaimer print
@@ -221,7 +221,8 @@ function generate_certificate_common()
             -keyfile ${issuer_key_file} -keyform PEM \
             ${issuer_key_passwd_command} \
             -in ${csr_file} \
-            -out ${cert_file}
+            -out ${cert_file} \
+            -outdir ${CERTIFICATE_DIR}/newcerts
     [ $? -eq 0 ] || exit $?
     chmod 444 ${cert_file}
     [ $? -eq 0 ] || exit $?

--- a/tools/CACertificates/openssl_root_ca.cnf
+++ b/tools/CACertificates/openssl_root_ca.cnf
@@ -83,14 +83,14 @@ emailAddress_default            =
 [ v3_ca ]
 # Extensions for a typical CA.
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always,issuer:always
 basicConstraints = critical, CA:true
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
 
 [ v3_intermediate_ca ]
 # Extensions for a typical intermediate CA.
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always,issuer:always
 basicConstraints = critical, CA:true
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
 
@@ -100,7 +100,7 @@ basicConstraints = CA:FALSE
 nsCertType = client, email
 nsComment = "OpenSSL Generated Client Certificate"
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer
+authorityKeyIdentifier = keyid:always,issuer:always
 keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, emailProtection
 
@@ -110,7 +110,7 @@ basicConstraints = CA:FALSE
 nsCertType = server
 nsComment = "OpenSSL Generated Server Certificate"
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
+authorityKeyIdentifier = keyid:always,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 

--- a/tools/CACertificates/openssl_root_ca.cnf
+++ b/tools/CACertificates/openssl_root_ca.cnf
@@ -5,7 +5,7 @@ default_ca = CA_default
 
 [ CA_default ]
 # Directory and file locations.
-dir               = .
+dir               = $ENV::TESTDIR
 certs             = $dir/certs
 crl_dir           = $dir/crl
 new_certs_dir     = $dir/newcerts

--- a/tools/CACertificates/openssl_root_ca.cnf
+++ b/tools/CACertificates/openssl_root_ca.cnf
@@ -5,7 +5,7 @@ default_ca = CA_default
 
 [ CA_default ]
 # Directory and file locations.
-dir               = $ENV::TESTDIR
+dir               = $ENV::CERTIFICATE_OUTPUT_DIR
 certs             = $dir/certs
 crl_dir           = $dir/crl
 new_certs_dir     = $dir/newcerts


### PR DESCRIPTION
Update the script to make it more amenable for implementation of automated test cases. 
- Updates include setting custom passphrases and the ability to invoke the script from any relative path.
- Added a fix to ensure the authority key identifier settings matched the HSM lib settings.