### PR TITLE
EdgeHub: Pull config from twin every hour

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             ValidateSchemaVersion(desiredProperties.SchemaVersion);
 
-            var routes = new List<(string Name, string Value, Route Route)>();
+            var routes = new Dictionary<string, RouteConfig>();
             if (desiredProperties.Routes != null)
             {
                 foreach (KeyValuePair<string, string> inputRoute in desiredProperties.Routes)
@@ -238,7 +238,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                         if (!string.IsNullOrWhiteSpace(inputRoute.Value))
                         {
                             Route route = this.routeFactory.Create(inputRoute.Value);
-                            routes.Add((inputRoute.Key, inputRoute.Value, route));
+                            routes.Add(inputRoute.Key, new RouteConfig(inputRoute.Key, inputRoute.Value, route));
                         }
                     }
                     catch (Exception ex)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Net;
     using System.Threading.Tasks;
@@ -248,7 +249,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 }
             }
 
-            return new EdgeHubConfig(desiredProperties.SchemaVersion, routes, desiredProperties.StoreAndForwardConfiguration);
+            return new EdgeHubConfig(desiredProperties.SchemaVersion, new ReadOnlyDictionary<string, RouteConfig>(routes), desiredProperties.StoreAndForwardConfiguration);
         }
 
         async Task HandleDesiredPropertiesUpdate(IMessage desiredPropertiesUpdate)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/ConfigUpdater.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/ConfigUpdater.cs
@@ -14,43 +14,68 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
     {
         readonly Router router;
         readonly IMessageStore messageStore;
+        readonly TimeSpan configUpdateFrequency;
         readonly AsyncLock updateLock = new AsyncLock();
 
-        public ConfigUpdater(Router router, IMessageStore messageStore)
+        Option<PeriodicTask> configUpdater;
+        Option<EdgeHubConfig> currentConfig;
+        Option<IConfigSource> configProvider;
+
+        public ConfigUpdater(Router router, IMessageStore messageStore, TimeSpan configUpdateFrequency)
         {
             this.router = Preconditions.CheckNotNull(router, nameof(router));
             this.messageStore = messageStore;
+            this.configUpdateFrequency = configUpdateFrequency;
         }
 
-        public async Task Init(IConfigSource configProvider)
+        public void Init(IConfigSource configProvider)
         {
             Preconditions.CheckNotNull(configProvider, nameof(configProvider));
             try
             {
-                using (await this.updateLock.LockAsync())
-                {
-                    configProvider.SetConfigUpdatedCallback(this.UpdateConfig);
-                    Option<EdgeHubConfig> edgeHubConfig = await configProvider.GetConfig();
+                configProvider.SetConfigUpdatedCallback(this.UpdateConfig);
+                this.configProvider = Option.Some(configProvider);
+                this.configUpdater = Option.Some(new PeriodicTask(this.PullConfig, this.configUpdateFrequency, TimeSpan.Zero, Events.Log, "Get EdgeHub config"));
+                Events.Initialized();
+            }
+            catch (Exception ex)
+            {
+                Events.InitializingError(ex);
+            }
+        }
 
+        async Task PullConfig()
+        {
+            try
+            {
+                Option<EdgeHubConfig> edgeHubConfig = await this.configProvider
+                        .Map(c => c.GetConfig())
+                        .GetOrElse(Task.FromResult(Option.None<EdgeHubConfig>()));
                     if (!edgeHubConfig.HasValue)
                     {
                         Events.EmptyConfigReceived();
                     }
                     else
                     {
-                        await edgeHubConfig.ForEachAsync(
-                            async ehc =>
-                            {
-                                await this.UpdateRoutes(ehc.Routes, false);
-                                this.UpdateStoreAndForwardConfig(ehc.StoreAndForwardConfiguration);
-                            });
-                        Events.Initialized();
+                        using (await this.updateLock.LockAsync())
+                        {
+                            await edgeHubConfig.ForEachAsync(
+                                async ehc =>
+                                {
+                                    bool hasUpdates = this.currentConfig.Map(cc => !cc.Equals(ehc)).GetOrElse(true);
+                                    if (hasUpdates)
+                                    {
+                                        await this.UpdateRoutes(ehc.Routes, this.currentConfig.HasValue);
+                                        this.UpdateStoreAndForwardConfig(ehc.StoreAndForwardConfiguration);
+                                        this.currentConfig = Option.Some(ehc);
+                                    }
+                                });
+                        }
                     }
-                }
             }
             catch (Exception ex)
             {
-                Events.InitializingError(ex);
+                Events.ErrorPullingConfig(ex);
             }
         }
 
@@ -72,12 +97,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
             }
         }
 
