### PR TITLE
Don't let `takeown` block on a user prompt

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -986,7 +986,7 @@ function Delete-Directory([string] $Path) {
     # Deleting them is a three-step process:
     #
     # 1. Take ownership of all files
-    Invoke-Native "takeown /r /skipsl /f ""$Path"""
+    Invoke-Native "takeown /r /skipsl /f /d y ""$Path"""
 
     # 2. Reset their ACLs so that they inherit from their container
     Invoke-Native "icacls ""$Path"" /reset /t /l /q /c"


### PR DESCRIPTION
`takeown` prompts the user to allow it to take ownership of a directory
if the user does not have the "List" permission for it. If this prompt
happens during the uninstaller, it blocks the uninstaller with no
indication that the user needs to press Y to continue.

With this change, the `/d Y` switch is used to answer Y to the prompt
automatically.

This is likely the reason for issues like #793