### PR TITLE
clean workspace before job run

### DIFF
--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -303,6 +303,8 @@ jobs:
       demands:
         - Build-Image -equals true
         - win-rs5
+    workspace:
+      clean: all
     variables:
       NetCorePackageUri: https://download.microsoft.com/download/4/0/9/40920432-3302-47a8-b13c-bbc4848ad114/dotnet-sdk-2.1.302-win-x64.zip
     steps:


### PR DESCRIPTION
Fix build image pipeline by cleaning workspace before job run.  I would like to leave other yamls as-is for now.