### PR TITLE
EdgeAgent: Add cancellation support to requests

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -81,6 +81,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string EnableStreams = "EnableStreams";
 
+        public const string RequestTimeoutSecs = "RequestTimeoutSecs";
+
         public static class Labels
         {
             public const string Version = "net.azure-devices.edge.version";

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/IRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/IRequestHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
 
@@ -8,6 +9,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
     {
         string RequestName { get; }
 
-        Task<Option<string>> HandleRequest(Option<string> payloadJson);
+        Task<Option<string>> HandleRequest(Option<string> payloadJson, CancellationToken cancellationToken);
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequestHandler.cs
@@ -20,11 +20,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
         public override string RequestName => "UploadLogs";
 
-        protected override async Task<Option<object>> HandleRequestInternal(Option<LogsUploadRequest> payloadOption)
+        protected override async Task<Option<object>> HandleRequestInternal(Option<LogsUploadRequest> payloadOption, CancellationToken cancellationToken)
         {
             LogsUploadRequest payload = payloadOption.Expect(() => new ArgumentException("Request payload not found"));
             var moduleLogOptions = new ModuleLogOptions(payload.Id, payload.Encoding, payload.ContentType, ModuleLogFilter.Empty);
-            byte[] logBytes = await this.logsProvider.GetLogs(moduleLogOptions, CancellationToken.None);
+            byte[] logBytes = await this.logsProvider.GetLogs(moduleLogOptions, cancellationToken);
             await this.logsUploader.Upload(payload.SasUrl, payload.Id, logBytes, payload.Encoding, payload.ContentType);
             return Option.None<object>();
         }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/PingRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/PingRequestHandler.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
 
@@ -8,7 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
     {
         public override string RequestName => "ping";
 
-        protected override Task<Option<object>> HandleRequestInternal(Option<object> payload)
+        protected override Task<Option<object>> HandleRequestInternal(Option<object> payload, CancellationToken token)
             => Task.FromResult(Option.None<object>());
 
         protected override Option<object> ParsePayload(Option<string> payloadJson)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestHandlerBase.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestHandlerBase.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -12,10 +13,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
     {
         public abstract string RequestName { get; }
 
-        public async Task<Option<string>> HandleRequest(Option<string> payloadJson)
+        public async Task<Option<string>> HandleRequest(Option<string> payloadJson, CancellationToken cancellationToken)
         {
             Option<TU> payload = this.ParsePayload(payloadJson);
-            Option<TV> result = await this.HandleRequestInternal(payload);
+            Option<TV> result = await this.HandleRequestInternal(payload, cancellationToken);
             Option<string> responseJson = result.Map(r => r.ToJson());
             return responseJson;
         }
@@ -32,6 +33,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
             }
         }
 
-        protected abstract Task<Option<TV>> HandleRequestInternal(Option<TU> payload);
+        protected abstract Task<Option<TV>> HandleRequestInternal(Option<TU> payload, CancellationToken cancellationToken);
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
@@ -38,10 +38,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
                 // This does not timeout the actual handle request operation.
                 // It relies on the handler to cancel the operation when the cancellation token is set to cancelled. 
-                var cancellationTokenSource = new CancellationTokenSource(this.maxRequestTimeout);
-                Option<string> responsePayload = await requestHandler.HandleRequest(Option.Maybe(payloadJson), cancellationTokenSource.Token);
-                Events.HandledRequest(request);
-                return ((int)HttpStatusCode.OK, responsePayload);
+                using (var cancellationTokenSource = new CancellationTokenSource(this.maxRequestTimeout))
+                {
+                    Option<string> responsePayload = await requestHandler.HandleRequest(Option.Maybe(payloadJson), cancellationTokenSource.Token);
+                    Events.HandledRequest(request);
+                    return ((int)HttpStatusCode.OK, responsePayload);
+                }
             }
             catch (Exception ex)
             {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
                 }
 
                 // This does not timeout the actual handle request operation.
-                // It relies on the handler to cancel the operation when the cancellation token is set to cancelled. 
+                // It relies on the handler to cancel the operation when the cancellation token is set to cancelled.
                 using (var cancellationTokenSource = new CancellationTokenSource(this.maxRequestTimeout))
                 {
                     Option<string> responsePayload = await requestHandler.HandleRequest(Option.Maybe(payloadJson), cancellationTokenSource.Token);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
                     throw new ArgumentException(message);
                 }
 
+                // This does not timeout the actual handle request operation.
+                // It relies on the handler to cancel the operation when the cancellation token is set to cancelled. 
                 var cancellationTokenSource = new CancellationTokenSource(this.maxRequestTimeout);
                 Option<string> responsePayload = await requestHandler.HandleRequest(Option.Maybe(payloadJson), cancellationTokenSource.Token);
                 Events.HandledRequest(request);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
@@ -3,9 +3,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -14,11 +14,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
     public class RequestManager : IRequestManager
     {
         readonly IDictionary<string, IRequestHandler> requestHandlers;
+        readonly TimeSpan maxRequestTimeout;
 
-        public RequestManager(IEnumerable<IRequestHandler> requestHandlers)
+        public RequestManager(IEnumerable<IRequestHandler> requestHandlers, TimeSpan maxRequestTimeout)
         {
             this.requestHandlers = Preconditions.CheckNotNull(requestHandlers, nameof(requestHandlers))
                 .ToDictionary(r => r.RequestName, r => r, StringComparer.OrdinalIgnoreCase);
+            this.maxRequestTimeout = maxRequestTimeout;
         }
 
         public async Task<(int statusCode, Option<string> responsePayload)> ProcessRequest(string request, string payloadJson)
@@ -34,7 +36,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
                     throw new ArgumentException(message);
                 }
 
-                Option<string> responsePayload = await requestHandler.HandleRequest(Option.Maybe(payloadJson));
+                var cancellationTokenSource = new CancellationTokenSource(this.maxRequestTimeout);
+                Option<string> responsePayload = await requestHandler.HandleRequest(Option.Maybe(payloadJson), cancellationTokenSource.Token);
                 Events.HandledRequest(request);
                 return ((int)HttpStatusCode.OK, responsePayload);
             }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 {
                     case "twin":
                         bool enableStreams = configuration.GetValue(Constants.EnableStreams, false);
-                        int requestTimeoutSecs = configuration.GetValue(Constants.RequestTimeoutSecs, 120);
+                        int requestTimeoutSecs = configuration.GetValue(Constants.RequestTimeoutSecs, 600);
                         builder.RegisterModule(
                             new TwinConfigSourceModule(
                                 iothubHostname,

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -135,7 +135,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 {
                     case "twin":
                         bool enableStreams = configuration.GetValue(Constants.EnableStreams, false);
-                        builder.RegisterModule(new TwinConfigSourceModule(iothubHostname, deviceId, backupConfigFilePath, configuration, versionInfo, TimeSpan.FromSeconds(configRefreshFrequencySecs), enableStreams));
+                        int requestTimeoutSecs = configuration.GetValue(Constants.RequestTimeoutSecs, 120);
+                        builder.RegisterModule(
+                            new TwinConfigSourceModule(
+                                iothubHostname,
+                                deviceId,
+                                backupConfigFilePath,
+                                configuration,
+                                versionInfo,
+                                TimeSpan.FromSeconds(configRefreshFrequencySecs),
+                                enableStreams,
+                                TimeSpan.FromSeconds(requestTimeoutSecs)));
                         break;
 
                     case "local":

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
@@ -92,14 +92,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 async c =>
                 {
                     var logsUploader = c.Resolve<ILogsUploader>();
-                    var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
-                    var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
-                    IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
-                    ILogsProvider logsProvider = await logsProviderTask;
+                    ILogsProvider logsProvider = await c.Resolve<Task<ILogsProvider>>();
                     var requestHandlers = new List<IRequestHandler>
                     {
                         new PingRequestHandler(),
-                        new LogsUploadRequestHandler(logsUploader, logsProvider, runtimeInfoProvider)
+                        new LogsUploadRequestHandler(logsUploader, logsProvider)
                     };
                     return new RequestManager(requestHandlers, this.requestTimeout) as IRequestManager;
                 })

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly string deviceId;
         readonly string iotHubHostName;
         readonly bool enableStreams;
+        readonly TimeSpan requestTimeout;
 
         public TwinConfigSourceModule(
             string iotHubHostname,
@@ -37,7 +38,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             IConfiguration config,
             VersionInfo versionInfo,
             TimeSpan configRefreshFrequency,
-            bool enableStreams)
+            bool enableStreams,
+            TimeSpan requestTimeout)
         {
             this.iotHubHostName = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
             this.deviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
@@ -46,6 +48,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.versionInfo = Preconditions.CheckNotNull(versionInfo, nameof(versionInfo));
             this.configRefreshFrequency = configRefreshFrequency;
             this.enableStreams = enableStreams;
+            this.requestTimeout = requestTimeout;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -89,13 +92,16 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 async c =>
                 {
                     var logsUploader = c.Resolve<ILogsUploader>();
-                    ILogsProvider logsProvider = await c.Resolve<Task<ILogsProvider>>();
+                    var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
+                    var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
+                    IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
+                    ILogsProvider logsProvider = await logsProviderTask;
                     var requestHandlers = new List<IRequestHandler>
                     {
                         new PingRequestHandler(),
-                        new LogsUploadRequestHandler(logsUploader, logsProvider)
+                        new LogsUploadRequestHandler(logsUploader, logsProvider, runtimeInfoProvider)
                     };
-                    return new RequestManager(requestHandlers) as IRequestManager;
+                    return new RequestManager(requestHandlers, this.requestTimeout) as IRequestManager;
                 })
                 .As<Task<IRequestManager>>()
                 .SingleInstance();

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
 
             // Act
             var logsUploadRequestHandler = new LogsUploadRequestHandler(logsUploader.Object, logsProvider.Object);
-            Option<string> response = await logsUploadRequestHandler.HandleRequest(Option.Maybe(payload));
+            Option<string> response = await logsUploadRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
 
             // Assert
             Assert.False(response.HasValue);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/PingRequestHandlerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/PingRequestHandlerTest.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
 {
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Requests;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -19,7 +20,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         {
             // Arrange/Act
             var pingRequestHandler = new PingRequestHandler();
-            Option<string> response = await pingRequestHandler.HandleRequest(Option.Maybe(payload));
+            Option<string> response = await pingRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
 
             // Assert
             Assert.False(response.HasValue);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestHandlerBaseTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestHandlerBaseTest.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Requests;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -24,11 +25,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
             // Act / Assert
             if (expectedException != null)
             {
-                await Assert.ThrowsAsync(expectedException, () => requestHandler.HandleRequest(Option.Maybe(payloadJson)));
+                await Assert.ThrowsAsync(expectedException, () => requestHandler.HandleRequest(Option.Maybe(payloadJson), CancellationToken.None));
             }
             else
             {
-                Option<string> responsePayload = await requestHandler.HandleRequest(Option.Maybe(payloadJson));
+                Option<string> responsePayload = await requestHandler.HandleRequest(Option.Maybe(payloadJson), CancellationToken.None);
                 Assert.True(responsePayload.HasValue);
                 Assert.Equal(payloadJson, responsePayload.OrDefault());
             }
@@ -38,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         {
             public override string RequestName => "TestImpl";
 
-            protected override Task<Option<RequestResponse>> HandleRequestInternal(Option<RequestPayload> payload)
+            protected override Task<Option<RequestResponse>> HandleRequestInternal(Option<RequestPayload> payload, CancellationToken token)
             {
                 RequestPayload requestPayload = payload.Expect(() => new ArgumentException("Payload should not be null"));
                 return Task.FromResult(Option.Some(new RequestResponse(requestPayload.Prop1, requestPayload.Prop2)));

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestManagerTest.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Requests;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -28,14 +29,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         {
             // Arrange
             var requestHandler = new Mock<IRequestHandler>();
-            requestHandler.Setup(r => r.HandleRequest(It.IsAny<Option<string>>()))
+            requestHandler.Setup(r => r.HandleRequest(It.IsAny<Option<string>>(), CancellationToken.None))
                 .ReturnsAsync(Option.Some("{\"prop3\":\"foo\",\"prop4\":100}"));
             requestHandler.SetupGet(r => r.RequestName).Returns("req1");
             var requestHandlers = new List<IRequestHandler>
             {
                 requestHandler.Object
             };
-            var requestManager = new RequestManager(requestHandlers);
+            var requestManager = new RequestManager(requestHandlers, TimeSpan.FromSeconds(60));
             string payload = "{\"prop2\":\"foo\",\"prop1\":100}";
 
             // Act
@@ -86,13 +87,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         {
             // Arrange
             var requestHandler = new Mock<IRequestHandler>();
-            requestHandler.Setup(r => r.HandleRequest(Option.Some(payload))).ThrowsAsync(handlerException);
+            requestHandler.Setup(r => r.HandleRequest(Option.Some(payload), CancellationToken.None)).ThrowsAsync(handlerException);
             requestHandler.SetupGet(r => r.RequestName).Returns("req1");
             var requestHandlers = new List<IRequestHandler>
             {
                 requestHandler.Object
             };
-            var requestManager = new RequestManager(requestHandlers);
+            var requestManager = new RequestManager(requestHandlers, TimeSpan.FromSeconds(60));
 
             // Act
             (int responseStatus, Option<string> responsePayload) = await requestManager.ProcessRequest("req1", payload);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestManagerTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         {
             // Arrange
             var requestHandler = new Mock<IRequestHandler>();
-            requestHandler.Setup(r => r.HandleRequest(It.IsAny<Option<string>>(), CancellationToken.None))
+            requestHandler.Setup(r => r.HandleRequest(It.IsAny<Option<string>>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(Option.Some("{\"prop3\":\"foo\",\"prop4\":100}"));
             requestHandler.SetupGet(r => r.RequestName).Returns("req1");
             var requestHandlers = new List<IRequestHandler>
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         {
             // Arrange
             var requestHandler = new Mock<IRequestHandler>();
-            requestHandler.Setup(r => r.HandleRequest(Option.Some(payload), CancellationToken.None)).ThrowsAsync(handlerException);
+            requestHandler.Setup(r => r.HandleRequest(Option.Some(payload), It.IsAny<CancellationToken>())).ThrowsAsync(handlerException);
             requestHandler.SetupGet(r => r.RequestName).Returns("req1");
             var requestHandlers = new List<IRequestHandler>
             {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Common.Exceptions;
@@ -29,6 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
     public class EdgeAgentConnectionTest
     {
         const string DockerType = "docker";
+        static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(60);
 
         public static async Task<Configuration> CreateConfigurationAsync(RegistryManager registryMananger, string configurationId, string targetCondition, int priority)
         {
@@ -191,7 +193,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 ISerde<DeploymentConfig> serde = new TypeSpecificSerDe<DeploymentConfig>(deserializerTypes);
                 IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
                 var streamRequestListener = Mock.Of<IStreamRequestListener>();
-                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers), streamRequestListener);
+                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
                 await Task.Delay(TimeSpan.FromSeconds(10));
 
                 Option<DeploymentConfigInfo> deploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
@@ -306,7 +308,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 ISerde<DeploymentConfig> serde = new TypeSpecificSerDe<DeploymentConfig>(deserializerTypes);
                 IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
                 var streamRequestListener = Mock.Of<IStreamRequestListener>();
-                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers), streamRequestListener);
+                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
                 await Task.Delay(TimeSpan.FromSeconds(20));
 
                 Option<DeploymentConfigInfo> deploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
@@ -405,7 +407,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var streamRequestListener = Mock.Of<IStreamRequestListener>();
 
             // Act
-            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers), streamRequestListener);
+            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
             Option<DeploymentConfigInfo> deploymentConfigInfo = await connection.GetDeploymentConfigInfoAsync();
 
             // Assert
@@ -455,7 +457,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var streamRequestListener = Mock.Of<IStreamRequestListener>();
 
             // Act
-            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers), streamRequestListener);
+            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
             Assert.NotNull(connectionStatusChangesHandler);
             connectionStatusChangesHandler.Invoke(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
 
@@ -502,7 +504,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var streamRequestListener = Mock.Of<IStreamRequestListener>();
 
             // Act
-            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers), streamRequestListener);
+            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
             Assert.NotNull(connectionStatusChangesHandler);
             connectionStatusChangesHandler.Invoke(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
 
@@ -566,7 +568,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var streamRequestListener = Mock.Of<IStreamRequestListener>();
 
             // Act
-            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers), streamRequestListener);
+            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
             Assert.NotNull(connectionStatusChangesHandler);
             connectionStatusChangesHandler.Invoke(ConnectionStatus.Connected, ConnectionStatusChangeReason.Connection_Ok);
             Option<DeploymentConfigInfo> deploymentConfigInfo = await connection.GetDeploymentConfigInfoAsync();
@@ -623,7 +625,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var streamRequestListener = Mock.Of<IStreamRequestListener>();
 
             // Act
-            IEdgeAgentConnection connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers), streamRequestListener, retryStrategy.Object, TimeSpan.FromHours(1));
+            IEdgeAgentConnection connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener, retryStrategy.Object, TimeSpan.FromHours(1));
             Assert.NotNull(connectionStatusChangesHandler);
             connectionStatusChangesHandler.Invoke(
                 ConnectionStatus.Connected,
@@ -699,7 +701,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var streamRequestListener = Mock.Of<IStreamRequestListener>();
 
             // Act
-            IEdgeAgentConnection connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers), streamRequestListener, retryStrategy.Object, TimeSpan.FromHours(1));
+            IEdgeAgentConnection connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener, retryStrategy.Object, TimeSpan.FromHours(1));
             Assert.NotNull(connectionStatusChangesHandler);
             Option<DeploymentConfigInfo> deploymentConfigInfo = await connection.GetDeploymentConfigInfoAsync();
 
