### PR TITLE
Update packages used by E2E, longhaul and stress jobs

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -102,7 +102,7 @@ jobs:
         - agent-osbits -equals 32
         - run-long-haul -equals true
     variables:
-      edgelet.artifact.name: 'iotedged-ubuntu16.04-arm32v7'
+      edgelet.artifact.name: 'iotedged-debian9-arm32v7'
     steps:
       - checkout: none
       - task: AzureKeyVault@1
@@ -166,7 +166,7 @@ jobs:
         - agent-osbits -equals 64
         - run-long-haul -equals true
     variables:
-      edgelet.artifact.name: 'iotedged-ubuntu16.04-aarch64'
+      edgelet.artifact.name: 'iotedged-ubuntu18.04-aarch64'
     steps:
       - checkout: none
       - task: AzureKeyVault@1

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -102,7 +102,7 @@ jobs:
         - run-stress -equals true
         - agent-osbits -equals 32
     variables:
-      edgelet.artifact.name: 'iotedged-ubuntu16.04-arm32v7'
+      edgelet.artifact.name: 'iotedged-debian9-arm32v7'
     steps:
       - checkout: none
       - task: AzureKeyVault@1
@@ -166,7 +166,7 @@ jobs:
         - run-stress -equals true
         - agent-osbits -equals 64
     variables:
-      edgelet.artifact.name: 'iotedged-ubuntu16.04-aarch64'
+      edgelet.artifact.name: 'iotedged-ubuntu18.04-aarch64'
     steps:
       - checkout: none
       - task: AzureKeyVault@1

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -71,9 +71,9 @@ function get_iotedged_artifact_folder() {
     if [ "$image_architecture_label" = 'amd64' ]; then
         path="$E2E_TEST_DIR/artifacts/iotedged-ubuntu16.04-amd64"
     elif [ "$image_architecture_label" = 'arm64v8' ]; then
-        path="$E2E_TEST_DIR/artifacts/iotedged-ubuntu16.04-aarch64"
+        path="$E2E_TEST_DIR/artifacts/iotedged-ubuntu18.04-aarch64"
     else
-        path="$E2E_TEST_DIR/artifacts/iotedged-ubuntu16.04-arm32v7"
+        path="$E2E_TEST_DIR/artifacts/iotedged-debian9-arm32v7"
     fi
 
     echo "$path"


### PR DESCRIPTION
ARM32 tests run on Raspbian 9, so they need to use the debian9 packages.
The ubuntu16.04 packages depend on libssl1.0.0 which does not exist in
Raspbian 9.

ARM64 tests run on Ubuntu 18.04, so they should use the ubuntu18.04 packages.
The ubuntu16.04 packages happen to work since ubuntu18.04 does have libssl1.0.0
but there is no reason to use the older distro's packages.