### PR TITLE
Don't check version when saving twin in store.

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/TwinStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/TwinStore.cs
@@ -91,18 +91,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
         {
             Events.UpdatingTwin(id);
             Preconditions.CheckNotNull(twin, nameof(twin));
+            // Don't check for version number here - just update the twin in the store.
+            // This is because, if the module, say A, was deleted and recreated, then the
+            // version number check won't really apply. So just override the twin.
             await this.twinEntityStore.PutOrUpdate(
                 id,
                 new TwinStoreEntity(twin),
-                twinInfo =>
-                {
-                    return twinInfo.Twin
-                        .Filter(
-                            storedTwin => storedTwin.Properties?.Desired?.Version < twin.Properties.Desired.Version
-                                          && storedTwin.Properties?.Reported?.Version < twin.Properties.Reported.Version)
-                        .Map(_ => new TwinStoreEntity(Option.Some(twin), twinInfo.ReportedPropertiesPatch))
-                        .GetOrElse(twinInfo);
-                });
+                twinInfo => new TwinStoreEntity(Option.Some(twin), twinInfo.ReportedPropertiesPatch));
             Events.DoneUpdatingTwin(id);
         }
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/TwinStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/TwinStoreTest.cs
@@ -369,25 +369,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                 Properties = new TwinProperties
                 {
                     Desired = desired3,
-                    Reported = reported1
-                }
-            };
-
-            var twin4 = new Twin
-            {
-                Properties = new TwinProperties
-                {
-                    Desired = desired2,
                     Reported = reported3
-                }
-            };
-
-            var twin5 = new Twin
-            {
-                Properties = new TwinProperties
-                {
-                    Desired = desired2,
-                    Reported = reported2
                 }
             };
 
@@ -426,26 +408,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
             // Assert
             twin = await twinStore.Get(id);
             Assert.True(twin.HasValue);
-            Assert.Equal("{\"p2\":\"vp2\",\"p3\":\"v3\",\"$version\":2}", twin.OrDefault().Properties.Desired.ToJson());
-            Assert.Equal("{\"p1\":\"vp1\",\"p2\":\"vp3\",\"$version\":2}", twin.OrDefault().Properties.Reported.ToJson());
-
-            // Act
-            await twinStore.Update(id, twin4);
-
-            // Assert
-            twin = await twinStore.Get(id);
-            Assert.True(twin.HasValue);
-            Assert.Equal("{\"p2\":\"vp2\",\"p3\":\"v3\",\"$version\":2}", twin.OrDefault().Properties.Desired.ToJson());
-            Assert.Equal("{\"p1\":\"vp1\",\"p2\":\"vp3\",\"$version\":2}", twin.OrDefault().Properties.Reported.ToJson());
-
-            // Act
-            await twinStore.Update(id, twin5);
-
-            // Assert
-            twin = await twinStore.Get(id);
-            Assert.True(twin.HasValue);
-            Assert.Equal("{\"p2\":\"vp2\",\"p3\":\"v3\",\"$version\":2}", twin.OrDefault().Properties.Desired.ToJson());
-            Assert.Equal("{\"p1\":\"vp1\",\"p2\":\"vp3\",\"$version\":2}", twin.OrDefault().Properties.Reported.ToJson());
+            Assert.Equal("{\"p2\":\"v10\",\"p3\":\"vp3\",\"$version\":3}", twin.OrDefault().Properties.Desired.ToJson());
+            Assert.Equal("{\"p1\":\"vp1\",\"p3\":\"v10\",\"$version\":3}", twin.OrDefault().Properties.Reported.ToJson());
         }
 
         static IEntityStore<string, TwinStoreEntity> GetTwinEntityStore()


### PR DESCRIPTION
Don't check for version number here - just update the twin in the store.
This is because, if the module, say A, was deleted and recreated, then the version number check won't really apply. So just override the twin.
There are other implications of having a module with the same name being deleted and re-created, but handling those will be a larger work item. Handling the basic twin update case here. 