### PR TITLE
Fix build for new Rust 1.33 stable

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -45,7 +45,7 @@ jobs:
         displayName: Set Version
       - script: edgelet/build/linux/install.sh
         displayName: Install Rust
-      - script: 'cargo install --git https://github.com/myagley/cross.git --branch set-path'
+      - script: 'cargo install --git https://github.com/arsing/cross.git --branch set-path'
         displayName: 'Install cross (fork with docker fix)'
       - script: 'cross build --target armv7-unknown-linux-gnueabihf'
         displayName: armv7-unknown-linux-gnueabihf build

--- a/builds/ci/edgelet.yaml
+++ b/builds/ci/edgelet.yaml
@@ -48,7 +48,7 @@ jobs:
         displayName: Install Rust
         inputs:
           filePath: edgelet/build/linux/install.sh
-      - script: cargo install --git https://github.com/myagley/cross.git --branch set-path
+      - script: cargo install --git https://github.com/arsing/cross.git --branch set-path
         displayName: Install cross (fork with docker fix)
       - task: Bash@3
         displayName: armv7-unknown-linux-gnueabihf build

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -29,7 +29,7 @@ jobs:
       - bash: 'echo "##vso[task.setvariable variable=PATH;]$HOME/.cargo/bin:$PATH"'
         displayName: Modify path
 
-      - bash: 'cargo install --git https://github.com/myagley/cross.git --branch set-path'
+      - bash: 'cargo install --git https://github.com/arsing/cross.git --branch set-path'
         displayName: 'Install cross (fork with docker fix)'
 
       - script: scripts/linux/buildBranch.sh -c Release --no-rocksdb-bin

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -73,7 +73,7 @@ jobs:
         displayName: 'Docker Login'
       - script: edgelet/build/linux/install.sh --package-arm
         displayName: Install Rust
-      - bash: 'cargo install --git https://github.com/myagley/cross.git --branch set-path'
+      - bash: 'cargo install --git https://github.com/arsing/cross.git --branch set-path'
         displayName: 'Install cross (fork with docker fix)'
       - bash: 'make deb CARGO=cross CARGOFLAGS="--target armv7-unknown-linux-gnueabihf" TARGET=target/armv7-unknown-linux-gnueabihf/release DPKGFLAGS="-b -us -uc -i --host-arch armhf"'
         workingDirectory: edgelet

--- a/edgelet/dps/src/lib.rs
+++ b/edgelet/dps/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate base64;
 extern crate bytes;

--- a/edgelet/edgelet-config/src/lib.rs
+++ b/edgelet/edgelet-config/src/lib.rs
@@ -1,18 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 #![deny(unused_extern_crates, warnings)]
-// Remove this when clippy stops warning about old-style `allow()`,
-// which can only be silenced by enabling a feature and thus requires nightly
-//
-// Ref: https://github.com/rust-lang-nursery/rust-clippy/issues/3159#issuecomment-420530386
-#![allow(renamed_and_removed_lints)]
-#![cfg_attr(feature = "cargo-clippy", deny(clippy, clippy_pedantic))]
-#![cfg_attr(feature = "cargo-clippy", allow(
-    doc_markdown, // clippy want the "IoT" of "IoT Hub" in a code fence
-    shadow_unrelated,
-    stutter,
-    use_self,
-))]
+#![deny(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::doc_markdown, // clippy want the "IoT" of "IoT Hub" in a code fence
+    clippy::module_name_repetitions,
+    clippy::shadow_unrelated,
+    clippy::use_self,
+)]
 
 extern crate base64;
 extern crate config;

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[cfg(test)]
 extern crate base64;

--- a/edgelet/edgelet-docker/src/lib.rs
+++ b/edgelet/edgelet-docker/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate base64;
 extern crate chrono;

--- a/edgelet/edgelet-hsm/src/lib.rs
+++ b/edgelet/edgelet-hsm/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate bytes;
 extern crate chrono;

