### PR TITLE
remove debug log to print connection string

### DIFF
--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -285,7 +285,7 @@ namespace IotEdgeQuickstart.Details
                 {
                     var settings = new ServiceClientTransportSettings();
                     this.proxy.ForEach(p => settings.HttpProxy = p);
-                    Console.WriteLine($"IoTHubConnectionString {this.context.IotHubConnectionString} TransportType {this.serviceClientTransportType}");
+
                     ServiceClient serviceClient =
                         ServiceClient.CreateFromConnectionString(this.context.IotHubConnectionString, this.serviceClientTransportType, settings);
 


### PR DESCRIPTION
We should not print iot hub connection string in Quickstart for E2E testing.