### PR TITLE
Fix direct method e2e tests on RPi

### DIFF
--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -135,20 +135,31 @@ function prepare_test_from_artifacts() {
             'directmethodmqtt')
                 echo "Copy deployment file from $dm_module_to_module_deployment_artifact_file"
                 cp "$dm_module_to_module_deployment_artifact_file" "$deployment_working_file"
-                
+
+                # Temporarily fix to run on RPi, bug is created (https://msazure.visualstudio.com/One/_workitems/edit/4396517)
+                if [[ "$image_architecture_label" == 'arm32v7' ]]; then
+                    sed -i -e "s@<UpstreamProtocol>@Amqp@g" "$deployment_working_file"
+                else
+                    sed -i -e "s@<UpstreamProtocol>@Mqtt@g" "$deployment_working_file"
+                fi
                 sed -i -e "s@<UpstreamProtocol>@Mqtt@g" "$deployment_working_file"
                 sed -i -e "s@<ClientTransportType>@Mqtt_Tcp_Only@g" "$deployment_working_file";;
             'directmethodmqttws')
                 echo "Copy deployment file from $dm_module_to_module_deployment_artifact_file"
                 cp "$dm_module_to_module_deployment_artifact_file" "$deployment_working_file"
 
-                sed -i -e "s@<UpstreamProtocol>@Mqttws@g" "$deployment_working_file"
+                # Temporarily fix to run on RPi, bug is created (https://msazure.visualstudio.com/One/_workitems/edit/4396517)
+                if [[ "$image_architecture_label" == 'arm32v7' ]]; then
+                    sed -i -e "s@<UpstreamProtocol>@AmqpWs@g" "$deployment_working_file"
+                else
+                    sed -i -e "s@<UpstreamProtocol>@MqttWs@g" "$deployment_working_file"
+                fi
                 sed -i -e "s@<ClientTransportType>@Mqtt_WebSocket_Only@g" "$deployment_working_file";;
             'longhaul' | 'stress')
                 if [[ "${TEST_NAME,,}" == 'longhaul' ]]; then
                     echo "Copy deployment file from $long_haul_deployment_artifact_file"
                     cp "$long_haul_deployment_artifact_file" "$deployment_working_file"
-                    
+
                     sed -i -e "s@<LoadGen.TransportType>@$LOADGEN_TRANSPORT_TYPE@g" "$deployment_working_file"
                     sed -i -e "s@<ServiceClientConnectionString>@$IOTHUB_CONNECTION_STRING@g" "$deployment_working_file"
                 else

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -136,7 +136,7 @@ function prepare_test_from_artifacts() {
                 echo "Copy deployment file from $dm_module_to_module_deployment_artifact_file"
                 cp "$dm_module_to_module_deployment_artifact_file" "$deployment_working_file"
 
-                # Temporarily fix to run on RPi, bug is created (https://msazure.visualstudio.com/One/_workitems/edit/4396517)
+                # Temporarily fix to avoid edgeHub fail when running on RPi, bug is created (https://msazure.visualstudio.com/One/_workitems/edit/4396517)
                 if [[ "$image_architecture_label" == 'arm32v7' ]]; then
                     sed -i -e "s@<UpstreamProtocol>@Amqp@g" "$deployment_working_file"
                 else
@@ -148,7 +148,7 @@ function prepare_test_from_artifacts() {
                 echo "Copy deployment file from $dm_module_to_module_deployment_artifact_file"
                 cp "$dm_module_to_module_deployment_artifact_file" "$deployment_working_file"
 
-                # Temporarily fix to run on RPi, bug is created (https://msazure.visualstudio.com/One/_workitems/edit/4396517)
+                # Temporarily fix to avoid edgeHub fail when running on RPi, bug is created (https://msazure.visualstudio.com/One/_workitems/edit/4396517)
                 if [[ "$image_architecture_label" == 'arm32v7' ]]; then
                     sed -i -e "s@<UpstreamProtocol>@AmqpWs@g" "$deployment_working_file"
                 else


### PR DESCRIPTION
Use amqp upstream protocol for Direct Method Mqtt/MqttWs e2e tests to avoid edgeHub crash.