### PR TITLE
Make edgeAgent also have a PVC

### DIFF
--- a/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
@@ -32,6 +32,12 @@ spec:
           image: "{{ .Values.edgeAgent.image.repository }}:{{ .Values.edgeAgent.image.tag }}"
           imagePullPolicy: {{ .Values.edgeAgent.image.pullPolicy }}
           env:
+          {{- if .Values.edgeAgent.data.persistentVolumeClaim }}
+          - name: BackupConfigFilePath
+            value: {{ printf "%s/backup.json" .Values.edgeAgent.data.targetPath }}
+          - name: StorageFolder
+            value: {{ .Values.edgeAgent.data.targetPath | quote }}
+          {{- end }}
           - name: IOTEDGE_MODULEGENERATIONID
             valueFrom:
               configMapKeyRef:

--- a/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
@@ -73,6 +73,11 @@ spec:
             value: {{ .Values.edgeAgent.env.enableK8sServiceCallTracing | quote }}
           - name: "K8sNamespaceBaseName"
             value: {{ .Values.namespace | quote }}
+          {{- if .Values.edgeAgent.data.persistentVolumeClaim }}
+          volumeMounts:
+            - name: agent-storage
+              mountPath: {{ .Values.edgeAgent.data.targetPath | quote }}
+          {{ end -}}
         - name: proxy
           image: "{{ .Values.iotedgedProxy.image.repository }}:{{ .Values.iotedgedProxy.image.tag }}"
           imagePullPolicy: {{ .Values.iotedgedProxy.image.pullPolicy }}
@@ -88,3 +93,9 @@ spec:
         - name: config-volume
           configMap:
             name: {{ include "edge-kubernetes.fullname" . }}-iotedged-proxy-config
+        {{- if .Values.edgeAgent.data.persistentVolumeClaim }}
+        - name: agent-storage
+          persistentVolumeClaim:
+            claimName: {{ .Values.edgeAgent.data.persistentVolumeClaim.name }}
+            readOnly: false
+        {{ end -}}

--- a/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/edge-agent-deployment.yaml
@@ -77,7 +77,8 @@ spec:
           volumeMounts:
             - name: agent-storage
               mountPath: {{ .Values.edgeAgent.data.targetPath | quote }}
-          {{ end -}}
+              readOnly: false
+          {{- end }}
         - name: proxy
           image: "{{ .Values.iotedgedProxy.image.repository }}:{{ .Values.iotedgedProxy.image.tag }}"
           imagePullPolicy: {{ .Values.iotedgedProxy.image.pullPolicy }}
@@ -99,3 +100,4 @@ spec:
             claimName: {{ .Values.edgeAgent.data.persistentVolumeClaim.name }}
             readOnly: false
         {{ end -}}
+

--- a/edgelet/build/charts/edge-kubernetes/templates/edge-agent-pvc.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/edge-agent-pvc.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.edgeAgent.data.persistentVolumeClaim }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Values.edgeAgent.data.persistentVolumeClaim.name | quote }}
+  namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+spec:
+  resources:
+    requests:
+      storage: 100Mi
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ .Values.edgeAgent.data.persistentVolumeClaim.storageClassName | quote }}
+  {{- end }}

--- a/edgelet/build/charts/edge-kubernetes/templates/iotedged-pvc.yaml
+++ b/edgelet/build/charts/edge-kubernetes/templates/iotedged-pvc.yaml
@@ -11,4 +11,4 @@ spec:
   accessModes:
     - ReadWriteMany
   storageClassName: {{ .Values.iotedged.data.persistentVolumeClaim.storageClassName | quote }}
-  {{- end }}
+{{- end }}

--- a/edgelet/build/charts/edge-kubernetes/values.yaml
+++ b/edgelet/build/charts/edge-kubernetes/values.yaml
@@ -74,6 +74,17 @@ edgeAgent:
     enableK8sServiceCallTracing: false
     # Configure edge agent log verbosity
     runtimeLogLevel: 'debug'
+  data:
+    # In order to benefit from HA, at a minimum the data location for edgeAgent
+    # should be backed by a persistent volume. Please setup a persistent volume
+    # and define a persistent volume claim and provide its reference below. If
+    # this is not provided then the iotedged pod will default to using an
+    # "emptyDir" volume which doesn't work for HA because its lifetime is linked
+    # to the pod's lifetime.
+    targetPath: /tmp/edgeAgent
+    # persistentVolumeClaim:
+    #   name: <CLAIM NAME HERE>
+    #   storageClassName: <STORAGE CLASS NAME HERE>
 
 # Optional registry credentials for module images
 # registryCredentials:

--- a/edgelet/build/charts/edge-kubernetes/values.yaml
+++ b/edgelet/build/charts/edge-kubernetes/values.yaml
@@ -81,7 +81,7 @@ edgeAgent:
     # this is not provided then the iotedged pod will default to using an
     # "emptyDir" volume which doesn't work for HA because its lifetime is linked
     # to the pod's lifetime.
-    targetPath: /tmp/edgeAgent
+    targetPath: /app/data/edgeAgent
     # persistentVolumeClaim:
     #   name: <CLAIM NAME HERE>
     #   storageClassName: <STORAGE CLASS NAME HERE>


### PR DESCRIPTION

Allow people to assign a PVC to edgeAgent, and mount that to /tmp/edgeAgent.

This allows edgeAgent to be moved around in the cluster.