### PR TITLE
Revert stateless nuget version

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
             this.machine.Configure(State.Connected)
                 .Permit(Trigger.CallTimedOut, State.Trying)
-                .InternalTransition(Trigger.CallSucceeded, () => this.ResetConnectedTimer())
+                .InternalTransition(Trigger.CallSucceeded, this.ResetConnectedTimer)
                 .OnEntry(this.OnConnected)
                 .OnExit(this.OnConnectedExit);
 
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
             this.machine.Configure(State.Disconnected)
                 .Permit(Trigger.CallSucceeded, State.Connected)
-                .InternalTransition(Trigger.CallTimedOut, () => this.ResetDisconnectedTimer())
+                .InternalTransition(Trigger.CallTimedOut, this.ResetDisconnectedTimer)
                 .OnEntry(this.OnDisconnected)
                 .OnExit(this.OnDisconnectedExit);
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.17.1" />
-    <PackageReference Include="Stateless" Version="4.2.1" />
+    <PackageReference Include="Stateless" Version="4.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I have seen NRE from the Stateless library with similar call stack after updating the nuget package last month. I have opened an issue against their github, but meanwhile reverting the version to the previous one. We hadn't seen this issue with the previous version of the nuget.