--- a/edgelet/edgelet-http-mgmt/src/lib.rs
+++ b/edgelet/edgelet-http-mgmt/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[cfg(test)]
 extern crate chrono;

--- a/edgelet/edgelet-http-workload/src/lib.rs
+++ b/edgelet/edgelet-http-workload/src/lib.rs
@@ -2,7 +2,11 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::type_complexity, clippy::use_self)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::type_complexity,
+    clippy::use_self
+)]
 
 extern crate base64;
 extern crate chrono;

--- a/edgelet/edgelet-http/src/lib.rs
+++ b/edgelet/edgelet-http/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
+    clippy::module_name_repetitions,
     clippy::similar_names,
-    clippy::stutter,
     clippy::use_self
 )]
 

--- a/edgelet/edgelet-http/src/route/regex.rs
+++ b/edgelet/edgelet-http/src/route/regex.rs
@@ -150,9 +150,9 @@ fn match_route(re: &Regex, path: &str) -> Option<Parameters> {
 fn normalize_pattern(pattern: &str) -> Cow<str> {
     let pattern = pattern
         .trim()
-        .trim_left_matches('^')
-        .trim_right_matches('$')
-        .trim_right_matches('/');
+        .trim_start_matches('^')
+        .trim_end_matches('$')
+        .trim_end_matches('/');
     match pattern {
         "" => "^/$".into(),
         s => format!("^{}/?$", s).into(),

--- a/edgelet/edgelet-http/tests/systemd.rs
+++ b/edgelet/edgelet-http/tests/systemd.rs
@@ -80,7 +80,6 @@ fn create_fd(family: AddressFamily, type_: SockType) -> Fd {
 }
 
 #[test]
-#[ignore] // TODO: Unignore when https://github.com/rust-lang/cargo/issues/6333 is fixed
 fn test_fd_ok() {
     let _l = lock_env();
     set_current_pid();

--- a/edgelet/edgelet-http/tests/systemd.rs
+++ b/edgelet/edgelet-http/tests/systemd.rs
@@ -85,12 +85,14 @@ fn test_fd_ok() {
 
     if fd != LISTEN_FDS_START {
         // In CI, fd 3 seems to be bound to something else already. The reason is unknown.
-        // It used to be because of https://github.com/rust-lang/cargo/issues/6333 but that is fixed since Rust 1.33.0.
+        // It used to be because of https://github.com/rust-lang/cargo/issues/6333 but that seems to have been fixed
+        // in Rust 1.33.0.
         //
         // Since the rest of the code assumes that all fds between LISTEN_FDS_START and LISTEN_FDS_START + ENV_FDS are valid,
-        // it's not possible to work around it.
+        // it's not possible to work around it by telling `Http` to bind to `fd://1/` - it'll just complain that `fd://0/` (ie fd 3)
+        // isn't a valid fd.
         //
-        // On local builds, fd 3 *is* available, and E2E tests also use fds, so we can just pretend
+        // On local builds, fd 3 *does* seem to be available, and E2E tests also use fds for the iotedged service, so we can just pretend
         // the test succeeded without losing coverage.
 
         unistd::close(fd).unwrap();

--- a/edgelet/edgelet-http/tests/systemd.rs
+++ b/edgelet/edgelet-http/tests/systemd.rs
@@ -28,7 +28,7 @@ use hyper::service::Service;
 use hyper::{Body, Request, Response, StatusCode};
 use nix::sys::socket::{self, AddressFamily, SockType};
 use nix::unistd::{self, getpid};
-use systemd::Fd;
+use systemd::{Fd, LISTEN_FDS_START};
 use url::Url;
 
 lazy_static! {
@@ -92,7 +92,7 @@ fn test_fd_ok() {
     // set the env var so that it contains the created fd
     env::set_var(ENV_FDS, format!("{}", fd - listen_fds_start + 1));
 
-    let url = Url::parse(&format!("fd://{}", fd - listen_fds_start)).unwrap();
+    let url = Url::parse(&format!("fd://{}", fd - LISTEN_FDS_START)).unwrap();
     let run = Http::new().bind_url(url, move || {
         let service = TestService {
             status_code: StatusCode::OK,

--- a/edgelet/edgelet-http/tests/systemd.rs
+++ b/edgelet/edgelet-http/tests/systemd.rs
@@ -35,12 +35,6 @@ lazy_static! {
     static ref LOCK: Mutex<()> = Mutex::new(());
 }
 
-// TODO: This works around https://github.com/rust-lang/cargo/issues/6333
-// `cargo test` opens /dev/random and /dev/urandom at fds 3 and 4 so the first fd bound is 5.
-// Remove the `cfg(test)` definition when that issue is fixed. Also see systemd/src/linux.rs
-#[cfg(test)]
-const LISTEN_FDS_START: Fd = 5;
-#[cfg(not(test))]
 const LISTEN_FDS_START: Fd = 3;
 
 const ENV_FDS: &str = "LISTEN_FDS";

--- a/edgelet/edgelet-iothub/src/lib.rs
+++ b/edgelet/edgelet-iothub/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate base64;
 #[cfg(test)]

--- a/edgelet/edgelet-kube/src/lib.rs
+++ b/edgelet/edgelet-kube/src/lib.rs
@@ -2,7 +2,11 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self, clippy::too_many_arguments)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::too_many_arguments,
+    clippy::use_self
+)]
 
 mod constants;
 mod convert;

--- a/edgelet/edgelet-test-utils/src/lib.rs
+++ b/edgelet/edgelet-test-utils/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
+    clippy::module_name_repetitions,
     clippy::similar_names,
-    clippy::stutter,
     clippy::use_self
 )]
 

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate failure;
 #[cfg(test)]

--- a/edgelet/hsm-rs/src/lib.rs
+++ b/edgelet/hsm-rs/src/lib.rs
@@ -4,9 +4,9 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::cyclomatic_complexity,
+    clippy::module_name_repetitions,
     clippy::similar_names,
     clippy::shadow_unrelated,
-    clippy::stutter,
     clippy::use_self
 )]
 

--- a/edgelet/hyper-named-pipe/src/lib.rs
+++ b/edgelet/hyper-named-pipe/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg(windows)]
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate edgelet_utils;
 extern crate failure;

--- a/edgelet/iotedge-diagnostics/src/main.rs
+++ b/edgelet/iotedge-diagnostics/src/main.rs
@@ -2,6 +2,7 @@
 
 #![deny(rust_2018_idioms, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
+#![allow(clippy::use_self)]
 
 #[macro_use]
 extern crate clap;

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -785,7 +785,7 @@ fn container_local_time(check: &mut Check) -> Result<Option<String>, failure::Er
     let output = std::str::from_utf8(output)
         .with_context(|_| format!("could not parse container output {:?}", output))?;
     let output = output
-        .trim_right()
+        .trim_end()
         .parse::<u64>()
         .with_context(|_| format!("could not parse container output {:?}", output))?;
     let actual_duration = std::time::Duration::from_secs(output);

--- a/edgelet/iotedge/src/lib.rs
+++ b/edgelet/iotedge/src/lib.rs
@@ -2,7 +2,11 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::type_complexity, clippy::use_self)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::type_complexity,
+    clippy::use_self
+)]
 
 extern crate bytes;
 extern crate chrono;

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::doc_markdown, // clippy want the "IoT" of "IoT Hub" in a code fence
+    clippy::module_name_repetitions,
     clippy::shadow_unrelated,
