### PR TITLE
EdgeHub: Upstream perf improvements

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -4,6 +4,7 @@ pr: none
 variables:
   azure.keyVault: 'edgebuildkv'
   azure.subscription: 'azureiotedge-arm'
+  Build.SyncSources: false
   edgelet.package.build: 55463
   images.artifact.name: 'core-linux'
   images.build: 55174
@@ -71,7 +72,9 @@ jobs:
             declare -a cnreg=( $(edgebuilds-azurecr-io) )
             testName="LongHaul"
             . $(Agent.HomeDirectory)/../artifacts/core-linux/artifactInfo.txt
+            chmod +x $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh
             sudo $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh -testDir "$(Agent.HomeDirectory)/.." -releaseLabel "LH" -artifactImageBuildNumber "$BuildNumber" -testName "$testName" -containerRegistryUsername "${cnreg[0]}" -containerRegistryPassword "${cnreg[1]}" -iotHubConnectionString "$(IotHubStressConnString)" -eventHubConnectionString "$(EventHubStressConnStr)" -snitchAlertUrl "$(SnitchLongHaulAlertUrl)" -snitchStorageMasterKey "$(StorageAccountMasterKeyStress)"
+          workingDirectory: "$(Agent.HomeDirectory)/.."
 
 ################################################################################
   - job: linux_arm32_moby
@@ -133,4 +136,6 @@ jobs:
             declare -a cnreg=( $(edgebuilds-azurecr-io) )
             testName="LongHaul"
             . $(Agent.HomeDirectory)/../artifacts/core-linux/artifactInfo.txt
+            chmod +x $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh
             sudo $(Agent.HomeDirectory)/../artifacts/core-linux/scripts/linux/runE2ETest.sh -testDir "$(Agent.HomeDirectory)/.." -releaseLabel "LH" -artifactImageBuildNumber "$BuildNumber" -testName "$testName" -containerRegistryUsername "${cnreg[0]}" -containerRegistryPassword "${cnreg[1]}" -iotHubConnectionString "$(IotHubStressConnString)" -eventHubConnectionString "$(EventHubStressConnStr)" -snitchAlertUrl "$(SnitchLongHaulAlertUrl)" -snitchStorageMasterKey "$(StorageAccountMasterKeyStress)"
+          workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
@@ -19,5 +19,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const string IotEdgeIdentityCapability = "iotEdge";
         public const string ServiceIdentityRefreshMethodName = "RefreshDeviceScopeIdentityCache";
         public static readonly Version ConfigSchemaVersion = new Version("1.0");
+
+        public const long MaxMessageSize = 256 * 1024; // matches IoTHub
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
@@ -18,8 +18,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public const string IotEdgeIdentityCapability = "iotEdge";
         public const string ServiceIdentityRefreshMethodName = "RefreshDeviceScopeIdentityCache";
-        public static readonly Version ConfigSchemaVersion = new Version("1.0");
 
         public const long MaxMessageSize = 256 * 1024; // matches IoTHub
+
+        public static readonly Version ConfigSchemaVersion = new Version("1.0");
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="App.Metrics" Version="3.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.18.1" />
-    <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
@@ -100,18 +100,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
 
             public Task CloseAsync(CancellationToken token) => Task.CompletedTask;
 
-            internal static int GetBatchSize(int batchSize, long messageSize)
-            {
-                while (true)
-                {
-                    if (batchSize == 1 || Constants.MaxMessageSize > messageSize * batchSize)
-                    {
-                        return batchSize;
-                    }
-
-                    batchSize = batchSize - 1;
-                }
-            }
+            internal static int GetBatchSize(int batchSize, long messageSize) =>
+                Math.Min((int)(Constants.MaxMessageSize / messageSize), batchSize);
 
             static bool IsRetryable(Exception ex) => ex != null && RetryableExceptions.Contains(ex.GetType());
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             string id,
             Func<string, Task<Util.Option<ICloudProxy>>> cloudProxyGetterFunc,
             Core.IMessageConverter<IRoutingMessage> messageConverter,
