### PR TITLE
[k8s] Replace config map replace to list + create or update

### DIFF
--- a/edgelet/edgelet-kube/src/module/create.rs
+++ b/edgelet/edgelet-kube/src/module/create.rs
@@ -57,18 +57,57 @@ where
     spec_to_service_account(runtime.settings(), module)
         .map_err(Error::from)
         .map(|(name, new_service_account)| {
+            let client_copy = runtime.client().clone();
+            let namespace_copy = runtime.settings().namespace().to_owned();
+
             runtime
                 .client()
                 .lock()
                 .expect("Unexpected lock error")
                 .borrow_mut()
-                .replace_service_account(
+                .list_service_accounts(
                     runtime.settings().namespace(),
-                    &name,
-                    &new_service_account,
+                    Some(&name),
+                    Some(&runtime.settings().device_hub_selector()),
                 )
                 .map_err(Error::from)
-                .map(|_| ())
+                .and_then(move |service_accounts| {
+                    if let Some(current) =
+                        service_accounts.items.into_iter().find(|service_account| {
+                            service_account.metadata.as_ref().map_or(false, |meta| {
+                                meta.name.as_ref().map_or(false, |n| *n == name)
+                            })
+                        })
+                    {
+                        if current == new_service_account {
+                            Either::A(Either::A(future::ok(())))
+                        } else {
+                            let fut = client_copy
+                                .lock()
+                                .expect("Unexpected lock error")
+                                .borrow_mut()
+                                .replace_service_account(
+                                    namespace_copy.as_str(),
+                                    &name,
+                                    &new_service_account,
+                                )
+                                .map_err(Error::from)
+                                .map(|_| ());
+
+                            Either::A(Either::B(fut))
+                        }
+                    } else {
+                        let fut = client_copy
+                            .lock()
+                            .expect("Unexpected lock error")
+                            .borrow_mut()
+                            .create_service_account(namespace_copy.as_str(), &new_service_account)
+                            .map_err(Error::from)
+                            .map(|_| ());
+
+                        Either::B(fut)
+                    }
+                })
         })
         .into_future()
         .flatten()
@@ -141,4 +180,370 @@ where
         })
         .into_future()
         .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use futures::future;
