### PR TITLE
1.0.8: Adding Experimental feature flags for the new experimental features

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Service
+{
+    using Microsoft.Extensions.Configuration;
+
+    public class ExperimentalFeatures
+    {
+        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool enableUploadLogs)
+        {
+            this.Enabled = enabled;
+            this.DisableCloudSubscriptions = disableCloudSubscriptions;
+            this.EnableUploadLogs = enableUploadLogs;
+        }
+
+        public static ExperimentalFeatures Init(IConfiguration experimentalFeaturesConfig)
+        {
+            bool enabled = experimentalFeaturesConfig.GetValue("Enabled", false);
+            bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("DisableCloudSubscriptions", false);
+            bool enableUploadLogs = enabled && experimentalFeaturesConfig.GetValue("EnableUploadLogs", false);
+            return new ExperimentalFeatures(enabled, disableCloudSubscriptions, enableUploadLogs);
+        }
+
+        public bool Enabled { get; }
+
+        public bool DisableCloudSubscriptions { get; }
+
+        public bool EnableUploadLogs { get; }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.Service
 {
+    using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
 
     public class ExperimentalFeatures
     {
@@ -12,12 +14,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             this.EnableUploadLogs = enableUploadLogs;
         }
 
-        public static ExperimentalFeatures Init(IConfiguration experimentalFeaturesConfig)
+        public static ExperimentalFeatures Init(IConfiguration experimentalFeaturesConfig, ILogger logger)
         {
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
             bool enableUploadLogs = enabled && experimentalFeaturesConfig.GetValue("enableUploadLogs", false);
-            return new ExperimentalFeatures(enabled, disableCloudSubscriptions, enableUploadLogs);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, enableUploadLogs);
+            logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
+            return experimentalFeatures;
         }
 
         public bool Enabled { get; }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
 
         public static ExperimentalFeatures Init(IConfiguration experimentalFeaturesConfig)
         {
-            bool enabled = experimentalFeaturesConfig.GetValue("Enabled", false);
-            bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("DisableCloudSubscriptions", false);
-            bool enableUploadLogs = enabled && experimentalFeaturesConfig.GetValue("EnableUploadLogs", false);
+            bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
+            bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
+            bool enableUploadLogs = enabled && experimentalFeaturesConfig.GetValue("enableUploadLogs", false);
             return new ExperimentalFeatures(enabled, disableCloudSubscriptions, enableUploadLogs);
         }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 bool closeOnIdleTimeout = configuration.GetValue(Constants.CloseOnIdleTimeout, false);
                 int idleTimeoutSecs = configuration.GetValue(Constants.IdleTimeoutSecs, 300);
                 TimeSpan idleTimeout = TimeSpan.FromSeconds(idleTimeoutSecs);
-                ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Init(configuration.GetSection("ExperimentalFeatures"));
+                ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Init(configuration.GetSection("experimentalFeatures"));
                 string iothubHostname;
                 string deviceId;
                 switch (mode.ToLowerInvariant())

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -107,6 +107,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 bool closeOnIdleTimeout = configuration.GetValue(Constants.CloseOnIdleTimeout, false);
                 int idleTimeoutSecs = configuration.GetValue(Constants.IdleTimeoutSecs, 300);
                 TimeSpan idleTimeout = TimeSpan.FromSeconds(idleTimeoutSecs);
+                ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Init(configuration.GetSection("ExperimentalFeatures"));
                 string iothubHostname;
                 string deviceId;
                 switch (mode.ToLowerInvariant())
@@ -142,7 +143,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                     case "twin":
                         bool enableStreams = configuration.GetValue(Constants.EnableStreams, false);
                         int requestTimeoutSecs = configuration.GetValue(Constants.RequestTimeoutSecs, 600);
-                        bool disableSubscriptions = configuration.GetValue(Constants.DisableCloudSubscriptions, false);
                         builder.RegisterModule(
                             new TwinConfigSourceModule(
                                 iothubHostname,
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                                 TimeSpan.FromSeconds(configRefreshFrequencySecs),
                                 enableStreams,
                                 TimeSpan.FromSeconds(requestTimeoutSecs),
-                                !disableSubscriptions));
+                                experimentalFeatures));
                         break;
 
                     case "local":

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 bool closeOnIdleTimeout = configuration.GetValue(Constants.CloseOnIdleTimeout, false);
                 int idleTimeoutSecs = configuration.GetValue(Constants.IdleTimeoutSecs, 300);
                 TimeSpan idleTimeout = TimeSpan.FromSeconds(idleTimeoutSecs);