-            int maxBatchSize)
+            int maxBatchSize = 10)
             : base(id)
         {
             Preconditions.CheckArgument(maxBatchSize > 0, "MaxBatchSize should be greater than 0");
@@ -47,6 +47,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         public override string Type => this.GetType().Name;
 
         public override IProcessor CreateProcessor() => new CloudMessageProcessor(this);
+
+        public override int FanOutFactor => 10;
 
         public override void LogUserMetrics(long messageCount, long latencyInMs)
         {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             {
                 if (token.IsCancellationRequested)
                 {
-                    Events.CancelledProcessingMessage(routingMessages);
+                    Events.CancelledProcessingMessages(routingMessages);
                     var sendFailureDetails = new SendFailureDetails(FailureKind.Transient, new EdgeHubConnectionException($"Cancelled sending messages to IotHub for device {this.cloudEndpoint.Id}"));
                     return new SinkResult<IRoutingMessage>(ImmutableList<IRoutingMessage>.Empty, routingMessages, sendFailureDetails);
                 }
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 Log.LogDebug((int)EventIds.ProcessingMessages, Invariant($"Sending {routingMessages.Count} message(s) upstream."));
             }
 
-            public static void CancelledProcessingMessage(ICollection<IRoutingMessage> messages)
+            public static void CancelledProcessingMessages(ICollection<IRoutingMessage> messages)
             {
                 if (messages.Count > 0)
                 {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
@@ -131,7 +131,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 List<InvalidDetails<IRoutingMessage>> invalid = routingMessages
                     .Select(m => new InvalidDetails<IRoutingMessage>(m, FailureKind.InvalidInput))
                     .ToList();
-                var sendFailureDetails = new SendFailureDetails(FailureKind.InvalidInput, new InvalidOperationException("Message does not contain device id"));
+                var sendFailureDetails = new SendFailureDetails(FailureKind.InvalidInput, ex);
                 return new SinkResult<IRoutingMessage>(ImmutableList<IRoutingMessage>.Empty, ImmutableList<IRoutingMessage>.Empty, invalid, sendFailureDetails);
             }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/EndpointFactory.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/EndpointFactory.cs
@@ -17,12 +17,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         readonly string edgeDeviceId;
         readonly ConcurrentDictionary<string, Endpoint> cache;
         readonly int maxBatchSize;
+        readonly int upstreamFanOutFactor;
 
         public EndpointFactory(
             IConnectionManager connectionManager,
             Core.IMessageConverter<IRoutingMessage> messageConverter,
             string edgeDeviceId,
-            int maxBatchSize)
+            int maxBatchSize,
+            int upstreamFanOutFactor)
         {
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
             this.messageConverter = Preconditions.CheckNotNull(messageConverter, nameof(messageConverter));
@@ -35,7 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         {
             if (CloudEndpointName.Equals(endpoint, StringComparison.OrdinalIgnoreCase))
             {
-                return this.cache.GetOrAdd(CloudEndpointName, s => new CloudEndpoint("iothub", id => this.connectionManager.GetCloudConnection(id), this.messageConverter, this.maxBatchSize));
+                return this.cache.GetOrAdd(CloudEndpointName, s => new CloudEndpoint("iothub", id => this.connectionManager.GetCloudConnection(id), this.messageConverter, this.maxBatchSize, this.upstreamFanOutFactor));
             }
             else
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/EndpointFactory.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/EndpointFactory.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
             this.cache = new ConcurrentDictionary<string, Endpoint>();
             this.maxBatchSize = maxBatchSize;
+            this.upstreamFanOutFactor = upstreamFanOutFactor;
         }
 
         public Endpoint CreateSystemEndpoint(string endpoint)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/EndpointFactory.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/EndpointFactory.cs
@@ -16,23 +16,26 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         readonly Core.IMessageConverter<IRoutingMessage> messageConverter;
         readonly string edgeDeviceId;
         readonly ConcurrentDictionary<string, Endpoint> cache;
+        readonly int maxBatchSize;
 
         public EndpointFactory(
             IConnectionManager connectionManager,
             Core.IMessageConverter<IRoutingMessage> messageConverter,
-            string edgeDeviceId)
+            string edgeDeviceId,
+            int maxBatchSize)
         {
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
             this.messageConverter = Preconditions.CheckNotNull(messageConverter, nameof(messageConverter));
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
             this.cache = new ConcurrentDictionary<string, Endpoint>();
+            this.maxBatchSize = maxBatchSize;
         }
 
         public Endpoint CreateSystemEndpoint(string endpoint)
         {
             if (CloudEndpointName.Equals(endpoint, StringComparison.OrdinalIgnoreCase))
             {
-                return this.cache.GetOrAdd(CloudEndpointName, s => new CloudEndpoint("iothub", id => this.connectionManager.GetCloudConnection(id), this.messageConverter));
+                return this.cache.GetOrAdd(CloudEndpointName, s => new CloudEndpoint("iothub", id => this.connectionManager.GetCloudConnection(id), this.messageConverter, this.maxBatchSize));
             }
             else
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             long messageSize = messageToBeValidated.Size();
             if (messageSize > Constants.MaxMessageSize)
             {
-                throw new EdgeHubMessageTooLargeException($"Message size is {messageSize} bytes which is greater than the max size {MaxMessageSize} bytes allowed");
+                throw new EdgeHubMessageTooLargeException($"Message size is {messageSize} bytes which is greater than the max size {Constants.MaxMessageSize} bytes allowed");
             }
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
     using SystemProperties = Microsoft.Azure.Devices.Edge.Hub.Core.SystemProperties;
 
     public class RoutingEdgeHub : IEdgeHub
-    {
-        const long MaxMessageSize = 256 * 1024; // matches IoTHub
+    {        
         readonly Router router;
         readonly Core.IMessageConverter<IRoutingMessage> messageConverter;
         readonly IConnectionManager connectionManager;
@@ -161,7 +160,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         static void ValidateMessageSize(IRoutingMessage messageToBeValidated)
         {
             long messageSize = messageToBeValidated.Size();
-            if (messageSize > MaxMessageSize)
+            if (messageSize > Constants.MaxMessageSize)
             {
                 throw new EdgeHubMessageTooLargeException($"Message size is {messageSize} bytes which is greater than the max size {MaxMessageSize} bytes allowed");
             }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
     using SystemProperties = Microsoft.Azure.Devices.Edge.Hub.Core.SystemProperties;
 
     public class RoutingEdgeHub : IEdgeHub
-    {        
+    {
         readonly Router router;
         readonly Core.IMessageConverter<IRoutingMessage> messageConverter;
         readonly IConnectionManager connectionManager;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool useV1TwinManager = this.GetConfigurationValueIfExists<string>("TwinManagerVersion")
                 .Map(v => v.Equals("v1", StringComparison.OrdinalIgnoreCase))
                 .GetOrElse(true);
+            int maxUpstreamBatchSize = this.configuration.GetValue("MaxUpstreamBatchSize", 10);
 
             builder.RegisterModule(
                 new RoutingModule(
@@ -151,7 +152,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     cloudOperationTimeout,
                     minTwinSyncPeriod,
                     reportedPropertiesSyncFrequency,
-                    useV1TwinManager));
+                    useV1TwinManager,
+                    maxUpstreamBatchSize));
         }
 
         void RegisterCommonModule(ContainerBuilder builder, bool optimizeForPerformance, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -131,6 +131,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 .Map(v => v.Equals("v1", StringComparison.OrdinalIgnoreCase))
                 .GetOrElse(true);
             int maxUpstreamBatchSize = this.configuration.GetValue("MaxUpstreamBatchSize", 10);
+            int upstreamFanOutFactor = this.configuration.GetValue("UpstreamFanOutFactor", 10);
 
             builder.RegisterModule(
                 new RoutingModule(
@@ -153,7 +154,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     minTwinSyncPeriod,
                     reportedPropertiesSyncFrequency,
                     useV1TwinManager,
-                    maxUpstreamBatchSize));
+                    maxUpstreamBatchSize,
+                    upstreamFanOutFactor));
         }
 
         void RegisterCommonModule(ContainerBuilder builder, bool optimizeForPerformance, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly Option<TimeSpan> reportedPropertiesSyncFrequency;
         readonly bool useV1TwinManager;
         readonly int maxUpstreamBatchSize;
+        readonly int upstreamFanOutFactor;
 
         public RoutingModule(
             string iotHubName,
@@ -68,7 +69,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             Option<TimeSpan> minTwinSyncPeriod,
             Option<TimeSpan> reportedPropertiesSyncFrequency,
             bool useV1TwinManager,
-            int maxUpstreamBatchSize)
+            int maxUpstreamBatchSize,
+            int upstreamFanOutFactor)
         {
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
@@ -90,6 +92,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.reportedPropertiesSyncFrequency = reportedPropertiesSyncFrequency;
             this.useV1TwinManager = useV1TwinManager;
             this.maxUpstreamBatchSize = maxUpstreamBatchSize;
+            this.upstreamFanOutFactor = upstreamFanOutFactor;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -242,7 +245,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     {
                         var messageConverter = c.Resolve<Core.IMessageConverter<IRoutingMessage>>();
                         IConnectionManager connectionManager = await c.Resolve<Task<IConnectionManager>>();
-                        return new EndpointFactory(connectionManager, messageConverter, this.edgeDeviceId, this.maxUpstreamBatchSize) as IEndpointFactory;
+                        return new EndpointFactory(connectionManager, messageConverter, this.edgeDeviceId, this.maxUpstreamBatchSize, this.upstreamFanOutFactor) as IEndpointFactory;
                     })
                 .As<Task<IEndpointFactory>>()
                 .SingleInstance();

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly Option<TimeSpan> minTwinSyncPeriod;
         readonly Option<TimeSpan> reportedPropertiesSyncFrequency;
         readonly bool useV1TwinManager;
+        readonly int maxUpstreamBatchSize;
 
         public RoutingModule(
             string iotHubName,
@@ -66,7 +67,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             TimeSpan operationTimeout,
             Option<TimeSpan> minTwinSyncPeriod,
             Option<TimeSpan> reportedPropertiesSyncFrequency,
-            bool useV1TwinManager)
+            bool useV1TwinManager,
+            int maxUpstreamBatchSize)
         {
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
@@ -87,6 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.minTwinSyncPeriod = minTwinSyncPeriod;
             this.reportedPropertiesSyncFrequency = reportedPropertiesSyncFrequency;
             this.useV1TwinManager = useV1TwinManager;
+            this.maxUpstreamBatchSize = maxUpstreamBatchSize;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -239,7 +242,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     {
                         var messageConverter = c.Resolve<Core.IMessageConverter<IRoutingMessage>>();
                         IConnectionManager connectionManager = await c.Resolve<Task<IConnectionManager>>();
-                        return new EndpointFactory(connectionManager, messageConverter, this.edgeDeviceId) as IEndpointFactory;
+                        return new EndpointFactory(connectionManager, messageConverter, this.edgeDeviceId, this.maxUpstreamBatchSize) as IEndpointFactory;
                     })
                 .As<Task<IEndpointFactory>>()
                 .SingleInstance();

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Endpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Endpoint.cs
@@ -33,6 +33,8 @@ namespace Microsoft.Azure.Devices.Routing.Core
 
         public abstract void LogUserMetrics(long messageCount, long latencyInMs);
 
+        public virtual int FanOutFactor => 1;
+
         public bool Equals(Endpoint other)
         {
             if (ReferenceEquals(null, other))

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             }
         }
 
-        class StoreMessagesProvider
+        internal class StoreMessagesProvider
         {
             readonly IMessageIterator iterator;
             readonly int batchSize;

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -128,7 +128,8 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             {
                 Events.StartSendMessagesPump(this);
                 IMessageIterator iterator = this.messageStore.GetMessageIterator(this.Endpoint.Id, this.checkpointer.Offset + 1);
-                var storeMessagesProvider = new StoreMessagesProvider(iterator, this.options.BatchTimeout, this.options.BatchSize);
+                int batchSize = this.options.BatchSize * this.Endpoint.FanOutFactor;
+                var storeMessagesProvider = new StoreMessagesProvider(iterator, this.options.BatchTimeout, batchSize);
                 while (!this.cts.IsCancellationRequested)
                 {
                     try

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -9,18 +9,20 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
     using App.Metrics;
     using App.Metrics.Counter;
     using App.Metrics.Timer;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine;
-    using Microsoft.Azure.Devices.Routing.Core.Util;
     using Microsoft.Azure.Devices.Routing.Core.Util.Concurrency;
     using Microsoft.Extensions.Logging;
+    using Nito.AsyncEx;
     using static System.FormattableString;
+    using AsyncLock = Microsoft.Azure.Devices.Routing.Core.Util.Concurrency.AsyncLock;
 
     public class StoringAsyncEndpointExecutor : IEndpointExecutor
     {
         readonly AtomicBoolean closed = new AtomicBoolean();
         readonly IMessageStore messageStore;
         readonly Task sendMessageTask;
-        readonly ManualResetEvent hasMessagesInQueue = new ManualResetEvent(true);
+        readonly AsyncManualResetEvent hasMessagesInQueue = new AsyncManualResetEvent(true);
         readonly ICheckpointer checkpointer;
         readonly AsyncEndpointExecutorOptions options;
         readonly EndpointExecutorFsm machine;
@@ -126,19 +128,22 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             {
                 Events.StartSendMessagesPump(this);
                 IMessageIterator iterator = this.messageStore.GetMessageIterator(this.Endpoint.Id, this.checkpointer.Offset + 1);
+                var storeMessagesProvider = new StoreMessagesProvider(iterator, this.options.BatchTimeout, this.options.BatchSize);
                 while (!this.cts.IsCancellationRequested)
                 {
                     try
                     {
-                        this.hasMessagesInQueue.WaitOne(this.options.BatchTimeout);
-                        IMessage[] messages = (await iterator.GetNext(this.options.BatchSize)).ToArray();
-                        await this.ProcessMessages(messages);
-                        Events.SendMessagesSuccess(this, messages);
-                        Metrics.DrainedCountIncrement(this.Endpoint.Id, messages.Length);
-
-                        // If store has no messages, then reset the hasMessagesInQueue flag.
-                        if (messages.Length == 0)
+                        await this.hasMessagesInQueue.WaitAsync(this.options.BatchTimeout);
+                        IMessage[] messages = await storeMessagesProvider.GetMessages();
+                        if (messages.Length > 0)
                         {
+                            await this.ProcessMessages(messages);
+                            Events.SendMessagesSuccess(this, messages);
+                            Metrics.DrainedCountIncrement(this.Endpoint.Id, messages.Length);
+                        }
+                        else
+                        {
+                            // If store has no messages, then reset the hasMessagesInQueue flag.
                             this.hasMessagesInQueue.Reset();
                         }
                     }
@@ -172,6 +177,69 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             }
         }
 
+        class StoreMessagesProvider
+        {
+            readonly IMessageIterator iterator;
+            readonly int batchSize;
+            readonly AsyncLock messagesLock = new AsyncLock();
+            readonly AsyncManualResetEvent messagesResetEvent = new AsyncManualResetEvent(true);
+            readonly TimeSpan timeout;
+            readonly Task populateTask;
+            List<IMessage> messagesList;
+
+            public StoreMessagesProvider(IMessageIterator iterator, TimeSpan timeout, int batchSize)
+            {
+                this.iterator = iterator;
+                this.batchSize = batchSize;
+                this.timeout = timeout;
+                this.populateTask = this.PopulatePump();
+            }
+
+            public async Task<IMessage[]> GetMessages()
+            {
+                List<IMessage> currentMessagesList;
+                using (await this.messagesLock.LockAsync())
+                {
+                    currentMessagesList = this.messagesList;
+                    this.messagesList = new List<IMessage>(this.batchSize);
+                    this.messagesResetEvent.Set();
+                }
+
+                return currentMessagesList.ToArray();
+            }
+
+            async Task PopulatePump()
+            {
+                while (true)
+                {
+                    try
+                    {
+                        await this.messagesResetEvent.WaitAsync(this.timeout);
+                        while (this.messagesList.Count < this.batchSize)
+                        {
+                            int curBatchSize = this.batchSize - this.messagesList.Count;
+                            IList<IMessage> messages = (await this.iterator.GetNext(curBatchSize)).ToList();
+                            if (!messages.Any())
+                            {
+                                break;
+                            }
+
+                            using (await this.messagesLock.LockAsync())
+                            {
+                                this.messagesList.AddRange(messages);
+                            }
+                        }
+
+                        this.messagesResetEvent.Reset();
+                    }
+                    catch (Exception e)
+                    {
+                        Events.ErrorInPopulatePump(e);
+                    }
+                }
+            }
+        }
+
         static class Events
         {
             const int IdStart = Routing.EventIds.StoringAsyncEndpointExecutor;
@@ -191,6 +259,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                 Close,
                 CloseSuccess,
                 CloseFailure,
+                ErrorInPopulatePump
             }
 
             public static void AddMessageSuccess(StoringAsyncEndpointExecutor executor, long offset)
@@ -262,6 +331,11 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             public static void CloseFailure(StoringAsyncEndpointExecutor executor, Exception ex)
             {
                 Log.LogError((int)EventIds.CloseFailure, ex, "[CloseFailure] Close failed. EndpointId: {0}, EndpointName: {1}", executor.Endpoint.Id, executor.Endpoint.Name);
+            }
+
+            public static void ErrorInPopulatePump(Exception ex)
+            {
+                Log.LogWarning((int)EventIds.ErrorInPopulatePump, ex, "Error in populate messages pump");
             }
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -178,6 +178,9 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             }
         }
 
+        // This class is used to prefetch messages from the store before they are needed.
+        // As soon as the previous batch is consumed, the next batch is fetched.
+        // A pump is started as soon as the object is created, and it keeps the messages list populated.
         internal class StoreMessagesProvider
         {
             readonly IMessageIterator iterator;

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -193,6 +193,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                 this.iterator = iterator;
                 this.batchSize = batchSize;
                 this.timeout = timeout;
+                this.messagesList = new List<IMessage>(this.batchSize);
                 this.populateTask = this.PopulatePump();
             }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
@@ -890,16 +890,16 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
                     Log.LogError((int)EventIds.CounterFailure, "[LogEventsProcessedCounterFailed] {0}", error);
                 }
 
-                TimeSpan totalTime = messages.Select(m => m.DequeuedTime).Aggregate(TimeSpan.Zero, (span, time) => span + (fsm.systemTime.UtcNow - time));
-                long averageLatencyInMs = totalTime < TimeSpan.Zero ? 0L : (long)(totalTime.TotalMilliseconds / messages.Count);
+                double totalTimeMSecs = messages.Select(m => m.DequeuedTime).Aggregate(0D, (span, time) => span + (fsm.systemTime.UtcNow - time).TotalMilliseconds);
+                long averageLatencyInMs = totalTimeMSecs < 0 ? 0L : (long)(totalTimeMSecs / messages.Count);
 
                 if (!Routing.PerfCounter.LogEventProcessingLatency(fsm.Endpoint.IotHubName, fsm.Endpoint.Name, fsm.Endpoint.Type, status, averageLatencyInMs, out error))
                 {
                     Log.LogError((int)EventIds.CounterFailure, "[LogEventProcessingLatencyCounterFailed] {0}", error);
                 }
 
-                TimeSpan messageE2EProcessingLatencyTotal = messages.Select(m => m.EnqueuedTime).Aggregate(TimeSpan.Zero, (span, time) => span + (fsm.systemTime.UtcNow - time));
-                long averageE2ELatencyInMs = messageE2EProcessingLatencyTotal < TimeSpan.Zero ? 0L : (long)(messageE2EProcessingLatencyTotal.TotalMilliseconds / messages.Count);
+                double messageE2EProcessingLatencyTotalMSecs = messages.Select(m => m.EnqueuedTime).Aggregate(0D, (span, time) => span + (fsm.systemTime.UtcNow - time).TotalMilliseconds);
+                long averageE2ELatencyInMs = messageE2EProcessingLatencyTotalMSecs < 0 ? 0L : (long)(messageE2EProcessingLatencyTotalMSecs / messages.Count);
 
                 if (!Routing.PerfCounter.LogE2EEventProcessingLatency(fsm.Endpoint.IotHubName, fsm.Endpoint.Name, fsm.Endpoint.Type, status, averageE2ELatencyInMs, out error))
                 {
@@ -921,8 +921,8 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
                 }
 
                 // calculate average latency
-                TimeSpan totalTime = messages.Select(m => m.EnqueuedTime).Aggregate(TimeSpan.Zero, (span, time) => span + (fsm.systemTime.UtcNow - time));
-                long averageLatencyInMs = totalTime < TimeSpan.Zero ? 0L : (long)(totalTime.TotalMilliseconds / messages.Count);
+                double totalTimeMSecs = messages.Select(m => m.EnqueuedTime).Aggregate(0D, (span, time) => span + (fsm.systemTime.UtcNow - time).TotalMilliseconds);
+                long averageLatencyInMs = totalTimeMSecs < 0 ? 0L : (long)(totalTimeMSecs / messages.Count);
 
                 fsm.Endpoint.LogUserMetrics(messages.Count, averageLatencyInMs);
             }

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
@@ -294,7 +294,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
                 {
                     ISinkResult<IMessage> result;
                     Events.Send(thisPtr, thisPtr.currentSendCommand.Messages, messages);
-                    
+
                     using (var cts = new CancellationTokenSource(endpointTimeout))
                     {
                         result = await thisPtr.processor.ProcessAsync(messages, cts.Token);

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
             TimeSpan retryAfter;
             ICollection<IMessage> messages = EmptyMessages;
             Stopwatch stopwatch = Stopwatch.StartNew();
-
+            TimeSpan endpointTimeout = TimeSpan.FromMilliseconds(thisPtr.config.Timeout.TotalMilliseconds * thisPtr.Endpoint.FanOutFactor);
             try
             {
                 Preconditions.CheckNotNull(thisPtr.currentSendCommand);
@@ -294,7 +294,8 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
                 {
                     ISinkResult<IMessage> result;
                     Events.Send(thisPtr, thisPtr.currentSendCommand.Messages, messages);
-                    using (var cts = new CancellationTokenSource(thisPtr.config.Timeout))
+                    
+                    using (var cts = new CancellationTokenSource(endpointTimeout))
                     {
                         result = await thisPtr.processor.ProcessAsync(messages, cts.Token);
                     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/util/CollectionEx.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/util/CollectionEx.cs
@@ -37,6 +37,6 @@ namespace Microsoft.Azure.Devices.Routing.Core.Util
             }
 
             return Option.None<T>();
-        }        
+        }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/util/CollectionEx.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/util/CollectionEx.cs
@@ -38,5 +38,24 @@ namespace Microsoft.Azure.Devices.Routing.Core.Util
 
             return Option.None<T>();
         }
+
+        public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> list, int batchSize)
+        {
+            var current = new List<T>();
+            foreach (T item in list)
+            {
+                current.Add(item);
+                if (current.Count == batchSize)
+                {
+                    yield return current;
+                    current = new List<T>(batchSize);
+                }
+            }
+
+            if (current.Count > 0)
+            {
+                yield return current;
+            }
+        }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/util/CollectionEx.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/util/CollectionEx.cs
@@ -37,25 +37,6 @@ namespace Microsoft.Azure.Devices.Routing.Core.Util
             }
 
             return Option.None<T>();
