### PR TITLE
Fix syntax error in yaml cron decl

### DIFF
--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -6,7 +6,8 @@ schedules:
 - cron: 0 3 * * *
   displayName: Nightly build
   branches:
-    include: master
+    include:
+    - master
   always: true
 
 pool:


### PR DESCRIPTION
I couldn't really test my addition of a scheduled trigger to the service deployment YAML build, because it needs to be in master to get picked up by the build. But I should have at least run a manual build to check for any blatant YAML syntax errors...I didn't think to do that.  :(  I copy/pasted the code directly from the Azure Pipelines documentation, so what could go wrong?

Turns out I made a mistake in the syntax, so the build won't run. This fix corrects the error, so manual builds will run. We'll still need to wait to see whether the scheduled trigger works as expected.