### PR TITLE
Fix artifact selection logic in end-to-end test build

### DIFF
--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -20,7 +20,7 @@ steps:
 - pwsh: |
     Set-PSDebug -Trace 2
 
-    Write-Output "1>> '$(Build.TriggeredBy.DefinitionName)'"
+    #Write-Output "1>> '$(Build.TriggeredBy.DefinitionName)'"
     Write-Output "2>> '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
     Write-Output "3>> '$(Build.TriggeredBy.BuildId)'"
     Write-Output "4>> '$(azure.pipeline.packages)'"

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -24,10 +24,11 @@ steps:
     Write-Output "2>> '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
     #Write-Output "3>> '$(Build.TriggeredBy.BuildId)'"
     Write-Output "4>> '$env:BUILD_TRIGGEREDBY_BUILDID'"
-    Write-Output "5>> '$(azure.pipeline.packages)'"
-    Write-Output "6>> '$(az.pipeline.packages.buildId)'"
-    Write-Output "7>> '$(azure.pipeline.images)'"
-    Write-Output "8>> '$(azure.pipeline.images.buildId)'"
+    #Write-Output "5>> '$(azure.pipeline.packages)'"
+    Write-Output "6>> '$env:AZURE_PIPELINE_PACKAGES'"
+    Write-Output "7>> '$(az.pipeline.packages.buildId)'"
+    Write-Output "8>> '$(azure.pipeline.images)'"
+    Write-Output "9>> '$(azure.pipeline.images.buildId)'"
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
     if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(azure.pipeline.packages)')

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -28,7 +28,7 @@ steps:
       Write-Output '##vso[task.setvariable variable=packageBuildId]$(Build.TriggeredBy.BuildId)'
     }
     # 2) 'Build Images' build triggered this build (use latest 'Edgelet Packages' build on master)
-    elseif ('$(Build.TriggeredBy.DefinitionName)' -eq '$(azure.pipeline.images)')
+    elseif ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(azure.pipeline.images)')
     {
       Write-Output '##vso[task.setvariable variable=whichPackageBuild]latestFromBranch'
       Write-Output '##vso[task.setvariable variable=whichImageBuild]specific'
@@ -44,9 +44,9 @@ steps:
     }
     else # Error
     {
-      if ('$(Build.TriggeredBy.DefinitionName)' -ne '')
+      if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -ne '')
       {
-        Write-Output "Build triggered by unrecognized build '$(Build.TriggeredBy.DefinitionName)'"
+        Write-Output "Build triggered by unrecognized build '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
       }
       else
       {

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -22,6 +22,7 @@ steps:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
     if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.packages)')
     {
+      Write-Output "Triggered by build '$(az.pipeline.packages)' \#$(Build.TriggeredBy.BuildId)"
       Write-Output '##vso[task.setvariable variable=whichPackageBuild]specific'
       Write-Output '##vso[task.setvariable variable=whichImageBuild]latestFromBranch'
       Write-Output '##vso[task.setvariable variable=packageBuildId]$(Build.TriggeredBy.BuildId)'
@@ -29,6 +30,7 @@ steps:
     # 2) 'Build Images' build triggered this build (use latest 'Edgelet Packages' build on master)
     elseif ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.images)')
     {
+      Write-Output "Triggered by build '$(az.pipeline.images)' \#$(Build.TriggeredBy.BuildId)"
       Write-Output '##vso[task.setvariable variable=whichPackageBuild]latestFromBranch'
       Write-Output '##vso[task.setvariable variable=whichImageBuild]specific'
       Write-Output '##vso[task.setvariable variable=imageBuildId]$(Build.TriggeredBy.BuildId)'

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -18,21 +18,6 @@ steps:
       TestRootCaPassword
 
 - pwsh: |
-    Set-PSDebug -Trace 2
-
-    #Write-Output "01>> '$(Build.TriggeredBy.DefinitionName)'"
-    Write-Output "02>> '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
-    #Write-Output "03>> '$(Build.TriggeredBy.BuildId)'"
-    Write-Output "04>> '$env:BUILD_TRIGGEREDBY_BUILDID'"
-    Write-Output "05>> '$(az.pipeline.packages)'"
-    Write-Output "06>> '$env:AZ_PIPELINE_PACKAGES'"
-    Write-Output "07>> '$(az.pipeline.packages.buildId)'"
-    Write-Output "08>> '$env:AZ_PIPELINE_PACKAGES_BUILDID'"
-    Write-Output "09>> '$(az.pipeline.images)'"
-    Write-Output "10>> '$env:AZ_PIPELINE_IMAGES'"
-    Write-Output "11>> '$(az.pipeline.images.buildId)'"
-    Write-Output "12>> '$env:AZ_PIPELINE_IMAGES_BUILDID'"
-
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
     if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.packages)')

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -18,6 +18,7 @@ steps:
       TestRootCaPassword
 
 - pwsh: |
