### PR TITLE
Revert edge_hsm_sas_auth_int integration test to use public TPM API

### DIFF
--- a/builds/checkin/libiothsm.yaml
+++ b/builds/checkin/libiothsm.yaml
@@ -22,7 +22,7 @@ jobs:
         displayName: Setup
         inputs:
           cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
-          cmakeArgs: -Drun_valgrind=ON -DBUILD_SHARED=ON -Drun_unittests=ON -Duse_emulator=OFF -Duse_http=OFF -DCMAKE_BUILD_TYPE=Release -DCPACK_DEBIAN_PACKAGE_RELEASE=$(Build.BuildNumber) ..
+          cmakeArgs: -Drun_valgrind=ON -DBUILD_SHARED=ON -Drun_unittests=ON -Duse_emulator=OFF -Duse_http=OFF -DUSE_TEST_TPM_INTERFACE_IN_MEM=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_DEBIAN_PACKAGE_RELEASE=$(Build.BuildNumber) ..
       - script: make package
         displayName: Build
         workingDirectory: edgelet/hsm-sys/azure-iot-hsm-c/build

--- a/builds/ci/libiothsm.yaml
+++ b/builds/ci/libiothsm.yaml
@@ -26,7 +26,7 @@ jobs:
         displayName: Setup
         inputs:
           cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
-          cmakeArgs: -Drun_valgrind=ON -DBUILD_SHARED=ON -Drun_unittests=ON -Duse_emulator=OFF -Duse_http=OFF -DCMAKE_BUILD_TYPE=Release -DCPACK_DEBIAN_PACKAGE_RELEASE=$(Build.BuildNumber) ..
+          cmakeArgs: -Drun_valgrind=ON -DBUILD_SHARED=ON -Drun_unittests=ON -Duse_emulator=OFF -Duse_http=OFF -DUSE_TEST_TPM_INTERFACE_IN_MEM=ON -DCMAKE_BUILD_TYPE=Release -DCPACK_DEBIAN_PACKAGE_RELEASE=$(Build.BuildNumber) ..
       - script: make package
         displayName: Build
         workingDirectory: edgelet/hsm-sys/azure-iot-hsm-c/build

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_sas_auth_int/edge_hsm_sas_auth_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_sas_auth_int/edge_hsm_sas_auth_int.c
@@ -19,7 +19,6 @@
 #include "azure_c_shared_utility/crt_abstractions.h"
 
 #include "hsm_client_data.h"
-#include "hsm_client_tpm_in_mem.h"
 
 //#############################################################################
 // Test defines and data
@@ -69,9 +68,9 @@ static void test_helper_tear_down_homedir(void)
 static HSM_CLIENT_HANDLE tpm_provision(void)
 {
     int status;
-    status = hsm_client_tpm_store_init();
+    status = hsm_client_tpm_init();
     ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
+    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
     HSM_CLIENT_HANDLE result = interface->hsm_client_tpm_create();
     ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
     return result;
@@ -84,7 +83,7 @@ static void tpm_activate_key
     size_t key_size
 )
 {
-    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
+    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
     int status = interface->hsm_client_activate_identity_key(hsm_handle, key, key_size);
     ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
 }
@@ -99,7 +98,7 @@ static int tpm_sign
     BUFFER_HANDLE hash
 )
 {
-    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
+    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
     unsigned char *digest;
     size_t digest_size;
     int status;
@@ -126,9 +125,9 @@ static int tpm_sign
 
 static void tpm_deprovision(HSM_CLIENT_HANDLE hsm_handle)
 {
-    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
+    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
     interface->hsm_client_tpm_destroy(hsm_handle);
-    hsm_client_tpm_store_deinit();
+    hsm_client_tpm_deinit();
 }
 
 static BUFFER_HANDLE test_helper_base64_converter(const char* input)


### PR DESCRIPTION
b5f281b6f6b7594bc4aa395c0088731e06400af3 changed this test to use the
`*tpm_store*` functions. But it fails to link on Windows since the functions
are not available to be linked to. Since it's an integration test,
it should be using the public libiothsm API anyway.

This change reverts the test to use the public libiothsm API again.