### PR TITLE
Fix build for new Rust 1.33 stable (#896)

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -45,7 +45,7 @@ jobs:
         displayName: Set Version
       - script: edgelet/build/linux/install.sh
         displayName: Install Rust
-      - script: 'cargo install --git https://github.com/myagley/cross.git --branch set-path'
+      - script: 'cargo install --git https://github.com/arsing/cross.git --branch set-path'
         displayName: 'Install cross (fork with docker fix)'
       - script: 'cross build --target armv7-unknown-linux-gnueabihf'
         displayName: armv7-unknown-linux-gnueabihf build

--- a/builds/ci/edgelet.yaml
+++ b/builds/ci/edgelet.yaml
@@ -48,7 +48,7 @@ jobs:
         displayName: Install Rust
         inputs:
           filePath: edgelet/build/linux/install.sh
-      - script: cargo install --git https://github.com/myagley/cross.git --branch set-path
+      - script: cargo install --git https://github.com/arsing/cross.git --branch set-path
         displayName: Install cross (fork with docker fix)
       - task: Bash@3
         displayName: armv7-unknown-linux-gnueabihf build

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -72,7 +72,7 @@ jobs:
         displayName: 'Docker Login'
       - script: edgelet/build/linux/install.sh --package-arm
         displayName: Install Rust
-      - bash: 'cargo install --git https://github.com/myagley/cross.git --branch set-path'
+      - bash: 'cargo install --git https://github.com/arsing/cross.git --branch set-path'
         displayName: 'Install cross (fork with docker fix)'
       - bash: 'make deb CARGO=cross CARGOFLAGS="--target armv7-unknown-linux-gnueabihf" TARGET=target/armv7-unknown-linux-gnueabihf/release DPKGFLAGS="-b -us -uc -i --host-arch armhf"'
         workingDirectory: edgelet

--- a/edgelet/dps/src/lib.rs
+++ b/edgelet/dps/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate base64;
 extern crate bytes;

--- a/edgelet/edgelet-core/src/authorization.rs
+++ b/edgelet/edgelet-core/src/authorization.rs
@@ -34,7 +34,7 @@ where
         name: Option<String>,
         pid: Pid,
     ) -> impl Future<Item = bool, Error = Error> {
-        let name = name.map(|n| n.trim_left_matches('$').to_string());
+        let name = name.map(|n| n.trim_start_matches('$').to_string());
         match self.policy {
             Policy::Anonymous => Either::A(Either::A(self.auth_anonymous())),
             Policy::Caller => Either::A(Either::B(self.auth_caller(name, pid))),

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[cfg(test)]
 extern crate base64;

--- a/edgelet/edgelet-docker/src/lib.rs
+++ b/edgelet/edgelet-docker/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate base64;
 extern crate chrono;

--- a/edgelet/edgelet-hsm/src/lib.rs
+++ b/edgelet/edgelet-hsm/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate bytes;
 extern crate chrono;

--- a/edgelet/edgelet-http-mgmt/src/lib.rs
+++ b/edgelet/edgelet-http-mgmt/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[cfg(test)]
 extern crate chrono;

--- a/edgelet/edgelet-http-workload/src/lib.rs
+++ b/edgelet/edgelet-http-workload/src/lib.rs
@@ -2,7 +2,11 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::type_complexity, clippy::use_self)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::type_complexity,
+    clippy::use_self
+)]
 
 extern crate base64;
 extern crate chrono;

--- a/edgelet/edgelet-http/src/lib.rs
+++ b/edgelet/edgelet-http/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
+    clippy::module_name_repetitions,
     clippy::similar_names,
-    clippy::stutter,
     clippy::use_self
 )]
 

--- a/edgelet/edgelet-http/src/route/regex.rs
+++ b/edgelet/edgelet-http/src/route/regex.rs
@@ -150,9 +150,9 @@ fn match_route(re: &Regex, path: &str) -> Option<Parameters> {
 fn normalize_pattern(pattern: &str) -> Cow<str> {
     let pattern = pattern
         .trim()
-        .trim_left_matches('^')
-        .trim_right_matches('$')
-        .trim_right_matches('/');
+        .trim_start_matches('^')
+        .trim_end_matches('$')
+        .trim_end_matches('/');
     match pattern {
         "" => "^/$".into(),
         s => format!("^{}/?$", s).into(),

--- a/edgelet/edgelet-iothub/src/lib.rs
+++ b/edgelet/edgelet-iothub/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate base64;
 #[cfg(test)]

--- a/edgelet/edgelet-kube/src/lib.rs
+++ b/edgelet/edgelet-kube/src/lib.rs
@@ -2,7 +2,11 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self, clippy::too_many_arguments)]
+#![allow(
+    clippy::module_name_repetitions,
+    clippy::too_many_arguments,
+    clippy::use_self
+)]
 
 mod constants;
 mod convert;

