### PR TITLE
1.0.9: EdgeHub: Fix delay in module 2 module messages (#1624)

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
@@ -36,7 +36,58 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 int sentMessagesCount = await task1;
                 Assert.Equal(messagesCount, sentMessagesCount);
 
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
+
+                Assert.Equal(messagesCount, receivedMessages.Count);
+            }
+            finally
+            {
+                if (rm != null)
+                {
+                    await rm.CloseAsync();
+                }
+
+                if (sender != null)
+                {
+                    await sender.Disconnect();
+                }
+
+                if (receiver != null)
+                {
+                    await receiver.Disconnect();
+                }
+            }
+
+            // wait for the connection to be closed on the Edge side
+            await Task.Delay(TimeSpan.FromSeconds(10));
+        }
+
+        [Theory]
+        [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
+        async Task SendOneTelemetryMessageTest(ITransportSettings[] transportSettings)
+        {
+            int messagesCount = 1;
+            TestModule sender = null;
+            TestModule receiver = null;
+
+            string edgeDeviceConnectionString = await SecretsHelper.GetSecretFromConfigKey("edgeCapableDeviceConnStrKey");
+            IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(edgeDeviceConnectionString);
+            RegistryManager rm = RegistryManager.CreateFromConnectionString(edgeDeviceConnectionString);
+
+            try
+            {
+                sender = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "sender1", transportSettings);
+                receiver = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "receiver1", transportSettings);
+
+                await receiver.SetupReceiveMessageHandler();
+
+                Task<int> task1 = sender.SendMessagesByCountAsync("output1", 0, messagesCount, TimeSpan.FromMinutes(2));
+
+                int sentMessagesCount = await task1;
+                Assert.Equal(messagesCount, sentMessagesCount);
+
+                await Task.Delay(TimeSpan.FromSeconds(3));
                 ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
 
                 Assert.Equal(messagesCount, receivedMessages.Count);


### PR DESCRIPTION
Cherry Pick ba5f28ada75633fb3adfe863aa962960697cab7e

* Add fix

* Fix delay in processing slow messages

* Add test

* Add unit tests

* Make GetMessagesTask not an option as it is never null