### PR TITLE
Fix the Windows 10 Kits Version var in package.ps1

### DIFF
--- a/edgelet/build/windows/package.ps1
+++ b/edgelet/build/windows/package.ps1
@@ -71,19 +71,19 @@ Function New-Package([string] $Name, [string] $Version)
         $Win10KitsRoot = Get-ItemProperty -Path 'HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows Kits\Installed Roots' -Name KitsRoot10 | % KitsRoot10
         Write-Host $Win10KitsRoot
         
-        $Version =
+        $LatestWin10KitsVersion =
             Get-ChildItem -Path "$Win10KitsRoot\bin" -ErrorAction Ignore |
             Sort-Object -Property Name -Descending |
             ?{ $_.Name -like '10.*' } |
             Select-Object -First 1 |
             % Name
-        Write-Host $Version
+        Write-Host $LatestWin10KitsVersion
 
-        if ($Version -eq $null) {
+        if ($LatestWin10KitsVersion -eq $null) {
             throw [System.IO.FileNotFoundException] 'Cannot find any Windows 10 kits on the build agent'
         }
 
-        $LatestWin10KitsX64Bin = "$Win10KitsRoot\bin\$Version\X64"
+        $LatestWin10KitsX64Bin = "$Win10KitsRoot\bin\$LatestWin10KitsVersion\X64"
         $oldPath = $env:PATH
         $env:PATH = $LatestWin10KitsX64Bin + ';' + $env:PATH
         Write-Host $env:PATH


### PR DESCRIPTION
Previously we defined `$Version` for the Windows 10 kits version, however, the same `$Version` was already defined as arguments to the function `Function New-Package([string] $Name, [string] $Version)`, later on when pkggen is called, the mistakenly updated `$Version` is passed to pkggen as the version of the package. so we have 10.0.17763.0 as the ARM32 cab version, while we should have something like 0.1.19149.2. This change fixes the var namings so we don't overwrite the argument `$Version`, so ARM cab can have a good increasing version.

Without this I cannot update the iotedge cabs on ARM32 IOTCORE because all cabs share the same version and DISM does not like it. Once this is in, I'll verify I can update cabs, so we can have e2e automation on RP3 IOTCORE, without manually reflashing the OS and deploy (IOTCORE does not support uninstall a cab)