### PR TITLE
Remove remaining mentions of IOTEDGE_USE_TPM_DEVICE env var

### DIFF
--- a/edgelet/hsm-sys/README-TPM.md
+++ b/edgelet/hsm-sys/README-TPM.md
@@ -114,29 +114,5 @@ $ ls -l /dev/tpm0
 crw-rw---- 1 root iotedge 10, 224 May 31 15:13 /dev/tpm0
 ```
 
-We also need to set a TPM environment variable in the service. To do that edit
-the service settings and restart it.
-```sh
-# sudo systemctl edit iotedge.service
-```
-
-This will open up an overrides file. Save the following entries in the file:
-```sh
-[Service]
-Environment=IOTEDGE_USE_TPM_DEVICE=ON
-```
-
-Verify the overrides
-```sh
-# sudo systemctl cat iotedge.service
-```
-
-Reload the settings
-```sh
-# sudo systemctl daemon-reload
-```
-
-The iotedged service is ready to run!
-
 Other suggested reading:
 [Create and provision a simulated TPM device using C device SDK for IoT Hub Device Provisioning Service](https://docs.microsoft.com/en-us/azure/iot-dps/quick-create-simulated-device)

--- a/edgelet/hsm-sys/README.md
+++ b/edgelet/hsm-sys/README.md
@@ -7,10 +7,6 @@ used by the HSM-RS crate to provide more Rust-friendly interfaces.
 
 ## TPM functionality
 
-The default hsm library built as part of this crate has two modes for the TPM functional interface: 
-an in-memory keystore, and a TPM device keystore.  The default is the in-memory keystore. To enable 
-the TPM device keystore set an environment variable `IOTEDGE_USE_TPM_DEVICE` to "ON".
-
 You may need additional setup for a TPM device see [README-TPM](README-TPM.md) for details.
 
 ## Memory allocation


### PR DESCRIPTION
The env var was removed in b5f281b6f6b7594bc4aa395c0088731e06400af3 but
these mentions of it in the docs were left behind.

---

Also needs to be removed from docs, like https://docs.microsoft.com/en-us/azure/iot-edge/how-to-auto-provision-simulated-device-linux