### PR TITLE
Explicitly link to advapi32 to fix Windows ARM32 linker failure

### DIFF
--- a/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
@@ -137,7 +137,7 @@ if (save_ut)
 endif(save_ut)
 
 if(WIN32)
-    target_link_libraries(iothsm aziotsharedutil utpm $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(iothsm aziotsharedutil utpm $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib advapi32)
 else()
     target_link_libraries(iothsm aziotsharedutil utpm ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ut/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ut/CMakeLists.txt
@@ -26,3 +26,7 @@ set(${theseTestsName}_h_files
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests")
+
+if(WIN32)
+    target_link_libraries(${theseTestsName}_exe advapi32)
+endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_ut/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_ut/CMakeLists.txt
@@ -24,3 +24,7 @@ set(${theseTestsName}_h_files
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
+
+if(WIN32)
+    target_link_libraries(${theseTestsName}_exe advapi32)
+endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_key_intf_sas_ut/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_key_intf_sas_ut/CMakeLists.txt
@@ -26,3 +26,7 @@ set(${theseTestsName}_h_files
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
+
+if(WIN32)
+    target_link_libraries(${theseTestsName}_exe advapi32)
+endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_tpm_ut/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_tpm_ut/CMakeLists.txt
@@ -25,3 +25,7 @@ set(${theseTestsName}_h_files
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
+
+if(WIN32)
+    target_link_libraries(${theseTestsName}_exe advapi32)
+endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_ut/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_ut/CMakeLists.txt
@@ -23,3 +23,7 @@ set(${theseTestsName}_h_files
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
+
+if(WIN32)
+    target_link_libraries(${theseTestsName}_exe advapi32)
+endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/CMakeLists.txt
@@ -26,3 +26,7 @@ set(${theseTestsName}_h_files
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
+
+if(WIN32)
+    target_link_libraries(${theseTestsName}_exe advapi32)
+endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/CMakeLists.txt
@@ -24,3 +24,7 @@ set(${theseTestsName}_h_files
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests")
+
+if(WIN32)
+    target_link_libraries(${theseTestsName}_exe advapi32)
+endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_tpm_select_ut/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_tpm_select_ut/CMakeLists.txt
@@ -25,3 +25,7 @@ set(${theseTestsName}_h_files
 )
 
 build_c_test_artifacts(${theseTestsName} ON "tests")
+
+if(WIN32)
+    target_link_libraries(${theseTestsName}_exe advapi32)
+endif(WIN32)


### PR DESCRIPTION
After https://github.com/Azure/iotedge/commit/b21239b137b0f6cd61beb63417f26a1436d8d776
the Windows ARM32 build would fail to link the libiothsm unit test binaries
because the linker could not find `ReportEventA` and `RegisterEventSourceA`.

This is probably the same as when the Windows ARM32 support was
originally added and we had to link the unit tests to shell32 explicitly,
even though the Windows AMD64 build did not complain.