### PR TITLE
`iotedge check` improvements part 4

### DIFF
--- a/doc/troubleshoot-checks.md
+++ b/doc/troubleshoot-checks.md
@@ -26,6 +26,8 @@ Errors have a high likelihood of preventing the IoT Edge runtime or the modules 
 
 Warnings might not affect immediate connectivity but are potential deviations from best practices, and may affect long term stability, offline operation or supportability of the edge device.
 
+If there are warnings but no errors, the tool will exit successfully with code 0. Use `--warnings-as-errors` to treat warnings as errors.
+
 
 # Configuration checks details
 

--- a/doc/troubleshoot-checks.md
+++ b/doc/troubleshoot-checks.md
@@ -118,15 +118,11 @@ When using manual provisioning, the FQDN of the IoT Hub is taken from the connec
 
 The IoT Edge daemon only uses the HTTPS protocol to connect to the IoT Hub, but connectivity from the host for the AMQP and MQTT protocols can be useful when investigating issues.
 
-If Edge Agent's `UpstreamProtocol` env var is set in the `config.yaml`, only the ports specified by that will be tested. For example, if set to `Amqp`, the MQTT port will not be tested. The HTTPS port is always tested, since the IoT Edge Security Daemon always uses the HTTPS endpoint.
-
 ## container on the default network can connect to IoT Hub AMQP / HTTPS / MQTT port
 
 The tool launches a diagnostics container on the default (`bridge`) container network. This container connects to the IoT Hub's AMQP port (5671), HTTPS port (443) and MQTT port (8883). This verifies that the IoT Hub is reachable from containers on the default container network.
 
 When using manual provisioning, the FQDN of the IoT Hub is taken from the connection string. For DPS provisioning, you must specify the FQDN of the IoT Hub using the `--iothub-hostname` parameter.
-
-If Edge Agent's `UpstreamProtocol` env var is set in the `config.yaml`, only the ports specified by that will be tested. For example, if set to `Amqp`, the HTTPS and MQTT ports will not be tested.
 
 Note that these checks do not perform a TLS handshake with the IoT Hub. They only test that a TCP connection can be established to the respective port.
 
@@ -138,9 +134,7 @@ The tool launches a diagnostics container on the IoT Edge container network spec
 
 When using manual provisioning, the FQDN of the IoT Hub is taken from the connection string. For DPS provisioning, you must specify the FQDN of the IoT Hub using the `--iothub-hostname` parameter.
 
-If Edge Agent's `UpstreamProtocol` env var is set in the `config.yaml`, only the ports specified by that will be tested. For example, if set to `Amqp`, the HTTPS and MQTT ports will not be tested.
-
-Note that these checks do not perform a TLS handshake with the IoT Hub.
+Note that these checks do not perform a TLS handshake with the IoT Hub. They only test that a TCP connection can be established to the respective port.
 
 ## Edge Hub can bind to ports on host
 

--- a/doc/troubleshoot-checks.md
+++ b/doc/troubleshoot-checks.md
@@ -118,21 +118,27 @@ When using manual provisioning, the FQDN of the IoT Hub is taken from the connec
 
 The IoT Edge daemon only uses the HTTPS protocol to connect to the IoT Hub, but connectivity from the host for the AMQP and MQTT protocols can be useful when investigating issues.
 
+If Edge Agent's `UpstreamProtocol` env var is set in the `config.yaml`, only the ports specified by that will be tested. For example, if set to `Amqp`, the MQTT port will not be tested. The HTTPS port is always tested, since the IoT Edge Security Daemon always uses the HTTPS endpoint.
+
 ## container on the default network can connect to IoT Hub AMQP / HTTPS / MQTT port
 
 The tool launches a diagnostics container on the default (`bridge`) container network. This container connects to the IoT Hub's AMQP port (5671), HTTPS port (443) and MQTT port (8883). This verifies that the IoT Hub is reachable from containers on the default container network.
 
 When using manual provisioning, the FQDN of the IoT Hub is taken from the connection string. For DPS provisioning, you must specify the FQDN of the IoT Hub using the `--iothub-hostname` parameter.
 
