### PR TITLE
Show certificate expiry in self-signed certs warning

### DIFF
--- a/edgelet/hsm-sys/azure-iot-hsm-c/src/constants.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/src/constants.c
@@ -30,4 +30,6 @@ const char* const EDGE_CA_ALIAS = "iotedged_ca";
 const char* const EDGE_CA_COMMON_NAME = "Test Iotedge CA";
 const char* const EDGE_DEVICE_ALIAS = "edgelet_device";
 
+// Note: `iotedge check` has a warning message that references the 90-day expiry in `fn settings_certificates`.
+// Update that when changing the value here.
 const uint64_t CA_VALIDITY = 90 * 24 * 3600; // 90 days

--- a/edgelet/iotedge/src/check/mod.rs
+++ b/edgelet/iotedge/src/check/mod.rs
@@ -212,6 +212,7 @@ pub struct Check {
     docker_host_arg: Option<String>,
     docker_server_version: Option<String>,
     iothub_hostname: Option<String>,
+    device_ca_cert_path: Option<PathBuf>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -367,6 +368,7 @@ impl Check {
                 docker_host_arg: None,
                 docker_server_version: None,
                 iothub_hostname,
+                device_ca_cert_path: None,
             })
         }))
     }
@@ -1275,26 +1277,6 @@ fn container_engine_dns(check: &mut Check) -> Result<CheckResult, failure::Error
     Ok(CheckResult::Ok)
 }
 
