### PR TITLE
Get E2E tests working on Windows behind a proxy

### DIFF
--- a/builds/e2e/Runner.ps1
+++ b/builds/e2e/Runner.ps1
@@ -84,6 +84,10 @@ New-Module -ScriptBlock {
         
         netsh winhttp set proxy "${ProxyHostname}:3128" "<local>"
 
+        # iotedge-moby needs this variable for `docker pull`
+        Write-Host 'Setting HTTPS_PROXY in environment'
+        [Environment]::SetEnvironmentVariable("HTTPS_PROXY", $proxyUri, [EnvironmentVariableTarget]::Machine)
+
         # Add public key so agent can SSH into this runner
         $authorizedKeys = Join-Path ${env:UserProfile} (Join-Path ".ssh" "authorized_keys")
         Write-Host "Adding public key to $authorizedKeys"

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -503,7 +503,6 @@ function Uninstall-IoTEdge {
         [Switch] $RestartIfNeeded
     )
 
-    $ProgressPreference = $PSCmdlet.GetVariableValue('ProgressPreference')
     $ErrorActionPreference = 'Stop'
     Set-StrictMode -Version 5
 

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -503,6 +503,7 @@ function Uninstall-IoTEdge {
         [Switch] $RestartIfNeeded
     )
 
+    $ProgressPreference = $PSCmdlet.GetVariableValue('ProgressPreference')
     $ErrorActionPreference = 'Stop'
     Set-StrictMode -Version 5
 

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -127,7 +127,7 @@ Param (
 
 Set-StrictMode -Version "Latest"
 $ErrorActionPreference = "Stop"
-$ProgressPreference = "SilentlyContinue"
+$global:ProgressPreference = "SilentlyContinue"
 
 Function AppendInstallationOption([string] $testCommand)
 {


### PR DESCRIPTION
Two more updates:
- Add a missed environment variable to one of the test environment deployment scripts
- Set $ProgressPreference _globally_ in Run-E2ETest.ps1 so that it impacts the module inside the installer script as well (normally modules do not inherit preference vars from their caller). This is needed because the proxy end-to-end tests invoke `Run-E2ETest.ps1` through SSH, and the terminal complains about Powershell's attempt to display its progress bar.