-                ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Init(configuration.GetSection("experimentalFeatures"));
+                ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Init(configuration.GetSection("experimentalFeatures"), logger);
                 string iothubHostname;
                 string deviceId;
                 switch (mode.ToLowerInvariant())

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceConnectivityManager.cs
@@ -282,7 +282,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
             internal static void Created(TimeSpan connectedCheckFrequency, TimeSpan disconnectedCheckFrequency)
             {
-                Log.LogDebug((int)EventIds.Created, Invariant($"Created DeviceConnectivityManager with connected check frequency {connectedCheckFrequency} and disconnected check frequency {disconnectedCheckFrequency}"));
+                Log.LogInformation((int)EventIds.Created, Invariant($"Created DeviceConnectivityManager with connected check frequency {connectedCheckFrequency} and disconnected check frequency {disconnectedCheckFrequency}"));
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/HubCoreEventIds.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/HubCoreEventIds.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const int DeviceScopeAuthenticator = EventIdStart + 1400;
         public const int SubscriptionProcessor = EventIdStart + 1500;
         public const int RetryingCloudProxy = EventIdStart + 1600;
+        public const int NullDeviceConnectivityManager = EventIdStart + 1700;
         const int EventIdStart = 1000;
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceConnectivityManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceConnectivityManager.cs
@@ -3,9 +3,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 {
     using System;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
 
     public class NullDeviceConnectivityManager : IDeviceConnectivityManager
     {
+        public NullDeviceConnectivityManager()
+        {
+            Events.Created();
+        }
+
         public event EventHandler DeviceConnected
         {
             add { }
@@ -21,5 +28,21 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public Task CallSucceeded() => Task.CompletedTask;
 
         public Task CallTimedOut() => Task.CompletedTask;
+
+        static class Events
+        {
+            const int IdStart = HubCoreEventIds.NullDeviceConnectivityManager;
+            static readonly ILogger Log = Logger.Factory.CreateLogger<NullDeviceConnectivityManager>();
+
+            enum EventIds
+            {
+                Created = IdStart
+            }
+
+            internal static void Created()
+            {
+                Log.LogInformation((int)EventIds.Created, $"Device connectivity check disabled");
+            }
+        }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool optimizeForPerformance = this.configuration.GetValue("OptimizeForPerformance", true);
             (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward = this.GetStoreAndForwardConfiguration();
 
-            IConfiguration configuration = this.configuration.GetSection("ExperimentalFeatures");
+            IConfiguration configuration = this.configuration.GetSection("experimentalFeatures");
             ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Init(configuration);
 
             this.RegisterCommonModule(builder, optimizeForPerformance, storeAndForward);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -76,8 +76,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool optimizeForPerformance = this.configuration.GetValue("OptimizeForPerformance", true);
             (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward = this.GetStoreAndForwardConfiguration();
 
+            IConfiguration configuration = this.configuration.GetSection("ExperimentalFeatures");
+            ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Init(configuration);
+
             this.RegisterCommonModule(builder, optimizeForPerformance, storeAndForward);
-            this.RegisterRoutingModule(builder, storeAndForward);
+            this.RegisterRoutingModule(builder, storeAndForward, experimentalFeatures);
             this.RegisterMqttModule(builder, storeAndForward, optimizeForPerformance);
             this.RegisterAmqpModule(builder);
             builder.RegisterModule(new HttpModule());
@@ -107,7 +110,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             builder.RegisterModule(new MqttModule(mqttSettingsConfiguration, topics, this.serverCertificate, storeAndForward.isEnabled, clientCertAuthEnabled, optimizeForPerformance));
         }
 
-        void RegisterRoutingModule(ContainerBuilder builder, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward)
+        void RegisterRoutingModule(
+            ContainerBuilder builder,
+            (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward,
+            ExperimentalFeatures experimentalFeatures)
         {
             var routes = this.configuration.GetSection("routes").Get<Dictionary<string, string>>();
             int connectionPoolSize = this.configuration.GetValue<int>("IotHubConnectionPoolSize");
@@ -133,8 +139,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             int maxUpstreamBatchSize = this.configuration.GetValue("MaxUpstreamBatchSize", 10);
             int upstreamFanOutFactor = this.configuration.GetValue("UpstreamFanOutFactor", 10);
             bool encryptTwinStore = this.configuration.GetValue("EncryptTwinStore", false);
-            bool disableCloudSubscriptions = this.configuration.GetValue("DisableCloudSubscriptions", false);
-            bool enableConnectivityCheck = this.configuration.GetValue("EnableConnectivityCheck", true);
             int configUpdateFrequencySecs = this.configuration.GetValue("ConfigRefreshFrequencySecs", 3600);
             TimeSpan configUpdateFrequency = TimeSpan.FromSeconds(configUpdateFrequencySecs);
 
@@ -162,9 +166,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     maxUpstreamBatchSize,
                     upstreamFanOutFactor,
                     encryptTwinStore,
-                    disableCloudSubscriptions,
                     configUpdateFrequency,
-                    enableConnectivityCheck));
+                    experimentalFeatures));
         }
 
         void RegisterCommonModule(ContainerBuilder builder, bool optimizeForPerformance, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath) storeAndForward)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     var loggerFactory = c.Resolve<ILoggerFactory>();
                     InternalLoggerFactory.DefaultFactory = loggerFactory;
 
-                    var eventListener = new LoggerEventListener(loggerFactory.CreateLogger("ProtocolGateway"));
+                    var eventListener = new LoggerEventListener(loggerFactory.CreateLogger("EdgeHub"));
                     eventListener.EnableEvents(CommonEventSource.Log, EventLevel.Informational);
                 });
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Service
+{
+    using Microsoft.Extensions.Configuration;
+
+    public class ExperimentalFeatures
+    {
+        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck)
+        {
+            this.Enabled = enabled;
+            this.DisableCloudSubscriptions = disableCloudSubscriptions;
+            this.DisableConnectivityCheck = disableConnectivityCheck;
+        }
+
+        public static ExperimentalFeatures Init(IConfiguration experimentalFeaturesConfig)
+        {
+            bool enabled = experimentalFeaturesConfig.GetValue("Enabled", false);
+            bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("DisableCloudSubscriptions", false);
+            bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("DisableConnectivityCheck", false);
+            return new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck);
+        }
+
+        public bool Enabled { get; }
+
+        public bool DisableCloudSubscriptions { get; }
+
+        public bool DisableConnectivityCheck { get; }
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class ExperimentalFeatures
     {
-        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck)
+        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
@@ -14,9 +14,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
         public static ExperimentalFeatures Init(IConfiguration experimentalFeaturesConfig)
         {
-            bool enabled = experimentalFeaturesConfig.GetValue("Enabled", false);
-            bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("DisableCloudSubscriptions", false);
-            bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("DisableConnectivityCheck", false);
+            bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
+            bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
+            bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("disableConnectivityCheck", false);
             return new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck);
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -49,9 +49,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly int maxUpstreamBatchSize;
         readonly int upstreamFanOutFactor;
         readonly bool encryptTwinStore;
