### PR TITLE
Fix device client NuGet package.

### DIFF
--- a/edge-modules/DirectMethodCloudSender/DirectMethodCloudSender.csproj
+++ b/edge-modules/DirectMethodCloudSender/DirectMethodCloudSender.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.3" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.21.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />


### PR DESCRIPTION
Roll back device client NuGet to stable version for DirectMethodCloudSender.