### PR TITLE
EdgeHub: Fix IsRetryable exception checks in endpoints

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/CloudEndpoint.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             internal static int GetBatchSize(int batchSize, long messageSize) =>
                 Math.Min((int)(Constants.MaxMessageSize / messageSize), batchSize);
 
-            static bool IsRetryable(Exception ex) => ex != null && RetryableExceptions.Contains(ex.GetType());
+            static bool IsRetryable(Exception ex) => ex != null && RetryableExceptions.Any(re => re.IsInstanceOfType(ex));
 
             static ISinkResult HandleNoIdentity(List<IRoutingMessage> routingMessages)
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/ModuleEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/ModuleEndpoint.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using System.IO;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
@@ -138,7 +139,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 return TaskEx.Done;
             }
 
-            static bool IsRetryable(Exception ex) => ex != null && RetryableExceptions.Contains(ex.GetType());
+            static bool IsRetryable(Exception ex) => ex != null && RetryableExceptions.Any(re => re.IsInstanceOfType(ex));
 
             Task<ISinkResult> ProcessNoConnection(ICollection<IRoutingMessage> routingMessages)
             {
@@ -172,7 +173,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                         else
                         {
                             Events.InvalidMessage(ex);
-                            invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.None));
+                            invalid.Add(new InvalidDetails<IRoutingMessage>(routingMessage, FailureKind.InvalidInput));
                         }
 
                         Events.ErrorSendingMessages(this.moduleEndpoint, ex);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudEndpointTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudEndpointTest.cs
@@ -3,17 +3,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.Immutable;
+    using System.IO;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Routing;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.Routing.Core;
+    using Microsoft.Azure.Devices.Routing.Core.MessageSources;
     using Moq;
     using Xunit;
     using IMessage = Microsoft.Azure.Devices.Edge.Hub.Core.IMessage;
     using IRoutingMessage = Microsoft.Azure.Devices.Routing.Core.IMessage;
+    using RoutingMessage = Microsoft.Azure.Devices.Routing.Core.Message;
 
     [Unit]
     public class CloudEndpointTest
@@ -115,6 +121,63 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             Assert.Equal(1, sinkResult.InvalidDetailsList.Count);
             Assert.Equal(0, sinkResult.Failed.Count);
             Assert.Equal(0, sinkResult.Succeeded.Count);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetRetryableExceptionsTestData))]
+        public async Task RetryableExceptionsTest(Exception exception, bool isRetryable)
+        {
+            // Arrange
+            string id = "d1";
+            var cloudProxy = new Mock<ICloudProxy>();
+            cloudProxy.Setup(c => c.SendMessageAsync(It.IsAny<IMessage>()))
+                .ThrowsAsync(exception);
+            var cloudEndpoint = new CloudEndpoint(Guid.NewGuid().ToString(), _ => Task.FromResult(Option.Some(cloudProxy.Object)), new RoutingMessageConverter());
+            IProcessor processor = cloudEndpoint.CreateProcessor();
+            var message = new RoutingMessage(TelemetryMessageSource.Instance, new byte[0], ImmutableDictionary<string, string>.Empty, new Dictionary<string, string>
+            {
+                [Core.SystemProperties.ConnectionDeviceId] = id
+            });
+
+            // Act
+            ISinkResult<IRoutingMessage> result = await processor.ProcessAsync(message, CancellationToken.None);
+
+            // Assert
+            Assert.NotNull(result);
+            if (isRetryable)
+            {
+                Assert.Equal(1, result.Failed.Count);
+                Assert.Equal(0, result.Succeeded.Count);
+                Assert.Equal(0, result.InvalidDetailsList.Count);
+                Assert.Equal(message, result.Failed.First());
+            }
+            else
+            {
+                Assert.Equal(1, result.InvalidDetailsList.Count);
+                Assert.Equal(0, result.Succeeded.Count);
+                Assert.Equal(0, result.Failed.Count);
+                Assert.Equal(message, result.InvalidDetailsList.First().Item);
+                Assert.Equal(FailureKind.InvalidInput, result.InvalidDetailsList.First().FailureKind);
+            }
+        }
+
+        public static IEnumerable<object[]> GetRetryableExceptionsTestData()
+        {
+            yield return new object[] { new IotHubException("Dummy"), true };
+
+            yield return new object[] { new IOException("Dummy"), true };
+
+            yield return new object[] { new TimeoutException("Dummy"), true };
+
+            yield return new object[] { new UnauthorizedException("Dummy"), true };
+
+            yield return new object[] { new DeviceMaximumQueueDepthExceededException("Dummy"), true };
+
+            yield return new object[] { new IotHubSuspendedException("Dummy"), true };
+
+            yield return new object[] { new ArgumentException("Dummy"), false };
+
+            yield return new object[] { new ArgumentNullException("dummy"), false };
         }
     }
 }


### PR DESCRIPTION
With the current checks, Exceptions derived from retryable exceptions were not considered retryable. This PR fixes this. 