### PR TITLE
EdgeHub: Allow EdgeProductInfo to be empty string

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ProductInfoStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ProductInfoStore.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public ProductInfoStore(IKeyValueStore<string, string> productInfoEntityStore, string edgeProductInfo)
         {
             this.productInfoEntityStore = Preconditions.CheckNotNull(productInfoEntityStore, nameof(productInfoEntityStore));
-            this.edgeProductInfo = Preconditions.CheckNonWhiteSpace(edgeProductInfo, nameof(edgeProductInfo));
+            this.edgeProductInfo = Preconditions.CheckNotNull(edgeProductInfo, nameof(edgeProductInfo));
         }
 
         public Task SetProductInfo(string id, string productInfo)

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ProductInfoStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ProductInfoStoreTest.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;
     using Xunit;
 
     [Unit]
@@ -55,6 +56,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 Assert.Equal(kvp.Value, receivedDeviceInfos[kvp.Key]);
                 Assert.Equal($"{kvp.Value} {edgeProductInfo}", receivedEdgeDeviceInfos[kvp.Key]);
             }
+        }
+
+        [Fact]
+        public void ProductInfoCtorTest()
+        {
+            new ProductInfoStore(Mock.Of<IKeyValueStore<string, string>>(), "Foo bar");
+
+            new ProductInfoStore(Mock.Of<IKeyValueStore<string, string>>(), string.Empty);
+
+            Assert.Throws<ArgumentNullException>(() => new ProductInfoStore(Mock.Of<IKeyValueStore<string, string>>(), null));
+
+            Assert.Throws<ArgumentNullException>(() => new ProductInfoStore(null, string.Empty));
         }
     }
 }


### PR DESCRIPTION
EdgeHub appends a custom string (containing the version information) to the ProductInfo (userAgent) string for each client. This fix is to allow that custom "EdgeProductInfo" string to be empty. 
This should fix the recent CI build regression.