+    Set-PSDebug -Trace 2
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
     if ('$(Build.TriggeredBy.DefinitionName)' -eq '$(azure.pipeline.packages)')

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -22,11 +22,12 @@ steps:
 
     #Write-Output "1>> '$(Build.TriggeredBy.DefinitionName)'"
     Write-Output "2>> '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
-    Write-Output "3>> '$(Build.TriggeredBy.BuildId)'"
-    Write-Output "4>> '$(azure.pipeline.packages)'"
-    Write-Output "5>> '$(az.pipeline.packages.buildId)'"
-    Write-Output "6>> '$(azure.pipeline.images)'"
-    Write-Output "7>> '$(azure.pipeline.images.buildId)'"
+    #Write-Output "3>> '$(Build.TriggeredBy.BuildId)'"
+    Write-Output "4>> '$env:BUILD_TRIGGEREDBY_BUILDID'"
+    Write-Output "5>> '$(azure.pipeline.packages)'"
+    Write-Output "6>> '$(az.pipeline.packages.buildId)'"
+    Write-Output "7>> '$(azure.pipeline.images)'"
+    Write-Output "8>> '$(azure.pipeline.images.buildId)'"
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
     if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(azure.pipeline.packages)')

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -19,6 +19,14 @@ steps:
 
 - pwsh: |
     Set-PSDebug -Trace 2
+
+    Write-Output "1>> '$(Build.TriggeredBy.DefinitionName)'"
+    Write-Output "2>> '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
+    Write-Output "3>> '$(Build.TriggeredBy.BuildId)'"
+    Write-Output "4>> '$(azure.pipeline.packages)'"
+    Write-Output "5>> '$(az.pipeline.packages.buildId)'"
+    Write-Output "6>> '$(azure.pipeline.images)'"
+    Write-Output "7>> '$(azure.pipeline.images.buildId)'"
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
     if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(azure.pipeline.packages)')
@@ -44,7 +52,7 @@ steps:
     }
     else # Error
     {
-      if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -ne '')
+      if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME)
       {
         Write-Output "Build triggered by unrecognized build '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
       }

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -24,25 +24,25 @@ steps:
     Write-Output "02>> '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
     #Write-Output "03>> '$(Build.TriggeredBy.BuildId)'"
     Write-Output "04>> '$env:BUILD_TRIGGEREDBY_BUILDID'"
-    #Write-Output "05>> '$(azure.pipeline.packages)'"
-    Write-Output "06>> '$env:AZURE_PIPELINE_PACKAGES'"
+    Write-Output "05>> '$(az.pipeline.packages)'"
+    Write-Output "06>> '$env:AZ_PIPELINE_PACKAGES'"
     Write-Output "07>> '$(az.pipeline.packages.buildId)'"
     Write-Output "08>> '$env:AZ_PIPELINE_PACKAGES_BUILDID'"
