### PR TITLE
Make edge agent ModuleConnection disposable

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -89,6 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
         public void Dispose()
         {
             this.refreshTwinTask.Dispose();
+            this.moduleConnection.Dispose();
         }
 
         public async Task UpdateReportedPropertiesAsync(TwinCollection patch)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/IModuleConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/IModuleConnection.cs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
 {
+    using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
 
-    public interface IModuleConnection
+    public interface IModuleConnection : IDisposable
     {
         Task<IModuleClient> GetOrCreateModuleClient();
 


### PR DESCRIPTION
This also fixes EdgeAgentConnection tests - 
Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.EdgeAgentConnectionTest.EdgeAgentConnectionStatusTest
Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.EdgeAgentConnectionTest.EdgeAgentPingMethodTest
