### PR TITLE
EdgeAgent: Fix error handling in GetTwin

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -662,9 +662,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             Option<DeploymentConfigInfo> deploymentConfigInfo = await connection.GetDeploymentConfigInfoAsync();
 
             // Assert
-            Assert.True(deploymentConfigInfo.HasValue);
-            Assert.False(deploymentConfigInfo.OrDefault().Exception.HasValue);
-            Assert.Equal(deploymentConfig, deploymentConfigInfo.OrDefault().DeploymentConfig);
+            Assert.False(deploymentConfigInfo.HasValue);
         }
 
         [Fact]
@@ -1153,7 +1151,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             moduleClientProvider.Setup(m => m.Create(It.IsAny<ConnectionStatusChangesHandler>()))
                 .ReturnsAsync(moduleClient.Object);
 
-
             IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler>();
             var retryStrategy = new FixedInterval(3, TimeSpan.FromSeconds(2));
 
@@ -1170,7 +1167,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
 
                 moduleClient.Setup(m => m.GetTwinAsync())
                     .ThrowsAsync(new ObjectDisposedException("Dummy obj disp"));
-
 
                 await Task.Delay(TimeSpan.FromSeconds(12));
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -1146,24 +1146,20 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
 
             var moduleClient = new Mock<IModuleClient>();
             moduleClient.Setup(m => m.GetTwinAsync())
-                .Callback(
-                    () =>
-                    {
-                        moduleClient.Setup(m => m.GetTwinAsync())
-                            .ThrowsAsync(new ObjectDisposedException("Dummy obj disp"));
-                    })
                 .ReturnsAsync(twin);
 
             var moduleClientProvider = new Mock<IModuleClientProvider>();
             moduleClientProvider.Setup(m => m.Create(It.IsAny<ConnectionStatusChangesHandler>()))
                 .ReturnsAsync(moduleClient.Object);
 
-            IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
+
+            IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler>();
+            var retryStrategy = new FixedInterval(3, TimeSpan.FromSeconds(2));
 
             // Act
