### PR TITLE
 1.0.8: EdgeHub: Fix delay in module 2 module messages

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -6,16 +6,13 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using App.Metrics;
-    using App.Metrics.Counter;
-    using App.Metrics.Timer;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Concurrency;
     using Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine;
-    using Microsoft.Azure.Devices.Routing.Core.Util.Concurrency;
     using Microsoft.Extensions.Logging;
     using Nito.AsyncEx;
     using static System.FormattableString;
-    using AsyncLock = Microsoft.Azure.Devices.Routing.Core.Util.Concurrency.AsyncLock;
+    using AsyncLock = Microsoft.Azure.Devices.Edge.Util.Concurrency.AsyncLock;
 
     public class StoringAsyncEndpointExecutor : IEndpointExecutor
     {
@@ -57,15 +54,11 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                     throw new InvalidOperationException($"Endpoint executor for endpoint {this.Endpoint} is closed.");
                 }
 
-                using (Metrics.StoreLatency(this.Endpoint.Id))
-                {
-                    long offset = await this.messageStore.Add(this.Endpoint.Id, message);
-                    this.checkpointer.Propose(message);
-                    Events.AddMessageSuccess(this, offset);
-                }
+                long offset = await this.messageStore.Add(this.Endpoint.Id, message);
+                this.checkpointer.Propose(message);
+                Events.AddMessageSuccess(this, offset);
 
                 this.hasMessagesInQueue.Set();
