### PR TITLE
Handle asynchronous errors from pulling container images

### DIFF
--- a/edgelet/docker-rs/src/apis/mod.rs
+++ b/edgelet/docker-rs/src/apis/mod.rs
@@ -4,9 +4,9 @@ use serde_json;
 
 #[derive(Debug)]
 pub enum Error<T> {
+    Api(ApiError<T>),
     Hyper(hyper::Error),
     Serde(serde_json::Error),
-    Api(ApiError<T>),
 }
 
 #[derive(Debug)]
@@ -33,6 +33,15 @@ where
             }),
             Err(e) => Error::from(e),
         }
+    }
+}
+
+impl<'de> From<(hyper::StatusCode, serde_json::Value)> for Error<serde_json::Value> {
+    fn from(e: (hyper::StatusCode, serde_json::Value)) -> Self {
+        Error::Api(ApiError {
+            code: e.0,
+            content: Some(e.1),
+        })
     }
 }
 

--- a/edgelet/edgelet-docker/src/error.rs
+++ b/edgelet/edgelet-docker/src/error.rs
@@ -26,7 +26,7 @@ fn get_message(
 
     match content {
         Some(serde_json::Value::Object(props)) => {
-            if let serde_json::Value::String(message) = &props["message"] {
+            if let Some(serde_json::Value::String(message)) = props.get("message") {
                 return Ok(message.clone());
             }
 


### PR DESCRIPTION
If a container image pull fails asynchronously, such as if the image exists
but does not have the right architecture, the overall HTTP response has
an OK status code but the last status object in the response body is
an error.

Before this change, only the status code was used to determine the overall
success of the operation. With this change, the last status object is also
used.

---

Eg, when using `microsoft/nanoserver:latest` as a module image on a Linux host:

```
<6>2019-03-01T23:12:03Z [INFO] - Pulling image microsoft/nanoserver:latest...
<4>2019-03-01T23:12:04Z [WARN] - Could not pull image microsoft/nanoserver:latest
<4>2019-03-01T23:12:04Z [WARN] -        caused by: image operating system "windows" cannot be used on this platform
<6>2019-03-01T23:12:04Z [INFO] - [mgmt] - - - [2019-03-01 23:12:04.453858271 UTC] "POST /modules?api-version=2018-06-28 HTTP/1.1" 500 Internal Server Error 192 "-" "-" pid(18397)
```