-        }
-
-        public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> list, int batchSize)
-        {
-            var current = new List<T>();
-            foreach (T item in list)
-            {
-                current.Add(item);
-                if (current.Count == batchSize)
-                {
-                    yield return current;
-                    current = new List<T>(batchSize);
-                }
-            }
-
-            if (current.Count > 0)
-            {
-                yield return current;
-            }
-        }
+        }        
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudEndpointTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudEndpointTest.cs
@@ -3,7 +3,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 {
     using System;
     using System.Collections.Generic;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
@@ -11,7 +10,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.Routing.Core;
-    using Microsoft.Azure.Devices.Routing.Core.MessageSources;
     using Moq;
     using Xunit;
     using IMessage = Microsoft.Azure.Devices.Edge.Hub.Core.IMessage;
@@ -64,7 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             IProcessor moduleMessageProcessor = cloudEndpoint.CreateProcessor();
             Task result = moduleMessageProcessor.CloseAsync(CancellationToken.None);
-            Assert.Equal(TaskEx.Done, result);
+            Assert.Equal(Task.CompletedTask, result);
         }
 
         [Fact]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudEndpointTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudEndpointTest.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 {
     using System;
     using System.Collections.Generic;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
@@ -10,6 +11,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.Routing.Core;
+    using Microsoft.Azure.Devices.Routing.Core.MessageSources;
     using Moq;
     using Xunit;
     using IMessage = Microsoft.Azure.Devices.Edge.Hub.Core.IMessage;

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudMessageProcessorTests.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudMessageProcessorTests.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -195,6 +196,190 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Assert.Empty(result1.Failed);
             Assert.Equal(2, result1.InvalidDetailsList.Count);
             Assert.True(result1.SendFailureDetails.HasValue);
+        }
+
+        [Fact]
+        public async Task ProcessInBatchesTest()
+        {
+            // Arrange
+            string device1 = "d1";
+            string device2 = "d2";
+            string device3 = "d3";
+
+            IList<IRoutingMessage> device1Messages = GetMessages(device1, 45);
+            IList<IRoutingMessage> device2Messages = GetMessages(device2, 25);
+            IList<IRoutingMessage> device3Messages = GetMessages(device3, 30);
+
+            IList<IRoutingMessage> messagesToProcess = device1Messages
+                .Concat(device2Messages)
+                .Concat(device3Messages)
+                .ToList();
+
+            Mock<ICloudProxy> InitCloudProxy(List<int> receivedMsgCountList)
+            {
+                var cp = new Mock<ICloudProxy>();
+                cp.Setup(c => c.SendMessageBatchAsync(It.IsAny<IEnumerable<IMessage>>()))
+                    .Callback<IEnumerable<IMessage>>(b => receivedMsgCountList.Add(b.Count()))
+                    .Returns(Task.CompletedTask);
+                cp.SetupGet(p => p.IsActive).Returns(true);
+                return cp;
+            }
+
+            var device1CloudReceivedMessagesCountList = new List<int>();
+            Mock<ICloudProxy> device1CloudProxy = InitCloudProxy(device1CloudReceivedMessagesCountList);
+
+            var device2CloudReceivedMessagesCountList = new List<int>();
+            Mock<ICloudProxy> device2CloudProxy = InitCloudProxy(device2CloudReceivedMessagesCountList);
+
+            var device3CloudReceivedMessagesCountList = new List<int>();
+            Mock<ICloudProxy> device3CloudProxy = InitCloudProxy(device3CloudReceivedMessagesCountList);
+
+            Task<Option<ICloudProxy>> GetCloudProxy(string id)
+            {
+                ICloudProxy cp = null;
+                if (id == device1)
+                {
+                    cp = device1CloudProxy.Object;
+                }
+                else if (id == device2)
+                {
+                    cp = device2CloudProxy.Object;
+                }
+                else if (id == device3)
+                {
+                    cp = device3CloudProxy.Object;
+                }
+
+                return Task.FromResult(Option.Maybe(cp));
+            }
+
+            Core.IMessageConverter<IRoutingMessage> routingMessageConverter = new RoutingMessageConverter();
+            string cloudEndpointId = Guid.NewGuid().ToString();
+            var cloudEndpoint = new CloudEndpoint(cloudEndpointId, GetCloudProxy, routingMessageConverter, 10);
+
+            // Act
+            IProcessor cloudMessageProcessor = cloudEndpoint.CreateProcessor();
+            ISinkResult<IRoutingMessage> sinkResult = await cloudMessageProcessor.ProcessAsync(messagesToProcess, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(messagesToProcess, sinkResult.Succeeded);
+            Assert.Equal(device1CloudReceivedMessagesCountList, new[] { 10, 10, 10, 10, 5 });
+            Assert.Equal(device2CloudReceivedMessagesCountList, new[] { 10, 10, 5 });
+            Assert.Equal(device3CloudReceivedMessagesCountList, new[] { 10, 10, 10 });
+        }
+
+        [Fact]
+        public async Task ProcessInBatchesWithBatchSizeTest()
+        {
+            // Arrange
+            string device1 = "d1";
+            string device2 = "d2";
+            string device3 = "d3";
+
+            IList<IRoutingMessage> device1Messages = GetMessages(device1, 45);
+            IList<IRoutingMessage> device2Messages = GetMessages(device2, 25);
+            IList<IRoutingMessage> device3Messages = GetMessages(device3, 30);
+
+            IList<IRoutingMessage> messagesToProcess = device1Messages
+                .Concat(device2Messages)
+                .Concat(device3Messages)
+                .ToList();
+
+            Mock<ICloudProxy> InitCloudProxy(List<int> receivedMsgCountList)
+            {
+                var cp = new Mock<ICloudProxy>();
+                cp.Setup(c => c.SendMessageBatchAsync(It.IsAny<IEnumerable<IMessage>>()))
+                    .Callback<IEnumerable<IMessage>>(b => receivedMsgCountList.Add(b.Count()))
+                    .Returns(Task.CompletedTask);
+                cp.SetupGet(p => p.IsActive).Returns(true);
+                return cp;
+            }
+
+            var device1CloudReceivedMessagesCountList = new List<int>();
+            Mock<ICloudProxy> device1CloudProxy = InitCloudProxy(device1CloudReceivedMessagesCountList);
+
+            var device2CloudReceivedMessagesCountList = new List<int>();
+            Mock<ICloudProxy> device2CloudProxy = InitCloudProxy(device2CloudReceivedMessagesCountList);
+
+            var device3CloudReceivedMessagesCountList = new List<int>();
+            Mock<ICloudProxy> device3CloudProxy = InitCloudProxy(device3CloudReceivedMessagesCountList);
+
+            Task<Option<ICloudProxy>> GetCloudProxy(string id)
+            {
+                ICloudProxy cp = null;
+                if (id == device1)
+                {
+                    cp = device1CloudProxy.Object;
+                }
+                else if (id == device2)
+                {
+                    cp = device2CloudProxy.Object;
+                }
+                else if (id == device3)
+                {
+                    cp = device3CloudProxy.Object;
+                }
+
+                return Task.FromResult(Option.Maybe(cp));
+            }
+
+            Core.IMessageConverter<IRoutingMessage> routingMessageConverter = new RoutingMessageConverter();
+            string cloudEndpointId = Guid.NewGuid().ToString();
+            var cloudEndpoint = new CloudEndpoint(cloudEndpointId, GetCloudProxy, routingMessageConverter, 30);
+
+            // Act
+            IProcessor cloudMessageProcessor = cloudEndpoint.CreateProcessor();
+            ISinkResult<IRoutingMessage> sinkResult = await cloudMessageProcessor.ProcessAsync(messagesToProcess, CancellationToken.None);
+
+            // Assert
+            Assert.Equal(messagesToProcess, sinkResult.Succeeded);
+            Assert.Equal(device1CloudReceivedMessagesCountList, new[] { 30, 15 });
+            Assert.Equal(device2CloudReceivedMessagesCountList, new[] { 25 });
+            Assert.Equal(device3CloudReceivedMessagesCountList, new[] { 30 });
+        }
+
+        [Theory]
+        [InlineData(10, 1024, 10)]
+        [InlineData(10, 64 * 1024, 3)]
+        [InlineData(20, 50 * 1024, 5)]
+        public void GetBatchSizeTest(int maxBatchSize, int maxMessageSize, int expectedBatchSize)
+        {
+            Assert.Equal(expectedBatchSize, CloudEndpoint.CloudMessageProcessor.GetBatchSize(maxBatchSize, maxMessageSize));
+        }
+
+        static IList<IRoutingMessage> GetMessages(string id, int count)
+        {
+            var messages = new List<IRoutingMessage>();
+            for (int i = 0; i < count; i++)
+            {
+                messages.Add(GetMessage(id));
+            }
+
+            return messages;
+        }
+
+        static IRoutingMessage GetMessage(string id)
+        {
+            byte[] messageBody = Encoding.UTF8.GetBytes("Message body");
+            var properties = new Dictionary<string, string>()
+            {
+                { "Prop1", "Val1" },
+                { "Prop2", "Val2" }
+            };
+
+            var systemProperties = new Dictionary<string, string>
+            {
+                { SystemProperties.DeviceId, id }
+            };
+
+            var cancelProperties = new Dictionary<string, string>()
+            {
+                { "Delay", "true" },
+                { "Prop2", "Val2" }
+            };
+
+            var message = new RoutingMessage(TelemetryMessageSource.Instance, messageBody, properties, systemProperties);
+            return message;
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudMessageProcessorTests.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudMessageProcessorTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                         : Option.None<ICloudProxy>());
             }
 