-Note that these checks do not perform a TLS handshake with the IoT Hub.
+If Edge Agent's `UpstreamProtocol` env var is set in the `config.yaml`, only the ports specified by that will be tested. For example, if set to `Amqp`, the HTTPS and MQTT ports will not be tested.
 
-Note that these checks do not run for Windows containers.
+Note that these checks do not perform a TLS handshake with the IoT Hub. They only test that a TCP connection can be established to the respective port.
+
+Note that these checks do not run for Windows containers since they are redundant with the following checks.
 
 ## container on the IoT Edge module network can connect to IoT Hub AMQP / HTTPS / MQTT port
 
 The tool launches a diagnostics container on the IoT Edge container network specified by the `moby_runtime.network` field (defaults to `azure-iot-edge` on Linux and `nat` on Windows). This container connects to the IoT Hub's AMQP port (5671), HTTPS port (443) and MQTT port (8883). This verifies that the IoT Hub is reachable from containers on the IoT Edge container network.
 
 When using manual provisioning, the FQDN of the IoT Hub is taken from the connection string. For DPS provisioning, you must specify the FQDN of the IoT Hub using the `--iothub-hostname` parameter.
+
+If Edge Agent's `UpstreamProtocol` env var is set in the `config.yaml`, only the ports specified by that will be tested. For example, if set to `Amqp`, the HTTPS and MQTT ports will not be tested.
 
 Note that these checks do not perform a TLS handshake with the IoT Hub.
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClientProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClientProvider.cs
@@ -153,9 +153,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                     {
                         // The device SDK doesn't appear to be falling back to WebSocket from TCP,
                         // so we'll do it explicitly until we can get the SDK sorted out.
-                        //
-                        // Note: `iotedge check`'s `connection_to_iot_hub_container` also contains logic to determine the default upstream protocol.
-                        // Ensure any changes here are replicated there.
                         Try<ISdkModuleClient> result = await Fallback.ExecuteAsync(
                             () => this.CreateAndOpenSdkModuleClient(UpstreamProtocol.Amqp, statusChangedHandler),
                             () => this.CreateAndOpenSdkModuleClient(UpstreamProtocol.AmqpWs, statusChangedHandler));

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClientProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClientProvider.cs
@@ -153,6 +153,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                     {
                         // The device SDK doesn't appear to be falling back to WebSocket from TCP,
                         // so we'll do it explicitly until we can get the SDK sorted out.
+                        //
+                        // Note: `iotedge check`'s `connection_to_iot_hub_container` also contains logic to determine the default upstream protocol.
+                        // Ensure any changes here are replicated there.
                         Try<ISdkModuleClient> result = await Fallback.ExecuteAsync(
                             () => this.CreateAndOpenSdkModuleClient(UpstreamProtocol.Amqp, statusChangedHandler),
                             () => this.CreateAndOpenSdkModuleClient(UpstreamProtocol.AmqpWs, statusChangedHandler));

--- a/edgelet/iotedge/src/check/mod.rs
+++ b/edgelet/iotedge/src/check/mod.rs
@@ -34,6 +34,145 @@ use self::additional_info::AdditionalInfo;
 mod stdout;
 use self::stdout::Stdout;
 
+static CHECKS: &[(
+    &str, // Section name
+    &[(
+        &str,                                                  // Check ID
+        &str,                                                  // Check description
+        fn(&mut Check) -> Result<CheckResult, failure::Error>, // Check function
+    )],
+)] = &[
+    (
+        "Configuration checks",
+        &[
+            ("config-yaml-well-formed", "config.yaml is well-formed", parse_settings),
+            (
+                "connection-string",
+                "config.yaml has well-formed connection string",
+                settings_connection_string,
+            ),
+            (
+                "container-engine-uri",
+                "container engine is installed and functional",
+                container_engine,
+            ),
+            ("windows-host-version", "Windows host version is supported", host_version),
+            ("hostname", "config.yaml has correct hostname", settings_hostname),
+            (
+                "connect-management-uri",
+                "config.yaml has correct URIs for daemon mgmt endpoint",
+                daemon_mgmt_endpoint_uri,
+            ),
+            ("iotedged-version", "latest security daemon", iotedged_version),
+            ("host-local-time", "host time is close to real time", host_local_time),
+            ("container-local-time", "container time is close to host time", container_local_time),
+            ("container-engine-dns", "DNS server", container_engine_dns),
+            ("certificates-quickstart", "production readiness: certificates", settings_certificates),
+            (
+                "certificates-expiry",
+                "production readiness: certificates expiry",
+                settings_certificates_expiry,
+            ),
+            (
+                "container-engine-is-moby",
+                "production readiness: container engine",
+                settings_moby_runtime_uri,
+            ),
+            (
+                "container-engine-logrotate",
+                "production readiness: logs policy",
+                container_engine_logrotate,
+            ),
+        ],
+    ),
+    (
+        "Connectivity checks",
+        &[
+            (
+                "host-connect-dps-endpoint",
+                "host can connect to and perform TLS handshake with DPS endpoint",
+                connection_to_dps_endpoint,
+            ),
+            (
+                "host-connect-iothub-amqp",
+                "host can connect to and perform TLS handshake with IoT Hub AMQP port",
+                |check| connection_to_iot_hub_host(check, 5671),
+            ),
+            (
+                "host-connect-iothub-https",
+                "host can connect to and perform TLS handshake with IoT Hub HTTPS / WebSockets port",
+                |check| connection_to_iot_hub_host(check, 443),
+            ),
+            (
+                "host-connect-iothub-mqtt",
+                "host can connect to and perform TLS handshake with IoT Hub MQTT port",
+                |check| connection_to_iot_hub_host(check, 8883),
+            ),
+            (
+                "container-default-connect-iothub-amqp",
+                "container on the default network can connect to IoT Hub AMQP port",
+                |check| {
+                    if cfg!(windows) {
+                        // The default network is the same as the IoT Edge module network,
+                        // so let the module network checks handle it.
+                        Ok(CheckResult::Ignored)
+                    } else {
+                        connection_to_iot_hub_container(check, 5671, false)
+                    }
+                },
+            ),
+            (
+                "container-default-connect-iothub-https",
+                "container on the default network can connect to IoT Hub HTTPS / WebSockets port",
+                |check| {
+                    if cfg!(windows) {
+                        // The default network is the same as the IoT Edge module network,
+                        // so let the module network checks handle it.
+                        Ok(CheckResult::Ignored)
+                    } else {
+                        connection_to_iot_hub_container(check, 443, false)
+                    }
+                },
+            ),
+            (
+                "container-default-connect-iothub-mqtt",
+                "container on the default network can connect to IoT Hub MQTT port",
+                |check| {
+                    if cfg!(windows) {
+                        // The default network is the same as the IoT Edge module network,
+                        // so let the module network checks handle it.
+                        Ok(CheckResult::Ignored)
+                    } else {
+                        connection_to_iot_hub_container(check, 8883, false)
+                    }
+                },
+            ),
+            (
+                "container-module-connect-iothub-amqp",
+                "container on the IoT Edge module network can connect to IoT Hub AMQP port",
+                |check| {
+                    connection_to_iot_hub_container(check, 5671, true)
+                },
+            ),
+            (
+                "container-module-connect-iothub-https",
+                "container on the IoT Edge module network can connect to IoT Hub HTTPS / WebSockets port",
+                |check| {
+                    connection_to_iot_hub_container(check, 443, true)
+                },
+            ),
+            (
+                "container-module-connect-iothub-mqtt",
+                "container on the IoT Edge module network can connect to IoT Hub MQTT port",
+                |check| {
+                    connection_to_iot_hub_container(check, 8883, true)
+                },
+            ),
+            ("edgehub-host-ports", "Edge Hub can bind to ports on host", edge_hub_ports_on_host),
+        ],
+    ),
+];
+
 pub struct Check {
     config_file: PathBuf,
     container_engine_config_path: PathBuf,
@@ -210,146 +349,46 @@ impl Check {
         })
     }
 
-    fn execute_inner(&mut self) -> Result<(), Error> {
-        const CHECKS: &[(
-            &str, // Section name
-            &[(
-                &str,                                                  // Check ID
-                &str,                                                  // Check description
-                fn(&mut Check) -> Result<CheckResult, failure::Error>, // Check function
-            )],
-        )] = &[
-            (
-                "Configuration checks",
-                &[
-                    ("config-yaml-well-formed", "config.yaml is well-formed", parse_settings),
-                    (
-                        "connection-string",
-                        "config.yaml has well-formed connection string",
-                        settings_connection_string,
-                    ),
-                    (
-                        "container-engine-uri",
-                        "container engine is installed and functional",
-                        container_engine,
-                    ),
-                    ("windows-host-version", "Windows host version is supported", host_version),
-                    ("hostname", "config.yaml has correct hostname", settings_hostname),
-                    (
-                        "connect-management-uri",
-                        "config.yaml has correct URIs for daemon mgmt endpoint",
-                        daemon_mgmt_endpoint_uri,
-                    ),
-                    ("iotedged-version", "latest security daemon", iotedged_version),
-                    ("host-local-time", "host time is close to real time", host_local_time),
-                    ("container-local-time", "container time is close to host time", container_local_time),
-                    ("container-engine-dns", "DNS server", container_engine_dns),
-                    ("certificates-quickstart", "production readiness: certificates", settings_certificates),
-                    (
-                        "certificates-expiry",
-                        "production readiness: certificates expiry",
-                        settings_certificates_expiry,
-                    ),
-                    (
-                        "container-engine-is-moby",
-                        "production readiness: container engine",
-                        settings_moby_runtime_uri,
-                    ),
-                    (
-                        "container-engine-logrotate",
-                        "production readiness: logs policy",
-                        container_engine_logrotate,
-                    ),
-                ],
-            ),
-            (
-                "Connectivity checks",
-                &[
-                    (
-                        "host-connect-dps-endpoint",
-                        "host can connect to and perform TLS handshake with DPS endpoint",
-                        connection_to_dps_endpoint,
-                    ),
-                    (
-                        "host-connect-iothub-amqp",
-                        "host can connect to and perform TLS handshake with IoT Hub AMQP port",
-                        |check| connection_to_iot_hub_host(check, 5671),
-                    ),
-                    (
-                        "host-connect-iothub-https",
-                        "host can connect to and perform TLS handshake with IoT Hub HTTPS / WebSockets port",
-                        |check| connection_to_iot_hub_host(check, 443),
-                    ),
-                    (
-                        "host-connect-iothub-mqtt",
-                        "host can connect to and perform TLS handshake with IoT Hub MQTT port",
-                        |check| connection_to_iot_hub_host(check, 8883),
-                    ),
-                    (
-                        "container-default-connect-iothub-amqp",
-                        "container on the default network can connect to IoT Hub AMQP port",
-                        |check| {
-                            if cfg!(windows) {
-                                // The default network is the same as the IoT Edge module network,
-                                // so let the module network checks handle it.
-                                Ok(CheckResult::Ignored)
-                            } else {
-                                connection_to_iot_hub_container(check, 5671, false)
-                            }
-                        },
-                    ),
-                    (
-                        "container-default-connect-iothub-https",
-                        "container on the default network can connect to IoT Hub HTTPS / WebSockets port",
-                        |check| {
-                            if cfg!(windows) {
-                                // The default network is the same as the IoT Edge module network,
-                                // so let the module network checks handle it.
-                                Ok(CheckResult::Ignored)
-                            } else {
-                                connection_to_iot_hub_container(check, 443, false)
-                            }
-                        },
-                    ),
-                    (
-                        "container-default-connect-iothub-mqtt",
-                        "container on the default network can connect to IoT Hub MQTT port",
-                        |check| {
-                            if cfg!(windows) {
-                                // The default network is the same as the IoT Edge module network,
-                                // so let the module network checks handle it.
-                                Ok(CheckResult::Ignored)
-                            } else {
-                                connection_to_iot_hub_container(check, 8883, false)
-                            }
-                        },
-                    ),
-                    (
-                        "container-module-connect-iothub-amqp",
-                        "container on the IoT Edge module network can connect to IoT Hub AMQP port",
-                        |check| {
-                            connection_to_iot_hub_container(check, 5671, true)
-                        },
-                    ),
-                    (
-                        "container-module-connect-iothub-https",
-                        "container on the IoT Edge module network can connect to IoT Hub HTTPS / WebSockets port",
-                        |check| {
-                            connection_to_iot_hub_container(check, 443, true)
-                        },
-                    ),
-                    (
-                        "container-module-connect-iothub-mqtt",
-                        "container on the IoT Edge module network can connect to IoT Hub MQTT port",
-                        |check| {
-                            connection_to_iot_hub_container(check, 8883, true)
-                        },
-                    ),
-                    ("edgehub-host-ports", "Edge Hub can bind to ports on host", edge_hub_ports_on_host),
-                ],
-            ),
-        ];
+    pub fn print_list() -> Result<(), Error> {
+        // All our text is ASCII, so we can check for number of chars rather than using unicode-segmentation to count graphemes.
+        let widest_section_name_len = CHECKS
+            .iter()
+            .map(|(section_name, _)| section_name.len())
+            .max()
+            .expect("Have at least one section");
+        let widest_check_id_len = CHECKS
+            .iter()
+            .flat_map(|(_, section_checks)| *section_checks)
+            .map(|(check_id, _, _)| check_id.len())
+            .max()
+            .expect("Have at least one check");
 
+        println!(
+            "CATEGORY{}ID{}DESCRIPTION",
+            " ".repeat(widest_section_name_len - "CATEGORY".len() + 1),
+            " ".repeat(widest_check_id_len - "ID".len() + 1),
+        );
+        println!();
+
+        for (section_name, section_checks) in CHECKS {
+            for (check_id, check_name, _) in *section_checks {
+                println!(
+                    "{}{}{}{}{}",
+                    section_name,
+                    " ".repeat(widest_section_name_len - section_name.len() + 1),
+                    check_id,
+                    " ".repeat(widest_check_id_len - check_id.len() + 1),
+                    check_name,
+                );
+            }
+
+            println!();
+        }
+
+        Ok(())
+    }
+
+    fn execute_inner(&mut self) -> Result<(), Error> {
         let mut checks: BTreeMap<&str, _> = Default::default();
 
         let mut stdout = Stdout::new(self.output_format);

--- a/edgelet/iotedge/src/check/mod.rs
+++ b/edgelet/iotedge/src/check/mod.rs
@@ -183,6 +183,7 @@ pub struct Check {
     ntp_server: String,
     output_format: OutputFormat,
     verbose: bool,
+    warnings_as_errors: bool,
 
     additional_info: AdditionalInfo,
 
@@ -232,6 +233,7 @@ impl Check {
         ntp_server: String,
         output_format: OutputFormat,
         verbose: bool,
+        warnings_as_errors: bool,
     ) -> impl Future<Item = Self, Error = Error> + Send {
         let latest_versions = if let Some(expected_iotedged_version) = expected_iotedged_version {
             future::Either::A(future::ok::<_, Error>(LatestVersions {
@@ -341,6 +343,7 @@ impl Check {
                 ntp_server,
                 output_format,
                 verbose,
+                warnings_as_errors,
 
                 additional_info: AdditionalInfo::new(),
 
@@ -441,7 +444,7 @@ impl Check {
                         });
                     }
 
-                    Ok(CheckResult::Warning(warning)) => {
+                    Ok(CheckResult::Warning(ref warning)) if !self.warnings_as_errors => {
                         num_warnings += 1;
 
                         checks.insert(
@@ -523,7 +526,7 @@ impl Check {
                         });
                     }
 
-                    Err(err) => {
+                    Ok(CheckResult::Warning(err)) | Err(err) => {
                         num_errors += 1;
 
                         checks.insert(
@@ -1806,6 +1809,7 @@ mod tests {
                     "pool.ntp.org:123".to_owned(), // unused for this test
                     super::OutputFormat::Text,     // unused for this test
                     false,
+                    false,
                 ))
                 .unwrap();
 
@@ -1876,6 +1880,7 @@ mod tests {
                 "pool.ntp.org:123".to_owned(), // unused for this test
                 super::OutputFormat::Text,     // unused for this test
                 false,
+                false,
             ))
             .unwrap();
 
@@ -1922,6 +1927,7 @@ mod tests {
                 "pool.ntp.org:123".to_owned(),              // unused for this test
                 super::OutputFormat::Text,                  // unused for this test
                 false,
+                false,
             ))
             .unwrap();
 
@@ -1959,6 +1965,7 @@ mod tests {
                 None,                          // pretend user did not specify --iothub-hostname
                 "pool.ntp.org:123".to_owned(), // unused for this test
                 super::OutputFormat::Text,     // unused for this test
+                false,
                 false,
             ))
             .unwrap();
@@ -2001,6 +2008,7 @@ mod tests {
                 None,                          // unused for this test
                 "pool.ntp.org:123".to_owned(), // unused for this test
                 super::OutputFormat::Text,     // unused for this test
+                false,
                 false,
             ))
             .unwrap();
@@ -2053,6 +2061,7 @@ mod tests {
                 None,                          // unused for this test
                 "pool.ntp.org:123".to_owned(), // unused for this test
                 super::OutputFormat::Text,     // unused for this test
+                false,
                 false,
             ))
             .unwrap();

--- a/edgelet/iotedge/src/check/upstream_protocol_port.rs
+++ b/edgelet/iotedge/src/check/upstream_protocol_port.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(super) enum UpstreamProtocolPort {
+    Amqp,
+    Https,
+    Mqtt,
+}
+
+impl UpstreamProtocolPort {
+    pub(super) fn as_port(self) -> u16 {
+        #[allow(clippy::match_same_arms)]
+        match self {
+            UpstreamProtocolPort::Amqp => 5671,
+            UpstreamProtocolPort::Https => 443,
+            UpstreamProtocolPort::Mqtt => 8883,
+        }
+    }
+}
+
+impl std::str::FromStr for UpstreamProtocolPort {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match &*s.to_lowercase() {
+            "amqp" => Ok(UpstreamProtocolPort::Amqp),
+            "amqpws" | "mqttws" => Ok(UpstreamProtocolPort::Https),
+            "mqtt" => Ok(UpstreamProtocolPort::Mqtt),
+            _ => Err(format!(
+                r#"expected one of "Amqp", "AmqpWs", "Mqtt" or "MqttWs" but got {:?}"#,
+                s,
+            )),
+        }
+    }
+}

--- a/edgelet/iotedge/src/check/upstream_protocol_port.rs
+++ b/edgelet/iotedge/src/check/upstream_protocol_port.rs
@@ -17,19 +17,3 @@ impl UpstreamProtocolPort {
         }
     }
 }
-
-impl std::str::FromStr for UpstreamProtocolPort {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match &*s.to_lowercase() {
-            "amqp" => Ok(UpstreamProtocolPort::Amqp),
-            "amqpws" | "mqttws" => Ok(UpstreamProtocolPort::Https),
-            "mqtt" => Ok(UpstreamProtocolPort::Mqtt),
-            _ => Err(format!(
-                r#"expected one of "Amqp", "AmqpWs", "Mqtt" or "MqttWs" but got {:?}"#,
-                s,
-            )),
-        }
-    }
-}

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -80,6 +80,9 @@ fn run() -> Result<(), Error> {
         edgelet_core::version().replace("~", "-")
     );
 
+    let mut possible_check_id_values: Vec<_> = Check::possible_ids().collect();
+    possible_check_id_values.sort();
+
     let matches = App::new(crate_name!())
         .version(edgelet_core::version_with_source_version())
         .about(crate_description!())
@@ -122,6 +125,15 @@ fn run() -> Result<(), Error> {
                         .help("Sets the name of the azureiotedge-diagnostics image.")
                         .takes_value(true)
                         .default_value(&default_diagnostics_image_name),
+                )
+                .arg(
+                    Arg::with_name("dont-run")
+                        .long("dont-run")
+                        .value_name("DONT_RUN")
+                        .help("Space-separated list of check IDs. The checks listed here will not be run. See 'iotedge check-list' for details of all checks.\n")
+                        .multiple(true)
+                        .takes_value(true)
+                        .possible_values(&possible_check_id_values),
                 )
                 .arg(
                     Arg::with_name("expected-iotedged-version")
@@ -249,6 +261,11 @@ fn run() -> Result<(), Error> {
                 args.value_of("diagnostics-image-name")
                     .expect("arg has a default value")
                     .to_string(),
+                args.values_of("dont-run")
+                    .into_iter()
+                    .flatten()
+                    .map(ToOwned::to_owned)
+                    .collect(),
                 args.value_of("expected-iotedged-version")
                     .map(ToOwned::to_owned),
                 args.value_of_os("iotedged")

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -173,6 +173,7 @@ fn run() -> Result<(), Error> {
                         .takes_value(false),
                 ),
         )
+        .subcommand(SubCommand::with_name("check-list").about("List the checks that are run for 'iotedge check'"))
         .subcommand(SubCommand::with_name("list").about("List modules"))
         .subcommand(
             SubCommand::with_name("restart")
@@ -269,9 +270,8 @@ fn run() -> Result<(), Error> {
             )
             .and_then(|mut check| check.execute()),
         ),
-        ("list", Some(_args)) => {
-            tokio_runtime.block_on(List::new(runtime()?, io::stdout()).execute())
-        }
+        ("check-list", _) => Check::print_list(),
+        ("list", _) => tokio_runtime.block_on(List::new(runtime()?, io::stdout()).execute()),
         ("restart", Some(args)) => tokio_runtime.block_on(
             Restart::new(
                 args.value_of("MODULE").unwrap().to_string(),
@@ -297,7 +297,7 @@ fn run() -> Result<(), Error> {
                 .with_since(since);
             tokio_runtime.block_on(Logs::new(id, options, runtime()?).execute())
         }
-        ("version", Some(_args)) => tokio_runtime.block_on(Version::new().execute()),
+        ("version", _) => tokio_runtime.block_on(Version::new().execute()),
         (command, _) => tokio_runtime.block_on(Unknown::new(command.to_string()).execute()),
     }
 }

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -183,6 +183,13 @@ fn run() -> Result<(), Error> {
                         .value_name("VERBOSE")
                         .help("Increases verbosity of output.")
                         .takes_value(false),
+                )
+                .arg(
+                    Arg::with_name("warnings-as-errors")
+                        .long("warnings-as-errors")
+                        .value_name("WARNINGS_AS_ERRORS")
+                        .help("Treats warnings as errors. Thus 'iotedge check' will exit with non-zero code if it encounters warnings.")
+                        .takes_value(false),
                 ),
         )
         .subcommand(SubCommand::with_name("check-list").about("List the checks that are run for 'iotedge check'"))
@@ -284,6 +291,7 @@ fn run() -> Result<(), Error> {
                     })
                     .expect("arg has a default value"),
                 args.occurrences_of("verbose") > 0,
+                args.occurrences_of("warnings-as-errors") > 0,
             )
             .and_then(|mut check| check.execute()),
         ),


### PR DESCRIPTION
- Add `iotedge check-list` to print information about all checks.

- Add `iotedge check --dont-run` to blacklist certain checks from running.

- Add `iotedge check --warnings-as-errors` to treat warnings as errors.

- ~~Use Edge Agent's `UpstreamProtocol` env var to filter
  container connectivity checks.~~