### PR TITLE
Add back V0 metrics

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using App.Metrics;
+    using App.Metrics.Timer;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Routing.Core;
@@ -90,20 +92,26 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
             // entity store. But that should be rare enough that it might be okay. Also it is better than not being able to forward the message.
             // Alternative is to add retry logic to the pump, but that is more complicated, and could affect performance.
             // TODO - Need to support transactions for these operations. The underlying storage layers support it.
-            await this.messageEntityStore.PutOrUpdate(
-                edgeMessageId,
-                new MessageWrapper(message),
-                (m) =>
-                {
-                    m.RefCount++;
-                    return m;
-                });
+            using (MetricsV0.MessageStoreLatency(endpointId))
+            {
+                await this.messageEntityStore.PutOrUpdate(
+                    edgeMessageId,
+                    new MessageWrapper(message),
+                    (m) =>
+                    {
+                        m.RefCount++;
+                        return m;
+                    });
+            }
 
             try
             {
-                long offset = await sequentialStore.Append(new MessageRef(edgeMessageId));
-                Events.MessageAdded(offset, edgeMessageId, endpointId, this.messageCount);
-                return offset;
+                using (MetricsV0.SequentialStoreLatency(endpointId))
+                {
+                    long offset = await sequentialStore.Append(new MessageRef(edgeMessageId));
+                    Events.MessageAdded(offset, edgeMessageId, endpointId, this.messageCount);
+                    return offset;
+                }
             }
             catch (Exception)
             {
@@ -513,6 +521,34 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
             public string EdgeMessageId { get; }
 
             public DateTime TimeStamp { get; }
+        }
+
+        static class MetricsV0
+        {
+            static readonly TimerOptions MessageEntityStorePutOrUpdateLatencyOptions = new TimerOptions
+            {
+                Name = "MessageEntityStorePutOrUpdateLatencyMs",
+                MeasurementUnit = Unit.None,
+                DurationUnit = TimeUnit.Milliseconds,
+                RateUnit = TimeUnit.Seconds
+            };
+
+            static readonly TimerOptions SequentialStoreAppendLatencyOptions = new TimerOptions
+            {
+                Name = "SequentialStoreAppendLatencyMs",
+                MeasurementUnit = Unit.None,
+                DurationUnit = TimeUnit.Milliseconds,
+                RateUnit = TimeUnit.Seconds
+            };
+
+            public static IDisposable MessageStoreLatency(string identity) => Util.Metrics.MetricsV0.Latency(GetTags(identity), MessageEntityStorePutOrUpdateLatencyOptions);
+
+            public static IDisposable SequentialStoreLatency(string identity) => Util.Metrics.MetricsV0.Latency(GetTags(identity), SequentialStoreAppendLatencyOptions);
+
+            internal static MetricTags GetTags(string id)
+            {
+                return new MetricTags("EndpointId", id);
+            }
         }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -62,6 +62,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             var metricsProvider = container.Resolve<IMetricsProvider>();
             Metrics.Init(metricsProvider, metricsListener, logger);
 
+            // Init V0 Metrics
+            MetricsV0.BuildMetricsCollector(configuration);
+
             // EdgeHub and CloudConnectionProvider have a circular dependency. So need to Bind the EdgeHub to the CloudConnectionProvider.
             IEdgeHub edgeHub = await container.Resolve<Task<IEdgeHub>>();
             ICloudConnectionProvider cloudConnectionProvider = await container.Resolve<Task<ICloudConnectionProvider>>();

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             builder.Register(
                     c =>
                         this.metricsConfig.Enabled
-                            ? new MetricsListener(this.metricsConfig.ListenerConfig)
+                            ? new MetricsListener(this.metricsConfig.ListenerConfig, c.Resolve<IMetricsProvider>())
                             : new NullMetricsListener() as IMetricsListener)
                 .As<IMetricsListener>()
                 .SingleInstance();

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -6,6 +6,9 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using App.Metrics;
+    using App.Metrics.Counter;
+    using App.Metrics.Timer;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Concurrency;
     using Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine;
@@ -54,11 +57,15 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                     throw new InvalidOperationException($"Endpoint executor for endpoint {this.Endpoint} is closed.");
                 }
 
-                long offset = await this.messageStore.Add(this.Endpoint.Id, message);
-                this.checkpointer.Propose(message);
-                Events.AddMessageSuccess(this, offset);
+                using (MetricsV0.StoreLatency(this.Endpoint.Id))
+                {
+                    long offset = await this.messageStore.Add(this.Endpoint.Id, message);
+                    this.checkpointer.Propose(message);
+                    Events.AddMessageSuccess(this, offset);
+                }
 
                 this.hasMessagesInQueue.Set();
