### PR TITLE
Support end-to-end tests on Windows behind a proxy

### DIFF
--- a/e2e_deployment_files/quickstart_deployment.template.json
+++ b/e2e_deployment_files/quickstart_deployment.template.json
@@ -1,0 +1,70 @@
+{
+  "modulesContent": {
+    "$edgeAgent": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "runtime": {
+          "type": "docker",
+          "settings": {
+            "minDockerVersion": "v1.25",
+            "loggingOptions": "",
+            "registryCredentials": {
+              "buildcr": {
+                "username": "<CR.Username>",
+                "password": "<CR.Password>",
+                "address": "edgebuilds.azurecr.io"
+              }
+            }
+          }
+        },
+        "systemModules": {
+          "edgeAgent": {
+            "type": "docker",
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-agent:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            },
+            "env": {}
+          },
+          "edgeHub": {
+            "type": "docker",
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-hub:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
+            },
+            "env": {
+              "OptimizeForPerformance": {
+                "value": "<OptimizeForPerformance>"
+              }
+            },
+            "status": "running",
+            "restartPolicy": "always"
+          }
+        },
+        "modules": {
+          "tempSensor": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            }
+          }
+        }
+      }
+    },
+    "$edgeHub": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "routes": {
+          "route": "FROM /* INTO $upstream"
+        },
+        "storeAndForwardConfiguration": {
+          "timeToLiveSecs": 7200
+        }
+      }
+    }
+  }
+}

