### PR TITLE
Update DPS settings in Edge configuration

### DIFF
--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -40,7 +40,6 @@ provisioning:
 #   attestation:
 #     method: "tpm"
 #     registration_id: "{registration_id}"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
 
 # DPS symmetric key provisioning configuration
 # provisioning:
@@ -50,7 +49,6 @@ provisioning:
 #   attestation:
 #     method: "symmetric_key"
 #     registration_id: "{registration_id}"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
 #     symmetric_key: "{symmetric_key}"
 
 # DPS X.509 provisioning configuration
@@ -61,9 +59,8 @@ provisioning:
 #   attestation:
 #     method: "x509"
 #     registration_id: "<OPTIONAL REGISTRATION ID. IF UNSPECIFIED CAN BE OBTAINED FROM CN OF identity_cert"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
-#     identity_cert: "<OPTIONAL PATH TO DEVICE IDENTITY CERTIFICATE HERE. IF UNSPECIFIED, DEVICE CA WILL ISSUE ONE>"
-#     identity_pk: "<OPTIONAL PATH TO DEVICE IDENTITY PRIVATE KEY HERE. IF UNSPECIFIED, DEVICE CA WILL ISSUE ONE>"
+#     identity_cert: "<REQUIRED PATH TO DEVICE IDENTITY CERTIFICATE HERE>"
+#     identity_pk: "<REQUIRED PATH TO DEVICE IDENTITY PRIVATE KEY HERE>"
 
 ###############################################################################
 # Certificate settings

--- a/edgelet/contrib/config/linux/debian/config.yaml
+++ b/edgelet/contrib/config/linux/debian/config.yaml
@@ -40,7 +40,6 @@ provisioning:
 #   attestation:
 #     method: "tpm"
 #     registration_id: "{registration_id}"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
 
 # DPS symmetric key provisioning configuration
 # provisioning:
@@ -50,7 +49,6 @@ provisioning:
 #   attestation:
 #     method: "symmetric_key"
 #     registration_id: "{registration_id}"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
 #     symmetric_key: "{symmetric_key}"
 
 # DPS X.509 provisioning configuration
@@ -61,9 +59,8 @@ provisioning:
 #   attestation:
 #     method: "x509"
 #     registration_id: "<OPTIONAL REGISTRATION ID. IF UNSPECIFIED CAN BE OBTAINED FROM CN OF identity_cert"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
-#     identity_cert: "<OPTIONAL PATH TO DEVICE IDENTITY CERTIFICATE HERE. IF UNSPECIFIED, DEVICE CA WILL ISSUE ONE>"
-#     identity_pk: "<OPTIONAL PATH TO DEVICE IDENTITY PRIVATE KEY HERE. IF UNSPECIFIED, DEVICE CA WILL ISSUE ONE>"
+#     identity_cert: "<REQUIRED PATH TO DEVICE IDENTITY CERTIFICATE HERE>"
+#     identity_pk: "<REQUIRED PATH TO DEVICE IDENTITY PRIVATE KEY HERE>"
 
 ###############################################################################
 # Certificate settings

--- a/edgelet/contrib/config/windows/config.yaml
+++ b/edgelet/contrib/config/windows/config.yaml
@@ -40,7 +40,6 @@ provisioning:
 #   attestation:
 #     method: "tpm"
 #     registration_id: "{registration_id}"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
 
 # DPS symmetric key provisioning configuration
 # provisioning:
@@ -50,7 +49,6 @@ provisioning:
 #   attestation:
 #     method: "symmetric_key"
 #     registration_id: "{registration_id}"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
 #     symmetric_key: "{symmetric_key}"
 
 # DPS X.509 provisioning configuration
@@ -61,9 +59,8 @@ provisioning:
 #   attestation:
 #     method: "x509"
 #     registration_id: "<OPTIONAL REGISTRATION ID. IF UNSPECIFIED CAN BE OBTAINED FROM CN OF identity_cert"
-#     device_id: "<OPTIONAL DEVICE ID TO BE PROVISIONED IN IOTHUB>"
-#     identity_cert: "<OPTIONAL PATH TO DEVICE IDENTITY CERTIFICATE HERE. IF UNSPECIFIED, DEVICE CA WILL ISSUE ONE>"
-#     identity_pk: "<OPTIONAL PATH TO DEVICE IDENTITY PRIVATE KEY HERE. IF UNSPECIFIED, DEVICE CA WILL ISSUE ONE>"
+#     identity_cert: "<REQUIRED PATH TO DEVICE IDENTITY CERTIFICATE HERE>"
+#     identity_pk: "<REQUIRED PATH TO DEVICE IDENTITY PRIVATE KEY HERE>"
 
 ###############################################################################
 # Certificate settings

