### PR TITLE
Bump libiothsm-std package dependency to >= 1.0.8

### DIFF
--- a/edgelet/contrib/centos/iotedge.spec
+++ b/edgelet/contrib/centos/iotedge.spec
@@ -16,7 +16,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       libiothsm-std > 1.0.4
+Requires:       libiothsm-std >= 1.0.8
 Source0:        iotedge-%{version}.tar.gz
 
 %description

--- a/edgelet/contrib/debian/control
+++ b/edgelet/contrib/debian/control
@@ -10,7 +10,7 @@ Homepage: https://github.com/azure/iot-edge
 Package: iotedge
 Architecture: any
 Multi-Arch: foreign
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, libiothsm-std (>> 1.0.4), sed
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, libiothsm-std (>= 1.0.8), sed
 Description: Azure IoT Edge Security Daemon
  Azure IoT Edge is a fully managed service that delivers cloud intelligence
  locally by deploying and running artificial intelligence (AI), Azure services,


### PR DESCRIPTION
As discussed offline, I'll make a proper fix for 1.0.9 that takes the right version automatically in #1473

Packages build: https://msazure.visualstudio.com/One/_build/results?buildId=23769980