+    use hyper::service::{service_fn, Service};
+    use hyper::{Body, Method, Request, Response, StatusCode};
+    use maplit::btreemap;
+    use native_tls::TlsConnector;
+    use serde_json::json;
+    use tokio::runtime::Runtime;
+    use typed_headers::{mime, ContentLength, ContentType, HeaderMapExt};
+    use url::Url;
+
+    use docker::models::{AuthConfig, ContainerCreateBody, HostConfig, Mount};
+    use edgelet_core::{ImagePullPolicy, ModuleSpec};
+    use edgelet_docker::DockerConfig;
+    use edgelet_test_utils::routes;
+    use edgelet_test_utils::web::{
+        make_req_dispatcher, HttpMethod, RequestHandler, RequestPath, ResponseFuture,
+    };
+    use kube_client::{Client as KubeClient, Config as KubeConfig, TokenSource};
+
+    use crate::module::create::{
+        create_or_update_deployment, create_or_update_role_binding,
+        create_or_update_service_account,
+    };
+    use crate::module::create_module;
+    use crate::tests::make_settings;
+    use crate::{Error, KubeModuleRuntime, Settings};
+
+    #[test]
+    fn it_replaces_deployment() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            PUT format!("/apis/apps/v1/namespaces/{}/deployments/edgeagent", settings.namespace()) => replace_deployment_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+        let module = create_module_spec("edgeagent");
+
+        let task = create_or_update_deployment(&runtime, &module);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn it_creates_or_updates_role_binding_for_edgeagent() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            PUT format!("/apis/rbac.authorization.k8s.io/v1/namespaces/{}/rolebindings/edgeagent", settings.namespace()) => replace_role_binding_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+        let module = create_module_spec("edgeagent");
+
+        let task = create_or_update_role_binding(&runtime, &module);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn it_does_not_create_or_update_role_binding_for_another_module() {
+        let settings = make_settings(None);
+
+        let dispatch_table = btreemap!();
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+        let module = create_module_spec("temp-sensor");
+
+        let task = create_or_update_role_binding(&runtime, &module);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn it_creates_new_service_account_if_does_not_exist() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/serviceaccounts", settings.namespace()) => empty_service_account_list_handler(),
+            POST format!("/api/v1/namespaces/{}/serviceaccounts", settings.namespace()) => create_service_account_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+        let module = create_module_spec("edgeagent");
+
+        let task = create_or_update_service_account(&runtime, &module);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn it_updates_existing_service_account_if_exists() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/serviceaccounts", settings.namespace()) => service_account_list_handler(),
+            PUT format!("/api/v1/namespaces/{}/serviceaccounts/edgeagent", settings.namespace()) => replace_service_account_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+        let module = create_module_spec("edgeagent");
+
+        let task = create_or_update_service_account(&runtime, &module);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn it_creates_all_required_resources() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/serviceaccounts", settings.namespace()) => empty_service_account_list_handler(),
+            POST format!("/api/v1/namespaces/{}/serviceaccounts", settings.namespace()) => create_service_account_handler(),
+            PUT format!("/apis/rbac.authorization.k8s.io/v1/namespaces/{}/rolebindings/edgeagent", settings.namespace()) => replace_role_binding_handler(),
+            PUT format!("/apis/apps/v1/namespaces/{}/deployments/edgeagent", settings.namespace()) => replace_deployment_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+        let module = create_module_spec("edgeagent");
+
+        let task = create_module(&runtime, &module);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    fn create_service_account_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::CREATED, || {
+                json!({
+                    "kind": "ServiceAccount",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": "edgeagent",
+                        "namespace": "my-namespace",
+                    }
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn empty_service_account_list_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "ServiceAccountList",
+                    "apiVersion": "v1",
+                    "items": []
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn service_account_list_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "ServiceAccountList",
+                    "apiVersion": "v1",
+                    "items": [
+                        {
+                            "metadata": {
+                                "name": "edgeagent",
+                                "namespace": "my-namespace",
+                            }
+                        }
+                    ]
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn replace_service_account_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "ServiceAccount",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": "edgeagent",
+                        "namespace": "my-namespace",
+                    }
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn replace_role_binding_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "RoleBinding",
+                    "apiVersion": "rbac.authorization.k8s.io/v1",
+                    "metadata": {
+                        "name": "edgeagent",
+                        "namespace": "my-namespace",
+                    },
+                    "subjects": [
+                        {
+                            "kind": "ServiceAccount",
+                            "name": "edgeagent",
+                            "namespace": "my-namespace"
+                        }
+                    ],
+                    "roleRef": {
+                        "apiGroup": "rbac.authorization.k8s.io",
+                        "kind": "ClusterRole",
+                        "name": "cluster-admin"
+                    }
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn replace_deployment_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "Deployment",
+                    "apiVersion": "apps/v1",
+                    "metadata": {
+                        "name": "edgeagent",
+                        "namespace": "my-namespace",
+                    },
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn response(
+        status_code: StatusCode,
+        response: impl Fn() -> String + Clone + Send + 'static,
+    ) -> ResponseFuture {
+        let response = response();
+        let response_len = response.len();
+
+        let mut response = Response::new(response.into());
+        *response.status_mut() = status_code;
+        response
+            .headers_mut()
+            .typed_insert(&ContentLength(response_len as u64));
+        response
+            .headers_mut()
+            .typed_insert(&ContentType(mime::APPLICATION_JSON));
+
+        Box::new(future::ok(response)) as ResponseFuture
+    }
+
+    fn not_found_handler(_: Request<Body>) -> ResponseFuture {
+        let response = Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::default())
+            .unwrap();
+
+        Box::new(future::ok(response))
+    }
+
+    fn create_module_spec(name: &str) -> ModuleSpec<DockerConfig> {
+        let create_body = ContainerCreateBody::new()
+            .with_host_config(
+                HostConfig::new()
+                    .with_binds(vec![String::from("/a:/b:ro"), String::from("/c:/d")])
+                    .with_privileged(true)
+                    .with_mounts(vec![
+                        Mount::new()
+                            .with__type(String::from("bind"))
+                            .with_read_only(true)
+                            .with_source(String::from("/e"))
+                            .with_target(String::from("/f")),
+                        Mount::new()
+                            .with__type(String::from("bind"))
+                            .with_source(String::from("/g"))
+                            .with_target(String::from("/h")),
+                        Mount::new()
+                            .with__type(String::from("volume"))
+                            .with_read_only(true)
+                            .with_source(String::from("i"))
+                            .with_target(String::from("/j")),
+                        Mount::new()
+                            .with__type(String::from("volume"))
+                            .with_source(String::from("k"))
+                            .with_target(String::from("/l")),
+                    ]),
+            )
+            .with_labels({
+                let mut labels = HashMap::<String, String>::new();
+                labels.insert(String::from("label1"), String::from("value1"));
+                labels.insert(String::from("label2"), String::from("value2"));
+                labels
+            });
+        let auth_config = AuthConfig::new()
+            .with_password(String::from("a password"))
+            .with_username(String::from("USERNAME"))
+            .with_serveraddress(String::from("REGISTRY"));
+        ModuleSpec::new(
+            name.to_string(),
+            "docker".to_string(),
+            DockerConfig::new("my-image:v1.0".to_string(), create_body, Some(auth_config)).unwrap(),
+            {
+                let mut env = HashMap::new();
+                env.insert(String::from("a"), String::from("b"));
+                env.insert(String::from("C"), String::from("D"));
+                env
+            },
+            ImagePullPolicy::default(),
+        )
+        .unwrap()
+    }
+
+    fn create_runtime<S: Service>(
+        settings: Settings,
+        service: S,
+    ) -> KubeModuleRuntime<TestTokenSource, S> {
+        let client = KubeClient::with_client(get_config(), service);
+        KubeModuleRuntime::new(client, settings)
+    }
+
+    fn get_config() -> KubeConfig<TestTokenSource> {
+        KubeConfig::new(
+            Url::parse("https://localhost:443").unwrap(),
+            "/api".to_string(),
+            TestTokenSource,
+            TlsConnector::new().unwrap(),
+        )
+    }
+
+    #[derive(Clone)]
+    struct TestTokenSource;
+
+    impl TokenSource for TestTokenSource {
+        type Error = Error;
+
+        fn get(&self) -> kube_client::error::Result<Option<String>> {
+            Ok(None)
+        }
+    }
 }

