### PR TITLE
EdgeHub: Don't send DP updates for empty patches

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/StoringTwinManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/StoringTwinManager.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json.Linq;
 
     public class StoringTwinManager : ITwinManager
     {
@@ -181,10 +182,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
                     Events.UpdatingTwinOnDeviceConnect(id);
                     await this.StoreTwinInStore(id, cloudTwin);
 
-                    string diffPatch = JsonEx.Diff(storeTwin.Properties.Desired, cloudTwin.Properties.Desired);
-                    if (!string.IsNullOrWhiteSpace(diffPatch))
+                    JObject diffPatch = JsonEx.Diff(JToken.FromObject(storeTwin.Properties.Desired), JToken.FromObject(cloudTwin.Properties.Desired));
+                    if (diffPatch != null && diffPatch.HasValues)
                     {
-                        var patch = new TwinCollection(diffPatch);
+                        var patch = new TwinCollection(diffPatch.ToString());
                         IMessage patchMessage = this.twinCollectionConverter.ToMessage(patch);
                         await this.SendPatchToDevice(id, patchMessage);
                     }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
@@ -101,7 +101,9 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
             // both 'from' and 'to' must be objects
             if (fromToken.Type != JTokenType.Object || toToken.Type != JTokenType.Object)
+            {
                 return patch;
+            }
 
             var from = (JObject)fromToken;
             var to = (JObject)toToken;


### PR DESCRIPTION
On device re-connection, EH gets twins for connected clients and sends DP updates if there is a diff. This fixes the case when the patch is empty.