### PR TITLE
Make UrlConnector clonable

### DIFF
--- a/edgelet/edgelet-http/src/util/connector.rs
+++ b/edgelet/edgelet-http/src/util/connector.rs
@@ -36,6 +36,7 @@ use crate::util::{socket_file_exists, StreamSelector};
 use crate::PIPE_SCHEME;
 use crate::{HTTP_SCHEME, UNIX_SCHEME};
 
+#[derive(Clone)]
 pub enum UrlConnector {
     Http(HttpConnector),
     #[cfg(windows)]

--- a/edgelet/hyper-named-pipe/src/lib.rs
+++ b/edgelet/hyper-named-pipe/src/lib.rs
@@ -21,6 +21,7 @@ pub use crate::uri::Uri;
 
 pub const NAMED_PIPE_SCHEME: &str = "npipe";
 
+#[derive(Clone)]
 pub struct PipeConnector;
 
 impl Connect for PipeConnector {


### PR DESCRIPTION
When attempting to use the `UrlConnector` type from snitcher, it turns out that this type needs to be clonable.