-            var cloudEndpoint = new CloudEndpoint(cloudEndpointId, GetCloudProxy, routingMessageConverter);
+            var cloudEndpoint = new CloudEndpoint(cloudEndpointId, GetCloudProxy, routingMessageConverter, maxBatchSize: 1);
             IProcessor cloudMessageProcessor = cloudEndpoint.CreateProcessor();
 
             ISinkResult<IRoutingMessage> result1 = await cloudMessageProcessor.ProcessAsync(message1, CancellationToken.None);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudMessageProcessorTests.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudMessageProcessorTests.cs
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
         [Theory]
         [InlineData(10, 1024, 10)]
-        [InlineData(10, 64 * 1024, 3)]
+        [InlineData(10, 64 * 1024, 4)]
         [InlineData(20, 50 * 1024, 5)]
         public void GetBatchSizeTest(int maxBatchSize, int maxMessageSize, int expectedBatchSize)
         {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/EndpointFactoryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/EndpointFactoryTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
         {
             var connectionManager = new Mock<IConnectionManager>();
             var messageConverter = new Mock<Core.IMessageConverter<IRoutingMessage>>();
-            this.endpointFactory = new EndpointFactory(connectionManager.Object, messageConverter.Object, "Device1");
+            this.endpointFactory = new EndpointFactory(connectionManager.Object, messageConverter.Object, "Device1", 10);
         }
 
         [Fact]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/EndpointFactoryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/EndpointFactoryTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
         {
             var connectionManager = new Mock<IConnectionManager>();
             var messageConverter = new Mock<Core.IMessageConverter<IRoutingMessage>>();
-            this.endpointFactory = new EndpointFactory(connectionManager.Object, messageConverter.Object, "Device1", 10);
+            this.endpointFactory = new EndpointFactory(connectionManager.Object, messageConverter.Object, "Device1", 10, 10);
         }
 
         [Fact]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -421,6 +421,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             var cloudProxy = new Mock<ICloudProxy>();
             cloudProxy.Setup(c => c.SendMessageAsync(It.IsAny<IMessage>())).Callback<IMessage>(m => iotHub.ReceivedMessages.Add(m)).Returns(Task.CompletedTask);
+            cloudProxy.Setup(c => c.SendMessageBatchAsync(It.IsAny<IEnumerable<IMessage>>())).Callback<IEnumerable<IMessage>>(m => iotHub.ReceivedMessages.AddRange(m)).Returns(Task.CompletedTask);
             cloudProxy.Setup(c => c.UpdateReportedPropertiesAsync(It.IsAny<IMessage>())).Callback<IMessage>(m => iotHub.ReceivedMessages.Add(m)).Returns(Task.CompletedTask);
             cloudProxy.SetupGet(c => c.IsActive).Returns(true);
             var cloudConnection = Mock.Of<ICloudConnection>(c => c.IsActive && c.CloudProxy == Option.Some(cloudProxy.Object));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), new IdentityProvider(iotHubName));
             var routingMessageConverter = new RoutingMessageConverter();
