### PR TITLE
Ensure symmetric key auth also uses backup

### DIFF
--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -328,7 +328,7 @@ impl Main {
                         dps_symmetric_key_provision(
                             &dps,
                             hyper_client.clone(),
-                            &dps_path,
+                            dps_path,
                             runtime,
                             &mut tokio_runtime,
                             key,
@@ -643,7 +643,7 @@ fn manual_provision(
 fn dps_symmetric_key_provision<HC, M>(
     provisioning: &Dps,
     hyper_client: HC,
-    _backup_path: &PathBuf,
+    backup_path: PathBuf,
     runtime: M,
     tokio_runtime: &mut tokio::runtime::Runtime,
     key: &str,
@@ -669,7 +669,9 @@ where
     .context(ErrorKind::Initialize(
         InitializeErrorReason::DpsProvisioningClient,
     ))?;
-    let provision = dps
+    let provision_with_file_backup = BackupProvisioning::new(dps, backup_path);
+
+    let provision = provision_with_file_backup
         .provision(memory_hsm.clone())
         .map_err(|err| {
             Error::from(err.context(ErrorKind::Initialize(


### PR DESCRIPTION
Changes here make symmetric key auth use the DPS registration backup in in order to be able to bootup in offline scenarios.