-fn settings_certificates(check: &mut Check) -> Result<CheckResult, failure::Error> {
-    let settings = if let Some(settings) = &check.settings {
-        settings
-    } else {
-        return Ok(CheckResult::Skipped);
-    };
-
-    if settings.certificates().is_none() {
-        return Ok(CheckResult::Warning(
-            Context::new(
-                "Device is using self-signed, automatically generated certs.\n\
-                 Please see https://aka.ms/iotedge-prod-checklist-certs for best practices.",
-            )
-            .into(),
-        ));
-    }
-
-    Ok(CheckResult::Ok)
-}
-
 fn settings_identity_certificates_expiry(check: &mut Check) -> Result<CheckResult, failure::Error> {
     let settings = if let Some(settings) = &check.settings {
         settings
@@ -1305,53 +1287,98 @@ fn settings_identity_certificates_expiry(check: &mut Check) -> Result<CheckResul
     if let Provisioning::Dps(dps) = settings.provisioning() {
         if let AttestationMethod::X509(x509_info) = dps.attestation() {
             let path = x509_info.identity_cert()?;
-            check_certificate_expiry(path)
-        } else {
-            Ok(CheckResult::Skipped)
+            return CertificateValidity::parse("DPS identity certificate", &path)?
+                .to_check_result();
         }
-    } else {
-        Ok(CheckResult::Skipped)
     }
+
+    Ok(CheckResult::Ignored)
 }
 
-fn settings_certificates_expiry(check: &mut Check) -> Result<CheckResult, failure::Error> {
+fn settings_certificates(check: &mut Check) -> Result<CheckResult, failure::Error> {
     let settings = if let Some(settings) = &check.settings {
         settings
     } else {
         return Ok(CheckResult::Skipped);
     };
 
-    let device_ca_cert_path = if let Some(certificates) = settings.certificates() {
-        let path = certificates.device_ca_cert()?;
-        path.to_owned()
-    } else {
-        let certs_dir = settings.homedir().join("hsm").join("certs");
+    check.device_ca_cert_path = Some({
+        if let Some(certificates) = settings.certificates() {
+            certificates.device_ca_cert()?
+        } else {
+            let certs_dir = settings.homedir().join("hsm").join("certs");
 
-        let mut device_ca_cert_path = None;
+            let mut device_ca_cert_path = None;
 
-        let entries = std::fs::read_dir(&certs_dir)
-            .with_context(|_| format!("Could not enumerate files under {}", certs_dir.display()))?;
-        for entry in entries {
-            let entry = entry.with_context(|_| {
+            let entries = std::fs::read_dir(&certs_dir).with_context(|_| {
                 format!("Could not enumerate files under {}", certs_dir.display())
             })?;
-            let path = entry.path();
-            if let Some(file_name) = path.file_name().and_then(OsStr::to_str) {
-                if file_name.starts_with("device_ca_alias") && file_name.ends_with(".cert.pem") {
-                    device_ca_cert_path = Some(path);
-                    break;
+            for entry in entries {
+                let entry = entry.with_context(|_| {
+                    format!("Could not enumerate files under {}", certs_dir.display())
+                })?;
+                let path = entry.path();
+                if let Some(file_name) = path.file_name().and_then(OsStr::to_str) {
+                    if file_name.starts_with("device_ca_alias") && file_name.ends_with(".cert.pem")
+                    {
+                        device_ca_cert_path = Some(path);
+                        break;
+                    }
                 }
             }
-        }
 
-        device_ca_cert_path.ok_or_else(|| {
-            Context::new(format!(
-                "Could not find device CA certificate under {}",
-                certs_dir.display(),
-            ))
-        })?
+            device_ca_cert_path.ok_or_else(|| {
+                Context::new(format!(
+                    "Could not find device CA certificate under {}",
+                    certs_dir.display(),
+                ))
+            })?
+        }
+    });
+
+    if settings.certificates().is_none() {
+        let CertificateValidity { not_after, .. } = CertificateValidity::parse(
+            "Device CA certificate",
+            check.device_ca_cert_path.as_ref().unwrap(),
+        )?;
+
+        let now = chrono::Utc::now();
+
+        if not_after < now {
+            return Ok(CheckResult::Warning(
+                Context::new(format!(
+                    "The Edge device is using self-signed automatically-generated development certificates.\n\
+                     The certs expired at {}. Restart the IoT Edge daemon to generate new development certs with 90-day expiry.\n\
+                     Please consider using production certificates instead. See https://aka.ms/iotedge-prod-checklist-certs for best practices.",
+                    not_after,
+                ))
+                .into(),
+            ));
+        } else {
+            return Ok(CheckResult::Warning(
+                Context::new(format!(
+                    "The Edge device is using self-signed automatically-generated development certificates.\n\
+                     They will expire in {} days (at {}) causing module-to-module and downstream device communication to fail on an active deployment.\n\
+                     After the certs have expired, restarting the IoT Edge daemon will trigger it to generate new development certs with 90-day expiry.\n\
+                     Please consider using production certificates instead. See https://aka.ms/iotedge-prod-checklist-certs for best practices.",
+                    (not_after - now).num_days(), not_after,
+                ))
+                .into(),
+            ));
+        }
+    }
+
+    Ok(CheckResult::Ok)
+}
+
+fn settings_certificates_expiry(check: &mut Check) -> Result<CheckResult, failure::Error> {
+    let device_ca_cert_path = if let Some(device_ca_cert_path) = &check.device_ca_cert_path {
+        device_ca_cert_path
+    } else {
+        return Ok(CheckResult::Skipped);
     };
-    check_certificate_expiry(device_ca_cert_path)
+
+    CertificateValidity::parse("Device CA certificate", &device_ca_cert_path)?.to_check_result()
 }
 
 fn settings_moby_runtime_uri(check: &mut Check) -> Result<CheckResult, failure::Error> {
@@ -1536,7 +1563,6 @@ fn storage_mounted_from_host(
             Context::new(format!(
                 "The {} module is not configured to persist its {} directory on the host filesystem.\n\
                  Data might be lost if the module is deleted or updated.\n\
-                 \n\
                  Please see https://aka.ms/iotedge-storage-host for best practices.",
                 container_name,
                 storage_directory.display(),
@@ -1723,69 +1749,88 @@ fn edge_hub_ports_on_host(check: &mut Check) -> Result<CheckResult, failure::Err
     Ok(CheckResult::Ok)
 }
 
-fn check_certificate_expiry(cert_path: PathBuf) -> Result<CheckResult, failure::Error> {
-    fn parse_openssl_time(
-        time: &openssl::asn1::Asn1TimeRef,
-    ) -> chrono::ParseResult<chrono::DateTime<chrono::Utc>> {
-        // openssl::asn1::Asn1TimeRef does not expose any way to convert the ASN1_TIME to a Rust-friendly type
-        //
-        // Its Display impl uses ASN1_TIME_print, so we convert it into a String and parse it back
-        // into a chrono::DateTime<chrono::Utc>
-        let time = time.to_string();
-        let time = chrono::NaiveDateTime::parse_from_str(&time, "%b %e %H:%M:%S %Y GMT")?;
-        Ok(chrono::DateTime::<chrono::Utc>::from_utc(time, chrono::Utc))
-    }
+#[derive(Debug)]
+struct CertificateValidity<'a> {
+    cert_name: &'a str,
+    cert_path: &'a Path,
+    not_after: chrono::DateTime<chrono::Utc>,
+    not_before: chrono::DateTime<chrono::Utc>,
+}
 
-    let cert_path_source = cert_path.to_string_lossy().into_owned();
-    let (not_after, not_before) = File::open(cert_path)
-        .map_err(failure::Error::from)
-        .and_then(|mut device_ca_cert_file| {
-            let mut device_ca_cert = vec![];
-            device_ca_cert_file.read_to_end(&mut device_ca_cert)?;
-            let device_ca_cert = openssl::x509::X509::stack_from_pem(&device_ca_cert)?;
-            let device_ca_cert = &device_ca_cert[0];
+impl<'a> CertificateValidity<'a> {
+    fn parse(cert_name: &'a str, cert_path: &'a Path) -> Result<Self, failure::Error> {
+        fn parse_openssl_time(
+            time: &openssl::asn1::Asn1TimeRef,
+        ) -> chrono::ParseResult<chrono::DateTime<chrono::Utc>> {
+            // openssl::asn1::Asn1TimeRef does not expose any way to convert the ASN1_TIME to a Rust-friendly type
+            //
+            // Its Display impl uses ASN1_TIME_print, so we convert it into a String and parse it back
+            // into a chrono::DateTime<chrono::Utc>
+            let time = time.to_string();
+            let time = chrono::NaiveDateTime::parse_from_str(&time, "%b %e %H:%M:%S %Y GMT")?;
+            Ok(chrono::DateTime::<chrono::Utc>::from_utc(time, chrono::Utc))
+        }
 
-            let not_after = parse_openssl_time(device_ca_cert.not_after())?;
-            let not_before = parse_openssl_time(device_ca_cert.not_before())?;
+        let (not_after, not_before) = File::open(cert_path)
+            .map_err(failure::Error::from)
+            .and_then(|mut device_ca_cert_file| {
+                let mut device_ca_cert = vec![];
+                device_ca_cert_file.read_to_end(&mut device_ca_cert)?;
+                let device_ca_cert = openssl::x509::X509::stack_from_pem(&device_ca_cert)?;
+                let device_ca_cert = &device_ca_cert[0];
 
-            Ok((not_after, not_before))
+                let not_after = parse_openssl_time(device_ca_cert.not_after())?;
+                let not_before = parse_openssl_time(device_ca_cert.not_before())?;
+
+                Ok((not_after, not_before))
+            })
+            .with_context(|_| {
+                format!(
+                    "Could not parse {} as a valid certificate file",
+                    cert_path.display(),
+                )
+            })?;
+
+        Ok(CertificateValidity {
+            cert_name,
+            cert_path,
+            not_after,
+            not_before,
         })
-        .with_context(|_| {
-            format!(
-                "Could not parse {} as a valid certificate file",
-                cert_path_source,
-            )
-        })?;
-
-    let now = chrono::Utc::now();
-
-    if not_before > now {
-        return Err(Context::new(format!(
-            "Device CA certificate in {} has not-before time {} which is in the future",
-            cert_path_source, not_before,
-        ))
-        .into());
     }
 
-    if not_after < now {
-        return Err(Context::new(format!(
-            "Device CA certificate in {} expired at {}",
-            cert_path_source, not_after,
-        ))
-        .into());
-    }
+    fn to_check_result(&self) -> Result<CheckResult, failure::Error> {
+        let cert_path_displayable = self.cert_path.display();
 
-    if not_after < now + chrono::Duration::days(7) {
-        return Ok(CheckResult::Warning(
-            Context::new(format!(
-                "Device CA certificate in {} will expire soon ({})",
-                cert_path_source, not_after,
+        let now = chrono::Utc::now();
+
+        if self.not_before > now {
+            Err(Context::new(format!(
+                "{} at {} has not-before time {} which is in the future",
+                self.cert_name, cert_path_displayable, self.not_before,
             ))
-            .into(),
-        ));
+            .into())
+        } else if self.not_after < now {
+            Err(Context::new(format!(
+                "{} at {} expired at {}",
+                self.cert_name, cert_path_displayable, self.not_after,
+            ))
+            .into())
+        } else if self.not_after < now + chrono::Duration::days(7) {
+            Ok(CheckResult::Warning(
+                Context::new(format!(
+                    "{} at {} will expire soon ({}, in {} days)",
+                    self.cert_name,
+                    cert_path_displayable,
+                    self.not_after,
+                    (self.not_after - now).num_days(),
+                ))
+                .into(),
+            ))
+        } else {
+            Ok(CheckResult::Ok)
+        }
     }
-
-    Ok(CheckResult::Ok)
 }
 
 fn docker<I>(docker_host_arg: &str, args: I) -> Result<Vec<u8>, (Option<String>, failure::Error)>

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -186,11 +186,12 @@ const IOTEDGED_VALIDITY: u64 = 7_776_000;
 // 90 days
 const IOTEDGED_COMMONNAME: &str = "iotedged workload ca";
 const IOTEDGED_TLS_COMMONNAME: &str = "iotedged";
-const IOTEDGED_MIN_EXPIRATION_DURATION: i64 = 300;
 // 5 mins
-const IOTEDGE_ID_CERT_MAX_DURATION_SECS: i64 = 7200;
+const IOTEDGED_MIN_EXPIRATION_DURATION: i64 = 5 * 60;
 // 2 hours
-const IOTEDGE_SERVER_CERT_MAX_DURATION_SECS: i64 = 7_776_000; // 90 days
+const IOTEDGE_ID_CERT_MAX_DURATION_SECS: i64 = 2 * 3600;
+// 90 days
+const IOTEDGE_SERVER_CERT_MAX_DURATION_SECS: i64 = 90 * 24 * 3600;
 
 // HSM lib version that the iotedge runtime required
 const IOTEDGE_COMPAT_HSM_VERSION: &str = "1.0.2";


### PR DESCRIPTION
Also fix DPS identity cert expiry check to return Ignored (success)
instead of Skipped (error) if the user is not using DPS X.509 attestation.

Cherry-pick from master of 0486817743ad5428c3e1b1d42a96764b028750c0
and b5b2fac574ba28d561b6bac6318ac27ea5715f36