### PR TITLE
Switch path to ProgramData env variable

### DIFF
--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -754,7 +754,7 @@ Function RunQuickstartCertsTest
     $testCommand = AppendInstallationOption($testCommand)
     Invoke-Expression $testCommand | Out-Host
 
-    $caCertPath = (Get-ChildItem C:\ProgramData\iotedge\hsm\certs\edge_owner_ca*.pem | Select -First 1).FullName
+    $caCertPath = (Get-ChildItem $env:ProgramData\iotedge\hsm\certs\edge_owner_ca*.pem | Select -First 1).FullName
     Write-Host "CA certificate path=$caCertPath"
 
     Write-Host "Run LeafDevice"


### PR DESCRIPTION
This change accommodates for Windows IoT Core which uses path C:\Data\ProgramData, instead of C:\ProgramData.