### PR TITLE
Normalize the name 'IotEdgeQuickstart'

### DIFF
--- a/doc/build-test.md
+++ b/doc/build-test.md
@@ -33,4 +33,4 @@ Our C# tests use [xUnit](https://xunit.github.io/docs/getting-started-dotnet-cor
 | Integration | Tests that verify interaction with dependencies _in isolation_ and core end-to-end scenarios.    | Require external configuration.                                                       | CI                |
 | Stress      | Specialized end-to-end tests for scenarios under heavy load.                                    |                                                                                       | N/A               |
 
-Besides these tests, E2E scenario testing is implemented in IoTEdgeQuickStart and LeafDevice project in smoke folder.  These tests will be run in Linux, Raspberry Pi and Windows to ensure all core IoT Edge features function correctly.
+Besides these tests, E2E scenario testing is implemented in IotEdgeQuickstart and LeafDevice project in smoke folder.  These tests will be run in Linux, Raspberry Pi and Windows to ensure all core IoT Edge features function correctly.

--- a/scripts/windows/build/Publish-Branch.ps1
+++ b/scripts/windows/build/Publish-Branch.ps1
@@ -228,25 +228,25 @@ Write-Host "Copying $SRC_CERT_TOOLS_DIR to $PUB_CERT_TOOLS_DIR"
 Copy-Item $SRC_CERT_TOOLS_DIR $PUB_CERT_TOOLS_DIR -Recurse -Force
 
 <#
- # Publish IoTEdgeQuickstart
+ # Publish IotEdgeQuickstart
  #>
-$IoTEdgeQuickstartProjectFolder = Join-Path $BuildRepositoryLocalPath "smoke/IoTEdgeQuickstart"
-$IoTEdgeQuickstartPublishBaseFolder = Join-Path $PUBLISH_FOLDER "IoTEdgeQuickstart"
+$IotEdgeQuickstartProjectFolder = Join-Path $BuildRepositoryLocalPath "smoke/IotEdgeQuickstart"
+$IotEdgeQuickstartPublishBaseFolder = Join-Path $PUBLISH_FOLDER "IotEdgeQuickstart"
 
-Write-Host "Publishing - IoTEdgeQuickstart x64"
-$ProjectPublishPath = Join-Path $IoTEdgeQuickstartPublishBaseFolder "x64"
-&$DOTNET_PATH publish -f netcoreapp2.1 -r "win10-x64" -c $Configuration -o $ProjectPublishPath $IoTEdgeQuickstartProjectFolder |
+Write-Host "Publishing - IotEdgeQuickstart x64"
+$ProjectPublishPath = Join-Path $IotEdgeQuickstartPublishBaseFolder "x64"
+&$DOTNET_PATH publish -f netcoreapp2.1 -r "win10-x64" -c $Configuration -o $ProjectPublishPath $IotEdgeQuickstartProjectFolder |
     Write-Host
 if ($LASTEXITCODE -ne 0) {
-    throw "Failed publishing IoTEdgeQuickstart x64."
+    throw "Failed publishing IotEdgeQuickstart x64."
 }
 
-Write-Host "Publishing - IoTEdgeQuickstart arm32"
-$ProjectPublishPath = Join-Path $IoTEdgeQuickstartPublishBaseFolder "arm32v7"
-&$DOTNET_PATH publish -f netcoreapp2.1 -r "win10-arm" -c $Configuration -o $ProjectPublishPath $IoTEdgeQuickstartProjectFolder |
+Write-Host "Publishing - IotEdgeQuickstart arm32"
+$ProjectPublishPath = Join-Path $IotEdgeQuickstartPublishBaseFolder "arm32v7"
+&$DOTNET_PATH publish -f netcoreapp2.1 -r "win10-arm" -c $Configuration -o $ProjectPublishPath $IotEdgeQuickstartProjectFolder |
     Write-Host
 if ($LASTEXITCODE -ne 0) {
-    throw "Failed publishing IoTEdgeQuickstart arm32."
+    throw "Failed publishing IotEdgeQuickstart arm32."
 }
 
 <#

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -222,8 +222,8 @@ Function PrepareTestFromArtifacts
     }
 
     # IoT Edge Quickstart
-    Write-Host "Copy IoT Edge Quickstart from $IoTEdgeQuickstartArtifactFolder to $QuickstartWorkingFolder"
-    Copy-Item $IoTEdgeQuickstartArtifactFolder -Destination $QuickstartWorkingFolder -Recurse -Force
+    Write-Host "Copy IoT Edge Quickstart from $IotEdgeQuickstartArtifactFolder to $QuickstartWorkingFolder"
+    Copy-Item $IotEdgeQuickstartArtifactFolder -Destination $QuickstartWorkingFolder -Recurse -Force
 
     # Leaf device
     If (($TestName -eq "QuickstartCerts") -Or ($TestName -eq "TransparentGateway"))
@@ -461,7 +461,7 @@ Function RunDirectMethodAmqpTest
     $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMAmqp"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
 
-    $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
+    $testCommand = "&$IotEdgeQuickstartExeTestPath ``
             -d `"$deviceId`" ``
             -c `"$IoTHubConnectionString`" ``
             -e `"$EventHubConnectionString`" ``
@@ -493,7 +493,7 @@ Function RunDirectMethodMqttTest
     $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-DMMqtt"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
 
