### PR TITLE
Change remaining paths /var/run/iotedge to /var/lib/iotedge

### DIFF
--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -159,7 +159,7 @@ connect:
 # These values can be different from the connect URIs. For instance, when
 # using the fd:// scheme for systemd:
 #     listen address is fd://iotedge.workload,
-#     connect address is unix:///var/run/iotedge/workload.sock
+#     connect address is unix:///var/lib/iotedge/workload.sock
 #
 # Note: When using the fd:// scheme for listen.management_uri or listen.workload_uri,
 # the path of connect.management_uri and connect.workload_uri must match

--- a/edgelet/contrib/config/linux/debian/config.yaml
+++ b/edgelet/contrib/config/linux/debian/config.yaml
@@ -134,8 +134,8 @@ hostname: "<ADD HOSTNAME HERE>"
 ###############################################################################
 
 connect:
-  management_uri: "unix:///var/run/iotedge/mgmt.sock"
-  workload_uri: "unix:///var/run/iotedge/workload.sock"
+  management_uri: "unix:///var/lib/iotedge/mgmt.sock"
+  workload_uri: "unix:///var/lib/iotedge/workload.sock"
 
 ###############################################################################
 # Listen settings
@@ -154,7 +154,7 @@ connect:
 # These values can be different from the connect URIs. For instance, when
 # using the fd:// scheme for systemd:
 #     listen address is fd://iotedge.workload,
-#     connect address is unix:///var/run/iotedge/workload.sock
+#     connect address is unix:///var/lib/iotedge/workload.sock
 #
 ###############################################################################
 

--- a/edgelet/contrib/systemd/debian/iotedge.mgmt.socket
+++ b/edgelet/contrib/systemd/debian/iotedge.mgmt.socket
@@ -4,7 +4,7 @@ Documentation=man:iotedged(8)
 PartOf=iotedge.service
 
 [Socket]
-ListenStream=/var/run/iotedge/mgmt.sock
+ListenStream=/var/lib/iotedge/mgmt.sock
 SocketMode=0660
 DirectoryMode=0755
 SocketUser=iotedge

--- a/edgelet/contrib/systemd/debian/iotedge.socket
+++ b/edgelet/contrib/systemd/debian/iotedge.socket
@@ -4,7 +4,7 @@ Documentation=man:iotedged(8)
 PartOf=iotedge.service
 
 [Socket]
-ListenStream=/var/run/iotedge/workload.sock
+ListenStream=/var/lib/iotedge/workload.sock
 SocketMode=0666
 DirectoryMode=0755
 SocketUser=iotedge

--- a/edgelet/edgelet-config/config/unix/default.yaml
+++ b/edgelet/edgelet-config/config/unix/default.yaml
@@ -13,12 +13,12 @@ agent:
 hostname: "localhost"
 
 connect:
-  management_uri: "unix:///var/run/iotedge/mgmt.sock"
-  workload_uri: "unix:///var/run/iotedge/workload.sock"
+  management_uri: "unix:///var/lib/iotedge/mgmt.sock"
+  workload_uri: "unix:///var/lib/iotedge/workload.sock"
 
 listen:
-  management_uri: "unix:///var/run/iotedge/mgmt.sock"
-  workload_uri: "unix:///var/run/iotedge/workload.sock"
+  management_uri: "unix:///var/lib/iotedge/mgmt.sock"
+  workload_uri: "unix:///var/lib/iotedge/workload.sock"
 
 homedir: "/var/lib/iotedge"
 

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -18,7 +18,7 @@ use edgelet_http_mgmt::ModuleClient;
 use iotedge::*;
 
 #[cfg(unix)]
-const MGMT_URI: &str = "unix:///var/run/iotedge/mgmt.sock";
+const MGMT_URI: &str = "unix:///var/lib/iotedge/mgmt.sock";
 #[cfg(windows)]
 const MGMT_URI: &str = "unix:///C:/ProgramData/iotedge/mgmt/sock";
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -205,8 +205,8 @@ namespace IotEdgeQuickstart.Details
             }
             else
             {
-                doc.ReplaceOrAdd("connect.management_uri", "unix:///var/run/iotedge/mgmt.sock");
-                doc.ReplaceOrAdd("connect.workload_uri", "unix:///var/run/iotedge/workload.sock");
+                doc.ReplaceOrAdd("connect.management_uri", "unix:///var/lib/iotedge/mgmt.sock");
+                doc.ReplaceOrAdd("connect.workload_uri", "unix:///var/lib/iotedge/workload.sock");
                 doc.ReplaceOrAdd("listen.management_uri", "fd://iotedge.mgmt.socket");
                 doc.ReplaceOrAdd("listen.workload_uri", "fd://iotedge.socket");
             }


### PR DESCRIPTION
This changes all remaining occurrences of `/var/run/iotedge` to `/var/lib/iotedge`. Otherwise the systemd service for iotedge would falsely create sockets in `/var/run/iotedge` instead of the used `/var/lib/iotedge`. Additionally the iotedge CLI now uses a correct default for `IOTEDGE_HOST`.

The changes introduced in version 1.0.2 (see #271 ) renamed the above paths but didn't catch all occurrences.

Other, somewhat related issues: #256 #228 