### PR TITLE
Enable windows-arm32 for azureiotedge-functions-filter

### DIFF
--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -386,7 +386,6 @@ jobs:
           name: Functions Sample
           imageName: azureiotedge-functions-filter
           project: EdgeHubTriggerCSharp
-          arm32v7: 'false'
 
       # Direct Method Sender
       - template: templates/image-windows.yaml


### PR DESCRIPTION
I'll use this PR for testing, also verify the output actually works on iotcore arm32. I'm not sure what else I should change to enable this, please let me know if there is any