### PR TITLE
Fix to X.509 test runner script

### DIFF
--- a/scripts/linux/runX509Tests.sh
+++ b/scripts/linux/runX509Tests.sh
@@ -202,6 +202,7 @@ function run_quickstart_as_gateway()
         -d ${edge_device_id} \
         -a ${packages} \
         -c ${connection_string} \
+        -e "somethingNonNullNeededHere" \
         -n ${edge_hostname} \
         -r ${registry} \
         -u ${registry_uname} \


### PR DESCRIPTION
When invoking the iotedgequickstart application, without the -e option, it attempted to fetch the event hub connection string from the secret store and failed. It failed because the credentials to access the secret store were not provided to the quick start since this is not the test approach followed any more since pipelines provide access to key value secrets.