### PR TITLE
Give a clear indicator why an id scope may be null.

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                     .GetOrElse(
                         () =>
                         {
-                            Events.NullResult(deviceId);
+                            Events.ScopeNotFound(deviceId);
                             return Option.None<ServiceIdentity>();
                         });
 
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                     .GetOrElse(
                         () =>
                         {
-                            Events.NullResult(id);
+                            Events.ScopeNotFound(id);
                             return Option.None<ServiceIdentity>();
                         });
 
@@ -129,6 +129,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             {
                 IteratorCreated = IdStart,
                 ScopeResultReceived,
+                NoScopeFound,
                 UnexpectedResult
             }
 
@@ -163,9 +164,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 Log.LogWarning((int)EventIds.UnexpectedResult, "Received null device scope result");
             }
 
-            public static void NullResult(string id)
+            public static void ScopeNotFound(string id)
             {
-                Log.LogWarning((int)EventIds.UnexpectedResult, $"Received null device scope result for {id}");
+                Log.LogWarning((int)EventIds.NoScopeFound, $"Device scope not found for {id}. Parent-child relationship is not set.");
             }
 
             public static void BadRequestResult(string id, HttpStatusCode statusCode)


### PR DESCRIPTION
Before, this warning said, "Received null device scope result for {id}"  which is true and accurate, but _what does it mean_?

Well, it means that we looked up a device or module to see if it is within the edge's scope (i.e. the edge is its parent) and didn't find it.  That generally means the user did not set a parent/child relationship.  We should leave this as a warning, because if the edge device goes offline, this leaf device will not be authenticated. 

So, now the warning says, "Device scope not found for {id}. Parent-child relationship is not set."