### PR TITLE
Fix issue template to ask for `iotedge check` without `--output json`

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,12 +27,12 @@ Need Support?
 
 ## Context (Environment)
 
-### Output of `iotedge check --output json`
+### Output of `iotedge check`
 
 <details>
 <summary>Click here</summary>
 
-```json
+```
 // Paste here
 ```
 </details>


### PR DESCRIPTION
a72a95fa124db8b8a9242796e6523a7c7bbbc668 added a section for
`iotedge check --output json` output, but `--output json` is not in 1.0.7
(5bf532453bb26a8af75ab4e9532c1d11e6490066).

This change changes it to ask for just `iotedge check` until 1.0.8 is released.


Ref: https://github.com/Azure/iotedge/issues/1324