### PR TITLE
Don't lower-case the keys in config.yaml

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -342,6 +342,7 @@ dependencies = [
  "tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "url_serde 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/edgelet/edgelet-config/Cargo.toml
+++ b/edgelet/edgelet-config/Cargo.toml
@@ -17,6 +17,7 @@ serde_json = "1.0"
 sha2 = "0.7.0"
 url = "1.7"
 url_serde = "0.2"
+yaml-rust = "0.4"
 
 edgelet-core = { path = "../edgelet-core" }
 edgelet-utils = { path = "../edgelet-utils" }

--- a/edgelet/edgelet-config/src/yaml_file_source.rs
+++ b/edgelet/edgelet-config/src/yaml_file_source.rs
@@ -1,0 +1,133 @@
+use std::borrow::Cow;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::Read;
+use std::path::PathBuf;
+
+use config::{ConfigError, Source, Value};
+use yaml_rust::{Yaml, YamlLoader};
+
+/// This is similar to [`config::File`] in that it parses a YAML string or file and implements `config::Source`.
+///
+/// We use this to parse our config.yaml instead of `config::File` because `config::File` lower-cases all field names that it reads.
+/// This causes issues with fields like `agent.config.createOptions` since the config crate returns `agent.config.createoptions`
+/// which the serde deserializer ignores.
+#[derive(Clone, Debug)]
+pub(crate) enum YamlFileSource {
+    File(PathBuf),
+    String(&'static str),
+}
+
+impl Source for YamlFileSource {
+    fn clone_into_box(&self) -> Box<dyn Source + Send + Sync> {
+        Box::new(self.clone())
+    }
+
+    fn collect(&self) -> Result<HashMap<String, Value>, ConfigError> {
+        let origin = match self {
+            YamlFileSource::File(path) => Some(path.to_string_lossy().into_owned()),
+            YamlFileSource::String(_) => None,
+        };
+
+        let s = match self {
+            YamlFileSource::File(path) => {
+                let mut file =
+                    File::open(path).map_err(|err| ConfigError::Foreign(Box::new(err)))?;
+                let mut contents = String::new();
+                let _ = file
+                    .read_to_string(&mut contents)
+                    .map_err(|err| ConfigError::Foreign(Box::new(err)))?;
+                Cow::Owned(contents)
+            }
+
+            YamlFileSource::String(s) => Cow::Borrowed(*s),
+        };
+
+        let docs =
+            YamlLoader::load_from_str(&*s).map_err(|err| ConfigError::Foreign(Box::new(err)))?;
+
+        let mut docs = docs.into_iter();
+        let doc = match docs.next() {
+            Some(doc) => {
+                if docs.next().is_some() {
+                    return Err(ConfigError::Foreign(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        "More than one YAML document provided",
+                    ))));
+                }
+
+                doc
+            }
+
+            None => Yaml::Hash(Default::default()),
+        };
+
+        let mut result = HashMap::new();
+
+        if let Yaml::Hash(hash) = doc {
+            for (key, value) in hash {
+                if let Yaml::String(key) = key {
+                    result.insert(key, from_yaml_value(origin.as_ref(), value)?);
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+/// Identical to https://github.com/mehcode/config-rs/blob/0.8.0/src/file/format/yaml.rs#L32-L68
+/// except that it does not lower-case hash keys.
+///
+/// Unfortunately the `ValueKind` enum used by the `Value` constructor is not exported from the crate.
+/// It does however impl `From` for the various corresponding standard types, so this code uses those.
+/// The only difference is the fallback `_` case at the end.
+fn from_yaml_value(uri: Option<&String>, value: Yaml) -> Result<Value, ConfigError> {
+    match value {
+        Yaml::String(value) => Ok(Value::new(uri, value)),
+        Yaml::Real(value) => {
+            // TODO: Figure out in what cases this can fail?
+            Ok(Value::new(
+                uri,
+                value
+                    .parse::<f64>()
+                    .map_err(|err| ConfigError::Foreign(Box::new(err)))?,
+            ))
+        }
+        Yaml::Integer(value) => Ok(Value::new(uri, value)),
+        Yaml::Boolean(value) => Ok(Value::new(uri, value)),
+        Yaml::Hash(table) => {
+            let mut m = HashMap::new();
+            for (key, value) in table {
+                if let Yaml::String(key) = key {
+                    m.insert(key, from_yaml_value(uri, value)?);
+                }
+                // TODO: should we do anything for non-string keys?
+            }
+            Ok(Value::new(uri, m))
+        }
+        Yaml::Array(array) => {
+            let mut l = vec![];
+
+            for value in array {
+                l.push(from_yaml_value(uri, value)?);
+            }
+
+            Ok(Value::new(uri, l))
+        }
+
+        // 1. Yaml NULL
+        // 2. BadValue – It shouldn't be possible to hit BadValue as this only happens when
+        //               using the index trait badly or on a type error but we send back nil.
+        // 3. Alias – No idea what to do with this and there is a note in the lib that its
+        //            not fully supported yet anyway
+        //
+        // The original function returns `Value::new(uri, ValueKind::Nil)` here.
+        // Since `ValueKind` is private, we have to return Err instead. It shouldn't be a problem for our use case
+        // since we don't expect null / bad value / alias.
+        value => Err(ConfigError::Foreign(Box::new(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("unrecognized YAML value {:?}", value),
+        )))),
+    }
+}

--- a/edgelet/edgelet-config/test/linux/case_sensitive.yaml
+++ b/edgelet/edgelet-config/test/linux/case_sensitive.yaml
@@ -1,0 +1,29 @@
+provisioning:
+  source: "manual"
+  device_connection_string: "HostName=something.something.com;DeviceId=something;SharedAccessKey=QXp1cmUgSW9UIEVkZ2U="
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env:
+    AbC: "VAluE1"
+    DeF: "VAluE2"
+  config:
+    image: "microsoft/azureiotedge-agent:1.0"
+    auth: {}
+    createOptions:
+      Hostname: VAluE3
+hostname: "localhost"
+
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+
+homedir: "/tmp"
+
+moby_runtime:
+  uri: "http://localhost:2375"
+  network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/windows/case_sensitive.yaml
+++ b/edgelet/edgelet-config/test/windows/case_sensitive.yaml
@@ -14,18 +14,16 @@ agent:
       Hostname: VAluE3
 hostname: "localhost"
 
-# Sets the connection uris for clients
 connect:
   workload_uri: "http://localhost:8081"
   management_uri: "http://localhost:8080"
 
-# Sets the uris to listen on
-# These can be different than the connect uris.
-# For instance, when using the fd:// scheme for systemd
 listen:
   workload_uri: "http://0.0.0.0:8081"
   management_uri: "http://0.0.0.0:8080"
+
 homedir: "C:\\Temp"
+
 moby_runtime:
   uri: "npipe://./pipe/iotedge_moby_engine"
   network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/windows/case_sensitive.yaml
+++ b/edgelet/edgelet-config/test/windows/case_sensitive.yaml
@@ -1,0 +1,31 @@
+provisioning:
+  source: "manual"
+  device_connection_string: "HostName=something.something.com;DeviceId=something;SharedAccessKey=QXp1cmUgSW9UIEVkZ2U="
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env:
+    AbC: "VAluE1"
+    DeF: "VAluE2"
+  config:
+    image: "microsoft/azureiotedge-agent:1.0"
+    auth: {}
+    createOptions:
+      Hostname: VAluE3
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+homedir: "C:\\Temp"
+moby_runtime:
+  uri: "npipe://./pipe/iotedge_moby_engine"
+  network: "azure-iot-edge"


### PR DESCRIPTION
Fixes #1036

---

TODO:

- [x] ~~This probably breaks the use of env vars like `IOTEDGED_HOSTNAME` that could be used to override the config.yaml. Need to confirm.~~ It didn't break those which have lower-case keys already, like `hostname`, since the `Environment` source does still lower-case the keys it parses from the environment.

  It's probably acceptable since the ones that have mixed-case keys are deeply nested, and there were probably no users overriding them with env vars.