--- a/edgelet/edgelet-config/test/linux/bad_settings.dps.x509.1.yaml
+++ b/edgelet/edgelet-config/test/linux/bad_settings.dps.x509.1.yaml
@@ -1,0 +1,34 @@
+# Configures the provisioning mode
+provisioning:
+  source: "dps"
+  global_endpoint: "scheme://jibba-jabba.net"
+  scope_id: "i got no time for the jibba-jabba"
+  attestation:
+    method: "x509"
+    registration_id: "register me fool"
+    identity_cert: "some/path/mr.t.cer.pem"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0-preview"
+    create_options: {}
+    auth: {}
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+docker_uri: "http://localhost:2375"
+homedir: "/tmp"
+network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/linux/bad_settings.dps.x509.2.yaml
+++ b/edgelet/edgelet-config/test/linux/bad_settings.dps.x509.2.yaml
@@ -1,0 +1,34 @@
+# Configures the provisioning mode
+provisioning:
+  source: "dps"
+  global_endpoint: "scheme://jibba-jabba.net"
+  scope_id: "i got no time for the jibba-jabba"
+  attestation:
+    method: "x509"
+    registration_id: "register me fool"
+    identity_pk: "some/path/mr.t.pk.pem"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0-preview"
+    create_options: {}
+    auth: {}
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+docker_uri: "http://localhost:2375"
+homedir: "/tmp"
+network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/linux/sample_settings.dps.x509.1.yaml
+++ b/edgelet/edgelet-config/test/linux/sample_settings.dps.x509.1.yaml
@@ -1,0 +1,34 @@
+# Configures the provisioning mode
+provisioning:
+  source: "dps"
+  global_endpoint: "scheme://jibba-jabba.net"
+  scope_id: "i got no time for the jibba-jabba"
+  attestation:
+    method: "x509"
+    identity_cert: "some/path/mr.t.cer.pem"
+    identity_pk: "some/path/mr.t.pk.pem"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0-preview"
+    create_options: {}
+    auth: {}
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+docker_uri: "http://localhost:2375"
+homedir: "/tmp"
+network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/linux/sample_settings.dps.x509.2.yaml
+++ b/edgelet/edgelet-config/test/linux/sample_settings.dps.x509.2.yaml
@@ -1,0 +1,35 @@
+# Configures the provisioning mode
+provisioning:
+  source: "dps"
+  global_endpoint: "scheme://jibba-jabba.net"
+  scope_id: "i got no time for the jibba-jabba"
+  attestation:
+    method: "x509"
+    registration_id: "register me fool"
+    identity_cert: "some/path/mr.t.cer.pem"
+    identity_pk: "some/path/mr.t.pk.pem"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0-preview"
+    create_options: {}
+    auth: {}
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+docker_uri: "http://localhost:2375"
+homedir: "/tmp"
+network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/windows/bad_settings.dps.x509.1.yaml
+++ b/edgelet/edgelet-config/test/windows/bad_settings.dps.x509.1.yaml
@@ -1,0 +1,34 @@
+# Configures the provisioning mode
+provisioning:
+  source: "dps"
+  global_endpoint: "scheme://jibba-jabba.net"
+  scope_id: "i got no time for the jibba-jabba"
+  attestation:
+    method: "x509"
+    registration_id: "register me fool"
+    identity_cert: "some/path/mr.t.cer.pem"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0-preview"
+    create_options: {}
+    auth: {}
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+docker_uri: "http://localhost:2375"
+homedir: "/tmp"
+network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/windows/bad_settings.dps.x509.2.yaml
+++ b/edgelet/edgelet-config/test/windows/bad_settings.dps.x509.2.yaml
@@ -1,0 +1,34 @@
+# Configures the provisioning mode
+provisioning:
+  source: "dps"
+  global_endpoint: "scheme://jibba-jabba.net"
+  scope_id: "i got no time for the jibba-jabba"
+  attestation:
+    method: "x509"
+    registration_id: "register me fool"
+    identity_pk: "some/path/mr.t.pk.pem"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0-preview"
+    create_options: {}
+    auth: {}
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+docker_uri: "http://localhost:2375"
+homedir: "/tmp"
+network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/windows/sample_settings.dps.x509.1.yaml
+++ b/edgelet/edgelet-config/test/windows/sample_settings.dps.x509.1.yaml
@@ -1,0 +1,34 @@
+# Configures the provisioning mode
+provisioning:
+  source: "dps"
+  global_endpoint: "scheme://jibba-jabba.net"
+  scope_id: "i got no time for the jibba-jabba"
+  attestation:
+    method: "x509"
+    identity_cert: "some/path/mr.t.cer.pem"
+    identity_pk: "some/path/mr.t.pk.pem"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0-preview"
+    create_options: {}
+    auth: {}
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+docker_uri: "http://localhost:2375"
+homedir: "/tmp"
+network: "azure-iot-edge"

