### PR TITLE
Change tags for messages_sent metric

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/ModuleMessageLinkHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/ModuleMessageLinkHandler.cs
@@ -45,13 +45,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
             static readonly IMetricsCounter MessagesMeter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "messages_sent",
                 "Messages sent to module",
-                new List<string> { "protocol", "from", "to" });
+                new List<string> { "from", "to" });
 
             public static void AddMessage(IIdentity identity, IMessage message)
             {
                 string from = message.GetSenderId();
                 string to = identity.Id;
-                MessagesMeter.Increment(1, new[] { "amqp", from, to });
+                MessagesMeter.Increment(1, new[] { from, to });
             }
         }
     }


### PR DESCRIPTION
The metric messages_sent is used for tracking messages sent to module and to cloud. These need to have the same tags, so removing the protocol tag to align the metrics. 
Will add the protocol tag in the future for all cases. 