### PR TITLE
Fix artifact folder

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -2,7 +2,6 @@ trigger: none
 pr: none
 
 variables:
-  Build.SyncSources: false
   images.artifact.name.linux: 'core-linux'
   images.artifact.name.windows: 'core-windows'
   vsts.project: $(System.TeamProjectId)
@@ -43,6 +42,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu-amd64'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -107,6 +107,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu-armhf'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -172,6 +173,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu-armhf'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -237,6 +239,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu16.04-aarch64'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -302,6 +305,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu16.04-aarch64'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -365,6 +369,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-windows'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -49,12 +49,6 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
-      - bash: |
-            echo "build artifact staging dir=$(Build.ArtifactStagingDirectory)"
-            echo "build staging dir=$(Build.StagingDirectory)"
-            echo "system artifact dir=$(System.ArtifactsDirectory)"
-        displayName: 'Print for debug'
-        workingDirectory: '$(Agent.HomeDirectory)'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -63,6 +57,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
+          downloadPath: '$(Build.StagingDirectory)'
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -72,6 +67,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
+          downloadPath: '$(Build.StagingDirectory)'
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-x64.tar.gz
@@ -111,6 +107,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu-armhf'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -181,6 +178,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu-armhf'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -251,6 +249,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu16.04-aarch64'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -321,6 +320,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu16.04-aarch64'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -389,6 +389,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-windows'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -63,7 +63,6 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.ArtifactStagingDirectory)'
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -73,7 +72,6 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.ArtifactStagingDirectory)'
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-x64.tar.gz

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -2,7 +2,6 @@ trigger: none
 pr: none
 
 variables:
-  Build.SyncSources: false
   images.artifact.name.linux: 'core-linux'
   images.artifact.name.windows: 'core-windows'
   vsts.project: $(System.TeamProjectId)
@@ -43,6 +42,7 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu-amd64'
     steps:
+      - checkout: none
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -49,6 +49,12 @@ jobs:
           azureSubscription: $(azure.subscription)
           KeyVaultName: $(azure.keyVault)
           SecretsFilter: 'edgebuilds-azurecr-io-username,edgebuilds-azurecr-io-pwd,IotHubStressConnString,EventHubStressConnStr,StorageAccountMasterKeyStress,SnitchStressAlertUrl'
+      - bash: |
+            echo "build artifact staging dir=$(Build.ArtifactStagingDirectory)"
+            echo "build staging dir=$(Build.StagingDirectory)"
+            echo "system artifact dir=$(System.ArtifactsDirectory)"
+        displayName: 'Print for debug'
+        workingDirectory: '$(Agent.HomeDirectory)'
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Edgelet Artifacts'
         inputs:
@@ -57,7 +63,7 @@ jobs:
           pipeline: $(edgelet.package.build)
           branchName: $(edgelet.package.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: '$(Build.ArtifactStagingDirectory)'
           artifactName: $(edgelet.artifact.name)
       - task: DownloadBuildArtifacts@0
         displayName: 'Download Images Artifacts'
@@ -67,7 +73,7 @@ jobs:
           pipeline: $(images.build)
           branchName: $(images.branchName)
           buildVersionToDownload: latestFromBranch
-          downloadPath: '$(Build.StagingDirectory)'
+          downloadPath: '$(Build.ArtifactStagingDirectory)'
           artifactName: $(images.artifact.name.linux)
           itemPattern: |
             $(images.artifact.name.linux)/IotEdgeQuickstart.linux-x64.tar.gz

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -1,5 +1,5 @@
 parameters:
-  release.Label: ''
+  release.label: ''
   edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -19,14 +19,14 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy Edgelet Artifact'
     inputs:
-      SourceFolder: '$(Build.StagingDirectory)/$(edgelet.artifact.name)'
-      TargetFolder: '$(Agent.HomeDirectory)/../artifacts/$(edgelet.artifact.name)'
+      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
+      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
       CleanTargetFolder: true
   - task: CopyFiles@2
     displayName: 'Copy Images artifact'
     inputs:
-      SourceFolder: '$(Build.StagingDirectory)/$(images.artifact.name)'
-      TargetFolder: '$(Agent.HomeDirectory)/../artifacts/$(images.artifact.name)'
+      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['images.artifact.name'] }}"
+      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
       CleanTargetFolder: true
   - task: Bash@3
     displayName: 'Run Long Haul Deployment'

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -1,5 +1,5 @@
 parameters:
