### PR TITLE
Fix new warnings-as-errors reported by GCC 9

### DIFF
--- a/edgelet/hsm-sys/azure-iot-hsm-c/src/edge_hsm_client_store.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/src/edge_hsm_client_store.c
@@ -2502,7 +2502,14 @@ static int verify_certificate_helper
 
         if ((issuer_cert_path == NULL) || !is_file_valid(issuer_cert_path))
         {
-            LOG_ERROR("Could not find issuer certificate file %s", issuer_cert_path);
+            if (issuer_cert_path == NULL)
+            {
+                LOG_ERROR("Could not find issuer certificate file (null)");
+            }
+            else
+            {
+                LOG_ERROR("Could not find issuer certificate file %s", issuer_cert_path);
+            }
             result = __FAILURE__;
         }
         else if (verify_certificate(cert_file_path, key_file_path, issuer_cert_path, cert_verified) != 0)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
@@ -395,7 +395,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            char tmp_msg[64];
+            char tmp_msg[96];
             sprintf(tmp_msg, "secure_device_riot_create failure in test %zu/%zu", index, count);
 
             //act
@@ -504,7 +504,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            char tmp_msg[64];
+            char tmp_msg[96];
             sprintf(tmp_msg, "hsm_client_tpm_activate_key failure in test %zu/%zu", index, count);
 
             //act
@@ -601,7 +601,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            char tmp_msg[64];
+            char tmp_msg[96];
             sprintf(tmp_msg, "hsm_client_tpm_get_endorsement_key failure in test %zu/%zu", index, count);
 
             int result = tpm_if->hsm_client_get_ek(sec_handle, &key, &key_len);
@@ -702,7 +702,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            char tmp_msg[64];
+            char tmp_msg[96];
             sprintf(tmp_msg, "hsm_client_tpm_get_storage_key failure in test %zu/%zu", index, count);
 
             int result = tpm_if->hsm_client_get_srk(sec_handle, &key, &key_len);
@@ -1074,7 +1074,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            char tmp_msg[64];
+            char tmp_msg[96];
             sprintf(tmp_msg, "hsm_client_derive_and_sign_with_identity failure in test %zu/%zu", index, count);
 
             //act


### PR DESCRIPTION
- `sprintf("%s")` with a string that might be `NULL`, which is technically UB.
  It happens to work with gcc/glibc and outputs `(null)`, so just do that
  explicitly.

- `sprintf("%zu")` but the string buffer is not large enough to contain
  the maximum length of a stringified `size_t` (20 chars).
  Increase the buffer size.