### PR TITLE
1.0.8: EdgeHub: Fix delay in module 2 module messages (#1624)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                 Events.StartSendMessagesPump(this);
                 IMessageIterator iterator = this.messageStore.GetMessageIterator(this.Endpoint.Id, this.checkpointer.Offset + 1);
                 int batchSize = this.options.BatchSize * this.Endpoint.FanOutFactor;
-                var storeMessagesProvider = new StoreMessagesProvider(iterator, this.options.BatchTimeout, batchSize);
+                var storeMessagesProvider = new StoreMessagesProvider(iterator, batchSize);
                 while (!this.cts.IsCancellationRequested)
                 {
                     try
@@ -185,63 +185,50 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
         {
             readonly IMessageIterator iterator;
             readonly int batchSize;
-            readonly AsyncLock messagesLock = new AsyncLock();
-            readonly AsyncManualResetEvent messagesResetEvent = new AsyncManualResetEvent(true);
-            readonly TimeSpan timeout;
-            readonly Task populateTask;
-            List<IMessage> messagesList;
+            readonly AsyncLock stateLock = new AsyncLock();
+            Task<IList<IMessage>> getMessagesTask;
 
-            public StoreMessagesProvider(IMessageIterator iterator, TimeSpan timeout, int batchSize)
+            public StoreMessagesProvider(IMessageIterator iterator, int batchSize)
             {
                 this.iterator = iterator;
                 this.batchSize = batchSize;
-                this.timeout = timeout;
-                this.messagesList = new List<IMessage>(this.batchSize);
-                this.populateTask = this.PopulatePump();
+                this.getMessagesTask = Task.Run(this.GetMessagesFromStore);
             }
 
             public async Task<IMessage[]> GetMessages()
             {
-                List<IMessage> currentMessagesList;
-                using (await this.messagesLock.LockAsync())
+                using (await this.stateLock.LockAsync())
                 {
-                    currentMessagesList = this.messagesList;
-                    this.messagesList = new List<IMessage>(this.batchSize);
-                    this.messagesResetEvent.Set();
-                }
+                    var messages = await this.getMessagesTask;
+                    if (messages.Count == 0)
+                    {
+                        messages = await this.GetMessagesFromStore();
+                    }
+                    else
+                    {
+                        this.getMessagesTask = Task.Run(this.GetMessagesFromStore);
+                    }
 
-                return currentMessagesList.ToArray();
+                    return messages.ToArray();
+                }
             }
 
-            async Task PopulatePump()
+            async Task<IList<IMessage>> GetMessagesFromStore()
             {
-                while (true)
+                var messagesList = new List<IMessage>();
+                while (messagesList.Count < this.batchSize)
                 {
-                    try
+                    int curBatchSize = this.batchSize - messagesList.Count;
+                    IList<IMessage> messages = (await this.iterator.GetNext(curBatchSize)).ToList();
+                    if (!messages.Any())
                     {
-                        await this.messagesResetEvent.WaitAsync(this.timeout);
-                        while (this.messagesList.Count < this.batchSize)
-                        {
-                            int curBatchSize = this.batchSize - this.messagesList.Count;
-                            IList<IMessage> messages = (await this.iterator.GetNext(curBatchSize)).ToList();
-                            if (!messages.Any())
-                            {
-                                break;
-                            }
-
-                            using (await this.messagesLock.LockAsync())
-                            {
-                                this.messagesList.AddRange(messages);
-                            }
-                        }
-
-                        this.messagesResetEvent.Reset();
+                        break;
                     }
-                    catch (Exception e)
-                    {
-                        Events.ErrorInPopulatePump(e);
-                    }
+
+                    messagesList.AddRange(messages);
                 }
+
+                return messagesList;
             }
         }
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
@@ -36,7 +36,58 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 int sentMessagesCount = await task1;
                 Assert.Equal(messagesCount, sentMessagesCount);
 
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
+
+                Assert.Equal(messagesCount, receivedMessages.Count);
+            }
+            finally
+            {
+                if (rm != null)
+                {
+                    await rm.CloseAsync();
+                }
+
+                if (sender != null)
+                {
+                    await sender.Disconnect();
+                }
+
+                if (receiver != null)
+                {
+                    await receiver.Disconnect();
+                }
+            }
+
+            // wait for the connection to be closed on the Edge side
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        [Theory]
+        [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
+        async Task SendOneTelemetryMessageTest(ITransportSettings[] transportSettings)
+        {
+            int messagesCount = 1;
+            TestModule sender = null;
+            TestModule receiver = null;
+
+            string edgeDeviceConnectionString = await SecretsHelper.GetSecretFromConfigKey("edgeCapableDeviceConnStrKey");
+            IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(edgeDeviceConnectionString);
+            RegistryManager rm = RegistryManager.CreateFromConnectionString(edgeDeviceConnectionString);
+
+            try
+            {
+                sender = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "sender1", transportSettings);
+                receiver = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "receiver1", transportSettings);
+
+                await receiver.SetupReceiveMessageHandler();
+
+                Task<int> task1 = sender.SendMessagesByCountAsync("output1", 0, messagesCount, TimeSpan.FromMinutes(2));
+
+                int sentMessagesCount = await task1;
+                Assert.Equal(messagesCount, sentMessagesCount);
+
+                await Task.Delay(TimeSpan.FromSeconds(3));
                 ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
 
                 Assert.Equal(messagesCount, receivedMessages.Count);


### PR DESCRIPTION
cherry-pick https://github.com/Azure/iotedge/commit/ba5f28ada75633fb3adfe863aa962960697cab7e

EdgeHub uses prefetching logic to improve message processing efficiency. However, the in the prefetch logic, if messages were coming in too slow, then it would cause a delay where the pump waited for more messages to come in.
This fix changes that so that every time sending messages is completed, we again check the messages store to see if there are any new messages to be processed.