### PR TITLE
Fix build for .net core 3.0

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.csproj
@@ -16,11 +16,14 @@
 
   <ItemGroup>
     <PackageReference Include="Docker.DotNet" Version="3.125.2" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
+    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix build for .net core 3.0 since microsoft.aspnetcore.all should not be used in Edge.Agent.Kubernetes test project when .net core 3.0 is used.