+                MetricsV0.StoredCountIncrement(this.Endpoint.Id);
             }
             catch (Exception ex)
             {
@@ -133,6 +140,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
                         {
                             await this.ProcessMessages(messages);
                             Events.SendMessagesSuccess(this, messages);
+                            MetricsV0.DrainedCountIncrement(this.Endpoint.Id, messages.Length);
                         }
                         else
                         {
@@ -333,6 +341,40 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             public static void ErrorInPopulatePump(Exception ex)
             {
                 Log.LogWarning((int)EventIds.ErrorInPopulatePump, ex, "Error in populate messages pump");
+            }
+        }
+
+        static class MetricsV0
+        {
+            static readonly CounterOptions EndpointMessageStoredCountOptions = new CounterOptions
+            {
+                Name = "EndpointMessageStoredCount",
+                MeasurementUnit = Unit.Events
+            };
+
+            static readonly CounterOptions EndpointMessageDrainedCountOptions = new CounterOptions
+            {
+                Name = "EndpointMessageDrainedCount",
+                MeasurementUnit = Unit.Events
+            };
+
+            static readonly TimerOptions EndpointMessageLatencyOptions = new TimerOptions
+            {
+                Name = "EndpointMessageStoredLatencyMs",
+                MeasurementUnit = Unit.None,
+                DurationUnit = TimeUnit.Milliseconds,
+                RateUnit = TimeUnit.Seconds
+            };
+
+            public static void StoredCountIncrement(string identity) => Edge.Util.Metrics.MetricsV0.CountIncrement(GetTags(identity), EndpointMessageStoredCountOptions, 1);
+
+            public static void DrainedCountIncrement(string identity, long amount) => Edge.Util.Metrics.MetricsV0.CountIncrement(GetTags(identity), EndpointMessageDrainedCountOptions, amount);
+
+            public static IDisposable StoreLatency(string identity) => Edge.Util.Metrics.MetricsV0.Latency(GetTags(identity), EndpointMessageLatencyOptions);
+
+            internal static MetricTags GetTags(string id)
+            {
+                return new MetricTags("EndpointId", id);
             }
         }
     }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/ColumnFamilyDbStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/ColumnFamilyDbStore.cs
@@ -4,6 +4,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
     using System;
     using System.Threading;
     using System.Threading.Tasks;
+    using App.Metrics;
+    using App.Metrics.Timer;
     using Microsoft.Azure.Devices.Edge.Util;
     using RocksDbSharp;
 
@@ -40,9 +42,12 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
             Preconditions.CheckNotNull(key, nameof(key));
 
             Option<byte[]> returnValue;
-            Func<byte[]> operation = () => this.db.Get(key, this.Handle);
-            byte[] value = await operation.ExecuteUntilCancelled(cancellationToken);
-            returnValue = value != null ? Option.Some(value) : Option.None<byte[]>();
+            using (MetricsV0.DbGetLatency("all"))
+            {
+                Func<byte[]> operation = () => this.db.Get(key, this.Handle);
+                byte[] value = await operation.ExecuteUntilCancelled(cancellationToken);
+                returnValue = value != null ? Option.Some(value) : Option.None<byte[]>();
+            }
 
             return returnValue;
         }
@@ -52,8 +57,11 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
             Preconditions.CheckNotNull(key, nameof(key));
             Preconditions.CheckNotNull(value, nameof(value));
 
-            Action operation = () => this.db.Put(key, value, this.Handle);
-            return operation.ExecuteUntilCancelled(cancellationToken);
+            using (MetricsV0.DbPutLatency("all"))
+            {
+                Action operation = () => this.db.Put(key, value, this.Handle);
+                return operation.ExecuteUntilCancelled(cancellationToken);
+            }
         }
 
         public Task Remove(byte[] key, CancellationToken cancellationToken)
@@ -157,6 +165,34 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
                     byte[] value = iterator.Value();
                     await callback(key, value);
                 }
