### PR TITLE
fix optimize for performance in e2e test

### DIFF
--- a/e2e_deployment_files/dm_module_to_module_deployment.json
+++ b/e2e_deployment_files/dm_module_to_module_deployment.json
@@ -37,12 +37,6 @@
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "OptimizeForPerformance": {
-                "value": "<OptimizeForPerformance>"
-              },
-              "MqttEventsProcessorThreadCount": {
-                "value": "<MqttEventsProcessorThreadCount>"
-              },
               "UpstreamProtocol" : {
                 "value": "<UpstreamProtocol>"
               }

--- a/e2e_deployment_files/module_to_functions_deployment.template.json
+++ b/e2e_deployment_files/module_to_functions_deployment.template.json
@@ -32,9 +32,6 @@
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "OptimizeForPerformance": {
-                "value": "<OptimizeForPerformance>"
-              }
             },
             "status": "running",
             "restartPolicy": "always"

--- a/e2e_deployment_files/module_to_module_deployment.template.json
+++ b/e2e_deployment_files/module_to_module_deployment.template.json
@@ -32,9 +32,6 @@
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "OptimizeForPerformance": {
-                "value": "<OptimizeForPerformance>"
-              }
             },
             "status": "running",
             "restartPolicy": "always"

--- a/e2e_deployment_files/quickstart_deployment.template.json
+++ b/e2e_deployment_files/quickstart_deployment.template.json
@@ -33,9 +33,6 @@
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "OptimizeForPerformance": {
-                "value": "<OptimizeForPerformance>"
-              }
             },
             "status": "running",
             "restartPolicy": "always"

