### PR TITLE
EdgeHub: Fix delay in module 2 module messages

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
@@ -36,7 +36,58 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 int sentMessagesCount = await task1;
                 Assert.Equal(messagesCount, sentMessagesCount);
 
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
+
+                Assert.Equal(messagesCount, receivedMessages.Count);
+            }
+            finally
+            {
+                if (rm != null)
+                {
+                    await rm.CloseAsync();
+                }
+
+                if (sender != null)
+                {
+                    await sender.Disconnect();
+                }
+
+                if (receiver != null)
+                {
+                    await receiver.Disconnect();
+                }
+            }
+
+            // wait for the connection to be closed on the Edge side
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        [Theory]
+        [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
+        async Task SendOneTelemetryMessageTest(ITransportSettings[] transportSettings)
+        {
+            int messagesCount = 1;
+            TestModule sender = null;
+            TestModule receiver = null;
+
+            string edgeDeviceConnectionString = await SecretsHelper.GetSecretFromConfigKey("edgeCapableDeviceConnStrKey");
+            IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(edgeDeviceConnectionString);
+            RegistryManager rm = RegistryManager.CreateFromConnectionString(edgeDeviceConnectionString);
+
+            try
+            {
+                sender = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "sender1", transportSettings);
+                receiver = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "receiver1", transportSettings);
+
+                await receiver.SetupReceiveMessageHandler();
+
+                Task<int> task1 = sender.SendMessagesByCountAsync("output1", 0, messagesCount, TimeSpan.FromMinutes(2));
+
+                int sentMessagesCount = await task1;
+                Assert.Equal(messagesCount, sentMessagesCount);
+
+                await Task.Delay(TimeSpan.FromSeconds(3));
                 ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
 
                 Assert.Equal(messagesCount, receivedMessages.Count);


### PR DESCRIPTION
EdgeHub uses prefetching logic to improve message processing efficiency. However, the in the prefetch logic, if messages were coming in too slow, then it would cause a delay where the pump waited for more messages to come in. 
This fix changes that so that every time sending messages is completed, we again check the messages store to see if there are any new messages to be processed. 