--- a/edgelet/edgelet-test-utils/src/lib.rs
+++ b/edgelet/edgelet-test-utils/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::default_trait_access,
+    clippy::module_name_repetitions,
     clippy::similar_names,
-    clippy::stutter,
     clippy::use_self
 )]
 

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate failure;
 #[cfg(test)]

--- a/edgelet/hsm-rs/src/lib.rs
+++ b/edgelet/hsm-rs/src/lib.rs
@@ -4,9 +4,9 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::cyclomatic_complexity,
+    clippy::module_name_repetitions,
     clippy::similar_names,
     clippy::shadow_unrelated,
-    clippy::stutter,
     clippy::use_self
 )]
 

--- a/edgelet/hyper-named-pipe/src/lib.rs
+++ b/edgelet/hyper-named-pipe/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg(windows)]
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate edgelet_utils;
 extern crate failure;

--- a/edgelet/iotedge/src/lib.rs
+++ b/edgelet/iotedge/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate bytes;
 extern crate chrono;

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::doc_markdown, // clippy want the "IoT" of "IoT Hub" in a code fence
+    clippy::module_name_repetitions,
     clippy::shadow_unrelated,
-    clippy::stutter,
     clippy::use_self,
 )]
 

--- a/edgelet/iothubservice/src/lib.rs
+++ b/edgelet/iothubservice/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[cfg(test)]
 extern crate chrono;

--- a/edgelet/kube-client/src/lib.rs
+++ b/edgelet/kube-client/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(
     clippy::doc_markdown, // clippy want the "IoT" of "IoT Hub" in a code fence
+    clippy::module_name_repetitions,
     clippy::shadow_unrelated,
-    clippy::stutter,
     clippy::use_self,
 )]
 

--- a/edgelet/management/src/lib.rs
+++ b/edgelet/management/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[macro_use]
 extern crate serde_derive;

--- a/edgelet/provisioning/src/lib.rs
+++ b/edgelet/provisioning/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate base64;
 extern crate bytes;

--- a/edgelet/systemd/src/lib.rs
+++ b/edgelet/systemd/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate failure;
 #[cfg(target_os = "linux")]
@@ -33,4 +33,4 @@ pub enum Socket {
 }
 
 #[cfg(target_os = "linux")]
-pub use self::linux::{listener, listener_name, listeners_name};
+pub use self::linux::{listener, listener_name, listeners_name, LISTEN_FDS_START};

--- a/edgelet/systemd/src/linux.rs
+++ b/edgelet/systemd/src/linux.rs
@@ -18,13 +18,7 @@ use nix::unistd::Pid;
 use error::{Error, ErrorKind, SocketLookupType};
 use {Fd, Socket};
 
-// TODO: This works around https://github.com/rust-lang/cargo/issues/6333
-// `cargo test` opens /dev/random and /dev/urandom at fds 3 and 4 so the first fd bound is 5.
-// Remove the `cfg(test)` definition when that issue is fixed. Also see edgelet-http/tests/systemd.rs
-#[cfg(test)]
-const LISTEN_FDS_START: Fd = 5;
-#[cfg(not(test))]
-const LISTEN_FDS_START: Fd = 3;
+pub const LISTEN_FDS_START: Fd = 3;
 
 const ENV_PID: &str = "LISTEN_PID";
 const ENV_FDS: &str = "LISTEN_FDS";
@@ -267,10 +261,8 @@ mod tests {
         env::set_var(ENV_PID, format!("{}", pid));
     }
 