--- a/e2e_deployment_files/runtime_only_deployment.template.json
+++ b/e2e_deployment_files/runtime_only_deployment.template.json
@@ -33,9 +33,6 @@
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "OptimizeForPerformance": {
-                "value": "<OptimizeForPerformance>"
-              }
             },
             "status": "running",
             "restartPolicy": "always"

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -192,8 +192,14 @@ function prepare_test_from_artifacts() {
                 cp "$module_to_functions_deployment_artifact_file" "$deployment_working_file";;
         esac
 
+        if [[ $image_architecture_label == 'arm32v7' ]] ||
+           [[ $image_architecture_label == 'arm64v8' ]]; then
+            sed -i -e "s@<OptimizeForPerformance>@false@g" "$deployment_working_file"
+        else
+            sed -i -e "s@<OptimizeForPerformance>@true@g" "$deployment_working_file"
+        fi
+
         sed -i -e "s@<Architecture>@$image_architecture_label@g" "$deployment_working_file"
-        sed -i -e "s@<OptimizeForPerformance>@true@g" "$deployment_working_file"
         sed -i -e "s/<Build.BuildNumber>/$ARTIFACT_IMAGE_BUILD_NUMBER/g" "$deployment_working_file"
         sed -i -e "s@<CR.Username>@$CONTAINER_REGISTRY_USERNAME@g" "$deployment_working_file"
         sed -i -e "s@<CR.Password>@$CONTAINER_REGISTRY_PASSWORD@g" "$deployment_working_file"

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -93,18 +93,6 @@ function get_long_haul_deployment_artifact_file() {
     echo "$path"
 }
 
-function get_optimize_for_performance_flag() {
-    local flag
-    if [[ $image_architecture_label == 'arm32v7' ]] ||
-       [[ $image_architecture_label == 'arm64v8' ]]; then
-       flag="false"
-    else
-       flag="true"
-    fi
-    
-    echo $flag
-}
-
 function prepare_test_from_artifacts() {
     print_highlighted_message 'Prepare test from artifacts'
 
@@ -147,11 +135,6 @@ function prepare_test_from_artifacts() {
             'directmethodmqtt')
                 echo "Copy deployment file from $dm_module_to_module_deployment_artifact_file"
                 cp "$dm_module_to_module_deployment_artifact_file" "$deployment_working_file"
-
-                if [[ $image_architecture_label == 'arm32v7' ]] ||
-                   [[ $image_architecture_label == 'arm64v8' ]]; then
-                    sed -i -e "s@<MqttEventsProcessorThreadCount>@1@g" "$deployment_working_file"
-                fi
                 
                 sed -i -e "s@<UpstreamProtocol>@Mqtt@g" "$deployment_working_file"
                 sed -i -e "s@<ClientTransportType>@Mqtt_Tcp_Only@g" "$deployment_working_file";;
@@ -159,11 +142,6 @@ function prepare_test_from_artifacts() {
                 echo "Copy deployment file from $dm_module_to_module_deployment_artifact_file"
                 cp "$dm_module_to_module_deployment_artifact_file" "$deployment_working_file"
 
-                if [[ $image_architecture_label == 'arm32v7' ]] ||
-                   [[ $image_architecture_label == 'arm64v8' ]]; then
-                    sed -i -e "s@<MqttEventsProcessorThreadCount>@1@g" "$deployment_working_file"
-                fi
-                
                 sed -i -e "s@<UpstreamProtocol>@Mqttws@g" "$deployment_working_file"
                 sed -i -e "s@<ClientTransportType>@Mqtt_WebSocket_Only@g" "$deployment_working_file";;
             'longhaul' | 'stress')
@@ -204,7 +182,6 @@ function prepare_test_from_artifacts() {
                 cp "$module_to_functions_deployment_artifact_file" "$deployment_working_file";;
         esac
 
-        sed -i -e "s@<OptimizeForPerformance>@$(get_optimize_for_performance_flag)@g" "$deployment_working_file"
         sed -i -e "s@<Architecture>@$image_architecture_label@g" "$deployment_working_file"
         sed -i -e "s/<Build.BuildNumber>/$ARTIFACT_IMAGE_BUILD_NUMBER/g" "$deployment_working_file"
         sed -i -e "s@<CR.Username>@$CONTAINER_REGISTRY_USERNAME@g" "$deployment_working_file"
@@ -554,7 +531,6 @@ function run_quickstartcerts_test() {
         -p "$CONTAINER_REGISTRY_PASSWORD" \
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" \
         --leave-running=Core \
-        --optimize_for_performance="$(get_optimize_for_performance_flag)" \
         --no-verify && ret=$? || ret=$?
 
     declare -a certs=( /var/lib/iotedge/hsm/certs/edge_owner_ca*.pem )
@@ -686,7 +662,6 @@ function run_tempsensor_test() {
         -u "$CONTAINER_REGISTRY_USERNAME" \
         -p "$CONTAINER_REGISTRY_PASSWORD" \
         -tw "$E2E_TEST_DIR/artifacts/core-linux/e2e_test_files/twin_test_tempSensor.json" \
-        --optimize_for_performance="$(get_optimize_for_performance_flag)" \
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" && ret=$? || ret=$?
 
     local elapsed_seconds=$SECONDS

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -282,9 +282,17 @@ Function PrepareTestFromArtifacts
             }
         }
 
+        If ($Architecture -eq "arm32v7") 
+        {
+            (Get-Content $DeploymentWorkingFilePath).replace('<OptimizeForPerformance>', 'false') | Set-Content $DeploymentWorkingFilePath
+        }
+        else
+        {
+            (Get-Content $DeploymentWorkingFilePath).replace('<OptimizeForPerformance>', 'true') | Set-Content $DeploymentWorkingFilePath
+        }
+        
         $ImageArchitectureLabel = $(GetImageArchitectureLabel)
         (Get-Content $DeploymentWorkingFilePath).replace('<Architecture>', $ImageArchitectureLabel) | Set-Content $DeploymentWorkingFilePath
-        (Get-Content $DeploymentWorkingFilePath).replace('<OptimizeForPerformance>', 'true') | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<Build.BuildNumber>', $ArtifactImageBuildNumber) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<CR.Username>', $ContainerRegistryUsername) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<CR.Password>', $ContainerRegistryPassword) | Set-Content $DeploymentWorkingFilePath

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -193,6 +193,16 @@ Function GetImageArchitectureLabel
     Throw "Can't find image architecture label for $Architecture"
 }
 
+Function GetOptimizeForPerformanceFlag
+{
+    If ($Architecture -eq "arm32v7") 
+    {
+        return "false";
+    }
+
+    return "true";
+}
+
 Function InitializeWorkingFolder
 {
     PrintHighlightedMessage "Prepare $TestWorkingFolder for test run"
@@ -282,17 +292,9 @@ Function PrepareTestFromArtifacts
             }
         }
 
-        If ($Architecture -eq "arm32v7") 
-        {
-            (Get-Content $DeploymentWorkingFilePath).replace('<OptimizeForPerformance>', 'false') | Set-Content $DeploymentWorkingFilePath
-        }
-        else
-        {
-            (Get-Content $DeploymentWorkingFilePath).replace('<OptimizeForPerformance>', 'true') | Set-Content $DeploymentWorkingFilePath
-        }
-        
         $ImageArchitectureLabel = $(GetImageArchitectureLabel)
         (Get-Content $DeploymentWorkingFilePath).replace('<Architecture>', $ImageArchitectureLabel) | Set-Content $DeploymentWorkingFilePath
+        (Get-Content $DeploymentWorkingFilePath).replace('<OptimizeForPerformance>', $(GetOptimizeForPerformanceFlag)) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<Build.BuildNumber>', $ArtifactImageBuildNumber) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<CR.Username>', $ContainerRegistryUsername) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<CR.Password>', $ContainerRegistryPassword) | Set-Content $DeploymentWorkingFilePath
@@ -546,7 +548,7 @@ Function RunQuickstartCertsTest
         -u `"$ContainerRegistryUsername`" ``
         -p `"$ContainerRegistryPassword`" ``
         -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