-            RouteFactory routeFactory = new EdgeRouteFactory(new EndpointFactory(connectionManager, routingMessageConverter, edgeDeviceId));
+            RouteFactory routeFactory = new EdgeRouteFactory(new EndpointFactory(connectionManager, routingMessageConverter, edgeDeviceId, 10));
             IEnumerable<Route> routesList = routeFactory.Create(routes).ToList();
             IEnumerable<Endpoint> endpoints = routesList.SelectMany(r => r.Endpoints);
             var routerConfig = new RouterConfig(endpoints, routesList);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -430,7 +430,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), new IdentityProvider(iotHubName));
             var routingMessageConverter = new RoutingMessageConverter();
-            RouteFactory routeFactory = new EdgeRouteFactory(new EndpointFactory(connectionManager, routingMessageConverter, edgeDeviceId, 10));
+            RouteFactory routeFactory = new EdgeRouteFactory(new EndpointFactory(connectionManager, routingMessageConverter, edgeDeviceId, 10, 10));
             IEnumerable<Route> routesList = routeFactory.Create(routes).ToList();
             IEnumerable<Endpoint> endpoints = routesList.SelectMany(r => r.Endpoints);
             var routerConfig = new RouterConfig(endpoints, routesList);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -138,6 +138,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     Option.None<TimeSpan>(),
                     Option.None<TimeSpan>(),
                     false,
