### PR TITLE
Add HSM version checks for all interfaces

### DIFF
--- a/edgelet/edgelet-core/src/crypto.rs
+++ b/edgelet/edgelet-core/src/crypto.rs
@@ -34,6 +34,10 @@ impl fmt::Display for KeyIdentity {
     }
 }
 
+pub trait GetHsmVersion {
+    fn get_version(&self) -> Result<String, Error>;
+}
+
 pub trait Activate {
     type Key: Sign;
 

--- a/edgelet/edgelet-core/src/error.rs
+++ b/edgelet/edgelet-core/src/error.rs
@@ -54,6 +54,9 @@ pub enum ErrorKind {
     #[fail(display = "An identity manager error occurred.")]
     IdentityManager,
 
+    #[fail(display = "An error occurred when obtaining the Hsm version")]
+    HsmVersion,
+
     #[fail(display = "Invalid image pull policy configuration {:?}", _0)]
     InvalidImagePullPolicy(String),
 

--- a/edgelet/edgelet-core/src/error.rs
+++ b/edgelet/edgelet-core/src/error.rs
@@ -54,7 +54,7 @@ pub enum ErrorKind {
     #[fail(display = "An identity manager error occurred.")]
     IdentityManager,
 
-    #[fail(display = "An error occurred when obtaining the Hsm version")]
+    #[fail(display = "An error occurred when obtaining the HSM version")]
     HsmVersion,
 
     #[fail(display = "Invalid image pull policy configuration {:?}", _0)]

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -28,7 +28,7 @@ pub use certificate_properties::{CertificateIssuer, CertificateProperties, Certi
 pub use crypto::{
     Certificate, CreateCertificate, Decrypt, Encrypt, GetDeviceIdentityCertificate, GetIssuerAlias,
     GetTrustBundle, KeyBytes, KeyIdentity, KeyStore, MakeRandom, MasterEncryptionKey, PrivateKey,
-    Signature, IOTEDGED_CA_ALIAS,
+    Signature, IOTEDGED_CA_ALIAS, GetHsmVersion
 };
 pub use error::{Error, ErrorKind};
 pub use identity::{AuthType, Identity, IdentityManager, IdentityOperation, IdentitySpec};

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -26,9 +26,9 @@ pub use authentication::Authenticator;
 pub use authorization::{AuthId, ModuleId, Policy};
 pub use certificate_properties::{CertificateIssuer, CertificateProperties, CertificateType};
 pub use crypto::{
-    Certificate, CreateCertificate, Decrypt, Encrypt, GetDeviceIdentityCertificate, GetIssuerAlias,
-    GetTrustBundle, KeyBytes, KeyIdentity, KeyStore, MakeRandom, MasterEncryptionKey, PrivateKey,
-    Signature, IOTEDGED_CA_ALIAS, GetHsmVersion
+    Certificate, CreateCertificate, Decrypt, Encrypt, GetDeviceIdentityCertificate, GetHsmVersion,
+    GetIssuerAlias, GetTrustBundle, KeyBytes, KeyIdentity, KeyStore, MakeRandom,
+    MasterEncryptionKey, PrivateKey, Signature, IOTEDGED_CA_ALIAS,
 };
 pub use error::{Error, ErrorKind};
 pub use identity::{AuthType, Identity, IdentityManager, IdentityOperation, IdentitySpec};

--- a/edgelet/edgelet-hsm/src/crypto.rs
+++ b/edgelet/edgelet-hsm/src/crypto.rs
@@ -11,7 +11,7 @@ use edgelet_core::{
     Decrypt as CoreDecrypt, Encrypt as CoreEncrypt, Error as CoreError, ErrorKind as CoreErrorKind,
     GetIssuerAlias as CoreGetIssuerAlias, GetTrustBundle as CoreGetTrustBundle,
     KeyBytes as CoreKeyBytes, MakeRandom as CoreMakeRandom,
-    MasterEncryptionKey as CoreMasterEncryptionKey, PrivateKey as CorePrivateKey,
+    MasterEncryptionKey as CoreMasterEncryptionKey, PrivateKey as CorePrivateKey, GetHsmVersion as CoreGetHsmVersion,
 };
 pub use hsm::{
     Buffer, Decrypt, Encrypt, GetCertificate as HsmGetCertificate, GetTrustBundle, HsmCertificate,
@@ -54,6 +54,15 @@ impl Crypto {
             crypto: Arc::new(crypto),
             hsm_lock,
         })
+    }
+}
+
+impl CoreGetHsmVersion for Crypto {
+    fn get_version(&self) -> Result<String, CoreError> {
+        let _hsm_lock = self.hsm_lock.0.lock().expect("Acquiring HSM lock failed");
+        self.crypto.get_version()
+            .map_err(|err| Error::from(err.context(ErrorKind::Hsm)))
+            .map_err(|err| CoreError::from(err.context(CoreErrorKind::HsmVersion)))
     }
 }
 

--- a/edgelet/edgelet-hsm/src/crypto.rs
+++ b/edgelet/edgelet-hsm/src/crypto.rs
@@ -9,9 +9,9 @@ use edgelet_core::{
     Certificate as CoreCertificate, CertificateIssuer as CoreCertificateIssuer,
     CertificateProperties as CoreCertificateProperties, CreateCertificate as CoreCreateCertificate,
     Decrypt as CoreDecrypt, Encrypt as CoreEncrypt, Error as CoreError, ErrorKind as CoreErrorKind,
-    GetIssuerAlias as CoreGetIssuerAlias, GetTrustBundle as CoreGetTrustBundle,
-    KeyBytes as CoreKeyBytes, MakeRandom as CoreMakeRandom,
-    MasterEncryptionKey as CoreMasterEncryptionKey, PrivateKey as CorePrivateKey, GetHsmVersion as CoreGetHsmVersion,
+    GetHsmVersion as CoreGetHsmVersion, GetIssuerAlias as CoreGetIssuerAlias,
+    GetTrustBundle as CoreGetTrustBundle, KeyBytes as CoreKeyBytes, MakeRandom as CoreMakeRandom,
+    MasterEncryptionKey as CoreMasterEncryptionKey, PrivateKey as CorePrivateKey,
 };
 pub use hsm::{
     Buffer, Decrypt, Encrypt, GetCertificate as HsmGetCertificate, GetTrustBundle, HsmCertificate,
@@ -60,7 +60,8 @@ impl Crypto {
 impl CoreGetHsmVersion for Crypto {
     fn get_version(&self) -> Result<String, CoreError> {
         let _hsm_lock = self.hsm_lock.0.lock().expect("Acquiring HSM lock failed");
-        self.crypto.get_version()
+        self.crypto
+            .get_version()
             .map_err(|err| Error::from(err.context(ErrorKind::Hsm)))
             .map_err(|err| CoreError::from(err.context(CoreErrorKind::HsmVersion)))
     }

--- a/edgelet/edgelet-hsm/src/tpm.rs
+++ b/edgelet/edgelet-hsm/src/tpm.rs
@@ -6,7 +6,8 @@ use bytes::Bytes;
 use failure::Fail;
 
 use edgelet_core::crypto::{
-    Activate, KeyIdentity, KeyStore as CoreKeyStore, Sign, SignatureAlgorithm, GetHsmVersion as CoreGetHsmVersion,
+    Activate, GetHsmVersion as CoreGetHsmVersion, KeyIdentity, KeyStore as CoreKeyStore, Sign,
+    SignatureAlgorithm,
 };
 use edgelet_core::{Error as CoreError, ErrorKind as CoreErrorKind};
 use hsm::{ManageTpmKeys, SignWithTpm, Tpm, TpmDigest};
@@ -83,7 +84,8 @@ impl TpmKeyStore {
 impl CoreGetHsmVersion for TpmKeyStore {
     fn get_version(&self) -> Result<String, CoreError> {
         let _hsm_lock = self.hsm_lock.0.lock().expect("Acquiring HSM lock failed");
-        self.tpm.get_version()
+        self.tpm
+            .get_version()
             .map_err(|err| Error::from(err.context(ErrorKind::Hsm)))
             .map_err(|err| CoreError::from(err.context(CoreErrorKind::HsmVersion)))
     }

--- a/edgelet/edgelet-hsm/src/tpm.rs
+++ b/edgelet/edgelet-hsm/src/tpm.rs
@@ -6,7 +6,7 @@ use bytes::Bytes;
 use failure::Fail;
 
 use edgelet_core::crypto::{
-    Activate, KeyIdentity, KeyStore as CoreKeyStore, Sign, SignatureAlgorithm,
+    Activate, KeyIdentity, KeyStore as CoreKeyStore, Sign, SignatureAlgorithm, GetHsmVersion as CoreGetHsmVersion,
 };
 use edgelet_core::{Error as CoreError, ErrorKind as CoreErrorKind};
 use hsm::{ManageTpmKeys, SignWithTpm, Tpm, TpmDigest};
@@ -77,6 +77,15 @@ impl TpmKeyStore {
             key_name: ROOT_KEY_NAME.to_string(),
             hsm_lock: self.hsm_lock.clone(),
         })
+    }
+}
+
+impl CoreGetHsmVersion for TpmKeyStore {
+    fn get_version(&self) -> Result<String, CoreError> {
+        let _hsm_lock = self.hsm_lock.0.lock().expect("Acquiring HSM lock failed");
+        self.tpm.get_version()
+            .map_err(|err| Error::from(err.context(ErrorKind::Hsm)))
+            .map_err(|err| CoreError::from(err.context(CoreErrorKind::HsmVersion)))
     }
 }
 

--- a/edgelet/edgelet-hsm/src/x509.rs
+++ b/edgelet/edgelet-hsm/src/x509.rs
@@ -13,7 +13,8 @@ use crate::HsmLock;
 
 use edgelet_core::{
     Error as CoreError, ErrorKind as CoreErrorKind,
-    GetDeviceIdentityCertificate as CoreGetDeviceIdentityCertificate, GetHsmVersion as CoreGetHsmVersion
+    GetDeviceIdentityCertificate as CoreGetDeviceIdentityCertificate,
+    GetHsmVersion as CoreGetHsmVersion,
 };
 
 /// The X.509 device identity HSM instance
@@ -48,7 +49,8 @@ impl X509 {
 impl CoreGetHsmVersion for X509 {
     fn get_version(&self) -> Result<String, CoreError> {
         let _hsm_lock = self.hsm_lock.0.lock().expect("Acquiring HSM lock failed");
-        self.x509.get_version()
+        self.x509
+            .get_version()
             .map_err(|err| Error::from(err.context(ErrorKind::Hsm)))
             .map_err(|err| CoreError::from(err.context(CoreErrorKind::HsmVersion)))
     }

--- a/edgelet/edgelet-hsm/src/x509.rs
+++ b/edgelet/edgelet-hsm/src/x509.rs
@@ -13,7 +13,7 @@ use crate::HsmLock;
 
 use edgelet_core::{
     Error as CoreError, ErrorKind as CoreErrorKind,
-    GetDeviceIdentityCertificate as CoreGetDeviceIdentityCertificate,
+    GetDeviceIdentityCertificate as CoreGetDeviceIdentityCertificate, GetHsmVersion as CoreGetHsmVersion
 };
 
 /// The X.509 device identity HSM instance
@@ -42,6 +42,15 @@ impl X509 {
             x509: Arc::new(x509),
             hsm_lock,
         })
+    }
+}
+
+impl CoreGetHsmVersion for X509 {
+    fn get_version(&self) -> Result<String, CoreError> {
+        let _hsm_lock = self.hsm_lock.0.lock().expect("Acquiring HSM lock failed");
+        self.x509.get_version()
+            .map_err(|err| Error::from(err.context(ErrorKind::Hsm)))
+            .map_err(|err| CoreError::from(err.context(CoreErrorKind::HsmVersion)))
     }
 }
 

--- a/edgelet/hsm-rs/src/crypto.rs
+++ b/edgelet/hsm-rs/src/crypto.rs
@@ -83,6 +83,15 @@ impl Crypto {
                 .into_owned()
         }
     }
+
+    pub fn get_version(&self) -> Result<String, Error> {
+        let version = unsafe {
+            CStr::from_ptr(hsm_get_version())
+                .to_string_lossy()
+                .into_owned()
+        };
+        Ok(version)
+    }
 }
 
 impl MakeRandom for Crypto {

--- a/edgelet/hsm-rs/src/tpm.rs
+++ b/edgelet/hsm-rs/src/tpm.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use std::ffi::CStr;
 use std::convert::AsRef;
+use std::ffi::CStr;
 use std::ops::{Deref, Drop};
 use std::os::raw::{c_uchar, c_void};
 use std::ptr;

--- a/edgelet/hsm-rs/src/tpm.rs
+++ b/edgelet/hsm-rs/src/tpm.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::ffi::CStr;
 use std::convert::AsRef;
 use std::ops::{Deref, Drop};
 use std::os::raw::{c_uchar, c_void};
@@ -59,6 +60,15 @@ impl Tpm {
             unsafe { hsm_client_tpm_deinit() };
             Err(ErrorKind::NullResponse)?
         }
+    }
+
+    pub fn get_version(&self) -> Result<String, Error> {
+        let version = unsafe {
+            CStr::from_ptr(hsm_get_version())
+                .to_string_lossy()
+                .into_owned()
+        };
+        Ok(version)
     }
 }
 

