### PR TITLE
[k8s] EdgeAgent should use namespaced role and role binding

### DIFF
--- a/edgelet/edgelet-http/src/pid.rs
+++ b/edgelet/edgelet-http/src/pid.rs
@@ -158,8 +158,8 @@ pub use self::impl_macos::get_pid;
 
 #[cfg(target_os = "macos")]
 pub mod impl_macos {
+    use std::io;
     use std::os::unix::io::AsRawFd;
-    use std::{io, mem};
 
     use libc::getpeereid;
     use tokio_uds::UnixStream;

--- a/edgelet/edgelet-kube/src/convert/to_k8s.rs
+++ b/edgelet/edgelet-kube/src/convert/to_k8s.rs
@@ -448,7 +448,7 @@ pub fn spec_to_service_account(
 pub fn spec_to_role_binding(
     settings: &Settings,
     spec: &ModuleSpec<DockerConfig>,
-) -> Result<(String, rbac::ClusterRoleBinding)> {
+) -> Result<(String, rbac::RoleBinding)> {
     let module_label_value = sanitize_dns_value(spec.name())?;
     let device_label_value =
         sanitize_dns_value(settings.device_id().ok_or(ErrorKind::MissingDeviceId)?)?;
@@ -470,7 +470,7 @@ pub fn spec_to_role_binding(
     let mut annotations = BTreeMap::new();
     annotations.insert(EDGE_ORIGINAL_MODULEID.to_string(), spec.name().to_string());
 
-    let role_binding = rbac::ClusterRoleBinding {
+    let role_binding = rbac::RoleBinding {
         metadata: Some(api_meta::ObjectMeta {
             name: Some(role_binding_name.clone()),
             namespace: Some(settings.namespace().to_string()),

--- a/edgelet/edgelet-kube/tests/runtime.rs
+++ b/edgelet/edgelet-kube/tests/runtime.rs
@@ -497,7 +497,7 @@ fn create_creates_or_updates_service_account_role_binding_deployment_for_edgeage
 
     let dispatch_table = routes!(
         PUT format!("/api/v1/namespaces/{}/serviceaccounts/edgeagent", settings.namespace()) => replace_service_account_handler(),
-        PUT "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/edgeagent" => replace_role_binding_handler(),
+        PUT format!("/apis/rbac.authorization.k8s.io/v1/namespaces/{}/rolebindings/edgeagent", settings.namespace()) => replace_role_binding_handler(),
         PUT format!("/apis/apps/v1/namespaces/{}/deployments/edgeagent", settings.namespace()) => replace_deployment_handler(),
     );
 
@@ -650,10 +650,11 @@ fn replace_role_binding_handler() -> impl Fn(Request<Body>) -> ResponseFuture + 
     move |_| {
         response(StatusCode::OK, || {
             json!({
-                "kind": "ClusterRoleBinding",
+                "kind": "RoleBinding",
                 "apiVersion": "rbac.authorization.k8s.io/v1",
                 "metadata": {
-                    "name": "edgeagent"
+                    "name": "edgeagent",
+                    "namespace": "my-namespace",
                 },
                 "subjects": [
                     {
@@ -681,7 +682,7 @@ fn replace_deployment_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Cl
                 "apiVersion": "apps/v1",
                 "metadata": {
                     "name": "edgeagent",
-                    "namespace": "msiot-dmolokan-iothub-dmolokan-edge-aks",
+                    "namespace": "my-namespace",
                 },
             })
             .to_string()


### PR DESCRIPTION
EdgeAgent should use namespaced role and role binding instead of cluster one