### PR TITLE
EdgeHub: Fix receiving messages over MQTT

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubMessageRejectedException.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubMessageRejectedException.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System;
+
+    public class EdgeHubMessageRejectedException : Exception
+    {
+        public EdgeHubMessageRejectedException(string message)
+            : base(message)
+        {
+        }
+    }
+}

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
                 }
                 else
                 {
-                    taskCompletionSource.SetException(new EdgeHubIOException($"Message not completed by client {this.Identity.Id}"));
+                    taskCompletionSource.SetException(new EdgeHubMessageRejectedException($"Message not completed by client {this.Identity.Id}"));
                 }
             }
             else if (this.c2dMessageTaskCompletionSources.TryRemove(messageId, out bool value) && value)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -154,8 +154,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                     : Constants.DownstreamOriginInterface;
                 message.SystemProperties[SystemProperties.EdgeHubOriginInterface] = edgeHubOriginInterface;
             }
-
-            message.SystemProperties[SystemProperties.EnqueuedTime] = DateTime.UtcNow.ToString("o");
         }
 
         static void ValidateMessageSize(IRoutingMessage messageToBeValidated)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
@@ -68,9 +68,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
         {
             message.SystemProperties.TryGetValue(SystemProperties.LockToken, out string lockToken);
 
-            // ProtocolGateway rejects messages that have creation time < subscription time.
-            // Since EdgeHub buffers messages, this does not work well, since older messages will get rejected.
-            // So always set the creation time to UtcNow. This is inline with the current EdgeHub behavior.
             DateTime createdTimeUtc = DateTime.UtcNow;
             if (message.SystemProperties.TryGetValue(SystemProperties.EnqueuedTime, out string createdTime))
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
@@ -68,11 +68,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
         {
             message.SystemProperties.TryGetValue(SystemProperties.LockToken, out string lockToken);
 
+            // ProtocolGateway rejects messages that have creation time < subscription time.
+            // Since EdgeHub buffers messages, this does not work well, since older messages will get rejected.
+            // So always set the creation time to UtcNow. This is inline with the current EdgeHub behavior.
             DateTime createdTimeUtc = DateTime.UtcNow;
-            if (message.SystemProperties.TryGetValue(SystemProperties.EnqueuedTime, out string createdTime))
-            {
-                createdTimeUtc = DateTime.Parse(createdTime, null, DateTimeStyles.RoundtripKind);
-            }
 
             if (!message.SystemProperties.TryGetValue(SystemProperties.OutboundUri, out string uriTemplateKey))
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
@@ -72,6 +72,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             // Since EdgeHub buffers messages, this does not work well, since older messages will get rejected.
             // So always set the creation time to UtcNow. This is inline with the current EdgeHub behavior.
             DateTime createdTimeUtc = DateTime.UtcNow;
+            if (message.SystemProperties.TryGetValue(SystemProperties.EnqueuedTime, out string createdTime))
+            {
+                createdTimeUtc = DateTime.Parse(createdTime, null, DateTimeStyles.RoundtripKind);
+            }
 
             if (!message.SystemProperties.TryGetValue(SystemProperties.OutboundUri, out string uriTemplateKey))
             {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/ProtocolGatewayMessageConverterTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/ProtocolGatewayMessageConverterTest.cs
@@ -242,6 +242,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Assert.Equal("fromDevice1", pgMessage.Properties["$.cdid"]);
             Assert.Equal("fromModule1", pgMessage.Properties["$.cmid"]);
             Assert.False(pgMessage.Properties.ContainsKey("$.on"));
+            Assert.True(DateTime.UtcNow - pgMessage.CreatedTimeUtc < TimeSpan.FromSeconds(3));
         }
 
         [Fact]


### PR DESCRIPTION
Issue: ProtocolGateway rejects messages if the message creation time is > Subscription time. 
This worked fine till now since the Message creation time was always set to UtcNow. But because of a change elsewhere in the codebase, this started getting set to EnqueuedTime. So in some cases, if the subscription came after the message was enqueued, the message was rejected by the PG. 
One other issue was that the EdgeHub treated rejected messages as retryable, so it kept retrying the same message. 

Fix: 
- Set message creation time for all messages sent to PG to DateTime.UtcNow
- Discard rejected messages.