-    fn create_fd(no: i32, family: AddressFamily, type_: SockType) -> Fd {
-        let fd = socket::socket(family, type_, socket::SockFlag::empty(), None).unwrap();
-        assert_eq!(fd, no);
-        fd
+    fn create_fd(family: AddressFamily, type_: SockType) -> Fd {
+        socket::socket(family, type_, socket::SockFlag::empty(), None).unwrap()
     }
 
     fn close_fds<I: IntoIterator<Item = Socket>>(sockets: I) {
@@ -288,10 +280,10 @@ mod tests {
         let _l = lock_env();
         set_current_pid();
         env::set_var(ENV_FDS, "1");
-        create_fd(LISTEN_FDS_START, AddressFamily::Unix, SockType::Stream);
-        let fds = listen_fds(true, LISTEN_FDS_START).unwrap();
+        let listen_fds_start = create_fd(AddressFamily::Unix, SockType::Stream);
+        let fds = listen_fds(true, listen_fds_start).unwrap();
         assert_eq!(1, fds.len());
-        assert_eq!(vec![Socket::Unix(LISTEN_FDS_START)], fds);
+        assert_eq!(vec![Socket::Unix(listen_fds_start)], fds);
         close_fds(fds);
     }
 
@@ -301,15 +293,19 @@ mod tests {
         set_current_pid();
         env::set_var(ENV_FDS, "2");
         env::set_var(ENV_NAMES, "a:b");
-        create_fd(LISTEN_FDS_START, AddressFamily::Inet, SockType::Stream);
-        create_fd(LISTEN_FDS_START + 1, AddressFamily::Unix, SockType::Stream);
-        let fds = listen_fds_with_names(true, LISTEN_FDS_START).unwrap();
+        let listen_fds_start = create_fd(AddressFamily::Inet, SockType::Stream);
+        assert_eq!(
+            create_fd(AddressFamily::Unix, SockType::Stream),
+            listen_fds_start + 1
+        );
+        let fds = listen_fds_with_names(true, listen_fds_start).unwrap();
         assert_eq!(2, fds.len());
-        if let Socket::Inet(LISTEN_FDS_START, _) = fds["a"][0] {
+        if let Socket::Inet(fd, _) = fds["a"][0] {
+            assert_eq!(fd, listen_fds_start);
         } else {
             panic!("Didn't parse Inet socket");
         }
-        assert_eq!(vec![Socket::Unix(LISTEN_FDS_START + 1)], fds["b"]);
+        assert_eq!(vec![Socket::Unix(listen_fds_start + 1)], fds["b"]);
 
         for (_, socks) in fds {
             close_fds(socks);
@@ -318,18 +314,15 @@ mod tests {
 
     #[test]
     fn test_listen_fds_with_missing_env() {
-        let r = {
-            let _l = lock_env();
-            panic::catch_unwind(|| listen_fds_with_names(true, LISTEN_FDS_START).unwrap())
-        };
+        let _l = lock_env();
 
-        match r {
+        match listen_fds_with_names(true, LISTEN_FDS_START) {
             Ok(_) => panic!("expected listen_fds_with_names to panic"),
-            Err(err) => match err.downcast_ref::<String>().map(String::as_str) {
-                Some(s) if s.contains(ENV_NAMES) => (),
-                other => panic!(
-                    "expected listen_fds_with_names to panic with {} but it panicked with {:?}",
-                    ENV_NAMES, other
+            Err(err) => match err.kind() {
+                ErrorKind::InvalidVar(s) if s == ENV_NAMES => (),
+                _ => panic!(
+                    "expected listen_fds_with_names to raise ErrorKind::InvalidVar({}) but it raised {:?}",
+                    ENV_NAMES, err
                 ),
             },
         }

--- a/edgelet/win-logger/src/lib.rs
+++ b/edgelet/win-logger/src/lib.rs
@@ -3,7 +3,7 @@
 #![cfg(windows)]
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 extern crate edgelet_utils;
 extern crate failure;

--- a/edgelet/workload/src/lib.rs
+++ b/edgelet/workload/src/lib.rs
@@ -2,7 +2,7 @@
 
 #![deny(unused_extern_crates, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
-#![allow(clippy::stutter, clippy::use_self)]
+#![allow(clippy::module_name_repetitions, clippy::use_self)]
 
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
- `str::trim_{left,right}` are deprecated in favor of `str::trim_{start,end}`

- `str::trim_{left,right}_matches` are deprecated in favor of
  `str::trim_{start,end}_matches`

- The `clippy::stutter` lint has been renamed to
  `clippy::module_name_repetitions`

- The cargo bug affecting systemd fd tests seems to have been fixed.
  However, CI runs still see fd 3 bound to something, so the first available
  fd inside tests is now 4. Local test runs don't have this problem, so
  the earlier workaround of re-defining `LISTEN_FDS_START` for tests
  cannot be used. Instead, the tests have been updated to use whatever fd
  they get as the first fd, and no longer assert that it is equal to 3.

(Cherry-pick of ad41fec507bb91a2e57a07cd32e287ada0ca08d8 from master.)