-    #Write-Output "09>> '$(azure.pipeline.images)'"
-    Write-Output "10>> '$env:AZURE_PIPELINE_IMAGES'"
-    Write-Output "11>> '$(azure.pipeline.images.buildId)'"
-    Write-Output "12>> '$env:AZURE_PIPELINE_IMAGES_BUILDID'"
+    Write-Output "09>> '$(az.pipeline.images)'"
+    Write-Output "10>> '$env:AZ_PIPELINE_IMAGES'"
+    Write-Output "11>> '$(az.pipeline.images.buildId)'"
+    Write-Output "12>> '$env:AZ_PIPELINE_IMAGES_BUILDID'"
 
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
-    if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(azure.pipeline.packages)')
+    if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.packages)')
     {
       Write-Output '##vso[task.setvariable variable=whichPackageBuild]specific'
       Write-Output '##vso[task.setvariable variable=whichImageBuild]latestFromBranch'
       Write-Output '##vso[task.setvariable variable=packageBuildId]$(Build.TriggeredBy.BuildId)'
     }
     # 2) 'Build Images' build triggered this build (use latest 'Edgelet Packages' build on master)
-    elseif ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(azure.pipeline.images)')
+    elseif ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.images)')
     {
       Write-Output '##vso[task.setvariable variable=whichPackageBuild]latestFromBranch'
       Write-Output '##vso[task.setvariable variable=whichImageBuild]specific'

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -20,15 +20,19 @@ steps:
 - pwsh: |
     Set-PSDebug -Trace 2
 
-    #Write-Output "1>> '$(Build.TriggeredBy.DefinitionName)'"
-    Write-Output "2>> '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
-    #Write-Output "3>> '$(Build.TriggeredBy.BuildId)'"
-    Write-Output "4>> '$env:BUILD_TRIGGEREDBY_BUILDID'"
-    #Write-Output "5>> '$(azure.pipeline.packages)'"
-    Write-Output "6>> '$env:AZURE_PIPELINE_PACKAGES'"
-    Write-Output "7>> '$(az.pipeline.packages.buildId)'"
-    Write-Output "8>> '$(azure.pipeline.images)'"
-    Write-Output "9>> '$(azure.pipeline.images.buildId)'"
+    #Write-Output "01>> '$(Build.TriggeredBy.DefinitionName)'"
+    Write-Output "02>> '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
+    #Write-Output "03>> '$(Build.TriggeredBy.BuildId)'"
+    Write-Output "04>> '$env:BUILD_TRIGGEREDBY_BUILDID'"
+    #Write-Output "05>> '$(azure.pipeline.packages)'"
+    Write-Output "06>> '$env:AZURE_PIPELINE_PACKAGES'"
+    Write-Output "07>> '$(az.pipeline.packages.buildId)'"
+    Write-Output "08>> '$env:AZ_PIPELINE_PACKAGES_BUILDID'"
+    #Write-Output "09>> '$(azure.pipeline.images)'"
+    Write-Output "10>> '$env:AZURE_PIPELINE_IMAGES'"
+    Write-Output "11>> '$(azure.pipeline.images.buildId)'"
+    Write-Output "12>> '$env:AZURE_PIPELINE_IMAGES_BUILDID'"
+
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
     if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(azure.pipeline.packages)')

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -51,7 +51,7 @@ steps:
       {
         Write-Output "Missing build parameter 'az.pipeline.packages.buildId' or 'az.pipeline.images.buildId'"
       }
-      return 1
+      exit 1
     }
   displayName: Locate edgelet packages, runtime images
 

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -21,7 +21,7 @@ steps:
     Set-PSDebug -Trace 2
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
-    if ('$(Build.TriggeredBy.DefinitionName)' -eq '$(azure.pipeline.packages)')
+    if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(azure.pipeline.packages)')
     {
       Write-Output '##vso[task.setvariable variable=whichPackageBuild]specific'
       Write-Output '##vso[task.setvariable variable=whichImageBuild]latestFromBranch'


### PR DESCRIPTION
There were three problems with the "Locate edgelet packages, runtime images" task:
1. The build variable `Build.TriggeredBy.DefinitionName` is only available when the build was triggered by build completion. Otherwise the Azure Pipelines parsing layer does not replace '$(Build.TriggeredBy.DefinitionName)', and pwsh fails with a syntax error. The fix is to use an environment variable in this case, which can always be tested.
2. The task referred to some variables incorrectly (`azure...` instead of `az...`), so I fixed those variable references.
3. The task was using `return` instead of `exit` in the error case, so $LASTEXITCODE wasn't being set and the task would always succeed. I fixed it be replacing `return 1` with `exit 1`.