-  release.Label: ''
+  release.label: ''
   edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -23,13 +23,13 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy Edgelet Artifact'
     inputs:
-      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
+      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
       CleanTargetFolder: true
   - task: CopyFiles@2
     displayName: 'Copy Images Artifact'
     inputs:
-      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['images.artifact.name'] }}"
+      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['images.artifact.name'] }}"
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
       CleanTargetFolder: true
   - bash: |

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -23,20 +23,23 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy Edgelet Artifact'
     inputs:
-      SourceFolder: "$(System.ArtifactsDirectory)/${{ parameters['edgelet.artifact.name'] }}"
+      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
       CleanTargetFolder: true
   - task: CopyFiles@2
     displayName: 'Copy Images Artifact'
     inputs:
-      SourceFolder: "$(System.ArtifactsDirectory)/${{ parameters['images.artifact.name'] }}"
+      SourceFolder: "$(Build.StagingDirectory)/${{ parameters['images.artifact.name'] }}"
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
       CleanTargetFolder: true
-  - bash: |
+  - task: Bash@3
+    displayName: 'Run Stress Test Deployment'
+    inputs:
+      targetType: inline
+      script: |
         declare -a cnreg=( ${{ parameters['container.registry.credential'] }} )
         testName="Stress"
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh
         sudo $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh -testDir "$(Agent.HomeDirectory)/.." -releaseLabel "${{ parameters['release.label'] }}" -artifactImageBuildNumber "$BuildNumber" -testName "$testName" -containerRegistry "${{ parameters['container.registry'] }}" -containerRegistryUsername "${{ parameters['container.registry.username'] }}" -containerRegistryPassword "${{ parameters['container.registry.password'] }}" -iotHubConnectionString "${{ parameters['iotHub.connectionString'] }}" -eventHubConnectionString "${{ parameters['eventHub.connectionString'] }}" -snitchBuildNumber "${{ parameters['snitch.build.number'] }}" -snitchStorageAccount "${{ parameters['snitch.storage.account'] }}" -snitchStorageMasterKey "${{ parameters['snitch.storage.masterKey'] }}" -snitchAlertUrl "${{ parameters['snitch.alert.url'] }}" -loadGen1TransportType "${{ parameters['loadGen1.transportType'] }}" -loadGen2TransportType "${{ parameters['loadGen2.transportType'] }}" -loadGen3TransportType "${{ parameters['loadGen3.transportType'] }}" -loadGen4TransportType "${{ parameters['loadGen4.transportType'] }}" -amqpSettingsEnabled "${{ parameters['amqp.settings.enabled'] }}" -mqttSettingsEnabled "${{ parameters['mqtt.settings.enabled'] }}" -loadGenMessageFrequency "${{ parameters['loadGen.message.frequency'] }}"
-    displayName: 'Run Stress Test Deployment'
-    workingDirectory: '$(Agent.HomeDirectory)/..'
+      workingDirectory: '$(Agent.HomeDirectory)/..'

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -23,13 +23,13 @@ steps:
   - task: CopyFiles@2
     displayName: 'Copy Edgelet Artifact'
     inputs:
-      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
+      SourceFolder: "$(System.ArtifactsDirectory)/${{ parameters['edgelet.artifact.name'] }}"
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['edgelet.artifact.name'] }}"
       CleanTargetFolder: true
   - task: CopyFiles@2
     displayName: 'Copy Images Artifact'
     inputs:
-      SourceFolder: "$(Build.ArtifactStagingDirectory)/${{ parameters['images.artifact.name'] }}"
+      SourceFolder: "$(System.ArtifactsDirectory)/${{ parameters['images.artifact.name'] }}"
       TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
       CleanTargetFolder: true
   - bash: |


### PR DESCRIPTION
remove Build.SyncSources and use checkout:none in each job; use same bash task syntax in long haul and stress test templates.