### PR TITLE
Make v2 TwinManager manager default

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 .Map(s => TimeSpan.FromSeconds(s));
             bool useV1TwinManager = this.GetConfigurationValueIfExists<string>("TwinManagerVersion")
                 .Map(v => v.Equals("v1", StringComparison.OrdinalIgnoreCase))
-                .GetOrElse(true);
+                .GetOrElse(false);
 
             builder.RegisterModule(
                 new RoutingModule(


### PR DESCRIPTION
Making V2 Twin Manager default, for the 1.0.8 release