--- a/e2e_deployment_files/runtime_only_deployment.template.json
+++ b/e2e_deployment_files/runtime_only_deployment.template.json
@@ -1,0 +1,59 @@
+{
+  "modulesContent": {
+    "$edgeAgent": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "runtime": {
+          "type": "docker",
+          "settings": {
+            "minDockerVersion": "v1.25",
+            "loggingOptions": "",
+            "registryCredentials": {
+              "buildcr": {
+                "username": "<CR.Username>",
+                "password": "<CR.Password>",
+                "address": "edgebuilds.azurecr.io"
+              }
+            }
+          }
+        },
+        "systemModules": {
+          "edgeAgent": {
+            "type": "docker",
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-agent:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            },
+            "env": {}
+          },
+          "edgeHub": {
+            "type": "docker",
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-hub:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
+            },
+            "env": {
+              "OptimizeForPerformance": {
+                "value": "<OptimizeForPerformance>"
+              }
+            },
+            "status": "running",
+            "restartPolicy": "always"
+          }
+        },
+        "modules": {}
+      }
+    },
+    "$edgeHub": {
+      "properties.desired": {
+        "schemaVersion": "1.0",
+        "routes": {
+          "route": "FROM /* INTO $upstream"
+        },
+        "storeAndForwardConfiguration": {
+          "timeToLiveSecs": 7200
+        }
+      }
+    }
+  }
+}

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -201,7 +201,7 @@ Function PrepareTestFromArtifacts
     If (($TestName -eq "DirectMethodAmqp") -Or
         ($TestName -eq "DirectMethodMqtt") -Or
         ($TestName -eq "TempFilter") -Or
-        ($TestName -eq "TempFilterFunctions") -or
+        ($TestName -eq "TempFilterFunctions") -Or
         (($ProxyUri) -and ($TestName -in "TempSensor", "QuickstartCerts", "TransparentGateway")))
     {
         Switch -Regex ($TestName)
@@ -413,8 +413,8 @@ Function RunDirectMethodAmqpTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMAmqp-$(Get-Date -UFormat %s)"
-    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMAmqp"
+    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
     
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
             -d `"$deviceId`" ``
@@ -444,8 +444,8 @@ Function RunDirectMethodMqttTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMMqtt-$(Get-Date -UFormat %s)"
-    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMMqtt"
+    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
     
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
             -d `"$deviceId`" ``
@@ -475,8 +475,8 @@ Function RunQuickstartCertsTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-QuickstartCerts-$(Get-Date -UFormat %s)"
-    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-QuickstartCerts"
+    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
 
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
         -d `"$deviceId`" ``
@@ -525,8 +525,8 @@ Function RunTempFilterTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilter-$(Get-Date -UFormat %s)"
-    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilter"
+    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
     
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
             -d `"$deviceId`" ``
@@ -562,8 +562,8 @@ Function RunTempFilterFunctionsTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilterFunc-$(Get-Date -UFormat %s)"
-    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilterFunc"
+    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
     
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
             -d `"$deviceId`" ``
@@ -593,7 +593,7 @@ Function RunTempSensorTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempSensor-$(Get-Date -UFormat %s)"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempSensor"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt."
 
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
@@ -626,7 +626,7 @@ Function RunTransparentGatewayTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-TransGW-$(Get-Date -UFormat %s)"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-TransGW"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt."
 
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -45,8 +45,11 @@
     .PARAMETER EventHubConnectionString
         Event hub connection string for receive D2C messages
 
+    .PARAMETER ProxyUri
+        (Optional) The URI of an HTTPS proxy server; if specified, all communications to IoT Hub will go through this proxy.
+
     .EXAMPLE
-        .\Run-E2ETest.ps1 -E2ETestFolder "C:\Data\e2etests" -ReleaseLabel "Release-ARM-1" -ArtifactImageBuildNumber "20190101.1" -TestName "TempSensor" -ContainerRegistry "edgebuilds.azurecr.io" -ContainerRegistryUsername "EdgeBuilds" -ContainerRegistryPassword "xxxx" -IoTHubConnectionString "xxxx" -EventHubConnectionString "xxxx"
+        .\Run-E2ETest.ps1 -E2ETestFolder "C:\Data\e2etests" -ReleaseLabel "Release-ARM-1" -ArtifactImageBuildNumber "20190101.1" -TestName "TempSensor" -ContainerRegistry "edgebuilds.azurecr.io" -ContainerRegistryUsername "EdgeBuilds" -ContainerRegistryPassword "xxxx" -IoTHubConnectionString "xxxx" -EventHubConnectionString "xxxx" -ProxyUri "http://proxyserver:3128"
 
     .NOTES
         This script is to make running E2E tests easier and centralize E2E test steps in 1 place for reusability.
@@ -82,7 +85,10 @@ Param (
     [string] $IoTHubConnectionString = $(Throw "IoT hub connection string is required"),
 
     [ValidateNotNullOrEmpty()]
-    [string] $EventHubConnectionString = $(Throw "Event hub connection string is required")
+    [string] $EventHubConnectionString = $(Throw "Event hub connection string is required"),
+
+    [ValidateScript({($_ -as [System.Uri]).AbsoluteUri -ne $null})]
+    [string] $ProxyUri = $null
 )
 
 Set-StrictMode -Version "Latest"
@@ -195,9 +201,10 @@ Function PrepareTestFromArtifacts
     If (($TestName -eq "DirectMethodAmqp") -Or
         ($TestName -eq "DirectMethodMqtt") -Or
         ($TestName -eq "TempFilter") -Or
-        ($TestName -eq "TempFilterFunctions"))
+        ($TestName -eq "TempFilterFunctions") -or
+        (($ProxyUri) -and ($TestName -in "TempSensor", "QuickstartCerts", "TransparentGateway")))
     {
-        Switch ($TestName)
+        Switch -Regex ($TestName)
         {
             "DirectMethodAmqp"
             {
@@ -228,6 +235,16 @@ Function PrepareTestFromArtifacts
                 Write-Host "Copy deployment file from $ModuleToFunctionDeploymentArtifactFilePath"
                 Copy-Item $ModuleToFunctionDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
             }
+            "TempSensor" # Only when $ProxyUri is specified
+            {
+                Write-Host "Copy deployment file from $QuickstartDeploymentArtifactFilePath"
+                Copy-Item $QuickstartDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
+            }
+            "QuickstartCerts|TransparentGateway" # Only when $ProxyUri is specified
+            {
+                Write-Host "Copy deployment file from $RuntimeOnlyDeploymentArtifactFilePath"
+                Copy-Item $RuntimeOnlyDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
+            }
         }
 
         $ImageArchitectureLabel = $(GetImageArchitectureLabel)
@@ -237,6 +254,39 @@ Function PrepareTestFromArtifacts
         (Get-Content $DeploymentWorkingFilePath).replace('<CR.Username>', $ContainerRegistryUsername) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<CR.Password>', $ContainerRegistryPassword) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('-linux-', '-windows-') | Set-Content $DeploymentWorkingFilePath
+
+        If ($ProxyUri)
+        {
+            # Add/remove/edit JSON values *after* replacing all the '<>' placeholders because
+            # ConvertTo-Json will encode angle brackets.
+            $httpsProxy = "{ `"value`": `"$ProxyUri`" }" | ConvertFrom-Json
+            $json = Get-Content $DeploymentWorkingFilePath | ConvertFrom-Json
+            $edgeAgentDesired = $json.modulesContent.'$edgeAgent'.'properties.desired'
+            $upstreamProtocol = $edgeAgentDesired.systemModules.edgeHub.env.PSObject.Properties['UpstreamProtocol']
+            If (($upstreamProtocol -ne $null) -and ($upstreamProtocol.Value.value -eq 'Mqtt')) {
+                $upstreamProtocol = '{ "value": "MqttWs" }' | ConvertFrom-Json
+            } else {
+                $upstreamProtocol = '{ "value": "AmqpWs" }' | ConvertFrom-Json
+            }
+
+            # Add edgeAgent env with 'https_proxy' and 'UpstreamProtocol'
+            if ($edgeAgentDesired.systemModules.edgeAgent.PSObject.Properties['env'] -eq $null) {
+                $edgeAgentDesired.systemModules.edgeAgent | `
+                    Add-Member -Name 'env' -Value ([pscustomobject]@{}) -MemberType NoteProperty
+            }
+            $edgeAgentDesired.systemModules.edgeAgent.env | `
+                Add-Member -Name 'https_proxy' -Value $httpsProxy -MemberType NoteProperty
+            $edgeAgentDesired.systemModules.edgeAgent.env | `
+                Add-Member -Name 'UpstreamProtocol' -Value $upstreamProtocol -MemberType NoteProperty -Force
+
+            # Add 'https_proxy' and 'UpstreamProtocol' to edgeHub env
+            $edgeAgentDesired.systemModules.edgeHub.env | `
+                Add-Member -Name 'https_proxy' -Value $httpsProxy -MemberType NoteProperty
+            $edgeAgentDesired.systemModules.edgeHub.env | `
+                Add-Member -Name 'UpstreamProtocol' -Value $upstreamProtocol -MemberType NoteProperty -Force
+            
+            $json | ConvertTo-Json -Depth 20 | Set-Content $DeploymentWorkingFilePath
+        }
     }
 }
 
@@ -268,7 +318,7 @@ Function PrintLogs
     Try
     {
         Write-Host "EDGE AGENT LOGS"
-        Invoke-Expression "$dockerCmd logs edgeAgent"
+        Invoke-Expression "$dockerCmd logs edgeAgent" | Out-Host
     } 
     Catch
     {
@@ -278,7 +328,7 @@ Function PrintLogs
     Try
     {
         Write-Host "EDGE HUB LOGS"
-        Invoke-Expression "$dockerCmd logs edgeHub"
+        Invoke-Expression "$dockerCmd logs edgeHub" | Out-Host
     } 
     Catch
     {
@@ -292,7 +342,7 @@ Function PrintLogs
         Try
         {
             Write-Host "TEMP SENSOR LOGS"
-            Invoke-Expression "$dockerCmd logs tempSensor"
+            Invoke-Expression "$dockerCmd logs tempSensor" | Out-Host
         } 
         Catch
         {
@@ -304,7 +354,7 @@ Function PrintLogs
     {
         Try {
             Write-Host "TEMP FILTER LOGS"
-            Invoke-Expression "$dockerCmd logs tempFilter"
+            Invoke-Expression "$dockerCmd logs tempFilter" | Out-Host
         }
         Catch
         {
@@ -316,7 +366,7 @@ Function PrintLogs
     {
         Try {
             Write-Host "TEMP FILTER FUNCTIONS LOGS"
-            Invoke-Expression "$dockerCmd logs tempFilterFunctions"
+            Invoke-Expression "$dockerCmd logs tempFilterFunctions" | Out-Host
         }
         Catch
         {
@@ -363,7 +413,7 @@ Function RunDirectMethodAmqpTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMAmqp"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMAmqp-$(Get-Date -UFormat %s)"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
     
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
@@ -375,6 +425,11 @@ Function RunDirectMethodAmqpTest
             -p `"$ContainerRegistryPassword`" --verify-data-from-module `"DirectMethodSender`" ``
             -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
             -l `"$DeploymentWorkingFilePath`""
+    If ($ProxyUri) {
+        $testCommand = "$testCommand ``
+            --upstream-protocol 'AmqpWs' ``
+            --proxy `"$ProxyUri`""
+    }
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
     $testExitCode = $LastExitCode
@@ -389,7 +444,7 @@ Function RunDirectMethodMqttTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMMqtt"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMMqtt-$(Get-Date -UFormat %s)"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
     
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
@@ -401,6 +456,11 @@ Function RunDirectMethodMqttTest
             -p `"$ContainerRegistryPassword`" --verify-data-from-module `"DirectMethodSender`" ``
             -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
             -l `"$DeploymentWorkingFilePath`""
+    If ($ProxyUri) {
+        $testCommand = "$testCommand ``
+            --upstream-protocol 'MqttWs' ``
+            --proxy `"$ProxyUri`""
+    }
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
     $testExitCode = $LastExitCode
@@ -415,8 +475,8 @@ Function RunQuickstartCertsTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-QuickstartCerts"
-    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-QuickstartCerts-$(Get-Date -UFormat %s)"
+    PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
 
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
         -d `"$deviceId`" ``
@@ -425,10 +485,17 @@ Function RunQuickstartCertsTest
         -n `"$env:computername`" ``
         -r `"$ContainerRegistry`" ``
         -u `"$ContainerRegistryUsername`" ``
-        -p `"$ContainerRegistryPassword`" --optimize_for_performance true ``
+        -p `"$ContainerRegistryPassword`" ``
         -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
-        --leave-running=Core ``
+        --optimize_for_performance true ``
+        --leave-running=All ``
         --no-verify"
+    If ($ProxyUri) {
+        $testCommand = "$testCommand ``
+            -l `"$DeploymentWorkingFilePath`" ``
+            --upstream-protocol 'AmqpWs' ``
+            --proxy `"$ProxyUri`""
+    }
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
 
@@ -436,12 +503,16 @@ Function RunQuickstartCertsTest
     Write-Host "CA certificate path=$caCertPath"
 
     Write-Host "Run LeafDevice"
-    &$LeafDeviceExeTestPath `
-        -d "${deviceId}-leaf" `
-        -c "$IoTHubConnectionString" `
-        -e "$EventHubConnectionString" `
-        -ct "$caCertPath" `
-        -ed "$env:computername" | Out-Host
+    $testCommand = "&$LeafDeviceExeTestPath ``
+        -d `"${deviceId}-leaf`" ``
+        -c `"$IoTHubConnectionString`" ``
+        -e `"$EventHubConnectionString`" ``
+        -ct `"$caCertPath`" ``
+        -ed `"$env:computername`""
+    If ($ProxyUri) {
+        $testCommand = "$testCommand --proxy `"$ProxyUri`""
+    }
+    Invoke-Expression $testCommand | Out-Host
     $testExitCode = $LastExitCode
     
     PrintLogs $testStartAt $testExitCode
@@ -454,7 +525,7 @@ Function RunTempFilterTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilter"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilter-$(Get-Date -UFormat %s)"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
     
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
@@ -466,6 +537,11 @@ Function RunTempFilterTest
             -p `"$ContainerRegistryPassword`" --verify-data-from-module `"tempFilter`" ``
             -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
             -l `"$DeploymentWorkingFilePath`""
+    If ($ProxyUri) {
+        $testCommand = "$testCommand ``
+            --upstream-protocol 'AmqpWs' ``
+            --proxy `"$ProxyUri`""
+    }
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
     $testExitCode = $LastExitCode
@@ -486,7 +562,7 @@ Function RunTempFilterFunctionsTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilterFunc"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilterFunc-$(Get-Date -UFormat %s)"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" and deployment file $DeploymentWorkingFilePath started at $testStartAt"
     
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
@@ -498,6 +574,11 @@ Function RunTempFilterFunctionsTest
             -p `"$ContainerRegistryPassword`" --verify-data-from-module `"tempFilterFunctions`" ``
             -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
             -l `"$DeploymentWorkingFilePath`""
+    If ($ProxyUri) {
+        $testCommand = "$testCommand ``
+            --upstream-protocol 'AmqpWs' ``
+            --proxy `"$ProxyUri`""
+    }
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
     $testExitCode = $LastExitCode
@@ -512,7 +593,7 @@ Function RunTempSensorTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempSensor"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempSensor-$(Get-Date -UFormat %s)"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt."
 
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
@@ -521,9 +602,16 @@ Function RunTempSensorTest
         -e `"$EventHubConnectionString`" ``
         -r `"$ContainerRegistry`" ``
         -u `"$ContainerRegistryUsername`" ``
-        -p `"$ContainerRegistryPassword`" --optimize_for_performance true ``
+        -p `"$ContainerRegistryPassword`" ``
         -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
-        -tw `"$TwinTestFileArtifactFilePath`""
+        -tw `"$TwinTestFileArtifactFilePath`" ``
+        --optimize_for_performance true"
+    If ($ProxyUri) {
+        $testCommand = "$testCommand ``
+            -l `"$DeploymentWorkingFilePath`" ``
+            --upstream-protocol 'AmqpWs' ``
+            --proxy `"$ProxyUri`""
+    }
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
     $testExitCode = $LastExitCode
@@ -538,7 +626,7 @@ Function RunTransparentGatewayTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-TransGW"
+    $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-TransGW-$(Get-Date -UFormat %s)"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt."
 
     $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
@@ -548,23 +636,34 @@ Function RunTransparentGatewayTest
         -n `"$env:computername`" ``
         -r `"$ContainerRegistry`" ``
         -u `"$ContainerRegistryUsername`" ``
-        -p `"$ContainerRegistryPassword`" --optimize_for_performance true ``
+        -p `"$ContainerRegistryPassword`" ``
         -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
-        --leave-running=Core ``
-        --no-verify ``
         --device_ca_cert `"$DeviceCACertificatePath`" ``
         --device_ca_pk `"$DeviceCAPrimaryKeyPath`" ``
-        --trusted_ca_certs `"$TrustedCACertificatePath`""
+        --trusted_ca_certs `"$TrustedCACertificatePath`" ``
+        --optimize_for_performance true ``
+        --leave-running=All ``
+        --no-verify"
+    If ($ProxyUri) {
+        $testCommand = "$testCommand ``
+            -l `"$DeploymentWorkingFilePath`" ``
+            --upstream-protocol 'AmqpWs' ``
+            --proxy `"$ProxyUri`""
+    }
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
 
     Write-Host "Run LeafDevice"
-    &$LeafDeviceExeTestPath `
-        -d "${deviceId}-leaf" `
-        -c "$IoTHubConnectionString" `
-        -e "$EventHubConnectionString" `
-        -ct "$TrustedCACertificatePath" `
-        -ed "$env:computername" | Out-Host
+    $testCommand = "&$LeafDeviceExeTestPath ``
+        -d `"${deviceId}-leaf`" ``
+        -c `"$IoTHubConnectionString`" ``
+        -e `"$EventHubConnectionString`" ``
+        -ct `"$TrustedCACertificatePath`" ``
+        -ed `"$env:computername`""
+    If ($ProxyUri) {
+        $testCommand = "$testCommand --proxy `"$ProxyUri`""
+    }
+    Invoke-Expression $testCommand | Out-Host
     $testExitCode = $LastExitCode
     
     PrintLogs $testStartAt $testExitCode
@@ -619,6 +718,10 @@ Function ValidateTestParameters
 
     If (($TestName -eq "QuickstartCerts") -Or ($TestName -eq "TransparentGateway"))
     {
+        if ($ProxyUri)
+        {
+            $validatingItems += $RuntimeOnlyDeploymentArtifactFilePath
+        }
         $validatingItems += (Join-Path $LeafDeviceArtifactFolder "*")
     }
 
@@ -634,6 +737,10 @@ Function ValidateTestParameters
 
     If ($TestName -eq "TempSensor")
     {
+        if ($ProxyUri)
+        {
+            $validatingItems += $QuickstartDeploymentArtifactFilePath
+        }
         $validatingItems += $TwinTestFileArtifactFilePath
     }
 
@@ -665,6 +772,8 @@ $InstallationScriptPath = Join-Path $E2ETestFolder "artifacts\core-windows\scrip
 $ModuleToModuleDeploymentFilename = "module_to_module_deployment.template.json"
 $ModuleToFunctionsDeploymentFilename = "module_to_functions_deployment.template.json"
 $DirectMethodModuleToModuleDeploymentFilename = "dm_module_to_module_deployment.json"
+$RuntimeOnlyDeploymentFilename = 'runtime_only_deployment.template.json'
+$QuickstartDeploymentFilename = 'quickstart_deployment.template.json'
 $TwinTestFilename = "twin_test_tempSensor.json"
 
 $IoTEdgeQuickstartArtifactFolder = Join-Path $E2ETestFolder "artifacts\core-windows\IoTEdgeQuickstart\$Architecture"
@@ -675,6 +784,8 @@ $DeploymentFilesFolder = Join-Path $E2ETestFolder "artifacts\core-windows\e2e_de
 $TestFileFolder = Join-Path $E2ETestFolder "artifacts\core-windows\e2e_test_files"
 $ModuleToModuleDeploymentArtifactFilePath = Join-Path $DeploymentFilesFolder $ModuleToModuleDeploymentFilename
 $ModuleToFunctionDeploymentArtifactFilePath = Join-Path $DeploymentFilesFolder $ModuleToFunctionsDeploymentFilename
+$RuntimeOnlyDeploymentArtifactFilePath = Join-Path $DeploymentFilesFolder $RuntimeOnlyDeploymentFilename
+$QuickstartDeploymentArtifactFilePath = Join-Path $DeploymentFilesFolder $QuickstartDeploymentFilename
 $TwinTestFileArtifactFilePath = Join-Path $TestFileFolder $TwinTestFilename
 $DirectMethodModuleToModuleDeploymentArtifactFilePath = Join-Path $DeploymentFilesFolder $DirectMethodModuleToModuleDeploymentFilename
 

--- a/smoke/IotEdgeQuickstart/Quickstart.cs
+++ b/smoke/IotEdgeQuickstart/Quickstart.cs
@@ -19,6 +19,7 @@ namespace IotEdgeQuickstart
             string iothubConnectionString,
             string eventhubCompatibleEndpointWithEntityPath,
             UpstreamProtocolType upstreamProtocol,
+            Option<string> proxy,
             string imageTag,
             string deviceId,
             string hostname,
@@ -34,7 +35,7 @@ namespace IotEdgeQuickstart
             bool optimizedForPerformance,
             LogLevel runtimeLogLevel,
             bool cleanUpExistingDeviceOnSuccess)
-            : base(bootstrapper, credentials, iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, upstreamProtocol, imageTag, deviceId, hostname, deploymentFileName, twinTestFileName, deviceCaCert, deviceCaPk, deviceCaCerts, optimizedForPerformance, runtimeLogLevel, cleanUpExistingDeviceOnSuccess)
+            : base(bootstrapper, credentials, iothubConnectionString, eventhubCompatibleEndpointWithEntityPath, upstreamProtocol, proxy, imageTag, deviceId, hostname, deploymentFileName, twinTestFileName, deviceCaCert, deviceCaPk, deviceCaCerts, optimizedForPerformance, runtimeLogLevel, cleanUpExistingDeviceOnSuccess)
         {
             this.leaveRunning = leaveRunning;
             this.noDeployment = noDeployment;

--- a/smoke/LeafDevice/LeafDevice.cs
+++ b/smoke/LeafDevice/LeafDevice.cs
@@ -16,6 +16,7 @@ namespace LeafDeviceTest
             string edgeHostName,
             string edgeDeviceId,
             DeviceProtocol protocol,
+            Option<string> proxy,
             Option<DeviceCertificate> deviceCertificate,
             Option<IList<string>> thumbprintCertificates)
             : base(
@@ -26,6 +27,7 @@ namespace LeafDeviceTest
                 edgeHostName,
                 edgeDeviceId,
                 protocol,
+                proxy,
                 deviceCertificate,
                 thumbprintCertificates)
         {
@@ -64,6 +66,7 @@ namespace LeafDeviceTest
             readonly string edgeHostName;
             readonly string edgeDeviceId;
             readonly DeviceProtocol protocol;
+            Option<string> proxy;
             bool usePrimaryThumbprintClientCert;
             Option<string> x509CACertPath;
             Option<string> x509CAKeyPath;
@@ -76,7 +79,8 @@ namespace LeafDeviceTest
                 string trustedCACertificateFileName,
                 string edgeHostName,
                 string edgeDeviceId,
-                DeviceProtocol protocol)
+                DeviceProtocol protocol,
+                Option<string> proxy)
             {
                 this.iothubConnectionString = Preconditions.CheckNotNull(iothubConnectionString);
                 this.eventhubCompatibleEndpointWithEntityPath = Preconditions.CheckNotNull(eventhubCompatibleEndpointWithEntityPath);
@@ -85,6 +89,7 @@ namespace LeafDeviceTest
                 this.edgeHostName = Preconditions.CheckNotNull(edgeHostName);
                 this.edgeDeviceId = Preconditions.CheckNotNull(edgeDeviceId);
                 this.protocol = protocol;
+                this.proxy = proxy;
                 this.usePrimaryThumbprintClientCert = false;
             }
 
@@ -143,6 +148,7 @@ namespace LeafDeviceTest
                     this.edgeHostName,
                     this.edgeDeviceId,
                     this.protocol,
+                    this.proxy,
                     deviceCert,
                     this.thumbprintCerts);
             }


### PR DESCRIPTION
- Added `-ProxyUri` parameter to Run-E2ETest.ps1
- If `-ProxyUri` is specified, add proxy info to the test deployment
- Add two new deployment template files
- Make sure all docker logs are printed to stdout
- Add a timestamp to E2E test device IDs to make them completely unique
- Add `--proxy` parameter to IotEdgeQuickstart **and** LeafDevice