-                Metrics.StoredCountIncrement(this.Endpoint.Id);
             }
             catch (Exception ex)
             {
@@ -129,7 +122,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                 Events.StartSendMessagesPump(this);
                 IMessageIterator iterator = this.messageStore.GetMessageIterator(this.Endpoint.Id, this.checkpointer.Offset + 1);
                 int batchSize = this.options.BatchSize * this.Endpoint.FanOutFactor;
-                var storeMessagesProvider = new StoreMessagesProvider(iterator, this.options.BatchTimeout, batchSize);
+                var storeMessagesProvider = new StoreMessagesProvider(iterator, batchSize);
                 while (!this.cts.IsCancellationRequested)
                 {
                     try
@@ -140,7 +133,6 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                         {
                             await this.ProcessMessages(messages);
                             Events.SendMessagesSuccess(this, messages);
-                            Metrics.DrainedCountIncrement(this.Endpoint.Id, messages.Length);
                         }
                         else
                         {
@@ -185,63 +177,50 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
         {
             readonly IMessageIterator iterator;
             readonly int batchSize;
-            readonly AsyncLock messagesLock = new AsyncLock();
-            readonly AsyncManualResetEvent messagesResetEvent = new AsyncManualResetEvent(true);
-            readonly TimeSpan timeout;
-            readonly Task populateTask;
-            List<IMessage> messagesList;
+            readonly AsyncLock stateLock = new AsyncLock();
+            Task<IList<IMessage>> getMessagesTask;
 
-            public StoreMessagesProvider(IMessageIterator iterator, TimeSpan timeout, int batchSize)
+            public StoreMessagesProvider(IMessageIterator iterator, int batchSize)
             {
                 this.iterator = iterator;
                 this.batchSize = batchSize;
-                this.timeout = timeout;
-                this.messagesList = new List<IMessage>(this.batchSize);
-                this.populateTask = this.PopulatePump();
+                this.getMessagesTask = Task.Run(this.GetMessagesFromStore);
             }
 
             public async Task<IMessage[]> GetMessages()
             {
-                List<IMessage> currentMessagesList;
-                using (await this.messagesLock.LockAsync())
+                using (await this.stateLock.LockAsync())
                 {
-                    currentMessagesList = this.messagesList;
-                    this.messagesList = new List<IMessage>(this.batchSize);
-                    this.messagesResetEvent.Set();
-                }
+                    var messages = await this.getMessagesTask;
+                    if (messages.Count == 0)
+                    {
+                        messages = await this.GetMessagesFromStore();
+                    }
+                    else
+                    {
+                        this.getMessagesTask = Task.Run(this.GetMessagesFromStore);
+                    }
 
-                return currentMessagesList.ToArray();
+                    return messages.ToArray();
+                }
             }
 
-            async Task PopulatePump()
+            async Task<IList<IMessage>> GetMessagesFromStore()
             {
-                while (true)
+                var messagesList = new List<IMessage>();
+                while (messagesList.Count < this.batchSize)
                 {
-                    try
+                    int curBatchSize = this.batchSize - messagesList.Count;
+                    IList<IMessage> messages = (await this.iterator.GetNext(curBatchSize)).ToList();
+                    if (!messages.Any())
                     {
-                        await this.messagesResetEvent.WaitAsync(this.timeout);
-                        while (this.messagesList.Count < this.batchSize)
-                        {
-                            int curBatchSize = this.batchSize - this.messagesList.Count;
-                            IList<IMessage> messages = (await this.iterator.GetNext(curBatchSize)).ToList();
-                            if (!messages.Any())
-                            {
-                                break;
-                            }
-
-                            using (await this.messagesLock.LockAsync())
-                            {
-                                this.messagesList.AddRange(messages);
-                            }
-                        }
-
-                        this.messagesResetEvent.Reset();
+                        break;
                     }
-                    catch (Exception e)
-                    {
-                        Events.ErrorInPopulatePump(e);
-                    }
+
+                    messagesList.AddRange(messages);
                 }
+
+                return messagesList;
             }
         }
 
@@ -341,40 +320,6 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             public static void ErrorInPopulatePump(Exception ex)
             {
                 Log.LogWarning((int)EventIds.ErrorInPopulatePump, ex, "Error in populate messages pump");
-            }
-        }
-
-        static class Metrics
-        {
-            static readonly CounterOptions EndpointMessageStoredCountOptions = new CounterOptions
-            {
-                Name = "EndpointMessageStoredCount",
-                MeasurementUnit = Unit.Events
-            };
-
-            static readonly CounterOptions EndpointMessageDrainedCountOptions = new CounterOptions
-            {
-                Name = "EndpointMessageDrainedCount",
-                MeasurementUnit = Unit.Events
-            };
-
-            static readonly TimerOptions EndpointMessageLatencyOptions = new TimerOptions
-            {
-                Name = "EndpointMessageStoredLatencyMs",
-                MeasurementUnit = Unit.None,
-                DurationUnit = TimeUnit.Milliseconds,
-                RateUnit = TimeUnit.Seconds
-            };
-
-            public static void StoredCountIncrement(string identity) => Edge.Util.Metrics.CountIncrement(GetTags(identity), EndpointMessageStoredCountOptions, 1);
-
-            public static void DrainedCountIncrement(string identity, long amount) => Edge.Util.Metrics.CountIncrement(GetTags(identity), EndpointMessageDrainedCountOptions, amount);
-
-            public static IDisposable StoreLatency(string identity) => Edge.Util.Metrics.Latency(GetTags(identity), EndpointMessageLatencyOptions);
-
-            internal static MetricTags GetTags(string id)
-            {
-                return new MetricTags("EndpointId", id);
             }
         }
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
@@ -36,7 +36,58 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 int sentMessagesCount = await task1;
                 Assert.Equal(messagesCount, sentMessagesCount);
 
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
+
+                Assert.Equal(messagesCount, receivedMessages.Count);
+            }
+            finally
+            {
+                if (rm != null)
+                {
+                    await rm.CloseAsync();
+                }
+
+                if (sender != null)
+                {
+                    await sender.Disconnect();
+                }
+
+                if (receiver != null)
+                {
+                    await receiver.Disconnect();
+                }
+            }
+
+            // wait for the connection to be closed on the Edge side
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        [Theory]
+        [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
+        async Task SendOneTelemetryMessageTest(ITransportSettings[] transportSettings)
+        {
+            int messagesCount = 1;
+            TestModule sender = null;
+            TestModule receiver = null;
+
+            string edgeDeviceConnectionString = await SecretsHelper.GetSecretFromConfigKey("edgeCapableDeviceConnStrKey");
+            IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(edgeDeviceConnectionString);
+            RegistryManager rm = RegistryManager.CreateFromConnectionString(edgeDeviceConnectionString);
+
+            try
+            {
+                sender = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "sender1", transportSettings);
+                receiver = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "receiver1", transportSettings);
+
+                await receiver.SetupReceiveMessageHandler();
+
+                Task<int> task1 = sender.SendMessagesByCountAsync("output1", 0, messagesCount, TimeSpan.FromMinutes(2));
+
+                int sentMessagesCount = await task1;
+                Assert.Equal(messagesCount, sentMessagesCount);
+
+                await Task.Delay(TimeSpan.FromSeconds(3));
                 ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
 
                 Assert.Equal(messagesCount, receivedMessages.Count);
@@ -152,6 +203,54 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 if (rm != null)
                 {
                     await rm.CloseAsync();
+                }
+            }
+
+            // wait for the connection to be closed on the Edge side
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        [Theory]
+        [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
+        async Task SendTelemetryWithDelayedReceiverTest(ITransportSettings[] transportSettings)
+        {
+            int messagesCount = 10;
+            TestModule sender = null;
+            TestModule receiver = null;
+
+            string edgeDeviceConnectionString = await SecretsHelper.GetSecretFromConfigKey("edgeCapableDeviceConnStrKey");
+            IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(edgeDeviceConnectionString);
+            RegistryManager rm = RegistryManager.CreateFromConnectionString(edgeDeviceConnectionString);
+
+            try
+            {
+                sender = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "sender1", transportSettings);
+                int sentMessagesCount = await sender.SendMessagesByCountAsync("output1", 0, messagesCount, TimeSpan.FromMinutes(2));
+                Assert.Equal(messagesCount, sentMessagesCount);
+
+                receiver = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "receiver1", transportSettings);
+                await receiver.SetupReceiveMessageHandler();
+
+                await Task.Delay(TimeSpan.FromSeconds(20));
+                ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
+
+                Assert.Equal(messagesCount, receivedMessages.Count);
+            }
+            finally
+            {
+                if (rm != null)
+                {
+                    await rm.CloseAsync();
+                }
+
+                if (sender != null)
+                {
+                    await sender.Disconnect();
+                }
+
+                if (receiver != null)
+                {
+                    await receiver.Disconnect();
                 }
             }
 


### PR DESCRIPTION
EdgeHub uses prefetching logic to improve message processing efficiency. However, the in the prefetch logic, if messages were coming in too slow, then it would cause a delay where the pump waited for more messages to come in.
This fix changes that so that every time sending messages is completed, we again check the messages store to see if there are any new messages to be processed.