-        readonly bool disableCloudSubscriptions;
         readonly TimeSpan configUpdateFrequency;
-        readonly bool enableConnectivityChecks;
+        readonly ExperimentalFeatures experimentalFeatures;
 
         public RoutingModule(
             string iotHubName,
@@ -76,9 +75,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             int maxUpstreamBatchSize,
             int upstreamFanOutFactor,
             bool encryptTwinStore,
-            bool disableCloudSubscriptions,
             TimeSpan configUpdateFrequency,
-            bool enableConnectivityChecks)
+            ExperimentalFeatures experimentalFeatures)
         {
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
             this.edgeDeviceId = Preconditions.CheckNonWhiteSpace(edgeDeviceId, nameof(edgeDeviceId));
@@ -102,9 +100,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.maxUpstreamBatchSize = maxUpstreamBatchSize;
             this.upstreamFanOutFactor = upstreamFanOutFactor;
             this.encryptTwinStore = encryptTwinStore;
-            this.disableCloudSubscriptions = disableCloudSubscriptions;
             this.configUpdateFrequency = configUpdateFrequency;
-            this.enableConnectivityChecks = enableConnectivityChecks;
+            this.experimentalFeatures = experimentalFeatures;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -179,9 +176,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     c =>
                     {
                         var edgeHubCredentials = c.ResolveNamed<IClientCredentials>("EdgeHubCredentials");
-                        IDeviceConnectivityManager deviceConnectivityManager = this.enableConnectivityChecks
-                            ? new DeviceConnectivityManager(this.connectivityCheckFrequency, TimeSpan.FromMinutes(2), edgeHubCredentials.Identity)
-                            : new NullDeviceConnectivityManager() as IDeviceConnectivityManager;
+                        IDeviceConnectivityManager deviceConnectivityManager = this.experimentalFeatures.Enabled && this.experimentalFeatures.DisableConnectivityCheck
+                            ? new NullDeviceConnectivityManager()
+                            : new DeviceConnectivityManager(this.connectivityCheckFrequency, TimeSpan.FromMinutes(2), edgeHubCredentials.Identity) as IDeviceConnectivityManager;
                         return deviceConnectivityManager;
                     })
                 .As<IDeviceConnectivityManager>()
