### PR TITLE
Simple change to reauthentication task logging.

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionReauthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionReauthenticator.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public static void ReauthenticatingClients()
             {
-                Log.LogInformation((int)EventIds.ReauthenticatingClients, "Reauthenticating connected clients");
+                Log.LogDebug((int)EventIds.ReauthenticatingClients, "Entering task to reauthenticate connected clients");
             }
 
             public static void EdgeHubConnectionReestablished()

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionReauthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionReauthenticator.cs
@@ -247,7 +247,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public static void ReauthenticatingClients()
             {
-                Log.LogDebug((int)EventIds.ReauthenticatingClients, "Entering task to reauthenticate connected clients");
+                Log.LogInformation((int)EventIds.ReauthenticatingClients, "Entering periodic task to reauthenticate connected clients");
             }
 
             public static void EdgeHubConnectionReestablished()


### PR DESCRIPTION
Help clarify the message coming at the top of the ConnectionReauthenticator task. See #1376 

Change message from "Reauthenticating connected clients" to
"Entering task to reauthenticate connected clients" for clarity.

Changed level to a debug message to reduce edgehub chatter.