### PR TITLE
Make V1 TwinManager as default

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 .Map(s => TimeSpan.FromSeconds(s));
             bool useV1TwinManager = this.GetConfigurationValueIfExists<string>("TwinManagerVersion")
                 .Map(v => v.Equals("v1", StringComparison.OrdinalIgnoreCase))
-                .GetOrElse(false);
+                .GetOrElse(true);
 
             builder.RegisterModule(
                 new RoutingModule(


### PR DESCRIPTION
Making V1 TwinManager default for the 1.0.7-RC1