-        async Task UpdateRoutes(IEnumerable<(string Name, string Value, Route Route)> routes, bool replaceExisting)
+        async Task UpdateRoutes(IReadOnlyDictionary<string, RouteConfig> routes, bool replaceExisting)
         {
             if (routes != null)
             {
-                List<(string Name, string Value, Route Route)> routesList = routes.ToList();
-                ISet<Route> routeSet = new HashSet<Route>(routesList.Select(r => r.Route));
+                ISet<Route> routeSet = new HashSet<Route>(routes.Select(r => r.Value.Route));
                 if (replaceExisting)
                 {
                     await this.router.ReplaceRoutes(routeSet);
@@ -90,7 +114,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
                     }
                 }
 
-                Events.RoutesUpdated(routesList);
+                Events.RoutesUpdated(routes);
             }
         }
 
@@ -106,7 +130,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
         static class Events
         {
             const int IdStart = HubCoreEventIds.ConfigUpdater;
-            static readonly ILogger Log = Logger.Factory.CreateLogger<ConfigUpdater>();
+            public static readonly ILogger Log = Logger.Factory.CreateLogger<ConfigUpdater>();
 
             enum EventIds
             {
@@ -116,7 +140,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
                 UpdatingConfig,
                 UpdatedRoutes,
                 UpdatedStoreAndForwardConfig,
-                EmptyConfig
+                EmptyConfig,
+                ErrorPullingConfig
             }
 
             internal static void Initialized()
@@ -145,12 +170,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
                 Log.LogInformation((int)EventIds.UpdatingConfig, "Updating edge hub configuration");
             }
 
