### PR TITLE
Update encrypted store from throwing if decryption operation fails

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EncryptedStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EncryptedStore.cs
@@ -9,13 +9,14 @@ namespace Microsoft.Azure.Devices.Edge.Storage
     public class EncryptedStore<TK, TV> : IKeyValueStore<TK, TV>
     {
         readonly IKeyValueStore<TK, string> entityStore;
-        readonly IEncryptionProvider encryptionProvider;
 
         public EncryptedStore(IKeyValueStore<TK, string> entityStore, IEncryptionProvider encryptionProvider)
         {
             this.entityStore = Preconditions.CheckNotNull(entityStore, nameof(entityStore));
-            this.encryptionProvider = Preconditions.CheckNotNull(encryptionProvider, nameof(encryptionProvider));
+            this.EncryptionProvider = Preconditions.CheckNotNull(encryptionProvider, nameof(encryptionProvider));
         }
+
+        protected IEncryptionProvider EncryptionProvider { get; }
 
         public Task Put(TK key, TV value) => this.Put(key, value, CancellationToken.None);
 
@@ -46,15 +47,19 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             return await encryptedValue.Map(
                     async e =>
                     {
-                        string decryptedValue = await this.DecryptValue(e);
-                        return Option.Some(decryptedValue.FromJson<TV>());
+                        Option<string> decryptedValue = await this.DecryptValue(e);
+                        return decryptedValue.Map(d => d.FromJson<TV>());
                     })
                 .GetOrElse(() => Task.FromResult(Option.None<TV>()));
         }
 
         public Task Remove(TK key, CancellationToken cancellationToken) => this.entityStore.Remove(key, cancellationToken);
 
-        public Task<bool> Contains(TK key, CancellationToken cancellationToken) => this.entityStore.Contains(key, cancellationToken);
+        public async Task<bool> Contains(TK key, CancellationToken cancellationToken)
+        {
+            Option<TV> value = await this.Get(key, cancellationToken);
+            return value.HasValue;
+        }
 
         public async Task<Option<(TK key, TV value)>> GetFirstEntry(CancellationToken cancellationToken)
         {
@@ -62,8 +67,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             return await encryptedValue.Map(
                     async e =>
                     {
-                        string decryptedValue = await this.DecryptValue(e.value);
-                        return Option.Some((e.key, decryptedValue.FromJson<TV>()));
+                        Option<string> decryptedValue = await this.DecryptValue(e.value);
+                        return decryptedValue.Map(d => (e.key, d.FromJson<TV>()));
                     })
                 .GetOrElse(() => Task.FromResult(Option.None<(TK key, TV value)>()));
         }
@@ -74,8 +79,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             return await encryptedValue.Map(
                     async e =>
                     {
-                        string decryptedValue = await this.DecryptValue(e.value);
-                        return Option.Some((e.key, decryptedValue.FromJson<TV>()));
+                        Option<string> decryptedValue = await this.DecryptValue(e.value);
+                        return decryptedValue.Map(d => (e.key, d.FromJson<TV>()));
                     })
                 .GetOrElse(() => Task.FromResult(Option.None<(TK key, TV value)>()));
         }
@@ -86,9 +91,13 @@ namespace Microsoft.Azure.Devices.Edge.Storage
                 batchSize,
                 async (key, stringValue) =>
                 {
-                    string decryptedValue = await this.DecryptValue(stringValue);
-                    var value = decryptedValue.FromJson<TV>();
-                    await perEntityCallback(key, value);
+                    Option<string> decryptedValue = await this.DecryptValue(stringValue);
+                    await decryptedValue.ForEachAsync(
+                        d =>
+                        {
+                            var value = d.FromJson<TV>();
+                            return perEntityCallback(key, value);
+                        });
                 },
                 cancellationToken);
         }
@@ -100,9 +109,13 @@ namespace Microsoft.Azure.Devices.Edge.Storage
                 batchSize,
                 async (key, stringValue) =>
                 {
-                    string decryptedValue = await this.DecryptValue(stringValue);
-                    var value = decryptedValue.FromJson<TV>();
-                    await perEntityCallback(key, value);
+                    Option<string> decryptedValue = await this.DecryptValue(stringValue);
+                    await decryptedValue.ForEachAsync(
+                        d =>
+                        {
+                            var value = d.FromJson<TV>();
+                            return perEntityCallback(key, value);
+                        });
                 },
                 cancellationToken);
         }
