### PR TITLE
Retire quickstart in service deployment build

### DIFF
--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -14,7 +14,8 @@ pool:
   vmImage: ubuntu-16.04
 
 steps:
-- checkout: none
+- checkout: self
+  fetchDepth: 100
 
 - task: AzureKeyVault@1
   displayName: Get secrets
@@ -25,65 +26,54 @@ steps:
       IotHubConnStr2,
       EventHubConnStr2
 
-- task: Docker@1
-  displayName: Docker login
+- pwsh: |
+    $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
+    dotnet build $testDir
+
+    $binDir = Convert-Path "$testDir/bin/Debug/netcoreapp2.1"
+    Write-Output "##vso[task.setvariable variable=binDir]$binDir"
+  displayName: Build tests
+
+- pwsh: |
+    $context = @{
+      logFile = Join-Path '$(binDir)' 'testoutput.log';
+    }
+    $context | ConvertTo-Json | Out-File -Encoding Utf8 '$(binDir)/context.json'
+  displayName: Create test arguments file (context.json)
+
+- pwsh: |
+    $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
+    sudo --preserve-env dotnet vstest $testFile --logger:trx --testcasefilter:Name=TempSensor
+  displayName: Run tests
+  env:
+    E2E_EVENT_HUB_ENDPOINT: $(EventHubConnStr2)
+    E2E_IOT_HUB_CONNECTION_STRING: $(IotHubConnStr2)
+
+- task: PublishTestResults@2
+  displayName: Publish test results
   inputs:
-    azureSubscriptionEndpoint: $(az.subscription)
-    azureContainerRegistry: $(az.containerRegistry)
-    command: login
+    testResultsFormat: vstest
+    testResultsFiles: '**/*.trx'
+    searchFolder: $(Build.SourcesDirectory)/TestResults
+    testRunTitle: Service deployment build  ($(Build.BuildNumber) linux amd64)
+    buildPlatform: amd64
+  condition: succeededOrFailed()
 
-- task: DownloadBuildArtifacts@0
-  displayName: Download smoke tests
-  inputs:
-    buildType: specific
-    project: one
-    pipeline: $(az.pipeline.artifacts)
-    buildVersionToDownload: latestFromBranch
-    branchName: refs/heads/master
-    downloadType: specific
-    itemPattern: core-linux/IotEdgeQuickstart.linux-x64.tar.gz
-
-- script: |
-    mkdir -p $(System.ArtifactsDirectory)/smoke
-    tar \
-      -C $(System.ArtifactsDirectory)/smoke \
-      -xzf $(System.ArtifactsDirectory)/core-linux/IotEdgeQuickstart.linux-x64.tar.gz
-    rm -r $(System.ArtifactsDirectory)/core-linux
-  displayName: Install smoke tests
-
-- script: |
-    #!/bin/bash
-
-    iothub_connstr="$(connstr.iotHub)"
-    if [ -z $iothub_connstr ]; then
-      iothub_connstr="$(IotHubConnStr2)"
-    fi
-    eventhub_connstr="$(connstr.eventHub)"
-    if [ -z $eventhub_connstr ]; then
-      eventhub_connstr="$(EventHubConnStr2)"
-    fi
-
-    # Run smoke tests
-    sudo $(System.ArtifactsDirectory)/smoke/IotEdgeQuickstart \
-      -c "$iothub_connstr" \
-      -e "$eventhub_connstr"
-    res=$?
-
-    # Collect logs
-    logdir=$(System.ArtifactsDirectory)/logs
-    mkdir -p $logdir
-    echo > "$logdir/$(Build.DefinitionName)-$(Build.BuildNumber)"
-    sudo journalctl > $logdir/iotedged.log
-    docker logs edgeAgent > $logdir/edgeAgent.log
-    docker logs edgeHub > $logdir/edgeHub.log
-    docker logs tempSensor > $logdir/tempSensor.log
-
-    exit $res
-  displayName: Run smoke tests
+- pwsh: |
+    $logDir = '$(Build.ArtifactStagingDirectory)/logs'
+    New-Item $logDir -ItemType Directory -Force | Out-Null
+    Out-File "$logDir/$(Build.DefinitionName)-$(Build.BuildNumber)"
+    Copy-Item "$(Build.SourcesDirectory)/TestResults" "$logDir/" -Recurse
+    # The setup fixture runs outside the scope of any test, so its logs (*-test-*.log) aren't
+    # included in the TRX. Copy them manually here.
+    Copy-Item "$(binDir)/*-test-*.log" "$logDir/"
+    Copy-Item "$(binDir)/testoutput.log" "$logDir/"
+  displayName: Collect Logs
+  condition: succeededOrFailed()
 
 - task: PublishBuildArtifacts@1
   displayName: Publish logs
   inputs:
-    PathtoPublish: $(System.ArtifactsDirectory)/logs
-    ArtifactName: logs
+    PathtoPublish: $(Build.ArtifactStagingDirectory)/logs
+    ArtifactName: logs-service-deployment-$(Build.BuildNumber)-linux-amd64
   condition: succeededOrFailed()

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -54,7 +54,7 @@ steps:
     }
 
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
-    E2E_EVENT_HUB_ENDPOINT=$eh E2E_IOT_HUB_CONNECTION_STRING=$ih sudo `
+    sudo E2E_EVENT_HUB_ENDPOINT=$eh E2E_IOT_HUB_CONNECTION_STRING=$ih `
       dotnet vstest $testFile --logger:trx --testcasefilter:Name=TempSensor
   displayName: Run tests
   env:

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -42,12 +42,26 @@ steps:
   displayName: Create test arguments file (context.json)
 
 - pwsh: |
+    if ($env:EH_ARG -and $env:IH_ARG)
+    {
+      $eh = $env:EH_ARG
+      $ih = $env:IH_ARG
+    }
+    else
+    {
+      $eh = $env:EH_KV
+      $ih = $env:IH_KV
+    }
+
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
-    sudo --preserve-env dotnet vstest $testFile --logger:trx --testcasefilter:Name=TempSensor
+    E2E_EVENT_HUB_ENDPOINT=$eh E2E_IOT_HUB_CONNECTION_STRING=$ih sudo `
+      dotnet vstest $testFile --logger:trx --testcasefilter:Name=TempSensor
   displayName: Run tests
   env:
-    E2E_EVENT_HUB_ENDPOINT: $(EventHubConnStr2)
-    E2E_IOT_HUB_CONNECTION_STRING: $(IotHubConnStr2)
+    EH_ARG: $(connstr.eventHub)
+    EH_KV: $(EventHubConnStr2)
+    IH_ARG: $(connstr.iotHub)
+    IH_KV: $(IotHubConnStr2)
 
 - task: PublishTestResults@2
   displayName: Publish test results

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -44,18 +44,17 @@ steps:
 - pwsh: |
     if ($env:EH_ARG -and $env:IH_ARG)
     {
-      $eh = $env:EH_ARG
-      $ih = $env:IH_ARG
+      $env:E2E_EVENT_HUB_ENDPOINT = $env:EH_ARG
+      $env:E2E_IOT_HUB_CONNECTION_STRING = $env:IH_ARG
     }
     else
     {
-      $eh = $env:EH_KV
-      $ih = $env:IH_KV
+      $env:E2E_EVENT_HUB_ENDPOINT = $env:EH_KV
+      $env:E2E_IOT_HUB_CONNECTION_STRING = $env:IH_KV
     }
 
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
-    sudo E2E_EVENT_HUB_ENDPOINT=$eh E2E_IOT_HUB_CONNECTION_STRING=$ih `
-      dotnet vstest $testFile --logger:trx --testcasefilter:Name=TempSensor
+    sudo --preserve-env dotnet vstest $testFile --logger:trx --testcasefilter:Name=TempSensor
   displayName: Run tests
   env:
     EH_ARG: $(connstr.eventHub)

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -39,9 +39,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 },
                 async () =>
                 {
-                    // Based on instructions at:
-                    // https://github.com/MicrosoftDocs/azure-docs/blob/058084949656b7df518b64bfc5728402c730536a/articles/iot-edge/how-to-install-iot-edge-linux.md
-
                     // TODO: 8/30/2019 support curl behind a proxy
                     string[] platformInfo = await Process.RunAsync("lsb_release", "-sir", token);
                     string os = platformInfo[0].Trim();
@@ -49,20 +46,25 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     switch (os)
                     {
                         case "Ubuntu":
-                            os = "ubuntu";
+                            return new[]
+                            {
+                                $"curl https://packages.microsoft.com/config/ubuntu/{version}/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
+                                "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
+                                "apt-get update",
+                                "apt-get install --yes iotedge"
+                            };
                         case "Raspbian":
-                            os = "debian";
-                            version = "stretch";
+                            return new[]
+                            {
+                                "curl -L https://aka.ms/libiothsm-std-linux-armhf-latest -o libiothsm-std.deb",
+                                "curl -L https://aka.ms/iotedged-linux-armhf-latest -o iotedge.deb",
+                                "dpkg --force-confnew -i libiothsm-std.deb iotedge.deb",
+                                "apt-get install -f",
+                                "rm libiothsm-std.deb iotedge.deb"
+                            };
                         default:
                             throw new NotImplementedException($"Don't know how to install daemon on operating system '{os}'");
                     }
-                    return new[]
-                    {
-                        $"curl https://packages.microsoft.com/config/{os}/{version}/multiarch/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
-                        "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
-                        "apt-get update",
-                        "apt-get install --yes iotedge"
-                    };
                 });
 
             await Profiler.Run(

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -50,11 +50,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     {
                         case "Ubuntu":
                             os = "ubuntu";
-                            break;
                         case "Raspbian":
                             os = "debian";
                             version = "stretch";
-                            break;
                         default:
                             throw new NotImplementedException($"Don't know how to install daemon on operating system '{os}'");
                     }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -50,9 +50,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     {
                         case "Ubuntu":
                             os = "ubuntu";
+                            break;
                         case "Raspbian":
                             os = "debian";
                             version = "stretch";
+                            break;
                         default:
                             throw new NotImplementedException($"Don't know how to install daemon on operating system '{os}'");
                     }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 },
                 async () =>
                 {
+                    // Based on instructions at:
+                    // https://github.com/MicrosoftDocs/azure-docs/blob/058084949656b7df518b64bfc5728402c730536a/articles/iot-edge/how-to-install-iot-edge-linux.md
+
                     // TODO: 8/30/2019 support curl behind a proxy
                     string[] platformInfo = await Process.RunAsync("lsb_release", "-sir", token);
                     string os = platformInfo[0].Trim();
@@ -46,25 +49,20 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     switch (os)
                     {
                         case "Ubuntu":
-                            return new[]
-                            {
-                                $"curl https://packages.microsoft.com/config/ubuntu/{version}/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
-                                "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
-                                "apt-get update",
-                                "apt-get install --yes iotedge"
-                            };
+                            os = "ubuntu";
                         case "Raspbian":
-                            return new[]
-                            {
-                                "curl -L https://aka.ms/libiothsm-std-linux-armhf-latest -o libiothsm-std.deb",
-                                "curl -L https://aka.ms/iotedged-linux-armhf-latest -o iotedge.deb",
-                                "dpkg --force-confnew -i libiothsm-std.deb iotedge.deb",
-                                "apt-get install -f",
-                                "rm libiothsm-std.deb iotedge.deb"
-                            };
+                            os = "debian";
+                            version = "stretch";
                         default:
                             throw new NotImplementedException($"Don't know how to install daemon on operating system '{os}'");
                     }
+                    return new[]
+                    {
+                        $"curl https://packages.microsoft.com/config/{os}/{version}/multiarch/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
+                        "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
+                        "apt-get update",
+                        "apt-get install --yes iotedge"
+                    };
                 });
 
             await Profiler.Run(


### PR DESCRIPTION
This change updates the service deployment build YAML to use the 'TempSensor' test from the new end-to-end tests, rather than quickstart.exe.