+            }
+        }
+
+        static class MetricsV0
+        {
+            static readonly TimerOptions DbPutLatencyOptions = new TimerOptions
+            {
+                Name = "DbPutLatencyMs",
+                MeasurementUnit = Unit.None,
+                DurationUnit = TimeUnit.Milliseconds,
+                RateUnit = TimeUnit.Seconds
+            };
+
+            static readonly TimerOptions DbGetLatencyOptions = new TimerOptions
+            {
+                Name = "DbGetLatencyMs",
+                MeasurementUnit = Unit.None,
+                DurationUnit = TimeUnit.Milliseconds,
+                RateUnit = TimeUnit.Seconds
+            };
+
+            public static IDisposable DbPutLatency(string identity) => Util.Metrics.MetricsV0.Latency(GetTags(identity), DbPutLatencyOptions);
+
+            public static IDisposable DbGetLatency(string identity) => Util.Metrics.MetricsV0.Latency(GetTags(identity), DbGetLatencyOptions);
+
+            static MetricTags GetTags(string id)
+            {
+                return new MetricTags("EndpointId", id);
             }
         }
     }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Microsoft.Azure.Devices.Edge.Util.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Microsoft.Azure.Devices.Edge.Util.csproj
@@ -23,6 +23,8 @@
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="3.0.0" />
     <PackageReference Include="App.Metrics.Formatters.Prometheus" Version="3.0.0" />
