### PR TITLE
1.0.8: Fix RegistryCredentials equality (#1313)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerRuntimeConfig.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerRuntimeConfig.cs
@@ -4,10 +4,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
     using System;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
 
     public class DockerRuntimeConfig : IEquatable<DockerRuntimeConfig>
     {
+        static readonly DictionaryComparer<string, RegistryCredentials> RegistryCredentialsDictionaryComparer = new DictionaryComparer<string, RegistryCredentials>();
+
         public DockerRuntimeConfig(string minDockerVersion, string loggingOptions)
             : this(minDockerVersion, null, loggingOptions)
         {
@@ -38,7 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
 
         public bool Equals(DockerRuntimeConfig other) =>
             other != null && this.MinDockerVersion == other.MinDockerVersion && this.LoggingOptions == other.LoggingOptions &&
-            EqualityComparer<IDictionary<string, RegistryCredentials>>.Default.Equals(this.RegistryCredentials, other.RegistryCredentials);
+            RegistryCredentialsDictionaryComparer.Equals(this.RegistryCredentials, other.RegistryCredentials);
 
         public override int GetHashCode()
         {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RegistryCredentials.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RegistryCredentials.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
         public override bool Equals(object obj) => this.Equals(obj as RegistryCredentials);
 
         public bool Equals(RegistryCredentials other) =>
+            other != null &&
             this.Address == other.Address &&
             this.Username == other.Username &&
             this.Password == other.Password;

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerRuntimeConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerRuntimeConfigTest.cs
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Xunit;
+
+    [Unit]
+    public class DockerRuntimeConfigTest
+    {
+        [Fact]
+        public void EqualityTest()
+        {
+            var drc1 = new DockerRuntimeConfig(
+                "1.0",
+                new Dictionary<string, RegistryCredentials>
+                {
+                    ["r1"] = new RegistryCredentials("foo.azurecr.io", "foo", "foo")
+                });
+
+            var drc2 = new DockerRuntimeConfig(
+                "1.0",
+                new Dictionary<string, RegistryCredentials>
+                {
+                    ["r1"] = new RegistryCredentials("foo.azurecr.io", "foo", "foo")
+                });
+
+            Assert.Equal(drc1, drc2);
+        }
+    }
+}

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerRuntimeInfoTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerRuntimeInfoTest.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Xunit;
+
+    [Unit]
+    public class DockerRuntimeInfoTest
+    {
+        [Fact]
+        public void EqualityTest()
+        {
+            var dri1 = new DockerRuntimeInfo(
+                "docker",
+                new DockerRuntimeConfig(
+                    "1.0",
+                    new Dictionary<string, RegistryCredentials>
+                    {
+                        ["r1"] = new RegistryCredentials("foo.azurecr.io", "foo", "foo")
+                    }));
+
+            var dri2 = new DockerRuntimeInfo(
+                "docker",
+                new DockerRuntimeConfig(
+                    "1.0",
+                    new Dictionary<string, RegistryCredentials>
+                    {
+                        ["r1"] = new RegistryCredentials("foo.azurecr.io", "foo", "foo")
+                    }));
+
+            Assert.Equal(dri1, dri2);
+        }
+    }
+}


### PR DESCRIPTION
Cherry-pick https://github.com/Azure/iotedge/commit/75a824823682f68296604993d53bc079d427c939