### PR TITLE
Remove redundant deployment of iotedge service

### DIFF
--- a/scripts/windows/test/Setup-Env.ps1
+++ b/scripts/windows/test/Setup-Env.ps1
@@ -101,10 +101,8 @@ If ($osEdition -eq "IoTUAP")    # Windows IoT Core - update iotedge
             shutdown -r -t 5
         }
     } Else {
-        Write-Host "$serviceName not found."
-        Write-Host "Installing $serviceName..."
-        # triggers reboot
-        deploy-iotedge
+        Write-Host "Service $serviceName not found. Device is clean."
+        # no need to do anything
     }
 
     # hide exit error caused by target reboot


### PR DESCRIPTION
"Offline installation" of service iotedge is not handled correctly here. This script needs only to setup a clean environment.
Deployment of iotedge service happens elsewhere (Run-E2ETest.ps1) where the case of "offline installation" is handled correctly.