### PR TITLE
Update long haul deployment

### DIFF
--- a/e2e_deployment_files/long_haul_deployment.template.arm32v7.amqp.json
+++ b/e2e_deployment_files/long_haul_deployment.template.arm32v7.amqp.json
@@ -143,6 +143,42 @@
               "createOptions": ""
             }
           },
+          "DirectMethodCloudSender": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "TargetModuleId": {
+                "value": "DirectMethodReceiver"
+              },
+              "ClientTransportType": {
+                "value": "Amqp_Tcp_Only"
+              },
+              "ServiceClientConnectionString": {
+                "value": "<ServiceClientConnectionString>"
+              }
+            },
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-direct-method-cloud-sender:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            }
+          },
+          "DirectMethodReceiver": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "ClientTransportType": {
+                "value": "Amqp_Tcp_Only"
+              }
+            },
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-direct-method-receiver:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            }
+          },
           "snitcher": {
             "version": "2.0",
             "type": "docker",
@@ -227,8 +263,7 @@
           "TempSensorToTempFilter": "FROM /messages/modules/tempSensor/outputs/temperatureOutput INTO BrokeredEndpoint(\"/modules/tempFilter/inputs/input1\")",
           "TempFilterToCloud2": "FROM /messages/modules/tempFilter2/outputs/* INTO $upstream",
           "TempSensorToTempFilter2": "FROM /messages/modules/tempSensor2/outputs/temperatureOutput INTO BrokeredEndpoint(\"/modules/tempFilter2/inputs/input1\")",
-          "upstreamDirectMethodCloudSender1": "FROM /messages/modules/DirectMethodCloudSender/outputs/output1 INTO $upstream",
-          "upstreamDirectMethodCloudSender2": "FROM /messages/modules/DirectMethodCloudSender2/outputs/output1 INTO $upstream"
+          "upstreamDirectMethodCloudSender1": "FROM /messages/modules/DirectMethodCloudSender/outputs/output1 INTO $upstream"
         },
         "storeAndForwardConfiguration": {
           "timeToLiveSecs": 86400

--- a/e2e_deployment_files/long_haul_deployment.template.arm32v7.mqtt.json
+++ b/e2e_deployment_files/long_haul_deployment.template.arm32v7.mqtt.json
@@ -143,6 +143,42 @@
               "createOptions": ""
             }
           },
