### PR TITLE
Update runtime log level for long haul and stress tests

### DIFF
--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -519,6 +519,7 @@ function run_longhaul_test() {
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" \
         --leave-running=All \
         -l "$deployment_working_file" \
+        --runtime-log-level "Info" \
         --no-verify && ret=$? || ret=$?
 
     local elapsed_seconds=$SECONDS
@@ -595,6 +596,7 @@ function run_stress_test() {
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" \
         --leave-running=All \
         -l "$deployment_working_file" \
+        --runtime-log-level "Info" \
         --no-verify && ret=$? || ret=$?
 
     local elapsed_seconds=$SECONDS


### PR DESCRIPTION
Update long haul and stress with Info runtime log level; in order to avoid huge size of log files are generated during tests.