### PR TITLE
Add support to upload all module logs with one command

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -82,6 +82,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         public const string EnableStreams = "EnableStreams";
 
         public const string RequestTimeoutSecs = "RequestTimeoutSecs";
+        
+        public const string AllModulesIdentifier = "all";
 
         public static class Labels
         {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         public const string EnableStreams = "EnableStreams";
 
         public const string RequestTimeoutSecs = "RequestTimeoutSecs";
-        
+
         public const string AllModulesIdentifier = "all";
 
         public static class Labels

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogFilter.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogFilter.cs
@@ -2,18 +2,20 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
 {
     using System;
+    using System.Collections.Generic;
     using System.Text.RegularExpressions;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
 
-    public class ModuleLogFilter
+    public class ModuleLogFilter : IEquatable<ModuleLogFilter>
     {
         public ModuleLogFilter(Option<int> tail, Option<int> since, Option<int> logLevel, Option<string> regex)
         {
             this.Tail = tail;
             this.Since = since;
             this.LogLevel = logLevel;
+            this.RegexString = regex;
             this.Regex = regex.Map(r => new Regex(r));
         }
 
@@ -37,8 +39,33 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
         [JsonConverter(typeof(OptionConverter<int>), true)]
         public Option<int> LogLevel { get; }
 
-        [JsonProperty("regex")]
-        [JsonConverter(typeof(OptionConverter<Regex>))]
+        [JsonIgnore]
         public Option<Regex> Regex { get; }
+
+        [JsonProperty("regex")]
+        [JsonConverter(typeof(OptionConverter<string>))]
+        public Option<string> RegexString { get; }
+
+        public override bool Equals(object obj)
+            => this.Equals(obj as ModuleLogFilter);
+
+        public bool Equals(ModuleLogFilter other)
+        {
+            return other != null &&
+                   this.Tail.Equals(other.Tail) &&
+                   this.Since.Equals(other.Since) &&
+                   this.LogLevel.Equals(other.LogLevel) &&
+                   this.Regex.Equals(other.Regex);
+        }
+
+        public override int GetHashCode()
+        {
+            var hashCode = -132418255;
+            hashCode = hashCode * -1521134295 + EqualityComparer<Option<int>>.Default.GetHashCode(this.Tail);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Option<int>>.Default.GetHashCode(this.Since);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Option<int>>.Default.GetHashCode(this.LogLevel);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Option<Regex>>.Default.GetHashCode(this.Regex);
+            return hashCode;
+        }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogFilter.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogFilter.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
 
     public class ModuleLogFilter : IEquatable<ModuleLogFilter>
     {
+        public static ModuleLogFilter Empty = new ModuleLogFilter(Option.None<int>(), Option.None<int>(), Option.None<int>(), Option.None<string>());
+
         public ModuleLogFilter(Option<int> tail, Option<int> since, Option<int> logLevel, Option<string> regex)
         {
             this.Tail = tail;
@@ -24,8 +26,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
             : this(Option.Maybe(tail), Option.Maybe(since), Option.Maybe(loglevel), Option.Maybe(regex))
         {
         }
-
-        public static ModuleLogFilter Empty = new ModuleLogFilter(Option.None<int>(), Option.None<int>(), Option.None<int>(), Option.None<string>());
 
         [JsonProperty("tail")]
         [JsonConverter(typeof(OptionConverter<int>), true)]
@@ -50,13 +50,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
             => this.Equals(obj as ModuleLogFilter);
 
         public bool Equals(ModuleLogFilter other)
-        {
-            return other != null &&
-                   this.Tail.Equals(other.Tail) &&
-                   this.Since.Equals(other.Since) &&
-                   this.LogLevel.Equals(other.LogLevel) &&
-                   this.Regex.Equals(other.Regex);
-        }
+            => other != null &&
+               this.Tail.Equals(other.Tail) &&
+               this.Since.Equals(other.Since) &&
+               this.LogLevel.Equals(other.LogLevel) &&
+               this.RegexString.Equals(other.RegexString);
 
         public override int GetHashCode()
         {
@@ -64,7 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
             hashCode = hashCode * -1521134295 + EqualityComparer<Option<int>>.Default.GetHashCode(this.Tail);
             hashCode = hashCode * -1521134295 + EqualityComparer<Option<int>>.Default.GetHashCode(this.Since);
             hashCode = hashCode * -1521134295 + EqualityComparer<Option<int>>.Default.GetHashCode(this.LogLevel);
-            hashCode = hashCode * -1521134295 + EqualityComparer<Option<Regex>>.Default.GetHashCode(this.Regex);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Option<string>>.Default.GetHashCode(this.RegexString);
             return hashCode;
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogMessageData.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogMessageData.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
             string fullText)
             : base(iotHub, deviceId, moduleId, stream, logLevel, timeStamp, text)
         {
-            this.FullText = Preconditions.CheckNonWhiteSpace(fullText, fullText);
+            this.FullText = Preconditions.CheckNotNull(fullText, fullText);
             this.FullFrame = Preconditions.CheckNotNull(fullFrame, nameof(fullFrame));
         }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogOptions.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogOptions.cs
@@ -1,9 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
 {
+    using System;
+    using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Util;
 
-    public class ModuleLogOptions
+    public class ModuleLogOptions : IEquatable<ModuleLogOptions>
     {
         public ModuleLogOptions(string id, LogsContentEncoding contentEncoding, LogsContentType contentType, ModuleLogFilter filter)
         {
@@ -14,8 +16,31 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
         }
 
         public string Id { get; }
+
         public LogsContentEncoding ContentEncoding { get; }
+
         public LogsContentType ContentType { get; }
+
         public ModuleLogFilter Filter { get; }
+
+        public override bool Equals(object obj)
+            => this.Equals(obj as ModuleLogOptions);
+
+        public bool Equals(ModuleLogOptions other)
+            => other != null &&
+               this.Id == other.Id &&
+               this.ContentEncoding == other.ContentEncoding &&
+               this.ContentType == other.ContentType &&
+               EqualityComparer<ModuleLogFilter>.Default.Equals(this.Filter, other.Filter);
+
+        public override int GetHashCode()
+        {
+            var hashCode = -1683996196;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(this.Id);
+            hashCode = hashCode * -1521134295 + this.ContentEncoding.GetHashCode();
+            hashCode = hashCode * -1521134295 + this.ContentType.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<ModuleLogFilter>.Default.GetHashCode(this.Filter);
+            return hashCode;
+        }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequest.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
             this.Encoding = encoding;
             this.ContentType = contentType;
             this.SasUrl = sasUrl;
-            this.Filter = filter;
+            this.Filter = filter ?? ModuleLogFilter.Empty;
         }
 
         [JsonConstructor]

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequest.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequest.cs
@@ -7,23 +7,39 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
     public class LogsUploadRequest
     {
-        public LogsUploadRequest(string id, LogsContentEncoding encoding, LogsContentType contentType, string sasUrl)
+        public LogsUploadRequest(
+            string id,
+            LogsContentEncoding encoding,
+            LogsContentType contentType,
+            string sasUrl,
+            ModuleLogFilter filter)
         {
             this.Id = Preconditions.CheckNonWhiteSpace(id, nameof(id));
             this.Encoding = encoding;
             this.ContentType = contentType;
             this.SasUrl = sasUrl;
+            this.Filter = filter;
         }
 
         [JsonConstructor]
-        LogsUploadRequest(string id, LogsContentEncoding? encoding, LogsContentType? contentType, string sasUrl)
-            : this(id, encoding.HasValue ? encoding.Value : LogsContentEncoding.None, contentType.HasValue ? contentType.Value : LogsContentType.Json, sasUrl)
+        LogsUploadRequest(
+            string id,
+            LogsContentEncoding? encoding,
+            LogsContentType? contentType,
+            string sasUrl,
+            ModuleLogFilter filter)
+            : this(id, encoding ?? LogsContentEncoding.None, contentType ?? LogsContentType.Json, sasUrl, filter)
         {
         }
 
         public string Id { get; }
+
         public LogsContentEncoding Encoding { get; }
+
         public LogsContentType ContentType { get; }
+
         public string SasUrl { get; }
+
+        public ModuleLogFilter Filter { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequestHandler.cs
@@ -2,6 +2,8 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Logs;
@@ -11,11 +13,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
     {
         readonly ILogsUploader logsUploader;
         readonly ILogsProvider logsProvider;
+        readonly IRuntimeInfoProvider runtimeInfoProvider;
 
-        public LogsUploadRequestHandler(ILogsUploader logsUploader, ILogsProvider logsProvider)
+        public LogsUploadRequestHandler(ILogsUploader logsUploader, ILogsProvider logsProvider, IRuntimeInfoProvider runtimeInfoProvider)
         {
             this.logsProvider = Preconditions.CheckNotNull(logsProvider, nameof(logsProvider));
             this.logsUploader = Preconditions.CheckNotNull(logsUploader, nameof(logsUploader));
+            this.runtimeInfoProvider = Preconditions.CheckNotNull(runtimeInfoProvider, nameof(runtimeInfoProvider));
         }
 
         public override string RequestName => "UploadLogs";
@@ -23,10 +27,30 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
         protected override async Task<Option<object>> HandleRequestInternal(Option<LogsUploadRequest> payloadOption, CancellationToken cancellationToken)
         {
             LogsUploadRequest payload = payloadOption.Expect(() => new ArgumentException("Request payload not found"));
-            var moduleLogOptions = new ModuleLogOptions(payload.Id, payload.Encoding, payload.ContentType, ModuleLogFilter.Empty);
-            byte[] logBytes = await this.logsProvider.GetLogs(moduleLogOptions, cancellationToken);
-            await this.logsUploader.Upload(payload.SasUrl, payload.Id, logBytes, payload.Encoding, payload.ContentType);
+
+            async Task<IList<string>> GetModuleIds()
+            {
+                if (payload.Id == "all")
+                {
+                    IEnumerable<ModuleRuntimeInfo> modules = await this.runtimeInfoProvider.GetModules(cancellationToken);
+                    return modules.Select(m => m.Name).ToList();
+                }
+                else
+                {
+                    return new List<string> { payload.Id };
+                }
+            }
+
+            IList<string> moduleIds = await GetModuleIds();
+            IEnumerable<Task> uploadTasks = moduleIds.Select(m => this.UploadLogs(payload.SasUrl, new ModuleLogOptions(m, payload.Encoding, payload.ContentType, payload.Filter), cancellationToken));
+            await Task.WhenAll(uploadTasks);
             return Option.None<object>();
+        }
+
+        async Task UploadLogs(string sasUrl, ModuleLogOptions moduleLogOptions, CancellationToken token)
+        {
+            byte[] logBytes = await this.logsProvider.GetLogs(moduleLogOptions, token);
+            await this.logsUploader.Upload(sasUrl, moduleLogOptions.Id, logBytes, moduleLogOptions.ContentEncoding, moduleLogOptions.ContentType);
         }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequestHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
             async Task<IList<string>> GetModuleIds()
             {
-                if (payload.Id == "all")
+                if (payload.Id == Constants.AllModulesIdentifier)
                 {
                     IEnumerable<ModuleRuntimeInfo> modules = await this.runtimeInfoProvider.GetModules(cancellationToken);
                     return modules.Select(m => m.Name).ToList();

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
@@ -92,11 +92,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 async c =>
                 {
                     var logsUploader = c.Resolve<ILogsUploader>();
-                    ILogsProvider logsProvider = await c.Resolve<Task<ILogsProvider>>();
+                    var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
+                    var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
+                    IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
+                    ILogsProvider logsProvider = await logsProviderTask;
                     var requestHandlers = new List<IRequestHandler>
                     {
                         new PingRequestHandler(),
-                        new LogsUploadRequestHandler(logsUploader, logsProvider)
+                        new LogsUploadRequestHandler(logsUploader, logsProvider, runtimeInfoProvider)
                     };
                     return new RequestManager(requestHandlers, this.requestTimeout) as IRequestManager;
                 })

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
@@ -16,6 +16,33 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
     [Unit]
     public class LogsUploadRequestHandlerTest
     {
+        public static IEnumerable<object[]> GetLogsUploadRequestHandlerData()
+        {
+            string sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, ModuleLogFilter.Empty };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""gzip""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, LogsContentEncoding.Gzip, LogsContentType.Json, ModuleLogFilter.Empty };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            yield return new object[] { @"{""id"": ""mod1"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""gzip"", ""contentType"": ""text""}".Replace("<sasurl>", sasUrl), "mod1", sasUrl, LogsContentEncoding.Gzip, LogsContentType.Text, ModuleLogFilter.Empty };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            yield return new object[] { @"{""id"": ""edgeHub"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""none"", ""contentType"": ""json""}".Replace("<sasurl>", sasUrl), "edgeHub", sasUrl, LogsContentEncoding.None, LogsContentType.Json, ModuleLogFilter.Empty };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some(1501000), Option.Some(3), Option.Some("ERR"));
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            filter = new ModuleLogFilter(Option.None<int>(), Option.Some(1501000), Option.None<int>(), Option.Some("ERR"));
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            filter = new ModuleLogFilter(Option.Some(100), Option.None<int>(), Option.Some(3), Option.None<string>());
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
+        }
+
         [Theory]
         [MemberData(nameof(GetLogsUploadRequestHandlerData))]
         public async Task TestLogsUploadRequest(string payload, string id, string sasUrl, LogsContentEncoding contentEncoding, LogsContentType contentType, ModuleLogFilter filter)
@@ -65,7 +92,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
 
             var logsUploader = new Mock<ILogsUploader>();
             var logsProvider = new Mock<ILogsProvider>();
-            
+
             var module1LogOptions = new ModuleLogOptions(mod1, contentEncoding, contentType, filter);
             var mod1LogBytes = new byte[100];
             logsProvider.Setup(l => l.GetLogs(module1LogOptions, It.IsAny<CancellationToken>()))
@@ -96,33 +123,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
             logsProvider.VerifyAll();
             logsUploader.VerifyAll();
             runtimeInfoProvider.VerifyAll();
-        }
-
-        public static IEnumerable<object[]> GetLogsUploadRequestHandlerData()
-        {
-            string sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, ModuleLogFilter.Empty };
-
-            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""gzip""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, LogsContentEncoding.Gzip, LogsContentType.Json, ModuleLogFilter.Empty };
-
-            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            yield return new object[] { @"{""id"": ""mod1"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""gzip"", ""contentType"": ""text""}".Replace("<sasurl>", sasUrl), "mod1", sasUrl, LogsContentEncoding.Gzip, LogsContentType.Text, ModuleLogFilter.Empty };
-
-            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            yield return new object[] { @"{""id"": ""edgeHub"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""none"", ""contentType"": ""json""}".Replace("<sasurl>", sasUrl), "edgeHub", sasUrl, LogsContentEncoding.None, LogsContentType.Json, ModuleLogFilter.Empty };
-
-            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            var filter = new ModuleLogFilter(Option.Some(100), Option.Some(1501000), Option.Some(3), Option.Some("ERR"));
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
-
-            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            filter = new ModuleLogFilter(Option.None<int>(), Option.Some(1501000), Option.None<int>(), Option.Some("ERR"));
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
-
-            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            filter = new ModuleLogFilter(Option.Some(100), Option.None<int>(), Option.Some(3), Option.None<string>());
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
 
             // Act
             var logsUploadRequestHandler = new LogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, runtimeInfoProvider.Object);
-            Option<string> response = await logsUploadRequestHandler.HandleRequest(Option.Maybe(payload));
+            Option<string> response = await logsUploadRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
 
             // Assert
             Assert.False(response.HasValue);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
                 .Returns(Task.CompletedTask);
 
             // Act
-            var logsUploadRequestHandler = new LogsUploadRequestHandler(logsUploader.Object, logsProvider.Object);
+            var logsUploadRequestHandler = new LogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, Mock.Of<IRuntimeInfoProvider>());
             Option<string> response = await logsUploadRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
 
             // Assert

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Logs;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Requests;
+    using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
@@ -17,13 +18,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
     {
         [Theory]
         [MemberData(nameof(GetLogsUploadRequestHandlerData))]
-        public async Task TestLogsUploadRequest(string payload, string id, string sasUrl, LogsContentEncoding contentEncoding, LogsContentType contentType)
+        public async Task TestLogsUploadRequest(string payload, string id, string sasUrl, LogsContentEncoding contentEncoding, LogsContentType contentType, ModuleLogFilter filter)
         {
             // Arrange
             var logsUploader = new Mock<ILogsUploader>();
             var logsProvider = new Mock<ILogsProvider>();
             var uploadBytes = new byte[100];
-            logsProvider.Setup(l => l.GetLogs(It.IsAny<ModuleLogOptions>(), It.IsAny<CancellationToken>()))
+            var moduleLogOptions = new ModuleLogOptions(id, contentEncoding, contentType, filter);
+            logsProvider.Setup(l => l.GetLogs(moduleLogOptions, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(uploadBytes);
             logsUploader.Setup(l => l.Upload(sasUrl, id, uploadBytes, contentEncoding, contentType))
                 .Returns(Task.CompletedTask);
@@ -36,19 +38,60 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
             Assert.False(response.HasValue);
         }
 
+        //[Fact]
+        //public async Task TestLogsUploadAllTaskRequest()
+        //{
+        //    // Arrange
+        //    string sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+        //    var filter = new ModuleLogFilter(Option.Some(100), Option.Some(1501000), Option.Some(3), Option.Some("ERR"));
+        //    LogsContentEncoding contentEncoding = LogsContentEncoding.None;
+        //    LogsContentType contentType = LogsContentType.Json;
+        //    string payload = @"{""id"": ""all"",  ""sasUrl"": ""<sasurl>""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, contentEncoding, contentType, filter);
+            
+
+
+        //    var logsUploader = new Mock<ILogsUploader>();
+        //    var logsProvider = new Mock<ILogsProvider>();
+        //    var uploadBytes = new byte[100];
+        //    var moduleLogOptions = new ModuleLogOptions(id, contentEncoding, contentType, filter);
+        //    logsProvider.Setup(l => l.GetLogs(moduleLogOptions, It.IsAny<CancellationToken>()))
+        //        .ReturnsAsync(uploadBytes);
+        //    logsUploader.Setup(l => l.Upload(sasUrl, id, uploadBytes, contentEncoding, contentType))
+        //        .Returns(Task.CompletedTask);
+
+        //    // Act
+        //    var logsUploadRequestHandler = new LogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, Mock.Of<IRuntimeInfoProvider>());
+        //    Option<string> response = await logsUploadRequestHandler.HandleRequest(Option.Maybe(payload));
+
+        //    // Assert
+        //    Assert.False(response.HasValue);
+        //}
+
         public static IEnumerable<object[]> GetLogsUploadRequestHandlerData()
         {
             string sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json };
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, ModuleLogFilter.Empty };
 
             sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""gzip""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, LogsContentEncoding.Gzip, LogsContentType.Json };
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""gzip""}".Replace("<sasurl>", sasUrl), "edgeAgent", sasUrl, LogsContentEncoding.Gzip, LogsContentType.Json, ModuleLogFilter.Empty };
 
             sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""gzip"", ""contentType"": ""text""}".Replace("<sasurl>", sasUrl), "mod1", sasUrl, LogsContentEncoding.Gzip, LogsContentType.Text };
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""gzip"", ""contentType"": ""text""}".Replace("<sasurl>", sasUrl), "mod1", sasUrl, LogsContentEncoding.Gzip, LogsContentType.Text, ModuleLogFilter.Empty };
 
             sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
-            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""none"", ""contentType"": ""json""}".Replace("<sasurl>", sasUrl), "edgeHub", sasUrl, LogsContentEncoding.None, LogsContentType.Json };
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""encoding"": ""none"", ""contentType"": ""json""}".Replace("<sasurl>", sasUrl), "edgeHub", sasUrl, LogsContentEncoding.None, LogsContentType.Json, ModuleLogFilter.Empty };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some(1501000), Option.Some(3), Option.Some("ERR"));
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            filter = new ModuleLogFilter(Option.None<int>(), Option.Some(1501000), Option.None<int>(), Option.Some("ERR"));
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
+
+            sasUrl = $"https://test1.blob.core.windows.net/cont2?st={Guid.NewGuid()}";
+            filter = new ModuleLogFilter(Option.Some(100), Option.None<int>(), Option.Some(3), Option.None<string>());
+            yield return new object[] { @"{""id"": ""edgeAgent"",  ""sasUrl"": ""<sasurl>"", ""filter"": <filter>}".Replace("<sasurl>", sasUrl).Replace("<filter>", filter.ToJson()), "edgeAgent", sasUrl, LogsContentEncoding.None, LogsContentType.Json, filter };
         }
     }
 }


### PR DESCRIPTION
If id="all" in the logs upload request, then EA will upload logs for all the modules to the container. 
This is to make it easier to grab all logs from the device. 
The logs are obtained individually and uploaded to separate files in the same Azure blob container.