### PR TITLE
Fix `iotedge check` to use version without commit hash for container image tag

### DIFF
--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -36,7 +36,9 @@ pub use module::{
 pub use workload::WorkloadConfig;
 
 lazy_static! {
-    static ref VERSION: String = option_env!("VERSION")
+    static ref VERSION: &'static str =
+        option_env!("VERSION").unwrap_or_else(|| include_str!("../../version.txt").trim());
+    static ref VERSION_WITH_SOURCE_VERSION: String = option_env!("VERSION")
         .map(|version| option_env!("BUILD_SOURCEVERSION")
             .map(|sha| format!("{} ({})", version, sha))
             .unwrap_or_else(|| version.to_string()))
@@ -45,6 +47,10 @@ lazy_static! {
 
 pub fn version() -> &'static str {
     &VERSION
+}
+
+pub fn version_with_source_version() -> &'static str {
+    &VERSION_WITH_SOURCE_VERSION
 }
 
 pub trait UrlExt {

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -343,7 +343,7 @@ impl SystemInfo {
         SystemInfo {
             os_type,
             architecture,
-            version: super::version(),
+            version: super::version_with_source_version(),
         }
     }
 

--- a/edgelet/edgelet-http-mgmt/src/server/system_info/get.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/system_info/get.rs
@@ -106,7 +106,10 @@ mod tests {
 
                 assert_eq!("os_type_sample", os_type);
                 assert_eq!("architecture_sample", architecture);
-                assert_eq!(edgelet_core::version(), system_info.version());
+                assert_eq!(
+                    edgelet_core::version_with_source_version(),
+                    system_info.version(),
+                );
 
                 Ok(())
             })

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -57,7 +57,7 @@ fn run() -> Result<(), Error> {
     );
 
     let matches = App::new(crate_name!())
-        .version(edgelet_core::version())
+        .version(edgelet_core::version_with_source_version())
         .about(crate_description!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .arg(

--- a/edgelet/iotedge/src/version.rs
+++ b/edgelet/iotedge/src/version.rs
@@ -22,7 +22,11 @@ impl Command for Version {
 
     #[allow(clippy::print_literal)]
     fn execute(&mut self) -> Self::Future {
-        println!("{} {}", crate_name!(), edgelet_core::version());
+        println!(
+            "{} {}",
+            crate_name!(),
+            edgelet_core::version_with_source_version(),
+        );
         future::ok(())
     }
 }

--- a/edgelet/iotedged/src/app.rs
+++ b/edgelet/iotedged/src/app.rs
@@ -15,7 +15,7 @@ use crate::logging;
 
 pub fn create_base_app<'a, 'b>() -> App<'a, 'b> {
     App::new(crate_name!())
-        .version(edgelet_core::version())
+        .version(edgelet_core::version_with_source_version())
         .author(crate_authors!("\n"))
         .about(crate_description!())
         .arg(
@@ -48,7 +48,7 @@ pub fn create_app<'a, 'b>() -> App<'a, 'b> {
 
 pub fn log_banner() {
     info!("Starting Azure IoT Edge Security Daemon");
-    info!("Version - {}", edgelet_core::version());
+    info!("Version - {}", edgelet_core::version_with_source_version());
 }
 
 pub fn init_common<'a>() -> Result<(Settings<DockerConfig>, ArgMatches<'a>), Error> {


### PR DESCRIPTION
Is there a better name for `version_with_source_version` ?