### PR TITLE
Fix race between tests that try to bind to a port

### DIFF
--- a/edgelet/edgelet-docker/src/config.rs
+++ b/edgelet/edgelet-docker/src/config.rs
@@ -92,15 +92,14 @@ mod tests {
     use super::*;
 
     #[test]
-    #[should_panic]
     fn empty_image_fails() {
-        DockerConfig::new("".to_string(), ContainerCreateBody::new(), None).unwrap();
+        let _ = DockerConfig::new("".to_string(), ContainerCreateBody::new(), None).unwrap_err();
     }
 
     #[test]
-    #[should_panic]
     fn white_space_image_fails() {
-        DockerConfig::new("    ".to_string(), ContainerCreateBody::new(), None).unwrap();
+        let _ =
+            DockerConfig::new("    ".to_string(), ContainerCreateBody::new(), None).unwrap_err();
     }
 
     #[test]

--- a/edgelet/edgelet-docker/src/module.rs
+++ b/edgelet/edgelet-docker/src/module.rs
@@ -28,6 +28,15 @@ pub struct DockerModule<C: Connect> {
     config: DockerConfig,
 }
 
+impl<C> std::fmt::Debug for DockerModule<C>
+where
+    C: Connect,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DockerModule").finish()
+    }
+}
+
 impl<C: 'static + Connect> DockerModule<C> {
     pub fn new(client: DockerClient<C>, name: String, config: DockerConfig) -> Result<Self> {
         ensure_not_empty_with_context(&name, || ErrorKind::InvalidModuleName(name.clone()))?;
@@ -242,25 +251,23 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn empty_name_fails() {
-        let _docker_module = DockerModule::new(
+        let _ = DockerModule::new(
             create_api_client("boo"),
             "".to_string(),
             DockerConfig::new("ubuntu".to_string(), ContainerCreateBody::new(), None).unwrap(),
         )
-        .unwrap();
+        .unwrap_err();
     }
 
     #[test]
-    #[should_panic]
     fn white_space_name_fails() {
-        let _docker_module = DockerModule::new(
+        let _ = DockerModule::new(
             create_api_client("boo"),
             "     ".to_string(),
             DockerConfig::new("ubuntu".to_string(), ContainerCreateBody::new(), None).unwrap(),
         )
-        .unwrap();
+        .unwrap_err();
     }
 
     fn get_inputs() -> Vec<(&'static str, i64, ModuleStatus)> {

--- a/edgelet/edgelet-http/src/lib.rs
+++ b/edgelet/edgelet-http/src/lib.rs
@@ -271,6 +271,15 @@ where
 
         Run(Box::new(main_execution))
     }
+
+    pub fn port(&self) -> Option<u16> {
+        match &self.incoming {
+            Incoming::Tcp(listener) => listener.local_addr().ok().map(|addr| addr.port()),
+            #[cfg(unix)]
+            Incoming::Tls(listener, _, _) => listener.local_addr().ok().map(|addr| addr.port()),
+            Incoming::Unix(_) => None,
+        }
+    }
 }
 
 pub trait HyperExt {

--- a/edgelet/edgelet-http/src/util/connector.rs
+++ b/edgelet/edgelet-http/src/util/connector.rs
@@ -105,6 +105,17 @@ impl UrlConnector {
     }
 }
 
+impl std::fmt::Debug for UrlConnector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UrlConnector::Http(_) => f.debug_struct("Http").finish(),
+            #[cfg(windows)]
+            UrlConnector::Pipe(_) => f.debug_struct("Pipe").finish(),
+            UrlConnector::Unix(_) => f.debug_struct("UnixConnector").finish(),
+        }
+    }
+}
+
 impl Connect for UrlConnector {
     type Transport = StreamSelector;
     type Error = io::Error;

--- a/edgelet/edgelet-http/src/util/connector.rs
+++ b/edgelet/edgelet-http/src/util/connector.rs
@@ -159,10 +159,11 @@ mod tests {
     use super::*;
 
     #[test]
-    #[should_panic(expected = "URL does not have a recognized scheme")]
     fn invalid_url_scheme() {
-        let _connector =
-            UrlConnector::new(&Url::parse("foo:///this/is/not/valid").unwrap()).unwrap();
+        let err = UrlConnector::new(&Url::parse("foo:///this/is/not/valid").unwrap()).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("URL does not have a recognized scheme")));
     }
 
     #[test]

