### PR TITLE
Use updated arm32 and arm64 base images with stripped RocksDB again

### DIFF
--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm32v7
+ARG base_tag=1.0.0-preview012-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm32v7
+ARG base_tag=1.0.0-preview012-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodCloudSender/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodCloudSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm32v7
+ARG base_tag=1.0.0-preview012-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodCloudSender/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/DirectMethodCloudSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm32v7
+ARG base_tag=1.0.0-preview012-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MessagesAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MessagesAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm32v7
+ARG base_tag=1.0.0-preview012-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MessagesAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MessagesAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm32v7
+ARG base_tag=1.0.0-preview012-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm32v7
+ARG base_tag=1.0.0-preview012-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm32v7
+ARG base_tag=1.0.0-preview012-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview011-linux-arm64v8
+ARG base_tag=1.0.0-preview012-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/scripts/linux/createArmBase.sh
+++ b/scripts/linux/createArmBase.sh
@@ -48,6 +48,7 @@ usage()
     echo "Note: You might have to run this as root or sudo."
     echo "Note: This script is only applicable on ARM architectures."
     echo ""
+    echo " -a, --arch           Architecture of the Docker image; either 'armv7l' or 'aarch64'. Defaults to 'uname -m'"
     echo " -i, --image-name     Image name (azureiotedge-module-base, azureiotedge-agent-base, or azureiotedge-hub-base)"
     echo " -d, --project-dir    Project directory (required)."
     echo "                      Directory which contains docker/linux/arm32v7/base/Dockerfile or docker/linux/arm64v8/base/Dockerfile"
@@ -84,6 +85,9 @@ process_args()
         elif [ $save_next_arg -eq 4 ]; then
             DOCKER_IMAGEVERSION="$arg"
             save_next_arg=0
+        elif [ $save_next_arg -eq 5 ]; then
+            ARCH="$arg"
+            save_next_arg=0
         else
             case "$arg" in
                 "-h" | "--help" ) usage;;
@@ -91,11 +95,14 @@ process_args()
                 "-i" | "--image-name" ) save_next_arg=2;;
                 "-n" | "--namespace" ) save_next_arg=3;;
                 "-v" | "--image-version" ) save_next_arg=4;;
+                "-a" | "--arch" ) save_next_arg=5;;
                 "--no-push" ) NO_PUSH=1;;
                 * ) usage;;
             esac
         fi
     done
+
+    check_arch
 
     if [[ -z ${PUBLISH_DIR} ]]; then
         echo "Docker project directory parameter invalid"
@@ -174,7 +181,6 @@ docker_push()
 ###############################################################################
 # Main Script Execution
 ###############################################################################
-check_arch
 process_args "$@"
 
 docker_build_and_tag


### PR DESCRIPTION
The previous base image had been built with unstripped RocksDB, leading to
a larger than necessary image.

This change also modifies `createArmBase.sh` to allow overriding
the Docker image arch with a CLI parameter. This way the same RPi with
arm64 Ubuntu can be used to build and publish both arm32v7 and arm64v8 images.