+                    10,
                     10));
 
             builder.RegisterModule(new HttpModule());

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -137,7 +137,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     TimeSpan.FromSeconds(20),
                     Option.None<TimeSpan>(),
                     Option.None<TimeSpan>(),
-                    false));
+                    false,
+                    10));
 
             builder.RegisterModule(new HttpModule());
             builder.RegisterModule(new MqttModule(mqttSettingsConfiguration.Object, topics, this.serverCertificate, false, false, false));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 // Set Edge hub desired properties
                 await this.SetDesiredProperties(registryManager, edgeDeviceId);
 
-                var endpointFactory = new EndpointFactory(connectionManager, new RoutingMessageConverter(), edgeDeviceId);
+                var endpointFactory = new EndpointFactory(connectionManager, new RoutingMessageConverter(), edgeDeviceId, 10);
                 var routeFactory = new EdgeRouteFactory(endpointFactory);
 
                 var dbStoreProvider = new InMemoryDbStoreProvider();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 // Set Edge hub desired properties
                 await this.SetDesiredProperties(registryManager, edgeDeviceId);
 
-                var endpointFactory = new EndpointFactory(connectionManager, new RoutingMessageConverter(), edgeDeviceId, 10);
+                var endpointFactory = new EndpointFactory(connectionManager, new RoutingMessageConverter(), edgeDeviceId, 10, 10);
                 var routeFactory = new EdgeRouteFactory(endpointFactory);
 
                 var dbStoreProvider = new InMemoryDbStoreProvider();

