### PR TITLE
EdgeHub: Update cleanup sleep time based on ttl

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
@@ -234,9 +234,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
 
                 try
                 {
-                    TimeSpan cleanupTaskSleepTime = this.messageStore.timeToLive.TotalSeconds / 2 < CleanupTaskFrequency.TotalSeconds
-                        ? TimeSpan.FromSeconds(this.messageStore.timeToLive.TotalSeconds / 2)
-                        : CleanupTaskFrequency;
                     while (true)
                     {
                         foreach (KeyValuePair<string, ISequentialStore<MessageRef>> endpointSequentialStore in this.messageStore.endpointSequentialStores)
@@ -308,7 +305,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
                             }
                         }
 
-                        await Task.Delay(cleanupTaskSleepTime);
+                        await Task.Delay(this.GetCleanupTaskSleepTime());
                     }
                 }
                 catch (Exception ex)
@@ -317,6 +314,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
                     throw;
                 }
             }
+
+            TimeSpan GetCleanupTaskSleepTime() => this.messageStore.timeToLive.TotalSeconds / 2 < CleanupTaskFrequency.TotalSeconds
+                ? TimeSpan.FromSeconds(this.messageStore.timeToLive.TotalSeconds / 2)
+                : CleanupTaskFrequency;
         }
 
         static class Events

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
         }
 
         [Fact]
-        public async Task CleanupTestTimeoutWithReadd()
+        public async Task CleanupTestTimeoutWithRead()
         {
             (IMessageStore messageStore, ICheckpointStore checkpointStore) result = await this.GetMessageStore(20);
             using (IMessageStore messageStore = result.messageStore)
@@ -204,6 +204,82 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
                 module1Iterator = messageStore.GetMessageIterator("module1");
                 batch = await module1Iterator.GetNext(100);
                 Assert.Empty(batch);
+            }
+        }
+
+        [Fact]
+        public async Task CleanupTestTimeoutUpdateTimeToLive()
+        {
+            (IMessageStore messageStore, ICheckpointStore checkpointStore) result = await this.GetMessageStore(20);
+            result.messageStore.SetTimeToLive(TimeSpan.FromSeconds(20));
+            using (IMessageStore messageStore = result.messageStore)
+            {
+                for (int i = 0; i < 200; i++)
+                {
+                    if (i % 2 == 0)
+                    {
+                        long offset = await messageStore.Add("module1", this.GetMessage(i));
+                        Assert.Equal(i / 2, offset);
+                    }
+                    else
+                    {
+                        long offset = await messageStore.Add("module2", this.GetMessage(i));
+                        Assert.Equal(i / 2, offset);
+                    }
+                }
+
+                IMessageIterator module1Iterator = messageStore.GetMessageIterator("module1");
+                IEnumerable<IMessage> batch = await module1Iterator.GetNext(100);
+                Assert.Equal(100, batch.Count());
+
+                IMessageIterator module2Iterator = messageStore.GetMessageIterator("module2");
+                batch = await module2Iterator.GetNext(100);
+                Assert.Equal(100, batch.Count());
+
+                await Task.Delay(TimeSpan.FromSeconds(100));
+
+                module1Iterator = messageStore.GetMessageIterator("module1");
+                batch = await module1Iterator.GetNext(100);
+                Assert.Empty(batch);
+
+                module2Iterator = messageStore.GetMessageIterator("module2");
+                batch = await module2Iterator.GetNext(100);
+                Assert.Empty(batch);
+
+                result.messageStore.SetTimeToLive(TimeSpan.FromSeconds(2000));
+                await Task.Delay(TimeSpan.FromSeconds(50));
+
+                for (int i = 0; i < 200; i++)
+                {
+                    if (i % 2 == 0)
+                    {
+                        long offset = await messageStore.Add("module1", this.GetMessage(i));
+                        Assert.Equal(100 + i / 2, offset);
+                    }
+                    else
+                    {
+                        long offset = await messageStore.Add("module2", this.GetMessage(i));
+                        Assert.Equal(100 + i / 2, offset);
+                    }
+                }
+
+                module1Iterator = messageStore.GetMessageIterator("module1");
+                batch = await module1Iterator.GetNext(100);
+                Assert.Equal(100, batch.Count());
+
+                module2Iterator = messageStore.GetMessageIterator("module2");
+                batch = await module2Iterator.GetNext(100);
+                Assert.Equal(100, batch.Count());
+
+                await Task.Delay(TimeSpan.FromSeconds(100));
+
+                module1Iterator = messageStore.GetMessageIterator("module1");
+                batch = await module1Iterator.GetNext(100);
+                Assert.Equal(100, batch.Count());
+
+                module2Iterator = messageStore.GetMessageIterator("module2");
+                batch = await module2Iterator.GetNext(100);
+                Assert.Equal(100, batch.Count());
             }
         }
 


### PR DESCRIPTION
Currently the message store cleanup task sleep time is based on the message store TTL, but if the TTL is updated via a deployment, the cleanup task sleep is not updated. 
This PR fixes that.