+          "DirectMethodCloudSender": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "TargetModuleId": {
+                "value": "DirectMethodReceiver"
+              },
+              "ClientTransportType": {
+                "value": "Mqtt_Tcp_Only"
+              },
+              "ServiceClientConnectionString": {
+                "value": "<ServiceClientConnectionString>"
+              }
+            },
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-direct-method-cloud-sender:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            }
+          },
+          "DirectMethodReceiver": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "ClientTransportType": {
+                "value": "Mqtt_Tcp_Only"
+              }
+            },
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-direct-method-receiver:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            }
+          },
           "snitcher": {
             "version": "2.0",
             "type": "docker",
@@ -227,8 +263,7 @@
           "TempSensorToTempFilter": "FROM /messages/modules/tempSensor/outputs/temperatureOutput INTO BrokeredEndpoint(\"/modules/tempFilter/inputs/input1\")",
           "TempFilterToCloud2": "FROM /messages/modules/tempFilter2/outputs/* INTO $upstream",
           "TempSensorToTempFilter2": "FROM /messages/modules/tempSensor2/outputs/temperatureOutput INTO BrokeredEndpoint(\"/modules/tempFilter2/inputs/input1\")",
-          "upstreamDirectMethodCloudSender1": "FROM /messages/modules/DirectMethodCloudSender/outputs/output1 INTO $upstream",
-          "upstreamDirectMethodCloudSender2": "FROM /messages/modules/DirectMethodCloudSender2/outputs/output1 INTO $upstream"
+          "upstreamDirectMethodCloudSender1": "FROM /messages/modules/DirectMethodCloudSender/outputs/output1 INTO $upstream"
         },
         "storeAndForwardConfiguration": {
           "timeToLiveSecs": 86400

--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -57,7 +57,25 @@
                 "value": "<LoadGen.MessageFrequency>"
               },
               "transportType": {
-                "value": "<LoadGen.TransportType>"
+                "value": "amqp"
+              }
+            },
+            "settings": {
+              "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-load-gen:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            }
+          },
+          "loadGen2": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "messageFrequency": {
+                "value": "<LoadGen.MessageFrequency>"
+              },
+              "transportType": {
+                "value": "mqtt"
               }
             },
             "settings": {
@@ -289,6 +307,7 @@
         "schemaVersion": "1.0",
         "routes": {
           "upstreamLoadGen1": "FROM /messages/modules/loadGen1/outputs/output1 INTO $upstream",
+          "upstreamLoadGen2": "FROM /messages/modules/loadGen2/outputs/output1 INTO $upstream",
           "TempFilterToCloud": "FROM /messages/modules/tempFilter/outputs/* INTO $upstream",
           "TempSensorToTempFilter": "FROM /messages/modules/tempSensor/outputs/temperatureOutput INTO BrokeredEndpoint(\"/modules/tempFilter/inputs/input1\")",
           "TempFilterToCloud2": "FROM /messages/modules/tempFilter2/outputs/* INTO $upstream",

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -160,7 +160,6 @@ function prepare_test_from_artifacts() {
                     echo "Copy deployment file from $long_haul_deployment_artifact_file"
                     cp "$long_haul_deployment_artifact_file" "$deployment_working_file"
 
-                    sed -i -e "s@<LoadGen.TransportType>@$LOADGEN_TRANSPORT_TYPE@g" "$deployment_working_file"
                     sed -i -e "s@<ServiceClientConnectionString>@$IOTHUB_CONNECTION_STRING@g" "$deployment_working_file"
                 else
                     echo "Copy deployment file from $stress_deployment_artifact_file"
@@ -294,48 +293,45 @@ function process_args() {
             EVENTHUB_CONNECTION_STRING="$arg"
             saveNextArg=0
         elif [ $saveNextArg -eq 10 ]; then
-            LOADGEN_TRANSPORT_TYPE="$arg"
-            saveNextArg=0
-        elif [ $saveNextArg -eq 11 ]; then
             LOADGEN_MESSAGE_FREQUENCY="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 12 ]; then
+        elif [ $saveNextArg -eq 11 ]; then
             SNITCH_ALERT_URL="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 13 ]; then
+        elif [ $saveNextArg -eq 12 ]; then
             SNITCH_BUILD_NUMBER="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 14 ]; then
+        elif [ $saveNextArg -eq 13 ]; then
             SNITCH_REPORTING_INTERVAL_IN_SECS="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 15 ]; then
+        elif [ $saveNextArg -eq 14 ]; then
             SNITCH_STORAGE_ACCOUNT="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 16 ]; then
+        elif [ $saveNextArg -eq 15 ]; then
             SNITCH_STORAGE_MASTER_KEY="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 17 ]; then
+        elif [ $saveNextArg -eq 16 ]; then
             SNITCH_TEST_DURATION_IN_SECS="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 18 ]; then
+        elif [ $saveNextArg -eq 17 ]; then
             LOADGEN1_TRANSPORT_TYPE="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 19 ]; then
+        elif [ $saveNextArg -eq 18 ]; then
             LOADGEN2_TRANSPORT_TYPE="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 20 ]; then
+        elif [ $saveNextArg -eq 19 ]; then
             LOADGEN3_TRANSPORT_TYPE="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 21 ]; then
+        elif [ $saveNextArg -eq 20 ]; then
             LOADGEN4_TRANSPORT_TYPE="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 22 ]; then
+        elif [ $saveNextArg -eq 21 ]; then
             AMQP_SETTINGS_ENABLED="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 23 ]; then
+        elif [ $saveNextArg -eq 22 ]; then
             MQTT_SETTINGS_ENABLED="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 24 ]; then
+        elif [ $saveNextArg -eq 23 ]; then
             LONG_HAUL_PROTOCOL_HEAD="$arg"
             saveNextArg=0
         else
@@ -350,21 +346,20 @@ function process_args() {
                 '-containerRegistryPassword' ) saveNextArg=7;;
                 '-iotHubConnectionString' ) saveNextArg=8;;
                 '-eventHubConnectionString' ) saveNextArg=9;;
-                '-loadGenTransportType' ) saveNextArg=10;;
-                '-loadGenMessageFrequency' ) saveNextArg=11;;
-                '-snitchAlertUrl' ) saveNextArg=12;;
-                '-snitchBuildNumber' ) saveNextArg=13;;
-                '-snitchReportingIntervalInSecs' ) saveNextArg=14;;
-                '-snitchStorageAccount' ) saveNextArg=15;;
-                '-snitchStorageMasterKey' ) saveNextArg=16;;
-                '-snitchTestDurationInSecs' ) saveNextArg=17;;
-                '-loadGen1TransportType' ) saveNextArg=18;;
-                '-loadGen2TransportType' ) saveNextArg=19;;
-                '-loadGen3TransportType' ) saveNextArg=20;;
-                '-loadGen4TransportType' ) saveNextArg=21;;
-                '-amqpSettingsEnabled' ) saveNextArg=22;;
-                '-mqttSettingsEnabled' ) saveNextArg=23;;
-                '-longHaulProtocolHead' ) saveNextArg=24;;
+                '-loadGenMessageFrequency' ) saveNextArg=10;;
+                '-snitchAlertUrl' ) saveNextArg=11;;
+                '-snitchBuildNumber' ) saveNextArg=12;;
+                '-snitchReportingIntervalInSecs' ) saveNextArg=13;;
+                '-snitchStorageAccount' ) saveNextArg=14;;
+                '-snitchStorageMasterKey' ) saveNextArg=15;;
+                '-snitchTestDurationInSecs' ) saveNextArg=16;;
+                '-loadGen1TransportType' ) saveNextArg=17;;
+                '-loadGen2TransportType' ) saveNextArg=18;;
+                '-loadGen3TransportType' ) saveNextArg=19;;
+                '-loadGen4TransportType' ) saveNextArg=20;;
+                '-amqpSettingsEnabled' ) saveNextArg=21;;
+                '-mqttSettingsEnabled' ) saveNextArg=22;;
+                '-longHaulProtocolHead' ) saveNextArg=23;;
                 * ) usage;;
             esac
         fi