--- a/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/StoringAsyncEndpointExecutorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/StoringAsyncEndpointExecutorTest.cs
@@ -169,13 +169,13 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints
             int batchSize = 100;
             List<IMessage> messages = GetNewMessages(batchSize, 0).ToList();
             var iterator = new Mock<IMessageIterator>();
-            iterator.SetupSequence(i => i.GetNext(It.IsAny<int>()))                
+            iterator.SetupSequence(i => i.GetNext(It.IsAny<int>()))
                 .ReturnsAsync(messages.Take(15))
                 .ReturnsAsync(messages.Skip(15).Take(15))
                 .ReturnsAsync(messages.Skip(30).Take(70));
 
             // Act
-            var messagesProvider = new StoringAsyncEndpointExecutor.StoreMessagesProvider(iterator.Object, TimeSpan.FromSeconds(5), 100);            
+            var messagesProvider = new StoringAsyncEndpointExecutor.StoreMessagesProvider(iterator.Object, TimeSpan.FromSeconds(5), 100);
 
             // Assert
             await Task.Delay(TimeSpan.FromSeconds(1));

--- a/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/StoringAsyncEndpointExecutorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/StoringAsyncEndpointExecutorTest.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util.Concurrency;
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints
     using Microsoft.Azure.Devices.Routing.Core.Checkpointers;
     using Microsoft.Azure.Devices.Routing.Core.Endpoints;
     using Microsoft.Azure.Devices.Routing.Core.MessageSources;
+    using Moq;
     using Xunit;
 
     [Integration]
@@ -158,6 +160,81 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints
 
             await executor.CloseAsync();
             await Assert.ThrowsAsync<InvalidOperationException>(() => executor.SetEndpoint(endpoint1));
