### PR TITLE
upstream protocol for direct method tests on ARM

### DIFF
--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -136,24 +136,13 @@ function prepare_test_from_artifacts() {
                 echo "Copy deployment file from $dm_module_to_module_deployment_artifact_file"
                 cp "$dm_module_to_module_deployment_artifact_file" "$deployment_working_file"
 
-                # Temporarily fix to avoid edgeHub fail when running on RPi, bug is created (https://msazure.visualstudio.com/One/_workitems/edit/4396517)
-                if [[ "$image_architecture_label" == 'arm32v7' ]]; then
-                    sed -i -e "s@<UpstreamProtocol>@Amqp@g" "$deployment_working_file"
-                else
-                    sed -i -e "s@<UpstreamProtocol>@Mqtt@g" "$deployment_working_file"
-                fi
                 sed -i -e "s@<UpstreamProtocol>@Mqtt@g" "$deployment_working_file"
                 sed -i -e "s@<ClientTransportType>@Mqtt_Tcp_Only@g" "$deployment_working_file";;
             'directmethodmqttws')
                 echo "Copy deployment file from $dm_module_to_module_deployment_artifact_file"
                 cp "$dm_module_to_module_deployment_artifact_file" "$deployment_working_file"
 
-                # Temporarily fix to avoid edgeHub fail when running on RPi, bug is created (https://msazure.visualstudio.com/One/_workitems/edit/4396517)
-                if [[ "$image_architecture_label" == 'arm32v7' ]]; then
-                    sed -i -e "s@<UpstreamProtocol>@AmqpWs@g" "$deployment_working_file"
-                else
-                    sed -i -e "s@<UpstreamProtocol>@MqttWs@g" "$deployment_working_file"
-                fi
+                sed -i -e "s@<UpstreamProtocol>@MqttWs@g" "$deployment_working_file"
                 sed -i -e "s@<ClientTransportType>@Mqtt_WebSocket_Only@g" "$deployment_working_file";;
             'longhaul' | 'stress')
                 if [[ "${TEST_NAME,,}" == 'longhaul' ]]; then


### PR DESCRIPTION
Revert back the change for upstream protocol for mqtt/mqttws direct method tests since it works with SDK 1.20