-    clippy::stutter,
     clippy::use_self,
 )]
 

--- a/edgelet/iothubservice/src/lib.rs
+++ b/edgelet/iothubservice/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[cfg(test)]
 extern crate chrono;

--- a/edgelet/kube-client/src/lib.rs
+++ b/edgelet/kube-client/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::doc_markdown, // clippy want the "IoT" of "IoT Hub" in a code fence
+    clippy::module_name_repetitions,
     clippy::shadow_unrelated,
-    clippy::stutter,
     clippy::use_self,
 )]
 

--- a/edgelet/management/src/lib.rs
+++ b/edgelet/management/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/edgelet/mini-sntp/src/lib.rs
+++ b/edgelet/mini-sntp/src/lib.rs
@@ -1,6 +1,10 @@
 #![deny(rust_2018_idioms, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::doc_markdown, clippy::stutter, clippy::use_self)]
+#![allow(
+    clippy::doc_markdown,
+    clippy::module_name_repetitions,
+    clippy::use_self
+)]
 
 use std::net::{SocketAddr, ToSocketAddrs, UdpSocket};
 

--- a/edgelet/provisioning/src/lib.rs
+++ b/edgelet/provisioning/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate bytes;
 extern crate failure;

--- a/edgelet/systemd/src/lib.rs
+++ b/edgelet/systemd/src/lib.rs
@@ -33,4 +33,4 @@ pub enum Socket {
 }
 
 #[cfg(target_os = "linux")]
