### PR TITLE
Fix build for new Rust stable 1.36.0 release

### DIFF
--- a/edgelet/edgelet-http/src/pid.rs
+++ b/edgelet/edgelet-http/src/pid.rs
@@ -159,10 +159,10 @@ pub use self::impl_macos::get_pid;
 #[cfg(target_os = "macos")]
 pub mod impl_macos {
     use std::os::unix::io::AsRawFd;
-    use std::{io, mem};
+    use std::io;
 
     use libc::getpeereid;
-    use tokio_uds::{UCred, UnixStream};
+    use tokio_uds::UnixStream;
 
     use super::*;
 
@@ -170,13 +170,14 @@ pub mod impl_macos {
         unsafe {
             let raw_fd = sock.as_raw_fd();
 
-            let mut ucred: UCred = mem::uninitialized();
+            let mut uid = 0;
+            let mut gid = 0;
 
-            let ret = getpeereid(raw_fd, &mut ucred.uid, &mut ucred.gid);
+            let ret = getpeereid(raw_fd, &mut uid, &mut gid);
 
             if ret == 0 {
                 #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-                Ok(Pid::Value(ucred.uid as _))
+                Ok(Pid::Value(uid as _))
             } else {
                 Err(io::Error::last_os_error())
             }

--- a/edgelet/edgelet-http/src/pid.rs
+++ b/edgelet/edgelet-http/src/pid.rs
@@ -158,8 +158,8 @@ pub use self::impl_macos::get_pid;
 
 #[cfg(target_os = "macos")]
 pub mod impl_macos {
-    use std::os::unix::io::AsRawFd;
     use std::io;
+    use std::os::unix::io::AsRawFd;
 
     use libc::getpeereid;
     use tokio_uds::UnixStream;

--- a/edgelet/kube-client/src/kube.rs
+++ b/edgelet/kube-client/src/kube.rs
@@ -20,7 +20,13 @@ where
     K: NameValue,
 {
     fn get(&self, name: &str) -> Option<&K::Item> {
-        self.iter().find(|v| v.name() == name).map(K::value)
+        self.iter().find_map(|v| {
+            if v.name() == name {
+                Some(v.value())
+            } else {
+                None
+            }
+        })
     }
 }
 


### PR DESCRIPTION
- `std::mem::uninitialized` will get deprecated in 1.38, but it wasn't
  necessary in the first place.

- New clippy lint wants `Iterator::find().map()` to be replaced with
  `Iterator::find_map()`

Cherry-pick of b3805bb39364c8a71dee975e6ca504ef427b3624 from master.