### PR TITLE
`iotedge check` improvements part 2

### DIFF
--- a/edgelet/build/linux/install.sh
+++ b/edgelet/build/linux/install.sh
@@ -117,7 +117,8 @@ if [[ -n "$ARM_PACKAGE" ]]; then
         gcc-4.8-arm-linux-gnueabihf=4.8.2-16ubuntu4cross0.11 \
         gcc-4.8-multilib-arm-linux-gnueabihf=4.8.2-16ubuntu4cross0.11 \
         libc6-armhf-cross=2.19-0ubuntu2cross1.104 \
-        gcc-arm-linux-gnueabihf=4:4.8.2-1
+        gcc-arm-linux-gnueabihf=4:4.8.2-1 \
+        binutils-aarch64-linux-gnu
 
     # For future reference:
     # ubuntu systems (host) sets openssl library version to 1.0.0,

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -40,7 +40,7 @@ lazy_static! {
         .map(|version| option_env!("BUILD_SOURCEVERSION")
             .map(|sha| format!("{} ({})", version, sha))
             .unwrap_or_else(|| version.to_string()))
-        .unwrap_or_else(|| include_str!("../../version.txt").to_string());
+        .unwrap_or_else(|| include_str!("../../version.txt").trim().to_string());
 }
 
 pub fn version() -> &'static str {

--- a/edgelet/iotedge-diagnostics/src/main.rs
+++ b/edgelet/iotedge-diagnostics/src/main.rs
@@ -51,29 +51,7 @@ fn main() -> Result<(), Error> {
                         .help("Port to connect to"),
                 ),
         )
-        .subcommand(clap::SubCommand::with_name("local-time").about("print local time"))
-        .subcommand(
-            clap::SubCommand::with_name("idle-module")
-                .about("idle for some time, then exit")
-                .arg(
-                    clap::Arg::with_name("duration")
-                        .long("duration")
-                        .required(true)
-                        .takes_value(true)
-                        .help("How long to idle for, in seconds"),
-                ),
-        )
-        .subcommand(
-            clap::SubCommand::with_name("resolve-module")
-                .about("tries to resolve the specified module")
-                .arg(
-                    clap::Arg::with_name("hostname")
-                        .long("hostname")
-                        .required(true)
-                        .takes_value(true)
-                        .help("The hostname to resolve"),
-                ),
-        );
+        .subcommand(clap::SubCommand::with_name("local-time").about("print local time"));
 
     let matches = app.get_matches();
 
@@ -175,24 +153,6 @@ fn main() -> Result<(), Error> {
                     .unwrap()
                     .as_secs()
             );
