### PR TITLE
Set Path env variable explicitly for E2E test

### DIFF
--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -866,7 +866,7 @@ Function RunTest
 Function SetEnvironmentVariable
 {
     # IoTEdgeQuickstart runs different processes to call iotedge list right after running installation script.
-    # E2E test failed randomly as running iotedge list command throws Win32Exception since Path environment variable may not be in place yet.
+    # E2E test failed randomly when running iotedge list command throws Win32Exception as Path environment variable may not be in place yet.
     # Therefore set it explicitly before running each test.
     $env:Path="$env:Path;C:\Program Files\iotedge-moby;C:\Program Files\iotedge"
 }

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -863,12 +863,21 @@ Function RunTest
     Return $testExitCode
 }
 
+Function SetEnvironmentVariable
+{
+    # IoTEdgeQuickstart runs different processes to call iotedge list right after running installation script.
+    # E2E test failed randomly as running iotedge list command throws Win32Exception since Path environment variable may not be in place yet.
+    # Therefore set it explicitly before running each test.
+    $env:Path="$env:Path;C:\Program Files\iotedge-moby;C:\Program Files\iotedge"
+}
+
 Function TestSetup
 {
     ValidateTestParameters
     CleanUp | Out-Host
     InitializeWorkingFolder
     PrepareTestFromArtifacts
+    SetEnvironmentVariable
 }
 
 Function ValidateTestParameters


### PR DESCRIPTION
Set iotedge folders in Path environment variable before each e2e test to avoid Win32Exception when calling iotedge list command.