@@ -121,12 +134,20 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             }
         }
 
-        protected IEncryptionProvider EncryptionProvider => this.encryptionProvider;
-
         protected virtual Task<string> EncryptValue(string value)
-            => this.encryptionProvider.EncryptAsync(value);
+            => this.EncryptionProvider.EncryptAsync(value);
 
-        protected virtual Task<string> DecryptValue(string encryptedValue)
-            => this.encryptionProvider.DecryptAsync(encryptedValue);
+        protected virtual async Task<Option<string>> DecryptValue(string encryptedValue)
+        {
+            try
+            {
+                string decryptedValue = await this.EncryptionProvider.DecryptAsync(encryptedValue);
+                return Option.Some(decryptedValue);
+            }
+            catch (Exception)
+            {
+                return Option.None<string>();
+            }
+        }
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/WorkloadClientVersioned.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/WorkloadClientVersioned.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged
     abstract class WorkloadClientVersioned
     {
         static readonly RetryStrategy TransientRetryStrategy =
-            new ExponentialBackoff(retryCount: 3, minBackoff: TimeSpan.FromSeconds(2), maxBackoff: TimeSpan.FromSeconds(30), deltaBackoff: TimeSpan.FromSeconds(3));
+            new ExponentialBackoff(retryCount: 2, minBackoff: TimeSpan.FromSeconds(1), maxBackoff: TimeSpan.FromSeconds(3), deltaBackoff: TimeSpan.FromSeconds(2));
 
         readonly ITransientErrorDetectionStrategy transientErrorDetectionStrategy;
 

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EncryptedStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EncryptedStoreTest.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Storage.Test
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Text;
     using System.Threading.Tasks;
@@ -106,6 +107,160 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
             Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
         }
 
