### PR TITLE
Convert iotedged rc versions to docker rc versions in check default

### DIFF
--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -63,7 +63,7 @@ fn run() -> Result<(), Error> {
     let default_uri = option_env!("IOTEDGE_HOST").unwrap_or(MGMT_URI);
     let default_diagnostics_image_name = format!(
         "mcr.microsoft.com/azureiotedge-diagnostics:{}",
-        edgelet_core::version()
+        edgelet_core::version().replace("~", "-")
     );
 
     let matches = App::new(crate_name!())


### PR DESCRIPTION
`iotedged` rc versions include a `~` to work with the deb pre-release scheme. However, this is an invalid character for docker image tags, so a `-` is used for rc docker image tags. The default version in `version.txt` needs to be converted from a `iotedged` version to a docker version by replacing `~` with `-`.