### PR TITLE
Add a task to build iotedged with feature=runtime-kubernetes during checkin.

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -25,6 +25,8 @@ jobs:
         displayName: Check submodules
       - bash: edgelet/build/linux/build.sh
         displayName: Build
+      - bash: edgelet/build/linux/build-k8s.sh
+        displayName: Build (runtime-kubernetes)
       - bash: edgelet/build/linux/test.sh
         displayName: Test
 

--- a/edgelet/build/linux/build-k8s.sh
+++ b/edgelet/build/linux/build-k8s.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+###############################################################################
+# This script builds the project
+###############################################################################
+
+set -e
+
+###############################################################################
+# Define Environment Variables
+###############################################################################
+# Get directory of running script
+DIR=$(cd "$(dirname "$0")" && pwd)
+
+BUILD_REPOSITORY_LOCALPATH=${BUILD_REPOSITORY_LOCALPATH:-$DIR/../../..}
+PROJECT_ROOT=${BUILD_REPOSITORY_LOCALPATH}/edgelet
+IOTEDGED_MANIFEST=${PROJECT_ROOT}/iotedged/Cargo.toml
+SCRIPT_NAME=$(basename "$0")
+CARGO="${CARGO_HOME:-"$HOME/.cargo"}/bin/cargo"
+TOOLCHAIN="stable-x86_64-unknown-linux-gnu"
+RELEASE=
+
+###############################################################################
+# Print usage information pertaining to this script and exit
+###############################################################################
+usage()
+{
+    echo "$SCRIPT_NAME [options]"
+    echo ""
+    echo "options"
+    echo " -h, --help          Print this help and exit."
+    echo " -t, --toolchain     Toolchain (default: stable-x86_64-unknown-linux-gnu)"
+    echo " -r, --release       Release build? (flag, default: false)"
+    exit 1;
+}
+
+###############################################################################
+# Obtain and validate the options supported by this script
+###############################################################################
+process_args()
+{
+    save_next_arg=0
+    for arg in "$@"
+    do
+        if [ $save_next_arg -eq 1 ]; then
+            TOOLCHAIN="$arg"
+            save_next_arg=0
+        elif [ $save_next_arg -eq 2 ]; then
+            RELEASE="true"
+            save_next_arg=0
+        else
+            case "$arg" in
+                "-h" | "--help" ) usage;;
+                "-t" | "--toolchain" ) save_next_arg=1;;
+                "-r" | "--release" ) save_next_arg=2;;
+                * ) usage;;
+            esac
+        fi
+    done
+}
+
+process_args "$@"
+
+if [[ -z ${RELEASE} ]]; then
+    cd "$PROJECT_ROOT" && $CARGO "+$TOOLCHAIN" build --manifest-path=${IOTEDGED_MANIFEST} --no-default-features --features runtime-kubernetes
+else
+    cd "$PROJECT_ROOT" && $CARGO "+$TOOLCHAIN" build --manifest-path=${IOTEDGED_MANIFEST} --no-default-features --features runtime-kubernetes --release
+fi

--- a/edgelet/build/linux/build.sh
+++ b/edgelet/build/linux/build.sh
@@ -7,6 +7,11 @@
 set -e
 
 ###############################################################################
+# These are the packages this script will build.
+###############################################################################
+packages=(iotedge iotedged iotedge-diagnostics iotedge-proxy)
+
+###############################################################################
 # Define Environment Variables
 ###############################################################################
 # Get directory of running script
@@ -78,8 +83,14 @@ codegen-units = 1
 incremental = false
 EOF
 
+PACKAGES=
+for p in "${packages[@]}"
+do
+    PACKAGES="${PACKAGES} -p ${p}"
+done
+
 if [[ -z ${RELEASE} ]]; then
-    cd "$PROJECT_ROOT" && $CARGO "+$TOOLCHAIN" build --all
+    cd "$PROJECT_ROOT" && $CARGO "+$TOOLCHAIN" build ${PACKAGES}
 else
-    cd "$PROJECT_ROOT" && $CARGO "+$TOOLCHAIN" build --all --release
+    cd "$PROJECT_ROOT" && $CARGO "+$TOOLCHAIN" build ${PACKAGES} --release
 fi


### PR DESCRIPTION
In order to make sure changes in one module runtime (Docker) don't break the other module runtime (Kubernetes), I added a step in the linux amd64 Checkin build to build iotedged with the runtime-kubernetes feature turned on.