-pub use self::linux::{listener, listener_name, listeners_name};
+pub use self::linux::{listener, listener_name, listeners_name, LISTEN_FDS_START};

--- a/edgelet/systemd/src/lib.rs
+++ b/edgelet/systemd/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate failure;
 #[cfg(target_os = "linux")]

--- a/edgelet/systemd/src/linux.rs
+++ b/edgelet/systemd/src/linux.rs
@@ -18,12 +18,6 @@ use nix::unistd::Pid;
 use error::{Error, ErrorKind, SocketLookupType};
 use {Fd, Socket};
 
-// TODO: This works around https://github.com/rust-lang/cargo/issues/6333
-// `cargo test` opens /dev/random and /dev/urandom at fds 3 and 4 so the first fd bound is 5.
-// Remove the `cfg(test)` definition when that issue is fixed. Also see edgelet-http/tests/systemd.rs
-#[cfg(test)]
-const LISTEN_FDS_START: Fd = 5;
-#[cfg(not(test))]
 const LISTEN_FDS_START: Fd = 3;
 
 const ENV_PID: &str = "LISTEN_PID";

--- a/edgelet/systemd/src/linux.rs
+++ b/edgelet/systemd/src/linux.rs
@@ -261,10 +261,8 @@ mod tests {
         env::set_var(ENV_PID, format!("{}", pid));
     }
 
