### PR TITLE
1.0.8: Add timeout to workload api operations (#1307)

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2018_06_28/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2018_06_28/WorkloadClient.cs
@@ -15,7 +15,12 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2018_06_28
             new ExponentialBackoff(retryCount: 3, minBackoff: TimeSpan.FromSeconds(2), maxBackoff: TimeSpan.FromSeconds(30), deltaBackoff: TimeSpan.FromSeconds(3));
 
         public WorkloadClient(Uri serverUri, ApiVersion apiVersion, string moduleId, string moduleGenerationId)
-            : base(serverUri, apiVersion, moduleId, moduleGenerationId, new ErrorDetectionStrategy())
+            : this(serverUri, apiVersion, moduleId, moduleGenerationId, Option.None<TimeSpan>())
+        {
+        }
+
+        internal WorkloadClient(Uri serverUri, ApiVersion apiVersion, string moduleId, string moduleGenerationId, Option<TimeSpan> operationTimeout)
+            : base(serverUri, apiVersion, moduleId, moduleGenerationId, new ErrorDetectionStrategy(), operationTimeout)
         {
         }
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
@@ -12,7 +12,12 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
     class WorkloadClient : WorkloadClientVersioned
     {
         public WorkloadClient(Uri serverUri, ApiVersion apiVersion, string moduleId, string moduleGenerationId)
-            : base(serverUri, apiVersion, moduleId, moduleGenerationId, new ErrorDetectionStrategy())
+            : this(serverUri, apiVersion, moduleId, moduleGenerationId, Option.None<TimeSpan>())
+        {
+        }
+
+        internal WorkloadClient(Uri serverUri, ApiVersion apiVersion, string moduleId, string moduleGenerationId, Option<TimeSpan> operationTimeout)
+            : base(serverUri, apiVersion, moduleId, moduleGenerationId, new ErrorDetectionStrategy(), operationTimeout)
         {
         }
 

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/edged/WorkloadClientTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/edged/WorkloadClientTest.cs
@@ -144,5 +144,45 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Edged
             string response = await workloadClient.GetTrustBundleAsync();
             Assert.Equal(new X509Certificate2(Encoding.UTF8.GetBytes(TestCertificateHelper.CertificatePem)), new X509Certificate2(Encoding.UTF8.GetBytes(response)));
         }
+
+        [Fact]
+        public async Task ExecuteTimeoutTest_Version_2018_06_28()
+        {
+            // Arrange
+            var client = new Util.Edged.Version_2018_06_28.WorkloadClient(this.serverUri, ApiVersion.Version20180628, "m1", Guid.NewGuid().ToString(), Option.Some(TimeSpan.FromSeconds(10)));
+
+            async Task<int> LongOperation()
+            {
+                await Task.Delay(TimeSpan.FromHours(1));
+                return 10;
+            }
+
+            // Act
+            Task assertTask = Assert.ThrowsAsync<TimeoutException>(() => client.Execute<int>(LongOperation, "Dummy"));
+            Task delayTask = Task.Delay(TimeSpan.FromSeconds(20));
+
+            Task completedTask = await Task.WhenAny(assertTask, delayTask);
+            Assert.Equal(assertTask, completedTask);
+        }
+
+        [Fact]
+        public async Task ExecuteTimeoutTest_Version_2019_01_30()
+        {
+            // Arrange
+            var client = new Util.Edged.Version_2019_01_30.WorkloadClient(this.serverUri, ApiVersion.Version20190130, "m1", Guid.NewGuid().ToString(), Option.Some(TimeSpan.FromSeconds(10)));
+
+            async Task<int> LongOperation()
+            {
+                await Task.Delay(TimeSpan.FromHours(1));
+                return 10;
+            }
+
+            // Act
+            Task assertTask = Assert.ThrowsAsync<TimeoutException>(() => client.Execute<int>(LongOperation, "Dummy"));
+            Task delayTask = Task.Delay(TimeSpan.FromSeconds(20));
+
+            Task completedTask = await Task.WhenAny(assertTask, delayTask);
+            Assert.Equal(assertTask, completedTask);
+        }
     }
 }


### PR DESCRIPTION
* Add default operation timeout to Workload api client

* Update WorkloadClientVersioned.cs

Cherry-pick https://github.com/Azure/iotedge/commit/da97168ce1529105422f5673e66dc184d95c6981