### PR TITLE
Fix bug in Docker codegen'd client that prevents health configs in module twin from working

### DIFF
--- a/edgelet/docker-rs/src/models/health_config.rs
+++ b/edgelet/docker-rs/src/models/health_config.rs
@@ -20,16 +20,16 @@ pub struct HealthConfig {
     test: Option<Vec<String>>,
     /// The time to wait between checks in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
     #[serde(rename = "Interval", skip_serializing_if = "Option::is_none")]
-    interval: Option<i32>,
+    interval: Option<i64>,
     /// The time to wait before considering the check to have hung. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
     #[serde(rename = "Timeout", skip_serializing_if = "Option::is_none")]
-    timeout: Option<i32>,
+    timeout: Option<i64>,
     /// The number of consecutive failures needed to consider a container as unhealthy. 0 means inherit.
     #[serde(rename = "Retries", skip_serializing_if = "Option::is_none")]
     retries: Option<i32>,
     /// Start period for the container to initialize before starting health-retries countdown in nanoseconds. It should be 0 or at least 1000000 (1 ms). 0 means inherit.
     #[serde(rename = "StartPeriod", skip_serializing_if = "Option::is_none")]
-    start_period: Option<i32>,
+    start_period: Option<i64>,
 }
 
 impl HealthConfig {
@@ -61,16 +61,16 @@ impl HealthConfig {
         self.test = None;
     }
 
-    pub fn set_interval(&mut self, interval: i32) {
+    pub fn set_interval(&mut self, interval: i64) {
         self.interval = Some(interval);
     }
 
-    pub fn with_interval(mut self, interval: i32) -> Self {
+    pub fn with_interval(mut self, interval: i64) -> Self {
         self.interval = Some(interval);
         self
     }
 
-    pub fn interval(&self) -> Option<i32> {
+    pub fn interval(&self) -> Option<i64> {
         self.interval
     }
 
@@ -78,16 +78,16 @@ impl HealthConfig {
         self.interval = None;
     }
 
-    pub fn set_timeout(&mut self, timeout: i32) {
+    pub fn set_timeout(&mut self, timeout: i64) {
         self.timeout = Some(timeout);
     }
 
-    pub fn with_timeout(mut self, timeout: i32) -> Self {
+    pub fn with_timeout(mut self, timeout: i64) -> Self {
         self.timeout = Some(timeout);
         self
     }
 
-    pub fn timeout(&self) -> Option<i32> {
+    pub fn timeout(&self) -> Option<i64> {
         self.timeout
     }
 
@@ -112,16 +112,16 @@ impl HealthConfig {
         self.retries = None;
     }
 
-    pub fn set_start_period(&mut self, start_period: i32) {
+    pub fn set_start_period(&mut self, start_period: i64) {
         self.start_period = Some(start_period);
     }
 
-    pub fn with_start_period(mut self, start_period: i32) -> Self {
+    pub fn with_start_period(mut self, start_period: i64) -> Self {
         self.start_period = Some(start_period);
         self
     }
 
-    pub fn start_period(&self) -> Option<i32> {
+    pub fn start_period(&self) -> Option<i64> {
         self.start_period
     }
 


### PR DESCRIPTION
The health config of a module has type `HealthConfig`, and its `Interval`,
`Timeout` and `StartPeriod` fields are defined in the Moby source as
`time.Duration`. Thus these fields are 64-bit integers representing
nanoseconds.

However the Moby Swagger spec defines these fields as `type=integer` without
the `format=int64` tag, which the generated code types them as `i32`.

Compare the actual struct at
https://github.com/docker/docker-ce/blob/19.03/components/engine/api/types/container/config.go#L28-L30
with the swagger spec at
https://github.com/docker/docker-ce/blob/19.03/components/engine/api/swagger.yaml#L612-L623

This meant that users could not set any of these fields to a value larger than
`i32::max_value()`

Fixes #1116

---

Upstream defect: https://github.com/moby/moby/issues/39131