### PR TITLE
Use .NET Core installer task for linux arm64 images pipeline

### DIFF
--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -17,7 +17,7 @@ jobs:
         displayName: Install .NET Core
         inputs:
           packageType: sdk
-          version: 3.0.100
+          version: 3.0.100-preview-010184
 
       - bash: 'docker login $(registry.address) --username $(registry.user) --password $(registry.password)'
         displayName: 'Docker Login'

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -12,12 +12,12 @@ jobs:
     displayName: LinuxARM64
     pool:
       vmImage: 'ubuntu-16.04'
-    variables:
-      NetCorePackageUri: https://download.visualstudio.microsoft.com/download/pr/efa6dde9-a5ee-4322-b13c-a2a02d3980f0/dad445eba341c1d806bae5c8afb47015/dotnet-sdk-3.0.100-preview-010184-linux-x64.tar.gz
     steps:
-      - script: scripts/linux/installPrereqs.sh -u $(NetCorePackageUri)
-        name: install
-        displayName: Install dependencies
+      - task: DotNetCoreInstaller@0
+        displayName: Install .NET Core
+        inputs:
+          packageType: sdk
+          version: 3.0.100
 
       - bash: 'docker login $(registry.address) --username $(registry.user) --password $(registry.password)'
         displayName: 'Docker Login'


### PR DESCRIPTION
The arm64 pipeline in the images build is using a script to install .NET Core, but then recent changes to the build script are looking on the PATH for dotnet so it doesn't use what was installed. This change updates the pipeline to use the .NET Core Installer task instead of our custom script.