+        }
+
+        [Fact]
+        public async Task StoreMessagesProviderInitTest()
+        {
+            // Arrange
+            int batchSize = 100;
+            List<IMessage> messages = GetNewMessages(batchSize, 0).ToList();
+            var iterator = new Mock<IMessageIterator>();
+            iterator.SetupSequence(i => i.GetNext(It.IsAny<int>()))                
+                .ReturnsAsync(messages.Take(15))
+                .ReturnsAsync(messages.Skip(15).Take(15))
+                .ReturnsAsync(messages.Skip(30).Take(70));
+
+            // Act
+            var messagesProvider = new StoringAsyncEndpointExecutor.StoreMessagesProvider(iterator.Object, TimeSpan.FromSeconds(5), 100);            
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            iterator.VerifyAll();
+
+            // Act
+            IMessage[] messagesBatch = await messagesProvider.GetMessages();
+
+            // Assert
+            Assert.NotNull(messagesBatch);
+            Assert.Equal(batchSize, messagesBatch.Length);
+            Assert.Equal(messages, messagesBatch);
+        }
+
+        [Fact]
+        public async Task StoreMessagesProviderTest()
+        {
+            // Arrange
+            int batchSize = 100;
+            List<IMessage> messages = GetNewMessages(batchSize * 3, 0).ToList();
+            var iterator = new Mock<IMessageIterator>();
+            iterator.SetupSequence(i => i.GetNext(It.IsAny<int>()))
+                .ReturnsAsync(messages.Take(15))
+                .ReturnsAsync(messages.Skip(15).Take(15))
+                .ReturnsAsync(messages.Skip(30).Take(70))
+                .ReturnsAsync(messages.Skip(100).Take(52))
+                .ReturnsAsync(messages.Skip(152).Take(48))
+                .ReturnsAsync(messages.Skip(200));
+
+            // Act
+            var messagesProvider = new StoringAsyncEndpointExecutor.StoreMessagesProvider(iterator.Object, TimeSpan.FromSeconds(5), 100);
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            IMessage[] messagesBatch = await messagesProvider.GetMessages();
+
+            // Assert
+            Assert.NotNull(messagesBatch);
+            Assert.Equal(batchSize, messagesBatch.Length);
+            Assert.Equal(messages.Take(100), messagesBatch);
+
+            // Act
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            messagesBatch = await messagesProvider.GetMessages();
+
+            // Assert
+            Assert.NotNull(messagesBatch);
+            Assert.Equal(batchSize, messagesBatch.Length);
+            Assert.Equal(messages.Skip(100).Take(100), messagesBatch);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            iterator.VerifyAll();
+
+            // Act
+            messagesBatch = await messagesProvider.GetMessages();
+
+            // Assert
+            Assert.NotNull(messagesBatch);
+            Assert.Equal(batchSize, messagesBatch.Length);
+            Assert.Equal(messages.Skip(200).Take(100), messagesBatch);
         }
 
         static IEnumerable<IMessage> GetNewMessages(int count, int indexStart)

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/Microsoft.Azure.Devices.Edge.Storage.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/Microsoft.Azure.Devices.Edge.Storage.csproj
@@ -19,9 +19,6 @@
     <OutputPath>bin\CodeCoverage</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
   </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.Azure.Devices.Edge.Util\Microsoft.Azure.Devices.Edge.Util.csproj" />

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CollectionEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CollectionEx.cs
@@ -132,5 +132,24 @@ namespace Microsoft.Azure.Devices.Edge.Util
             value = default(TValue);
             return false;
         }
+
+        public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> list, int batchSize)
+        {
+            var current = new List<T>();
+            foreach (T item in list)
+            {
+                current.Add(item);
+                if (current.Count == batchSize)
+                {
+                    yield return current;
+                    current = new List<T>(batchSize);
+                }
+            }
+
+            if (current.Count > 0)
+            {
+                yield return current;
+            }
+        }
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Microsoft.Azure.Devices.Edge.Util.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Microsoft.Azure.Devices.Edge.Util.csproj
@@ -26,6 +26,7 @@
     <PackageReference Include="App.Metrics.Reporting.TextFile" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ResetEventEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ResetEventEx.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+    using System.Threading.Tasks;
+    using Nito.AsyncEx;
+
+    public static class ResetEventEx
+    {
+        public static Task<bool> WaitAsync(this AsyncManualResetEvent resetEvent, TimeSpan timeout)
+            => WaitAsync(resetEvent.WaitAsync(), timeout);
+
+        public static Task<bool> WaitAsync(this AsyncAutoResetEvent resetEvent, TimeSpan timeout)
+            => WaitAsync(resetEvent.WaitAsync(), timeout);
+
+        static async Task<bool> WaitAsync(Task waitTask, TimeSpan timeout)
+        {            
+            Task timeoutTask = Task.Delay(timeout);
+            Task completedTask = await Task.WhenAny(waitTask, timeoutTask);
+            return completedTask == waitTask;
+        }
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ResetEventEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ResetEventEx.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
             => WaitAsync(resetEvent.WaitAsync(), timeout);
 
         static async Task<bool> WaitAsync(Task waitTask, TimeSpan timeout)
-        {            
+        {
             Task timeoutTask = Task.Delay(timeout);
             Task completedTask = await Task.WhenAny(waitTask, timeoutTask);
             return completedTask == waitTask;

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/CollectionExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/CollectionExTest.cs
@@ -214,6 +214,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 {
                     Assert.Equal(list[ctr * batchSize + i], batch[i]);
                 }
+
                 ctr++;
             }
         }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/CollectionExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/CollectionExTest.cs
@@ -195,5 +195,52 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             Assert.Equal(obj, returnedObj);
             Assert.False(objectDictionary.TryGetNonEmptyValue("2", out returnedObj));
         }
+
+        [Theory]
+        [MemberData(nameof(GetBatchTestData))]
+        public void BatchTest(IList<int> list, int batchSize, IList<int> expectedBatches)
+        {
+            // Act
+            IList<IEnumerable<int>> batches = list.Batch(batchSize).ToList();
+
+            // Assert
+            Assert.Equal(expectedBatches.Count, batches.Count);
+            int ctr = 0;
+            foreach (int expectedBatchSize in expectedBatches)
+            {
+                IList<int> batch = batches[ctr].ToList();
+                Assert.Equal(expectedBatchSize, batch.Count);
+                for (int i = 0; i < batch.Count; i++)
+                {
+                    Assert.Equal(list[ctr * batchSize + i], batch[i]);
+                }
+                ctr++;
+            }
+        }
+
+        public static IEnumerable<object[]> GetBatchTestData()
+        {
+            var rand = new Random();
+
+            int batchSize = 10;
+            var list = Enumerable.Range(0, 64).Select(n => rand.Next()).ToList();
+            var expectedBatches = new List<int> { 10, 10, 10, 10, 10, 10, 4 };
+            yield return new object[] { list, batchSize, expectedBatches };
+
+            batchSize = 100;
+            list = Enumerable.Range(0, 64).Select(n => rand.Next()).ToList();
+            expectedBatches = new List<int> { 64 };
+            yield return new object[] { list, batchSize, expectedBatches };
+
+            batchSize = 1;
+            list = Enumerable.Range(0, 6).Select(n => rand.Next()).ToList();
+            expectedBatches = new List<int> { 1, 1, 1, 1, 1, 1 };
+            yield return new object[] { list, batchSize, expectedBatches };
+
+            batchSize = 10;
+            list = Enumerable.Range(0, 50).Select(n => rand.Next()).ToList();
+            expectedBatches = new List<int> { 10, 10, 10, 10, 10 };
+            yield return new object[] { list, batchSize, expectedBatches };
+        }
     }
 }


### PR DESCRIPTION
This PR includes the following -
- Prefetching messages from store for processing (should benefit all messaging endpoints)
- Batching messages while sending upstream
- Processing upstream messages for each client in parallel
- Increasing batch size to process based on endpoint fan-out factor

With these changes, a perf gain of 6-8x was observed in testing. 