### PR TITLE
Get k8s systeminfo from edgelet

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesRuntimeInfoProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesRuntimeInfoProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         {
             this.deviceNamespace = Preconditions.CheckNonWhiteSpace(deviceNamespace, nameof(deviceNamespace));
             this.client = Preconditions.CheckNotNull(client, nameof(client));
+            this.moduleManager = Preconditions.CheckNotNull(moduleManager, nameof(moduleManager));
             this.moduleRuntimeInfo = new ConcurrentDictionary<string, ModuleRuntimeInfo>();
         }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesRuntimeInfoProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesRuntimeInfoProvider.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
     using k8s;
     using k8s.Models;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
+    using Microsoft.Azure.Devices.Edge.Agent.Edgelet;
     using Microsoft.Azure.Devices.Edge.Util;
     using AgentDocker = Microsoft.Azure.Devices.Edge.Agent.Docker;
 
@@ -18,8 +19,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         readonly string deviceNamespace;
         readonly IKubernetes client;
         readonly ConcurrentDictionary<string, ModuleRuntimeInfo> moduleRuntimeInfo;
+        readonly IModuleManager moduleManager;
 
-        public KubernetesRuntimeInfoProvider(string deviceNamespace, IKubernetes client)
+        public KubernetesRuntimeInfoProvider(string deviceNamespace, IKubernetes client, IModuleManager moduleManager)
         {
             this.deviceNamespace = Preconditions.CheckNonWhiteSpace(deviceNamespace, nameof(deviceNamespace));
             this.client = Preconditions.CheckNotNull(client, nameof(client));
@@ -51,29 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
         public Task<SystemInfo> GetSystemInfo()
         {
-            // Comment this out to unblock testing.
-            // V1NodeList k8SNodes = await this.client.ListNodeAsync();
-            // string osType = string.Empty;
-            // string arch = string.Empty;
-            // string version = string.Empty;
-            // if (k8SNodes.Items != null)
-            // {
-            //     V1Node firstNode = k8SNodes.Items.FirstOrDefault();
-            //     if (firstNode?.Status?.NodeInfo != null)
-            //     {
-            //         osType = firstNode.Status.NodeInfo.OperatingSystem;
-            //         arch = firstNode.Status.NodeInfo.Architecture;
-            //         version = firstNode.Status.NodeInfo.OsImage;
-            //     }
-            //     else
-            //     {
-            //         Events.NullNodeInfoResponse(firstNode?.Metadata?.Name ?? "UNKNOWN");
-            //     }
-            // }
-            string osType = "Kubernetes";
-            string arch = "Kubernetes";
-            string version = "Kubernetes";
-            return Task.FromResult(new SystemInfo(osType, arch, version));
+            return this.moduleManager.GetSystemInfoAsync();
         }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -135,8 +135,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .SingleInstance();
 
             // IModuleManager
-            var moduleManager = new ModuleManagementHttpClient(this.managementUri, this.apiVersion, Core.Constants.EdgeletClientApiVersion);
-            builder.Register(c => moduleManager)
+            builder.Register(c => new ModuleManagementHttpClient(this.managementUri, this.apiVersion, Core.Constants.EdgeletClientApiVersion))
                 .As<IModuleManager>()
                 .As<IIdentityManager>()
                 .SingleInstance();

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -135,7 +135,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .SingleInstance();
 
             // IModuleManager
-            builder.Register(c => new ModuleManagementHttpClient(this.managementUri, this.apiVersion, Core.Constants.EdgeletClientApiVersion))
+            var moduleManager = new ModuleManagementHttpClient(this.managementUri, this.apiVersion, Core.Constants.EdgeletClientApiVersion);
+            builder.Register(c => moduleManager)
                 .As<IModuleManager>()
                 .As<IIdentityManager>()
                 .SingleInstance();
@@ -183,7 +184,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .SingleInstance();
 
             // KubernetesRuntimeInfoProvider
-            builder.Register(c => new KubernetesRuntimeInfoProvider(this.deviceNamespace, c.Resolve<IKubernetes>()))
+            builder.Register(c => new KubernetesRuntimeInfoProvider(this.deviceNamespace, c.Resolve<IKubernetes>(), c.Resolve<IModuleManager>()))
                 .As<IRuntimeInfoProvider>()
                 .As<IRuntimeInfoSource>();
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesRuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesRuntimeInfoProviderTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
     using k8s.Models;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
     using Microsoft.Azure.Devices.Edge.Agent.Docker;
+    using Microsoft.Azure.Devices.Edge.Agent.Edgelet;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Rest;
@@ -42,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
 
             Assert.Throws<ArgumentException>(() => new KubernetesRuntimeInfoProvider(null, client.Object, moduleManager.Object));
             Assert.Throws<ArgumentNullException>(() => new KubernetesRuntimeInfoProvider("namespace ", null, moduleManager.Object));
-            Assert.Throws<ArgumentException>(() => new KubernetesRuntimeInfoProvider("namespace", client.Object, null));
+            Assert.Throws<ArgumentNullException>(() => new KubernetesRuntimeInfoProvider("namespace", client.Object, null));
         }
 
         [Fact]

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -503,7 +503,6 @@ pub enum RuntimeOperation {
     GetModuleLogs(String),
     Init,
     ListModules,
-    ListNodes,
     RemoveModule(String),
     RestartModule(String),
     StartModule(String),
@@ -522,7 +521,6 @@ impl fmt::Display for RuntimeOperation {
             }
             RuntimeOperation::Init => write!(f, "Could not initialize module runtime"),
             RuntimeOperation::ListModules => write!(f, "Could not list modules"),
-            RuntimeOperation::ListNodes => write!(f, "Could not list nodes"),
             RuntimeOperation::RemoveModule(name) => write!(f, "Could not remove module {}", name),
             RuntimeOperation::RestartModule(name) => write!(f, "Could not restart module {}", name),
             RuntimeOperation::StartModule(name) => write!(f, "Could not start module {}", name),

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -503,6 +503,7 @@ pub enum RuntimeOperation {
     GetModuleLogs(String),
     Init,
     ListModules,
+    ListNodes,
     RemoveModule(String),
     RestartModule(String),
     StartModule(String),
@@ -521,6 +522,7 @@ impl fmt::Display for RuntimeOperation {
             }
             RuntimeOperation::Init => write!(f, "Could not initialize module runtime"),
             RuntimeOperation::ListModules => write!(f, "Could not list modules"),
+            RuntimeOperation::ListNodes => write!(f, "Could not list nodes"),
             RuntimeOperation::RemoveModule(name) => write!(f, "Could not remove module {}", name),
             RuntimeOperation::RestartModule(name) => write!(f, "Could not restart module {}", name),
             RuntimeOperation::StartModule(name) => write!(f, "Could not start module {}", name),

--- a/edgelet/edgelet-kube/src/error.rs
+++ b/edgelet/edgelet-kube/src/error.rs
@@ -65,10 +65,7 @@ pub enum ErrorKind {
     Config,
 
     #[fail(display = "An error occurred obtaining the client identity certificate")]
-    IdentityCertificate,
-
-    #[fail(display = "Could not get the system info")]
-    SystemInfo,
+    IdentityCertificate
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/edgelet/edgelet-kube/src/error.rs
+++ b/edgelet/edgelet-kube/src/error.rs
@@ -66,6 +66,9 @@ pub enum ErrorKind {
 
     #[fail(display = "An error occurred obtaining the client identity certificate")]
     IdentityCertificate,
+
+    #[fail(display = "Could not get the system info")]
+    SystemInfo,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/edgelet/edgelet-kube/src/runtime.rs
+++ b/edgelet/edgelet-kube/src/runtime.rs
@@ -249,7 +249,7 @@ where
             .expect("Unexpected lock error")
             .borrow_mut()
             .list_nodes()
-            .map_err(|err| Error::from(err.context(ErrorKind::SystemInfo)))
+            .map_err(|err| Error::from(err.context(ErrorKind::RuntimeOperation(RuntimeOperation::SystemInfo))))
             .map(|nodes| {
                 // Accumulate the architectures and their node counts into a map
                 let architectures = nodes
@@ -432,7 +432,7 @@ mod tests {
         let mut runtime = Runtime::new().unwrap();
         let info = runtime.block_on(task).unwrap();
 
-        assert_eq!(info.architecture(), "[{\"name\":\"amd64\",\"nodes_count\":2},{\"name\":\"arm32\",\"nodes_count\":1}]");
+        assert_eq!(info.architecture(), "[{\"name\":\"amd64\",\"nodes_count\":2}]");
     }
 
     fn list_node_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
@@ -457,25 +457,6 @@ mod tests {
                                   "kubeProxyVersion": "v1.13.10",
                                   "operatingSystem": "linux",
                                   "architecture": "amd64"
-                                },
-                            }
-                        },
-                        {
-                            "kind" : "Node",
-                            "status" :
-                            {
-                                "nodeInfo":
-                                {
-                                  "machineID": "5aedea612a1a481a9f967578995b2930",
-                                  "systemUUID": "0331B348-6DBE-4344-BF93-6A3407C31879",
-                                  "bootID": "e8c73b01-12e6-45d1-a008-aeb3b5ae4225",
-                                  "kernelVersion": "4.15.0-1052-azure",
-                                  "osImage": "Ubuntu 16.04.6 LTS",
-                                  "containerRuntimeVersion": "docker://3.0.6",
-                                  "kubeletVersion": "v1.13.10",
-                                  "kubeProxyVersion": "v1.13.10",
-                                  "operatingSystem": "linux",
-                                  "architecture": "arm32"
                                 },
                             }
                         },

--- a/edgelet/edgelet-kube/src/runtime.rs
+++ b/edgelet/edgelet-kube/src/runtime.rs
@@ -431,12 +431,8 @@ mod tests {
 
         let mut runtime = Runtime::new().unwrap();
         let info = runtime.block_on(task).unwrap();
-        println!(
-            "{}\n{}\n{}",
-            info.os_type(),
-            info.architecture(),
-            info.version()
-        );
+
+        assert_eq!(info.architecture(), "[{\"name\":\"amd64\",\"nodes_count\":2},{\"name\":\"arm32\",\"nodes_count\":1}]");
     }
 
     fn list_node_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {

--- a/edgelet/edgelet-kube/src/runtime.rs
+++ b/edgelet/edgelet-kube/src/runtime.rs
@@ -237,39 +237,50 @@ where
     }
 
     fn system_info(&self) -> Self::SystemInfoFuture {
-        let result = self
+        #[derive(Debug, serde_derive::Serialize)]
+        pub struct Architecture {
+            name: String,
+            nodes_count: u32,
+        };
+
+        let fut = self
             .client
             .lock()
             .expect("Unexpected lock error")
             .borrow_mut()
             .list_nodes()
-            .map_err(|err| {
-                Error::from(err.context(ErrorKind::RuntimeOperation(RuntimeOperation::ListNodes)))
-            })
+            .map_err(|err| Error::from(err.context(ErrorKind::SystemInfo)))
             .map(|nodes| {
-                // Accumulate the architectures and their node counts into a hashmap
-                let mut arch_map: HashMap<String, u32> = HashMap::new();
-                for node in nodes.items.into_iter() {
-                    *(arch_map
-                        .entry(node.status.unwrap().node_info.unwrap().architecture)
-                        .or_insert(1)) += 1;
-                }
+                // Accumulate the architectures and their node counts into a map
+                let architectures = nodes
+                    .items
+                    .into_iter()
+                    .filter_map(|node| {
+                        node.status
+                            .and_then(|status| status.node_info.map(|info| info.architecture))
+                    })
+                    .fold(HashMap::new(), |mut architectures, current_arch| {
+                        let count = architectures.entry(current_arch).or_insert(0);
+                        *count += 1;
+                        architectures
+                    });
 
-                // Flatten the hashmap into a formatted string
-                let mut arch_string = String::from("[\n");
-                for arch_entry in arch_map.into_iter() {
-                    arch_string.push_str(&*format!(
-                            "{{Name: \"{}\", NodesCount: \"{}\"}},\n",
-                            &arch_entry.0,
-                            &arch_entry.1.to_string()
-                        ));
-                }
-                arch_string.push_str("]");
+                // Convert a map to a list of architectures
+                let architectures = architectures
+                    .into_iter()
+                    .map(|(name, count)| Architecture {
+                        name,
+                        nodes_count: count,
+                    })
+                    .collect::<Vec<Architecture>>();
 
-                SystemInfo::new("Kubernetes".to_string(), arch_string)
+                SystemInfo::new(
+                    "Kubernetes".to_string(),
+                    serde_json::to_string(&architectures).unwrap(),
+                )
             });
 
-        Box::new(result)
+        Box::new(fut)
     }
 
     fn list(&self) -> Self::ListFuture {
@@ -385,5 +396,116 @@ impl Extend<u8> for Chunk {
 impl AsRef<[u8]> for Chunk {
     fn as_ref(&self) -> &[u8] {
         self.0.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::service::service_fn;
+    use hyper::{Body, Method, Request, StatusCode};
+    use maplit::btreemap;
+    use serde_json::json;
+    use tokio::runtime::Runtime;
+
+    use edgelet_core::ModuleRuntime;
+    use edgelet_test_utils::routes;
+    use edgelet_test_utils::web::{
+        make_req_dispatcher, HttpMethod, RequestHandler, RequestPath, ResponseFuture,
+    };
+
+    use crate::tests::{create_runtime, make_settings, not_found_handler, response};
+
+    #[test]
+    fn runtime_get_system_info() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            GET "/api/v1/nodes" => list_node_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+
+        let task = runtime.system_info();
+
+        let mut runtime = Runtime::new().unwrap();
+        let info = runtime.block_on(task).unwrap();
+        println!(
+            "{}\n{}\n{}",
+            info.os_type(),
+            info.architecture(),
+            info.version()
+        );
+    }
+
+    fn list_node_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind" : "NodeList",
+                    "items" : [
+                        {
+                            "kind" : "Node",
+                            "status" :
+                            {
+                                "nodeInfo":
+                                {
+                                  "machineID": "5aedea612a1a481a9f967578995b2930",
+                                  "systemUUID": "0331B348-6DBE-4344-BF93-6A3407C31879",
+                                  "bootID": "e8c73b01-12e6-45d1-a008-aeb3b5ae4225",
+                                  "kernelVersion": "4.15.0-1052-azure",
+                                  "osImage": "Ubuntu 16.04.6 LTS",
+                                  "containerRuntimeVersion": "docker://3.0.6",
+                                  "kubeletVersion": "v1.13.10",
+                                  "kubeProxyVersion": "v1.13.10",
+                                  "operatingSystem": "linux",
+                                  "architecture": "amd64"
+                                },
+                            }
+                        },
+                        {
+                            "kind" : "Node",
+                            "status" :
+                            {
+                                "nodeInfo":
+                                {
+                                  "machineID": "5aedea612a1a481a9f967578995b2930",
+                                  "systemUUID": "0331B348-6DBE-4344-BF93-6A3407C31879",
+                                  "bootID": "e8c73b01-12e6-45d1-a008-aeb3b5ae4225",
+                                  "kernelVersion": "4.15.0-1052-azure",
+                                  "osImage": "Ubuntu 16.04.6 LTS",
+                                  "containerRuntimeVersion": "docker://3.0.6",
+                                  "kubeletVersion": "v1.13.10",
+                                  "kubeProxyVersion": "v1.13.10",
+                                  "operatingSystem": "linux",
+                                  "architecture": "arm32"
+                                },
+                            }
+                        },
+                        {
+                            "kind" : "Node",
+                            "status" :
+                            {
+                                "nodeInfo":
+                                {
+                                  "machineID": "5aedea612a1a481a9f967578995b2930",
+                                  "systemUUID": "0331B348-6DBE-4344-BF93-6A3407C31879",
+                                  "bootID": "e8c73b01-12e6-45d1-a008-aeb3b5ae4225",
+                                  "kernelVersion": "4.15.0-1052-azure",
+                                  "osImage": "Ubuntu 16.04.6 LTS",
+                                  "containerRuntimeVersion": "docker://3.0.6",
+                                  "kubeletVersion": "v1.13.10",
+                                  "kubeProxyVersion": "v1.13.10",
+                                  "operatingSystem": "linux",
+                                  "architecture": "amd64"
+                                },
+                            }
+                        }
+                    ]
+                })
+                .to_string()
+            })
+        }
     }
 }

