### PR TITLE
Change Content-Length to be the UTF8 Byte Count

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/TwinsController.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/TwinsController.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
         static int GetContentLength(MethodResult methodResult)
         {
             string json = JsonConvert.SerializeObject(methodResult);
-            return json.Length;
+            return Encoding.UTF8.GetByteCount(json);
         }
 
         async Task<IActionResult> InvokeMethodAsync(DirectMethodRequest directMethodRequest)

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var validator = new Mock<IValidator<MethodRequest>>();
             validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
 
-            var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
+            var httpContext = new DefaultHttpContext();
             var controllerContext = new ControllerContext()
             {
                 HttpContext = httpContext,
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var validator = new Mock<IValidator<MethodRequest>>();
             validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
 
-            var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
+            var httpContext = new DefaultHttpContext();
             var controllerContext = new ControllerContext()
             {
                 HttpContext = httpContext,
@@ -270,7 +270,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var validator = new Mock<IValidator<MethodRequest>>();
             validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
 
-            var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
+            var httpContext = new DefaultHttpContext();
             var controllerContext = new ControllerContext()
             {
                 HttpContext = httpContext,
@@ -315,7 +315,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var validator = new Mock<IValidator<MethodRequest>>();
             validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
 
-            var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
+            var httpContext = new DefaultHttpContext();
             var controllerContext = new ControllerContext()
             {
                 HttpContext = httpContext,
@@ -340,7 +340,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var methodResult = objectResult.Value as MethodResult;
             Assert.NotNull(methodResult);
             Assert.Equal(200, methodResult.Status);
-            Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
             Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
             long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
             Assert.Equal(methodResultByteCount, testController.Response.ContentLength);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             Assert.NotNull(methodResult);
             Assert.Equal(200, methodResult.Status);
             Assert.Null(methodResult.Payload);
-            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, objectResult.StatusCode);
         }
 
         [Fact]
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             Assert.NotNull(methodResult);
             Assert.Equal(200, methodResult.Status);
             Assert.Null(methodResult.Payload);
-            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, objectResult.StatusCode);
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
             long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
             Assert.Equal(methodResultByteCount, testController.Response.ContentLength);
-            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, objectResult.StatusCode);
         }
 
         [Fact]
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
                 ControllerContext = controllerContext
             };
             testController.OnActionExecuting(actionExecutingContext);
-            
+
             string toDeviceId = "edgedevice";
             string toModuleId = "module2";
             string command = "showdown";
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
             long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
             Assert.Equal(methodResultByteCount, testController.Response.ContentLength);
-            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, objectResult.StatusCode);
         }
 
         [Fact]
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
             long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
             Assert.Equal(methodResultByteCount, testController.Response.ContentLength);
-            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, objectResult.StatusCode);
         }
 
         [Fact]
@@ -272,7 +272,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
             long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
             Assert.Equal(methodResultByteCount, testController.Response.ContentLength);
-            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+            Assert.Equal((int)HttpStatusCode.OK, objectResult.StatusCode);
         }
 
         [Fact]
@@ -308,7 +308,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             Assert.Equal(0, methodResult.Status);
             Assert.Null(methodResult.Payload);
             Assert.Equal(timeoutException.Message, methodResult.Message);
-            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.GatewayTimeout);
+            Assert.Equal((int)HttpStatusCode.GatewayTimeout, objectResult.StatusCode);
         }
 
         [Unit]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
@@ -164,6 +164,190 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         }
 
         [Fact]
