### PR TITLE
1.0.9: EdgeHub:  Put metrics support behind experimental flag (#1652)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
@@ -5,11 +5,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class ExperimentalFeatures
     {
-        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck)
+        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck, bool enableMetrics)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
             this.DisableConnectivityCheck = disableConnectivityCheck;
+            this.EnableMetrics = enableMetrics;
         }
 
         public static ExperimentalFeatures Create(IConfiguration experimentalFeaturesConfig)
@@ -17,7 +18,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
             bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("disableConnectivityCheck", false);
-            return new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck);
+            bool enableMetrics = enabled && experimentalFeaturesConfig.GetValue("enableMetrics", false);
+            return new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableMetrics);
         }
 
         public bool Enabled { get; }
@@ -25,5 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         public bool DisableCloudSubscriptions { get; }
 
         public bool DisableConnectivityCheck { get; }
+
+        public bool EnableMetrics { get; }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             var mqttSettingsConfiguration = new Mock<IConfiguration>();
             mqttSettingsConfiguration.Setup(c => c.GetSection(It.IsAny<string>())).Returns(Mock.Of<IConfigurationSection>(s => s.Value == null));
 
-            var experimentalFeatures = new ExperimentalFeatures(true, false, false);
+            var experimentalFeatures = new ExperimentalFeatures(true, false, false, true);
 
             builder.RegisterBuildCallback(
                 c =>
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
 
             var versionInfo = new VersionInfo("v1", "b1", "c1");
             var storeAndForwardConfiguration = new StoreAndForwardConfiguration(-1);
-            var metricsConfig = new MetricsConfig(false, new MetricsListenerConfig());
+            var metricsConfig = new MetricsConfig(true, new MetricsListenerConfig());
 
             builder.RegisterModule(
                 new CommonModule(

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/MetricsConfig.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/MetricsConfig.cs
@@ -1,23 +1,12 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Util.Metrics
 {
-    using Microsoft.Extensions.Configuration;
-
     public class MetricsConfig
     {
         public MetricsConfig(bool enabled, MetricsListenerConfig listenerConfig)
         {
             this.Enabled = enabled;
             this.ListenerConfig = listenerConfig;
-        }
-
-        public static MetricsConfig Create(IConfiguration config)
-        {
-            bool enabled = config.GetValue("enabled", false);
-            MetricsListenerConfig listenerConfig = enabled
-                ? MetricsListenerConfig.Create(config.GetSection("listener"))
-                : new MetricsListenerConfig();
-            return new MetricsConfig(enabled, listenerConfig);
         }
 
         public bool Enabled { get; }


### PR DESCRIPTION
Cherry-pick https://github.com/Azure/iotedge/commit/f4370f710bc53013b8a731d21b3016438241012b

* Put metrics support behind experimental flag

* Hook up metrics for tests