### PR TITLE
Fix Windows install in symmetric key provisioning mode

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -1640,7 +1640,7 @@ function Set-ProvisioningMode {
         }
         else {
             $attestationMethod = Get-DpsProvisioningSettings
-            $selectionRegex = '(?:[^\S\n]*#[^\S\n]*)?provisioning:\s*#?\s*source:\s*".*"\s*#?\s*global_endpoint:\s*".*"\s*#?\s*scope_id:\s*".*"\s*#?\s*attestation:\s*#?\s*method:\s*"' + $attestationMethod + '"\s*#?\s*registration_id:\s*".*"\s*#?\s*device_id:\s*".*"'
+            $selectionRegex = '(?:[^\S\n]*#[^\S\n]*)?provisioning:\s*#?\s*source:\s*".*"\s*#?\s*global_endpoint:\s*".*"\s*#?\s*scope_id:\s*".*"\s*#?\s*attestation:\s*#?\s*method:\s*"' + $attestationMethod + '"\s*#?\s*registration_id:\s*".*"'
 
             if ($attestationMethod -eq 'symmetric_key') {
                 $selectionRegex += '\s*#?\s*symmetric_key:\s".*"'


### PR DESCRIPTION
The fix entails removing the "device_id" from the yaml selection regex. Device id was removed from the provisioning settings however was left behind in this install script. This issue was discovered in E2E tests as part of test coverage improvements.