@@ -767,7 +769,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
 
             IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
             var streamRequestListener = Mock.Of<IStreamRequestListener>();
-            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers), streamRequestListener);
+            var connection = new EdgeAgentConnection(deviceClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
 
             await Task.Delay(TimeSpan.FromSeconds(5));
 
@@ -860,7 +862,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 Assert.NotNull(edgeAgentModule);
                 Assert.True(edgeAgentModule.ConnectionState == DeviceConnectionState.Disconnected);
 
-                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers), streamRequestListener);
+                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
                 await Task.Delay(TimeSpan.FromSeconds(5));
 
                 edgeAgentModule = await registryManager.GetModuleAsync(edgeDeviceId, Constants.EdgeAgentModuleIdentityName);
@@ -950,7 +952,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 // Assert
                 await Assert.ThrowsAsync<DeviceNotFoundException>(() => serviceClient.InvokeDeviceMethodAsync(edgeDeviceId, Constants.EdgeAgentModuleIdentityName, new CloudToDeviceMethod("ping")));
 
-                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers), streamRequestListener);
+                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener);
                 await Task.Delay(TimeSpan.FromSeconds(10));
 
                 CloudToDeviceMethodResult methodResult = await serviceClient.InvokeDeviceMethodAsync(edgeDeviceId, Constants.EdgeAgentModuleIdentityName, new CloudToDeviceMethod("ping"));
@@ -1043,7 +1045,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var streamRequestListener = Mock.Of<IStreamRequestListener>();
 
             // Act
-            using (var edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider.Object, serde, new RequestManager(requestHandlers), streamRequestListener, TimeSpan.FromSeconds(3)))
+            using (var edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider.Object, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), streamRequestListener, TimeSpan.FromSeconds(3)))
             {
                 await Task.Delay(TimeSpan.FromSeconds(8));
 


### PR DESCRIPTION
Adding cancellation support for EdgeAgent requests. This is a preventive measure, to avoid long running or _stuck_ requests to keep processing for a long time. 