### PR TITLE
Avoid using "*" to specify the NuGet version

### DIFF
--- a/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
+++ b/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
@@ -16,6 +16,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.*" />
+	<PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.20.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Using "*" in PackageRef version makes the restore graph to pull old versions of  `Microsoft.Azure.Amqp` that result in the same issue reported in #937 

/c @mmydland @drajput