### PR TITLE
Return a specific error code when iotedged can't parse config.yaml

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -1000,6 +1000,7 @@ dependencies = [
  "hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iothubservice 0.1.0",
  "kube-client 0.1.0",
+ "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "provisioning 0.1.0",

--- a/edgelet/edgelet-core/src/error.rs
+++ b/edgelet/edgelet-core/src/error.rs
@@ -52,7 +52,8 @@ pub enum ErrorKind {
     ConnectionStringMalformedParameter(&'static str),
 
     #[fail(
-        display = "Edge device information is required.\nPlease update config.yaml with the IoT Hub connection information.\nSee {} for more details.", _0
+        display = "Edge device information is required.\nPlease update config.yaml with the IoT Hub connection information.\nSee {} for more details.",
+        _0
     )]
     ConnectionStringNotConfigured(&'static str),
 

--- a/edgelet/edgelet-core/src/error.rs
+++ b/edgelet/edgelet-core/src/error.rs
@@ -51,6 +51,11 @@ pub enum ErrorKind {
     )]
     ConnectionStringMalformedParameter(&'static str),
 
+    #[fail(
+        display = "Edge device information is required.\nPlease update config.yaml with the IoT Hub connection information.\nSee {} for more details.", _0
+    )]
+    ConnectionStringNotConfigured(&'static str),
+
     #[fail(display = "An error occurred when obtaining the device identity certificate.")]
     DeviceIdentityCertificate,
 

--- a/edgelet/edgelet-core/src/settings.rs
+++ b/edgelet/edgelet-core/src/settings.rs
@@ -98,9 +98,15 @@ impl ManualDeviceConnectionString {
         }
 
         if self.device_connection_string == DEFAULT_CONNECTION_STRING {
-            return Err(Error::from(ErrorKind::Initialize(
-                InitializeErrorReason::NotConfigured,
-            )));
+            return Err(Error::from(
+                ErrorKind::ConnectionStringNotConfigured(
+                    if cfg!(windows) {
+                        "https://aka.ms/iot-edge-configure-windows"
+                    } else {
+                        "https://aka.ms/iot-edge-configure-linux"
+                    }
+                ),
+            ));
         }
 
         let mut key = None;

--- a/edgelet/edgelet-core/src/settings.rs
+++ b/edgelet/edgelet-core/src/settings.rs
@@ -98,15 +98,13 @@ impl ManualDeviceConnectionString {
         }
 
         if self.device_connection_string == DEFAULT_CONNECTION_STRING {
-            return Err(Error::from(
-                ErrorKind::ConnectionStringNotConfigured(
-                    if cfg!(windows) {
-                        "https://aka.ms/iot-edge-configure-windows"
-                    } else {
-                        "https://aka.ms/iot-edge-configure-linux"
-                    }
-                ),
-            ));
+            return Err(Error::from(ErrorKind::ConnectionStringNotConfigured(
+                if cfg!(windows) {
+                    "https://aka.ms/iot-edge-configure-windows"
+                } else {
+                    "https://aka.ms/iot-edge-configure-linux"
+                },
+            )));
         }
 
         let mut key = None;

--- a/edgelet/edgelet-core/src/settings.rs
+++ b/edgelet/edgelet-core/src/settings.rs
@@ -18,6 +18,9 @@ const SHAREDACCESSKEY_KEY: &str = "SharedAccessKey";
 const DEVICEID_REGEX: &str = r"^[A-Za-z0-9\-:.+%_#*?!(),=@;$']{1,128}$";
 const HOSTNAME_REGEX: &str = r"^[a-zA-Z0-9_\-\.]+$";
 
+/// This is the default connection string
+pub const DEFAULT_CONNECTION_STRING: &str = "<ADD DEVICE CONNECTION STRING HERE>";
+
 #[derive(Clone, Debug, serde_derive::Deserialize, serde_derive::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub struct ManualX509Auth {
@@ -92,6 +95,12 @@ impl ManualDeviceConnectionString {
     pub fn parse_device_connection_string(&self) -> Result<(MemoryKey, String, String), Error> {
         if self.device_connection_string.is_empty() {
             return Err(Error::from(ErrorKind::ConnectionStringEmpty));
+        }
+
+        if self.device_connection_string == DEFAULT_CONNECTION_STRING {
+            return Err(Error::from(ErrorKind::Initialize(
+                InitializeErrorReason::NotConfigured,
+            )));
         }
 
         let mut key = None;

--- a/edgelet/edgelet-docker/src/settings.rs
+++ b/edgelet/edgelet-docker/src/settings.rs
@@ -56,21 +56,16 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn new(filename: Option<&Path>) -> Result<Self, LoadSettingsError> {
-        let filename = filename.map(|filename| {
-            filename.to_str().unwrap_or_else(|| {
-                panic!(
-                    "cannot load config from {} because it is not a utf-8 path",
-                    filename.display()
-                )
-            })
+    pub fn new(filename: &Path) -> Result<Self, LoadSettingsError> {
+        let filename = filename.to_str().unwrap_or_else(|| {
+            panic!(
+                "cannot load config from {} because it is not a utf-8 path",
+                filename.display()
+            )
         });
         let mut config = Config::default();
         config.merge(YamlFileSource::String(DEFAULTS))?;
-        if let Some(file) = filename {
-            config.merge(YamlFileSource::File(file.into()))?;
-        }
-
+        config.merge(YamlFileSource::File(filename.into()))?;
         config.merge(Environment::with_prefix("iotedge"))?;
 
         let mut settings: Self = config.try_into()?;
@@ -384,7 +379,7 @@ mod tests {
 
     #[test]
     fn network_get_settings() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_NETWORK)));
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_NETWORK));
         assert!(settings.is_ok());
         let s = settings.unwrap();
         let moby_runtime = s.moby_runtime();
@@ -420,64 +415,64 @@ mod tests {
 
     #[test]
     fn no_file_gets_error() {
-        let settings = Settings::new(Some(Path::new("garbage")));
+        let settings = Settings::new(Path::new("garbage"));
         assert!(settings.is_err());
     }
 
     #[test]
     fn bad_file_gets_error() {
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_CS2)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_CS2));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_DPS_DEFAULT)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_DPS_DEFAULT));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_DPS_TPM)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_DPS_TPM));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_DPS_SYM_KEY)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_DPS_SYM_KEY));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_DPS_X5091)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_DPS_X5091));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_DPS_X5092)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_DPS_X5092));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_DPS_X5093)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_DPS_X5093));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_DPS_X5094)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_DPS_X5094));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH1)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH1));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH2)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH2));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH3)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH3));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH4)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH4));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH5)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_X509_AUTH5));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_CS_AUTH1)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_CS_AUTH1));
         assert!(settings.is_err());
 
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_CS_AUTH3)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_CS_AUTH3));
         assert!(settings.is_err());
     }
 
     #[test]
     fn manual_file_gets_sample_connection_string() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS)));
