### PR TITLE
Add support for encrypting twins at rest

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -132,6 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 .GetOrElse(false);
             int maxUpstreamBatchSize = this.configuration.GetValue("MaxUpstreamBatchSize", 10);
             int upstreamFanOutFactor = this.configuration.GetValue("UpstreamFanOutFactor", 10);
+            bool encryptTwinStore = this.configuration.GetValue("EncryptTwinStore", false);
 
             builder.RegisterModule(
                 new RoutingModule(
@@ -155,7 +156,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     reportedPropertiesSyncFrequency,
                     useV1TwinManager,
                     maxUpstreamBatchSize,
-                    upstreamFanOutFactor));
+                    upstreamFanOutFactor,
+                    encryptTwinStore));
         }
 
         void RegisterCommonModule(ContainerBuilder builder, bool optimizeForPerformance, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -3,7 +3,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
 {
     using System;
     using System.Collections.Generic;
-    using System.Data;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
@@ -553,11 +552,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         {
             var storeProvider = context.Resolve<IStoreProvider>();
             Option<IEncryptionProvider> encryptionProvider = await context.Resolve<Task<Option<IEncryptionProvider>>>();
-           IEntityStore<TK, TV> entityStore = encryptionProvider.Map(
+            IEntityStore<TK, TV> entityStore = encryptionProvider.Map(
                     e =>
                     {
                         IEntityStore<string, string> underlyingEntityStore = storeProvider.GetEntityStore<string, string>($"underlying{entityName}");
-                        IKeyValueStore<string, string> es = new EncryptedStore<string, string>(underlyingEntityStore, e);                    
+                        IKeyValueStore<string, string> es = new EncryptedStore<string, string>(underlyingEntityStore, e);
                         ITypeMapper<TK, string> keyMapper = new JsonMapper<TK>();
                         ITypeMapper<TV, string> valueMapper = new JsonMapper<TV>();
                         IKeyValueStore<TK, TV> dbStoreMapper = new KeyValueStoreMapper<TK, string, TV, string>(es, keyMapper, valueMapper);
@@ -566,7 +565,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     })
                 .GetOrElse(
                     () => storeProvider.GetEntityStore<TK, TV>(entityName));
-                
+
             return entityStore;
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -560,7 +560,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         IKeyValueStore<string, string> es = new EncryptedStore<string, string>(underlyingEntityStore, e);                    
                         ITypeMapper<TK, string> keyMapper = new JsonMapper<TK>();
                         ITypeMapper<TV, string> valueMapper = new JsonMapper<TV>();
-                        IKeyValueStore<TK, TV> dbStoreMapper = new DbStoreMapper<TK, string, TV, string>(es, keyMapper, valueMapper);
+                        IKeyValueStore<TK, TV> dbStoreMapper = new KeyValueStoreMapper<TK, string, TV, string>(es, keyMapper, valueMapper);
                         IEntityStore<TK, TV> tes = new EntityStore<TK, TV>(dbStoreMapper, entityName);
                         return tes;
                     })

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -551,7 +551,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             base.Load(builder);
         }
 
-        static async Task<IEntityStore<TK, TV>> GetEncryptedEntityStoreIfSupported<TK, TV>(IComponentContext context, string entityName)
+        static async Task<IEntityStore<TK, TV>> GetUpdatableEncryptedEntityStoreIfSupported<TK, TV>(IComponentContext context, string entityName)
         {
             var storeProvider = context.Resolve<IStoreProvider>();
             Option<IEncryptionProvider> encryptionProvider = await context.Resolve<Task<Option<IEncryptionProvider>>>();
@@ -559,7 +559,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     e =>
                     {
                         IEntityStore<string, string> underlyingEntityStore = storeProvider.GetEntityStore<string, string>($"underlying{entityName}");
-                        IKeyValueStore<string, string> es = new EncryptedStore<string, string>(underlyingEntityStore, e);
+                        IKeyValueStore<string, string> es = new UpdatableEncryptedStore<string, string>(underlyingEntityStore, e);
                         ITypeMapper<TK, string> keyMapper = new JsonMapper<TK>();
                         ITypeMapper<TV, string> valueMapper = new JsonMapper<TV>();
                         IKeyValueStore<TK, TV> dbStoreMapper = new KeyValueStoreMapper<TK, string, TV, string>(es, keyMapper, valueMapper);
@@ -578,7 +578,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             IEntityStore<string, TwinStoreEntity> twinStore;
             if (this.encryptTwinStore)
             {
-                twinStore = await GetEncryptedEntityStoreIfSupported<string, TwinStoreEntity>(context, entityName);
+                twinStore = await GetUpdatableEncryptedEntityStoreIfSupported<string, TwinStoreEntity>(context, entityName);
             }
             else
             {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var serviceProxy = new Mock<IServiceProxy>();
             serviceProxy.Setup(s => s.GetServiceIdentitiesIterator()).Returns(iterator.Object);
 
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthentication = new ServiceAuthentication(ServiceAuthenticationType.None);
             var si1 = new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
             var si2 = new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task RefreshCacheTest()
         {
             // Arrange
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthentication = new ServiceAuthentication(ServiceAuthenticationType.None);
             Func<ServiceIdentity> si1 = () => new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
             Func<ServiceIdentity> si2 = () => new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
@@ -139,7 +139,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task RefreshCacheWithRefreshRequestTest()
         {
             // Arrange
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthentication = new ServiceAuthentication(ServiceAuthenticationType.None);
             Func<ServiceIdentity> si1 = () => new ServiceIdentity("d1", "1234", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
             Func<ServiceIdentity> si2 = () => new ServiceIdentity("d2", "m1", "2345", Enumerable.Empty<string>(), serviceAuthentication, ServiceIdentityStatus.Enabled);
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task RefreshServiceIdentityTest_Device()
         {
             // Arrange
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
             var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
 
@@ -343,7 +343,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task RefreshServiceIdentityTest_List()
         {
             // Arrange
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
             var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
 
@@ -410,7 +410,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task RefreshServiceIdentityTest_Module()
         {
             // Arrange
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
             var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
 
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task GetServiceIdentityTest_Device()
         {
             // Arrange
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
             var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
 
@@ -538,7 +538,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task GetServiceIdentityTest_Module()
         {
             // Arrange
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
             var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
 
@@ -603,7 +603,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         public async Task GetServiceIdentityFromServiceTest()
         {
             // Arrange
-            var store = new EntityStore<string, string>(new InMemoryDbStore(), "cache");
+            var store = GetEntityStore("cache");
             var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
             var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
 
@@ -628,5 +628,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         }
 
         static string GetKey() => Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()));
+
+        static IEntityStore<string, string> GetEntityStore(string entityName)
+            => new EntityStore<string, string>(new KeyValueStoreMapper<string, byte[], string, byte[]>(new InMemoryDbStore(), new BytesMapper<string>(), new BytesMapper<string>()), entityName);
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -139,7 +139,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     Option.None<TimeSpan>(),
                     false,
                     10,
-                    10));
+                    10,
+                    false));
 
             builder.RegisterModule(new HttpModule());
             builder.RegisterModule(new MqttModule(mqttSettingsConfiguration.Object, topics, this.serverCertificate, false, false, false));

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/DbStoreMapper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/DbStoreMapper.cs
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Storage
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public class DbStoreMapper<TK, TK1, TV, TV1> : IKeyValueStore<TK, TV>
+    {
+        readonly IKeyValueStore<TK1, TV1> dbStore;
+        readonly ITypeMapper<TK, TK1> keyMapper;
+        readonly ITypeMapper<TV, TV1> valueMapper;
+
+        public DbStoreMapper(IKeyValueStore<TK1, TV1> dbStore, ITypeMapper<TK, TK1> keyMapper, ITypeMapper<TV, TV1> valueMapper)
+        {
+            this.dbStore = Preconditions.CheckNotNull(dbStore, nameof(dbStore));
+            this.keyMapper = Preconditions.CheckNotNull(keyMapper, nameof(keyMapper));
+            this.valueMapper = Preconditions.CheckNotNull(valueMapper, nameof(valueMapper));
+        }
+
+        public void Dispose()
+        {
+            this.dbStore?.Dispose();
+        }
+
+        public Task Put(TK key, TV value) => this.Put(key, value, CancellationToken.None);
+
+        public Task<Option<TV>> Get(TK key) => this.Get(key, CancellationToken.None);
+
+        public Task Remove(TK key) => this.Remove(key, CancellationToken.None);
+
+        public Task<bool> Contains(TK key) => this.Contains(key, CancellationToken.None);
+
+        public Task<Option<(TK key, TV value)>> GetFirstEntry() => this.GetFirstEntry(CancellationToken.None);
+
+        public Task<Option<(TK key, TV value)>> GetLastEntry() => this.GetLastEntry(CancellationToken.None);
+
+        public Task IterateBatch(int batchSize, Func<TK, TV, Task> perEntityCallback) => this.IterateBatch(batchSize, perEntityCallback, CancellationToken.None);
+
+        public Task IterateBatch(TK startKey, int batchSize, Func<TK, TV, Task> perEntityCallback) => this.IterateBatch(startKey, batchSize, perEntityCallback, CancellationToken.None);
+
+        public Task Put(TK key, TV value, CancellationToken cancellationToken)
+            => this.dbStore.Put(this.keyMapper.From(key), this.valueMapper.From(value), cancellationToken);
+
+        public async Task<Option<TV>> Get(TK key, CancellationToken cancellationToken)
+        {
+            Option<TV1> valueTk1 = await this.dbStore.Get(this.keyMapper.From(key), cancellationToken);
+            Option<TV> value = valueTk1.Map(this.valueMapper.To);
+            return value;
+        }
+
+        public Task Remove(TK key, CancellationToken cancellationToken)
+            => this.dbStore.Remove(this.keyMapper.From(key), cancellationToken);
+
+        public Task<bool> Contains(TK key, CancellationToken cancellationToken)
+            => this.dbStore.Contains(this.keyMapper.From(key), cancellationToken);
+
+        public async Task<Option<(TK key, TV value)>> GetFirstEntry(CancellationToken cancellationToken)
+        {
+            Option<(TK1 key, TV1 value)> firstEntry = await this.dbStore.GetFirstEntry(cancellationToken);
+            return firstEntry.Map(e => (this.keyMapper.To(e.key), this.valueMapper.To(e.value)));
+        }
+
+        public async Task<Option<(TK key, TV value)>> GetLastEntry(CancellationToken cancellationToken)
+        {
+            Option<(TK1 key, TV1 value)> lastEntry = await this.dbStore.GetLastEntry(cancellationToken);
+            return lastEntry.Map(e => (this.keyMapper.To(e.key), this.valueMapper.To(e.value)));
+        }
+
+        public Task IterateBatch(TK startKey, int batchSize, Func<TK, TV, Task> callback, CancellationToken cancellationToken)
+            => this.IterateBatch(Option.Some(startKey), batchSize, callback, cancellationToken);
+
+        public Task IterateBatch(int batchSize, Func<TK, TV, Task> callback, CancellationToken cancellationToken)
+            => this.IterateBatch(Option.None<TK>(), batchSize, callback, cancellationToken);
+
+        Task IterateBatch(Option<TK> startKey, int batchSize, Func<TK, TV, Task> callback, CancellationToken cancellationToken)
+        {
+            Preconditions.CheckRange(batchSize, 1, nameof(batchSize));
+            Preconditions.CheckNotNull(callback, nameof(callback));
+
+            Task DeserializingCallback(TK1 key, TV1 value)
+                => callback(this.keyMapper.To(key), this.valueMapper.To(value));
+
+            return startKey.Match(
+                k => this.dbStore.IterateBatch(this.keyMapper.From(k), batchSize, DeserializingCallback, cancellationToken),
+                () => this.dbStore.IterateBatch(batchSize, DeserializingCallback, cancellationToken));
+        }
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EntityStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EntityStore.cs
@@ -55,10 +55,10 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         }
 
         public virtual Task Remove(TK key, CancellationToken cancellationToken)
-        => this.dbStore.Remove(key, cancellationToken);
-        
-        public Task<bool> Remove(TK key, Func<TV, bool> predicate) =>
-            this.Remove(key, predicate, CancellationToken.None);
+            => this.dbStore.Remove(key, cancellationToken);
+
+        public Task<bool> Remove(TK key, Func<TV, bool> predicate)
+            => this.Remove(key, predicate, CancellationToken.None);
 
         public async Task<bool> Remove(TK key, Func<TV, bool> predicate, CancellationToken cancellationToken)
         {

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EntityStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EntityStore.cs
@@ -15,10 +15,10 @@ namespace Microsoft.Azure.Devices.Edge.Storage
     /// </summary>
     public class EntityStore<TK, TV> : IEntityStore<TK, TV>
     {
-        readonly IDbStore dbStore;
+        readonly IKeyValueStore<TK, TV> dbStore;
         readonly AsyncLockProvider<TK> keyLockProvider;
 
-        public EntityStore(IDbStore dbStore, string entityName, int keyShardCount = 1)
+        public EntityStore(IKeyValueStore<TK, TV> dbStore, string entityName, int keyShardCount = 1)
         {
             this.dbStore = Preconditions.CheckNotNull(dbStore, nameof(dbStore));
             this.keyLockProvider = new AsyncLockProvider<TK>(Preconditions.CheckRange(keyShardCount, 1, nameof(keyShardCount)));
@@ -27,12 +27,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 
         public string EntityName { get; }
 
-        public async Task<Option<TV>> Get(TK key, CancellationToken cancellationToken)
-        {
-            Option<byte[]> valueBytes = await this.dbStore.Get(key.ToBytes(), cancellationToken);
-            Option<TV> value = valueBytes.Map(v => v.FromBytes<TV>());
-            return value;
-        }
+        public Task<Option<TV>> Get(TK key, CancellationToken cancellationToken)
+            => this.dbStore.Get(key, cancellationToken);
 
         public Task Put(TK key, TV value) => this.Put(key, value, CancellationToken.None);
 
@@ -54,15 +50,13 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         {
             using (await this.keyLockProvider.GetLock(key).LockAsync(cancellationToken))
             {
-                await this.dbStore.Put(key.ToBytes(), value.ToBytes(), cancellationToken);
+                await this.dbStore.Put(key, value, cancellationToken);
             }
         }
 
         public virtual Task Remove(TK key, CancellationToken cancellationToken)
-        {
-            return this.dbStore.Remove(key.ToBytes(), cancellationToken);
-        }
-
+        => this.dbStore.Remove(key, cancellationToken);
+        
         public Task<bool> Remove(TK key, Func<TV, bool> predicate) =>
             this.Remove(key, predicate, CancellationToken.None);
 
@@ -90,12 +84,10 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             Preconditions.CheckNotNull(updator, nameof(updator));
             using (await this.keyLockProvider.GetLock(key).LockAsync(cancellationToken))
             {
-                byte[] keyBytes = key.ToBytes();
-                byte[] existingValueBytes = (await this.dbStore.Get(keyBytes, cancellationToken))
+                TV existingValue = (await this.dbStore.Get(key, cancellationToken))
                     .Expect(() => new InvalidOperationException("Value not found in store"));
-                var existingValue = existingValueBytes.FromBytes<TV>();
                 TV updatedValue = updator(existingValue);
-                await this.dbStore.Put(keyBytes, updatedValue.ToBytes(), cancellationToken);
+                await this.dbStore.Put(key, updatedValue, cancellationToken);
                 return updatedValue;
             }
         }
@@ -109,18 +101,17 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             using (await this.keyLockProvider.GetLock(key).LockAsync(cancellationToken))
             {
                 byte[] keyBytes = key.ToBytes();
-                Option<byte[]> existingValueBytes = await this.dbStore.Get(keyBytes, cancellationToken);
-                TV newValue = await existingValueBytes.Map(
+                Option<TV> existingValue = await this.dbStore.Get(key, cancellationToken);
+                TV newValue = await existingValue.Map(
                     async e =>
                     {
-                        var existingValue = e.FromBytes<TV>();
-                        TV updatedValue = updator(existingValue);
-                        await this.dbStore.Put(keyBytes, updatedValue.ToBytes(), cancellationToken);
+                        TV updatedValue = updator(e);
+                        await this.dbStore.Put(key, updatedValue, cancellationToken);
                         return updatedValue;
                     }).GetOrElse(
                     async () =>
                     {
-                        await this.dbStore.Put(keyBytes, value.ToBytes(), cancellationToken);
+                        await this.dbStore.Put(key, value, cancellationToken);
                         return value;
                     });
                 return newValue;
@@ -134,37 +125,30 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         {
             using (await this.keyLockProvider.GetLock(key).LockAsync(cancellationToken))
             {
-                byte[] keyBytes = key.ToBytes();
-                Option<byte[]> existingValueBytes = await this.dbStore.Get(keyBytes, cancellationToken);
-                if (!existingValueBytes.HasValue)
+                Option<TV> existingValue = await this.dbStore.Get(key, cancellationToken);
+                if (!existingValue.HasValue)
                 {
-                    await this.dbStore.Put(keyBytes, value.ToBytes(), cancellationToken);
+                    await this.dbStore.Put(key, value, cancellationToken);
                 }
 
-                return existingValueBytes.Map(e => e.FromBytes<TV>()).GetOrElse(value);
+                return existingValue.GetOrElse(value);
             }
         }
 
-        public async Task<Option<(TK key, TV value)>> GetFirstEntry(CancellationToken cancellationToken)
-        {
-            Option<(byte[] key, byte[] value)> firstEntry = await this.dbStore.GetFirstEntry(cancellationToken);
-            return firstEntry.Map(e => (e.key.FromBytes<TK>(), e.value.FromBytes<TV>()));
-        }
+        public Task<Option<(TK key, TV value)>> GetFirstEntry(CancellationToken cancellationToken)
+            => this.dbStore.GetFirstEntry(cancellationToken);
 
-        public async Task<Option<(TK key, TV value)>> GetLastEntry(CancellationToken cancellationToken)
-        {
-            Option<(byte[] key, byte[] value)> lastEntry = await this.dbStore.GetLastEntry(cancellationToken);
-            return lastEntry.Map(e => (e.key.FromBytes<TK>(), e.value.FromBytes<TV>()));
-        }
+        public Task<Option<(TK key, TV value)>> GetLastEntry(CancellationToken cancellationToken)
+            => this.dbStore.GetLastEntry(cancellationToken);
 
         public Task IterateBatch(TK startKey, int batchSize, Func<TK, TV, Task> callback, CancellationToken cancellationToken)
-            => this.IterateBatch(Option.Some(startKey), batchSize, callback, cancellationToken);
+            => this.dbStore.IterateBatch(startKey, batchSize, callback, cancellationToken);
 
         public Task IterateBatch(int batchSize, Func<TK, TV, Task> callback, CancellationToken cancellationToken)
-            => this.IterateBatch(Option.None<TK>(), batchSize, callback, cancellationToken);
+            => this.dbStore.IterateBatch(batchSize, callback, cancellationToken);
 
         public Task<bool> Contains(TK key, CancellationToken cancellationToken)
-            => this.dbStore.Contains(key.ToBytes(), cancellationToken);
+            => this.dbStore.Contains(key, cancellationToken);
 
         public void Dispose()
         {
@@ -178,23 +162,6 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             {
                 this.dbStore?.Dispose();
             }
-        }
-
-        Task IterateBatch(Option<TK> startKey, int batchSize, Func<TK, TV, Task> callback, CancellationToken cancellationToken)
-        {
-            Preconditions.CheckRange(batchSize, 1, nameof(batchSize));
-            Preconditions.CheckNotNull(callback, nameof(callback));
-
-            Task DeserializingCallback(byte[] keyBytes, byte[] valueBytes)
-            {
-                var value = valueBytes.FromBytes<TV>();
-                var key = keyBytes.FromBytes<TK>();
-                return callback(key, value);
-            }
-
-            return startKey.Match(
-                k => this.dbStore.IterateBatch(k.ToBytes(), batchSize, DeserializingCallback, cancellationToken),
-                () => this.dbStore.IterateBatch(batchSize, DeserializingCallback, cancellationToken));
         }
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/KeyValueStoreMapper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/KeyValueStoreMapper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             this.underlyingStore = Preconditions.CheckNotNull(underlyingStore, nameof(underlyingStore));
             this.keyMapper = Preconditions.CheckNotNull(keyMapper, nameof(keyMapper));
             this.valueMapper = Preconditions.CheckNotNull(valueMapper, nameof(valueMapper));
-        }        
+        }
 
         public void Dispose()
         {

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/SequentialStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/SequentialStore.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             this.EntityName = entityName;
         }
 
-        public string EntityName {get; }
+        public string EntityName { get; }
 
         public static Task<ISequentialStore<T>> Create(IKeyValueStore<byte[], T> entityStore, string entityName)
             => Create(entityStore, entityName, DefaultHeadOffset);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/SequentialStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/SequentialStore.cs
@@ -17,33 +17,35 @@ namespace Microsoft.Azure.Devices.Edge.Storage
     class SequentialStore<T> : ISequentialStore<T>
     {
         const long DefaultHeadOffset = 0;
-        readonly IEntityStore<byte[], T> entityStore;
+        readonly IKeyValueStore<byte[], T> entityStore;
         readonly AsyncLock headLockObject = new AsyncLock();
         readonly AsyncLock tailLockObject = new AsyncLock();
         long tailOffset;
         long headOffset;
 
-        SequentialStore(IEntityStore<byte[], T> entityStore, long headOffset, long tailOffset)
+        SequentialStore(IKeyValueStore<byte[], T> entityStore, string entityName, long headOffset, long tailOffset)
         {
             this.entityStore = entityStore;
             this.headOffset = headOffset;
             this.tailOffset = tailOffset;
+            this.EntityName = entityName;
         }
 
-        public string EntityName => this.entityStore.EntityName;
+        public string EntityName {get; }
 
-        public static Task<ISequentialStore<T>> Create(IEntityStore<byte[], T> entityStore)
-            => Create(entityStore, DefaultHeadOffset);
+        public static Task<ISequentialStore<T>> Create(IKeyValueStore<byte[], T> entityStore, string entityName)
+            => Create(entityStore, entityName, DefaultHeadOffset);
 
-        public static async Task<ISequentialStore<T>> Create(IEntityStore<byte[], T> entityStore, long defaultHeadOffset)
+        public static async Task<ISequentialStore<T>> Create(IKeyValueStore<byte[], T> entityStore, string entityName, long defaultHeadOffset)
         {
             Preconditions.CheckNotNull(entityStore, nameof(entityStore));
+            Preconditions.CheckNonWhiteSpace(entityName, nameof(entityName));
             Option<(byte[] key, T value)> firstEntry = await entityStore.GetFirstEntry(CancellationToken.None);
             Option<(byte[] key, T value)> lastEntry = await entityStore.GetLastEntry(CancellationToken.None);
             long MapLocalFunction((byte[] key, T) e) => StoreUtils.GetOffsetFromKey(e.key);
             long headOffset = firstEntry.Map(MapLocalFunction).GetOrElse(defaultHeadOffset);
             long tailOffset = lastEntry.Map(MapLocalFunction).GetOrElse(defaultHeadOffset - 1);
-            var sequentialStore = new SequentialStore<T>(entityStore, headOffset, tailOffset);
+            var sequentialStore = new SequentialStore<T>(entityStore, entityName, headOffset, tailOffset);
             return sequentialStore;
         }
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/StoreProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/StoreProvider.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         public IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
         {
             IDbStore entityDbStore = this.dbStoreProvider.GetDbStore(Preconditions.CheckNonWhiteSpace(entityName, nameof(entityName)));
-            IEntityStore<TK, TV> entityStore = new EntityStore<TK, TV>(entityDbStore, entityName, 12);
+            IKeyValueStore<TK, TV> dbStoreMapper = new DbStoreMapper<TK, byte[], TV, byte[]>(entityDbStore, new BytesMapper<TK>(), new BytesMapper<TV>());
+            IEntityStore<TK, TV> entityStore = new EntityStore<TK, TV>(dbStoreMapper, entityName, 12);
             IEntityStore<TK, TV> timedEntityStore = new TimedEntityStore<TK, TV>(entityStore, this.operationTimeout);
             return timedEntityStore;
         }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/StoreProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/StoreProvider.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         public IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
         {
             IDbStore entityDbStore = this.dbStoreProvider.GetDbStore(Preconditions.CheckNonWhiteSpace(entityName, nameof(entityName)));
-            IKeyValueStore<TK, TV> dbStoreMapper = new DbStoreMapper<TK, byte[], TV, byte[]>(entityDbStore, new BytesMapper<TK>(), new BytesMapper<TV>());
+            IKeyValueStore<TK, TV> dbStoreMapper = new KeyValueStoreMapper<TK, byte[], TV, byte[]>(entityDbStore, new BytesMapper<TK>(), new BytesMapper<TV>());
             IEntityStore<TK, TV> entityStore = new EntityStore<TK, TV>(dbStoreMapper, entityName, 12);
             IEntityStore<TK, TV> timedEntityStore = new TimedEntityStore<TK, TV>(entityStore, this.operationTimeout);
             return timedEntityStore;
@@ -34,14 +34,14 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         public async Task<ISequentialStore<T>> GetSequentialStore<T>(string entityName)
         {
             IEntityStore<byte[], T> underlyingStore = this.GetEntityStore<byte[], T>(entityName);
-            ISequentialStore<T> sequentialStore = await SequentialStore<T>.Create(underlyingStore);
+            ISequentialStore<T> sequentialStore = await SequentialStore<T>.Create(underlyingStore, entityName);
             return sequentialStore;
         }
 
         public async Task<ISequentialStore<T>> GetSequentialStore<T>(string entityName, long defaultHeadOffset)
         {
             IEntityStore<byte[], T> underlyingStore = this.GetEntityStore<byte[], T>(entityName);
-            ISequentialStore<T> sequentialStore = await SequentialStore<T>.Create(underlyingStore, defaultHeadOffset);
+            ISequentialStore<T> sequentialStore = await SequentialStore<T>.Create(underlyingStore, entityName, defaultHeadOffset);
             return sequentialStore;
         }
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/TypeMappers.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/TypeMappers.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
     }
 
     public class BytesMapper<T> : ITypeMapper<T, byte[]>
-    {        
+    {
         public byte[] From(T value) => value.ToBytes();
 
         public T To(byte[] value) => value.FromBytes<T>();

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/TypeMappers.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/TypeMappers.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Storage
+{
+    public interface ITypeMapper<TK, TU>
+    {
+        TU From(TK value);
+
+        TK To(TU value);
+    }
+
+    public class BytesMapper<T> : ITypeMapper<T, byte[]>
+    {        
+        public byte[] From(T value) => value.ToBytes();
+
+        public T To(byte[] value) => value.FromBytes<T>();
+    }
+
+    public class JsonMapper<T> : ITypeMapper<T, string>
+    {
+        public string From(T value) => value.ToJson();
+
+        public T To(string value) => value.FromJson<T>();
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/UpdatableEncryptedStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/UpdatableEncryptedStore.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Storage
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Newtonsoft.Json;
+
+    public class UpdatableEncryptedStore<TK, TV> : EncryptedStore<TK, TV>
+    {
+        public UpdatableEncryptedStore(IKeyValueStore<TK, string> entityStore, IEncryptionProvider encryptionProvider)
+            : base(entityStore, encryptionProvider)
+        {
+        }
+
+        protected override async Task<string> EncryptValue(string value)
+        {
+            string encryptedValue = await this.EncryptionProvider.EncryptAsync(value);
+            var encryptedData = new EncryptedData(true, encryptedValue);
+            string encryptedDataString = encryptedData.ToJson();
+            return encryptedDataString;
+        }
+
+        protected override async Task<string> DecryptValue(string value)
+        {
+            string decryptedValue;
+            try
+            {
+                var encryptedData = value.FromJson<EncryptedData>();
+                if (encryptedData.Encrypted)
+                {
+                    decryptedValue = await this.EncryptionProvider.DecryptAsync(encryptedData.Payload);
+                }
+                else
+                {
+                    decryptedValue = encryptedData.Payload;
+                }
+            }
+            catch (JsonSerializationException)
+            {
+                decryptedValue = value;
+            }
+
+            return decryptedValue;
+        }
+
+        public class EncryptedData
+        {
+            public EncryptedData(bool encrypted, string payload)
+            {
+                this.Encrypted = encrypted;
+                this.Payload = payload;
+            }
+
+            [JsonProperty("encrypted", Required = Required.Always)]
+            public bool Encrypted { get; }
+
+            [JsonProperty("payload", Required = Required.Always)]
+            public string Payload { get; }
+        }
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/UpdatableEncryptedStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/UpdatableEncryptedStore.cs
@@ -1,11 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Storage
 {
-    using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
 
+    // UpdatableEncryptedStore allows updating an un-encrypted store to an encrypted store.
+    // For example, this allows upgrading existing Edge deployments,
+    // where the Twin store is not encrypted to using an Encrypted twin store.
     public class UpdatableEncryptedStore<TK, TV> : EncryptedStore<TK, TV>
     {
         public UpdatableEncryptedStore(IKeyValueStore<TK, string> entityStore, IEncryptionProvider encryptionProvider)
@@ -38,6 +40,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             }
             catch (JsonSerializationException)
             {
+                // If the json serialization fails, then assume the stored value
+                // was unencrypted and return it.
                 decryptedValue = value;
             }
 

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/ColumnFamilyStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/ColumnFamilyStoreTest.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         [Fact]
         public async Task BasicTest()
         {
-            IDbStore columnFamilyDbStore = this.rocksDbStoreProvider.GetColumnStoreFamily("test");
+            IDbStore columnFamilyDbStore = this.rocksDbStoreProvider.GetDbStore("test");
 
             string key = "key1";
             string value = "value1";
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         [Fact]
         public async Task FirstLastTest()
         {
-            IDbStore columnFamilyDbStore = this.rocksDbStoreProvider.GetColumnStoreFamily("firstLastTest");
+            IDbStore columnFamilyDbStore = this.rocksDbStoreProvider.GetDbStore("firstLastTest");
 
             string firstKey = "firstKey";
             string firstValue = "firstValue";

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/EntityStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/EntityStoreTest.cs
@@ -6,13 +6,14 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
     public class EntityStoreTest : EntityStoreTestBase, IClassFixture<TestRocksDbStoreProvider>
     {
-        readonly TestRocksDbStoreProvider rocksDbStoreProvider;
+        readonly IStoreProvider storeProvider;
 
         public EntityStoreTest(TestRocksDbStoreProvider rocksDbStoreProvider)
         {
-            this.rocksDbStoreProvider = rocksDbStoreProvider;
+            this.storeProvider = new StoreProvider(rocksDbStoreProvider);
         }
 
-        protected override IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName) => new EntityStore<TK, TV>(this.rocksDbStoreProvider.GetColumnStoreFamily(entityName), entityName);
+        protected override IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
+            => this.storeProvider.GetEntityStore<TK, TV>(entityName);
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/SequentialStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/SequentialStoreTest.cs
@@ -6,13 +6,14 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
     public class SequentialStoreTest : SequentialStoreTestBase, IClassFixture<TestRocksDbStoreProvider>
     {
-        readonly TestRocksDbStoreProvider rocksDbStoreProvider;
+        readonly IStoreProvider storeProvider;
 
         public SequentialStoreTest(TestRocksDbStoreProvider rocksDbStoreProvider)
         {
-            this.rocksDbStoreProvider = rocksDbStoreProvider;
+            this.storeProvider = new StoreProvider(rocksDbStoreProvider);
         }
 
-        protected override IEntityStore<byte[], TV> GetEntityStore<TV>(string entityName) => new EntityStore<byte[], TV>(this.rocksDbStoreProvider.GetColumnStoreFamily(entityName), entityName);
+        protected override IEntityStore<byte[], TV> GetEntityStore<TV>(string entityName)
+            => this.storeProvider.GetEntityStore<byte[], TV>(entityName);
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
     using System.IO;
     using Microsoft.Azure.Devices.Edge.Util;
 
-    public class TestRocksDbStoreProvider : IDisposable
+    public class TestRocksDbStoreProvider : IDbStoreProvider
     {
         readonly string rocksDbFolder;
         readonly DbStoreProvider rocksDbStoreProvider;
@@ -22,10 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
             Directory.CreateDirectory(this.rocksDbFolder);
             this.rocksDbStoreProvider = DbStoreProvider.Create(options, this.rocksDbFolder, new string[0]);
-        }
-
-        public IDbStore GetColumnStoreFamily(string columnFamilyName) =>
-            this.rocksDbStoreProvider.GetDbStore(columnFamilyName);
+        }           
 
         public void Dispose()
         {
@@ -35,5 +32,11 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
                 Directory.Delete(this.rocksDbFolder, true);
             }
         }
+
+        public IDbStore GetDbStore(string partitionName) => this.rocksDbStoreProvider.GetDbStore(partitionName);
+
+        public IDbStore GetDbStore() => this.rocksDbStoreProvider.GetDbStore("default");
+
+        public void RemoveDbStore(string partitionName) => throw new NotImplementedException();
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
             Directory.CreateDirectory(this.rocksDbFolder);
             this.rocksDbStoreProvider = DbStoreProvider.Create(options, this.rocksDbFolder, new string[0]);
-        }           
+        }
 
         public void Dispose()
         {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EncryptedStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EncryptedStoreTest.cs
@@ -106,7 +106,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
             Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
         }
 
-        static IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName) => new EntityStore<TK, TV>(new InMemoryDbStore(), entityName);
+        static IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
+            => new EntityStore<TK, TV>(new KeyValueStoreMapper<TK, byte[], TV, byte[]>(new InMemoryDbStore(), new BytesMapper<TK>(), new BytesMapper<TV>()), entityName);
 
         public class KeyAuth
         {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EntityStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EntityStoreTest.cs
@@ -3,6 +3,14 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
 {
     public class EntityStoreTest : EntityStoreTestBase
     {
-        protected override IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName) => new EntityStore<TK, TV>(new InMemoryDbStore(), entityName);
+        readonly IStoreProvider storeProvider;
+
+        public EntityStoreTest()
+        {
+            this.storeProvider = new StoreProvider(new InMemoryDbStoreProvider());
+        }
+
+        protected override IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
+            => this.storeProvider.GetEntityStore<TK, TV>(entityName);
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/KeyValueStoreMapperTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/KeyValueStoreMapperTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
             var objectData = new Dictionary<TestClass, TestClass>();
             for (int i = 0; i < 10; i++)
             {
-                objectData[new TestClass($"key{i}", i)] =new TestClass($"value{i}", i);
+                objectData[new TestClass($"key{i}", i)] = new TestClass($"value{i}", i);
             }
 
             var objectData2 = new Dictionary<string, TestClass>();

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/KeyValueStoreMapperTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/KeyValueStoreMapperTest.cs
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Storage.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    [Unit]
+    public class KeyValueStoreMapperTest
+    {
+        public static IEnumerable<object[]> GetMappers()
+        {
+            var stringData = new Dictionary<string, string>();
+            for (int i = 0; i < 10; i++)
+            {
+                stringData[$"key{i}"] = $"value{i}";
+            }
+
+            var objectData = new Dictionary<TestClass, TestClass>();
+            for (int i = 0; i < 10; i++)
+            {
+                objectData[new TestClass($"key{i}", i)] =new TestClass($"value{i}", i);
+            }
+
+            var objectData2 = new Dictionary<string, TestClass>();
+            for (int i = 0; i < 10; i++)
+            {
+                objectData2[$"key{i}"] = new TestClass($"value{i}", i);
+            }
+
+            yield return new object[]
+            {
+                new InMemoryDbStore(),
+                new BytesMapper<string>(),
+                new BytesMapper<string>(),
+                stringData
+            };
+
+            yield return new object[]
+            {
+                new InMemoryDbStore(),
+                new BytesMapper<TestClass>(),
+                new BytesMapper<TestClass>(),
+                objectData
+            };
+
+            yield return new object[]
+            {
+                new InMemoryDbStore(),
+                new BytesMapper<string>(),
+                new BytesMapper<TestClass>(),
+                objectData2
+            };
+
+            yield return new object[]
+            {
+                new KeyValueStoreMapper<string, byte[], string, byte[]>(new InMemoryDbStore(), new BytesMapper<string>(), new BytesMapper<string>()),
+                new JsonMapper<string>(),
+                new JsonMapper<TestClass>(),
+                objectData2
+            };
+
+            yield return new object[]
+            {
+                new KeyValueStoreMapper<string, byte[], string, byte[]>(new InMemoryDbStore(), new BytesMapper<string>(), new BytesMapper<string>()),
+                new JsonMapper<TestClass>(),
+                new JsonMapper<TestClass>(),
+                objectData
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetMappers))]
+        public async Task BasicMapperTest<TK, TK1, TV, TV1>(
+            IKeyValueStore<TK, TV> underlyingStore,
+            ITypeMapper<TK1, TK> keyMapper,
+            ITypeMapper<TV1, TV> valueMapper,
+            IDictionary<TK1, TV1> items)
+        {
+            // Arrange
+            var keyValueMapper = new KeyValueStoreMapper<TK1, TK, TV1, TV>(underlyingStore, keyMapper, valueMapper);
+
+            // Act
+            KeyValuePair<TK1, TV1> item = items.First();
+            await keyValueMapper.Put(item.Key, item.Value);
+
+            // Assert
+            Option<TV1> value = await keyValueMapper.Get(item.Key);
+            Assert.True(value.HasValue);
+            Option<TV> underlyingValue = await underlyingStore.Get(keyMapper.From(item.Key));
+            Assert.True(underlyingValue.HasValue);
+            Assert.Equal(underlyingValue.OrDefault(), valueMapper.From(value.OrDefault()));
+        }
+
+        class TestClass : IEquatable<TestClass>
+        {
+            public TestClass(string prop1, int prop2)
+            {
+                this.Prop1 = prop1;
+                this.Prop2 = prop2;
+            }
+
+            [JsonProperty("prop1")]
+            public string Prop1 { get; }
+
+            [JsonProperty("prop2")]
+            public int Prop2 { get; }
+
+            public override bool Equals(object obj)
+                => this.Equals(obj as TestClass);
+
+            public bool Equals(TestClass other)
+                => other != null &&
+                   this.Prop1 == other.Prop1 &&
+                   this.Prop2 == other.Prop2;
+
+            public override int GetHashCode()
+                => HashCode.Combine(this.Prop1, this.Prop2);
+        }
+    }
+}

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTest.cs
@@ -11,6 +11,6 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
         }
 
         protected override IEntityStore<byte[], TV> GetEntityStore<TV>(string entityName)
-            => this.storeProvider.GetEntityStore< byte[], TV>(entityName);
+            => this.storeProvider.GetEntityStore<byte[], TV>(entityName);
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTest.cs
@@ -3,6 +3,14 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
 {
     public class SequentialStoreTest : SequentialStoreTestBase
     {
-        protected override IEntityStore<byte[], TV> GetEntityStore<TV>(string entityName) => new EntityStore<byte[], TV>(new InMemoryDbStore(), entityName);
+        readonly IStoreProvider storeProvider;
+
+        public SequentialStoreTest()
+        {
+            this.storeProvider = new StoreProvider(new InMemoryDbStoreProvider());
+        }
+
+        protected override IEntityStore<byte[], TV> GetEntityStore<TV>(string entityName)
+            => this.storeProvider.GetEntityStore< byte[], TV>(entityName);
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTestBase.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/SequentialStoreTestBase.cs
@@ -15,12 +15,13 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
         [Fact]
         public async Task CreateTest()
         {
-            IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>($"testEntity{Guid.NewGuid().ToString()}");
-            ISequentialStore<Item> sequentialStore = await SequentialStore<Item>.Create(entityStore);
+            string entityName = $"testEntity{Guid.NewGuid().ToString()}";
+            IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>(entityName);
+            ISequentialStore<Item> sequentialStore = await SequentialStore<Item>.Create(entityStore, entityName);
             long offset = await sequentialStore.Append(new Item { Prop1 = 10 });
             Assert.Equal(0, offset);
 
-            sequentialStore = await SequentialStore<Item>.Create(entityStore);
+            sequentialStore = await SequentialStore<Item>.Create(entityStore, entityName);
             offset = await sequentialStore.Append(new Item { Prop1 = 20 });
             Assert.Equal(1, offset);
         }
@@ -28,19 +29,20 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
         [Fact]
         public async Task CreateWithOffsetTest()
         {
-            IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>($"testEntity{Guid.NewGuid().ToString()}");
-            ISequentialStore<Item> sequentialStore = await SequentialStore<Item>.Create(entityStore, 10150);
+            string entityName = $"testEntity{Guid.NewGuid().ToString()}";
+            IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>(entityName);
+            ISequentialStore<Item> sequentialStore = await SequentialStore<Item>.Create(entityStore, entityName, 10150);
             long offset = await sequentialStore.Append(new Item { Prop1 = 10 });
             Assert.Equal(10150, offset);
 
-            sequentialStore = await SequentialStore<Item>.Create(entityStore);
+            sequentialStore = await SequentialStore<Item>.Create(entityStore, entityName);
             for (int i = 0; i < 10; i++)
             {
                 offset = await sequentialStore.Append(new Item { Prop1 = 20 });
                 Assert.Equal(10151 + i, offset);
             }
 
-            sequentialStore = await SequentialStore<Item>.Create(entityStore);
+            sequentialStore = await SequentialStore<Item>.Create(entityStore, entityName);
             offset = await sequentialStore.Append(new Item { Prop1 = 20 });
             Assert.Equal(10161, offset);
 
@@ -211,8 +213,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
         {
             IEntityStore<byte[], Item> entityStore = this.GetEntityStore<Item>(entityName);
             ISequentialStore<Item> sequentialStore = await defaultHeadOffset
-                .Map(d => SequentialStore<Item>.Create(entityStore, d))
-                .GetOrElse(() => SequentialStore<Item>.Create(entityStore));
+                .Map(d => SequentialStore<Item>.Create(entityStore, entityName, d))
+                .GetOrElse(() => SequentialStore<Item>.Create(entityStore, entityName));
             return sequentialStore;
         }
 

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/UpdatableEncryptedStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/UpdatableEncryptedStoreTest.cs
@@ -1,0 +1,222 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Storage.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Newtonsoft.Json;
+    using Xunit;
+
+    [Unit]
+    public class UpdatableEncryptedStoreTest
+    {
+        [Fact]
+        public async Task SmokeTest()
+        {
+            // Arrange
+            IEncryptionProvider encryptionProvider = new TestEncryptionProvider();
+            IEntityStore<string, string> entityStore = GetEntityStore<string, string>("smokeTest");
+            IKeyValueStore<string, TestDevice> encryptedStore = new UpdatableEncryptedStore<string, TestDevice>(entityStore, encryptionProvider);
+            string key = "device1";
+            var device = new TestDevice(Guid.NewGuid().ToString(), new KeyAuth(Guid.NewGuid().ToString()));
+            var deviceNew = new TestDevice(Guid.NewGuid().ToString(), new KeyAuth(Guid.NewGuid().ToString()));
+
+            // Act / Assert
+            bool contains = await encryptedStore.Contains("device1");
+            Assert.False(contains);
+            contains = await entityStore.Contains("device1");
+            Assert.False(contains);
+
+            // Add a value to the underlying store and make sure encrypted store returns it correctly
+            await entityStore.Put(key, device.ToJson());
+
+            contains = await encryptedStore.Contains("device1");
+            Assert.True(contains);
+            contains = await entityStore.Contains("device1");
+            Assert.True(contains);
+
+            Option<TestDevice> retrievedValue = await encryptedStore.Get("device1");
+            Assert.True(retrievedValue.HasValue);
+            Assert.Equal(device.GenId, retrievedValue.OrDefault().GenId);
+            Assert.Equal(device.Auth.Key, retrievedValue.OrDefault().Auth.Key);
+
+            Option<string> storedValue = await entityStore.Get("device1");
+            Assert.True(storedValue.HasValue);
+            TestDevice storedTestDevice = storedValue.OrDefault().FromJson<TestDevice>();
+
+            Assert.Equal(device.GenId, storedTestDevice.GenId);
+            Assert.Equal(device.Auth.Key, storedTestDevice.Auth.Key);
+
+            // Add a value to the encrypted store and make sure underlying store sees the encrypted value
+            await encryptedStore.Put(key, deviceNew);
+
+            contains = await encryptedStore.Contains("device1");
+            Assert.True(contains);
+
+            retrievedValue = await encryptedStore.Get("device1");
+            Assert.True(retrievedValue.HasValue);
+            Assert.Equal(deviceNew.GenId, retrievedValue.OrDefault().GenId);
+            Assert.Equal(deviceNew.Auth.Key, retrievedValue.OrDefault().Auth.Key);
+
+            storedValue = await entityStore.Get("device1");
+            Assert.True(storedValue.HasValue);
+
+            string encryptedDeviceJson = Convert.ToBase64String(Encoding.UTF8.GetBytes(deviceNew.ToJson()));
+            var encryptedData = new UpdatableEncryptedStore<string, TestDevice>.EncryptedData(true, encryptedDeviceJson);
+            Assert.Equal(encryptedData.ToJson(), storedValue.OrDefault());
+
+            retrievedValue = await encryptedStore.Get("device2");
+            Assert.False(retrievedValue.HasValue);
+
+            await encryptedStore.Remove("device1");
+            contains = await encryptedStore.Contains("device1");
+            Assert.False(contains);
+
+            retrievedValue = await encryptedStore.Get("device1");
+            Assert.False(retrievedValue.HasValue);
+        }
+
+        [Fact]
+        public async Task BatchTest()
+        {
+            // Arrange
+            IEncryptionProvider encryptionProvider = new TestEncryptionProvider();
+            IEntityStore<string, string> entityStore = GetEntityStore<string, string>("smokeTest");
+            IKeyValueStore<string, TestDevice> encryptedStore = new UpdatableEncryptedStore<string, TestDevice>(entityStore, encryptionProvider);
+            IDictionary<string, TestDevice> devices = new Dictionary<string, TestDevice>();
+            for (int i = 0; i < 10; i++)
+            {
+                devices[$"d{i}"] = new TestDevice(Guid.NewGuid().ToString(), new KeyAuth(Guid.NewGuid().ToString()));
+            }
+
+            // Act
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                await encryptedStore.Put(device.Key, device.Value);
+            }
+
+            IDictionary<string, TestDevice> obtainedDevices = new Dictionary<string, TestDevice>();
+            await encryptedStore.IterateBatch(
+                10,
+                (key, device) =>
+                {
+                    obtainedDevices[key] = device;
+                    return Task.CompletedTask;
+                });
+
+            // Assert
+            Assert.Equal(devices.Count, obtainedDevices.Count);
+
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                Assert.Equal(device.Value.GenId, obtainedDevices[device.Key].GenId);
+                Assert.Equal(device.Value.Auth.Key, obtainedDevices[device.Key].Auth.Key);
+            }
+
+            // Act
+            Option<(string key, TestDevice value)> first = await encryptedStore.GetFirstEntry();
+            Option<(string key, TestDevice value)> last = await encryptedStore.GetLastEntry();
+
+            // Assert
+            Assert.True(first.HasValue);
+            Assert.True(last.HasValue);
+
+            Assert.Equal("d0", first.OrDefault().key);
+            Assert.Equal(devices["d0"].GenId, first.OrDefault().value.GenId);
+            Assert.Equal("d9", last.OrDefault().key);
+            Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
+        }
+
+        [Fact]
+        public async Task UpdatedBatchTest()
+        {
+            // Arrange
+            IEncryptionProvider encryptionProvider = new TestEncryptionProvider();
+            IEntityStore<string, string> entityStore = GetEntityStore<string, string>("smokeTest");
+            IKeyValueStore<string, TestDevice> encryptedStore = new UpdatableEncryptedStore<string, TestDevice>(entityStore, encryptionProvider);
+            IDictionary<string, TestDevice> devices = new Dictionary<string, TestDevice>();
+            for (int i = 0; i < 10; i++)
+            {
+                devices[$"d{i}"] = new TestDevice(Guid.NewGuid().ToString(), new KeyAuth(Guid.NewGuid().ToString()));
+            }
+
+            // Act
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                await entityStore.Put(device.Key, device.Value.ToJson());
+            }
+
+            IDictionary<string, TestDevice> obtainedDevices = new Dictionary<string, TestDevice>();
+            await encryptedStore.IterateBatch(
+                10,
+                (key, device) =>
+                {
+                    obtainedDevices[key] = device;
+                    return Task.CompletedTask;
+                });
+
+            // Assert
+            Assert.Equal(devices.Count, obtainedDevices.Count);
+
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                Assert.Equal(device.Value.GenId, obtainedDevices[device.Key].GenId);
+                Assert.Equal(device.Value.Auth.Key, obtainedDevices[device.Key].Auth.Key);
+            }
+
+            // Act
+            Option<(string key, TestDevice value)> first = await encryptedStore.GetFirstEntry();
+            Option<(string key, TestDevice value)> last = await encryptedStore.GetLastEntry();
+
+            // Assert
+            Assert.True(first.HasValue);
+            Assert.True(last.HasValue);
+
+            Assert.Equal("d0", first.OrDefault().key);
+            Assert.Equal(devices["d0"].GenId, first.OrDefault().value.GenId);
+            Assert.Equal("d9", last.OrDefault().key);
+            Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
+        }
+
+        static IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
+            => new EntityStore<TK, TV>(new KeyValueStoreMapper<TK, byte[], TV, byte[]>(new InMemoryDbStore(), new BytesMapper<TK>(), new BytesMapper<TV>()), entityName);
+
+        public class KeyAuth
+        {
+            [JsonConstructor]
+            public KeyAuth(string key)
+            {
+                this.Key = key;
+            }
+
+            [JsonProperty("key")]
+            public string Key { get; }
+        }
+
+        class TestDevice
+        {
+            [JsonConstructor]
+            public TestDevice(string genId, KeyAuth auth)
+            {
+                this.GenId = genId;
+                this.Auth = auth;
+            }
+
+            [JsonProperty("genId")]
+            public string GenId { get; }
+
+            [JsonProperty("auth")]
+            public KeyAuth Auth { get; }
+        }
+
+        class TestEncryptionProvider : IEncryptionProvider
+        {
+            public Task<string> DecryptAsync(string encryptedText) => Task.FromResult(Encoding.UTF8.GetString(Convert.FromBase64String(encryptedText)));
+
+            public Task<string> EncryptAsync(string plainText) => Task.FromResult(Convert.ToBase64String(Encoding.UTF8.GetBytes(plainText)));
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for encrypting Twins at rest. To encrypt twins at rest, you need to -
- Use TwinManager V2
- Set the environment variable EncryptTwinStore to true (false by default)
- Be deployed in iotedge mode (is not supported if there is no edgelet).

This change is backward compatible - you can enable this on your existing store. The next time the twins are written out, they will be encrypted. It will not sweep the store and encrypt all the existing twins. 