### PR TITLE
Fix long haul yaml

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -4,6 +4,7 @@ pr: none
 variables:
   azure.keyVault: 'edgebuildkv'
   azure.subscription: 'azureiotedge-arm'
+  Build.SyncSources: false
   edgelet.package.build: 55463
   images.artifact.name: 'core-linux'
   images.build: 55174
@@ -71,6 +72,7 @@ jobs:
             declare -a cnreg=( $(edgebuilds-azurecr-io) )
             testName="LongHaul"
             . $(Agent.HomeDirectory)/../artifacts/core-linux/artifactInfo.txt
+            chmod +x $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh
             sudo $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh -testDir "$(Agent.HomeDirectory)/.." -releaseLabel "LH" -artifactImageBuildNumber "$BuildNumber" -testName "$testName" -containerRegistryUsername "${cnreg[0]}" -containerRegistryPassword "${cnreg[1]}" -iotHubConnectionString "$(IotHubStressConnString)" -eventHubConnectionString "$(EventHubStressConnStr)" -snitchAlertUrl "$(SnitchLongHaulAlertUrl)" -snitchStorageMasterKey "$(StorageAccountMasterKeyStress)"
 
 ################################################################################
@@ -133,4 +135,5 @@ jobs:
             declare -a cnreg=( $(edgebuilds-azurecr-io) )
             testName="LongHaul"
             . $(Agent.HomeDirectory)/../artifacts/core-linux/artifactInfo.txt
+            chmod +x $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh
             sudo $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh -testDir "$(Agent.HomeDirectory)/.." -releaseLabel "LH" -artifactImageBuildNumber "$BuildNumber" -testName "$testName" -containerRegistryUsername "${cnreg[0]}" -containerRegistryPassword "${cnreg[1]}" -iotHubConnectionString "$(IotHubStressConnString)" -eventHubConnectionString "$(EventHubStressConnStr)" -snitchAlertUrl "$(SnitchLongHaulAlertUrl)" -snitchStorageMasterKey "$(StorageAccountMasterKeyStress)"

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -74,6 +74,7 @@ jobs:
             . $(Agent.HomeDirectory)/../artifacts/core-linux/artifactInfo.txt
             chmod +x $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh
             sudo $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh -testDir "$(Agent.HomeDirectory)/.." -releaseLabel "LH" -artifactImageBuildNumber "$BuildNumber" -testName "$testName" -containerRegistryUsername "${cnreg[0]}" -containerRegistryPassword "${cnreg[1]}" -iotHubConnectionString "$(IotHubStressConnString)" -eventHubConnectionString "$(EventHubStressConnStr)" -snitchAlertUrl "$(SnitchLongHaulAlertUrl)" -snitchStorageMasterKey "$(StorageAccountMasterKeyStress)"
+          workingDirectory: "$(Agent.HomeDirectory)/.."
 
 ################################################################################
   - job: linux_arm32_moby
@@ -137,3 +138,4 @@ jobs:
             . $(Agent.HomeDirectory)/../artifacts/core-linux/artifactInfo.txt
             chmod +x $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh
             sudo $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh -testDir "$(Agent.HomeDirectory)/.." -releaseLabel "LH" -artifactImageBuildNumber "$BuildNumber" -testName "$testName" -containerRegistryUsername "${cnreg[0]}" -containerRegistryPassword "${cnreg[1]}" -iotHubConnectionString "$(IotHubStressConnString)" -eventHubConnectionString "$(EventHubStressConnStr)" -snitchAlertUrl "$(SnitchLongHaulAlertUrl)" -snitchStorageMasterKey "$(StorageAccountMasterKeyStress)"
+          workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -1,6 +1,5 @@
 trigger: none
 
-jobs:
 variables:
   azure.keyVault: 'edgebuildkv'
   azure.subscription: 'azureiotedge-arm'
@@ -9,6 +8,8 @@ variables:
   images.build: 55174
   pool.name: 'Azure-IoT-Edge-Core'
   vsts.project: $(System.TeamProjectId)
+
+jobs:
 ################################################################################
   - job: linux_amd64_moby
 ################################################################################

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -1,4 +1,5 @@
 trigger: none
+pr: none
 
 variables:
   azure.keyVault: 'edgebuildkv'


### PR DESCRIPTION
1. Add Build.SyncSources to skip download repo from github.
2. Add "chmod" for runE2ETest.sh (don't know why it is not executable when downloaded from artifact); just to be safe.
3. Add working directory ( this is odd, I got error complaining this input is missing, but this field is optional from documentation; after I added it passed the build.  Totally don't know why is needed)