### PR TITLE
Add scheduled trigger to service deployment build

### DIFF
--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -2,6 +2,12 @@
 
 pr: none
 trigger: none
+schedules:
+- cron: 0 3 * * *
+  displayName: Nightly build
+  branches:
+    include: master
+  always: true
 
 pool:
   vmImage: ubuntu-16.04


### PR DESCRIPTION
The service deployment build is currently set up to run nightly through a scheduled trigger in the Azure Pipelines UI. This change adds the same schedule (nightly, 3AM UTC) to our YAML definition. Then I can remove the trigger from the UI.