### PR TITLE
Update Stress template yaml for IoT Core

### DIFF
--- a/builds/e2e/templates/deploy-iotuap.yaml
+++ b/builds/e2e/templates/deploy-iotuap.yaml
@@ -16,9 +16,9 @@ parameters:
   mqtt.settings.enabled: 'true'
   loadGen.message.frequency: ''
   loadGen1.transportType: 'Amqp_Tcp_Only'
-  loadGen2.transportType: 'Amqp_WebSocket_Only'
+  loadGen2.transportType: 'Amqp_Tcp_Only'
   loadGen3.transportType: 'Mqtt_Tcp_Only'
-  loadGen4.transportType: 'Mqtt_WebSocket_Only'
+  loadGen4.transportType: 'Mqtt_Tcp_Only'
 
 steps:
   - task: CopyFiles@2


### PR DESCRIPTION
Update Stress test to run on non-web socket protocols for Windows IoT Core, like Windows 10 x64 and Server Core x64.