-        --optimize_for_performance true ``
+        --optimize_for_performance $(GetOptimizeForPerformanceFlag) ``
         --leave-running=All ``
         --no-verify"
     If ($ProxyUri) {
@@ -664,7 +666,7 @@ Function RunTempSensorTest
         -p `"$ContainerRegistryPassword`" ``
         -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
         -tw `"$TwinTestFileArtifactFilePath`" ``
-        --optimize_for_performance true"
+        --optimize_for_performance $(GetOptimizeForPerformanceFlag)"
     If ($ProxyUri) {
         $testCommand = "$testCommand ``
             -l `"$DeploymentWorkingFilePath`" ``
@@ -821,7 +823,7 @@ Function RunTransparentGatewayTest
         --device_ca_cert `"$EdgeCertGenScriptDir\certs\iot-edge-device-$edgeDeviceId-full-chain.cert.pem`" ``
         --device_ca_pk `"$EdgeCertGenScriptDir\private\iot-edge-device-$edgeDeviceId.key.pem`" ``
         --trusted_ca_certs `"$TrustedCACertificatePath`" ``
-        --optimize_for_performance true ``
+        --optimize_for_performance $(GetOptimizeForPerformanceFlag) ``
         --leave-running=All ``
         --no-verify"
 

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -193,16 +193,6 @@ Function GetImageArchitectureLabel
     Throw "Can't find image architecture label for $Architecture"
 }
 
-Function GetOptimizeForPerformanceFlag
-{
-    If ($Architecture -eq "arm32v7") 
-    {
-        return "false";
-    }
-
-    return "true";
-}
-
 Function InitializeWorkingFolder
 {
     PrintHighlightedMessage "Prepare $TestWorkingFolder for test run"
@@ -264,11 +254,6 @@ Function PrepareTestFromArtifacts
                 Copy-Item $DirectMethodModuleToModuleDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
                 (Get-Content $DeploymentWorkingFilePath).replace('<UpstreamProtocol>','Mqtt') | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<ClientTransportType>','Mqtt_Tcp_Only') | Set-Content $DeploymentWorkingFilePath
-
-                If ($Architecture -eq "arm32v7")
-                {
-                    (Get-Content $DeploymentWorkingFilePath).replace('<MqttEventsProcessorThreadCount>','1') | Set-Content $DeploymentWorkingFilePath
-                }
             }
             "TempFilter"
             {
@@ -294,7 +279,6 @@ Function PrepareTestFromArtifacts
 
         $ImageArchitectureLabel = $(GetImageArchitectureLabel)
         (Get-Content $DeploymentWorkingFilePath).replace('<Architecture>', $ImageArchitectureLabel) | Set-Content $DeploymentWorkingFilePath
-        (Get-Content $DeploymentWorkingFilePath).replace('<OptimizeForPerformance>', $(GetOptimizeForPerformanceFlag)) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<Build.BuildNumber>', $ArtifactImageBuildNumber) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<CR.Username>', $ContainerRegistryUsername) | Set-Content $DeploymentWorkingFilePath
         (Get-Content $DeploymentWorkingFilePath).replace('<CR.Password>', $ContainerRegistryPassword) | Set-Content $DeploymentWorkingFilePath
@@ -548,7 +532,6 @@ Function RunQuickstartCertsTest
         -u `"$ContainerRegistryUsername`" ``
         -p `"$ContainerRegistryPassword`" ``
         -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
-        --optimize_for_performance $(GetOptimizeForPerformanceFlag) ``
         --leave-running=All ``
         --no-verify"
     If ($ProxyUri) {
@@ -665,8 +648,8 @@ Function RunTempSensorTest
         -u `"$ContainerRegistryUsername`" ``
         -p `"$ContainerRegistryPassword`" ``
         -t `"${ArtifactImageBuildNumber}-windows-$(GetImageArchitectureLabel)`" ``
-        -tw `"$TwinTestFileArtifactFilePath`" ``
-        --optimize_for_performance $(GetOptimizeForPerformanceFlag)"
+        -tw `"$TwinTestFileArtifactFilePath`""
+
     If ($ProxyUri) {
         $testCommand = "$testCommand ``
             -l `"$DeploymentWorkingFilePath`" ``
@@ -823,7 +806,6 @@ Function RunTransparentGatewayTest
         --device_ca_cert `"$EdgeCertGenScriptDir\certs\iot-edge-device-$edgeDeviceId-full-chain.cert.pem`" ``
         --device_ca_pk `"$EdgeCertGenScriptDir\private\iot-edge-device-$edgeDeviceId.key.pem`" ``
         --trusted_ca_certs `"$TrustedCACertificatePath`" ``
-        --optimize_for_performance $(GetOptimizeForPerformanceFlag) ``
         --leave-running=All ``
         --no-verify"
 


### PR DESCRIPTION
remove all usage about OptimizeForPerformance and MqttEventsProcessorThreadCount from script and deployment file since they are defined in docker file already.