### PR TITLE
EdgeAgent: Add support to get logs using direct method

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/AgentEventIds.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/AgentEventIds.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         public const int KubernetesOperator = EventIdStart + 2400;
         public const int LogsUploadRequestHandler = EventIdStart + 2500;
         public const int ModuleClientProvider = EventIdStart + 2600;
+        public const int LogsRequestHandler = EventIdStart + 2700;
         const int EventIdStart = 100000;
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequest.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequest.cs
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
+{
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.Logs;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Json;
+    using Newtonsoft.Json;
+
+    public class LogsRequest
+    {
+        public LogsRequest(
+            string schemaVersion,
+            List<LogRequestItem> items,
+            LogsContentEncoding encoding,
+            LogsContentType contentType)
+        {
+            this.SchemaVersion = Preconditions.CheckNonWhiteSpace(schemaVersion, nameof(schemaVersion));
+            this.Encoding = encoding;
+            this.ContentType = contentType;
+            this.Items = Preconditions.CheckNotNull(items, nameof(items));
+        }
+
+        [JsonConstructor]
+        LogsRequest(
+            string schemaVersion,
+            List<LogRequestItem> items,
+            LogsContentEncoding? encoding,
+            LogsContentType? contentType)
+            : this(schemaVersion, items, encoding ?? LogsContentEncoding.None, contentType ?? LogsContentType.Json)
+        {
+        }
+
+        [JsonProperty("schemaVersion")]
+        public string SchemaVersion { get; }
+
+        [JsonProperty("items")]
+        [JsonConverter(typeof(SingleOrArrayConverter<LogRequestItem>))]
+        public List<LogRequestItem> Items { get; }
+
+        [JsonProperty("encoding", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(LogsContentEncoding.None)]
+        public LogsContentEncoding Encoding { get; }
+
+        [JsonProperty("contentType", DefaultValueHandling = DefaultValueHandling.Populate)]
+        [DefaultValue(LogsContentType.Text)]
+        public LogsContentType ContentType { get; }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequestHandler.cs
@@ -9,9 +9,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
     using Microsoft.Azure.Devices.Edge.Agent.Core.Logs;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
 
     public class LogsRequestHandler : RequestHandlerBase<LogsRequest, IEnumerable<LogsResponse>>
     {
+        const int MaxTailValue = 500;
         readonly ILogsProvider logsProvider;
         readonly IRuntimeInfoProvider runtimeInfoProvider;
 
@@ -26,7 +28,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
         protected override async Task<Option<IEnumerable<LogsResponse>>> HandleRequestInternal(Option<LogsRequest> payloadOption, CancellationToken cancellationToken)
         {
             LogsRequest payload = payloadOption.Expect(() => new ArgumentException("Request payload not found"));
-
             ILogsRequestToOptionsMapper requestToOptionsMapper = new LogsRequestToOptionsMapper(
                 this.runtimeInfoProvider,
                 payload.Encoding,
@@ -39,25 +40,60 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
             IEnumerable<Task<LogsResponse>> uploadLogsTasks = logOptionsList.Select(
                 async l =>
                 {
+                    Events.ReceivedLogOptions(l);
                     ModuleLogOptions logOptions = l.logOptions.Filter.Tail
-                        .Filter(t => t < 1000)
+                        .Filter(t => t < MaxTailValue)
                         .Map(t => l.logOptions)
                         .GetOrElse(
                             () =>
                             {
-                                var filter = new ModuleLogFilter(Option.Some(1000), l.logOptions.Filter.Since, l.logOptions.Filter.LogLevel, l.logOptions.Filter.RegexString);
+                                var filter = new ModuleLogFilter(Option.Some(MaxTailValue), l.logOptions.Filter.Since, l.logOptions.Filter.LogLevel, l.logOptions.Filter.RegexString);
                                 return new ModuleLogOptions(l.logOptions.ContentEncoding, l.logOptions.ContentType, filter, l.logOptions.OutputFraming, l.logOptions.OutputGroupingConfig, l.logOptions.Follow);
                             });
 
                     byte[] moduleLogs = await this.logsProvider.GetLogs(l.id, logOptions, cancellationToken);
 
-                    Console.WriteLine($"Logs size - {moduleLogs.Length}");
+                    Events.ReceivedModuleLogs(moduleLogs, l.id);
                     return logOptions.ContentEncoding == LogsContentEncoding.Gzip
                         ? new LogsResponse(l.id, moduleLogs)
                         : new LogsResponse(l.id, moduleLogs.FromBytes());
                 });
             IEnumerable<LogsResponse> response = await Task.WhenAll(uploadLogsTasks);
             return Option.Some(response);
+        }
+
+        static class Events
+        {
+            const int IdStart = AgentEventIds.LogsRequestHandler;
+            static readonly ILogger Log = Logger.Factory.CreateLogger<LogsRequestHandler>();
+
+            enum EventIds
+            {
+                ReceivedModuleLogs = IdStart + 1,
+                ReceivedLogOptions
+            }
+
+            public static void ReceivedModuleLogs(byte[] moduleLogs, string id)
+            {
+                Log.LogInformation((int)EventIds.ReceivedModuleLogs, $"Received {moduleLogs.Length} bytes of logs for {id}");
+            }
+
+            public static void ReceivedLogOptions((string id, ModuleLogOptions logOptions) receivedLogOptions)
+            {
+                if (receivedLogOptions.logOptions.Filter.Tail.HasValue)
+                {
+                    receivedLogOptions.logOptions.Filter.Tail.ForEach(
+                        t => Log.LogInformation(
+                            (int)EventIds.ReceivedLogOptions,
+                            t < MaxTailValue
+                                ? $"Received log options for {receivedLogOptions.id} with tail value {t}"
+                                : $"Received log options for {receivedLogOptions.id} with tail value {t} which is larger than the maximum supported value, setting tail value to {MaxTailValue}"));
+                }
+                else
+                {
+                    Log.LogInformation((int)EventIds.ReceivedLogOptions, $"Received log options for {receivedLogOptions.id} with no tail value specified, setting tail value to {MaxTailValue}");
+                }
+            }
         }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequestHandler.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.Logs;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public class LogsRequestHandler : RequestHandlerBase<LogsRequest, IEnumerable<LogsResponse>>
+    {
+        readonly ILogsProvider logsProvider;
+        readonly IRuntimeInfoProvider runtimeInfoProvider;
+
+        public LogsRequestHandler(ILogsProvider logsProvider, IRuntimeInfoProvider runtimeInfoProvider)
+        {
+            this.logsProvider = Preconditions.CheckNotNull(logsProvider, nameof(logsProvider));
+            this.runtimeInfoProvider = Preconditions.CheckNotNull(runtimeInfoProvider, nameof(runtimeInfoProvider));
+        }
+
+        public override string RequestName => "GetLogs";
+
+        protected override async Task<Option<IEnumerable<LogsResponse>>> HandleRequestInternal(Option<LogsRequest> payloadOption, CancellationToken cancellationToken)
+        {
+            LogsRequest payload = payloadOption.Expect(() => new ArgumentException("Request payload not found"));
+
+            ILogsRequestToOptionsMapper requestToOptionsMapper = new LogsRequestToOptionsMapper(
+                this.runtimeInfoProvider,
+                LogsContentEncoding.None,
+                payload.ContentType,
+                LogOutputFraming.None,
+                Option.None<LogsOutputGroupingConfig>(),
+                false);
+            IList<(string id, ModuleLogOptions logOptions)> logOptionsList = await requestToOptionsMapper.MapToLogOptions(payload.Items, cancellationToken);
+            IEnumerable<Task<LogsResponse>> uploadLogsTasks = logOptionsList.Select(async l =>
+            {
+                byte[] moduleLogs = await this.logsProvider.GetLogs(l.id, l.logOptions, cancellationToken);
+                return new LogsResponse(l.id, moduleLogs);
+            });
+            IEnumerable<LogsResponse> response = await Task.WhenAll(uploadLogsTasks);
+            return Option.Some(response);
+        }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsResponse.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsResponse.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 {
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
 
     public class LogsResponse
@@ -9,13 +10,26 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
         public LogsResponse(string id, byte[] payload)
         {
             this.Id = Preconditions.CheckNonWhiteSpace(id, nameof(id));
-            this.Payload = Preconditions.CheckNotNull(payload, nameof(payload));
+            this.PayloadBytes = Option.Some(Preconditions.CheckNotNull(payload, nameof(payload)));
+            this.Payload = Option.None<string>();
+        }
+
+        public LogsResponse(string id, string payload)
+        {
+            this.Id = Preconditions.CheckNonWhiteSpace(id, nameof(id));
+            this.Payload = Option.Some(Preconditions.CheckNotNull(payload, nameof(payload)));
+            this.PayloadBytes = Option.None<byte[]>();
         }
 
         [JsonProperty("id")]
         public string Id { get; }
 
+        [JsonProperty("payloadBytes")]
+        [JsonConverter(typeof(OptionConverter<byte[]>))]
+        public Option<byte[]> PayloadBytes { get; }
+
         [JsonProperty("payload")]
-        public byte[] Payload { get; }
+        [JsonConverter(typeof(OptionConverter<string>))]
+        public Option<string> Payload { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsResponse.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsResponse.cs
@@ -7,18 +7,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
     public class LogsResponse
     {
-        public LogsResponse(string id, byte[] payload)
+        public LogsResponse(string id, byte[] payloadBytes)
+            : this(id, null, payloadBytes)
         {
-            this.Id = Preconditions.CheckNonWhiteSpace(id, nameof(id));
-            this.PayloadBytes = Option.Some(Preconditions.CheckNotNull(payload, nameof(payload)));
-            this.Payload = Option.None<string>();
         }
 
         public LogsResponse(string id, string payload)
+            : this(id, payload, null)
+        {
+        }
+
+        [JsonConstructor]
+        LogsResponse(string id, string payload, byte[] payloadBytes)
         {
             this.Id = Preconditions.CheckNonWhiteSpace(id, nameof(id));
-            this.Payload = Option.Some(Preconditions.CheckNotNull(payload, nameof(payload)));
-            this.PayloadBytes = Option.None<byte[]>();
+            this.PayloadBytes = Option.Maybe(payloadBytes);
+            this.Payload = Option.Maybe(payload);
         }
 
         [JsonProperty("id")]

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsResponse.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsResponse.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
+{
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Newtonsoft.Json;
+
+    public class LogsResponse
+    {
+        public LogsResponse(string id, byte[] payload)
+        {
+            this.Id = Preconditions.CheckNonWhiteSpace(id, nameof(id));
+            this.Payload = Preconditions.CheckNotNull(payload, nameof(payload));
+        }
+
+        [JsonProperty("id")]
+        public string Id { get; }
+
+        [JsonProperty("payload")]
+        public byte[] Payload { get; }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                     var requestHandlers = new List<IRequestHandler>
                     {
                         new PingRequestHandler(),
-                        new LogsUploadRequestHandler(logsUploader, logsProvider, runtimeInfoProvider)
+                        new LogsUploadRequestHandler(logsUploader, logsProvider, runtimeInfoProvider),
+                        new LogsRequestHandler(logsProvider, runtimeInfoProvider)
                     };
                     return new RequestManager(requestHandlers, this.requestTimeout) as IRequestManager;
                 })

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsRequestHandlerTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsRequestHandlerTests.cs
@@ -1,0 +1,275 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.Logs;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.Requests;
+    using Microsoft.Azure.Devices.Edge.Storage;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;
+    using Xunit;
+
+    [Unit]
+    public class LogsRequestHandlerTests
+    {
+        [Fact]
+        public async Task GetJsonLogsTest()
+        {
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some(1501000), Option.Some(3), Option.Some("ERR"));
+            LogsContentEncoding contentEncoding = LogsContentEncoding.None;
+            LogsContentType contentType = LogsContentType.Json;
+
+            string payload =
+                @"{
+                    ""schemaVersion"": ""1.0"",
+                    ""items"": {
+                        ""id"": ""m1"",
+                        ""filter"": <filter>
+                    },
+                    ""encoding"": ""none"",
+                    ""contentType"": ""json""
+                }"
+                    .Replace("<filter>", filter.ToJson());
+
+            string iotHub = "foo.azure-devices.net";
+            string deviceId = "d1";
+            string mod1 = "m1";
+            string mod2 = "m2";
+            string mod3 = "m3";
+            var moduleRuntimeInfoList = new List<ModuleRuntimeInfo>
+            {
+                new ModuleRuntimeInfo(mod1, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>()),
+                new ModuleRuntimeInfo(mod2, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>()),
+                new ModuleRuntimeInfo(mod3, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>())
+            };
+            var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
+            runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(moduleRuntimeInfoList);
+
+            var logsProvider = new Mock<ILogsProvider>();
+
+            var module1LogOptions = new ModuleLogOptions(contentEncoding, contentType, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
+            var mod1Logs = new List<ModuleLogMessage>
+            {
+                new ModuleLogMessage(iotHub, deviceId, mod1, "0", 6, Option.None<DateTime>(), "log line 1"),
+                new ModuleLogMessage(iotHub, deviceId, mod1, "0", 6, Option.None<DateTime>(), "log line 2"),
+                new ModuleLogMessage(iotHub, deviceId, mod1, "0", 6, Option.None<DateTime>(), "log line 3")
+            };
+
+            logsProvider.Setup(l => l.GetLogs(mod1, module1LogOptions, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mod1Logs.ToBytes());
+
+            // Act
+            var logsRequestHandler = new LogsRequestHandler(logsProvider.Object, runtimeInfoProvider.Object);
+            Option<string> response = await logsRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
+
+            // Assert
+            Assert.True(response.HasValue);
+            logsProvider.VerifyAll();
+            runtimeInfoProvider.VerifyAll();
+            var logsResponseList = response.OrDefault().FromJson<List<LogsResponse>>();
+            Assert.NotNull(logsResponseList);
+            Assert.Single(logsResponseList);
+            LogsResponse logsResponse = logsResponseList[0];
+            Assert.Equal(mod1, logsResponse.Id);
+            Assert.True(logsResponse.Payload.HasValue);
+            Assert.False(logsResponse.PayloadBytes.HasValue);
+            Assert.Equal(mod1Logs.ToJson(), logsResponse.Payload.OrDefault());
+        }
+
+        [Fact]
+        public async Task GetTextLogsTest()
+        {
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some(1501000), Option.Some(3), Option.Some("ERR"));
+            LogsContentEncoding contentEncoding = LogsContentEncoding.None;
+            LogsContentType contentType = LogsContentType.Text;
+
+            string payload =
+                @"{
+                    ""schemaVersion"": ""1.0"",
+                    ""items"": {
+                        ""id"": ""m1"",
+                        ""filter"": <filter>
+                    },
+                    ""encoding"": ""none"",
+                    ""contentType"": ""text""
+                }"
+                    .Replace("<filter>", filter.ToJson());
+
+            string mod1 = "m1";
+            string mod2 = "m2";
+            string mod3 = "m3";
+            var moduleRuntimeInfoList = new List<ModuleRuntimeInfo>
+            {
+                new ModuleRuntimeInfo(mod1, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>()),
+                new ModuleRuntimeInfo(mod2, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>()),
+                new ModuleRuntimeInfo(mod3, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>())
+            };
+            var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
+            runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(moduleRuntimeInfoList);
+
+            var logsProvider = new Mock<ILogsProvider>();
+
+            var module1LogOptions = new ModuleLogOptions(contentEncoding, contentType, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
+            string mod1Logs = new []
+            {
+                "Log line 1\n",
+                "Log line 2\n",
+                "Log line 3\n"
+            }.Join(string.Empty);
+
+            logsProvider.Setup(l => l.GetLogs(mod1, module1LogOptions, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mod1Logs.ToBytes());
+
+            // Act
+            var logsRequestHandler = new LogsRequestHandler(logsProvider.Object, runtimeInfoProvider.Object);
+            Option<string> response = await logsRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
+
+            // Assert
+            Assert.True(response.HasValue);
+            logsProvider.VerifyAll();
+            runtimeInfoProvider.VerifyAll();
+            var logsResponseList = response.OrDefault().FromJson<List<LogsResponse>>();
+            Assert.NotNull(logsResponseList);
+            Assert.Single(logsResponseList);
+            LogsResponse logsResponse = logsResponseList[0];
+            Assert.Equal(mod1, logsResponse.Id);
+            Assert.True(logsResponse.Payload.HasValue);
+            Assert.False(logsResponse.PayloadBytes.HasValue);
+            Assert.Equal(mod1Logs, logsResponse.Payload.OrDefault());
+        }
+
+        [Fact]
+        public async Task GetJsonGzipLogsTest()
+        {
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some(1501000), Option.Some(3), Option.Some("ERR"));
+            LogsContentEncoding contentEncoding = LogsContentEncoding.Gzip;
+            LogsContentType contentType = LogsContentType.Json;
+
+            string payload =
+                @"{
+                    ""schemaVersion"": ""1.0"",
+                    ""items"": {
+                        ""id"": ""m1"",
+                        ""filter"": <filter>
+                    },
+                    ""encoding"": ""gzip"",
+                    ""contentType"": ""json""
+                }"
+                    .Replace("<filter>", filter.ToJson());
+
+            string iotHub = "foo.azure-devices.net";
+            string deviceId = "d1";
+            string mod1 = "m1";
+            string mod2 = "m2";
+            string mod3 = "m3";
+            var moduleRuntimeInfoList = new List<ModuleRuntimeInfo>
+            {
+                new ModuleRuntimeInfo(mod1, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>()),
+                new ModuleRuntimeInfo(mod2, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>()),
+                new ModuleRuntimeInfo(mod3, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>())
+            };
+            var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
+            runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(moduleRuntimeInfoList);
+
+            var logsProvider = new Mock<ILogsProvider>();
+
+            var module1LogOptions = new ModuleLogOptions(contentEncoding, contentType, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
+            var mod1Logs = new List<ModuleLogMessage>
+            {
+                new ModuleLogMessage(iotHub, deviceId, mod1, "0", 6, Option.None<DateTime>(), "log line 1"),
+                new ModuleLogMessage(iotHub, deviceId, mod1, "0", 6, Option.None<DateTime>(), "log line 2"),
+                new ModuleLogMessage(iotHub, deviceId, mod1, "0", 6, Option.None<DateTime>(), "log line 3")
+            };
+            byte[] mod1LogBytes = Compression.CompressToGzip(mod1Logs.ToBytes());
+            logsProvider.Setup(l => l.GetLogs(mod1, module1LogOptions, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mod1LogBytes);
+
+            // Act
+            var logsRequestHandler = new LogsRequestHandler(logsProvider.Object, runtimeInfoProvider.Object);
+            Option<string> response = await logsRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
+
+            // Assert
+            Assert.True(response.HasValue);
+            logsProvider.VerifyAll();
+            runtimeInfoProvider.VerifyAll();
+            var logsResponseList = response.OrDefault().FromJson<List<LogsResponse>>();
+            Assert.NotNull(logsResponseList);
+            Assert.Single(logsResponseList);
+            LogsResponse logsResponse = logsResponseList[0];
+            Assert.Equal(mod1, logsResponse.Id);
+            Assert.False(logsResponse.Payload.HasValue);
+            Assert.True(logsResponse.PayloadBytes.HasValue);
+            Assert.Equal(mod1LogBytes, logsResponse.PayloadBytes.OrDefault());
+        }
+
+        [Fact]
+        public async Task GetTextGzipLogsTest()
+        {
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some(1501000), Option.Some(3), Option.Some("ERR"));
+            LogsContentEncoding contentEncoding = LogsContentEncoding.Gzip;
+            LogsContentType contentType = LogsContentType.Text;
+
+            string payload =
+                @"{
+                    ""schemaVersion"": ""1.0"",
+                    ""items"": {
+                        ""id"": ""m1"",
+                        ""filter"": <filter>
+                    },
+                    ""encoding"": ""gzip"",
+                    ""contentType"": ""text""
+                }"
+                    .Replace("<filter>", filter.ToJson());
+
+            string mod1 = "m1";
+            string mod2 = "m2";
+            string mod3 = "m3";
+            var moduleRuntimeInfoList = new List<ModuleRuntimeInfo>
+            {
+                new ModuleRuntimeInfo(mod1, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>()),
+                new ModuleRuntimeInfo(mod2, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>()),
+                new ModuleRuntimeInfo(mod3, "docker", ModuleStatus.Running, string.Empty, 0, Option.None<DateTime>(), Option.None<DateTime>())
+            };
+            var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
+            runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(moduleRuntimeInfoList);
+
+            var logsProvider = new Mock<ILogsProvider>();
+
+            var module1LogOptions = new ModuleLogOptions(contentEncoding, contentType, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
+            string mod1Logs = new[]
+            {
+                "Log line 1\n",
+                "Log line 2\n",
+                "Log line 3\n"
+            }.Join(string.Empty);
+            byte[] mod1LogBytes = Compression.CompressToGzip(mod1Logs.ToBytes());
+            logsProvider.Setup(l => l.GetLogs(mod1, module1LogOptions, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(mod1LogBytes);
+
+            // Act
+            var logsRequestHandler = new LogsRequestHandler(logsProvider.Object, runtimeInfoProvider.Object);
+            Option<string> response = await logsRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
+
+            // Assert
+            Assert.True(response.HasValue);
+            logsProvider.VerifyAll();
+            runtimeInfoProvider.VerifyAll();
+            var logsResponseList = response.OrDefault().FromJson<List<LogsResponse>>();
+            Assert.NotNull(logsResponseList);
+            Assert.Single(logsResponseList);
+            LogsResponse logsResponse = logsResponseList[0];
+            Assert.Equal(mod1, logsResponse.Id);
+            Assert.False(logsResponse.Payload.HasValue);
+            Assert.True(logsResponse.PayloadBytes.HasValue);
+            Assert.Equal(mod1LogBytes, logsResponse.PayloadBytes.OrDefault());
+        }
+    }
+}

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsRequestHandlerTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsRequestHandlerTests.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
             var logsProvider = new Mock<ILogsProvider>();
 
             var module1LogOptions = new ModuleLogOptions(contentEncoding, contentType, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
-            string mod1Logs = new []
+            string mod1Logs = new[]
             {
                 "Log line 1\n",
                 "Log line 2\n",

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsRequestHandlerTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsRequestHandlerTests.cs
@@ -271,5 +271,30 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
             Assert.True(logsResponse.PayloadBytes.HasValue);
             Assert.Equal(mod1LogBytes, logsResponse.PayloadBytes.OrDefault());
         }
+
+        [Fact]
+        public void InvalidCtorTest()
+        {
+            Assert.Throws<ArgumentNullException>(() => new LogsRequestHandler(null, Mock.Of<IRuntimeInfoProvider>()));
+
+            Assert.Throws<ArgumentNullException>(() => new LogsRequestHandler(Mock.Of<ILogsProvider>(), null));
+        }
+
+        [Fact]
+        public async Task InvalidInputsTest()
+        {
+            var logsRequestHandler = new LogsRequestHandler(Mock.Of<ILogsProvider>(), Mock.Of<IRuntimeInfoProvider>());
+            await Assert.ThrowsAsync<ArgumentException>(() => logsRequestHandler.HandleRequest(Option.None<string>(), CancellationToken.None));
+
+            string payload = @"{
+                    ""items"": {
+                        ""id"": ""m1"",
+                        ""filter"": <filter>
+                    },
+                    ""encoding"": ""gzip"",
+                    ""contentType"": ""text""
+                }";
+            await Assert.ThrowsAsync<ArgumentException>(() => logsRequestHandler.HandleRequest(Option.Some(payload), CancellationToken.None));
+        }
     }
 }


### PR DESCRIPTION
This PR adds support to get module logs using a direct method. This will allow showing a snippet of a module log in a client like the Azure Portal.