--- a/edgelet/edgelet-config/test/windows/sample_settings.dps.x509.2.yaml
+++ b/edgelet/edgelet-config/test/windows/sample_settings.dps.x509.2.yaml
@@ -1,0 +1,35 @@
+# Configures the provisioning mode
+provisioning:
+  source: "dps"
+  global_endpoint: "scheme://jibba-jabba.net"
+  scope_id: "i got no time for the jibba-jabba"
+  attestation:
+    method: "x509"
+    registration_id: "register me fool"
+    identity_cert: "some/path/mr.t.cer.pem"
+    identity_pk: "some/path/mr.t.pk.pem"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0-preview"
+    create_options: {}
+    auth: {}
+hostname: "localhost"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+docker_uri: "http://localhost:2375"
+homedir: "/tmp"
+network: "azure-iot-edge"

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -136,11 +136,6 @@ function Initialize-IoTEdge {
         [ValidateNotNullOrEmpty()]
         [String] $RegistrationId,
 
-        # The DPS device ID.
-        [Parameter(ParameterSetName = 'DPS')]
-        [ValidateNotNullOrEmpty()]
-        [String] $DeviceId,
-
         # The DPS symmetric key to provision the Edge device identity
         [Parameter(ParameterSetName = 'DPS')]
         [ValidateNotNullOrEmpty()]
@@ -480,11 +475,6 @@ function Install-IoTEdge {
         [ValidateNotNullOrEmpty()]
         [String] $RegistrationId,
 
-        # The DPS device ID.
-        [Parameter(ParameterSetName = 'DPS')]
-        [ValidateNotNullOrEmpty()]
-        [String] $DeviceId,
-
         # The DPS symmetric key to provision the Edge device identity
         [Parameter(ParameterSetName = 'DPS')]
         [ValidateNotNullOrEmpty()]
@@ -594,7 +584,6 @@ function Install-IoTEdge {
     if ($ScopeId) { $Params["-ScopeId"] = $ScopeId }
     if ($RegistrationId) { $Params["-RegistrationId"] = $RegistrationId }
     if ($SymmetricKey) { $Params["-SymmetricKey"] = $SymmetricKey }
-    if ($DeviceId) { $Params["-DeviceId"] = $DeviceId }
     if ($X509IdentityCertificate) { $Params["-X509IdentityCertificate"] = $X509IdentityCertificate }
     if ($X509IdentityPrivateKey) { $Params["-X509IdentityPrivateKey"] = $X509IdentityPrivateKey }
     if ($AutoGenX509IdentityCertificate) { $Params["-AutoGenX509IdentityCertificate"] = $AutoGenX509IdentityCertificate }
@@ -866,7 +855,7 @@ function Setup-Environment {
             'See https://aka.ms/iotedge-platsup for more details.')
         $preRequisitesMet = $false
     }
-    
+
     if (Test-IoTCore) {
         if (-not (Get-Service vmcompute -ErrorAction SilentlyContinue) -or (-not [bool] (Get-Package $ContainersFeaturePackageName)) -or (-not [bool] (Get-Package $ContainersFeatureLangPackageName))) {
             Write-HostRed "The container host does not have 'Containers Feature' enabled. Please build an Iot Core image with 'Containers Feature' enabled."
@@ -1582,9 +1571,6 @@ function Set-ProvisioningMode {
                 "    method: '$attestationMethod'")
             if ($RegistrationId) {
                 $replacementContent += "    registration_id: '$RegistrationId'"
-            }
-            if ($DeviceId) {
-                $replacementContent += "    device_id: '$DeviceId'"
             }
             if ($SymmetricKey) {
                 $replacementContent += "    symmetric_key: '$SymmetricKey'"


### PR DESCRIPTION
Removed deviceID config from DPS provisioning setting since this is not going to be supported in DPS. Additionally made the identity certificates as required parameters when provisioning using X.509 auth method.

Updated tests, default configuration files and windows installer.