--- a/edgelet/kube-client/src/client.rs
+++ b/edgelet/kube-client/src/client.rs
@@ -318,6 +318,23 @@ where
             .flatten()
     }
 
+    pub fn list_nodes(&mut self) -> impl Future<Item = api_core::NodeList, Error = Error> {
+        api_core::Node::list_node(Default::default())
+            .map_err(|err| Error::from(err.context(ErrorKind::Request(RequestType::NodeList))))
+            .map(|req| {
+                self.request(req)
+                    .and_then(|response| match response {
+                        api_core::ListNodeResponse::Ok(list) => Ok(list),
+                        _ => Err(Error::from(ErrorKind::Response(RequestType::NodeList))),
+                    })
+                    .map_err(|err| {
+                        Error::from(err.context(ErrorKind::Response(RequestType::NodeList)))
+                    })
+            })
+            .into_future()
+            .flatten()
+    }
+
     pub fn list_secrets(
         &mut self,
         namespace: &str,

--- a/edgelet/kube-client/src/client.rs
+++ b/edgelet/kube-client/src/client.rs
@@ -319,7 +319,7 @@ where
     }
 
     pub fn list_nodes(&mut self) -> impl Future<Item = api_core::NodeList, Error = Error> {
-        api_core::Node::list_node(Default::default())
+        api_core::Node::list_node(api_core::ListNodeOptional::default())
             .map_err(|err| Error::from(err.context(ErrorKind::Request(RequestType::NodeList))))
             .map(|req| {
                 self.request(req)
@@ -871,6 +871,60 @@ mod tests {
 
         if let Err(err) = Runtime::new().unwrap().block_on(fut) {
             assert_eq!(err.kind(), &ErrorKind::Response(RequestType::PodList))
+        } else {
+            panic!("Expected and error result")
+        }
+    }
+
+    const LIST_NODE_RESPONSE: &str = r###"{
+            "kind" : "NodeList",
+            "items" : [
+                {
+                    "kind" : "Node"
+                },
+                {
+                    "kind" : "Node"
+                }
+            ]
+        }"###;
+
+    #[test]
+    fn list_nodes_success() {
+        let service = service_fn(|_req: Request<Body>| -> Result<Response<Body>, HyperError> {
+            Ok(Response::new(Body::from(LIST_NODE_RESPONSE)))
+        });
+
+        let mut client = make_test_client(service);
+
+        let fut = client
+            .list_nodes()
+            .map(|nodes| {
+                assert_eq!(2, nodes.items.len());
+            });
+
+        Runtime::new()
+            .unwrap()
+            .block_on(fut)
+            .expect("Expected future to be OK");
+    }
+
+    #[test]
+    fn list_nodes_error_response() {
+        let service = service_fn(
+            |_req: Request<Body>| -> Result<Response<Body>, HyperError> {
+                let res = Response::builder()
+                    .status(StatusCode::SERVICE_UNAVAILABLE)
+                    .body(Body::empty())
+                    .unwrap();
+                Ok(res)
+            },
+        );
+
+        let mut client = make_test_client(service);
+        let fut = client.list_nodes();
+
+        if let Err(err) = Runtime::new().unwrap().block_on(fut) {
+            assert_eq!(err.kind(), &ErrorKind::Response(RequestType::NodeList))
         } else {
             panic!("Expected and error result")
         }

--- a/edgelet/kube-client/src/error.rs
+++ b/edgelet/kube-client/src/error.rs
@@ -137,6 +137,7 @@ pub enum RequestType {
     DeploymentCreate,
     DeploymentReplace,
     PodList,
+    NodeList,
     SecretList,
     SecretCreate,
     SecretReplace,

--- a/kubernetes/charts/edge-kubernetes/templates/edge-rbac.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/edge-rbac.yaml
@@ -32,6 +32,9 @@ metadata:
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
 rules:
   - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list"]
+  - apiGroups: [""]
     resources: ["pods", "pods/log"]
     verbs: ["list", "watch"]
   - apiGroups: [""]


### PR DESCRIPTION
This changes makes it so that the edgelet provides systeminfo (OS, arch, version) for the k8s agent.

UTs for the new functionality in edgelet will be coming in a later iteration of this PR.