+        let settings = Settings::new(Path::new(GOOD_SETTINGS));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();
@@ -491,7 +486,7 @@ mod tests {
 
     #[test]
     fn manual_authentication_connection_string() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_MANUAL_CS_AUTH)));
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_MANUAL_CS_AUTH));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();
@@ -505,7 +500,7 @@ mod tests {
 
     #[test]
     fn manual_empty_connection_string_fails() {
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_CS3)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_CS3));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();
@@ -523,7 +518,7 @@ mod tests {
 
     #[test]
     fn manual_authentication_bad_connection_string_fails() {
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_CS_AUTH2)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_CS_AUTH2));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();
@@ -541,7 +536,7 @@ mod tests {
 
     #[test]
     fn manual_authentication_empty_connection_string_fails() {
-        let settings = Settings::new(Some(Path::new(BAD_SETTINGS_MANUAL_CS_AUTH4)));
+        let settings = Settings::new(Path::new(BAD_SETTINGS_MANUAL_CS_AUTH4));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();
@@ -663,7 +658,7 @@ mod tests {
             &trust_bundle_path,
             false,
         );
-        let settings = Settings::new(Some(&settings_path)).expect("Settings create failed");
+        let settings = Settings::new(&settings_path).expect("Settings create failed");
         println!("{:?}", settings);
         let certificates = settings.certificates();
         certificates
@@ -694,7 +689,7 @@ mod tests {
             &trust_bundle_path,
             true,
         );
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
         println!("{:?}", settings);
         let certificates = settings.certificates();
         certificates
@@ -722,7 +717,7 @@ mod tests {
             &id_cert_path,
             &id_key_path,
         );
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
         println!("{:?}", settings);
         match settings.provisioning() {
             Provisioning::Manual(manual) => match manual.authentication_method() {
@@ -754,7 +749,7 @@ mod tests {
 
     #[test]
     fn dps_prov_default_get_settings() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_DEFAULT)));
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_DEFAULT));
         assert!(settings.is_ok());
         let s = settings.unwrap();
         match s.provisioning() {
@@ -775,7 +770,7 @@ mod tests {
 
     #[test]
     fn dps_prov_tpm_get_settings() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_TPM)));
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_TPM));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();
@@ -797,7 +792,7 @@ mod tests {
 
     #[test]
     fn dps_prov_symmetric_key_get_settings() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_SYM_KEY)));
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_SYM_KEY));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();
@@ -862,7 +857,7 @@ mod tests {
         let key_path = tmp_dir.path().join("test_key");
         let settings_path = tmp_dir.path().join("test_settings.yaml");
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
         println!("{:?}", settings);
         match settings.provisioning() {
             Provisioning::Dps(ref dps) => {
@@ -904,7 +899,7 @@ mod tests {
         let key_path = tmp_dir.path().join("test_key");
         let settings_path = tmp_dir.path().join("test_settings.yaml");
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
         println!("{:?}", settings);
         match settings.provisioning() {
             Provisioning::Dps(ref dps) => {
@@ -941,7 +936,7 @@ mod tests {
 
     #[test]
     fn external_prov_get_settings() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_EXTERNAL)));
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_EXTERNAL));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();
@@ -955,7 +950,7 @@ mod tests {
 
     #[test]
     fn case_of_names_of_keys_is_preserved() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_CASE_SENSITIVE))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_CASE_SENSITIVE)).unwrap();
 
         let env = settings.agent().env();
         assert_eq!(env.get("AbC").map(AsRef::as_ref), Some("VAluE1"));
@@ -967,7 +962,7 @@ mod tests {
 
     #[test]
     fn watchdog_settings_are_read() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS)));
+        let settings = Settings::new(Path::new(GOOD_SETTINGS));
         println!("{:?}", settings);
         assert!(settings.is_ok());
         let s = settings.unwrap();