--- a/edgelet/hsm-rs/src/x509.rs
+++ b/edgelet/hsm-rs/src/x509.rs
@@ -56,6 +56,15 @@ impl X509 {
             Err(ErrorKind::NullResponse)?
         }
     }
+
+    pub fn get_version(&self) -> Result<String, Error> {
+        let version = unsafe {
+            CStr::from_ptr(hsm_get_version())
+                .to_string_lossy()
+                .into_owned()
+        };
+        Ok(version)
+    }
 }
 
 impl GetDeviceIdentityCertificate for X509 {

--- a/edgelet/iotedged/src/error.rs
+++ b/edgelet/iotedged/src/error.rs
@@ -168,6 +168,7 @@ pub enum InitializeErrorReason {
     HybridAuthKeyCreate,
     HybridAuthKeyLoad,
     HybridAuthKeyInvalid,
+    IncompatibleHsmVersion,
     InvalidDeviceCertCredentials,
     InvalidDeviceConfig,
     InvalidHubConfig,
@@ -258,6 +259,10 @@ impl fmt::Display for InitializeErrorReason {
 
             InitializeErrorReason::HybridAuthKeyInvalid => {
                 write!(f, "The loaded hybrid identity key was invalid")
+            }
+
+            InitializeErrorReason::IncompatibleHsmVersion => {
+                write!(f, "Incompatible HSM lib version")
             }
 
             InitializeErrorReason::InvalidDeviceCertCredentials => {

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -45,7 +45,7 @@ use dps::DPS_API_VERSION;
 use edgelet_core::crypto::{
     Activate, CreateCertificate, Decrypt, DerivedKeyStore, Encrypt, GetDeviceIdentityCertificate,
     GetIssuerAlias, GetTrustBundle, KeyIdentity, KeyStore, MakeRandom, MasterEncryptionKey,
-    MemoryKey, MemoryKeyStore, Sign, Signature, SignatureAlgorithm, IOTEDGED_CA_ALIAS,
+    MemoryKey, MemoryKeyStore, Sign, Signature, SignatureAlgorithm, IOTEDGED_CA_ALIAS, GetHsmVersion,
 };
 use edgelet_core::watchdog::Watchdog;
 use edgelet_core::{
@@ -191,6 +191,9 @@ const IOTEDGE_ID_CERT_MAX_DURATION_SECS: i64 = 7200;
 // 2 hours
 const IOTEDGE_SERVER_CERT_MAX_DURATION_SECS: i64 = 7_776_000; // 90 days
 
+// HSM lib version that the iotedge runtime required
+const IOTEDGE_COMPAT_HSM_VERSION: &str = "1.0.2";
+
 #[derive(PartialEq)]
 enum StartApiReturnStatus {
     Restart,
@@ -264,6 +267,17 @@ where
         info!("Initializing hsm...");
         let crypto = Crypto::new(hsm_lock.clone())
             .context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
+
+        let hsm_version = crypto.get_version()
+            .context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
+
+        if hsm_version != IOTEDGE_COMPAT_HSM_VERSION {
+            info!("Incompatible HSM crypto interface version. Found {}, required {}", hsm_version, IOTEDGE_COMPAT_HSM_VERSION);
+            return Err(Error::from(ErrorKind::Initialize(
+                InitializeErrorReason::IncompatibleHsmVersion,
+            )));
+        }
+
         // ensure a master encryption key is initialized
         crypto.create_key().context(ErrorKind::Initialize(
             InitializeErrorReason::CreateMasterEncryptionKey,
@@ -586,6 +600,16 @@ where
         info!("Initializing hsm X509 interface...");
         let x509 =
             X509::new(hsm_lock).context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
+
+        let hsm_version = x509.get_version()
+            .context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
+
+        if hsm_version != IOTEDGE_COMPAT_HSM_VERSION {
+            info!("Incompatible HSM X.509 identity interface version. Found {}, required {}", hsm_version, IOTEDGE_COMPAT_HSM_VERSION);
+            return Err(Error::from(ErrorKind::Initialize(
+                InitializeErrorReason::IncompatibleHsmVersion,
+            )));
+        }
 
         let device_identity_cert = x509
             .get()
@@ -1412,6 +1436,17 @@ where
     let tpm = Tpm::new().context(ErrorKind::Initialize(
         InitializeErrorReason::DpsProvisioningClient,
     ))?;
+
+    let hsm_version = tpm.get_version()
+        .context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
+
+    if hsm_version != IOTEDGE_COMPAT_HSM_VERSION {
+        info!("Incompatible HSM interface version for TPM. Found {}, required {}", hsm_version, IOTEDGE_COMPAT_HSM_VERSION);
+        return Err(Error::from(ErrorKind::Initialize(
+            InitializeErrorReason::IncompatibleHsmVersion,
+        )));
+    }
+
     let ek_result = tpm.get_ek().context(ErrorKind::Initialize(
         InitializeErrorReason::DpsProvisioningClient,
     ))?;

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -44,8 +44,9 @@ use url::Url;
 use dps::DPS_API_VERSION;
 use edgelet_core::crypto::{
     Activate, CreateCertificate, Decrypt, DerivedKeyStore, Encrypt, GetDeviceIdentityCertificate,
-    GetIssuerAlias, GetTrustBundle, KeyIdentity, KeyStore, MakeRandom, MasterEncryptionKey,
-    MemoryKey, MemoryKeyStore, Sign, Signature, SignatureAlgorithm, IOTEDGED_CA_ALIAS, GetHsmVersion,
+    GetHsmVersion, GetIssuerAlias, GetTrustBundle, KeyIdentity, KeyStore, MakeRandom,
+    MasterEncryptionKey, MemoryKey, MemoryKeyStore, Sign, Signature, SignatureAlgorithm,
+    IOTEDGED_CA_ALIAS,
 };
 use edgelet_core::watchdog::Watchdog;
 use edgelet_core::{
@@ -268,11 +269,15 @@ where
         let crypto = Crypto::new(hsm_lock.clone())
             .context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
 
-        let hsm_version = crypto.get_version()
+        let hsm_version = crypto
+            .get_version()
             .context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
 
         if hsm_version != IOTEDGE_COMPAT_HSM_VERSION {
-            info!("Incompatible HSM crypto interface version. Found {}, required {}", hsm_version, IOTEDGE_COMPAT_HSM_VERSION);
+            info!(
+                "Incompatible HSM crypto interface version. Found {}, required {}",
+                hsm_version, IOTEDGE_COMPAT_HSM_VERSION
+            );
             return Err(Error::from(ErrorKind::Initialize(
                 InitializeErrorReason::IncompatibleHsmVersion,
             )));
@@ -601,11 +606,15 @@ where
         let x509 =
             X509::new(hsm_lock).context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
 
-        let hsm_version = x509.get_version()
+        let hsm_version = x509
+            .get_version()
             .context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
 
         if hsm_version != IOTEDGE_COMPAT_HSM_VERSION {
-            info!("Incompatible HSM X.509 identity interface version. Found {}, required {}", hsm_version, IOTEDGE_COMPAT_HSM_VERSION);
+            info!(
+                "Incompatible HSM X.509 identity interface version. Found {}, required {}",
+                hsm_version, IOTEDGE_COMPAT_HSM_VERSION
+            );
             return Err(Error::from(ErrorKind::Initialize(
                 InitializeErrorReason::IncompatibleHsmVersion,
             )));
@@ -1437,11 +1446,15 @@ where
         InitializeErrorReason::DpsProvisioningClient,
     ))?;
 
-    let hsm_version = tpm.get_version()
+    let hsm_version = tpm
+        .get_version()
         .context(ErrorKind::Initialize(InitializeErrorReason::Hsm))?;
 
     if hsm_version != IOTEDGE_COMPAT_HSM_VERSION {
-        info!("Incompatible HSM interface version for TPM. Found {}, required {}", hsm_version, IOTEDGE_COMPAT_HSM_VERSION);
+        info!(
+            "Incompatible HSM interface version for TPM. Found {}, required {}",
+            hsm_version, IOTEDGE_COMPAT_HSM_VERSION
+        );
         return Err(Error::from(ErrorKind::Initialize(
             InitializeErrorReason::IncompatibleHsmVersion,
         )));


### PR DESCRIPTION
Explicitly fail if an incompatible HSM lib version was found on the target Edge device.