+    <PackageReference Include="App.Metrics.Reporting.InfluxDB" Version="3.0.0" />
+    <PackageReference Include="App.Metrics.Reporting.TextFile" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="Nito.AsyncEx" Version="5.0.0-pre-05" />

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/MetricsV0.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/MetricsV0.cs
@@ -1,0 +1,156 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util.Metrics
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using App.Metrics;
+    using App.Metrics.Counter;
+    using App.Metrics.Formatters.Json;
+    using App.Metrics.Gauge;
+    using App.Metrics.Scheduling;
+    using App.Metrics.Timer;
+    using Microsoft.Extensions.Configuration;
+
+    public static class MetricsV0
+    {
+        static readonly object gaugeListLock;
+
+        static MetricsV0()
+        {
+            MetricsCollector = Option.None<IMetricsRoot>();
+            Gauges = new List<Action>();
+            gaugeListLock = new object();
+        }
+
+        public static Option<IMetricsRoot> MetricsCollector { get; private set; }
+
+        static List<Action> Gauges { get; set; }
+
+        public static void BuildMetricsCollector(IConfigurationRoot configuration)
+        {
+            bool collectMetrics = configuration.GetValue("CollectMetrics", false);
+
+            if (collectMetrics)
+            {
+                IConfiguration metricsConfigurationSection = configuration.GetSection("Metrics");
+                string metricsStoreType = metricsConfigurationSection.GetValue<string>("MetricsStoreType");
+
+                if (metricsStoreType == "influxdb")
+                {
+                    string metricsDbName = metricsConfigurationSection.GetValue("MetricsDbName", "metricsdatabase");
+                    string influxDbUrl = metricsConfigurationSection.GetValue("InfluxDbUrl", "http://influxdb:8086");
+                    IMetricsRoot metricsCollector = new MetricsBuilder()
+                        .Report.ToInfluxDb(
+                            options =>
+                            {
+                                options.InfluxDb.BaseUri = new Uri(influxDbUrl);
+                                options.InfluxDb.Database = metricsDbName;
+                                options.InfluxDb.CreateDataBaseIfNotExists = true;
+                                options.FlushInterval = TimeSpan.FromSeconds(10);
+                            }).Build();
+                    MetricsCollector = Option.Some(metricsCollector);
+                    StartReporting(metricsCollector);
+                }
+                else
+                {
+                    string metricsStoreLocation = metricsConfigurationSection.GetValue("MetricsStoreLocation", "metrics");
+                    bool appendToMetricsFile = metricsConfigurationSection.GetValue("MetricsStoreAppend", false);
+                    IMetricsRoot metricsCollector = new MetricsBuilder()
+                        .Report.ToTextFile(
+                            options =>
+                            {
+                                options.MetricsOutputFormatter = new MetricsJsonOutputFormatter();
+                                options.AppendMetricsToTextFile = appendToMetricsFile;
+                                options.FlushInterval = TimeSpan.FromSeconds(20);
+                                options.OutputPathAndFileName = metricsStoreLocation;
+                            }).Build();
+                    MetricsCollector = Option.Some(metricsCollector);
+                    StartReporting(metricsCollector);
+                }
+            }
+        }
+
+        public static void RegisterGaugeCallback(Action callback)
+        {
+            lock (gaugeListLock)
+            {
+                Gauges.Add(callback);
+            }
+        }
+
+        public static void CountIncrement(MetricTags tags, CounterOptions options, long amount)
+        {
+            Preconditions.CheckNotNull(tags);
+            Preconditions.CheckNotNull(options);
+            Preconditions.CheckNotNull(amount);
+
+            MetricsCollector.ForEach(mroot => { mroot.Measure.Counter.Increment(options, tags, amount); });
+        }
+
+        public static void CountDecrement(MetricTags tags, CounterOptions options, long amount)
+        {
+            Preconditions.CheckNotNull(tags);
+            Preconditions.CheckNotNull(options);
+            Preconditions.CheckNotNull(amount);
+
+            MetricsCollector.ForEach(mroot => { mroot.Measure.Counter.Decrement(options, tags, amount); });
+        }
+
+        public static void CountIncrement(CounterOptions options, long amount)
+        {
+            Preconditions.CheckNotNull(options);
+            Preconditions.CheckNotNull(amount);
+
+            MetricsCollector.ForEach(mroot => { mroot.Measure.Counter.Increment(options, amount); });
+        }
+
+        public static void CountDecrement(CounterOptions options, long amount)
+        {
+            Preconditions.CheckNotNull(options);
+            Preconditions.CheckNotNull(amount);
+
+            MetricsCollector.ForEach(mroot => { mroot.Measure.Counter.Decrement(options, amount); });
+        }
+
+        public static IDisposable Latency(MetricTags tags, TimerOptions options)
+        {
+            Preconditions.CheckNotNull(tags);
+            Preconditions.CheckNotNull(options);
+
+            return MetricsCollector.Map(mroot => mroot.Measure.Timer.Time(options, tags) as IDisposable).GetOrElse(() => new NullDisposable());
+        }
+
+        public static void SetGauge(GaugeOptions options, long amount)
+        {
+            Preconditions.CheckNotNull(options);
+            Preconditions.CheckNotNull(amount);
+
+            MetricsCollector.ForEach(mroot => { mroot.Measure.Gauge.SetValue(options, amount); });
+        }
+
+        static void StartReporting(IMetricsRoot metricsCollector)
+        {
+            // Start reporting metrics every 5s
+            var scheduler = new AppMetricsTaskScheduler(
+                TimeSpan.FromSeconds(5),
+                async () =>
+                {
+                    foreach (var callback in Gauges)
+                    {
+                        callback();
+                    }
+
+                    await Task.WhenAll(metricsCollector.ReportRunner.RunAllAsync());
+                });
+            scheduler.Start();
+        }
+
+        class NullDisposable : IDisposable
+        {
+            public void Dispose()
+            {
+            }
+        }
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsListener.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsListener.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
 {
+    using System;
     using global::Prometheus;
     using Microsoft.Extensions.Logging;
 
@@ -11,10 +12,15 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
 
         ILogger logger;
 
-        public MetricsListener(MetricsListenerConfig listenerConfig)
+        public MetricsListener(MetricsListenerConfig listenerConfig, IMetricsProvider metricsProvider)
         {
+            if (!(metricsProvider is MetricsProvider prometheusMetricsProvider))
+            {
+                throw new ArgumentException($"IMetricsProvider of type {metricsProvider.GetType()} is incompatible with {this.GetType()}");
+            }
+
             this.listenerConfig = Preconditions.CheckNotNull(listenerConfig, nameof(listenerConfig));
-            this.metricServer = new MetricServer(listenerConfig.Host, listenerConfig.Port, listenerConfig.Suffix.Trim('/') + '/');
+            this.metricServer = new MetricServer(listenerConfig.Host, listenerConfig.Port, listenerConfig.Suffix.Trim('/') + '/', prometheusMetricsProvider.DefaultRegistry);
         }
 
         public void Dispose()

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsProvider.cs
@@ -21,6 +21,14 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
             Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
             Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
             this.defaultLabelNames = new List<string> { iotHubName, deviceId };
+
+            // TODO:
+            // By default, the Prometheus.Net library emits some default metrics.
+            // While useful, these are emitted without any tags. This will make it hard to
+            // consume and make sense of these metrics. So suppressing the default metrics for
+            // now. We can look at ways to add tags to the default metrics, or emiting the
+            // metrics manually.
+            Metrics.SuppressDefaultMetrics();
         }
 
         public IMetricsGauge CreateGauge(string name, string description, List<string> labelNames)
@@ -46,6 +54,8 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
                 return ms.ToArray();
             }
         }
+
+        internal CollectorRegistry DefaultRegistry => Metrics.DefaultRegistry;
 
         string GetCounterName(string name) => string.Format(CultureInfo.InvariantCulture, CounterNameFormat, this.namePrefix, name);
 


### PR DESCRIPTION
Cherry pick https://github.com/Azure/iotedge/commit/a26e4e8e30cea32bb1268620fcac35c8d39516f5

Removing the existing EdgeHub metrics is a breaking change. So we need to deprecate it for now, and take it out eventually. So adding back the old metrics to EdgeHub.