@@ -808,7 +803,6 @@ function usage() {
     echo ' -containerRegistryPassword      Password of given username for container registory.'
     echo ' -iotHubConnectionString         IoT hub connection string for creating edge device.'
     echo ' -eventHubConnectionString       Event hub connection string for receive D2C messages.'
-    echo ' -loadGenTransportType           Transport type for LoadGen for long haul test. Default is mqtt.'
     echo ' -loadGenMessageFrequency        Frequency to send messages in LoadGen module for long haul and stress test. Default is 00.00.01 for long haul and 00:00:00.03 for stress test.'
     echo ' -snitchAlertUrl                 Alert Url pointing to Azure Logic App for email preparation and sending for long haul and stress test.'
     echo ' -snitchBuildNumber              Build number for snitcher docker image for long haul and stress test. Default is 1.1.'
@@ -829,7 +823,6 @@ function usage() {
 process_args "$@"
 
 E2E_TEST_DIR="${E2E_TEST_DIR:-$(pwd)}"
-LOADGEN_TRANSPORT_TYPE="${LOADGEN_TRANSPORT_TYPE:-mqtt}"
 LONG_HAUL_PROTOCOL_HEAD="${LONG_HAUL_PROTOCOL_HEAD:-amqp}"
 SNITCH_BUILD_NUMBER="${SNITCH_BUILD_NUMBER:-1.1}"
 LOADGEN1_TRANSPORT_TYPE="${LOADGEN1_TRANSPORT_TYPE:-amqp}"


### PR DESCRIPTION
Update long haul deployment to have loadGen modules for amqp and mqtt client transport type on Linux x64; and add direct method cloud sender/receiver modules for ARM.