--- a/edgelet/edgelet-docker/src/settings.rs
+++ b/edgelet/edgelet-docker/src/settings.rs
@@ -57,12 +57,6 @@ pub struct Settings {
 
 impl Settings {
     pub fn new(filename: &Path) -> Result<Self, LoadSettingsError> {
-        let filename = filename.to_str().unwrap_or_else(|| {
-            panic!(
-                "cannot load config from {} because it is not a utf-8 path",
-                filename.display()
-            )
-        });
         let mut config = Config::default();
         config.merge(YamlFileSource::String(DEFAULTS))?;
         config.merge(YamlFileSource::File(filename.into()))?;

--- a/edgelet/edgelet-docker/test/linux/bad_sample_settings.cs.4.yaml
+++ b/edgelet/edgelet-docker/test/linux/bad_sample_settings.cs.4.yaml
@@ -1,0 +1,31 @@
+# default (boilerplate) connection string provided
+provisioning:
+  source: "manual"
+  device_connection_string: "<ADD DEVICE CONNECTION STRING HERE>"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0"
+    auth: {}
+
+hostname: "localhost"
+
+watchdog:
+  max_retries: 3
+
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+
+homedir: "/tmp"
+
+moby_runtime:
+  uri: "http://localhost:2375"
+  network: "azure-iot-edge"

--- a/edgelet/edgelet-docker/test/windows/bad_sample_settings.cs.4.yaml
+++ b/edgelet/edgelet-docker/test/windows/bad_sample_settings.cs.4.yaml
@@ -1,0 +1,31 @@
+# default (boilerplate) connection string provided
+provisioning:
+  source: "manual"
+  device_connection_string: "<ADD DEVICE CONNECTION STRING HERE>"
+
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env: {}
+  config:
+    image: "microsoft/azureiotedge-agent:1.0"
+    auth: {}
+
+hostname: "localhost"
+
+watchdog:
+  max_retries: 3
+
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+
+homedir: "C:\\Temp"
+
+moby_runtime:
+  uri: "npipe://./pipe/iotedge_moby_engine"
+  network: "azure-iot-edge"

--- a/edgelet/edgelet-kube/src/settings.rs
+++ b/edgelet/edgelet-kube/src/settings.rs
@@ -33,25 +33,15 @@ pub struct Settings {
 }
 
 impl Settings {
-    pub fn new(filename: Option<&Path>) -> Result<Self, Error> {
-        let filename = filename.map(|filename| {
-            filename.to_str().unwrap_or_else(|| {
-                panic!(
-                    "cannot load config from {} because it is not a utf-8 path",
-                    filename.display()
-                )
-            })
-        });
+    pub fn new(filename: &Path) -> Result<Self, Error> {
         let mut config = Config::default();
         config
             .merge(YamlFileSource::String(DEFAULTS))
             .context(ErrorKind::Config)?;
 
-        if let Some(file) = filename {
-            config
-                .merge(YamlFileSource::File(file.into()))
-                .context(ErrorKind::Config)?;
-        }
+        config
+            .merge(YamlFileSource::File(filename.into()))
+            .context(ErrorKind::Config)?;
 
         config
             .merge(Environment::with_prefix("iotedge"))

--- a/edgelet/iotedge/src/check/mod.rs
+++ b/edgelet/iotedge/src/check/mod.rs
@@ -694,7 +694,7 @@ fn parse_settings(check: &mut Check) -> Result<CheckResult, failure::Error> {
         }
     }
 
-    let settings = match Settings::new(Some(config_file)) {
+    let settings = match Settings::new(config_file) {
         Ok(settings) => settings,
         Err(err) => {
             let message = if check.verbose {

--- a/edgelet/iotedged/Cargo.toml
+++ b/edgelet/iotedged/Cargo.toml
@@ -49,6 +49,7 @@ winapi = { version = "0.3.5", features = ["shellapi"] }
 win-logger = { path = "../win-logger" }
 
 [dev_dependencies]
+lazy_static = "1"
 rand = "0.5"
 tempdir = "0.3.7"
 

--- a/edgelet/iotedged/src/app.rs
+++ b/edgelet/iotedged/src/app.rs
@@ -72,9 +72,7 @@ fn init_common(running_as_windows_service: bool) -> Result<Settings, Error> {
         let mut default_config_file = program_data.clone();
         default_config_file.push("iotedge");
         default_config_file.push("config.yaml");
-        let default_config_file = Cow::Owned(default_config_file);
-
-        default_config_file
+        Cow::Owned(default_config_file)
     } else {
         Cow::Borrowed(Path::new("/etc/iotedge/config.yaml"))
     };

--- a/edgelet/iotedged/src/app.rs
+++ b/edgelet/iotedged/src/app.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use std::borrow::Cow;
-use std::path::{Path, PathBuf};
+use std::ffi::{OsStr, OsString};
+use std::path::PathBuf;
 
 use clap::{crate_authors, crate_description, crate_name, App, Arg};
 use failure::ResultExt;
@@ -16,7 +16,7 @@ use edgelet_kube::Settings;
 use crate::error::{Error, ErrorKind, InitializeErrorReason};
 use crate::logging;
 
-fn create_app() -> App<'static, 'static> {
+fn create_app<'a>(default_config_file: &'a OsStr) -> App<'a, 'a> {
     let app = App::new(crate_name!())
         .version(edgelet_core::version_with_source_version())
         .author(crate_authors!("\n"))
@@ -27,7 +27,8 @@ fn create_app() -> App<'static, 'static> {
                 .long("config-file")
                 .value_name("FILE")
                 .help("Sets daemon configuration file")
-                .takes_value(true),
+                .takes_value(true)
+                .default_value_os(default_config_file),
         );
 
     if cfg!(windows) {
@@ -46,7 +47,19 @@ fn create_app() -> App<'static, 'static> {
 }
 
 fn init_common(running_as_windows_service: bool) -> Result<Settings, Error> {
-    let matches = create_app().get_matches();
+    let default_config_file = if cfg!(windows) {
+        let program_data: PathBuf =
+            std::env::var_os("PROGRAMDATA").map_or_else(|| r"C:\ProgramData".into(), Into::into);
+
+        let mut default_config_file = program_data;
+        default_config_file.push("iotedge");
+        default_config_file.push("config.yaml");
+        default_config_file.into()
+    } else {
+        OsString::from("/etc/iotedge/config.yaml")
+    };
+
+    let matches = create_app(&default_config_file).get_matches();
 
     // If running as a Windows service, logging was already initialized by init_win_svc_logging(), so don't do it again.
     if !running_as_windows_service {
@@ -65,28 +78,15 @@ fn init_common(running_as_windows_service: bool) -> Result<Settings, Error> {
     };
     info!("Version - {}", edgelet_core::version_with_source_version());
 
-    let default_config_file = if cfg!(windows) {
-        let program_data: PathBuf =
-            std::env::var_os("PROGRAMDATA").map_or_else(|| r"C:\ProgramData".into(), Into::into);
-
-        let mut default_config_file = program_data.clone();
-        default_config_file.push("iotedge");
-        default_config_file.push("config.yaml");
-        Cow::Owned(default_config_file)
-    } else {
-        Cow::Borrowed(Path::new("/etc/iotedge/config.yaml"))
-    };
-
-    let config_file = matches
+    let config_file: PathBuf = matches
         .value_of_os("config-file")
-        .and_then(|name| {
-            let name = Path::new(name);
-            Some(name)
-        })
-        .unwrap_or(&*default_config_file);
+        .expect("arg has a default value")
+        .to_os_string()
+        .into();
+
     info!("Using config file: {}", config_file.display());
 
-    let settings = Settings::new(config_file)
+    let settings = Settings::new(&config_file)
         .context(ErrorKind::Initialize(InitializeErrorReason::LoadSettings))?;
 
     Ok(settings)

--- a/edgelet/iotedged/src/app.rs
+++ b/edgelet/iotedged/src/app.rs
@@ -65,20 +65,19 @@ fn init_common(running_as_windows_service: bool) -> Result<Settings, Error> {
     };
     info!("Version - {}", edgelet_core::version_with_source_version());
 
-    let default_config_file =
-        if cfg!(windows) {
-            let program_data: PathBuf = std::env::var_os("PROGRAMDATA")
-                .map_or_else(|| r"C:\ProgramData".into(), Into::into);
+    let default_config_file = if cfg!(windows) {
+        let program_data: PathBuf =
+            std::env::var_os("PROGRAMDATA").map_or_else(|| r"C:\ProgramData".into(), Into::into);
 
-            let mut default_config_file = program_data.clone();
-            default_config_file.push("iotedge");
-            default_config_file.push("config.yaml");
-            let default_config_file = Cow::Owned(default_config_file);
+        let mut default_config_file = program_data.clone();
+        default_config_file.push("iotedge");
+        default_config_file.push("config.yaml");
+        let default_config_file = Cow::Owned(default_config_file);
 
-            default_config_file
-        } else {
-            Cow::Borrowed(Path::new("/etc/iotedge/config.yaml"))
-        };
+        default_config_file
+    } else {
+        Cow::Borrowed(Path::new("/etc/iotedge/config.yaml"))
+    };
 
     let config_file = matches
         .value_of_os("config-file")

--- a/edgelet/iotedged/src/app.rs
+++ b/edgelet/iotedged/src/app.rs
@@ -16,7 +16,7 @@ use edgelet_kube::Settings;
 use crate::error::{Error, ErrorKind, InitializeErrorReason};
 use crate::logging;
 
-fn create_app<'a>(default_config_file: &'a OsStr) -> App<'a, 'a> {
+fn create_app(default_config_file: &OsStr) -> App<'_, '_> {
     let app = App::new(crate_name!())
         .version(edgelet_core::version_with_source_version())
         .author(crate_authors!("\n"))

--- a/edgelet/iotedged/src/error.rs
+++ b/edgelet/iotedged/src/error.rs
@@ -144,7 +144,7 @@ impl From<&ErrorKind> for i32 {
             ErrorKind::Initialize(InitializeErrorReason::InvalidDeviceConfig) => 150,
             ErrorKind::Initialize(InitializeErrorReason::InvalidHubConfig) => 151,
             ErrorKind::InvalidSignedToken => 152,
-            ErrorKind::Initialize(InitializeErrorReason::NotConfigured) => 153,
+            ErrorKind::Initialize(InitializeErrorReason::LoadSetting) => 153,
             _ => 1,
         }
     }
@@ -182,7 +182,6 @@ pub enum InitializeErrorReason {
     ManagementService,
     ManualProvisioningClient,
     ModuleRuntime,
-    NotConfigured,
     PrepareWorkloadCa,
     #[cfg(windows)]
     RegisterWindowsService,
@@ -321,18 +320,6 @@ impl fmt::Display for InitializeErrorReason {
             InitializeErrorReason::ModuleRuntime => {
                 write!(f, "Could not initialize module runtime")
             }
-
-            InitializeErrorReason::NotConfigured => write!(
-                f,
-                "Edge device information is required.\n\
-                 Please update the config.yaml and provide the IoTHub connection information.\n\
-                 See {} for more details.",
-                if cfg!(windows) {
-                    "https://aka.ms/iot-edge-configure-windows"
-                } else {
-                    "https://aka.ms/iot-edge-configure-linux"
-                }
-            ),
 
             InitializeErrorReason::PrepareWorkloadCa => {
                 write!(f, "Could not prepare workload CA certificate")

--- a/edgelet/iotedged/src/error.rs
+++ b/edgelet/iotedged/src/error.rs
@@ -182,6 +182,7 @@ pub enum InitializeErrorReason {
     ManagementService,
     ManualProvisioningClient,
     ModuleRuntime,
+    NotConfigured,
     PrepareWorkloadCa,
     #[cfg(windows)]
     RegisterWindowsService,
@@ -320,6 +321,18 @@ impl fmt::Display for InitializeErrorReason {
             InitializeErrorReason::ModuleRuntime => {
                 write!(f, "Could not initialize module runtime")
             }
+
+            InitializeErrorReason::NotConfigured => write!(
+                f,
+                "Edge device information is required.\n\
+                 Please update the config.yaml and provide the IoTHub connection information.\n\
+                 See {} for more details.",
+                if cfg!(windows) {
+                    "https://aka.ms/iot-edge-configure-windows"
+                } else {
+                    "https://aka.ms/iot-edge-configure-linux"
+                }
+            ),
 
             InitializeErrorReason::PrepareWorkloadCa => {
                 write!(f, "Could not prepare workload CA certificate")

--- a/edgelet/iotedged/src/error.rs
+++ b/edgelet/iotedged/src/error.rs
@@ -182,7 +182,6 @@ pub enum InitializeErrorReason {
     ManagementService,
     ManualProvisioningClient,
     ModuleRuntime,
-    NotConfigured,
     PrepareWorkloadCa,
     #[cfg(windows)]
     RegisterWindowsService,
@@ -321,18 +320,6 @@ impl fmt::Display for InitializeErrorReason {
             InitializeErrorReason::ModuleRuntime => {
                 write!(f, "Could not initialize module runtime")
             }
-
-            InitializeErrorReason::NotConfigured => write!(
-                f,
-                "Edge device information is required.\n\
-                 Please update the config.yaml and provide the IoTHub connection information.\n\
-                 See {} for more details.",
-                if cfg!(windows) {
-                    "https://aka.ms/iot-edge-configure-windows"
-                } else {
-                    "https://aka.ms/iot-edge-configure-linux"
-                }
-            ),
 
             InitializeErrorReason::PrepareWorkloadCa => {
                 write!(f, "Could not prepare workload CA certificate")

--- a/edgelet/iotedged/src/error.rs
+++ b/edgelet/iotedged/src/error.rs
@@ -144,7 +144,7 @@ impl From<&ErrorKind> for i32 {
             ErrorKind::Initialize(InitializeErrorReason::InvalidDeviceConfig) => 150,
             ErrorKind::Initialize(InitializeErrorReason::InvalidHubConfig) => 151,
             ErrorKind::InvalidSignedToken => 152,
-            ErrorKind::Initialize(InitializeErrorReason::LoadSetting) => 153,
+            ErrorKind::Initialize(InitializeErrorReason::LoadSettings) => 153,
             _ => 1,
         }
     }

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -2195,7 +2195,7 @@ mod tests {
 
     #[test]
     fn default_settings_raise_unconfigured_error() {
-        let settings = Settings::new(Some(Path::new(DEFAULT_CONNECTION_STRING_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(DEFAULT_CONNECTION_STRING_SETTINGS)).unwrap();
         let main = Main::<DockerModuleRuntime>::new(settings);
         let result = main.run_until(signal::shutdown);
         match result.unwrap_err().kind() {
@@ -2206,7 +2206,7 @@ mod tests {
 
     #[test]
     fn empty_connection_string_raises_manual_provisioning_error() {
-        let settings = Settings::new(Some(Path::new(EMPTY_CONNECTION_STRING_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(EMPTY_CONNECTION_STRING_SETTINGS)).unwrap();
         let main = Main::<DockerModuleRuntime>::new(settings);
         let result = main.run_until(signal::shutdown);
         match result.unwrap_err().kind() {
@@ -2218,7 +2218,7 @@ mod tests {
     #[test]
     fn settings_with_invalid_issuer_ca_fails() {
         let tmp_dir = TempDir::new("blah").unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
         let config = DockerConfig::new(
             "microsoft/test-image".to_string(),
             ContainerCreateBody::new(),
@@ -2261,7 +2261,7 @@ mod tests {
     #[test]
     fn settings_with_expired_issuer_ca_fails() {
         let tmp_dir = TempDir::new("blah").unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
         let config = DockerConfig::new(
             "microsoft/test-image".to_string(),
             ContainerCreateBody::new(),
@@ -2304,7 +2304,7 @@ mod tests {
     #[test]
     fn settings_manual_connection_string_auth_first_time_creates_backup() {
         let tmp_dir = TempDir::new("blah").unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
         let config = DockerConfig::new(
             "microsoft/test-image".to_string(),
             ContainerCreateBody::new(),
@@ -2364,7 +2364,7 @@ mod tests {
     #[test]
     fn settings_dps_symm_key_auth_first_time_creates_backup() {
         let tmp_dir = TempDir::new("blah").unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_SYMM_KEY))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_SYMM_KEY)).unwrap();
         let config = DockerConfig::new(
             "microsoft/test-image".to_string(),
             ContainerCreateBody::new(),
@@ -2424,7 +2424,7 @@ mod tests {
     #[test]
     fn settings_dps_tpm_auth_first_time_creates_backup() {
         let tmp_dir = TempDir::new("blah").unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_TPM1))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_TPM1)).unwrap();
         let config = DockerConfig::new(
             "microsoft/test-image".to_string(),
             ContainerCreateBody::new(),
@@ -2484,7 +2484,7 @@ mod tests {
     #[test]
     fn settings_change_creates_new_backup() {
         let tmp_dir = TempDir::new("blah").unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
         let config = DockerConfig::new(
             "microsoft/test-image".to_string(),
             ContainerCreateBody::new(),
@@ -2525,7 +2525,7 @@ mod tests {
             .read_to_string(&mut written)
             .unwrap();
 
-        let settings1 = Settings::new(Some(Path::new(GOOD_SETTINGS1))).unwrap();
+        let settings1 = Settings::new(Path::new(GOOD_SETTINGS1)).unwrap();
         let mut tokio_runtime = tokio::runtime::Runtime::new().unwrap();
         check_settings_state::<TestRuntime<_, Settings>, _>(
             tmp_dir.path(),
@@ -2593,7 +2593,7 @@ mod tests {
     fn diff_with_same_cached_returns_false() {
         let tmp_dir = TempDir::new("blah").unwrap();
         let path = tmp_dir.path().join("cache");
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
         let settings_to_write = serde_json::to_string(&settings).unwrap();
         let sha_to_write = Sha256::digest_str(&settings_to_write);
         let base64_to_write = base64::encode(&sha_to_write);
@@ -2608,7 +2608,7 @@ mod tests {
     fn diff_with_tpm_default_and_explicit_returns_false() {
         let tmp_dir = TempDir::new("blah").unwrap();
         let path = tmp_dir.path().join("cache");
-        let settings1 = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_DEFAULT))).unwrap();
+        let settings1 = Settings::new(Path::new(GOOD_SETTINGS_DPS_DEFAULT)).unwrap();
         let settings_to_write = serde_json::to_string(&settings1).unwrap();
         let sha_to_write = Sha256::digest_str(&settings_to_write);
         let base64_to_write = base64::encode(&sha_to_write);
@@ -2616,7 +2616,7 @@ mod tests {
             .unwrap()
             .write_all(base64_to_write.as_bytes())
             .unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_TPM1))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_TPM1)).unwrap();
         assert!(!diff_with_cached(&settings, &path, None));
     }
 
@@ -2624,7 +2624,7 @@ mod tests {
     fn diff_with_tpm_explicit_and_default_returns_false() {
         let tmp_dir = TempDir::new("blah").unwrap();
         let path = tmp_dir.path().join("cache");
-        let settings1 = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_TPM1))).unwrap();
+        let settings1 = Settings::new(Path::new(GOOD_SETTINGS_DPS_TPM1)).unwrap();
         let settings_to_write = serde_json::to_string(&settings1).unwrap();
         let sha_to_write = Sha256::digest_str(&settings_to_write);
         let base64_to_write = base64::encode(&sha_to_write);
@@ -2632,7 +2632,7 @@ mod tests {
             .unwrap()
             .write_all(base64_to_write.as_bytes())
             .unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_DEFAULT))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_DEFAULT)).unwrap();
         assert!(!diff_with_cached(&settings, &path, None));
     }
 
@@ -2640,7 +2640,7 @@ mod tests {
     fn diff_with_same_cached_env_var_unordered_returns_false() {
         let tmp_dir = TempDir::new("blah").unwrap();
         let path = tmp_dir.path().join("cache");
-        let settings1 = Settings::new(Some(Path::new(GOOD_SETTINGS2))).unwrap();
+        let settings1 = Settings::new(Path::new(GOOD_SETTINGS2)).unwrap();
         let settings_to_write = serde_json::to_string(&settings1).unwrap();
         let sha_to_write = Sha256::digest_str(&settings_to_write);
         let base64_to_write = base64::encode(&sha_to_write);
@@ -2648,7 +2648,7 @@ mod tests {
             .unwrap()
             .write_all(base64_to_write.as_bytes())
             .unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
         assert!(!diff_with_cached(&settings, &path, None));
     }
 
@@ -2656,7 +2656,7 @@ mod tests {
     fn diff_with_different_cached_returns_true() {
         let tmp_dir = TempDir::new("blah").unwrap();
         let path = tmp_dir.path().join("cache");
-        let settings1 = Settings::new(Some(Path::new(GOOD_SETTINGS1))).unwrap();
+        let settings1 = Settings::new(Path::new(GOOD_SETTINGS1)).unwrap();
         let settings_to_write = serde_json::to_string(&settings1).unwrap();
         let sha_to_write = Sha256::digest_str(&settings_to_write);
         let base64_to_write = base64::encode(&sha_to_write);
@@ -2664,19 +2664,19 @@ mod tests {
             .unwrap()
             .write_all(base64_to_write.as_bytes())
             .unwrap();
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
         assert!(diff_with_cached(&settings, &path, None));
     }
 
     #[test]
     fn diff_with_no_file_returns_true() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
         assert!(diff_with_cached(&settings, Path::new("i dont exist"), None));
     }
 
     #[test]
     fn get_provisioning_auth_method_returns_sas_key_for_manual_connection_string() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS1))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS1)).unwrap();
         assert_eq!(
             ProvisioningAuthMethod::SharedAccessKey,
             get_provisioning_auth_method(&settings, None).unwrap()
@@ -2685,7 +2685,7 @@ mod tests {
 
     #[test]
     fn get_provisioning_auth_method_returns_saskey_for_dps_tpm_provisioning() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_TPM1))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_TPM1)).unwrap();
         assert_eq!(
             ProvisioningAuthMethod::SharedAccessKey,
             get_provisioning_auth_method(&settings, None).unwrap()
@@ -2694,7 +2694,7 @@ mod tests {
 
     #[test]
     fn get_provisioning_auth_method_returns_saskey_for_dps_symm_key_provisioning() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_DPS_SYMM_KEY))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_DPS_SYMM_KEY)).unwrap();
         assert_eq!(
             ProvisioningAuthMethod::SharedAccessKey,
             get_provisioning_auth_method(&settings, None).unwrap()
@@ -2816,7 +2816,7 @@ mod tests {
         let settings_path = tmp_dir.path().join("test_settings.yaml");
 
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
         assert_eq!(
             ProvisioningAuthMethod::X509,
             get_provisioning_auth_method(&settings, None).unwrap()
@@ -2831,7 +2831,7 @@ mod tests {
         let settings_path = tmp_dir.path().join("test_settings.yaml");
 
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
 
         let path = tmp_dir.path().join("cache");
         let base64_to_write = compute_settings_digest(&settings, Some("thumbprint-1")).unwrap();
@@ -2861,7 +2861,7 @@ mod tests {
         let settings_path = tmp_dir.path().join("test_settings.yaml");
 
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
 
         let crypto = TestCrypto {
             use_expired_ca: false,
@@ -2915,7 +2915,7 @@ mod tests {
         let settings_path = tmp_dir.path().join("test_settings.yaml");
 
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
 
         let crypto = TestCrypto {
             use_expired_ca: false,
@@ -3022,7 +3022,7 @@ mod tests {
         let settings_path = tmp_dir.path().join("test_settings.yaml");
 
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &cert_key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
 
         let crypto = TestCrypto {
             use_expired_ca: false,
@@ -3076,7 +3076,7 @@ mod tests {
         let settings_path = tmp_dir.path().join("test_settings.yaml");
 
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
 
         let crypto = TestCrypto {
             use_expired_ca: false,
@@ -3105,7 +3105,7 @@ mod tests {
         let settings_path = tmp_dir.path().join("test_settings.yaml");
 
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
 
         let crypto = TestCrypto {
             use_expired_ca: false,
@@ -3215,7 +3215,7 @@ mod tests {
         let settings_path = tmp_dir.path().join("test_settings.yaml");
 
         prepare_test_dps_x509_settings_yaml(&settings_path, &cert_path, &key_path);
-        let settings = Settings::new(Some(&settings_path)).unwrap();
+        let settings = Settings::new(&settings_path).unwrap();
 
         let crypto = TestCrypto {
             use_expired_ca: false,
@@ -3338,7 +3338,7 @@ mod tests {
             .expect("Stale iv file could not be written");
 
         // prepare a non x509 provisioning configuration
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS)).unwrap();
 
         let crypto = TestCrypto {
             use_expired_ca: false,

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -2188,6 +2188,17 @@ mod tests {
     }
 
     #[test]
+    fn default_settings_raise_unconfigured_error() {
+        let settings = Settings::new(None).unwrap();
+        let main = Main::<DockerModuleRuntime>::new(settings);
+        let result = main.run_until(signal::shutdown);
+        match result.unwrap_err().kind() {
+            ErrorKind::Initialize(InitializeErrorReason::NotConfigured) => (),
+            kind => panic!("Expected `NotConfigured` but got {:?}", kind),
+        }
+    }
+
+    #[test]
     fn empty_connection_string_raises_manual_provisioning_error() {
         let settings = Settings::new(Some(Path::new(EMPTY_CONNECTION_STRING_SETTINGS))).unwrap();
         let main = Main::<DockerModuleRuntime>::new(settings);

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -1499,7 +1499,7 @@ fn manual_provision_connection_string(
     let (key, device_id, hub) =
         cs.parse_device_connection_string()
             .context(ErrorKind::Initialize(
-                InitializeErrorReason::ManualProvisioningClient,
+                InitializeErrorReason::LoadSettings,
             ))?;
     let manual = ManualProvisioning::new(key, device_id, hub);
     let memory_hsm = MemoryKeyStore::new();

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -2194,8 +2194,8 @@ mod tests {
     }
 
     lazy_static! {
-        // Main::new tests cannot run in parallel because they initialize hsm-sys (such as hsm_client_crypto_init)
-        // which is not thread-safe.
+        // Tests that call Main::new cannot run in parallel because they initialize hsm-sys
+        // (via hsm_client_crypto_init) which is not thread-safe.
         static ref LOCK: Mutex<()> = Mutex::new(());
     }
 

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -2194,7 +2194,7 @@ mod tests {
     }
 
     #[test]
-    fn default_settings_raise_unconfigured_error() {
+    fn default_settings_raise_load_error() {
         let settings = Settings::new(Path::new(DEFAULT_CONNECTION_STRING_SETTINGS)).unwrap();
         let main = Main::<DockerModuleRuntime>::new(settings);
         let result = main.run_until(signal::shutdown);
@@ -2205,7 +2205,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_connection_string_raises_manual_provisioning_error() {
+    fn empty_connection_string_raises_load_error() {
         let settings = Settings::new(Path::new(EMPTY_CONNECTION_STRING_SETTINGS)).unwrap();
         let main = Main::<DockerModuleRuntime>::new(settings);
         let result = main.run_until(signal::shutdown);

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -2044,6 +2044,9 @@ mod tests {
     static EMPTY_CONNECTION_STRING_SETTINGS: &str =
         "../edgelet-docker/test/linux/bad_sample_settings.cs.3.yaml";
     #[cfg(unix)]
+    static DEFAULT_CONNECTION_STRING_SETTINGS: &str =
+        "../edgelet-docker/test/linux/bad_sample_settings.cs.4.yaml";
+    #[cfg(unix)]
     static GOOD_SETTINGS_EXTERNAL: &str =
         "../edgelet-docker/test/linux/sample_settings.external.yaml";
 
@@ -2063,6 +2066,9 @@ mod tests {
     #[cfg(windows)]
     static EMPTY_CONNECTION_STRING_SETTINGS: &str =
         "../edgelet-docker/test/windows/bad_sample_settings.cs.3.yaml";
+    #[cfg(windows)]
+    static DEFAULT_CONNECTION_STRING_SETTINGS: &str =
+        "../edgelet-docker/test/windows/bad_sample_settings.cs.4.yaml";
     #[cfg(windows)]
     static GOOD_SETTINGS_EXTERNAL: &str =
         "../edgelet-docker/test/windows/sample_settings.external.yaml";
@@ -2189,12 +2195,12 @@ mod tests {
 
     #[test]
     fn default_settings_raise_unconfigured_error() {
-        let settings = Settings::new(None).unwrap();
+        let settings = Settings::new(Some(Path::new(DEFAULT_CONNECTION_STRING_SETTINGS))).unwrap();
         let main = Main::<DockerModuleRuntime>::new(settings);
         let result = main.run_until(signal::shutdown);
         match result.unwrap_err().kind() {
-            ErrorKind::Initialize(InitializeErrorReason::NotConfigured) => (),
-            kind => panic!("Expected `NotConfigured` but got {:?}", kind),
+            ErrorKind::Initialize(InitializeErrorReason::LoadSettings) => (),
+            kind => panic!("Expected `LoadSettings` but got {:?}", kind),
         }
     }
 
@@ -2204,8 +2210,8 @@ mod tests {
         let main = Main::<DockerModuleRuntime>::new(settings);
         let result = main.run_until(signal::shutdown);
         match result.unwrap_err().kind() {
-            ErrorKind::Initialize(InitializeErrorReason::ManualProvisioningClient) => (),
-            kind => panic!("Expected `ManualProvisioningClient` but got {:?}", kind),
+            ErrorKind::Initialize(InitializeErrorReason::LoadSettings) => (),
+            kind => panic!("Expected `LoadSettings` but got {:?}", kind),
         }
     }
 

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -2701,7 +2701,7 @@ mod tests {
 
     #[test]
     fn get_provisioning_auth_method_returns_x509_for_external_provisioning_with_x509_auth_type() {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_EXTERNAL))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_EXTERNAL)).unwrap();
 
         let x509_credential = X509Credential::new("".to_string(), "".to_string());
         let credentials =
@@ -2726,7 +2726,7 @@ mod tests {
     #[test]
     fn get_provisioning_auth_method_returns_sas_key_for_external_provisioning_with_sas_key_auth_type(
     ) {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_EXTERNAL))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_EXTERNAL)).unwrap();
 
         let symmetric_key_credential = SymmetricKeyCredential::new(vec![0_u8; 10]);
         let credentials = Credentials::new(
@@ -2753,7 +2753,7 @@ mod tests {
     #[test]
     fn get_provisioning_auth_method_returns_error_with_no_provisioning_result_in_external_provisioning(
     ) {
-        let settings = Settings::new(Some(Path::new(GOOD_SETTINGS_EXTERNAL))).unwrap();
+        let settings = Settings::new(Path::new(GOOD_SETTINGS_EXTERNAL)).unwrap();
 
         assert_eq!(
             &ErrorKind::Initialize(InitializeErrorReason::ExternalProvisioningClient(

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -1496,11 +1496,9 @@ fn manual_provision_connection_string(
     cs: &ManualDeviceConnectionString,
     tokio_runtime: &mut tokio::runtime::Runtime,
 ) -> Result<(DerivedKeyStore<MemoryKey>, ProvisioningResult, MemoryKey), Error> {
-    let (key, device_id, hub) =
-        cs.parse_device_connection_string()
-            .context(ErrorKind::Initialize(
-                InitializeErrorReason::LoadSettings,
-            ))?;
+    let (key, device_id, hub) = cs
+        .parse_device_connection_string()
+        .context(ErrorKind::Initialize(InitializeErrorReason::LoadSettings))?;
     let manual = ManualProvisioning::new(key, device_id, hub);
     let memory_hsm = MemoryKeyStore::new();
     let provision = manual


### PR DESCRIPTION
#1582 changed the error codes that are returned when iotedged cannot parse the connection string out of config.yaml. The changes broke the behavior of `RestartPreventExitStatus` in our service definition (introduced by #1278); i.e. iotedged was no longer returning error code 153 when users forgot to update the connection string in config.yaml.

This change restores the behavior introduced by #1278.

Other changes:
Since no one is passing `None` to `Settings::new` (edgelet-docker crate) anymore, I changed the `Option<&Path>` argument to just `&Path`.