@@ -462,7 +459,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     async c =>
                     {
                         var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();
-                        if (this.disableCloudSubscriptions)
+                        if (this.experimentalFeatures.Enabled && this.experimentalFeatures.DisableCloudSubscriptions)
                         {
                             return new LocalSubscriptionProcessor(await connectionManagerTask) as ISubscriptionProcessor;
                         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     c =>
                     {
                         var edgeHubCredentials = c.ResolveNamed<IClientCredentials>("EdgeHubCredentials");
-                        IDeviceConnectivityManager deviceConnectivityManager = this.experimentalFeatures.Enabled && this.experimentalFeatures.DisableConnectivityCheck
+                        IDeviceConnectivityManager deviceConnectivityManager = this.experimentalFeatures.DisableConnectivityCheck
                             ? new NullDeviceConnectivityManager()
                             : new DeviceConnectivityManager(this.connectivityCheckFrequency, TimeSpan.FromMinutes(2), edgeHubCredentials.Identity) as IDeviceConnectivityManager;
                         return deviceConnectivityManager;
@@ -459,7 +459,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     async c =>
                     {
                         var connectionManagerTask = c.Resolve<Task<IConnectionManager>>();
-                        if (this.experimentalFeatures.Enabled && this.experimentalFeatures.DisableCloudSubscriptions)
+                        if (this.experimentalFeatures.DisableCloudSubscriptions)
                         {
                             return new LocalSubscriptionProcessor(await connectionManagerTask) as ISubscriptionProcessor;
                         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             var mqttSettingsConfiguration = new Mock<IConfiguration>();
             mqttSettingsConfiguration.Setup(c => c.GetSection(It.IsAny<string>())).Returns(Mock.Of<IConfigurationSection>(s => s.Value == null));
 
+            var experimentalFeatures = new ExperimentalFeatures(true, false, false);
+
             builder.RegisterBuildCallback(
                 c =>
                 {
@@ -141,9 +143,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     10,
                     10,
                     false,
-                    false,
                     TimeSpan.FromHours(1),
-                    true));
+                    experimentalFeatures));
 
             builder.RegisterModule(new HttpModule());
             builder.RegisterModule(new MqttModule(mqttSettingsConfiguration.Object, topics, this.serverCertificate, false, false, false));


### PR DESCRIPTION
Adding experimentalFeature* flags to the new experimental features. To enable a feature, you need to also enable Experimental features. 

For example, to enable UploadLogs, you would set the following env vars - 
experimentalFeatures__enabled=true
experimentalFeatures__enableUploadLogs=true