-    $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
+    $testCommand = "&$IotEdgeQuickstartExeTestPath ``
             -d `"$deviceId`" ``
             -c `"$IoTHubConnectionString`" ``
             -e `"$EventHubConnectionString`" ``
@@ -525,7 +525,7 @@ Function RunQuickstartCertsTest
     $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-QuickstartCerts"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
 
-    $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
+    $testCommand = "&$IotEdgeQuickstartExeTestPath ``
         -d `"$deviceId`" ``
         -c `"$IoTHubConnectionString`" ``
         -e `"doesNotNeed`" ``
@@ -574,7 +574,7 @@ Function RunTempFilterTest
     $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilter"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
 
-    $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
+    $testCommand = "&$IotEdgeQuickstartExeTestPath ``
             -d `"$deviceId`" ``
             -c `"$IoTHubConnectionString`" ``
             -e `"$EventHubConnectionString`" ``
@@ -612,7 +612,7 @@ Function RunTempFilterFunctionsTest
     $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempFilterFunc"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt"
 
-    $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
+    $testCommand = "&$IotEdgeQuickstartExeTestPath ``
             -d `"$deviceId`" ``
             -c `"$IoTHubConnectionString`" ``
             -e `"$EventHubConnectionString`" ``
@@ -644,7 +644,7 @@ Function RunTempSensorTest
     $deviceId = "e2e-${ReleaseLabel}-Windows-${Architecture}-tempSensor"
     PrintHighlightedMessage "Run quickstart test with -d ""$deviceId"" started at $testStartAt."
 
-    $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
+    $testCommand = "&$IotEdgeQuickstartExeTestPath ``
         -d `"$deviceId`" ``
         -c `"$IoTHubConnectionString`" ``
         -e `"$EventHubConnectionString`" ``
@@ -799,7 +799,7 @@ Function RunTransparentGatewayTest
     New-CACertsEdgeDevice $edgeDeviceId
 
     #launch the edge as a transparent gateway
-    $testCommand = "&$IoTEdgeQuickstartExeTestPath ``
+    $testCommand = "&$IotEdgeQuickstartExeTestPath ``
         -d `"$edgeDeviceId`" ``
         -c `"$IoTHubConnectionString`" ``
         -e `"doesNotNeed`" ``
@@ -862,7 +862,7 @@ Function RunTest
 
 Function SetEnvironmentVariable
 {
-    # IoTEdgeQuickstart runs different processes to call iotedge list right after running installation script.
+    # IotEdgeQuickstart runs different processes to call iotedge list right after running installation script.
     # E2E test failed randomly when running iotedge list command throws Win32Exception as Path environment variable may not be in place yet.
     # Therefore set it explicitly before running each test.
     $env:Path="$env:Path;C:\Program Files\iotedge-moby;C:\Program Files\iotedge"
@@ -887,7 +887,7 @@ Function ValidateTestParameters
     }
 
     $validatingItems = @(
-        (Join-Path $IoTEdgeQuickstartArtifactFolder "*"),
+        (Join-Path $IotEdgeQuickstartArtifactFolder "*"),
         $InstallationScriptPath)
 
     If (($TestName -eq "DirectMethodAmqp") -Or ($TestName -eq "DirectMethodMqtt"))
@@ -961,7 +961,7 @@ $RuntimeOnlyDeploymentFilename = 'runtime_only_deployment.template.json'
 $QuickstartDeploymentFilename = 'quickstart_deployment.template.json'
 $TwinTestFilename = "twin_test_tempSensor.json"
 
-$IoTEdgeQuickstartArtifactFolder = Join-Path $E2ETestFolder "artifacts\core-windows\IoTEdgeQuickstart\$Architecture"
+$IotEdgeQuickstartArtifactFolder = Join-Path $E2ETestFolder "artifacts\core-windows\IotEdgeQuickstart\$Architecture"
 $LeafDeviceArtifactFolder = Join-Path $E2ETestFolder "artifacts\core-windows\LeafDevice\$Architecture"
 $IoTEdgedArtifactFolder = Join-Path $E2ETestFolder "artifacts\iotedged-windows"
 $PackagesArtifactFolder = Join-Path $E2ETestFolder "artifacts\packages"
@@ -979,7 +979,7 @@ $QuickstartWorkingFolder = (Join-Path $TestWorkingFolder "quickstart")
 $LeafDeviceWorkingFolder = (Join-Path $TestWorkingFolder "leafdevice")
 $IoTEdgedWorkingFolder = (Join-Path $TestWorkingFolder "iotedged")
 $PackagesWorkingFolder = (Join-Path $TestWorkingFolder "packages")
-$IoTEdgeQuickstartExeTestPath = (Join-Path $QuickstartWorkingFolder "IotEdgeQuickstart.exe")
+$IotEdgeQuickstartExeTestPath = (Join-Path $QuickstartWorkingFolder "IotEdgeQuickstart.exe")
 $LeafDeviceExeTestPath = (Join-Path $LeafDeviceWorkingFolder "LeafDevice.exe")
 $DeploymentWorkingFilePath = Join-Path $QuickstartWorkingFolder "deployment.json"
 


### PR DESCRIPTION
I noticed a few different variations of capitalization on the name 'IotEdgeQuickstart' creeping in. I'm worried  this could lead to hard-to-diagnose problems in the Linux builds that produce/consume this test app as an artifact.

This change is purely a tool-based search/replace to normalize all instances of the name.