### PR TITLE
Fix artifact download path

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -83,7 +83,6 @@ jobs:
       - template: templates/longhaul-deploy.yaml
         parameters:
           release.label: 'lh'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -118,6 +117,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchLongHaulAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -126,7 +130,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -136,7 +140,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-arm.tar.gz
@@ -147,7 +151,6 @@ jobs:
       - template: templates/longhaul-deploy.yaml
         parameters:
           release.label: 'lh-amqp'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -183,6 +186,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchLongHaulAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -191,7 +199,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -201,7 +209,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-arm.tar.gz
@@ -212,7 +220,6 @@ jobs:
       - template: templates/longhaul-deploy.yaml
         parameters:
           release.label: 'lh-mqtt'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -248,6 +255,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchLongHaulAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -256,7 +268,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -266,7 +278,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-arm64.tar.gz
@@ -277,7 +289,6 @@ jobs:
       - template: templates/longhaul-deploy.yaml
         parameters:
           release.label: 'lh-amqp'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -313,6 +324,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchLongHaulAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -321,7 +337,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -331,7 +347,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-arm64.tar.gz
@@ -342,7 +358,6 @@ jobs:
       - template: templates/longhaul-deploy.yaml
         parameters:
           release.label: 'lh-mqtt'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -376,6 +391,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchLongHaulAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -384,7 +404,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -394,7 +414,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.windows)
           itemPattern: |
             $(images.artifact.name.windows)/IotEdgeQuickstart/x64/*
@@ -406,7 +426,6 @@ jobs:
       - template: templates/longhaul-deploy-windows.yaml
         parameters:
           release.label: 'lh'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -53,7 +53,7 @@ jobs:
         displayName: 'Clean Artifacts folder'
         inputs:
           sourceFolder: $(Agent.HomeDirectory)/../artifacts
-          contents: **
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -49,6 +49,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchLongHaulAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: **
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -57,7 +62,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: $(Build.ArtifactStagingDirectory)
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -67,7 +72,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: $(Build.ArtifactStagingDirectory)
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-x64.tar.gz

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -57,7 +57,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Build.ArtifactStagingDirectory)
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -67,7 +67,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Build.ArtifactStagingDirectory)
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-x64.tar.gz

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -51,7 +51,9 @@ jobs:
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
       - bash: |
             echo "build artifact staging dir=$(Build.ArtifactStagingDirectory)"
+            echo "build staging dir=$(Build.StagingDirectory)"
         displayName: 'Print debug'
+        workingDirectory: '$(Agent.HomeDirectory)/..'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -53,7 +53,7 @@ jobs:
         displayName: 'Clean Artifacts folder'
         inputs:
           sourceFolder: $(Agent.HomeDirectory)/../artifacts
-          contents: **
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -49,6 +49,9 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
+      - bash: |
+        echo "build artifact staging dir=$(Build.ArtifactStagingDirectory)"
+        displayName: 'Print debug'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -49,11 +49,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
-      - bash: |
-            echo "build artifact staging dir=$(Build.ArtifactStagingDirectory)"
-            echo "build staging dir=$(Build.StagingDirectory)"
-        displayName: 'Print debug'
-        workingDirectory: '$(Agent.HomeDirectory)/..'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: **
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -62,7 +62,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: $(Build.ArtifactStagingDirectory)
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -72,7 +72,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: $(Build.ArtifactStagingDirectory)
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-x64.tar.gz

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -57,7 +57,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Build.ArtifactStagingDirectory)
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -67,7 +67,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Build.ArtifactStagingDirectory)
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-x64.tar.gz

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -50,7 +50,7 @@ jobs:
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
       - bash: |
-        echo "build artifact staging dir=$(Build.ArtifactStagingDirectory)"
+            echo "build artifact staging dir=$(Build.ArtifactStagingDirectory)"
         displayName: 'Print debug'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -83,7 +83,6 @@ jobs:
       - template: templates/stresstest-deploy.yaml
         parameters:
           release.label: 'st'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -118,6 +117,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -126,7 +130,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -136,7 +140,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-arm.tar.gz
@@ -147,7 +151,6 @@ jobs:
       - template: templates/stresstest-deploy.yaml
         parameters:
           release.label: 'st-amqp'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -188,6 +191,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -196,7 +204,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -206,7 +214,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-arm.tar.gz
@@ -217,7 +225,6 @@ jobs:
       - template: templates/stresstest-deploy.yaml
         parameters:
           release.label: 'st-mqtt'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -258,6 +265,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -266,7 +278,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -276,7 +288,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-arm64.tar.gz
@@ -287,7 +299,6 @@ jobs:
       - template: templates/stresstest-deploy.yaml
         parameters:
           release.label: 'st-amqp'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -328,6 +339,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -336,7 +352,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -346,7 +362,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-arm64.tar.gz
@@ -357,7 +373,6 @@ jobs:
       - template: templates/stresstest-deploy.yaml
         parameters:
           release.label: 'st-mqtt'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'
@@ -396,6 +411,11 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
+      - task: DeleteFiles@1
+        displayName: 'Clean Artifacts folder'
+        inputs:
+          sourceFolder: $(Agent.HomeDirectory)/../artifacts
+          contents: '**'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -404,7 +424,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -414,7 +434,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: $(Agent.HomeDirectory)/../artifacts
           artifactName: $(images.artifact.name.windows)
           itemPattern: |
             $(images.artifact.name.windows)/IotEdgeQuickstart/x64/*
@@ -426,7 +446,6 @@ jobs:
       - template: templates/stresstest-deploy-windows.yaml
         parameters:
           release.label: 'st'
-          edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'
           container.registry.username: '$(edgebuilds-azurecr-io-username)'

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -1,6 +1,5 @@
 parameters:
-  release.Label: ''
-  edgelet.artifact.name: ''
+  release.label: ''
   images.artifact.name: ''
   container.registry: ''
   container.registry.username: ''
@@ -14,18 +13,6 @@ parameters:
   loadGen.message.frequency: ''
 
 steps:
-  - task: CopyFiles@2
-    displayName: 'Copy Edgelet Artifact'
-    inputs:
-      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
-      CleanTargetFolder: true
-  - task: CopyFiles@2
-    displayName: 'Copy Images Artifact'
-    inputs:
-      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['images.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
-      CleanTargetFolder: true
   - task: PowerShell@2
     displayName: 'Run Long Haul Deployment'
     inputs:

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -1,6 +1,5 @@
 parameters:
   release.label: ''
-  edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''
   container.registry.username: ''
@@ -16,14 +15,11 @@ parameters:
   longHaul.protocolHead: ''
 
 steps:
-  - task: Bash@3
-    displayName: 'Run Long Haul Deployment'
-    inputs:
-      targetType: inline
-      script: |
+  - bash: |
         declare -a cnreg=( ${{ parameters['container.registry.credential'] }} )
         testName="LongHaul"
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh
         sudo $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh -testDir "$(Agent.HomeDirectory)/.." -releaseLabel "${{ parameters['release.label'] }}" -artifactImageBuildNumber "$BuildNumber" -testName "$testName" -containerRegistry "${{ parameters['container.registry'] }}" -containerRegistryUsername "${{ parameters['container.registry.username'] }}" -containerRegistryPassword "${{ parameters['container.registry.password'] }}" -iotHubConnectionString "${{ parameters['iotHub.connectionString'] }}" -eventHubConnectionString "${{ parameters['eventHub.connectionString'] }}" -snitchBuildNumber "${{ parameters['snitch.build.number'] }}" -snitchStorageAccount "${{ parameters['snitch.storage.account'] }}" -snitchStorageMasterKey "${{ parameters['snitch.storage.masterKey'] }}" -snitchAlertUrl "${{ parameters['snitch.alert.url'] }}" -loadGenMessageFrequency "${{ parameters['loadGen.message.frequency'] }}" -longHaulProtocolHead "${{ parameters['longHaul.protocolHead'] }}"
-      workingDirectory: "$(Agent.HomeDirectory)/.."
+    displayName: 'Run Long Haul Deployment'
+    workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -16,18 +16,6 @@ parameters:
   longHaul.protocolHead: ''
 
 steps:
-  - task: CopyFiles@2
-    displayName: 'Copy Edgelet Artifact'
-    inputs:
-      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
-      CleanTargetFolder: true
-  - task: CopyFiles@2
-    displayName: 'Copy Images artifact'
-    inputs:
-      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['images.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
-      CleanTargetFolder: true
   - task: Bash@3
     displayName: 'Run Long Haul Deployment'
     inputs:

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -19,14 +19,14 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy Edgelet Artifact'
     inputs:
-      SourceFolder: '$(Build.StagingDirectory)/$(edgelet.artifact.name)'
-      TargetFolder: '$(Agent.HomeDirectory)/../artifacts/$(edgelet.artifact.name)'
+      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
+      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
       CleanTargetFolder: true
   - task: CopyFiles@2
     displayName: 'Copy Images artifact'
     inputs:
-      SourceFolder: '$(Build.StagingDirectory)/$(images.artifact.name)'
-      TargetFolder: '$(Agent.HomeDirectory)/../artifacts/$(images.artifact.name)'
+      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['images.artifact.name'] }}"
+      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
       CleanTargetFolder: true
   - task: Bash@3
     displayName: 'Run Long Haul Deployment'

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -1,6 +1,5 @@
 parameters:
-  release.Label: ''
-  edgelet.artifact.name: ''
+  release.label: ''
   images.artifact.name: ''
   container.registry: ''
   container.registry.username: ''
@@ -20,18 +19,6 @@ parameters:
   loadGen4.transportType: 'Mqtt_WebSocket_Only'
 
 steps:
-  - task: CopyFiles@2
-    displayName: 'Copy Edgelet Artifact'
-    inputs:
-      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
-      CleanTargetFolder: true
-  - task: CopyFiles@2
-    displayName: 'Copy Images Artifact'
-    inputs:
-      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['images.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
-      CleanTargetFolder: true
   - task: PowerShell@2
     displayName: 'Run Stress Test Deployment'
     inputs:

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -20,18 +20,6 @@ parameters:
   loadGen4.transportType: 'Mqtt_WebSocket_Only'
 
 steps:
-  - task: CopyFiles@2
-    displayName: 'Copy Edgelet Artifact'
-    inputs:
-      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
-      CleanTargetFolder: true
-  - task: CopyFiles@2
-    displayName: 'Copy Images Artifact'
-    inputs:
-      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['images.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
-      CleanTargetFolder: true
   - bash: |
         declare -a cnreg=( ${{ parameters['container.registry.credential'] }} )
         testName="Stress"

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -23,13 +23,13 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy Edgelet Artifact'
     inputs:
-      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
+      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
       CleanTargetFolder: true
   - task: CopyFiles@2
     displayName: 'Copy Images Artifact'
     inputs:
-      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['images.artifact.name'] }}"
+      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['images.artifact.name'] }}"
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
       CleanTargetFolder: true
   - bash: |

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -1,6 +1,5 @@
 parameters:
   release.label: ''
-  edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''
   container.registry.username: ''


### PR DESCRIPTION
Predefined VSTS variable Build.StagingDirectory or Build.StagingArtifactDirectory are missing; probabaly a bug in VSTS pipeline.  Therefore change to clean artifacts folder and copy directly to it instead.  Tested with Linux x64, it works as expected.