### PR TITLE
EdgeHub: Suppress default metrics

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             builder.Register(
                     c =>
                         this.metricsConfig.Enabled
-                            ? new MetricsListener(this.metricsConfig.ListenerConfig)
+                            ? new MetricsListener(this.metricsConfig.ListenerConfig, c.Resolve<IMetricsProvider>())
                             : new NullMetricsListener() as IMetricsListener)
                 .As<IMetricsListener>()
                 .SingleInstance();

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsListener.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsListener.cs
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
 {
+    using System;
     using global::Prometheus;
     using Microsoft.Extensions.Logging;
-    using System;
 
     public class MetricsListener : IMetricsListener
     {
@@ -14,10 +14,11 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
 
         public MetricsListener(MetricsListenerConfig listenerConfig, IMetricsProvider metricsProvider)
         {
-            if(!(metricsProvider is MetricsProvider prometheusMetricsProvider))
+            if (!(metricsProvider is MetricsProvider prometheusMetricsProvider))
             {
                 throw new ArgumentException($"IMetricsProvider of type {metricsProvider.GetType()} is incompatible with {this.GetType()}");
             }
+
             this.listenerConfig = Preconditions.CheckNotNull(listenerConfig, nameof(listenerConfig));
             this.metricServer = new MetricServer(listenerConfig.Host, listenerConfig.Port, listenerConfig.Suffix.Trim('/') + '/', prometheusMetricsProvider.DefaultRegistry);
         }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsListener.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsListener.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
 {
     using global::Prometheus;
     using Microsoft.Extensions.Logging;
+    using System;
 
     public class MetricsListener : IMetricsListener
     {
@@ -11,10 +12,14 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
 
         ILogger logger;
 
-        public MetricsListener(MetricsListenerConfig listenerConfig)
+        public MetricsListener(MetricsListenerConfig listenerConfig, IMetricsProvider metricsProvider)
         {
+            if(!(metricsProvider is MetricsProvider prometheusMetricsProvider))
+            {
+                throw new ArgumentException($"IMetricsProvider of type {metricsProvider.GetType()} is incompatible with {this.GetType()}");
+            }
             this.listenerConfig = Preconditions.CheckNotNull(listenerConfig, nameof(listenerConfig));
-            this.metricServer = new MetricServer(listenerConfig.Host, listenerConfig.Port, listenerConfig.Suffix.Trim('/') + '/');
+            this.metricServer = new MetricServer(listenerConfig.Host, listenerConfig.Port, listenerConfig.Suffix.Trim('/') + '/', prometheusMetricsProvider.DefaultRegistry);
         }
 
         public void Dispose()

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsProvider.cs
@@ -55,6 +55,8 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
             }
         }
 
+        internal CollectorRegistry DefaultRegistry => Metrics.DefaultRegistry;
+
         string GetCounterName(string name) => string.Format(CultureInfo.InvariantCulture, CounterNameFormat, this.namePrefix, name);
 
         string GetName(string name) => string.Format(CultureInfo.InvariantCulture, NameFormat, this.namePrefix, name);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsProvider.cs
@@ -21,6 +21,14 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
             Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
             Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
             this.defaultLabelNames = new List<string> { iotHubName, deviceId };
+
+            // TODO:
+            // By default, the Prometheus.Net library emits some default metrics.
+            // While useful, these are emitted without any tags. This will make it hard to
+            // consume and make sense of these metrics. So suppressing the default metrics for
+            // now. We can look at ways to add tags to the default metrics, or emiting the
+            // metrics manually.
+            Metrics.SuppressDefaultMetrics();
         }
 
         public IMetricsGauge CreateGauge(string name, string description, List<string> labelNames)


### PR DESCRIPTION
EdgeHub uses Prometheus.Net library to emit metrics. This library emits some dotnet metrics by default. 
While these metrics are useful, they are emitted without any tags (or support to add tags). Their documentation says they were mostly added for testing so that there are some metrics always emitted. 
The right way to add these metrics would be to suppress the default metrics, and emit the useful metrics explicitly. 
But those metrics need to be spec'ed. So just disabling the metrics for now (for the next release)