-            using (var edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider.Object, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), true, TimeSpan.FromSeconds(10)))
+            using (var edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider.Object, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), true, TimeSpan.FromSeconds(10), retryStrategy))
             {
-                await Task.Delay(TimeSpan.FromSeconds(5));
+                await Task.Delay(TimeSpan.FromSeconds(3));
                 Option<DeploymentConfigInfo> receivedDeploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
 
                 // Assert
@@ -1171,13 +1167,132 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 Assert.False(receivedDeploymentConfigInfo.OrDefault().Exception.HasValue);
                 Assert.Equal(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
 
-                await Task.Delay(TimeSpan.FromSeconds(10));
+                moduleClient.Setup(m => m.GetTwinAsync())
+                    .ThrowsAsync(new ObjectDisposedException("Dummy obj disp"));
+
+
+                await Task.Delay(TimeSpan.FromSeconds(12));
+
+                // Act
+                receivedDeploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
 
                 // Assert
                 moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(4));
                 Assert.True(receivedDeploymentConfigInfo.HasValue);
                 Assert.False(receivedDeploymentConfigInfo.OrDefault().Exception.HasValue);
                 Assert.Equal(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
+            }
+        }
+
+        [Fact]
+        [Unit]
+        public async Task GetTwinRetryLogicGetsNewClient()
+        {
+            // Arrange
+            var moduleDeserializerTypes = new Dictionary<string, Type>
+            {
+                { DockerType, typeof(DockerDesiredModule) }
+            };
+
+            var edgeAgentDeserializerTypes = new Dictionary<string, Type>
+            {
+                { DockerType, typeof(EdgeAgentDockerModule) }
+            };
+
+            var edgeHubDeserializerTypes = new Dictionary<string, Type>
+            {
+                { DockerType, typeof(EdgeHubDockerModule) }
+            };
+
+            var runtimeInfoDeserializerTypes = new Dictionary<string, Type>
+            {
+                { DockerType, typeof(DockerRuntimeInfo) }
+            };
+
+            var deserializerTypes = new Dictionary<Type, IDictionary<string, Type>>
+            {
+                [typeof(IModule)] = moduleDeserializerTypes,
+                [typeof(IEdgeAgentModule)] = edgeAgentDeserializerTypes,
+                [typeof(IEdgeHubModule)] = edgeHubDeserializerTypes,
+                [typeof(IRuntimeInfo)] = runtimeInfoDeserializerTypes,
+            };
+
+            ISerde<DeploymentConfig> serde = new TypeSpecificSerDe<DeploymentConfig>(deserializerTypes);
+
+            var runtimeInfo = new DockerRuntimeInfo("docker", new DockerRuntimeConfig("1.0", null));
+            var edgeAgentDockerModule = new EdgeAgentDockerModule("docker", new DockerConfig("image", string.Empty), null, null);
+            var edgeHubDockerModule = new EdgeHubDockerModule(
+                "docker",
+                ModuleStatus.Running,
+                RestartPolicy.Always,
+                new DockerConfig("image", string.Empty),
+                null,
+                null);
+            var deploymentConfig = new DeploymentConfig(
+                "1.0",
+                runtimeInfo,
+                new SystemModules(edgeAgentDockerModule, edgeHubDockerModule),
+                new Dictionary<string, IModule>());
+            string deploymentConfigJson = serde.Serialize(deploymentConfig);
+            var twin = new Twin(new TwinProperties { Desired = new TwinCollection(deploymentConfigJson) });
+
+            var edgeHubDockerModule2 = new EdgeHubDockerModule(
+                "docker",
+                ModuleStatus.Running,
+                RestartPolicy.Always,
+                new DockerConfig("image2", string.Empty),
+                null,
+                null);
+            var deploymentConfig2 = new DeploymentConfig(
+                "1.0",
+                runtimeInfo,
+                new SystemModules(edgeAgentDockerModule, edgeHubDockerModule2),
+                new Dictionary<string, IModule>());
+            string deploymentConfigJson2 = serde.Serialize(deploymentConfig2);
+            var twin2 = new Twin(new TwinProperties { Desired = new TwinCollection(deploymentConfigJson2) });
+
+            var moduleClient = new Mock<IModuleClient>();
+            moduleClient.Setup(m => m.GetTwinAsync())
+                .ReturnsAsync(twin);
+            moduleClient.SetupGet(m => m.IsActive).Returns(true);
+
+            var moduleClientProvider = new Mock<IModuleClientProvider>();
+            moduleClientProvider.Setup(m => m.Create(It.IsAny<ConnectionStatusChangesHandler>()))
+                .ReturnsAsync(moduleClient.Object);
+
+            IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler>();
+            var retryStrategy = new FixedInterval(3, TimeSpan.FromSeconds(2));
+
+            // Act
+            using (var edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider.Object, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), true, TimeSpan.FromSeconds(10), retryStrategy))
+            {
+                await Task.Delay(TimeSpan.FromSeconds(3));
+                Option<DeploymentConfigInfo> receivedDeploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
+
+                // Assert
+                Assert.True(receivedDeploymentConfigInfo.HasValue);
+                Assert.False(receivedDeploymentConfigInfo.OrDefault().Exception.HasValue);
+                Assert.Equal(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
+                Assert.NotEqual(deploymentConfig2, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
+
+                moduleClient.SetupSequence(m => m.GetTwinAsync())
+                  .ThrowsAsync(new ObjectDisposedException("Dummy obj disp"))
+                  .ThrowsAsync(new ObjectDisposedException("Dummy obj disp 2"))
+                  .ReturnsAsync(twin2);
+
+                await Task.Delay(TimeSpan.FromSeconds(12));
+
+                // Assert
+                moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(4));
+
+                // Act
+                receivedDeploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
+
+                // Assert
+                Assert.True(receivedDeploymentConfigInfo.HasValue);
+                Assert.False(receivedDeploymentConfigInfo.OrDefault().Exception.HasValue);
+                Assert.Equal(deploymentConfig2, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
+                Assert.NotEqual(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
             }
         }
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -605,7 +605,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
 
         [Fact]
         [Unit]
-        public async Task GetDeploymentConfigInfoAsyncIncludesExceptionWhenGetTwinThrows()
+        public async Task GetDeploymentConfigInfoAsyncIDoesNotIncludeExceptionWhenGetTwinThrows()
         {
             // Arrange
             var deviceClient = new Mock<IModuleClient>();
@@ -663,8 +663,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
 
             // Assert
             Assert.True(deploymentConfigInfo.HasValue);
-            Assert.True(deploymentConfigInfo.OrDefault().Exception.HasValue);
-            Assert.IsType<InvalidOperationException>(deploymentConfigInfo.OrDefault().Exception.OrDefault());
+            Assert.False(deploymentConfigInfo.OrDefault().Exception.HasValue);
+            Assert.Equal(deploymentConfig, deploymentConfigInfo.OrDefault().DeploymentConfig);
         }
 
         [Fact]
@@ -1147,6 +1147,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var moduleClient = new Mock<IModuleClient>();
             moduleClient.Setup(m => m.GetTwinAsync())
                 .ReturnsAsync(twin);
+            moduleClient.SetupGet(m => m.IsActive).Returns(true);
 
             var moduleClientProvider = new Mock<IModuleClientProvider>();
             moduleClientProvider.Setup(m => m.Create(It.IsAny<ConnectionStatusChangesHandler>()))
@@ -1177,7 +1178,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 receivedDeploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
 
                 // Assert
-                moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(4));
+                moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(5));
                 Assert.True(receivedDeploymentConfigInfo.HasValue);
                 Assert.False(receivedDeploymentConfigInfo.OrDefault().Exception.HasValue);
                 Assert.Equal(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);


### PR DESCRIPTION
The issue - 
- Currently the EdgeAgentConnection gets the EdgeAgent config from the twin once initially, and thereafter via a desired properties update callback or periodic GetTwin call. 
- The twin that is returned in the Reconcile loop is the cached value. 
- If getting the twin and parsing it fails, an error is returned to the Reconcile loop (via the IConfigSource interface) instead. 
- Because of this, if the periodic GetTwin call fails, an error gets cached and returned for each of the subsequent Reconcile loops. 

The fix 
- The GetTwin code has retry to deal with transient errors. This PR updates that code to get a new ModuleClient every time. This takes care of the case where the SDK throws an ObjectDisposedException on the GetTwin call and goes into a bad state. The subsequent GetTwin calls should now succeed. 
- If the GetTwin fails, it is not regarded as bad config and not returned to Reconcile. Instead the previous cached config is returned. Only if a GetTwin succeeds but parsing the twin fails, it is regarded as bad input and returned to the Reconcile logic as an Exception.