--- a/edgelet/edgelet-http/tests/connector.rs
+++ b/edgelet/edgelet-http/tests/connector.rs
@@ -8,8 +8,7 @@ use std::io;
 use edgelet_http::UrlConnector;
 #[cfg(windows)]
 use edgelet_test_utils::run_pipe_server;
-use edgelet_test_utils::run_uds_server;
-use edgelet_test_utils::{get_unused_tcp_port, run_tcp_server};
+use edgelet_test_utils::{run_tcp_server, run_uds_server};
 use futures::future;
 use futures::prelude::*;
 use hyper::{
@@ -40,9 +39,8 @@ fn hello_handler(_: Request<Body>) -> impl Future<Item = Response<Body>, Error =
 
 #[test]
 fn tcp_get() {
-    let port = get_unused_tcp_port();
-    let server =
-        run_tcp_server("127.0.0.1", port, hello_handler).map_err(|err| eprintln!("{}", err));
+    let (server, port) = run_tcp_server("127.0.0.1", hello_handler);
+    let server = server.map_err(|err| panic!(err));
 
     let url = format!("http://localhost:{}", port);
     let connector = UrlConnector::new(&Url::parse(&url).unwrap()).unwrap();
@@ -166,9 +164,8 @@ fn post_handler(
 
 #[test]
 fn tcp_post() {
-    let port = get_unused_tcp_port();
-    let server =
-        run_tcp_server("127.0.0.1", port, post_handler).map_err(|err| eprintln!("{}", err));
+    let (server, port) = run_tcp_server("127.0.0.1", post_handler);
+    let server = server.map_err(|err| panic!(err));
 
     let url = format!("http://localhost:{}", port);
     let connector = UrlConnector::new(&Url::parse(&url).unwrap()).unwrap();

--- a/edgelet/edgelet-iothub/src/lib.rs
+++ b/edgelet/edgelet-iothub/src/lib.rs
@@ -436,7 +436,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "KeyStore could not fetch keys for module")]
     fn get_key_pair_fails_for_no_module() {
         let key_store = MemoryKeyStore::new();
         let api_version = "2018-04-10".to_string();
@@ -451,11 +450,13 @@ mod tests {
         let device_client = DeviceClient::new(client, "d1".to_string()).unwrap();
 
         let identity_manager = HubIdentityManager::new(key_store, device_client);
-        identity_manager.get_key_pair("m1", "g1").unwrap();
+        let err = identity_manager.get_key_pair("m1", "g1").unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("KeyStore could not fetch keys for module")));
     }
 
     #[test]
-    #[should_panic(expected = "KeyStore could not fetch keys for module")]
     fn get_key_pair_fails_for_no_pkey() {
         let mut key_store = MemoryKeyStore::new();
         key_store.insert(
@@ -476,11 +477,13 @@ mod tests {
         let device_client = DeviceClient::new(client, "d1".to_string()).unwrap();
 
         let identity_manager = HubIdentityManager::new(key_store, device_client);
-        identity_manager.get_key_pair("m1", "g1").unwrap();
+        let err = identity_manager.get_key_pair("m1", "g1").unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("KeyStore could not fetch keys for module")));
     }
 
     #[test]
-    #[should_panic(expected = "KeyStore could not fetch keys for module")]
     fn get_key_pair_fails_for_no_skey() {
         let mut key_store = MemoryKeyStore::new();
         key_store.insert(
@@ -501,7 +504,10 @@ mod tests {
         let device_client = DeviceClient::new(client, "d1".to_string()).unwrap();
 
         let identity_manager = HubIdentityManager::new(key_store, device_client);
-        identity_manager.get_key_pair("m1", "g1").unwrap();
+        let err = identity_manager.get_key_pair("m1", "g1").unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("KeyStore could not fetch keys for module")));
     }
 
     #[test]

--- a/edgelet/edgelet-test-utils/src/lib.rs
+++ b/edgelet/edgelet-test-utils/src/lib.rs
@@ -9,8 +9,6 @@
     clippy::use_self
 )]
 