+        public async Task TestInvokeMethodWithResponsePayloadWithNoUmlautAndResponseContentLengthIsEqualToByteCount()
+        {
+            var identity = Mock.Of<IIdentity>(i => i.Id == "edgedevice/module1");
+            ActionExecutingContext actionExecutingContext = this.GetActionExecutingContextMock(identity);
+
+            string responsePayload = "{ \"resp1\" : \"respvalue1\" }";
+            var directMethodResponse = new DirectMethodResponse(Guid.NewGuid().ToString(), Encoding.UTF8.GetBytes(responsePayload), 200);
+            var edgeHub = new Mock<IEdgeHub>();
+            edgeHub.Setup(e => e.InvokeMethodAsync(It.Is<string>(i => i == identity.Id), It.IsAny<DirectMethodRequest>()))
+                .ReturnsAsync(directMethodResponse);
+
+            var validator = new Mock<IValidator<MethodRequest>>();
+            validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
+            
+            var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
+            var controllerContext = new ControllerContext()
+            {
+                HttpContext = httpContext,
+            };
+            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object) 
+            {
+                ControllerContext = controllerContext
+            };
+            testController.OnActionExecuting(actionExecutingContext);
+
+            string toDeviceId = "device1";
+            string command = "showdown";
+            string payload = "{ \"prop1\" : \"value1\" }";
+
+            var methodRequest = new MethodRequest(command, new JRaw(payload));
+            IActionResult actionResult = await testController.InvokeDeviceMethodAsync(toDeviceId, methodRequest);
+
+            Assert.NotNull(actionResult);
+            var objectResult = actionResult as ObjectResult;
+            Assert.NotNull(objectResult);
+            var methodResult = objectResult.Value as MethodResult;
+            Assert.NotNull(methodResult);
+            Assert.Equal(200, methodResult.Status);
+            Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
+            long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
+            Assert.Equal(methodResultByteCount, testController.Response.ContentLength);
+            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task TestInvokeMethodOnModuleWithResponsePayloadWithNoUmlautAndResponseContentLengthHeaderIsEqualToByteCount()
+        {
+            var identity = Mock.Of<IIdentity>(i => i.Id == "edgedevice/module1");
+            ActionExecutingContext actionExecutingContext = this.GetActionExecutingContextMock(identity);
+
+            string responsePayload = "{ \"resp1\" : \"respvalue1\" }";
+            var directMethodResponse = new DirectMethodResponse(Guid.NewGuid().ToString(), Encoding.UTF8.GetBytes(responsePayload), 200);
+            var edgeHub = new Mock<IEdgeHub>();
+            edgeHub.Setup(e => e.InvokeMethodAsync(It.Is<string>(i => i == identity.Id), It.IsAny<DirectMethodRequest>()))
+                .ReturnsAsync(directMethodResponse);
+
+            var validator = new Mock<IValidator<MethodRequest>>();
+            validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
+
+            var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
+            var controllerContext = new ControllerContext()
+            {
+                HttpContext = httpContext,
+            };
+            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object) 
+            {
+                ControllerContext = controllerContext
+            };
+            testController.OnActionExecuting(actionExecutingContext);
+
+            string toDeviceId = "edgedevice";
+            string toModuleId = "module2";
+            string command = "showdown";
+            string payload = "{ \"prop1\" : \"value1\" }";
+
+            var methodRequest = new MethodRequest(command, new JRaw(payload));
+            IActionResult actionResult = await testController.InvokeModuleMethodAsync(WebUtility.UrlEncode(toDeviceId), WebUtility.UrlEncode(toModuleId), methodRequest);
+
+            Assert.NotNull(actionResult);
+            var objectResult = actionResult as ObjectResult;
+            Assert.NotNull(objectResult);
+            var methodResult = objectResult.Value as MethodResult;
+            Assert.NotNull(methodResult);
+            Assert.Equal(200, methodResult.Status);
+            Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
+            Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
+            long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
+            Assert.Equal(methodResultByteCount, testController.Response.ContentLength);
+            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task TestInvokeMethodWithResponsePayloadWithUmlautAndResponseContentLengthIsEqualToByteCount()
+        {
+            var identity = Mock.Of<IIdentity>(i => i.Id == "edgedevice/module1");
+            ActionExecutingContext actionExecutingContext = this.GetActionExecutingContextMock(identity);
+
+            string responsePayload = "{ \"resp1\" : \"respvalüe1\" }";
+            var directMethodResponse = new DirectMethodResponse(Guid.NewGuid().ToString(), Encoding.UTF8.GetBytes(responsePayload), 200);
+            var edgeHub = new Mock<IEdgeHub>();
+            edgeHub.Setup(e => e.InvokeMethodAsync(It.Is<string>(i => i == identity.Id), It.IsAny<DirectMethodRequest>()))
+                .ReturnsAsync(directMethodResponse);
+
+            var validator = new Mock<IValidator<MethodRequest>>();
+            validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
+            
+            var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
+            var controllerContext = new ControllerContext()
+            {
+                HttpContext = httpContext,
+            };
+            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object) 
+            {
+                ControllerContext = controllerContext
+            };
+            testController.OnActionExecuting(actionExecutingContext);
+
+            string toDeviceId = "device1";
+            string command = "showdown";
+            string payload = "{ \"prop1\" : \"value1\" }";
+
+            var methodRequest = new MethodRequest(command, new JRaw(payload));
+            IActionResult actionResult = await testController.InvokeDeviceMethodAsync(toDeviceId, methodRequest);
+
+            Assert.NotNull(actionResult);
+            var objectResult = actionResult as ObjectResult;
+            Assert.NotNull(objectResult);
+            var methodResult = objectResult.Value as MethodResult;
+            Assert.NotNull(methodResult);
+            Assert.Equal(200, methodResult.Status);
+            Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
+            long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
+            Assert.Equal(methodResultByteCount, testController.Response.ContentLength);
+            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+        }
+
+        [Fact]
+        public async Task TestInvokeMethodOnModuleWithResponsePayloadWithUmlautAndResponseContentLengthHeaderIsEqualToByteCount()
+        {
+            var identity = Mock.Of<IIdentity>(i => i.Id == "edgedevice/module1");
+            ActionExecutingContext actionExecutingContext = this.GetActionExecutingContextMock(identity);
+
+            string responsePayload = "{ \"resp1\" : \"respvalüe1\" }";
+            var directMethodResponse = new DirectMethodResponse(Guid.NewGuid().ToString(), Encoding.UTF8.GetBytes(responsePayload), 200);
+            var edgeHub = new Mock<IEdgeHub>();
+            edgeHub.Setup(e => e.InvokeMethodAsync(It.Is<string>(i => i == identity.Id), It.IsAny<DirectMethodRequest>()))
+                .ReturnsAsync(directMethodResponse);
+
+            var validator = new Mock<IValidator<MethodRequest>>();
+            validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
+
+            var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
+            var controllerContext = new ControllerContext()
+            {
+                HttpContext = httpContext,
+            };
+            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object) 
+            {
+                ControllerContext = controllerContext
+            };
+            testController.OnActionExecuting(actionExecutingContext);
+
+            string toDeviceId = "edgedevice";
+            string toModuleId = "module2";
+            string command = "showdown";
+            string payload = "{ \"prop1\" : \"value1\" }";
+
+            var methodRequest = new MethodRequest(command, new JRaw(payload));
+            IActionResult actionResult = await testController.InvokeModuleMethodAsync(WebUtility.UrlEncode(toDeviceId), WebUtility.UrlEncode(toModuleId), methodRequest);
+
+            Assert.NotNull(actionResult);
+            var objectResult = actionResult as ObjectResult;
+            Assert.NotNull(objectResult);
+            var methodResult = objectResult.Value as MethodResult;
+            Assert.NotNull(methodResult);
+            Assert.Equal(200, methodResult.Status);
+            Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
+            Assert.Equal(new JRaw(responsePayload), methodResult.Payload);
+            long methodResultByteCount = Encoding.UTF8.GetByteCount(JsonConvert.SerializeObject(methodResult));
+            Assert.Equal(methodResultByteCount, testController.Response.ContentLength);
+            Assert.Equal(objectResult.StatusCode, (int)HttpStatusCode.OK);
+        }
+
+        [Fact]
         public async Task TestInvokeMethodWithException()
         {
             var identity = Mock.Of<IIdentity>(i => i.Id == "edgedevice/module1");

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
@@ -177,13 +177,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
 
             var validator = new Mock<IValidator<MethodRequest>>();
             validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
-            
+
             var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
             var controllerContext = new ControllerContext()
             {
                 HttpContext = httpContext,
             };
-            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object) 
+            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object)
             {
                 ControllerContext = controllerContext
             };
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             {
                 HttpContext = httpContext,
             };
