### PR TITLE
Update end-to-end build YAML for new tests

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -19,6 +19,7 @@ steps:
     }
   displayName: Run tests
   env:
+    E2E_DPS_GROUP_KEY: $(TestDpsGroupKeySymmetric)
     E2E_EVENT_HUB_ENDPOINT: $(TestEventHubCompatibleEndpoint)
     E2E_IOT_HUB_CONNECTION_STRING: $(TestIotHubConnectionString)
     E2E_REGISTRIES__0__PASSWORD: $(TestContainerRegistryPassword)

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -19,7 +19,7 @@ steps:
     }
   displayName: Run tests
   env:
-    E2E_DPS_GROUP_KEY: '$(TestDpsGroupKeySymmetric)'
+    E2E_DPS_GROUP_KEY: $(TestDpsGroupKeySymmetric)
     E2E_EVENT_HUB_ENDPOINT: $(TestEventHubCompatibleEndpoint)
     E2E_IOT_HUB_CONNECTION_STRING: $(TestIotHubConnectionString)
     E2E_REGISTRIES__0__PASSWORD: $(TestContainerRegistryPassword)

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -19,7 +19,7 @@ steps:
     }
   displayName: Run tests
   env:
-    E2E_DPS_GROUP_KEY: $(TestDpsGroupKeySymmetric)
+    E2E_DPS_GROUP_KEY: '$(TestDpsGroupKeySymmetric)'
     E2E_EVENT_HUB_ENDPOINT: $(TestEventHubCompatibleEndpoint)
     E2E_IOT_HUB_CONNECTION_STRING: $(TestIotHubConnectionString)
     E2E_REGISTRIES__0__PASSWORD: $(TestContainerRegistryPassword)

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -1,6 +1,5 @@
 steps:
 - pwsh: |
-    Write-Host ">>> Length of DPS group key: $env:E2E_DPS_GROUP_KEY.length"
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
 
     if ($IsWindows)

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -1,5 +1,6 @@
 steps:
 - pwsh: |
+    Write-Host ">>> Length of DPS group key: $env:E2E_DPS_GROUP_KEY.length"
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
 
     if ($IsWindows)

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -10,6 +10,7 @@ steps:
     keyVaultName: $(kv.name)
     secretsFilter: >-
       TestContainerRegistryPassword,
+      TestDpsGroupKeySymmetric,
       TestEventHubCompatibleEndpoint,
       TestIotedgedPackageRootSigningCert,
       TestIotHubConnectionString,

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -107,8 +107,10 @@ steps:
     $imageId = ($imageId -split '=')[1]
     $imageTag = "$imageId-$(os)-$(arch)"
     $context = @{
+      dpsIdScope = '$(dps.idScope)'
       edgeAgentImage = "$imagePrefix-agent:$imageTag";
       edgeHubImage = "$imagePrefix-hub:$imageTag";
+      tempFilterImage = "$imagePrefix-temperature-filter:$imageTag";
       tempSensorImage = "$imagePrefix-simulated-temperature-sensor:$imageTag";
       methodSenderImage = "$imagePrefix-direct-method-sender:$imageTag";
       methodReceiverImage = "$imagePrefix-direct-method-receiver:$imageTag";

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             string defaultId =
                 $"e2e-{string.Concat(Dns.GetHostName().Take(14)).TrimEnd(new[] { '-' })}-{DateTime.Now:yyMMdd'-'HHmmss'.'fff}";
 
-            this.CaCertScriptPath = Get("caCertScriptPath");
+            this.CaCertScriptPath = Option.Maybe(Get("caCertScriptPath"));
             this.ConnectionString = Get("IOT_HUB_CONNECTION_STRING");
             this.DeviceId = IdentityLimits.CheckEdgeId(GetOrDefault("deviceId", defaultId));
             this.DpsIdScope = Option.Maybe(Get("dpsIdScope"));
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
         public static Context Current => Default.Value;
 
-        public string CaCertScriptPath { get; }
+        public Option<string> CaCertScriptPath { get; }
 
         public string ConnectionString { get; }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/CustomCertificatesFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/CustomCertificatesFixture.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                 {
                     (string, string, string) rootCa =
                         Context.Current.RootCaKeys.Expect(() => new InvalidOperationException("Missing root CA keys"));
+                    string caCertScriptPath =
+                        Context.Current.CaCertScriptPath.Expect(() => new InvalidOperationException("Missing CA cert script path"));
 
                     using (var cts = new CancellationTokenSource(Context.Current.SetupTimeout))
                     {
@@ -31,7 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                             this.ca = await CertificateAuthority.CreateAsync(
                                 Context.Current.DeviceId,
                                 rootCa,
-                                Context.Current.CaCertScriptPath,
+                                caCertScriptPath,
                                 token);
 
                             await this.daemon.ConfigureAsync(

--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ The end-to-end tests take several parameters, which they expect to find in a fil
 
 | Name | Required | Description |
 |------|----------|-------------|
-| `caCertScriptPath` | ✔ | Path to the folder containing `certGen.sh` (Linux) or `ca-certs.ps1` (Windows). |
+| `caCertScriptPath` | * | Path to the folder containing `certGen.sh` (Linux) or `ca-certs.ps1` (Windows). Required when running the test 'TransparentGateway', ignored otherwise. |
 | `deviceId` || Name by which the edge device-under-test will be registered in IoT Hub. If not given, a name will automatically be generated in the format: `e2e-{device hostname}-{yyMMdd-HHmmss.fff}`. DPS tests will derive their "registration ID" from `deviceId` by appending the normalized test name (lowercased, with sequences of non-word characters replaced by a single dash). |
 | `dpsIdScope` | * | The [ID Scope](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-device#id-scope) assigned to a Device Provisioning Service. Required when running any DPS tests, ignored otherwise. |
 | `edgeAgentImage` || Docker image to pull/use for Edge Agent. If not given, the default value `mcr.microsoft.com/azureiotedge-agent:1.0` is used. Note also that the default value is ALWAYS used in config.yaml to start IoT Edge; this setting only applies to any configurations deployed by the tests. |


### PR DESCRIPTION
Two new end-to-end tests have been added recently, but they both fail in automated builds because they rely on new context.json parameters and secrets that haven't been added to the YAML build. This change fixes that.

Note this change also makes the context.json parameter `caCertScriptPath` optional because it's only required for the `TransparentGateway` tests.