### PR TITLE
EdgeAgent: Fix log upload formatting

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequestHandler.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
     public class LogsRequestHandler : RequestHandlerBase<LogsRequest, IEnumerable<LogsResponse>>
     {
+        static readonly Version ExpectedSchemaVersion = new Version("1.0");
         const int MaxTailValue = 500;
         readonly ILogsProvider logsProvider;
         readonly IRuntimeInfoProvider runtimeInfoProvider;
@@ -28,6 +29,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
         protected override async Task<Option<IEnumerable<LogsResponse>>> HandleRequestInternal(Option<LogsRequest> payloadOption, CancellationToken cancellationToken)
         {
             LogsRequest payload = payloadOption.Expect(() => new ArgumentException("Request payload not found"));
+            if (ExpectedSchemaVersion.CompareMajorVersion(payload.SchemaVersion, "logs upload request schema") != 0)
+            {
+                Events.MismatchedMinorVersions(payload.SchemaVersion, ExpectedSchemaVersion);
+            }
+            Events.ProcessingRequest(payload);
+
             ILogsRequestToOptionsMapper requestToOptionsMapper = new LogsRequestToOptionsMapper(
                 this.runtimeInfoProvider,
                 payload.Encoding,
@@ -70,7 +77,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
             enum EventIds
             {
                 ReceivedModuleLogs = IdStart + 1,
-                ReceivedLogOptions
+                ReceivedLogOptions,
+                ProcessingRequest,
+                MismatchedMinorVersions
             }
 
             public static void ReceivedModuleLogs(byte[] moduleLogs, string id)
@@ -93,6 +102,16 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
                 {
                     Log.LogInformation((int)EventIds.ReceivedLogOptions, $"Received log options for {receivedLogOptions.id} with no tail value specified, setting tail value to {MaxTailValue}");
                 }
+            }
+
+            public static void ProcessingRequest(LogsRequest payload)
+            {
+                Log.LogInformation((int)EventIds.ProcessingRequest, $"Processing request to get logs for {payload.ToJson()}");
+            }
+
+            public static void MismatchedMinorVersions(string payloadSchemaVersion, Version expectedSchemaVersion)
+            {
+                Log.LogWarning((int)EventIds.MismatchedMinorVersions, $"Logs upload request schema version {payloadSchemaVersion} does not match expected schema version {expectedSchemaVersion}. Some settings may not be supported.");
             }
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsRequestHandler.cs
@@ -13,8 +13,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
     public class LogsRequestHandler : RequestHandlerBase<LogsRequest, IEnumerable<LogsResponse>>
     {
-        static readonly Version ExpectedSchemaVersion = new Version("1.0");
         const int MaxTailValue = 500;
+
+        static readonly Version ExpectedSchemaVersion = new Version("1.0");
+
         readonly ILogsProvider logsProvider;
         readonly IRuntimeInfoProvider runtimeInfoProvider;
 
@@ -33,6 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
             {
                 Events.MismatchedMinorVersions(payload.SchemaVersion, ExpectedSchemaVersion);
             }
+
             Events.ProcessingRequest(payload);
 
             ILogsRequestToOptionsMapper requestToOptionsMapper = new LogsRequestToOptionsMapper(

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequest.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
         [DefaultValue(LogsContentType.Text)]
         public LogsContentType ContentType { get; }
 
-        [JsonProperty("sasUrl")]
+        [JsonIgnore]
         public string SasUrl { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequestHandler.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/LogsUploadRequestHandler.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Logs;
+    using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
 
@@ -36,6 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
                 Events.MismatchedMinorVersions(payload.SchemaVersion, ExpectedSchemaVersion);
             }
 
+            Events.ProcessingRequest(payload);
             ILogsRequestToOptionsMapper requestToOptionsMapper = new LogsRequestToOptionsMapper(
                 this.runtimeInfoProvider,
                 payload.Encoding,
@@ -70,12 +72,18 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
             enum EventIds
             {
-                MismatchedMinorVersions = IdStart
+                MismatchedMinorVersions = IdStart,
+                ProcessingRequest
             }
 
             public static void MismatchedMinorVersions(string payloadSchemaVersion, Version expectedSchemaVersion)
             {
                 Log.LogWarning((int)EventIds.MismatchedMinorVersions, $"Logs upload request schema version {payloadSchemaVersion} does not match expected schema version {expectedSchemaVersion}. Some settings may not be supported.");
+            }
+
+            public static void ProcessingRequest(LogsUploadRequest payload)
+            {
+                Log.LogInformation((int)EventIds.ProcessingRequest, $"Processing request to upload logs for {payload.ToJson()}");
             }
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestManager.cs
@@ -80,17 +80,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
 
             enum EventIds
             {
-                ScheduledModule = IdStart + 1,
-                HandlingRequest,
+                HandlingRequest = IdStart + 1,
                 ErrorHandlingRequest
-            }
-
-            public static void ScheduledModule(IRuntimeModule module, TimeSpan elapsedTime, TimeSpan coolOffPeriod)
-            {
-                TimeSpan timeLeft = coolOffPeriod - elapsedTime;
-                Log.LogInformation(
-                    (int)EventIds.ScheduledModule,
-                    $"Module '{module.Name}' scheduled to restart after {coolOffPeriod.Humanize()} ({timeLeft.Humanize()} left).");
             }
 
             public static void ErrorHandlingRequest(string request, Exception exception)
@@ -104,7 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
                     (int)EventIds.HandlingRequest,
                     string.IsNullOrWhiteSpace(payloadJson)
                         ? $"Received request {request}"
-                        : $"Received request {request} with payload {payloadJson}");
+                        : $"Received request {request} with payload");
             }
 
             public static void HandledRequest(string request)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/logs/LogsProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/logs/LogsProviderTest.cs
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
 
             // Assert
             Assert.NotEmpty(receivedBytes);
-            Assert.Equal(dockerLogsStreamBytes, receivedBytes);
+            Assert.Equal(string.Join(string.Empty, TestLogTexts).ToBytes(), receivedBytes);
         }
 
         [Fact]
@@ -403,13 +403,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             receivedText.Sort();
 
             Assert.Equal(expectedTextLines, receivedText);
-        }
-
-        [Theory]
-        [MemberData(nameof(GetNeedToProcessStreamTestData))]
-        public void NeedToProcessStreamTest(ModuleLogOptions logOptions, bool expectedResult)
-        {
-            Assert.Equal(expectedResult, LogsProvider.NeedToProcessStream(logOptions));
         }
     }
 }


### PR DESCRIPTION
Logs to be uploaded as text also need to be passed through the processing pipeline to parse incoming bytes. Otherwise the docker format shows up in uploaded logs. 
Also sanitize the logs to not emit the upload logs sas token