--- a/edgelet/edgelet-kube/src/module/mod.rs
+++ b/edgelet/edgelet-kube/src/module/mod.rs
@@ -2,9 +2,11 @@
 
 mod authentication;
 mod create;
+mod trust_bundle;
 
 pub use authentication::authenticate;
 pub use create::create_module;
+pub use trust_bundle::init_trust_bundle;
 
 use edgelet_core::{Module, ModuleRuntimeState, ModuleStatus};
 use edgelet_docker::DockerConfig;

--- a/edgelet/edgelet-kube/src/module/trust_bundle.rs
+++ b/edgelet/edgelet-kube/src/module/trust_bundle.rs
@@ -1,0 +1,342 @@
+use crate::convert::trust_bundle_to_config_map;
+use crate::{Error, ErrorKind, KubeModuleRuntime};
+use edgelet_core::GetTrustBundle;
+use failure::Fail;
+use futures::future::Either;
+use futures::{future, Future, IntoFuture, Stream};
+use hyper::service::Service;
+use hyper::Body;
+use kube_client::{Error as KubeClientError, TokenSource};
+
+pub fn init_trust_bundle<T, S>(
+    runtime: &KubeModuleRuntime<T, S>,
+    crypto: &impl GetTrustBundle,
+) -> impl Future<Item = (), Error = Error>
+where
+    T: TokenSource,
+    S: Service + 'static,
+    S::ReqBody: From<Vec<u8>>,
+    S::ResBody: Stream,
+    Body: From<S::ResBody>,
+    S::Error: Into<KubeClientError>,
+{
+    crypto
+        .get_trust_bundle()
+        .map_err(|err| Error::from(err.context(ErrorKind::IdentityCertificate)))
+        .and_then(|cert| trust_bundle_to_config_map(runtime.settings(), &cert).map_err(Error::from))
+        .map(|(name, new_config_map)| {
+            let client_copy = runtime.client().clone();
+            let namespace_copy = runtime.settings().namespace().to_owned();
+
+            runtime
+                .client()
+                .lock()
+                .expect("Unexpected lock error")
+                .borrow_mut()
+                .list_config_maps(
+                    runtime.settings().namespace(),
+                    Some(&name),
+                    Some(&runtime.settings().device_hub_selector()),
+                )
+                .map_err(Error::from)
+                .and_then(move |config_maps| {
+                    if let Some(current) = config_maps.items.into_iter().find(|config_map| {
+                        config_map.metadata.as_ref().map_or(false, |meta| {
+                            meta.name.as_ref().map_or(false, |n| *n == name)
+                        })
+                    }) {
+                        if current == new_config_map {
+                            Either::A(Either::A(future::ok(())))
+                        } else {
+                            let fut = client_copy
+                                .lock()
+                                .expect("Unexpected lock error")
+                                .borrow_mut()
+                                .replace_config_map(namespace_copy.as_str(), &name, &new_config_map)
+                                .map_err(Error::from)
+                                .map(|_| ());
+
+                            Either::A(Either::B(fut))
+                        }
+                    } else {
+                        let fut = client_copy
+                            .lock()
+                            .expect("Unexpected lock error")
+                            .borrow_mut()
+                            .create_config_map(namespace_copy.as_str(), &new_config_map)
+                            .map_err(Error::from)
+                            .map(|_| ());
+
+                        Either::B(fut)
+                    }
+                })
+        })
+        .into_future()
+        .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::service::{service_fn, Service};
+    use hyper::{Body, Error as HyperError, Method, Request, Response, StatusCode};
+    use native_tls::TlsConnector;
+    use url::Url;
+
+    use edgelet_test_utils::cert::TestCert;
+    use edgelet_test_utils::crypto::TestHsm;
+    use kube_client::{Client as KubeClient, Config as KubeConfig, Error, TokenSource};
+
+    use crate::constants;
+    use crate::module::init_trust_bundle;
+    use crate::tests::make_settings;
+    use crate::{ErrorKind, KubeModuleRuntime};
+    use edgelet_test_utils::routes;
+    use edgelet_test_utils::web::{
+        make_req_dispatcher, HttpMethod, RequestHandler, RequestPath, ResponseFuture,
+    };
+    use futures::future;
+    use maplit::btreemap;
+    use serde_json::json;
+    use typed_headers::{mime, ContentLength, ContentType, HeaderMapExt};
+
+    #[test]
+    fn init_trust_bundle_fails_when_trust_bundle_unavailable() {
+        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
+            Ok(Response::new(Body::empty()))
+        });
+        let crypto = TestHsm::default().with_fail_call(true);
+
+        let runtime = create_runtime(service);
+        let task = init_trust_bundle(&runtime, &crypto);
+
+        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+        let err = runtime.block_on(task).unwrap_err();
+
+        assert_eq!(err.kind(), &ErrorKind::IdentityCertificate)
+    }
+
+    #[test]
+    fn init_trust_bundle_fails_when_cert_unavailable() {
+        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
+            Ok(Response::new(Body::empty()))
+        });
+        let cert = TestCert::default().with_fail_pem(true);
+        let crypto = TestHsm::default().with_cert(cert);
+
+        let runtime = create_runtime(service);
+        let task = init_trust_bundle(&runtime, &crypto);
+
+        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+        let err = runtime.block_on(task).unwrap_err();
+
+        assert_eq!(err.kind(), &ErrorKind::IdentityCertificate)
+    }
+
+    #[test]
+    fn init_trust_bundle_fails_when_k8s_api_call_fails() {
+        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
+            Ok(Response::new(Body::empty()))
+        });
+        let cert = TestCert::default().with_cert(b"secret_cert".to_vec());
+        let crypto = TestHsm::default().with_cert(cert);
+
+        let runtime = create_runtime(service);
+        let task = init_trust_bundle(&runtime, &crypto);
+
+        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+        let err = runtime.block_on(task).unwrap_err();
+
+        assert_eq!(err.kind(), &ErrorKind::KubeClient)
+    }
+
+    #[test]
+    fn init_trust_bundle_updates_existing_trust_bundle_config_map() {
+        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
+            let body = r###"{
+                    "kind": "ConfigMap",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": "ca-pemstore",
+                        "namespace": "default"
+                    }
+                }"###;
+            Ok(Response::new(Body::from(body)))
+        });
+
+        let runtime = create_runtime(service);
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/configmaps", runtime.settings().namespace()) => config_map_list(),
+            PUT format!("/api/v1/namespaces/{}/configmaps/{}", runtime.settings().namespace(), constants::PROXY_CONFIG_TRUST_BUNDLE_NAME) => update_config_map(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+
+        let cert = TestCert::default().with_cert(b"secret_cert".to_vec());
+        let crypto = TestHsm::default().with_cert(cert);
+
+        let runtime = create_runtime(service);
+        let task = init_trust_bundle(&runtime, &crypto);
+
+        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn init_trust_bundle_creates_new_trust_bundle_config_map() {
+        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
+            let body = r###"{
+                    "kind": "ConfigMap",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": "ca-pemstore",
+                        "namespace": "default"
+                    }
+                }"###;
+            Ok(Response::new(Body::from(body)))
+        });
+
+        let runtime = create_runtime(service);
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/configmaps", runtime.settings().namespace()) => empty_config_map_list(),
+            POST format!("/api/v1/namespaces/{}/configmaps", runtime.settings().namespace()) => create_config_map(),
+        );
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+
+        let cert = TestCert::default().with_cert(b"secret_cert".to_vec());
+        let crypto = TestHsm::default().with_cert(cert);
+
+        let runtime = create_runtime(service);
+        let task = init_trust_bundle(&runtime, &crypto);
+
+        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    fn create_runtime<S: Service>(service: S) -> KubeModuleRuntime<TestTokenSource, S> {
+        let settings = make_settings(None);
+        let client = KubeClient::with_client(get_config(), service);
+
+        KubeModuleRuntime::new(client, settings)
+    }
+
+    fn get_config() -> KubeConfig<TestTokenSource> {
+        KubeConfig::new(
+            Url::parse("https://localhost:443").unwrap(),
+            "/api".to_string(),
+            TestTokenSource,
+            TlsConnector::new().unwrap(),
+        )
+    }
+
+    fn config_map_list() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "ConfigMapList",
+                    "apiVersion": "v1",
+                    "items": [
+                        {
+                            "metadata": {
+                                "name": constants::PROXY_CONFIG_TRUST_BUNDLE_NAME,
+                                "namespace": "my-namespace",
+                            },
+                            "data": {
+                                "cert.pem": "trust bundle"
+                            }
+                        }
+                    ]
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn update_config_map() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "ConfigMap",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": constants::PROXY_CONFIG_TRUST_BUNDLE_NAME,
+                        "namespace": "my-namespace",
+                    }
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn create_config_map() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::CREATED, || {
+                json!({
+                    "kind": "ConfigMap",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": "c",
+                        "namespace": "my-namespace",
+                    }
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn empty_config_map_list() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |req| {
+            println!("{:?}", req);
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "ConfigMapList",
+                    "apiVersion": "v1",
+                    "items": []
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn response(
+        status_code: StatusCode,
+        response: impl Fn() -> String + Clone + Send + 'static,
+    ) -> ResponseFuture {
+        let response = response();
+        let response_len = response.len();
+
+        let mut response = Response::new(response.into());
+        *response.status_mut() = status_code;
+        response
+            .headers_mut()
+            .typed_insert(&ContentLength(response_len as u64));
+        response
+            .headers_mut()
+            .typed_insert(&ContentType(mime::APPLICATION_JSON));
+
+        Box::new(future::ok(response)) as ResponseFuture
+    }
+
+    fn not_found_handler(_: Request<Body>) -> ResponseFuture {
+        let response = Response::builder()
+            .status(StatusCode::NOT_FOUND)
+            .body(Body::default())
+            .unwrap();
+
+        Box::new(future::ok(response))
+    }
+
+    #[derive(Clone)]
+    struct TestTokenSource;
+
+    impl TokenSource for TestTokenSource {
+        type Error = Error;
+
+        fn get(&self) -> kube_client::error::Result<Option<String>> {
+            Ok(None)
+        }
+    }
+}

--- a/edgelet/edgelet-kube/src/runtime.rs
+++ b/edgelet/edgelet-kube/src/runtime.rs
@@ -24,9 +24,9 @@ use kube_client::{
 };
 use provisioning::ProvisioningResult;
 
-use crate::convert::{auth_to_image_pull_secret, pod_to_module, trust_bundle_to_config_map};
+use crate::convert::{auth_to_image_pull_secret, pod_to_module};
 use crate::error::{Error, ErrorKind};
-use crate::module::{authenticate, create_module, KubeModule};
+use crate::module::{authenticate, create_module, init_trust_bundle, KubeModule};
 use crate::settings::Settings;
 
 pub struct KubeModuleRuntime<T, S> {
@@ -171,44 +171,11 @@ impl MakeModuleRuntime
         let fut = get_config()
             .map(|config| KubeModuleRuntime::new(KubeClient::new(config), settings))
             .map_err(Error::from)
-            .map(|runtime| runtime.init_trust_bundle(&crypto).map(|_| runtime))
+            .map(|runtime| init_trust_bundle(&runtime, &crypto).map(|_| runtime))
             .into_future()
             .flatten();
 
         Box::new(fut)
-    }
-}
-
-impl<T, S> KubeModuleRuntime<T, S>
-where
-    T: TokenSource,
-    S: Service + 'static,
-    S::ReqBody: From<Vec<u8>>,
-    S::ResBody: Stream,
-    Body: From<S::ResBody>,
-    S::Error: Into<KubeClientError>,
-{
-    fn init_trust_bundle(
-        &self,
-        crypto: &impl GetTrustBundle,
-    ) -> impl Future<Item = (), Error = Error> {
-        crypto
-            .get_trust_bundle()
-            .map_err(|err| Error::from(err.context(ErrorKind::IdentityCertificate)))
-            .and_then(|cert| {
-                trust_bundle_to_config_map(self.settings(), &cert).map_err(Error::from)
-            })
-            .map(|(name, config_map)| {
-                self.client()
-                    .lock()
-                    .expect("Unexpected lock error")
-                    .borrow_mut()
-                    .replace_config_map(&self.settings().namespace(), &name, &config_map)
-                    .map_err(Error::from)
-                    .map(|_| ())
-            })
-            .into_future()
-            .flatten()
     }
 }
 
@@ -386,116 +353,5 @@ impl Extend<u8> for Chunk {
 impl AsRef<[u8]> for Chunk {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use hyper::service::{service_fn, Service};
-    use hyper::{Body, Error as HyperError, Request, Response};
-    use native_tls::TlsConnector;
-    use url::Url;
-
-    use edgelet_test_utils::cert::TestCert;
-    use edgelet_test_utils::crypto::TestHsm;
-    use kube_client::{Client as KubeClient, Config as KubeConfig, Error, TokenSource};
-
-    use crate::tests::make_settings;
-    use crate::{ErrorKind, KubeModuleRuntime};
-
-    #[test]
-    fn init_trust_bundle_fails_when_trust_bundle_unavailable() {
-        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
-            Ok(Response::new(Body::empty()))
-        });
-        let crypto = TestHsm::default().with_fail_call(true);
-
-        let task = create_runtime(service).init_trust_bundle(&crypto);
-
-        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-        let err = runtime.block_on(task).unwrap_err();
-
-        assert_eq!(err.kind(), &ErrorKind::IdentityCertificate)
-    }
-
-    #[test]
-    fn init_trust_bundle_fails_when_cert_unavailable() {
-        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
-            Ok(Response::new(Body::empty()))
-        });
-        let cert = TestCert::default().with_fail_pem(true);
-        let crypto = TestHsm::default().with_cert(cert);
-
-        let task = create_runtime(service).init_trust_bundle(&crypto);
-
-        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-        let err = runtime.block_on(task).unwrap_err();
-
-        assert_eq!(err.kind(), &ErrorKind::IdentityCertificate)
-    }
-
-    #[test]
-    fn init_trust_bundle_fails_when_k8s_api_call_fails() {
-        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
-            Ok(Response::new(Body::empty()))
-        });
-        let cert = TestCert::default().with_cert(b"secret_cert".to_vec());
-        let crypto = TestHsm::default().with_cert(cert);
-
-        let task = create_runtime(service).init_trust_bundle(&crypto);
-
-        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-        let err = runtime.block_on(task).unwrap_err();
-
-        assert_eq!(err.kind(), &ErrorKind::KubeClient)
-    }
-
-    #[test]
-    fn init_trust_bundle_creates_trust_bundle_config_map() {
-        let service = service_fn(|_: Request<Body>| -> Result<Response<Body>, HyperError> {
-            let body = r###"{
-                    "kind": "ConfigMap",
-                    "apiVersion": "v1",
-                    "metadata": {
-                        "name": "ca-pemstore",
-                        "namespace": "default"
-                    }
-                }"###;
-            Ok(Response::new(Body::from(body)))
-        });
-        let cert = TestCert::default().with_cert(b"secret_cert".to_vec());
-        let crypto = TestHsm::default().with_cert(cert);
-
-        let task = create_runtime(service).init_trust_bundle(&crypto);
-
-        let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-        runtime.block_on(task).unwrap();
-    }
-
-    fn create_runtime<S: Service>(service: S) -> KubeModuleRuntime<TestTokenSource, S> {
-        let settings = make_settings(None);
-        let client = KubeClient::with_client(get_config(), service);
-
-        KubeModuleRuntime::new(client, settings)
-    }
-
-    fn get_config() -> KubeConfig<TestTokenSource> {
-        KubeConfig::new(
-            Url::parse("https://localhost:443").unwrap(),
-            "/api".to_string(),
-            TestTokenSource,
-            TlsConnector::new().unwrap(),
-        )
-    }
-
-    #[derive(Clone)]
-    struct TestTokenSource;
-
-    impl TokenSource for TestTokenSource {
-        type Error = Error;
-
-        fn get(&self) -> kube_client::error::Result<Option<String>> {
-            Ok(None)
-        }
     }
 }

