### PR TITLE
Add agent-group in long haul yaml

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -34,7 +34,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
-        - agent-group: $(agent.group)
+        - agent-group -equals $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals X64
         - run-long-haul -equals true
@@ -98,7 +98,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
-        - agent-group: $(agent.group)
+        - agent-group -equals $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 32
@@ -163,7 +163,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
-        - agent-group: $(agent.group)
+        - agent-group -equals $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 64
@@ -228,7 +228,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
-        - agent-group: $(agent.group)
+        - agent-group -equals $(agent.group)
         - Agent.OS -equals Windows_NT
         - Agent.OSArchitecture -equals X64
         - agent-os-name -equals WinPro_x64
@@ -295,7 +295,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
-        - agent-group: $(agent.group)
+        - agent-group -equals $(agent.group)
         - Agent.OS -equals Windows_NT
         - Agent.OSArchitecture -equals X64
         - agent-os-name -equals WinServerCore_x64
@@ -362,7 +362,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
-        - agent-group: $(agent.group)
+        - agent-group -equals $(agent.group)
         - run-long-haul -equals true
         - runner-os-name -equals WinIoTCore_x64
     variables:

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -34,6 +34,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
+        - agent-group: $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals X64
         - run-long-haul -equals true
@@ -97,6 +98,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
+        - agent-group: $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 32
@@ -161,6 +163,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
+        - agent-group: $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 64
@@ -225,6 +228,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
+        - agent-group: $(agent.group)
         - Agent.OS -equals Windows_NT
         - Agent.OSArchitecture -equals X64
         - agent-os-name -equals WinPro_x64
@@ -291,6 +295,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
+        - agent-group: $(agent.group)
         - Agent.OS -equals Windows_NT
         - Agent.OSArchitecture -equals X64
         - agent-os-name -equals WinServerCore_x64
@@ -357,7 +362,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
-        #- longhaul_iotuap_x64 -equals true
+        - agent-group: $(agent.group)
         - run-long-haul -equals true
         - runner-os-name -equals WinIoTCore_x64
     variables:

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -76,7 +76,7 @@ jobs:
       # Deploy long haul
       - template: templates/longhaul-deploy.yaml
         parameters:
-          release.label: 'lh'
+          release.label: 'lh$(agent.group)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -141,7 +141,7 @@ jobs:
       # Deploy long haul
       - template: templates/longhaul-deploy.yaml
         parameters:
-          release.label: 'lh'
+          release.label: 'lh$(agent.group)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -206,7 +206,7 @@ jobs:
       # Deploy long haul
       - template: templates/longhaul-deploy.yaml
         parameters:
-          release.label: 'lh'
+          release.label: 'lh$(agent.group)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -273,7 +273,7 @@ jobs:
       # Deploy long haul
       - template: templates/longhaul-deploy-windows.yaml
         parameters:
-          release.label: 'winpro-lh'
+          release.label: 'winpro-lh$(agent.group)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'
@@ -340,7 +340,7 @@ jobs:
       # Deploy long haul
       - template: templates/longhaul-deploy-windows.yaml
         parameters:
-          release.label: 'servercore-lh'
+          release.label: 'servercore-lh$(agent.group)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'
@@ -406,7 +406,7 @@ jobs:
       - template: templates/deploy-iotuap.yaml
         parameters:
           testName: 'LongHaul'
-          release.label: 'iotuap-lh'
+          release.label: 'iotuap-lh$(agent.group)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'


### PR DESCRIPTION
Add agent-group in demands in order to run test on agents in specific agent group, which is used for different environments/branches, e.g. master, release candidate or dev branch.