### PR TITLE
Only build windows-arm32v7 image if previous task succeeded

### DIFF
--- a/builds/misc/templates/image-windows.yaml
+++ b/builds/misc/templates/image-windows.yaml
@@ -10,4 +10,4 @@ steps:
     displayName: Build Image - ${{ parameters.name }} - amd64
   - powershell: scripts/windows/build/Publish-DockerImage.ps1 -Name "${{ parameters.imageName }}" -Project "${{ parameters.project }}" -Version $(Build.BuildNumber) -Registry $(registry.address) -Namespace "${{ parameters.namespace }}" -Architecture "arm32v7" -Push
     displayName: Build Image - ${{ parameters.name }} - arm32
-    condition: eq('${{ parameters.arm32v7 }}', 'true')
+    condition: and(succeeded(), eq('${{ parameters.arm32v7 }}', 'true'))


### PR DESCRIPTION
The Build Images pipeline continues to build windows-arm32v7 docker images even if the build fails or is cancelled. That's because the windows-arm32v7 YAML step has an explicit `condition` set which overrides the default `condition: succeeded()`. The fix is to add the `succeeded()` requirement to the explicit condition.