--- a/edgelet/edgelet-kube/tests/runtime.rs
+++ b/edgelet/edgelet-kube/tests/runtime.rs
@@ -3,7 +3,6 @@
 #![deny(rust_2018_idioms, warnings)]
 #![deny(clippy::all, clippy::pedantic)]
 
-use std::collections::HashMap;
 use std::path::Path;
 
 use config::{Config, File, FileFormat};
@@ -15,14 +14,14 @@ use json_patch::merge;
 use maplit::btreemap;
 use native_tls::TlsConnector;
 use serde_json::{self, json, Value as JsonValue};
+use tokio::runtime::Runtime;
 use typed_headers::{mime, ContentLength, ContentType, HeaderMapExt};
 use url::Url;
 
-use docker::models::{AuthConfig, ContainerCreateBody, HostConfig, Mount};
 use edgelet_core::{
-    AuthId, Authenticator, Certificates, Connect, GetTrustBundle, ImagePullPolicy, Listen,
-    MakeModuleRuntime, ModuleRuntime, ModuleSpec, Provisioning,
-    ProvisioningResult as CoreProvisioningResult, RuntimeSettings, WatchdogSettings,
+    AuthId, Authenticator, Certificates, Connect, GetTrustBundle, Listen, MakeModuleRuntime,
+    ModuleSpec, Provisioning, ProvisioningResult as CoreProvisioningResult, RuntimeSettings,
+    WatchdogSettings,
 };
 use edgelet_docker::DockerConfig;
 use edgelet_kube::{ErrorKind, KubeModuleRuntime, Settings};
