### PR TITLE
Fix Windows to initialize logging before anything that can fail

### DIFF
--- a/edgelet/iotedged/src/app.rs
+++ b/edgelet/iotedged/src/app.rs
@@ -2,7 +2,7 @@
 
 use std::path::Path;
 
-use clap::{crate_authors, crate_description, crate_name, App, Arg, ArgMatches};
+use clap::{crate_authors, crate_description, crate_name, App, Arg};
 use failure::ResultExt;
 use log::info;
 
@@ -13,8 +13,8 @@ use edgelet_docker::DockerConfig;
 use crate::error::{Error, ErrorKind, InitializeErrorReason};
 use crate::logging;
 
-pub fn create_base_app<'a, 'b>() -> App<'a, 'b> {
-    App::new(crate_name!())
+fn create_app() -> App<'static, 'static> {
+    let app = App::new(crate_name!())
         .version(edgelet_core::version_with_source_version())
         .author(crate_authors!("\n"))
         .about(crate_description!())
@@ -25,81 +25,70 @@ pub fn create_base_app<'a, 'b>() -> App<'a, 'b> {
                 .value_name("FILE")
                 .help("Sets daemon configuration file")
                 .takes_value(true),
+        );
+
+    if cfg!(windows) {
+        app.arg(
+            Arg::with_name("use-event-logger")
+                .short("e")
+                .long("use-event-logger")
+                .value_name("USE_EVENT_LOGGER")
+                .help("Log to Windows event logger instead of stdout")
+                .required(false)
+                .takes_value(false),
         )
+    }
+    else {
+        app
+    }
 }
 
-#[cfg(not(target_os = "windows"))]
-pub fn create_app<'a, 'b>() -> App<'a, 'b> {
-    create_base_app()
-}
-
-#[cfg(target_os = "windows")]
-pub fn create_app<'a, 'b>() -> App<'a, 'b> {
-    create_base_app().arg(
-        Arg::with_name("use-event-logger")
-            .short("e")
-            .long("use-event-logger")
-            .value_name("USE_EVENT_LOGGER")
-            .help("Log to Windows event logger instead of stdout")
-            .required(false)
-            .takes_value(false),
-    )
-}
-
-pub fn log_banner() {
-    info!("Starting Azure IoT Edge Security Daemon");
-    info!("Version - {}", edgelet_core::version_with_source_version());
-}
-
-pub fn init_common<'a>() -> Result<(Settings<DockerConfig>, ArgMatches<'a>), Error> {
+fn init_common(running_as_windows_service: bool) -> Result<Settings<DockerConfig>, Error> {
     let matches = create_app().get_matches();
-    let settings = {
-        let config_file = matches
-            .value_of_os("config-file")
-            .and_then(|name| {
-                let name = Path::new(name);
-                info!("Using config file: {}", name.display());
-                Some(name)
-            })
-            .or_else(|| {
-                info!("Using default configuration");
-                None
-            });
 
-        Settings::<DockerConfig>::new(config_file)
-            .context(ErrorKind::Initialize(InitializeErrorReason::LoadSettings))?
-    };
-
-    Ok((settings, matches))
-}
-
-#[cfg(target_os = "windows")]
-pub fn init() -> Result<Settings<DockerConfig>, Error> {
-    let (settings, matches) = init_common()?;
-
-    if matches.is_present("use-event-logger") {
-        logging::init_win_log();
-    } else {
-        logging::init();
+    // If running as a Windows service, logging was already initialized by init_win_svc_logging(), so don't do it again.
+    if !running_as_windows_service {
+        if cfg!(windows) && matches.is_present("use-event-logger") {
+            #[cfg(windows)]
+            logging::init_win_log();
+        }
+        else {
+            logging::init();
+        }
     }
 
-    log_banner();
+    info!("Starting Azure IoT Edge Security Daemon");
+    info!("Version - {}", edgelet_core::version_with_source_version());
+
+    let config_file = matches
+        .value_of_os("config-file")
+        .and_then(|name| {
+            let name = Path::new(name);
+            info!("Using config file: {}", name.display());
+            Some(name)
+        })
+        .or_else(|| {
+            info!("Using default configuration");
+            None
+        });
+
+    let settings =
+        Settings::<DockerConfig>::new(config_file)
+            .context(ErrorKind::Initialize(InitializeErrorReason::LoadSettings))?;
 
     Ok(settings)
 }
 
-#[cfg(not(target_os = "windows"))]
 pub fn init() -> Result<Settings<DockerConfig>, Error> {
-    logging::init();
-    let (settings, _) = init_common()?;
-    log_banner();
-    Ok(settings)
+    init_common(false)
 }
 
-#[cfg(target_os = "windows")]
+#[cfg(windows)]
 pub fn init_win_svc() -> Result<Settings<DockerConfig>, Error> {
+    init_common(true)
+}
+
+#[cfg(windows)]
+pub fn init_win_svc_logging() {
     logging::init_win_log();
-    let (settings, _) = init_common()?;
-    log_banner();
-    Ok(settings)
 }

--- a/edgelet/iotedged/src/app.rs
+++ b/edgelet/iotedged/src/app.rs
@@ -37,8 +37,7 @@ fn create_app() -> App<'static, 'static> {
                 .required(false)
                 .takes_value(false),
         )
-    }
-    else {
+    } else {
         app
     }
 }
@@ -51,8 +50,7 @@ fn init_common(running_as_windows_service: bool) -> Result<Settings<DockerConfig
         if cfg!(windows) && matches.is_present("use-event-logger") {
             #[cfg(windows)]
             logging::init_win_log();
-        }
-        else {
+        } else {
             logging::init();
         }
     }
@@ -72,9 +70,8 @@ fn init_common(running_as_windows_service: bool) -> Result<Settings<DockerConfig
             None
         });
 
-    let settings =
-        Settings::<DockerConfig>::new(config_file)
-            .context(ErrorKind::Initialize(InitializeErrorReason::LoadSettings))?;
+    let settings = Settings::<DockerConfig>::new(config_file)
+        .context(ErrorKind::Initialize(InitializeErrorReason::LoadSettings))?;
 
     Ok(settings)
 }

--- a/edgelet/iotedged/src/windows.rs
+++ b/edgelet/iotedged/src/windows.rs
@@ -113,6 +113,10 @@ pub fn run() -> Result<(), Error> {
         run_as_console()?;
         Ok(())
     } else {
+        // Initialize logging before starting the service so that errors can be logged even if the service never starts,
+        // such as if we couldn't connect to the service controller.
+        app::init_win_svc_logging();
+
         // kick-off the Windows service dance
         service_dispatcher::start(IOTEDGED_SERVICE_NAME, ffi_service_main)
             .map_err(ServiceError::from)


### PR DESCRIPTION
Before this change, the Windows console mode would exit silently if it failed
to parse the config file. Also, the Windows service mode would exit silently
if it could never start the service, such as if it could not connect to
the service controller.

With this change, these errors are logged.