+        [Fact]
+        public async Task KeyResetTest()
+        {
+            // Arrange
+            var encryptionProvider = new ResettableEncryptionProvider();
+            IEntityStore<string, string> entityStore = GetEntityStore<string, string>("smokeTest");
+            IKeyValueStore<string, TestDevice> encryptedStore = new EncryptedStore<string, TestDevice>(entityStore, encryptionProvider);
+            string key = "device1";
+            var device = new TestDevice(Guid.NewGuid().ToString(), new KeyAuth(Guid.NewGuid().ToString()));
+
+            // Act / Assert
+            bool contains = await encryptedStore.Contains("device1");
+            Assert.False(contains);
+
+            await encryptedStore.Put(key, device);
+
+            contains = await encryptedStore.Contains("device1");
+            Assert.True(contains);
+
+            Option<TestDevice> retrievedValue = await encryptedStore.Get("device1");
+            Assert.True(retrievedValue.HasValue);
+            Assert.Equal(device.GenId, retrievedValue.OrDefault().GenId);
+            Assert.Equal(device.Auth.Key, retrievedValue.OrDefault().Auth.Key);
+
+            encryptionProvider.Reset();
+
+            retrievedValue = await encryptedStore.Get("device1");
+            Assert.False(retrievedValue.HasValue);
+
+            contains = await encryptedStore.Contains("device1");
+            Assert.False(contains);
+
+            await encryptedStore.Put(key, device);
+
+            contains = await encryptedStore.Contains("device1");
+            Assert.True(contains);
+
+            retrievedValue = await encryptedStore.Get("device1");
+            Assert.True(retrievedValue.HasValue);
+            Assert.Equal(device.GenId, retrievedValue.OrDefault().GenId);
+            Assert.Equal(device.Auth.Key, retrievedValue.OrDefault().Auth.Key);
+        }
+
+        [Fact]
+        public async Task BatchWithKeyResetTest()
+        {
+            // Arrange
+            var encryptionProvider = new ResettableEncryptionProvider();
+            IEntityStore<string, string> entityStore = GetEntityStore<string, string>("smokeTest");
+            IKeyValueStore<string, TestDevice> encryptedStore = new EncryptedStore<string, TestDevice>(entityStore, encryptionProvider);
+            IDictionary<string, TestDevice> devices = new Dictionary<string, TestDevice>();
+            for (int i = 0; i < 10; i++)
+            {
+                devices[$"d{i}"] = new TestDevice(Guid.NewGuid().ToString(), new KeyAuth(Guid.NewGuid().ToString()));
+            }
+
+            // Act
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                await encryptedStore.Put(device.Key, device.Value);
+            }
+
+            IDictionary<string, TestDevice> obtainedDevices = new Dictionary<string, TestDevice>();
+            await encryptedStore.IterateBatch(
+                10,
+                (key, device) =>
+                {
+                    obtainedDevices[key] = device;
+                    return Task.CompletedTask;
+                });
+
+            // Assert
+            Assert.Equal(devices.Count, obtainedDevices.Count);
+
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                Assert.Equal(device.Value.GenId, obtainedDevices[device.Key].GenId);
+                Assert.Equal(device.Value.Auth.Key, obtainedDevices[device.Key].Auth.Key);
+            }
+
+            // Act
+            Option<(string key, TestDevice value)> first = await encryptedStore.GetFirstEntry();
+            Option<(string key, TestDevice value)> last = await encryptedStore.GetLastEntry();
+
+            // Assert
+            Assert.True(first.HasValue);
+            Assert.True(last.HasValue);
+
+            Assert.Equal("d0", first.OrDefault().key);
+            Assert.Equal(devices["d0"].GenId, first.OrDefault().value.GenId);
+            Assert.Equal("d9", last.OrDefault().key);
+            Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
+
+            // Act
+            encryptionProvider.Reset();
+
+            obtainedDevices = new Dictionary<string, TestDevice>();
+            await encryptedStore.IterateBatch(
+                10,
+                (key, device) =>
+                {
+                    obtainedDevices[key] = device;
+                    return Task.CompletedTask;
+                });
+
+            // Assert
+            Assert.Equal(0, obtainedDevices.Count);
+
+            // Act
+            first = await encryptedStore.GetFirstEntry();
+            last = await encryptedStore.GetLastEntry();
+
+            // Assert
+            Assert.False(first.HasValue);
+            Assert.False(last.HasValue);
+
+            // Act
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                await encryptedStore.Put(device.Key, device.Value);
+            }
+
+            obtainedDevices = new Dictionary<string, TestDevice>();
+            await encryptedStore.IterateBatch(
+                10,
+                (key, device) =>
+                {
+                    obtainedDevices[key] = device;
+                    return Task.CompletedTask;
+                });
+
+            // Assert
+            Assert.Equal(devices.Count, obtainedDevices.Count);
+
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                Assert.Equal(device.Value.GenId, obtainedDevices[device.Key].GenId);
+                Assert.Equal(device.Value.Auth.Key, obtainedDevices[device.Key].Auth.Key);
+            }
+
+            // Act
+            first = await encryptedStore.GetFirstEntry();
+            last = await encryptedStore.GetLastEntry();
+
+            // Assert
+            Assert.True(first.HasValue);
+            Assert.True(last.HasValue);
+
+            Assert.Equal("d0", first.OrDefault().key);
+            Assert.Equal(devices["d0"].GenId, first.OrDefault().value.GenId);
+            Assert.Equal("d9", last.OrDefault().key);
+            Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
+        }
+
         static IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
             => new EntityStore<TK, TV>(new KeyValueStoreMapper<TK, byte[], TV, byte[]>(new InMemoryDbStore(), new BytesMapper<TK>(), new BytesMapper<TV>()), entityName);
 
@@ -135,6 +290,30 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
 
             [JsonProperty("auth")]
             public KeyAuth Auth { get; }