@@ -113,7 +112,7 @@ fn authenticate_returns_none_when_no_auth_token_provided() {
 
     let task = runtime.authenticate(&req);
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     runtime.spawn(server);
     let auth_id = runtime.block_on(task).unwrap();
 
@@ -143,7 +142,7 @@ fn authenticate_returns_none_when_invalid_auth_header_provided() {
 
     let task = runtime.authenticate(&req);
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     runtime.spawn(server);
     let auth_id = runtime.block_on(task).unwrap();
 
@@ -175,7 +174,7 @@ fn authenticate_returns_none_when_invalid_auth_token_provided() {
 
     let task = runtime.authenticate(&req);
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     runtime.spawn(server);
     let err = runtime.block_on(task).unwrap_err();
 
@@ -207,7 +206,7 @@ fn authenticate_returns_none_when_unknown_auth_token_provided() {
 
     let task = runtime.authenticate(&req);
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     runtime.spawn(server);
     let auth_id = runtime.block_on(task).unwrap();
 
@@ -237,7 +236,7 @@ fn authenticate_returns_none_when_module_auth_token_provided_but_service_account
 
     let task = runtime.authenticate(&req);
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     runtime.spawn(server);
     let err = runtime.block_on(task).unwrap_err();
 
@@ -269,7 +268,7 @@ fn authenticate_returns_sa_name_when_module_auth_token_provided_but_service_acco
 
     let task = runtime.authenticate(&req);
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     runtime.spawn(server);
     let auth_id = runtime.block_on(task).unwrap();
 
@@ -300,7 +299,7 @@ fn authenticate_returns_auth_id_when_module_auth_token_provided() {
 
     let task = runtime.authenticate(&req);
 
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
+    let mut runtime = Runtime::new().unwrap();
     runtime.spawn(server);
     let auth_id = runtime.block_on(task).unwrap();
 
@@ -494,111 +493,6 @@ fn make_token_review_handler(
     }
 }
 
-#[test]
-fn create_creates_or_updates_service_account_role_binding_deployment_for_edgeagent() {
-    let port = get_unused_tcp_port();
-
-    let (settings, runtime) = create_runtime(&format!("http://localhost:{}", port));
-    let module = create_module_spec("$edgeAgent");
-
-    let dispatch_table = routes!(
-        PUT format!("/api/v1/namespaces/{}/serviceaccounts/edgeagent", settings.namespace()) => replace_service_account_handler(),
-        PUT format!("/apis/rbac.authorization.k8s.io/v1/namespaces/{}/rolebindings/edgeagent", settings.namespace()) => replace_role_binding_handler(),
-        PUT format!("/apis/apps/v1/namespaces/{}/deployments/edgeagent", settings.namespace()) => replace_deployment_handler(),
-    );
-
-    let server = run_tcp_server(
-        "127.0.0.1",
-        port,
-        make_req_dispatcher(dispatch_table, Box::new(not_found_handler)),
-    )
-    .map_err(|err| eprintln!("{}", err));
-
-    let task = runtime.create(module);
-
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-    runtime.spawn(server);
-    runtime.block_on(task).unwrap();
-}
-
-#[test]
-fn create_do_not_create_role_binding_for_module_that_is_not_edgeagent() {
-    let port = get_unused_tcp_port();
-
-    let (settings, runtime) = create_runtime(&format!("http://localhost:{}", port));
-    let module = create_module_spec("temp-sensor");
-
-    let dispatch_table = routes!(
-        PUT format!("/api/v1/namespaces/{}/serviceaccounts/{}", settings.namespace(), "temp-sensor") => replace_service_account_handler(),
-        PUT format!("/apis/apps/v1/namespaces/{}/deployments/{}", settings.namespace(), "temp-sensor") => replace_deployment_handler(),
-    );
-
-    let server = run_tcp_server(
-        "127.0.0.1",
-        port,
-        make_req_dispatcher(dispatch_table, Box::new(not_found_handler)),
-    )
-    .map_err(|err| eprintln!("{}", err));
-
-    let task = runtime.create(module);
-
-    let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
-    runtime.spawn(server);
-    runtime.block_on(task).unwrap();
-}
-
-fn create_module_spec(name: &str) -> ModuleSpec<DockerConfig> {
-    let create_body = ContainerCreateBody::new()
-        .with_host_config(
-            HostConfig::new()
-                .with_binds(vec![String::from("/a:/b:ro"), String::from("/c:/d")])
-                .with_privileged(true)
-                .with_mounts(vec![
-                    Mount::new()
-                        .with__type(String::from("bind"))
-                        .with_read_only(true)
-                        .with_source(String::from("/e"))
-                        .with_target(String::from("/f")),
-                    Mount::new()
-                        .with__type(String::from("bind"))
-                        .with_source(String::from("/g"))
-                        .with_target(String::from("/h")),
-                    Mount::new()
-                        .with__type(String::from("volume"))
-                        .with_read_only(true)
-                        .with_source(String::from("i"))
-                        .with_target(String::from("/j")),
-                    Mount::new()
-                        .with__type(String::from("volume"))
-                        .with_source(String::from("k"))
-                        .with_target(String::from("/l")),
-                ]),
-        )
-        .with_labels({
-            let mut labels = HashMap::<String, String>::new();
-            labels.insert(String::from("label1"), String::from("value1"));
-            labels.insert(String::from("label2"), String::from("value2"));
-            labels
-        });
-    let auth_config = AuthConfig::new()
-        .with_password(String::from("a password"))
-        .with_username(String::from("USERNAME"))
-        .with_serveraddress(String::from("REGISTRY"));
-    ModuleSpec::new(
-        name.to_string(),
-        "docker".to_string(),
-        DockerConfig::new("my-image:v1.0".to_string(), create_body, Some(auth_config)).unwrap(),
-        {
-            let mut env = HashMap::new();
-            env.insert(String::from("a"), String::from("b"));
-            env.insert(String::from("C"), String::from("D"));
-            env
-        },
-        ImagePullPolicy::default(),
-    )
-    .unwrap()
-}
-
 fn get_service_account_with_annotations_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone
 {
     move |_| {
@@ -630,66 +524,6 @@ fn get_service_account_without_annotations_handler(
                     "name": "edgeagent",
                     "namespace": "my-namespace",
                 }
-            })
-            .to_string()
-        })
-    }
-}
-
-fn replace_service_account_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
-    move |_| {
-        response(StatusCode::OK, || {
-            json!({
-                "kind": "ServiceAccount",
-                "apiVersion": "v1",
-                "metadata": {
-                    "name": "edgeagent",
-                    "namespace": "my-namespace",
-                }
-            })
-            .to_string()
-        })
-    }
-}
-
-fn replace_role_binding_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
-    move |_| {
-        response(StatusCode::OK, || {
-            json!({
-                "kind": "RoleBinding",
-                "apiVersion": "rbac.authorization.k8s.io/v1",
-                "metadata": {
-                    "name": "edgeagent",
-                    "namespace": "my-namespace",
-                },
-                "subjects": [
-                    {
-                        "kind": "ServiceAccount",
-                        "name": "edgeagent",
-                        "namespace": "my-namespace"
-                    }
-                ],
-                "roleRef": {
-                    "apiGroup": "rbac.authorization.k8s.io",
-                    "kind": "ClusterRole",
-                    "name": "cluster-admin"
-                }
-            })
-            .to_string()
-        })
-    }
-}
-
-fn replace_deployment_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
-    move |_| {
-        response(StatusCode::OK, || {
-            json!({
-                "kind": "Deployment",
-                "apiVersion": "apps/v1",
-                "metadata": {
-                    "name": "edgeagent",
-                    "namespace": "my-namespace",
-                },
             })
             .to_string()
         })


### PR DESCRIPTION
k8s API doesn't `upsert` semantic for a replace config map operation. Changed replace to list config maps and create new or replace existing config map with a trust bundle if required.