### PR TITLE
Remove unused arg from docker build

### DIFF
--- a/scripts/linux/buildImage.sh
+++ b/scripts/linux/buildImage.sh
@@ -263,7 +263,7 @@ docker_build_and_tag_and_push \
     "$ARCH" \
     "$DOCKERFILE" \
     "$PUBLISH_DIR/$PROJECT" \
-    "${build_args[@]/#/--build-arg buildno=$BUILD_BUILDNUMBER --build-arg }"
+    "${build_args[@]/#/--build-arg }"
 [ $? -eq 0 ] || exit $?
 
 echo "Done building and pushing Docker image $DOCKER_IMAGENAME for $PROJECT"


### PR DESCRIPTION
`ARG buildno` was added to several Dockerfiles in the past, but then the argument was removed. The argument reference in the build script should also have been removed, but it wasn't. This change removes the unused argument so that it isn't passed to the `docker build` command.