-        }
-
-        ("idle-module", Some(matches)) => {
-            let duration = matches.value_of("duration").expect("parameter is required");
-            let duration: u64 = duration
-                .parse()
-                .map_err(|err| format!("could not parse duration: {}", err))?;
-
-            std::thread::sleep(std::time::Duration::from_secs(duration));
-        }
-
-        ("resolve-module", Some(matches)) => {
-            let hostname = matches.value_of("hostname").expect("parameter is required");
-
-            let _ = std::net::ToSocketAddrs::to_socket_addrs(&(hostname, 80))
-                .map_err(|err| format!("could not resolve {}: {}", hostname, err))?
-                .next()
-                .ok_or_else(|| format!("could not resolve {}: no addresses found", hostname))?;
         }
 
         (subcommand, _) => panic!("unexpected subcommand {}", subcommand),

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -586,10 +586,10 @@ fn settings_hostname(check: &mut Check) -> Result<CheckResult, failure::Error> {
             match winapi::um::winsock2::WSAStartup(0x202, &mut wsa_data) {
                 0 => (),
                 result => {
-                    return Err(format!(
+                    return Err(Context::new(format!(
                         "Could not get hostname: WSAStartup failed with {}",
                         result,
-                    )
+                    ))
                     .into());
                 }
             }
@@ -598,10 +598,10 @@ fn settings_hostname(check: &mut Check) -> Result<CheckResult, failure::Error> {
                 // Can't use std::io::Error::last_os_error() because that calls GetLastError, not WSAGetLastError
                 let winsock_err = winapi::um::winsock2::WSAGetLastError();
 
-                return Err(format!(
+                return Err(Context::new(format!(
                     "Could not get hostname: gethostname failed with {}",
                     winsock_err,
-                )
+                ))
                 .into());
             }
         }

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -1053,16 +1053,18 @@ fn container_engine_logrotate(_: &mut Check) -> Result<CheckResult, failure::Err
         Ok(daemon_config_file) => daemon_config_file,
         Err(err) => {
             return Ok(CheckResult::Warning(format!(
-                "Could not open container engine config file {}: {}",
-                CONTAINER_ENGINE_CONFIG_PATH, err,
+                "Could not open container engine config file {}: {}\n\
+                 {}",
+                CONTAINER_ENGINE_CONFIG_PATH, err, MESSAGE,
             )));
         }
     };
     let daemon_config: DaemonConfig =
         serde_json::from_reader(daemon_config_file).with_context(|_| {
             format!(
-                "Could not parse container engine config file {}",
-                CONTAINER_ENGINE_CONFIG_PATH,
+                "Could not parse container engine config file {}\n\
+                 {}",
+                CONTAINER_ENGINE_CONFIG_PATH, MESSAGE,
             )
         })?;
 
@@ -1099,16 +1101,18 @@ fn container_engine_dns(_: &mut Check) -> Result<CheckResult, failure::Error> {
         Ok(daemon_config_file) => daemon_config_file,
         Err(err) => {
             return Ok(CheckResult::Warning(format!(
-                "Could not open container engine config file {}: {}",
-                CONTAINER_ENGINE_CONFIG_PATH, err,
+                "Could not open container engine config file {}: {}\n\
+                 {}",
+                CONTAINER_ENGINE_CONFIG_PATH, err, MESSAGE,
             )));
         }
     };
     let daemon_config: DaemonConfig =
         serde_json::from_reader(daemon_config_file).with_context(|_| {
             format!(
-                "Could not parse container engine config file {}",
-                CONTAINER_ENGINE_CONFIG_PATH,
+                "Could not parse container engine config file {}\n\
+                 {}",
+                CONTAINER_ENGINE_CONFIG_PATH, MESSAGE,
             )
         })?;
 

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -551,7 +551,7 @@ fn settings_connection_string(check: &mut Check) -> Result<CheckResult, failure:
 
     if let Provisioning::Manual(manual) = settings.provisioning() {
         let (_, _, hub) = manual.parse_device_connection_string().context(
-            "Invalid connection string format detected. \
+            "Invalid connection string format detected.\n\
              Please check the value of the provisioning.device_connection_string parameter.",
         )?;
         check.iothub_hostname = Some(hub.to_owned());
@@ -595,7 +595,7 @@ fn container_engine(check: &mut Check) -> Result<CheckResult, failure::Error> {
         Ok(output) => output,
         Err((message, err)) => {
             let mut error_message = format!(
-                "Could not communicate with container engine at {}. \
+                "Could not communicate with container engine at {}.\n\
                  Please check your moby-engine installation and ensure the service is running.",
                 uri,
             );
@@ -833,7 +833,7 @@ fn iotedged_version(check: &mut Check) -> Result<CheckResult, failure::Error> {
     if version != latest_versions.iotedged {
         return Ok(CheckResult::Warning(
             Context::new(format!(
-                "Installed IoT Edge daemon has version {} but version {} is available. \
+                "Installed IoT Edge daemon has version {} but version {} is available.\n\
                  Please see https://aka.ms/iotedge-update-runtime for update instructions.",
                 version, latest_versions.iotedged,
             ))
@@ -874,7 +874,7 @@ fn host_local_time(check: &mut Check) -> Result<CheckResult, failure::Error> {
 
     if local_clock_offset.num_seconds().abs() >= 10 {
         return Ok(CheckResult::Warning(Context::new(format!(
-            "Time on the device is out of sync with the NTP server. This may cause problems connecting to IoT Hub. \
+            "Time on the device is out of sync with the NTP server. This may cause problems connecting to IoT Hub.\n\
              Please ensure time on device is accurate, for example by {}.",
             if cfg!(windows) {
                 "setting up the Windows Time service to automatically sync with a time server"
@@ -927,7 +927,7 @@ fn container_local_time(check: &mut Check) -> Result<CheckResult, failure::Error
 
 fn container_engine_dns(_: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
-        "Container engine is not configured with DNS server setting, which may impact connectivity to IoT Hub. \
+        "Container engine is not configured with DNS server setting, which may impact connectivity to IoT Hub.\n\
          Please see https://aka.ms/iotedge-prod-checklist-dns for best practices.\n\
          You can ignore this warning if you are setting DNS server per module in the Edge deployment.";
 
@@ -975,7 +975,7 @@ fn settings_certificates(check: &mut Check) -> Result<CheckResult, failure::Erro
 
     if settings.certificates().is_none() {
         return Ok(CheckResult::Warning(Context::new(
-            "Device is using self-signed, automatically generated certs. \
+            "Device is using self-signed, automatically generated certs.\n\
              Please see https://aka.ms/iotedge-prod-checklist-certs for certificate management best practices.",
         ).into()));
     }
@@ -1092,7 +1092,7 @@ fn settings_certificates_expiry(check: &mut Check) -> Result<CheckResult, failur
 
 fn settings_moby_runtime_uri(check: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
-        "Device is not using a production-supported container engine (moby-engine). \
+        "Device is not using a production-supported container engine (moby-engine).\n\
          Please see https://aka.ms/iotedge-prod-checklist-moby for details.";
 
     let settings = if let Some(settings) = &check.settings {
@@ -1144,7 +1144,7 @@ fn settings_moby_runtime_uri(check: &mut Check) -> Result<CheckResult, failure::
 
 fn container_engine_logrotate(_: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
-        "Container engine is not configured to rotate module logs which may cause it run out of disk space. \
+        "Container engine is not configured to rotate module logs which may cause it run out of disk space.\n\
          Please see https://aka.ms/iotedge-prod-checklist-logs for best practices.\n\
          You can ignore this warning if you are setting log policy per module in the Edge deployment.";
 
@@ -1365,7 +1365,7 @@ fn edge_hub_ports_on_host(check: &mut Check) -> Result<CheckResult, failure::Err
 
             Err(ref err) if err.kind() == std::io::ErrorKind::AddrInUse => {
                 return Err(Context::new(format!(
-                    "Edge hub cannot start on device because port {} is already in use. \
+                    "Edge hub cannot start on device because port {} is already in use.\n\
                      Please stop the application using the port or remove the port binding from Edge hub's deployment.",
                     port_binding,
                 )).into());

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -266,7 +266,14 @@ impl Check {
         let mut stdout = termcolor::StandardStream::stdout(termcolor::ColorChoice::Auto);
         let success_color_spec = {
             let mut success_color_spec = termcolor::ColorSpec::new();
-            success_color_spec.set_fg(Some(termcolor::Color::Green));
+            if cfg!(windows) {
+                // `Color::Green` maps to `FG_GREEN` which is too hard to read on the default blue-background profile that PS uses.
+                // PS uses `FG_GREEN | FG_INTENSITY` == 8 == `[ConsoleColor]::Green` as the foreground color for its error text,
+                // so mimic that.
+                success_color_spec.set_fg(Some(termcolor::Color::Rgb(0, 255, 0)));
+            } else {
+                success_color_spec.set_fg(Some(termcolor::Color::Green));
+            }
             success_color_spec
         };
         let warning_color_spec = {

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -283,7 +283,7 @@ impl Check {
                 // In its default blue-background profile, PS uses `ConsoleColor::DarkYellow` as its default foreground text color
                 // and maps it to a dark gray.
                 //
-                // So use explicit RGB to define yellow for Windows.
+                // So use explicit RGB to define yellow for Windows. Also use a black background to mimic PS warnings.
                 //
                 // Ref:
                 // - https://docs.rs/termcolor/0.3.6/src/termcolor/lib.rs.html#1380 defines `termcolor::Color::Yellow` as `wincolor::Color::Yellow`
@@ -293,6 +293,7 @@ impl Check {
                 // - https://docs.microsoft.com/en-us/dotnet/api/system.consolecolor#fields defines `6` as `[ConsoleColor]::DarkYellow`
                 // - `$Host.UI.RawUI.ForegroundColor` in the default PS profile is `DarkYellow`, and writing in it prints dark gray text.
                 warning_color_spec.set_fg(Some(termcolor::Color::Rgb(255, 255, 0)));
+                warning_color_spec.set_bg(Some(termcolor::Color::Black));
             } else {
                 warning_color_spec.set_fg(Some(termcolor::Color::Yellow));
             }

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -899,8 +899,8 @@ fn container_local_time(check: &mut Check) -> Result<CheckResult, failure::Error
 fn container_engine_dns(_: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
         "Container engine is not configured with DNS server setting, which may impact connectivity to IoT Hub. \
-         Please see https://aka.ms/iotedge-prod-checklist-dns for best practices.\n\
-         You can ignore this warning if you are setting DNS server per module in the Edge deployment.";
+         Please see https://aka.ms/iotedge-prod-checklist-dns for best practices.\n\
+         You can ignore this warning if you are setting DNS server per module in the Edge deployment.";
 
     #[derive(serde_derive::Deserialize)]
     struct DaemonConfig {
@@ -1107,8 +1107,8 @@ fn settings_moby_runtime_uri(check: &mut Check) -> Result<CheckResult, failure::
 fn container_engine_logrotate(_: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
         "Container engine is not configured to rotate module logs which may cause it run out of disk space. \
-         Please see https://aka.ms/iotedge-prod-checklist-logs for best practices.\n\
-         You can ignore this warning if you are setting log policy per module in the Edge deployment.";
+         Please see https://aka.ms/iotedge-prod-checklist-logs for best practices.\n\
+         You can ignore this warning if you are setting log policy per module in the Edge deployment.";
 
     #[derive(serde_derive::Deserialize)]
     struct DaemonConfig {

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -1008,20 +1008,12 @@ fn settings_moby_runtime_uri(check: &mut Check) -> Result<CheckResult, failure::
         .map(std::str::FromStr::from_str);
     let docker_server_major_version: u32 = match docker_server_major_version {
         Some(Ok(docker_server_major_version)) => docker_server_major_version,
-        Some(Err(err)) => {
-            return Err(err
-                .context(format!(
-                    "Container engine returned malformed version string {:?}",
-                    docker_server_version,
-                ))
-                .into());
-        }
-        None => {
-            return Err(Context::new(format!(
-                "Container engine returned malformed version string {:?}",
-                docker_server_version,
-            ))
-            .into());
+        Some(Err(_)) | None => {
+            return Ok(CheckResult::Warning(format!(
+                "Container engine returned malformed version string {:?}\n\
+                 {}",
+                docker_server_version, MESSAGE,
+            )));
         }
     };
 

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -982,10 +982,13 @@ fn settings_certificates(check: &mut Check) -> Result<CheckResult, failure::Erro
     };
 
     if settings.certificates().is_none() {
-        return Ok(CheckResult::Warning(Context::new(
-            "Device is using self-signed, automatically generated certs.\n\
-             Please see https://aka.ms/iotedge-prod-checklist-certs for certificate management best practices.",
-        ).into()));
+        return Ok(CheckResult::Warning(
+            Context::new(
+                "Device is using self-signed, automatically generated certs.\n\
+                 Please see https://aka.ms/iotedge-prod-checklist-certs for best practices.",
+            )
+            .into(),
+        ));
     }
 
     Ok(CheckResult::Ok)

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -293,7 +293,15 @@ impl Check {
         };
         let error_color_spec = {
             let mut error_color_spec = termcolor::ColorSpec::new();
-            error_color_spec.set_fg(Some(termcolor::Color::Red));
+            if cfg!(windows) {
+                // `Color::Red` maps to `FG_RED` which is too hard to read on the default blue-background profile that PS uses.
+                // PS uses `FG_RED | FG_INTENSITY` == 12 == `[ConsoleColor]::Red` as the foreground color for its error text,
+                // with black background, so mimic that.
+                error_color_spec.set_fg(Some(termcolor::Color::Rgb(255, 0, 0)));
+                error_color_spec.set_bg(Some(termcolor::Color::Black));
+            } else {
+                error_color_spec.set_fg(Some(termcolor::Color::Red));
+            }
             error_color_spec
         };
         let is_a_tty = atty::is(atty::Stream::Stdout);

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -899,7 +899,8 @@ fn container_local_time(check: &mut Check) -> Result<CheckResult, failure::Error
 fn container_engine_dns(_: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
         "Container engine is not configured with DNS server setting, which may impact connectivity to IoT Hub. \
-         Please see https://aka.ms/iotedge-prod-checklist-dns for best practices.";
+         Please see https://aka.ms/iotedge-prod-checklist-dns for best practices.\n\
+         You can ignore this warning if you are setting DNS server per module in the Edge deployment.";
 
     #[derive(serde_derive::Deserialize)]
     struct DaemonConfig {
@@ -1105,8 +1106,9 @@ fn settings_moby_runtime_uri(check: &mut Check) -> Result<CheckResult, failure::
 
 fn container_engine_logrotate(_: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
-        "Device is not configured to rotate module logs which may cause it run out of disk space. \
-         Please see https://aka.ms/iotedge-prod-checklist-logs for best practices.";
+        "Container engine is not configured to rotate module logs which may cause it run out of disk space. \
+         Please see https://aka.ms/iotedge-prod-checklist-logs for best practices.\n\
+         You can ignore this warning if you are setting log policy per module in the Edge deployment.";
 
     #[derive(serde_derive::Deserialize)]
     struct DaemonConfig {

--- a/edgelet/iotedge/src/check.rs
+++ b/edgelet/iotedge/src/check.rs
@@ -750,9 +750,9 @@ fn iotedged_version(check: &mut Check) -> Result<CheckResult, failure::Error> {
 
     if version != latest_versions.iotedged {
         return Ok(CheckResult::Warning(format!(
-            "Installed IoT Edge daemon has version {} but version {} is available. Please see <TODO: aka.ms URL> for update instructions.",
-            version,
-            latest_versions.iotedged,
+            "Installed IoT Edge daemon has version {} but version {} is available. \
+             Please see https://aka.ms/iotedge-update-runtime for update instructions.",
+            version, latest_versions.iotedged,
         )));
     }
 
@@ -850,7 +850,7 @@ fn settings_certificates(check: &mut Check) -> Result<CheckResult, failure::Erro
     if settings.certificates().is_none() {
         return Ok(CheckResult::Warning(
             "Device is using self-signed, automatically generated certs. \
-             Please see <TODO: aka.ms URL> for certificate management best practices."
+             Please see https://aka.ms/iotedge-prod-checklist-certs for certificate management best practices."
                 .to_owned(),
         ));
     }
@@ -965,7 +965,7 @@ fn settings_certificates_expiry(check: &mut Check) -> Result<CheckResult, failur
 fn settings_moby_runtime_uri(check: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
         "Device is not using a production-supported container engine (moby-engine). \
-         See https://aka.ms/iotedge-platsup#container-engines for details.";
+         Please see https://aka.ms/iotedge-prod-checklist-moby for details.";
 
     let settings = if let Some(settings) = &check.settings {
         settings
@@ -1022,7 +1022,7 @@ fn settings_moby_runtime_uri(check: &mut Check) -> Result<CheckResult, failure::
 fn container_engine_logrotate(_: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
         "Device is not configured to rotate module logs which may cause it run out of disk space. \
-         Please see <TODO: aka.ms URL> for best practices.";
+         Please see https://aka.ms/iotedge-prod-checklist-logs for best practices.";
 
     #[derive(serde_derive::Deserialize)]
     struct DaemonConfig {
@@ -1081,7 +1081,7 @@ fn container_engine_logrotate(_: &mut Check) -> Result<CheckResult, failure::Err
 fn container_engine_dns(_: &mut Check) -> Result<CheckResult, failure::Error> {
     const MESSAGE: &str =
         "Container engine is not configured with DNS server setting, which may impact connectivity to IoT Hub. \
-         Please see <TODO: aka.ms URL> for best practices.";
+         Please see https://aka.ms/iotedge-prod-checklist-dns for best practices.";
 
     #[derive(serde_derive::Deserialize)]
     struct DaemonConfig {

--- a/scripts/linux/buildDiagnostics.sh
+++ b/scripts/linux/buildDiagnostics.sh
@@ -17,10 +17,13 @@ cp -R $BUILD_REPOSITORY_LOCALPATH/edgelet/iotedge-diagnostics/docker $PUBLISH_FO
 cd "$BUILD_REPOSITORY_LOCALPATH/edgelet"
 
 cross build -p iotedge-diagnostics --release --target x86_64-unknown-linux-musl
+strip $BUILD_REPOSITORY_LOCALPATH/edgelet/target/x86_64-unknown-linux-musl/release/iotedge-diagnostics
 cp $BUILD_REPOSITORY_LOCALPATH/edgelet/target/x86_64-unknown-linux-musl/release/iotedge-diagnostics $PUBLISH_FOLDER/azureiotedge-diagnostics/docker/linux/amd64/
 
 cross build -p iotedge-diagnostics --release --target armv7-unknown-linux-musleabihf
+strip $BUILD_REPOSITORY_LOCALPATH/edgelet/target/armv7-unknown-linux-musleabihf/release/iotedge-diagnostics
 cp $BUILD_REPOSITORY_LOCALPATH/edgelet/target/armv7-unknown-linux-musleabihf/release/iotedge-diagnostics $PUBLISH_FOLDER/azureiotedge-diagnostics/docker/linux/arm32v7/
 
 cross build -p iotedge-diagnostics --release --target aarch64-unknown-linux-musl
+strip $BUILD_REPOSITORY_LOCALPATH/edgelet/target/aarch64-unknown-linux-musl/release/iotedge-diagnostics
 cp $BUILD_REPOSITORY_LOCALPATH/edgelet/target/aarch64-unknown-linux-musl/release/iotedge-diagnostics $PUBLISH_FOLDER/azureiotedge-diagnostics/docker/linux/arm64v8/

--- a/scripts/linux/buildDiagnostics.sh
+++ b/scripts/linux/buildDiagnostics.sh
@@ -21,9 +21,9 @@ strip $BUILD_REPOSITORY_LOCALPATH/edgelet/target/x86_64-unknown-linux-musl/relea
 cp $BUILD_REPOSITORY_LOCALPATH/edgelet/target/x86_64-unknown-linux-musl/release/iotedge-diagnostics $PUBLISH_FOLDER/azureiotedge-diagnostics/docker/linux/amd64/
 
 cross build -p iotedge-diagnostics --release --target armv7-unknown-linux-musleabihf
-strip $BUILD_REPOSITORY_LOCALPATH/edgelet/target/armv7-unknown-linux-musleabihf/release/iotedge-diagnostics
+arm-linux-gnueabihf-strip $BUILD_REPOSITORY_LOCALPATH/edgelet/target/armv7-unknown-linux-musleabihf/release/iotedge-diagnostics
 cp $BUILD_REPOSITORY_LOCALPATH/edgelet/target/armv7-unknown-linux-musleabihf/release/iotedge-diagnostics $PUBLISH_FOLDER/azureiotedge-diagnostics/docker/linux/arm32v7/
 
 cross build -p iotedge-diagnostics --release --target aarch64-unknown-linux-musl
-strip $BUILD_REPOSITORY_LOCALPATH/edgelet/target/aarch64-unknown-linux-musl/release/iotedge-diagnostics
+aarch64-linux-gnu-strip $BUILD_REPOSITORY_LOCALPATH/edgelet/target/aarch64-unknown-linux-musl/release/iotedge-diagnostics
 cp $BUILD_REPOSITORY_LOCALPATH/edgelet/target/aarch64-unknown-linux-musl/release/iotedge-diagnostics $PUBLISH_FOLDER/azureiotedge-diagnostics/docker/linux/arm64v8/


### PR DESCRIPTION
- Update user-friendly error messages according to new spec.

- Only display error causes when `--verbose` is set.

- Add causes to warning messages, and only display then when `--verbose`
  is set.

- Also check expiry of quickstart device CA cert.

- Print message reminding user to run as root if "Edge Hub can bind to ports"
  check fails with EPERM, since 443 is a privileged port.

- Remove "container can resolve other container hostname" check, since it is
  not a reported issue.

- Remove "container on default network can resolve IoT Hub" checks
  on Windows since the "module runtime network" checks already cover it.

- Tweak colors on Windows to match default PowerShell colors.

- Strip `iotedge-diagnostics` binary to reduce container image size.

---

TODO:

- [x] ~~Get new aka.ms URLs from Venkat (marked `<TODO: aka.ms URL>`).~~