-            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object) 
+            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object)
             {
                 ControllerContext = controllerContext
             };
@@ -269,13 +269,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
 
             var validator = new Mock<IValidator<MethodRequest>>();
             validator.Setup(v => v.Validate(It.IsAny<MethodRequest>()));
-            
+
             var httpContext = new DefaultHttpContext(); // or mock a `HttpContext`
             var controllerContext = new ControllerContext()
             {
                 HttpContext = httpContext,
             };
-            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object) 
+            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object)
             {
                 ControllerContext = controllerContext
             };
@@ -320,7 +320,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             {
                 HttpContext = httpContext,
             };
-            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object) 
+            var testController = new TwinsController(Task.FromResult(edgeHub.Object), validator.Object)
             {
                 ControllerContext = controllerContext
             };


### PR DESCRIPTION
This PR is supposed to fix the current behaviour when a message payload contains umlauts.

### Current behaviour
When a payload that contains umlauts (e.g. `ü, ö, ä`) is sent, an unhandled exception is thrown with the following message `System.InvalidOperationException: Response Content-Length mismatch: too many bytes written`

This happens because the Content-Length HTTP header is set to be the length of the string, and not the byte count. 

### New behaviour
The Content-Length is correctly set to the UTF8 byte count and no exception is thrown. 
The UTF8 encoding was used, as it is already being used in other sections of the code.