+        }
+
+        class ResettableEncryptionProvider : IEncryptionProvider
+        {
+            IDictionary<string, string> encryptedVals = new ConcurrentDictionary<string, string>();
+
+            public Task<string> DecryptAsync(string encryptedText)
+            {
+                if (!this.encryptedVals.TryGetValue(encryptedText, out string plainText))
+                {
+                    return Task.FromException<string>(new InvalidOperationException("Error decrypting"));
+                }
+
+                return Task.FromResult(plainText);
+            }
+
+            public Task<string> EncryptAsync(string plainText)
+            {
+                string encryptedValue = Guid.NewGuid().ToString();
+                this.encryptedVals.Add(encryptedValue, plainText);
+                return Task.FromResult(encryptedValue);
+            }
+
+            public void Reset() => this.encryptedVals = new ConcurrentDictionary<string, string>();
         }
 
         class TestEncryptionProvider : IEncryptionProvider

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/UpdatableEncryptedStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/UpdatableEncryptedStoreTest.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Storage.Test
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Text;
     using System.Threading.Tasks;
@@ -181,6 +182,160 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
             Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
         }
 
+        [Fact]
+        public async Task KeyResetTest()
+        {
+            // Arrange
+            var encryptionProvider = new ResettableEncryptionProvider();
+            IEntityStore<string, string> entityStore = GetEntityStore<string, string>("smokeTest");
+            IKeyValueStore<string, TestDevice> encryptedStore = new EncryptedStore<string, TestDevice>(entityStore, encryptionProvider);
+            string key = "device1";
+            var device = new TestDevice(Guid.NewGuid().ToString(), new KeyAuth(Guid.NewGuid().ToString()));
+
+            // Act / Assert
+            bool contains = await encryptedStore.Contains("device1");
+            Assert.False(contains);
+
+            await encryptedStore.Put(key, device);
+
+            contains = await encryptedStore.Contains("device1");
+            Assert.True(contains);
+
+            Option<TestDevice> retrievedValue = await encryptedStore.Get("device1");
+            Assert.True(retrievedValue.HasValue);
+            Assert.Equal(device.GenId, retrievedValue.OrDefault().GenId);
+            Assert.Equal(device.Auth.Key, retrievedValue.OrDefault().Auth.Key);
+
+            encryptionProvider.Reset();
+
+            retrievedValue = await encryptedStore.Get("device1");
+            Assert.False(retrievedValue.HasValue);
+
+            contains = await encryptedStore.Contains("device1");
+            Assert.False(contains);
+
+            await encryptedStore.Put(key, device);
+
+            contains = await encryptedStore.Contains("device1");
+            Assert.True(contains);
+
+            retrievedValue = await encryptedStore.Get("device1");
+            Assert.True(retrievedValue.HasValue);
+            Assert.Equal(device.GenId, retrievedValue.OrDefault().GenId);
+            Assert.Equal(device.Auth.Key, retrievedValue.OrDefault().Auth.Key);
+        }
+
+        [Fact]
+        public async Task BatchWithKeyResetTest()
+        {
+            // Arrange
+            var encryptionProvider = new ResettableEncryptionProvider();
+            IEntityStore<string, string> entityStore = GetEntityStore<string, string>("smokeTest");
+            IKeyValueStore<string, TestDevice> encryptedStore = new EncryptedStore<string, TestDevice>(entityStore, encryptionProvider);
+            IDictionary<string, TestDevice> devices = new Dictionary<string, TestDevice>();
+            for (int i = 0; i < 10; i++)
+            {
+                devices[$"d{i}"] = new TestDevice(Guid.NewGuid().ToString(), new KeyAuth(Guid.NewGuid().ToString()));
+            }
+
+            // Act
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                await encryptedStore.Put(device.Key, device.Value);
+            }
+
+            IDictionary<string, TestDevice> obtainedDevices = new Dictionary<string, TestDevice>();
+            await encryptedStore.IterateBatch(
+                10,
+                (key, device) =>
+                {
+                    obtainedDevices[key] = device;
+                    return Task.CompletedTask;
+                });
+
+            // Assert
+            Assert.Equal(devices.Count, obtainedDevices.Count);
+
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                Assert.Equal(device.Value.GenId, obtainedDevices[device.Key].GenId);
+                Assert.Equal(device.Value.Auth.Key, obtainedDevices[device.Key].Auth.Key);
+            }
+
+            // Act
+            Option<(string key, TestDevice value)> first = await encryptedStore.GetFirstEntry();
+            Option<(string key, TestDevice value)> last = await encryptedStore.GetLastEntry();
+
+            // Assert
+            Assert.True(first.HasValue);
+            Assert.True(last.HasValue);
+
+            Assert.Equal("d0", first.OrDefault().key);
+            Assert.Equal(devices["d0"].GenId, first.OrDefault().value.GenId);
+            Assert.Equal("d9", last.OrDefault().key);
+            Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
+
+            // Act
+            encryptionProvider.Reset();
+
+            obtainedDevices = new Dictionary<string, TestDevice>();
+            await encryptedStore.IterateBatch(
+                10,
+                (key, device) =>
+                {
+                    obtainedDevices[key] = device;
+                    return Task.CompletedTask;
+                });
+
+            // Assert
+            Assert.Equal(0, obtainedDevices.Count);
+
+            // Act
+            first = await encryptedStore.GetFirstEntry();
+            last = await encryptedStore.GetLastEntry();
+
+            // Assert
+            Assert.False(first.HasValue);
+            Assert.False(last.HasValue);
+
+            // Act
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                await encryptedStore.Put(device.Key, device.Value);
+            }
+
+            obtainedDevices = new Dictionary<string, TestDevice>();
+            await encryptedStore.IterateBatch(
+                10,
+                (key, device) =>
+                {
+                    obtainedDevices[key] = device;
+                    return Task.CompletedTask;
+                });
+
+            // Assert
+            Assert.Equal(devices.Count, obtainedDevices.Count);
+
+            foreach (KeyValuePair<string, TestDevice> device in devices)
+            {
+                Assert.Equal(device.Value.GenId, obtainedDevices[device.Key].GenId);
+                Assert.Equal(device.Value.Auth.Key, obtainedDevices[device.Key].Auth.Key);
+            }
+
+            // Act
+            first = await encryptedStore.GetFirstEntry();
+            last = await encryptedStore.GetLastEntry();
+
+            // Assert
+            Assert.True(first.HasValue);
+            Assert.True(last.HasValue);
+
+            Assert.Equal("d0", first.OrDefault().key);
+            Assert.Equal(devices["d0"].GenId, first.OrDefault().value.GenId);
+            Assert.Equal("d9", last.OrDefault().key);
+            Assert.Equal(devices["d9"].GenId, last.OrDefault().value.GenId);
+        }
+
         static IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
             => new EntityStore<TK, TV>(new KeyValueStoreMapper<TK, byte[], TV, byte[]>(new InMemoryDbStore(), new BytesMapper<TK>(), new BytesMapper<TV>()), entityName);
 