-use std::net::TcpListener;
-
 pub mod cert;
 pub mod crypto;
 pub mod identity;
@@ -24,11 +22,3 @@ pub use crate::web::run_uds_server;
 
 #[cfg(windows)]
 pub use crate::web::run_pipe_server;
-
-pub fn get_unused_tcp_port() -> u16 {
-    TcpListener::bind("127.0.0.1:0")
-        .unwrap()
-        .local_addr()
-        .unwrap()
-        .port()
-}

--- a/edgelet/edgelet-utils/src/ser_de.rs
+++ b/edgelet/edgelet-utils/src/ser_de.rs
@@ -147,14 +147,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn deser_from_bad_str_fails() {
         let container_json = json!({
             "options": "not really json you know"
         })
         .to_string();
 
-        let _container: Container = serde_json::from_str(&container_json).unwrap();
+        let _ = serde_json::from_str::<Container>(&container_json).unwrap_err();
     }
 
     #[test]

--- a/edgelet/hsm-rs/src/crypto.rs
+++ b/edgelet/hsm-rs/src/crypto.rs
@@ -1053,72 +1053,73 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn no_random_bytes_api_fail() {
         let hsm_crypto = fake_no_if_hsm_crypto();
         let mut test_array = [0_u8; 4];
-        hsm_crypto.get_random_bytes(&mut test_array).unwrap();
-        println!("You should never see this print");
+        let err = hsm_crypto.get_random_bytes(&mut test_array).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn no_create_master_key_api_fail() {
         let hsm_crypto = fake_no_if_hsm_crypto();
-        hsm_crypto.create_master_encryption_key().unwrap();
-        println!("You should never see this print");
+        let err = hsm_crypto.create_master_encryption_key().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn no_destroy_master_key_api_fail() {
         let hsm_crypto = fake_no_if_hsm_crypto();
-        hsm_crypto.destroy_master_encryption_key().unwrap();
-        println!("You should never see this print");
+        let err = hsm_crypto.destroy_master_encryption_key().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn no_create_certificate_api_fail() {
         let props = CertificateProperties::default();
         let hsm_crypto = fake_no_if_hsm_crypto();
-        let result = hsm_crypto.create_certificate(&props).unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_crypto.create_certificate(&props).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn no_trust_bundle_api_fail() {
         let hsm_crypto = fake_no_if_hsm_crypto();
-        let result = hsm_crypto.get_trust_bundle().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_crypto.get_trust_bundle().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn no_encrypt_api_fail() {
         let client_id = b"client_id";
         let plaintext = b"plaintext";
         let initialization_vector = b"initialization_vector";
         let hsm_crypto = fake_no_if_hsm_crypto();
-        let result = hsm_crypto
+        let err = hsm_crypto
             .encrypt(client_id, plaintext, initialization_vector)
-            .unwrap();
-        println!("You should never see this print {:?}", result);
+            .unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn no_decrypt_api_fail() {
         let client_id = b"client_id";
         let ciphertext = b"ciphertext";
         let initialization_vector = b"initialization_vector";
         let hsm_crypto = fake_no_if_hsm_crypto();
-        let result = hsm_crypto
+        let err = hsm_crypto
             .encrypt(client_id, ciphertext, initialization_vector)
-            .unwrap();
-        println!("You should never see this print {:?}", result);
+            .unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
+
     fn fake_bad_hsm_crypto() -> Crypto {
         Crypto {
             handle: unsafe { fake_handle_create_bad() },
@@ -1141,65 +1142,66 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn hsm_get_random_bytes_errors() {
         let hsm_crypto = fake_bad_hsm_crypto();
         let mut test_array = [0_u8; 4];
-        hsm_crypto.get_random_bytes(&mut test_array).unwrap();
-        println!("You should never see this print");
+        let err = hsm_crypto.get_random_bytes(&mut test_array).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn hsm_create_master_encryption_key_errors() {
         let hsm_crypto = fake_bad_hsm_crypto();
-        hsm_crypto.create_master_encryption_key().unwrap();
-        println!("You should never see this print");
+        let err = hsm_crypto.create_master_encryption_key().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn hsm_destroy_master_encryption_key_errors() {
         let hsm_crypto = fake_bad_hsm_crypto();
-        hsm_crypto.destroy_master_encryption_key().unwrap();
-        println!("You should never see this print");
+        let err = hsm_crypto.destroy_master_encryption_key().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API returned an invalid null response")]
     fn hsm_create_certificate_errors() {
         let hsm_crypto = fake_bad_hsm_crypto();
         let props = CertificateProperties::default();
-
-        let result = hsm_crypto.create_certificate(&props).unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_crypto.create_certificate(&props).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("HSM API returned an invalid null response")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API returned an invalid null response")]
     fn hsm_get_trust_bundle_errors() {
         let hsm_crypto = fake_bad_hsm_crypto();
-        let result = hsm_crypto.get_trust_bundle().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_crypto.get_trust_bundle().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("HSM API returned an invalid null response")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn hsm_encrypt_errors() {
         let hsm_crypto = fake_bad_hsm_crypto();
-        let result = hsm_crypto
+        let err = hsm_crypto
             .encrypt(b"client_id", b"plaintext", b"init_vector")
-            .unwrap();
-        println!("You should never see this print {:?}", result);
+            .unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn hsm_decrypt_errors() {
         let hsm_crypto = fake_bad_hsm_crypto();
-        let result = hsm_crypto
+        let err = hsm_crypto
             .decrypt(b"client_id", b"ciphertext", b"init_vector")
-            .unwrap();
-        println!("You should never see this print {:?}", result);
+            .unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
 
     fn fake_good_hsm_crypto() -> Crypto {

--- a/edgelet/hsm-rs/src/tpm.rs
+++ b/edgelet/hsm-rs/src/tpm.rs
@@ -379,49 +379,49 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn tpm_no_activate_function_fail() {
         let hsm_tpm = fake_no_if_tpm_hsm();
         let key = b"key data";
-        hsm_tpm.activate_identity_key(key).unwrap();
-        println!("You should never see this print");
+        let err = hsm_tpm.activate_identity_key(key).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn tpm_no_getek_function_fail() {
         let hsm_tpm = fake_no_if_tpm_hsm();
-        let result = hsm_tpm.get_ek().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_tpm.get_ek().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn tpm_no_getsrk_function_fail() {
         let hsm_tpm = fake_no_if_tpm_hsm();
-        let result = hsm_tpm.get_srk().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_tpm.get_srk().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn tpm_no_sign_function_fail() {
         let hsm_tpm = fake_no_if_tpm_hsm();
         let key = b"key data";
-        let result = hsm_tpm.sign_with_identity(key).unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_tpm.sign_with_identity(key).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn tpm_no_derive_and_sign_function_fail() {
         let hsm_tpm = fake_no_if_tpm_hsm();
         let key = b"key data";
         let identity = b"identity";
-        let result = hsm_tpm
+        let err = hsm_tpm
             .derive_and_sign_with_identity(key, identity)
-            .unwrap();
-        println!("You should never see this print {:?}", result);
+            .unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     fn fake_good_tpm_hsm() -> Tpm {
@@ -442,7 +442,6 @@ mod tests {
 
     #[test]
     #[allow(clippy::let_unit_value)]
-
     fn tpm_success() {
         let hsm_tpm = fake_good_tpm_hsm();
         let k1 = b"A fake key";
@@ -485,47 +484,48 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn tpm_activate_identity_errors() {
         let hsm_tpm = fake_bad_tpm_hsm();
         let k1 = b"A fake key";
-        hsm_tpm.activate_identity_key(k1).unwrap();
-        println!("You should never see this print");
+        let err = hsm_tpm.activate_identity_key(k1).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn tpm_getek_errors() {
         let hsm_tpm = fake_bad_tpm_hsm();
-        let result = hsm_tpm.get_ek().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_tpm.get_ek().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn tpm_getsrk_errors() {
         let hsm_tpm = fake_bad_tpm_hsm();
-        let result = hsm_tpm.get_srk().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_tpm.get_srk().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn tpm_sign_errors() {
         let hsm_tpm = fake_bad_tpm_hsm();
         let k1 = b"A fake buffer";
-        let result = hsm_tpm.sign_with_identity(k1).unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_tpm.sign_with_identity(k1).unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API failure occurred")]
     fn tpm_derive_and_sign_errors() {
         let hsm_tpm = fake_bad_tpm_hsm();
         let k1 = b"A fake buffer";
         let identity = b"an identity";
-        let result = hsm_tpm.derive_and_sign_with_identity(k1, identity).unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_tpm
+            .derive_and_sign_with_identity(k1, identity)
+            .unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API failure occurred")));
     }
-
 }

--- a/edgelet/hsm-rs/src/x509.rs
+++ b/edgelet/hsm-rs/src/x509.rs
@@ -398,35 +398,35 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn x509_no_getcert_function_fail() {
         let hsm_x509 = fake_no_if_x509_hsm();
-        let result = hsm_x509.get_cert().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_x509.get_cert().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn x509_no_getkey_function_fail() {
         let hsm_x509 = fake_no_if_x509_hsm();
-        let result = hsm_x509.get_key().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_x509.get_key().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn x509_no_getname_function_fail() {
         let hsm_x509 = fake_no_if_x509_hsm();
-        let result = hsm_x509.get_common_name().unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_x509.get_common_name().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API Not Implemented")]
     fn x509_no_sign_with_private_key_function_fail() {
         let hsm_x509 = fake_no_if_x509_hsm();
-        let result = hsm_x509.sign_with_private_key(b"aabb").unwrap();
-        println!("You should never see this print {:?}", result);
+        let err = hsm_x509.sign_with_private_key(b"aabb").unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM API Not Implemented")));
     }
 
     fn fake_good_x509_hsm() -> X509 {
@@ -509,44 +509,46 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "HSM API returned an invalid null response")]
     fn get_cert_null() {
         let hsm_x509 = fake_bad_x509_hsm();
-        let result1 = hsm_x509.get_cert().unwrap();
-        let string1 = &result1;
-        assert!(string1.is_null());
+        let err = hsm_x509.get_cert().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("HSM API returned an invalid null response")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API returned an invalid null response")]
     fn get_key_null() {
         let hsm_x509 = fake_bad_x509_hsm();
-        let result2 = hsm_x509.get_key().unwrap();
-        let string2 = &result2;
-        assert!(string2.is_null());
+        let err = hsm_x509.get_key().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("HSM API returned an invalid null response")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API returned an invalid null response")]
     fn common_name_error() {
         let hsm_x509 = fake_bad_x509_hsm();
-        let result3 = hsm_x509.get_common_name().unwrap();
-        println!("This string should not be displayed {:?}", result3);
+        let err = hsm_x509.get_common_name().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("HSM API returned an invalid null response")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM API sign with private key failed")]
     fn sign_with_private_key_error() {
         let hsm_x509 = fake_bad_x509_hsm();
-        let result = hsm_x509.sign_with_private_key(b"aabbcc").unwrap();
-        println!("This string should not be displayed {:?}", result);
+        let err = hsm_x509.sign_with_private_key(b"aabbcc").unwrap_err();
+        assert!(failure::Fail::iter_chain(&err).any(|err| err
+            .to_string()
+            .contains("HSM API sign with private key failed")));
     }
 
     #[test]
-    #[should_panic(expected = "HSM certificate info get failed")]
     fn get_certificate_info_error() {
         let hsm_x509 = fake_bad_x509_hsm();
-        let result = hsm_x509.get_certificate_info().unwrap();
-        println!("This string should not be displayed {:?}", result);
+        let err = hsm_x509.get_certificate_info().unwrap_err();
+        assert!(failure::Fail::iter_chain(&err)
+            .any(|err| err.to_string().contains("HSM certificate info get failed")));
     }
 }

--- a/edgelet/tokio-named-pipe/Cargo.toml
+++ b/edgelet/tokio-named-pipe/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2018"
 futures = "0.1"
 mio-named-pipes = "0.1"
 tokio = "0.1"
-winapi = { version = "0.3.5", features = ["namedpipeapi"] }
+winapi = { version = "0.3.5", features = ["namedpipeapi", "winerror"] }
 
 [dev-dependencies]
 mio = "0.6"

--- a/edgelet/tokio-named-pipe/tests/smoke.rs
+++ b/edgelet/tokio-named-pipe/tests/smoke.rs
@@ -39,7 +39,9 @@ fn server() -> (NamedPipe, String) {
 fn connect_invalid_path() {
     let err = PipeStream::connect(r"\\.\pipe\boo", None).unwrap_err();
     #[allow(clippy::cast_sign_loss)]
-    assert_eq!(err.raw_os_error().unwrap() as u32, ERROR_FILE_NOT_FOUND);
+    {
+        assert_eq!(err.raw_os_error().unwrap() as u32, ERROR_FILE_NOT_FOUND);
+    }
 }
 
 #[test]

--- a/edgelet/tokio-named-pipe/tests/smoke.rs
+++ b/edgelet/tokio-named-pipe/tests/smoke.rs
@@ -15,6 +15,7 @@ use mio_named_pipes::NamedPipe;
 use rand::Rng;
 use tokio::codec::{FramedRead, FramedWrite, LinesCodec};
 use tokio::io as tio;
+use winapi::shared::winerror::ERROR_FILE_NOT_FOUND;
 
 use tokio_named_pipe::PipeStream;
 
@@ -35,9 +36,10 @@ fn server() -> (NamedPipe, String) {
 }
 
 #[test]
-#[should_panic(expected = "The system cannot find the file specified")]
 fn connect_invalid_path() {
-    let _stream = PipeStream::connect(r"\\.\pipe\boo", None).unwrap();
+    let err = PipeStream::connect(r"\\.\pipe\boo", None).unwrap_err();
+    #[allow(clippy::cast_sign_loss)]
+    assert_eq!(err.raw_os_error().unwrap() as u32, ERROR_FILE_NOT_FOUND);
 }
 
 #[test]


### PR DESCRIPTION
The original code would create a TcpListener and throw it away, which meant
that multiple calls to `get_unused_port` could end up with the same port.

Also, enable all the edgelet-docker tests that had been disabled on Windows
due to the original issue (even though it was not a Windows-specific problem).

However this means that the number of tests in the edgelet-docker crate running
at the same time is much higher, so it's more likely for the tests to hit
the issue described in https://github.com/rust-lang/backtrace-rs/issues/230#issuecomment-521036540
Specifically, any test that panics at the same time as another test is
using `failure` to collect a backtrace has a chance of crashing the entire
test binary with STATUS_HEAP_CORRUPTION on Windows, if the `RUST_BACKTRACE`
env var is set.

To avoid this, I've modified the tests that assert that an operation must fail
via `#[should_panic]` + `Result::unwrap` to instead use `Result::unwrap_err`
I've only done this for edgelet-docker since it has a large number of
concurrent tests so it has a very high chance of hitting this, in comparison to
the other crates that use `#[should_panic]`