### PR TITLE
Collect logs after setting up transparent gateway end-to-end tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -83,12 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                         }
                         finally
                         {
-                            string prefix = $"{Context.Current.DeviceId}-{TestContext.CurrentContext.Test.NormalizedName()}";
-                            IEnumerable<string> paths = await EdgeLogs.CollectAsync(startTime, prefix, token);
-                            foreach (string path in paths)
-                            {
-                                TestContext.AddTestAttachment(path);
-                            }
+                            await NUnitLogs.CollectAsync(startTime, token);
                         }
                     }
                 },

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceBase.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceBase.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Test.Common;
@@ -29,6 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
                     using (var cts = new CancellationTokenSource(Context.Current.SetupTimeout))
                     {
+                        DateTime startTime = DateTime.Now;
                         CancellationToken token = cts.Token;
 
                         this.iotHub = new IotHub(
@@ -36,32 +38,50 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                             Context.Current.EventHubEndpoint,
                             proxy);
 
-                        this.ca = await CertificateAuthority.CreateAsync(
-                            deviceId,
-                            rootCa,
-                            Context.Current.CaCertScriptPath,
-                            token);
+                        try
+                        {
+                            this.ca = await CertificateAuthority.CreateAsync(
+                                deviceId,
+                                rootCa,
+                                Context.Current.CaCertScriptPath,
+                                token);
 
-                        this.daemon = OsPlatform.Current.CreateEdgeDaemon(Context.Current.InstallerPath);
-                        await this.daemon.ConfigureAsync(
-                            config =>
+                            this.daemon = OsPlatform.Current.CreateEdgeDaemon(Context.Current.InstallerPath);
+                            await this.daemon.ConfigureAsync(
+                                config =>
+                                {
+                                    config.SetCertificates(this.ca.Certificates);
+                                    config.Update();
+                                    return Task.FromResult(("with edge certificates", Array.Empty<object>()));
+                                },
+                                token);
+
+                            var runtime = new EdgeRuntime(
+                                deviceId,
+                                Context.Current.EdgeAgentImage,
+                                Context.Current.EdgeHubImage,
+                                proxy,
+                                Context.Current.Registries,
+                                Context.Current.OptimizeForPerformance,
+                                this.iotHub);
+
+                            await runtime.DeployConfigurationAsync(token);
+                        }
+
+                        // ReSharper disable once RedundantCatchClause
+                        catch
+                        {
+                            throw;
+                        }
+                        finally
+                        {
+                            string prefix = $"{Context.Current.DeviceId}-{TestContext.CurrentContext.Test.NormalizedName()}";
+                            IEnumerable<string> paths = await EdgeLogs.CollectAsync(startTime, prefix, token);
+                            foreach (string path in paths)
                             {
-                                config.SetCertificates(this.ca.Certificates);
-                                config.Update();
-                                return Task.FromResult(("with edge certificates", Array.Empty<object>()));
-                            },
-                            token);
-
-                        var runtime = new EdgeRuntime(
-                            deviceId,
-                            Context.Current.EdgeAgentImage,
-                            Context.Current.EdgeHubImage,
-                            proxy,
-                            Context.Current.Registries,
-                            Context.Current.OptimizeForPerformance,
-                            this.iotHub);
-
-                        await runtime.DeployConfigurationAsync(token);
+                                TestContext.AddTestAttachment(path);
+                            }
+                        }
                     }
                 },
                 "Completed custom certificate setup");

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceBase.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceBase.cs
@@ -75,12 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                         }
                         finally
                         {
-                            string prefix = $"{Context.Current.DeviceId}-{TestContext.CurrentContext.Test.NormalizedName()}";
-                            IEnumerable<string> paths = await EdgeLogs.CollectAsync(startTime, prefix, token);
-                            foreach (string path in paths)
-                            {
-                                TestContext.AddTestAttachment(path);
-                            }
+                            await NUnitLogs.CollectAsync(startTime, token);
                         }
                     }
                 },

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/NUnitLogs.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/NUnitLogs.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Test.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Test.Common;
+    using NUnit.Framework;
+
+    public static class NUnitLogs
+    {
+        public static async Task CollectAsync(DateTime testStartTime, CancellationToken token)
+        {
+            string prefix = $"{Context.Current.DeviceId}-{TestContext.CurrentContext.Test.NormalizedName()}";
+            IEnumerable<string> paths = await EdgeLogs.CollectAsync(testStartTime, prefix, token);
+            foreach (string path in paths)
+            {
+                TestContext.AddTestAttachment(path);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestBase.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestBase.cs
@@ -39,12 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                     {
                         using (var cts = new CancellationTokenSource(Context.Current.TeardownTimeout))
                         {
-                            string prefix = $"{Context.Current.DeviceId}-{TestContext.CurrentContext.Test.NormalizedName()}";
-                            IEnumerable<string> paths = await EdgeLogs.CollectAsync(this.testStartTime, prefix, cts.Token);
-                            foreach (string path in paths)
-                            {
-                                TestContext.AddTestAttachment(path);
-                            }
+                            await NUnitLogs.CollectAsync(this.testStartTime, cts.Token);
                         }
                     }
                 },


### PR DESCRIPTION
I recently saw a failure in the new end-to-end tests during one-time setup for the device tests (transparent gateway):

```
Starting test execution, please wait...
[21:39:27 INF] [  +0.121s] Created edge device 'e2e-fv-az486-190820-213926.855' on hub 'damon-hub.azure-devices.net'
[21:39:35 INF] [  +7.519s] Uninstalled edge daemon
[21:39:52 INF] [ +16.989s] Installed edge daemon from packages in 'D:\a\1\a\iotedged-windows'
[21:39:52 INF] [  +0.021s] Edge daemon entered the 'running' state
[21:40:33 INF] [ +40.978s] Module 'edgeAgent' entered the 'running' state
[21:40:38 INF] [  +5.397s] Pinged module 'edgeAgent' from the cloud
[21:40:39 INF] [ +72.436s] Completed end-to-end test setup
[21:40:44 INF] [  +2.574s] Created certificates for edge device
[21:40:51 INF] [  +6.455s] Configured edge daemon
[21:40:51 INF] [  +0.148s] Deployed edge configuration to device with modules:
    edgebuilds.azurecr.io/microsoft/azureiotedge-agent:20190820.2-windows-amd64
    edgebuilds.azurecr.io/microsoft/azureiotedge-hub:20190820.2-windows-amd64
[21:45:39 ERR] Encountered exception during task "Modules (edgeAgent, edgeHub) entered the 'running' state": A task was canceled.
[21:45:39 ERR] Encountered exception during task "Completed custom certificate setup": A task was canceled.
```

I realized I can't really see what happened because we don't collect iotedged/edgeAgent/edgeHub logs during this setup phase. We **do** collect logs after the higher-level one-time setup for all tests, and of course after each test case, but not here.

This change adds the logic to collect logs in this missed phase. Also, since there are now three places that collect logs, I created an NUnitLogs class that centralizes the logic to get rid of duplication.