### PR TITLE
Fix workload certificate generation due to invalid issuer alias

### DIFF
--- a/edgelet/edgelet-core/src/crypto.rs
+++ b/edgelet/edgelet-core/src/crypto.rs
@@ -13,7 +13,7 @@ use failure::ResultExt;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
-use crate::certificate_properties::{CertificateProperties, CertificateIssuer};
+use crate::certificate_properties::{CertificateIssuer, CertificateProperties};
 use crate::error::{Error, ErrorKind};
 
 /// This is the issuer alias used when `CertificateIssuer::DefaultCa` is provided by the caller

--- a/edgelet/edgelet-core/src/crypto.rs
+++ b/edgelet/edgelet-core/src/crypto.rs
@@ -13,7 +13,7 @@ use failure::ResultExt;
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 
-use crate::certificate_properties::CertificateProperties;
+use crate::certificate_properties::{CertificateProperties, CertificateIssuer};
 use crate::error::{Error, ErrorKind};
 
 /// This is the issuer alias used when `CertificateIssuer::DefaultCa` is provided by the caller
@@ -111,6 +111,10 @@ where
             PrivateKey::Key(ref val) => PrivateKey::Key(val.clone()),
         }
     }
+}
+
+pub trait GetIssuerAlias {
+    fn get_issuer_alias(&self, issuer: CertificateIssuer) -> Result<String, Error>;
 }
 
 pub trait GetDeviceIdentityCertificate {

--- a/edgelet/edgelet-core/src/error.rs
+++ b/edgelet/edgelet-core/src/error.rs
@@ -54,6 +54,9 @@ pub enum ErrorKind {
     #[fail(display = "An identity manager error occurred.")]
     IdentityManager,
 
+    #[fail(display = "Invalid or unsupported certificate issuer.")]
+    InvalidIssuer,
+
     #[fail(display = "An error occurred in the key store.")]
     KeyStore,
 

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -23,9 +23,9 @@ pub mod workload;
 pub use authorization::{Authorization, Policy};
 pub use certificate_properties::{CertificateIssuer, CertificateProperties, CertificateType};
 pub use crypto::{
-    Certificate, CreateCertificate, Decrypt, Encrypt, GetDeviceIdentityCertificate, GetTrustBundle,
-    KeyBytes, KeyIdentity, KeyStore, MasterEncryptionKey, PrivateKey, Signature, IOTEDGED_CA_ALIAS,
-    GetIssuerAlias,
+    Certificate, CreateCertificate, Decrypt, Encrypt, GetDeviceIdentityCertificate, GetIssuerAlias,
+    GetTrustBundle, KeyBytes, KeyIdentity, KeyStore, MasterEncryptionKey, PrivateKey, Signature,
+    IOTEDGED_CA_ALIAS,
 };
 pub use error::{Error, ErrorKind};
 pub use identity::{AuthType, Identity, IdentityManager, IdentityOperation, IdentitySpec};

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -25,6 +25,7 @@ pub use certificate_properties::{CertificateIssuer, CertificateProperties, Certi
 pub use crypto::{
     Certificate, CreateCertificate, Decrypt, Encrypt, GetDeviceIdentityCertificate, GetTrustBundle,
     KeyBytes, KeyIdentity, KeyStore, MasterEncryptionKey, PrivateKey, Signature, IOTEDGED_CA_ALIAS,
+    GetIssuerAlias,
 };
 pub use error::{Error, ErrorKind};
 pub use identity::{AuthType, Identity, IdentityManager, IdentityOperation, IdentitySpec};

--- a/edgelet/edgelet-hsm/src/crypto.rs
+++ b/edgelet/edgelet-hsm/src/crypto.rs
@@ -6,11 +6,12 @@ use std::sync::{Arc, Mutex};
 use failure::Fail;
 
 use edgelet_core::{
-    Certificate as CoreCertificate, CertificateProperties as CoreCertificateProperties,
-    CreateCertificate as CoreCreateCertificate, Decrypt as CoreDecrypt, Encrypt as CoreEncrypt,
-    Error as CoreError, ErrorKind as CoreErrorKind, GetTrustBundle as CoreGetTrustBundle,
+    Certificate as CoreCertificate, CertificateIssuer as CoreCertificateIssuer,
+    CertificateProperties as CoreCertificateProperties, CreateCertificate as CoreCreateCertificate,
+    Decrypt as CoreDecrypt, Encrypt as CoreEncrypt, Error as CoreError, ErrorKind as CoreErrorKind,
+    GetIssuerAlias as CoreGetIssuerAlias, GetTrustBundle as CoreGetTrustBundle,
     KeyBytes as CoreKeyBytes, MasterEncryptionKey as CoreMasterEncryptionKey,
-    PrivateKey as CorePrivateKey, GetIssuerAlias as CoreGetIssuerAlias, CertificateIssuer as CoreCertificateIssuer,
+    PrivateKey as CorePrivateKey,
 };
 pub use hsm::{
     Buffer, Decrypt, Encrypt, GetCertificate as HsmGetCertificate, GetTrustBundle, HsmCertificate,
@@ -144,8 +145,7 @@ impl CoreGetIssuerAlias for Crypto {
         if issuer == CoreCertificateIssuer::DeviceCa {
             let crypto = self.crypto.lock().expect("Lock on crypto structure failed");
             Ok(crypto.get_device_ca_alias())
-        }
-        else {
+        } else {
             Err(CoreError::from(CoreErrorKind::InvalidIssuer))
         }
     }

--- a/edgelet/edgelet-hsm/tests/crypto_create_cert_success.rs
+++ b/edgelet/edgelet-hsm/tests/crypto_create_cert_success.rs
@@ -4,6 +4,7 @@
 #![deny(clippy::all, clippy::pedantic)]
 
 use lazy_static::lazy_static;
+use std::convert::TryFrom;
 use std::sync::Mutex;
 
 use edgelet_core::{
@@ -41,7 +42,7 @@ fn crypto_create_cert_success() {
     assert!(diff > 0);
     // create the default issuing CA cert properties
     let edgelet_ca_props = CertificateProperties::new(
-        diff as u64,
+        u64::try_from(diff).unwrap(),
         "test-iotedge-cn".to_string(),
         CertificateType::Ca,
         IOTEDGED_CA_ALIAS.to_string(),

--- a/edgelet/edgelet-hsm/tests/crypto_create_cert_success.rs
+++ b/edgelet/edgelet-hsm/tests/crypto_create_cert_success.rs
@@ -8,7 +8,7 @@ use std::sync::Mutex;
 
 use edgelet_core::{
     Certificate, CertificateIssuer, CertificateProperties, CertificateType, CreateCertificate,
-    KeyBytes, PrivateKey, Signature, IOTEDGED_CA_ALIAS, GetIssuerAlias
+    GetIssuerAlias, KeyBytes, PrivateKey, Signature, IOTEDGED_CA_ALIAS,
 };
 use edgelet_hsm::Crypto;
 mod test_utils;
@@ -28,11 +28,11 @@ fn crypto_create_cert_success() {
     let workload_ca_cert = crypto.get_certificate(IOTEDGED_CA_ALIAS.to_string());
     assert!(workload_ca_cert.is_err());
 
-    let issuer_alias = crypto.get_issuer_alias(CertificateIssuer::DeviceCa).unwrap();
-
-    let issuer_ca = crypto
-        .get_certificate(issuer_alias)
+    let issuer_alias = crypto
+        .get_issuer_alias(CertificateIssuer::DeviceCa)
         .unwrap();
+
+    let issuer_ca = crypto.get_certificate(issuer_alias).unwrap();
     let issuer_validity = issuer_ca.get_valid_to().unwrap();
 
     let now = chrono::Utc::now();

--- a/edgelet/edgelet-hsm/tests/crypto_create_cert_success.rs
+++ b/edgelet/edgelet-hsm/tests/crypto_create_cert_success.rs
@@ -26,12 +26,16 @@ fn crypto_create_cert_success() {
 
     let crypto = Crypto::new().unwrap();
 
-    let workload_ca_cert = crypto.get_certificate(IOTEDGED_CA_ALIAS.to_string());
-    assert!(workload_ca_cert.is_err());
-
+    // tests to ensure that the Device CA alias exists and is valid
+    assert!(crypto.get_issuer_alias(CertificateIssuer::DefaultCa).is_err());
     let issuer_alias = crypto
         .get_issuer_alias(CertificateIssuer::DeviceCa)
         .unwrap();
+    assert!(!issuer_alias.is_empty());
+
+    // ensure workload CA does not exist
+    let workload_ca_cert = crypto.get_certificate(IOTEDGED_CA_ALIAS.to_string());
+    assert!(workload_ca_cert.is_err());
 
     let issuer_ca = crypto.get_certificate(issuer_alias).unwrap();
     let issuer_validity = issuer_ca.get_valid_to().unwrap();

--- a/edgelet/edgelet-hsm/tests/crypto_create_cert_success.rs
+++ b/edgelet/edgelet-hsm/tests/crypto_create_cert_success.rs
@@ -27,7 +27,9 @@ fn crypto_create_cert_success() {
     let crypto = Crypto::new().unwrap();
 
     // tests to ensure that the Device CA alias exists and is valid
-    assert!(crypto.get_issuer_alias(CertificateIssuer::DefaultCa).is_err());
+    assert!(crypto
+        .get_issuer_alias(CertificateIssuer::DefaultCa)
+        .is_err());
     let issuer_alias = crypto
         .get_issuer_alias(CertificateIssuer::DeviceCa)
         .unwrap();

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -46,8 +46,8 @@ use edgelet_config::{
     TpmAttestationInfo, DEFAULT_CONNECTION_STRING,
 };
 use edgelet_core::crypto::{
-    Activate, CreateCertificate, Decrypt, DerivedKeyStore, Encrypt, GetTrustBundle, KeyIdentity,
-    KeyStore, MasterEncryptionKey, MemoryKey, MemoryKeyStore, Sign, IOTEDGED_CA_ALIAS, GetIssuerAlias,
+    Activate, CreateCertificate, Decrypt, DerivedKeyStore, Encrypt, GetIssuerAlias, GetTrustBundle,
+    KeyIdentity, KeyStore, MasterEncryptionKey, MemoryKey, MemoryKeyStore, Sign, IOTEDGED_CA_ALIAS,
 };
 use edgelet_core::watchdog::Watchdog;
 use edgelet_core::{
@@ -368,10 +368,10 @@ where
     C: CreateCertificate + GetIssuerAlias,
 {
     let issuer_alias = crypto
-                        .get_issuer_alias(CertificateIssuer::DeviceCa)
-                        .context(ErrorKind::Initialize(
-                            InitializeErrorReason::PrepareWorkloadCa,
-                        ))?;
+        .get_issuer_alias(CertificateIssuer::DeviceCa)
+        .context(ErrorKind::Initialize(
+            InitializeErrorReason::PrepareWorkloadCa,
+        ))?;
 
     let issuer_ca = crypto
         .get_certificate(issuer_alias)
@@ -1134,12 +1134,15 @@ mod tests {
     }
 
     impl GetIssuerAlias for TestCrypto {
-        fn get_issuer_alias(&self, _issuer: CertificateIssuer) -> Result<String, edgelet_core::Error> {
+        fn get_issuer_alias(
+            &self,
+            _issuer: CertificateIssuer,
+        ) -> Result<String, edgelet_core::Error> {
             if self.fail_device_ca_alias {
-                Err(edgelet_core::Error::from(edgelet_core::ErrorKind::InvalidIssuer))
-            }
-            else
-            {
+                Err(edgelet_core::Error::from(
+                    edgelet_core::ErrorKind::InvalidIssuer,
+                ))
+            } else {
                 Ok("test-device-ca".to_string())
             }
         }
@@ -1166,7 +1169,8 @@ mod tests {
             TestModule::new("test-module".to_string(), config, Ok(state));
         let runtime = TestRuntime::new(Ok(module));
         let crypto = TestCrypto {
-            use_expired_ca: true, fail_device_ca_alias: true,
+            use_expired_ca: false,
+            fail_device_ca_alias: true,
         };
         let mut tokio_runtime = tokio::runtime::Runtime::new().unwrap();
         let result = check_settings_state(
@@ -1193,7 +1197,8 @@ mod tests {
             TestModule::new("test-module".to_string(), config, Ok(state));
         let runtime = TestRuntime::new(Ok(module));
         let crypto = TestCrypto {
-            use_expired_ca: true, fail_device_ca_alias: false,
+            use_expired_ca: true,
+            fail_device_ca_alias: false,
         };
         let mut tokio_runtime = tokio::runtime::Runtime::new().unwrap();
         let result = check_settings_state(
@@ -1220,7 +1225,8 @@ mod tests {
             TestModule::new("test-module".to_string(), config, Ok(state));
         let runtime = TestRuntime::new(Ok(module));
         let crypto = TestCrypto {
-            use_expired_ca: false, fail_device_ca_alias: false,
+            use_expired_ca: false,
+            fail_device_ca_alias: false,
         };
         let mut tokio_runtime = tokio::runtime::Runtime::new().unwrap();
         check_settings_state(
@@ -1254,7 +1260,8 @@ mod tests {
             TestModule::new("test-module".to_string(), config, Ok(state));
         let runtime = TestRuntime::new(Ok(module));
         let crypto = TestCrypto {
-            use_expired_ca: false, fail_device_ca_alias: false,
+            use_expired_ca: false,
+            fail_device_ca_alias: false,
         };
         let mut tokio_runtime = tokio::runtime::Runtime::new().unwrap();
         check_settings_state(


### PR DESCRIPTION
Due to an incorrect specification of the issuer alias, the workload CA failed to generate. Added the fix and unit tests. Also added a smoke test to ensure this bootstrap scenario is tested.