-    fn create_fd(no: i32, family: AddressFamily, type_: SockType) -> Fd {
-        let fd = socket::socket(family, type_, socket::SockFlag::empty(), None).unwrap();
-        assert_eq!(fd, no);
-        fd
+    fn create_fd(family: AddressFamily, type_: SockType) -> Fd {
+        socket::socket(family, type_, socket::SockFlag::empty(), None).unwrap()
     }
 
     fn close_fds<I: IntoIterator<Item = Socket>>(sockets: I) {
@@ -282,10 +280,10 @@ mod tests {
         let _l = lock_env();
         set_current_pid();
         env::set_var(ENV_FDS, "1");
-        create_fd(LISTEN_FDS_START, AddressFamily::Unix, SockType::Stream);
-        let fds = listen_fds(true, LISTEN_FDS_START).unwrap();
+        let listen_fds_start = create_fd(AddressFamily::Unix, SockType::Stream);
+        let fds = listen_fds(true, listen_fds_start).unwrap();
         assert_eq!(1, fds.len());
-        assert_eq!(vec![Socket::Unix(LISTEN_FDS_START)], fds);
+        assert_eq!(vec![Socket::Unix(listen_fds_start)], fds);
         close_fds(fds);
     }
 
@@ -295,15 +293,16 @@ mod tests {
         set_current_pid();
         env::set_var(ENV_FDS, "2");
         env::set_var(ENV_NAMES, "a:b");
-        create_fd(LISTEN_FDS_START, AddressFamily::Inet, SockType::Stream);
-        create_fd(LISTEN_FDS_START + 1, AddressFamily::Unix, SockType::Stream);
-        let fds = listen_fds_with_names(true, LISTEN_FDS_START).unwrap();
+        let listen_fds_start = create_fd(AddressFamily::Inet, SockType::Stream);
+        assert_eq!(create_fd(AddressFamily::Unix, SockType::Stream), listen_fds_start + 1);
+        let fds = listen_fds_with_names(true, listen_fds_start).unwrap();
         assert_eq!(2, fds.len());
-        if let Socket::Inet(LISTEN_FDS_START, _) = fds["a"][0] {
+        if let Socket::Inet(fd, _) = fds["a"][0] {
+            assert_eq!(fd, listen_fds_start);
         } else {
             panic!("Didn't parse Inet socket");
         }
-        assert_eq!(vec![Socket::Unix(LISTEN_FDS_START + 1)], fds["b"]);
+        assert_eq!(vec![Socket::Unix(listen_fds_start + 1)], fds["b"]);
 
         for (_, socks) in fds {
             close_fds(socks);
@@ -312,18 +311,15 @@ mod tests {
 
     #[test]
     fn test_listen_fds_with_missing_env() {
-        let r = {
-            let _l = lock_env();
-            panic::catch_unwind(|| listen_fds_with_names(true, LISTEN_FDS_START).unwrap())
-        };
+        let _l = lock_env();
 
-        match r {
+        match listen_fds_with_names(true, LISTEN_FDS_START) {
             Ok(_) => panic!("expected listen_fds_with_names to panic"),
-            Err(err) => match err.downcast_ref::<String>().map(String::as_str) {
-                Some(s) if s.contains(ENV_NAMES) => (),
-                other => panic!(
-                    "expected listen_fds_with_names to panic with {} but it panicked with {:?}",
-                    ENV_NAMES, other
+            Err(err) => match err.kind() {
+                ErrorKind::InvalidVar(s) if s == ENV_NAMES => (),
+                _ => panic!(
+                    "expected listen_fds_with_names to raise ErrorKind::InvalidVar({}) but it raised {:?}",
+                    ENV_NAMES, err
                 ),
             },
         }

--- a/edgelet/systemd/src/linux.rs
+++ b/edgelet/systemd/src/linux.rs
@@ -294,7 +294,10 @@ mod tests {
         env::set_var(ENV_FDS, "2");
         env::set_var(ENV_NAMES, "a:b");
         let listen_fds_start = create_fd(AddressFamily::Inet, SockType::Stream);
-        assert_eq!(create_fd(AddressFamily::Unix, SockType::Stream), listen_fds_start + 1);
+        assert_eq!(
+            create_fd(AddressFamily::Unix, SockType::Stream),
+            listen_fds_start + 1
+        );
         let fds = listen_fds_with_names(true, listen_fds_start).unwrap();
         assert_eq!(2, fds.len());
         if let Socket::Inet(fd, _) = fds["a"][0] {

--- a/edgelet/systemd/src/linux.rs
+++ b/edgelet/systemd/src/linux.rs
@@ -18,7 +18,7 @@ use nix::unistd::Pid;
 use error::{Error, ErrorKind, SocketLookupType};
 use {Fd, Socket};
 
-const LISTEN_FDS_START: Fd = 3;
+pub const LISTEN_FDS_START: Fd = 3;
 
 const ENV_PID: &str = "LISTEN_PID";
 const ENV_FDS: &str = "LISTEN_FDS";

--- a/edgelet/win-logger/src/lib.rs
+++ b/edgelet/win-logger/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg(windows)]
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate edgelet_utils;
 extern crate failure;

--- a/edgelet/workload/src/lib.rs
+++ b/edgelet/workload/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
- `trim_{left,right}` deprecated in favor of `trim_{start,end}`
- `trim_{left,right}_matches` deprecated in favor of `trim_{start,end}_matches`
- `clippy::stutter` renamed to `clippy::module_name_repetitions`
- Cargo bug affecting systemd fd tests seems to be fixed.