### PR TITLE
Allow tests to set OptimizeForPerformance on edge hub

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/EdgeConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/EdgeConfigBuilder.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
             return builder;
         }
 
-        public IModuleConfigBuilder AddEdgeHub(string image = null)
+        public IModuleConfigBuilder AddEdgeHub(string image = null, bool optimizeForPerformance = true)
         {
             Option<string> imageOption = Option.Maybe(image);
-            var builder = new HubModuleConfigBuilder(imageOption);
+            var builder = new HubModuleConfigBuilder(imageOption, optimizeForPerformance);
             this.moduleBuilders.Add(builder.Name, builder);
             return builder;
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/HubModuleConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/HubModuleConfigBuilder.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
         const string DefaultImage = "mcr.microsoft.com/azureiotedge-hub:1.0";
         const string HubCreateOptions = "{\"HostConfig\":{\"PortBindings\":{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}],\"5671/tcp\":[{\"HostPort\":\"5671\"}]}}}";
 
-        public HubModuleConfigBuilder(Option<string> image)
+        public HubModuleConfigBuilder(Option<string> image, bool optimizeForPerformance)
             : base("$edgeHub", image.GetOrElse(DefaultImage), Option.Some(HubCreateOptions))
         {
             this.WithDesiredProperties(
@@ -19,6 +19,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
                     ["routes"] = new { route1 = "from /* INTO $upstream" },
                     ["storeAndForwardConfiguration"] = new { timeToLiveSecs = 7200 }
                 });
+
+            if (!optimizeForPerformance)
+            {
+                this.WithEnvironment(new[] { ("OptimizeForPerformance", false.ToString()) });
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Context.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 this.MethodReceiverImage = Option.Maybe(Get("methodReceiverImage"));
                 this.LogFile = Option.Maybe(Get("logFile"));
                 this.Verbose = context.GetValue<bool>("verbose");
+                this.OptimizeForPerformance = context.GetValue("optimizeForPerformance", true);
                 this.SetupTimeout = TimeSpan.FromMinutes(context.GetValue("setupTimeoutMinutes", 5));
                 this.TeardownTimeout = TimeSpan.FromMinutes(context.GetValue("teardownTimeoutMinutes", 2));
                 this.TestTimeout = TimeSpan.FromMinutes(context.GetValue("testTimeoutMinutes", 5));
@@ -90,6 +91,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
         public Option<string> MethodReceiverImage { get; }
 
         public Option<string> LogFile { get; }
+
+        public bool OptimizeForPerformance { get; }
 
         public bool Verbose { get; }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/EndToEnd.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EndToEnd.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             string agentImage = Context.Current.EdgeAgentImage.Expect(() => new ArgumentException());
             string hubImage = Context.Current.EdgeHubImage.Expect(() => new ArgumentException());
             string sensorImage = Context.Current.TempSensorImage.Expect(() => new ArgumentException());
+            bool optimizeForPerformance = Context.Current.OptimizeForPerformance;
             Option<Uri> proxy = Context.Current.Proxy;
 
             CancellationToken token = this.cts.Token;
@@ -49,7 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     Context.Current.Registry.ForEach(
                         r => builder.AddRegistryCredentials(r.address, r.username, r.password));
                     builder.AddEdgeAgent(agentImage).WithProxy(proxy);
-                    builder.AddEdgeHub(hubImage).WithProxy(proxy);
+                    builder.AddEdgeHub(hubImage, optimizeForPerformance).WithProxy(proxy);
                     builder.AddModule("tempSensor", sensorImage);
                     await builder.Build().DeployAsync(iotHub, token);
 
@@ -106,6 +107,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             string hubImage = Context.Current.EdgeHubImage.Expect(() => new ArgumentException());
             string senderImage = Context.Current.MethodSenderImage.Expect(() => new ArgumentException());
             string receiverImage = Context.Current.MethodReceiverImage.Expect(() => new ArgumentException());
+            bool optimizeForPerformance = Context.Current.OptimizeForPerformance;
             Option<Uri> proxy = Context.Current.Proxy;
 
             CancellationToken token = this.cts.Token;
@@ -133,7 +135,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     Context.Current.Registry.ForEach(
                         r => builder.AddRegistryCredentials(r.address, r.username, r.password));
                     builder.AddEdgeAgent(agentImage).WithProxy(proxy);
-                    builder.AddEdgeHub(hubImage).WithProxy(proxy);
+                    builder.AddEdgeHub(hubImage, optimizeForPerformance).WithProxy(proxy);
                     builder.AddModule(methodSender, senderImage)
                         .WithEnvironment(
                             new[]


### PR DESCRIPTION
This change helps the new end-to-end tests run on Raspberry Pi. If you don't set OptimizeForPerformance in the test settings (context.json), or if you set it to `true`, then the tests will _not_ set the environment variable in edge hub. If you set it to `false`, then the tests will set the environment variable OptimizeForPerformance=False in edge hub.