### PR TITLE
Fix bug in Docker codegen'd client that prevents modules from using more than 2GiB SHM

### DIFF
--- a/edgelet/docker-rs/src/models/host_config.rs
+++ b/edgelet/docker-rs/src/models/host_config.rs
@@ -205,7 +205,7 @@ pub struct HostConfig {
     userns_mode: Option<String>,
     /// Size of `/dev/shm` in bytes. If omitted, the system uses 64MB.
     #[serde(rename = "ShmSize", skip_serializing_if = "Option::is_none")]
-    shm_size: Option<i32>,
+    shm_size: Option<i64>,
     /// A list of kernel parameters (sysctls) to set in the container. For example: `{\"net.ipv4.ip_forward\": \"1\"}`
     #[serde(rename = "Sysctls", skip_serializing_if = "Option::is_none")]
     sysctls: Option<::std::collections::HashMap<String, String>>,
@@ -1360,16 +1360,16 @@ impl HostConfig {
         self.userns_mode = None;
     }
 
-    pub fn set_shm_size(&mut self, shm_size: i32) {
+    pub fn set_shm_size(&mut self, shm_size: i64) {
         self.shm_size = Some(shm_size);
     }
 
-    pub fn with_shm_size(mut self, shm_size: i32) -> Self {
+    pub fn with_shm_size(mut self, shm_size: i64) -> Self {
         self.shm_size = Some(shm_size);
         self
     }
 
-    pub fn shm_size(&self) -> Option<i32> {
+    pub fn shm_size(&self) -> Option<i64> {
         self.shm_size
     }
 


### PR DESCRIPTION
The `HostConfig.ShmSize` field in the Moby source has type `int64`, but
the Swagger spec incorrectly annotates it as `type: integer` without
a `format: int64` tag. So the Rust swagger generator emitted it as
an `i32` field.

https://github.com/docker/docker-ce/blob/19.03/components/engine/api/types/container/host_config.go#L402

https://github.com/docker/docker-ce/blob/19.03/components/engine/api/swagger.yaml#L805-L808

Upstream issue: moby/moby#39131

Fixes #1513