@@ -217,6 +372,30 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
             public Task<string> DecryptAsync(string encryptedText) => Task.FromResult(Encoding.UTF8.GetString(Convert.FromBase64String(encryptedText)));
 
             public Task<string> EncryptAsync(string plainText) => Task.FromResult(Convert.ToBase64String(Encoding.UTF8.GetBytes(plainText)));
+        }
+
+        class ResettableEncryptionProvider : IEncryptionProvider
+        {
+            IDictionary<string, string> encryptedVals = new ConcurrentDictionary<string, string>();
+
+            public Task<string> DecryptAsync(string encryptedText)
+            {
+                if (!this.encryptedVals.TryGetValue(encryptedText, out string plainText))
+                {
+                    return Task.FromException<string>(new InvalidOperationException("Error decrypting"));
+                }
+
+                return Task.FromResult(plainText);
+            }
+
+            public Task<string> EncryptAsync(string plainText)
+            {
+                string encryptedValue = Guid.NewGuid().ToString();
+                this.encryptedVals.Add(encryptedValue, plainText);
+                return Task.FromResult(encryptedValue);
+            }
+
+            public void Reset() => this.encryptedVals = new ConcurrentDictionary<string, string>();
         }
     }
 }


### PR DESCRIPTION
If the key used to decrypt changes in the iotedged, the decryption operation fails. 
If the EdgeHub has its storage volume mounted into the container, this currently causes the EdgeHub to crash. 
This PR fixes this by updating the EncryptionProvider to treat a decryption failure as "value not found".
Also changed the retry/backoff strategy for the Workload client, to avoid the decryption failure to be retried too many times and for too long, causing the EdgeHub to back off.

The ideal fix for this would be to return a different status from the iotedged if decryption fails instead of 500, which can be handled differently. But looks like that is tricky to do at the moment, because of the way the hsm lib is implemented. 