-            internal static void RoutesUpdated(List<(string Name, string Value, Route Route)> routes)
+            internal static void RoutesUpdated(IReadOnlyDictionary<string, RouteConfig> routes)
             {
                 if (routes.Count > 0)
                 {
                     Log.LogInformation((int)EventIds.UpdatedRoutes, $"Set the following {routes.Count} route(s) in edge hub");
-                    routes.ForEach(r => Log.LogInformation((int)EventIds.UpdatedRoutes, $"{r.Name}: {r.Value}"));
+                    foreach (KeyValuePair<string, RouteConfig> route in routes)
+                    {
+                        Log.LogInformation((int)EventIds.UpdatedRoutes, $"{route.Value.Name}: {route.Value.Value}");
+                    }
                 }
                 else
                 {
@@ -166,6 +194,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
             internal static void EmptyConfigReceived()
             {
                 Log.LogWarning((int)EventIds.EmptyConfig, FormattableString.Invariant($"Empty edge hub configuration received. Ignoring..."));
+            }
+
+            public static void ErrorPullingConfig(Exception ex)
+            {
+                Log.LogWarning((int)EventIds.ErrorPullingConfig, ex, FormattableString.Invariant($"Error getting edge hub configuration."));
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/ConfigUpdater.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/ConfigUpdater.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
             catch (Exception ex)
             {
                 Events.InitializingError(ex);
+                throw;
             }
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubConfig.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubConfig.cs
@@ -49,8 +49,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
             unchecked
             {
                 int hashCode = (this.SchemaVersion != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(this.SchemaVersion) : 0);
-                hashCode = (hashCode * 397) ^ (this.Routes != null ? this.Routes.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (this.StoreAndForwardConfiguration != null ? this.StoreAndForwardConfiguration.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (this.Routes?.GetHashCode() ?? 0);
+                hashCode = (hashCode * 397) ^ (this.StoreAndForwardConfiguration?.GetHashCode() ?? 0);
                 return hashCode;
             }
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubConfig.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubConfig.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
         {
             unchecked
             {
-                int hashCode = (this.SchemaVersion != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(this.SchemaVersion) : 0);
+                int hashCode = this.SchemaVersion != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(this.SchemaVersion) : 0;
                 hashCode = (hashCode * 397) ^ (this.Routes?.GetHashCode() ?? 0);
                 hashCode = (hashCode * 397) ^ (this.StoreAndForwardConfiguration?.GetHashCode() ?? 0);
                 return hashCode;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubConfig.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubConfig.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Routing.Core;
 
-    public class EdgeHubConfig
+    public class EdgeHubConfig : IEquatable<EdgeHubConfig>
     {
-        public EdgeHubConfig(string schemaVersion, IEnumerable<(string Name, string Value, Route Route)> routes, StoreAndForwardConfiguration storeAndForwardConfiguration)
+        public EdgeHubConfig(string schemaVersion, IReadOnlyDictionary<string, RouteConfig> routes, StoreAndForwardConfiguration storeAndForwardConfiguration)
         {
             this.SchemaVersion = Preconditions.CheckNonWhiteSpace(schemaVersion, nameof(schemaVersion));
             this.Routes = Preconditions.CheckNotNull(routes, nameof(routes));
@@ -16,8 +16,43 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
 
         public string SchemaVersion { get; }
 
-        public IEnumerable<(string Name, string Value, Route Route)> Routes { get; }
+        public IReadOnlyDictionary<string, RouteConfig> Routes { get; }
 
         public StoreAndForwardConfiguration StoreAndForwardConfiguration { get; }
+
+        public static bool operator ==(EdgeHubConfig left, EdgeHubConfig right) => Equals(left, right);
+
+        public static bool operator !=(EdgeHubConfig left, EdgeHubConfig right) => !Equals(left, right);
+
+        public bool Equals(EdgeHubConfig other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return string.Equals(this.SchemaVersion, other.SchemaVersion, StringComparison.OrdinalIgnoreCase)
+                   && new ReadOnlyDictionaryComparer<string, RouteConfig>().Equals(this.Routes, other.Routes)
+                   && Equals(this.StoreAndForwardConfiguration, other.StoreAndForwardConfiguration);
+        }
+
+        public override bool Equals(object obj)
+            => this.Equals(obj as EdgeHubConfig);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = (this.SchemaVersion != null ? StringComparer.OrdinalIgnoreCase.GetHashCode(this.SchemaVersion) : 0);
+                hashCode = (hashCode * 397) ^ (this.Routes != null ? this.Routes.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (this.StoreAndForwardConfiguration != null ? this.StoreAndForwardConfiguration.GetHashCode() : 0);
+                return hashCode;
+            }
+        }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/LocalConfigSource.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/LocalConfigSource.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -18,8 +19,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
             Preconditions.CheckNotNull(routeFactory, nameof(routeFactory));
             Preconditions.CheckNotNull(routes, nameof(routes));
             Preconditions.CheckNotNull(storeAndForwardConfiguration, nameof(storeAndForwardConfiguration));
-            IEnumerable<(string Name, string Value, Route Route)> parsedRoutes = routes.Select(r => (r.Key, r.Value, routeFactory.Create(r.Value)));
-            this.edgeHubConfig = new EdgeHubConfig(Constants.ConfigSchemaVersion.ToString(), parsedRoutes, storeAndForwardConfiguration);
+            IDictionary<string, RouteConfig> parsedRoutes = routes.ToDictionary(r => r.Key, r => new RouteConfig(r.Key, r.Value, routeFactory.Create(r.Value)));
+            this.edgeHubConfig = new EdgeHubConfig(Constants.ConfigSchemaVersion.ToString(), new ReadOnlyDictionary<string, RouteConfig>(parsedRoutes), storeAndForwardConfiguration);
         }
 
         public Task<Option<EdgeHubConfig>> GetConfig() => Task.FromResult(Option.Some(this.edgeHubConfig));

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/RouteConfig.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/RouteConfig.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
+{
+    using System;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Routing.Core;
+
+    public class RouteConfig : IEquatable<RouteConfig>
+    {
+        public RouteConfig(string name, string value, Route route)
+        {
+            this.Name = Preconditions.CheckNonWhiteSpace(name, nameof(name));
+            this.Value = Preconditions.CheckNonWhiteSpace(value, nameof(value));
+            this.Route = Preconditions.CheckNotNull(route, nameof(route));
+        }
+
+        public string Name { get; }
+        public string Value { get; }
+        public Route Route { get; }
+
+        public bool Equals(RouteConfig other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return string.Equals(this.Name, other.Name)
+                   && string.Equals(this.Value, other.Value);
+        }
+
+        public override bool Equals(object obj)
+            => this.Equals(obj as RouteConfig);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hashCode = this.Name?.GetHashCode() ?? 0;
+                hashCode = (hashCode * 397) ^ (this.Value?.GetHashCode() ?? 0);
+                return hashCode;
+            }
+        }
+
+        public static bool operator ==(RouteConfig left, RouteConfig right) => Equals(left, right);
+
+        public static bool operator !=(RouteConfig left, RouteConfig right) => !Equals(left, right);
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/StoreAndForwardConfiguration.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/StoreAndForwardConfiguration.cs
@@ -1,10 +1,10 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
 {
     using System;
     using Newtonsoft.Json;
 
-    public class StoreAndForwardConfiguration
+    public class StoreAndForwardConfiguration : IEquatable<StoreAndForwardConfiguration>
     {
         [JsonConstructor]
         public StoreAndForwardConfiguration(int timeToLiveSecs)
@@ -18,5 +18,35 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
 
         [JsonIgnore]
         public TimeSpan TimeToLive { get; }
+
+        public bool Equals(StoreAndForwardConfiguration other)
+        {
+            if (ReferenceEquals(null, other))
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.TimeToLiveSecs == other.TimeToLiveSecs;
+        }
+
+        public override bool Equals(object obj)
+            => this.Equals(obj as StoreAndForwardConfiguration);
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return (this.TimeToLiveSecs * 397) ^ this.TimeToLive.GetHashCode();
+            }
+        }
+
+        public static bool operator ==(StoreAndForwardConfiguration left, StoreAndForwardConfiguration right) => Equals(left, right);
+
+        public static bool operator !=(StoreAndForwardConfiguration left, StoreAndForwardConfiguration right) => !Equals(left, right);
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -134,6 +134,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             int upstreamFanOutFactor = this.configuration.GetValue("UpstreamFanOutFactor", 10);
             bool encryptTwinStore = this.configuration.GetValue("EncryptTwinStore", false);
             bool disableCloudSubscriptions = this.configuration.GetValue("DisableCloudSubscriptions", false);
+            int configUpdateFrequencySecs = this.configuration.GetValue("ConfigRefreshFrequencySecs", 3600);
+            TimeSpan configUpdateFrequency = TimeSpan.FromSeconds(configUpdateFrequencySecs);
 
             builder.RegisterModule(
                 new RoutingModule(
@@ -159,7 +161,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     maxUpstreamBatchSize,
                     upstreamFanOutFactor,
                     encryptTwinStore,
-                    disableCloudSubscriptions));
+                    disableCloudSubscriptions,
+                    configUpdateFrequency));
         }
 
         void RegisterCommonModule(ContainerBuilder builder, bool optimizeForPerformance, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             logger.LogInformation("Initializing configuration");
             IConfigSource configSource = await container.Resolve<Task<IConfigSource>>();
             ConfigUpdater configUpdater = await container.Resolve<Task<ConfigUpdater>>();
-            await configUpdater.Init(configSource);
+            configUpdater.Init(configSource);
 
             if (!Enum.TryParse(configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode)
                 || authenticationMode != AuthenticationMode.Cloud)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly int upstreamFanOutFactor;
         readonly bool encryptTwinStore;
         readonly bool disableCloudSubscriptions;
+        readonly TimeSpan configUpdateFrequency;
 
         public RoutingModule(
             string iotHubName,
@@ -74,7 +75,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             int maxUpstreamBatchSize,
             int upstreamFanOutFactor,
             bool encryptTwinStore,
-            bool disableCloudSubscriptions)
+            bool disableCloudSubscriptions,
+            TimeSpan configUpdateFrequency)
         {
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
@@ -99,6 +101,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.upstreamFanOutFactor = upstreamFanOutFactor;
             this.encryptTwinStore = encryptTwinStore;
             this.disableCloudSubscriptions = disableCloudSubscriptions;
+            this.configUpdateFrequency = configUpdateFrequency;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -504,7 +507,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     {
                         IMessageStore messageStore = this.isStoreAndForwardEnabled ? c.Resolve<IMessageStore>() : null;
                         Router router = await c.Resolve<Task<Router>>();
-                        var configUpdater = new ConfigUpdater(router, messageStore);
+                        var configUpdater = new ConfigUpdater(router, messageStore, this.configUpdateFrequency);
                         return configUpdater;
                     })
                 .As<Task<ConfigUpdater>>()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConfigUpdaterTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConfigUpdaterTest.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Config;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Routing;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Microsoft.Azure.Devices.Routing.Core;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class ConfigUpdaterTest
+    {
+        static readonly Dictionary<string, string> Routes = new Dictionary<string, string>
+        {
+            ["r1"] = "FROM /messages/* INTO $upstream",
+            ["r2"] = "FROM /messages/modules* INTO $upstream",
+            ["r3"] = "FROM /messages/modules/m1* INTO $upstream",
+            ["r4"] = "FROM /messages/modules/m1/outputs/o1* INTO $upstream",
+        };
+
+        [Fact]
+        public async Task TestPeriodicConfigUpdate()
+        {
+            // Arrange
+            string id = "id";
+            string iotHub = "foo.azure-devices.net";
+            var routerConfig = new RouterConfig(Enumerable.Empty<Route>());
+
+            var messageStore = new Mock<IMessageStore>();
+            messageStore.Setup(m => m.SetTimeToLive(It.IsAny<TimeSpan>()));
+
+            TimeSpan updateFrequency = TimeSpan.FromSeconds(10);
+
+            Endpoint GetEndpoint() => new ModuleEndpoint("id", Guid.NewGuid().ToString(), "in1", Mock.Of<IConnectionManager>(), Mock.Of<Core.IMessageConverter<IMessage>>());
+            var endpointFactory = new Mock<IEndpointFactory>();
+            endpointFactory.Setup(e => e.CreateSystemEndpoint($"$upstream")).Returns(GetEndpoint);
+            var routeFactory = new EdgeRouteFactory(endpointFactory.Object);
+
+            var endpointExecutorFactory = new Mock<IEndpointExecutorFactory>();
+            endpointExecutorFactory.Setup(e => e.CreateAsync(It.IsAny<Endpoint>()))
+                .Returns<Endpoint>(endpoint => Task.FromResult(Mock.Of<IEndpointExecutor>(e => e.Endpoint == endpoint)));
+            Router router = await Router.CreateAsync(id, iotHub, routerConfig, endpointExecutorFactory.Object);
+
+            var routes1 = Routes.Take(2)
+                .ToDictionary(r => r.Key, r => new RouteConfig(r.Key, r.Value, routeFactory.Create(r.Value)));
+            var storeAndForwardConfiguration1 = new StoreAndForwardConfiguration(7200);
+            var edgeHubConfig1 = new EdgeHubConfig("1.0", routes1, storeAndForwardConfiguration1);
+
+            var routes2 = Routes.Take(2)
+                .ToDictionary(r => r.Key, r => new RouteConfig(r.Key, r.Value, routeFactory.Create(r.Value)));
+            var storeAndForwardConfiguration2 = new StoreAndForwardConfiguration(7200);
+            var edgeHubConfig2 = new EdgeHubConfig("1.0", routes2, storeAndForwardConfiguration2);
+
+            var routes3 = Routes.Take(2)
+                .ToDictionary(r => r.Key, r => new RouteConfig(r.Key, r.Value, routeFactory.Create(r.Value)));
+            var storeAndForwardConfiguration3 = new StoreAndForwardConfiguration(7200);
+            var edgeHubConfig3 = new EdgeHubConfig("1.0", routes3, storeAndForwardConfiguration3);
+
+            var routes4 = Routes.Skip(2)
+                .ToDictionary(r => r.Key, r => new RouteConfig(r.Key, r.Value, routeFactory.Create(r.Value)));
+            var storeAndForwardConfiguration4 = new StoreAndForwardConfiguration(7200);
+            var edgeHubConfig4 = new EdgeHubConfig("1.0", routes4, storeAndForwardConfiguration4);
+
+            var routes5 = Routes
+                .ToDictionary(r => r.Key, r => new RouteConfig(r.Key, r.Value, routeFactory.Create(r.Value)));
+            var storeAndForwardConfiguration5 = new StoreAndForwardConfiguration(7200);
+            var edgeHubConfig5 = new EdgeHubConfig("1.0", routes5, storeAndForwardConfiguration5);
+
+            var routes6 = Routes
+                .ToDictionary(r => r.Key, r => new RouteConfig(r.Key, r.Value, routeFactory.Create(r.Value)));
+            var storeAndForwardConfiguration6 = new StoreAndForwardConfiguration(3600);
+            var edgeHubConfig6 = new EdgeHubConfig("1.0", routes6, storeAndForwardConfiguration6);
+
+            var configProvider = new Mock<IConfigSource>();
+            configProvider.SetupSequence(c => c.GetConfig())
+                .ReturnsAsync(Option.Some(edgeHubConfig1))
+                .ReturnsAsync(Option.Some(edgeHubConfig2))
+                .ReturnsAsync(Option.Some(edgeHubConfig3))
+                .ReturnsAsync(Option.Some(edgeHubConfig4))
+                .ReturnsAsync(Option.Some(edgeHubConfig5))
+                .ReturnsAsync(Option.Some(edgeHubConfig6));
+            configProvider.Setup(c => c.SetConfigUpdatedCallback(It.IsAny<Func<EdgeHubConfig, Task>>()));
+
+            // Act
+            var configUpdater = new ConfigUpdater(router, messageStore.Object, updateFrequency);
+            configUpdater.Init(configProvider.Object);
+
+            // Assert
+            await Task.Delay(TimeSpan.FromSeconds(8));
+            configProvider.Verify(c => c.GetConfig(), Times.Once);
+            endpointExecutorFactory.Verify(e => e.CreateAsync(It.IsAny<Endpoint>()), Times.Once);
+            messageStore.Verify(m => m.SetTimeToLive(It.IsAny<TimeSpan>()), Times.Once);
+
+            await Task.Delay(TimeSpan.FromSeconds(20));
+            configProvider.Verify(c => c.GetConfig(), Times.Exactly(3));
+            endpointExecutorFactory.Verify(e => e.CreateAsync(It.IsAny<Endpoint>()), Times.Once);
+            messageStore.Verify(m => m.SetTimeToLive(It.IsAny<TimeSpan>()), Times.Once);
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+            configProvider.Verify(c => c.GetConfig(), Times.Exactly(4));
+            endpointExecutorFactory.Verify(e => e.CreateAsync(It.IsAny<Endpoint>()), Times.Once);
+            messageStore.Verify(m => m.SetTimeToLive(It.IsAny<TimeSpan>()), Times.Exactly(2));
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+            configProvider.Verify(c => c.GetConfig(), Times.Exactly(5));
+            endpointExecutorFactory.Verify(e => e.CreateAsync(It.IsAny<Endpoint>()), Times.Once);
+            messageStore.Verify(m => m.SetTimeToLive(It.IsAny<TimeSpan>()), Times.Exactly(3));
+
+            await Task.Delay(TimeSpan.FromSeconds(10));
+            configProvider.Verify(c => c.GetConfig(), Times.Exactly(6));
+            endpointExecutorFactory.Verify(e => e.CreateAsync(It.IsAny<Endpoint>()), Times.Once);
+            messageStore.Verify(m => m.SetTimeToLive(It.IsAny<TimeSpan>()), Times.Exactly(4));
+        }
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/EdgeHubConfigTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/EdgeHubConfigTest.cs
@@ -3,24 +3,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
+    using System.Collections.ObjectModel;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Config;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
-    using Microsoft.Azure.Devices.Routing.Core;
     using Xunit;
 
     [Unit]
     public class EdgeHubConfigTest
-    {
+    { 
         [Fact]
         public void ConstructorHappyPath()
         {
             // Arrange
-            IEnumerable<(string Name, string Value, Route route)> routes = Enumerable.Empty<(string Name, string Value, Route route)>();
+            IReadOnlyDictionary<string, RouteConfig> routes = new ReadOnlyDictionary<string, RouteConfig>(new Dictionary<string, RouteConfig>());
             var snfConfig = new StoreAndForwardConfiguration(1000);
 
             // Act
-            var edgeHubConfig = new EdgeHubConfig("1.0", routes, snfConfig);
+            var edgeHubConfig = new EdgeHubConfig("1.0", new Dictionary<string, RouteConfig>(), snfConfig);
 
             // Assert
             Assert.NotNull(edgeHubConfig);
@@ -28,7 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
         [Theory]
         [MemberData(nameof(GetConstructorInvalidParameters))]
-        public void ConstructorInvalidParameters(string schemaVersion, IEnumerable<(string Name, string Value, Route Route)> routes, StoreAndForwardConfiguration configuration)
+        public void ConstructorInvalidParameters(string schemaVersion, Dictionary<string, RouteConfig> routes, StoreAndForwardConfiguration configuration)
         {
             // Act & Assert
             Assert.ThrowsAny<ArgumentException>(() => new EdgeHubConfig(schemaVersion, routes, configuration));
@@ -36,9 +35,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
         public static IEnumerable<object[]> GetConstructorInvalidParameters()
         {
-            yield return new object[] { null, new List<(string Name, string Value, Route route)>(), new StoreAndForwardConfiguration(1000) };
+            yield return new object[] { null, new Dictionary<string, RouteConfig>(), new StoreAndForwardConfiguration(1000) };
             yield return new object[] { "1.0", null, new StoreAndForwardConfiguration(1000) };
-            yield return new object[] { "1.0", new List<(string Name, string Value, Route route)>(), null };
+            yield return new object[] { "1.0", new Dictionary<string, RouteConfig>(), null };
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/EdgeHubConfigTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/EdgeHubConfigTest.cs
@@ -10,7 +10,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
     [Unit]
     public class EdgeHubConfigTest
-    { 
+    {
+        public static IEnumerable<object[]> GetConstructorInvalidParameters()
+        {
+            yield return new object[] { null, new Dictionary<string, RouteConfig>(), new StoreAndForwardConfiguration(1000) };
+            yield return new object[] { "1.0", null, new StoreAndForwardConfiguration(1000) };
+            yield return new object[] { "1.0", new Dictionary<string, RouteConfig>(), null };
+        }
+
         [Fact]
         public void ConstructorHappyPath()
         {
@@ -31,13 +38,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             // Act & Assert
             Assert.ThrowsAny<ArgumentException>(() => new EdgeHubConfig(schemaVersion, routes, configuration));
-        }
-
-        public static IEnumerable<object[]> GetConstructorInvalidParameters()
-        {
-            yield return new object[] { null, new Dictionary<string, RouteConfig>(), new StoreAndForwardConfiguration(1000) };
-            yield return new object[] { "1.0", null, new StoreAndForwardConfiguration(1000) };
-            yield return new object[] { "1.0", new Dictionary<string, RouteConfig>(), null };
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/EdgeHubConfigTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/EdgeHubConfigTest.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var snfConfig = new StoreAndForwardConfiguration(1000);
 
             // Act
-            var edgeHubConfig = new EdgeHubConfig("1.0", new Dictionary<string, RouteConfig>(), snfConfig);
+            var edgeHubConfig = new EdgeHubConfig("1.0", routes, snfConfig);
 
             // Assert
             Assert.NotNull(edgeHubConfig);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/ConfigUpdaterTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/ConfigUpdaterTest.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config.Test
 {
     using System;
     using System.Collections.Generic;

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/EdgeHubConfigTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/EdgeHubConfigTest.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.config
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Config;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Microsoft.Azure.Devices.Routing.Core;
+    using Microsoft.Azure.Devices.Routing.Core.MessageSources;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class EdgeHubConfigTest
+    {
+        [Theory]
+        [MemberData(nameof(GetEdgeHubConfigData))]
+        public void EqualityTest(EdgeHubConfig e1, EdgeHubConfig e2, bool areEqual)
+        {
+            Assert.Equal(areEqual, e1.Equals(e2));
+        }
+
+        public static IEnumerable<object[]> GetEdgeHubConfigData()
+        {
+            var r1 = new Route("id", string.Empty, "iotHub", Mock.Of<IMessageSource>(), new HashSet<Endpoint>());
+            var r2 = new Route("id", string.Empty, "iotHub", Mock.Of<IMessageSource>(), new HashSet<Endpoint>());
+
+            var routeConfig1 = new RouteConfig("r1", "FROM /* INTO $upstream", r1);
+            var routeConfig2 = new RouteConfig("r2", "FROM /messages/* INTO $upstream", r2);
+
+            var routes1 = new Dictionary<string, RouteConfig>
+            {
+                [routeConfig1.Name] = routeConfig1,
+                [routeConfig2.Name] = routeConfig2
+            };
+
+            var routes2 = new Dictionary<string, RouteConfig>
+            {
+                [routeConfig1.Name] = routeConfig1
+            };
+
+            var routes3 = new Dictionary<string, RouteConfig>
+            {
+                [routeConfig2.Name] = routeConfig2
+            };
+
+            var storeAndForwardConfig1 = new StoreAndForwardConfiguration(-1);
+            var storeAndForwardConfig2 = new StoreAndForwardConfiguration(7200);
+            var storeAndForwardConfig3 = new StoreAndForwardConfiguration(3600);
+
+            string version = "1.0";
+
+            var edgeHubConfig1 = new EdgeHubConfig(version, routes1, storeAndForwardConfig1);
+            var edgeHubConfig2 = new EdgeHubConfig(version, routes2, storeAndForwardConfig1);
+            var edgeHubConfig3 = new EdgeHubConfig(version, routes3, storeAndForwardConfig1);
+            var edgeHubConfig4 = new EdgeHubConfig(version, routes1, storeAndForwardConfig1);
+            var edgeHubConfig5 = new EdgeHubConfig(version, routes1, storeAndForwardConfig2);
+            var edgeHubConfig6 = new EdgeHubConfig(version, routes1, storeAndForwardConfig3);
+            var edgeHubConfig7 = new EdgeHubConfig(version, routes2, storeAndForwardConfig2);
+            var edgeHubConfig8 = new EdgeHubConfig(version, routes2, storeAndForwardConfig3);
+            var edgeHubConfig9 = new EdgeHubConfig(version, routes3, storeAndForwardConfig3);
+            var edgeHubConfig10 = new EdgeHubConfig(version, routes3, storeAndForwardConfig3);
+
+            yield return new object[] { edgeHubConfig1, edgeHubConfig2, false };
+            yield return new object[] { edgeHubConfig2, edgeHubConfig3, false };
+            yield return new object[] { edgeHubConfig3, edgeHubConfig4, false };
+            yield return new object[] { edgeHubConfig4, edgeHubConfig5, false };
+            yield return new object[] { edgeHubConfig5, edgeHubConfig6, false };
+            yield return new object[] { edgeHubConfig6, edgeHubConfig7, false };
+            yield return new object[] { edgeHubConfig7, edgeHubConfig8, false };
+            yield return new object[] { edgeHubConfig8, edgeHubConfig9, false };
+            yield return new object[] { edgeHubConfig9, edgeHubConfig10, true };
+        }
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/EdgeHubConfigTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/EdgeHubConfigTest.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.config
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Config
 {
     using System.Collections;
     using System.Collections.Generic;

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/RouteConfigTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/RouteConfigTest.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Config
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Config;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Microsoft.Azure.Devices.Routing.Core;
+    using Microsoft.Azure.Devices.Routing.Core.MessageSources;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class RouteConfigTest
+    {
+        [Theory]
+        [MemberData(nameof(GetEqualityTest))]
+        public void EqualityTest(RouteConfig c1, RouteConfig c2, bool isEqual)
+        {
+            Assert.Equal(isEqual, c1.Equals(c2));
+        }
+
+        public static IEnumerable<object[]> GetEqualityTest()
+        {
+            var r1 = new Route("id", string.Empty, "iotHub", Mock.Of<IMessageSource>(), new HashSet<Endpoint>());
+            var r2 = new Route("id", string.Empty, "iotHub", Mock.Of<IMessageSource>(), new HashSet<Endpoint>());
+            var routeConfig1 = new RouteConfig("r1", "FROM /* INTO $upstream", r1);
+            var routeConfig2 = new RouteConfig("r1", "FROM /* INTO $upstream", r2);
+            var routeConfig3 = new RouteConfig("r2", "FROM /* INTO $upstream", r2);
+            var routeConfig4 = new RouteConfig("r2", "FROM /messages/* INTO $upstream", r2);
+            var routeConfig5 = new RouteConfig("r2", "FROM /messages/* INTO $upstream", r2);
+
+            yield return new object[] { routeConfig1, routeConfig2, true };
+            yield return new object[] { routeConfig2, routeConfig3, false };
+            yield return new object[] { routeConfig3, routeConfig4, false };
+            yield return new object[] { routeConfig4, routeConfig5, true };
+        }
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     10,
                     10,
                     false,
+                    false,
                     TimeSpan.FromHours(1)));
 
             builder.RegisterModule(new HttpModule());

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     10,
                     10,
                     false,
-                    false));
+                    TimeSpan.FromHours(1)));
 
             builder.RegisterModule(new HttpModule());
             builder.RegisterModule(new MqttModule(mqttSettingsConfiguration.Object, topics, this.serverCertificate, false, false, false));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -131,29 +131,29 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 Assert.NotNull(edgeHubConfig.StoreAndForwardConfiguration);
                 Assert.Equal(20, edgeHubConfig.StoreAndForwardConfiguration.TimeToLiveSecs);
 
-                List<(string Name, string Value, Route Route)> routes = edgeHubConfig.Routes.ToList();
+                IReadOnlyDictionary<string, RouteConfig> routes = edgeHubConfig.Routes;
                 Assert.Equal(4, routes.Count);
 
-                (string Name, string Value, Route Route) route1 = routes[0];
+                RouteConfig route1 = routes["route1"];
                 Assert.True(route1.Route.Endpoints.First().GetType() == typeof(CloudEndpoint));
                 Assert.Equal("route1", route1.Name);
                 Assert.Equal("from /* INTO $upstream", route1.Value);
 
-                (string Name, string Value, Route Route) route2 = routes[1];
+                RouteConfig route2 = routes["route2"];
                 Endpoint endpoint = route2.Route.Endpoints.First();
                 Assert.True(endpoint.GetType() == typeof(ModuleEndpoint));
                 Assert.Equal($"{edgeDeviceId}/module2/input1", endpoint.Id);
                 Assert.Equal("route2", route2.Name);
                 Assert.Equal("from /modules/module1 INTO BrokeredEndpoint(\"/modules/module2/inputs/input1\")", route2.Value);
 
-                (string Name, string Value, Route Route) route3 = routes[2];
+                RouteConfig route3 = routes["route3"];
                 endpoint = route3.Route.Endpoints.First();
                 Assert.True(endpoint.GetType() == typeof(ModuleEndpoint));
                 Assert.Equal($"{edgeDeviceId}/module3/input1", endpoint.Id);
                 Assert.Equal("route3", route3.Name);
                 Assert.Equal("from /modules/module2 INTO BrokeredEndpoint(\"/modules/module3/inputs/input1\")", route3.Value);
 
-                (string Name, string Value, Route Route) route4 = routes[3];
+                RouteConfig route4 = routes["route4"];
                 endpoint = route4.Route.Endpoints.First();
                 Assert.True(endpoint.GetType() == typeof(ModuleEndpoint));
                 Assert.Equal($"{edgeDeviceId}/module4/input1", endpoint.Id);
@@ -207,29 +207,29 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     Assert.NotNull(updatedConfig.StoreAndForwardConfiguration);
                     Assert.NotNull(updatedConfig.Routes);
 
-                    routes = updatedConfig.Routes.ToList();
+                    routes = updatedConfig.Routes;
                     Assert.Equal(4, routes.Count);
 
-                    route1 = routes[0];
+                    route1 = routes["route1"];
                     Assert.True(route1.Route.Endpoints.First().GetType() == typeof(CloudEndpoint));
                     Assert.Equal("route1", route1.Name);
                     Assert.Equal("from /* INTO $upstream", route1.Value);
 
-                    route2 = routes[1];
+                    route2 = routes["route2"];
                     endpoint = route2.Route.Endpoints.First();
                     Assert.True(endpoint.GetType() == typeof(ModuleEndpoint));
                     Assert.Equal($"{edgeDeviceId}/module2/input1", endpoint.Id);
                     Assert.Equal("route2", route2.Name);
                     Assert.Equal("from /modules/module1 INTO BrokeredEndpoint(\"/modules/module2/inputs/input1\")", route2.Value);
 
-                    route3 = routes[2];
+                    route3 = routes["route4"];
                     endpoint = route3.Route.Endpoints.First();
                     Assert.True(endpoint.GetType() == typeof(ModuleEndpoint));
                     Assert.Equal($"{edgeDeviceId}/module5/input1", endpoint.Id);
                     Assert.Equal("route4", route3.Name);
                     Assert.Equal("from /modules/module3 INTO BrokeredEndpoint(\"/modules/module5/inputs/input1\")", route3.Value);
 
-                    route4 = routes[3];
+                    route4 = routes["route5"];
                     endpoint = route4.Route.Endpoints.First();
                     Assert.True(endpoint.GetType() == typeof(ModuleEndpoint));
                     Assert.Equal($"{edgeDeviceId}/module6/input1", endpoint.Id);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/ProtocolHeadFixture.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/ProtocolHeadFixture.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
 
                 IConfigSource configSource = await this.container.Resolve<Task<IConfigSource>>();
                 ConfigUpdater configUpdater = await this.container.Resolve<Task<ConfigUpdater>>();
-                await configUpdater.Init(configSource);
+                configUpdater.Init(configSource);
 
                 ILogger logger = this.container.Resolve<ILoggerFactory>().CreateLogger("EdgeHub");
                 MqttProtocolHead mqttProtocolHead = await this.container.Resolve<Task<MqttProtocolHead>>();


### PR DESCRIPTION
Adding logic in EdgeHub to pull its config from the twin every hour. This is same as the EdgeAgent behavior, and helps in "pull only" scenarios.