### PR TITLE
Handle different ProgramData path in long haul and stress test

### DIFF
--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -20,15 +20,17 @@ steps:
 - pwsh: |
     # We care about three cases:
     # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
-    if ('$(Build.TriggeredBy.DefinitionName)' -eq '$(azure.pipeline.packages)')
+    if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.packages)')
     {
+      Write-Output "Triggered by build '$(az.pipeline.packages)' \#$(Build.TriggeredBy.BuildId)"
       Write-Output '##vso[task.setvariable variable=whichPackageBuild]specific'
       Write-Output '##vso[task.setvariable variable=whichImageBuild]latestFromBranch'
       Write-Output '##vso[task.setvariable variable=packageBuildId]$(Build.TriggeredBy.BuildId)'
     }
     # 2) 'Build Images' build triggered this build (use latest 'Edgelet Packages' build on master)
-    elseif ('$(Build.TriggeredBy.DefinitionName)' -eq '$(azure.pipeline.images)')
+    elseif ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.images)')
     {
+      Write-Output "Triggered by build '$(az.pipeline.images)' \#$(Build.TriggeredBy.BuildId)"
       Write-Output '##vso[task.setvariable variable=whichPackageBuild]latestFromBranch'
       Write-Output '##vso[task.setvariable variable=whichImageBuild]specific'
       Write-Output '##vso[task.setvariable variable=imageBuildId]$(Build.TriggeredBy.BuildId)'
@@ -43,15 +45,15 @@ steps:
     }
     else # Error
     {
-      if ('$(Build.TriggeredBy.DefinitionName)' -ne '')
+      if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME)
       {
-        Write-Output "Build triggered by unrecognized build '$(Build.TriggeredBy.DefinitionName)'"
+        Write-Output "Build triggered by unrecognized build '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
       }
       else
       {
         Write-Output "Missing build parameter 'az.pipeline.packages.buildId' or 'az.pipeline.images.buildId'"
       }
-      return 1
+      exit 1
     }
   displayName: Locate edgelet packages, runtime images
 

--- a/e2e_deployment_files/long_haul_deployment.template.windows.json
+++ b/e2e_deployment_files/long_haul_deployment.template.windows.json
@@ -188,7 +188,7 @@
             },
             "settings": {
               "image": "<Container_Registry>/microsoft/snitcher:<Snitch.BuildNumber>-windows-<Architecture>",
-              "createOptions": "{\"HostConfig\":{\"Binds\":[\"C:\\\\ProgramData\\\\iotedge\\\\mgmt:C:\\\\ProgramData\\\\iotedge\\\\mgmt\"]}}"
+              "createOptions": "{\"HostConfig\":{\"Binds\":[<Snitch.Binds>]}}"
             }
           },
           "analyzer": {

--- a/e2e_deployment_files/long_haul_deployment.template.windows.json
+++ b/e2e_deployment_files/long_haul_deployment.template.windows.json
@@ -183,12 +183,12 @@
                 "value": "snitcher=info"
               },
               "MANAGEMENT_URI": {
-                "value": "unix:///C:/ProgramData/iotedge/mgmt/sock"
+                "value": "<Management.Uri>"
               }
             },
             "settings": {
               "image": "<Container_Registry>/microsoft/snitcher:<Snitch.BuildNumber>-windows-<Architecture>",
-              "createOptions": "{\"HostConfig\":{\"Binds\":[<Snitch.Binds>]}}"
+              "createOptions": "{\"HostConfig\":{\"Binds\":[\"C:\\\\ProgramData\\\\iotedge\\\\mgmt:C:\\\\ProgramData\\\\iotedge\\\\mgmt\"]}}"
             }
           },
           "analyzer": {

--- a/e2e_deployment_files/stress_deployment.template.windows.json
+++ b/e2e_deployment_files/stress_deployment.template.windows.json
@@ -153,7 +153,7 @@
                 "value": "snitcher=info"
               },
               "MANAGEMENT_URI": {
-                "value": "unix:///C:/ProgramData/iotedge/mgmt/sock"
+                "value": "<Management.Uri>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.windows.json
+++ b/e2e_deployment_files/stress_deployment.template.windows.json
@@ -158,7 +158,7 @@
             },
             "settings": {
               "image": "<Container_Registry>/microsoft/snitcher:<Snitch.BuildNumber>-windows-<Architecture>",
-              "createOptions": "{\"HostConfig\":{\"Binds\":[\"C:\\\\ProgramData\\\\iotedge\\\\mgmt:C:\\\\ProgramData\\\\iotedge\\\\mgmt\"]}}"
+              "createOptions": "{\"HostConfig\":{\"Binds\":[<Snitch.Binds>]}}"
             }
           },
           "analyzer": {

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -444,6 +444,8 @@ Function PrepareTestFromArtifacts
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.TestDurationInSecs>',$SnitchTestDurationInSecs) | Set-Content $DeploymentWorkingFilePath
                 $SnitcherBinds = "\""$($env:ProgramData.Replace("\", "\\\\"))\\\\iotedge\\\\mgmt:$($env:ProgramData.Replace("\", "\\\\"))\\\\iotedge\\\\mgmt\"""
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.Binds>',$SnitcherBinds) | Set-Content $DeploymentWorkingFilePath
+                $ManagementUri = "unix:///$($env:ProgramData.Replace("\", "/"))/iotedge/mgmt/sock"
+                (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.Binds>',$SnitcherBinds) | Set-Content $DeploymentWorkingFilePath
             }
             "TempFilter"
             {

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -445,7 +445,7 @@ Function PrepareTestFromArtifacts
                 $SnitcherBinds = "\""$($env:ProgramData.Replace("\", "\\\\"))\\\\iotedge\\\\mgmt:$($env:ProgramData.Replace("\", "\\\\"))\\\\iotedge\\\\mgmt\"""
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.Binds>',$SnitcherBinds) | Set-Content $DeploymentWorkingFilePath
                 $ManagementUri = "unix:///$($env:ProgramData.Replace("\", "/"))/iotedge/mgmt/sock"
-                (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.Binds>',$SnitcherBinds) | Set-Content $DeploymentWorkingFilePath
+                (Get-Content $DeploymentWorkingFilePath).replace('<Management.Uri>',$ManagementUri) | Set-Content $DeploymentWorkingFilePath
             }
             "TempFilter"
             {

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -442,6 +442,8 @@ Function PrepareTestFromArtifacts
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.StorageAccount>',$SnitchStorageAccount) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.StorageMasterKey>',$SnitchStorageMasterKey) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.TestDurationInSecs>',$SnitchTestDurationInSecs) | Set-Content $DeploymentWorkingFilePath
+                $SnitcherBinds = "\""$($env:ProgramData.Replace("\", "\\\\"))\\\\iotedge\\\\mgmt:$($env:ProgramData.Replace("\", "\\\\"))\\\\iotedge\\\\mgmt\"""
+                (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.Binds>',$SnitcherBinds) | Set-Content $DeploymentWorkingFilePath
             }
             "TempFilter"
             {


### PR DESCRIPTION
Update e2e test script to use ProgramData environment variable to set binds in deployment json for long haul and stress test.