### PR TITLE
#5321638: RuntimeInfoProvider.GetModules is racy

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RuntimeInfoProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RuntimeInfoProvider.cs
@@ -64,13 +64,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                                         c => this.client.Containers
                                                  .InspectContainerAsync(c.ID)
                                                  .MayThrow(typeof(DockerContainerNotFoundException)))
-                                    .Concat(new[] {
+                                    .Concat(new[]
+                                    {
                                         this.client.Containers
                                                  .InspectContainerAsync(CoreConstants.EdgeAgentModuleName)
                                                  .MayThrow(EdgeAgentNotFoundAlternative, typeof(DockerContainerNotFoundException))
-                                    })
-                       );
-            
+                                    }));
+
             List<ModuleRuntimeInfo> modules = containerInspectResponses
                                                  .FilterMap()
                                                  .Select(InspectResponseToModule)
@@ -222,6 +222,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                     edgeAgentContainerNotFoundReported = true;
                 }
             }
-        }        
-    }    
+        }
+    }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RuntimeInfoProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RuntimeInfoProvider.cs
@@ -57,11 +57,25 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                 }
             };
             IList<ContainerListResponse> containers = await this.client.Containers.ListContainersAsync(parameters, ctsToken);
-            List<ContainerInspectResponse> containerInspectResponses = (await Task.WhenAll(containers.Select(c => this.client.Containers.InspectContainerAsync(c.ID)))).ToList();
-            Option<ContainerInspectResponse> edgeAgentReponse = await this.GetEdgeAgentContainerAsync();
-            edgeAgentReponse.ForEach(e => containerInspectResponses.Add(e));
 
-            List<ModuleRuntimeInfo> modules = containerInspectResponses.Select(InspectResponseToModule).ToList();
+            Option<ContainerInspectResponse>[] containerInspectResponses =
+                await Task.WhenAll(
+                         containers.Select(
+                                        c => this.client.Containers
+                                                 .InspectContainerAsync(c.ID)
+                                                 .MayThrow(typeof(DockerContainerNotFoundException)))
+                                    .Concat(new[] {
+                                        this.client.Containers
+                                                 .InspectContainerAsync(CoreConstants.EdgeAgentModuleName)
+                                                 .MayThrow(EdgeAgentNotFoundAlternative, typeof(DockerContainerNotFoundException))
+                                    })
+                       );
+            
+            List<ModuleRuntimeInfo> modules = containerInspectResponses
+                                                 .FilterMap()
+                                                 .Select(InspectResponseToModule)
+                                                 .ToList();
+
             return modules;
         }
 
@@ -177,18 +191,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             return status;
         }
 
-        async Task<Option<ContainerInspectResponse>> GetEdgeAgentContainerAsync()
+        static Option<ContainerInspectResponse> EdgeAgentNotFoundAlternative(Exception ex)
         {
-            try
-            {
-                ContainerInspectResponse response = await this.client.Containers.InspectContainerAsync(CoreConstants.EdgeAgentModuleName);
-                return Option.Some(response);
-            }
-            catch (DockerContainerNotFoundException ex)
-            {
                 Events.EdgeAgentContainerNotFound(ex);
                 return Option.None<ContainerInspectResponse>();
-            }
         }
 
         static class Events
@@ -208,7 +214,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                 Log.LogInformation((int)EventIds.InvalidContainerStatus, $"Encountered an unrecognized container state from Docker - {status}");
             }
 
-            public static void EdgeAgentContainerNotFound(DockerContainerNotFoundException ex)
+            public static void EdgeAgentContainerNotFound(Exception ex)
             {
                 if (edgeAgentContainerNotFoundReported == false)
                 {
@@ -216,6 +222,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                     edgeAgentContainerNotFoundReported = true;
                 }
             }
-        }
-    }
+        }        
+    }    
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             var missingContainerName = "container2";
             var containersToReturn = new[] { "container1", "container2", "container3" };
 
-            var dockerClient = SetupDockerClient(missingContainerName, containersToReturn);
+            var dockerClient = this.SetupDockerClient(missingContainerName, containersToReturn);
             var provider = await RuntimeInfoProvider.CreateAsync(dockerClient);
 
             var moduleInfo = await provider.GetModules(CancellationToken.None);
@@ -350,8 +350,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
 
             var expectedContainerNames = containersToReturn
                                             .Where(c => !c.Equals(missingContainerName))
-                                            .Select(c => c.Substring(1))    // cuts the first letter
-                                            .Concat(new[] { "dgeAgent" });  // added anyway
+                                            .Select(c => c.Substring(1))
+                                            .Concat(new[] { "dgeAgent" });
 
             Assert.Equal(expectedContainerNames, actualContainerNames);
         }
@@ -363,7 +363,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             var missingContainerName = "edgeAgent";
             var containersToReturn = new[] { "container1", "container2", "container3" };
 
-            var dockerClient = SetupDockerClient(missingContainerName, containersToReturn);
+            var dockerClient = this.SetupDockerClient(missingContainerName, containersToReturn);
             var provider = await RuntimeInfoProvider.CreateAsync(dockerClient);
 
             var moduleInfo = await provider.GetModules(CancellationToken.None);
@@ -372,7 +372,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
                                             .Select(m => m.Name);
 
             var expectedContainerNames = containersToReturn
-                                            .Select(c => c.Substring(1));    // cuts the first letter
+                                            .Select(c => c.Substring(1));
 
             Assert.Equal(expectedContainerNames, actualContainerNames);
         }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
@@ -350,8 +350,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
 
             var expectedContainerNames = containersToReturn
                                             .Where(c => !c.Equals(missingContainerName))
-                                            .Select(c => c.Substring(1))
-                                            .Concat(new[] { "dgeAgent" });
+                                            .Concat(new[] { "edgeAgent" });
 
             Assert.Equal(expectedContainerNames, actualContainerNames);
         }
@@ -361,18 +360,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         public async Task GetModules_Handles_MissingEdgeAgent()
         {
             var missingContainerName = "edgeAgent";
-            var containersToReturn = new[] { "container1", "container2", "container3" };
+            var expectedContainerNames = new[] { "container1", "container2", "container3" };
 
-            var dockerClient = this.SetupDockerClient(missingContainerName, containersToReturn);
+            var dockerClient = this.SetupDockerClient(missingContainerName, expectedContainerNames);
             var provider = await RuntimeInfoProvider.CreateAsync(dockerClient);
 
             var moduleInfo = await provider.GetModules(CancellationToken.None);
 
-            var actualContainerNames = moduleInfo
-                                            .Select(m => m.Name);
-
-            var expectedContainerNames = containersToReturn
-                                            .Select(c => c.Substring(1));
+            var actualContainerNames = moduleInfo.Select(m => m.Name);
 
             Assert.Equal(expectedContainerNames, actualContainerNames);
         }
@@ -405,7 +400,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
                                     {
                                         return Task.FromResult(new ContainerInspectResponse()
                                         {
-                                            Name = a,
+                                            Name = "/" + a,
                                             Config = new Config() { Image = "dummy:latest" },
                                             State = new ContainerState() { Status = "running" }
                                         });

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
@@ -332,5 +332,91 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             receivedLogs = Encoding.UTF8.GetString(buffer, 0, readBytes);
             Assert.Equal(dummyLogs, receivedLogs);
         }
+
+        [Fact]
+        [Unit]
+        public async Task GetModules_Handles_NotFoundException()
+        {
+            var missingContainerName = "container2";
+            var containersToReturn = new[] { "container1", "container2", "container3" };
+
+            var dockerClient = SetupDockerClient(missingContainerName, containersToReturn);
+            var provider = await RuntimeInfoProvider.CreateAsync(dockerClient);
+
+            var moduleInfo = await provider.GetModules(CancellationToken.None);
+
+            var actualContainerNames = moduleInfo
+                                            .Select(m => m.Name);
+
+            var expectedContainerNames = containersToReturn
+                                            .Where(c => !c.Equals(missingContainerName))
+                                            .Select(c => c.Substring(1))    // cuts the first letter
+                                            .Concat(new[] { "dgeAgent" });  // added anyway
+
+            Assert.Equal(expectedContainerNames, actualContainerNames);
+        }
+
+        [Fact]
+        [Unit]
+        public async Task GetModules_Handles_MissingEdgeAgent()
+        {
+            var missingContainerName = "edgeAgent";
+            var containersToReturn = new[] { "container1", "container2", "container3" };
+
+            var dockerClient = SetupDockerClient(missingContainerName, containersToReturn);
+            var provider = await RuntimeInfoProvider.CreateAsync(dockerClient);
+
+            var moduleInfo = await provider.GetModules(CancellationToken.None);
+
+            var actualContainerNames = moduleInfo
+                                            .Select(m => m.Name);
+
+            var expectedContainerNames = containersToReturn
+                                            .Select(c => c.Substring(1));    // cuts the first letter
+
+            Assert.Equal(expectedContainerNames, actualContainerNames);
+        }
+
+        private IDockerClient SetupDockerClient(string nonExistingContainer, params string[] containers)
+        {
+            var dockerClient = new Mock<IDockerClient>();
+            var dockerContainer = new Mock<IContainerOperations>();
+            var dockerSystem = new Mock<ISystemOperations>();
+            var containerList = containers.Select(c => new ContainerListResponse { ID = c }).ToList();
+            var systemInfoResponse = new SystemInfoResponse() { OSType = OperatingSystemType, Architecture = Architecture, ServerVersion = "42" };
+
+            dockerClient.Setup(call => call.Containers).Returns(dockerContainer.Object);
+            dockerClient.Setup(call => call.System).Returns(dockerSystem.Object);
+
+            dockerContainer.Setup(
+                call => call.ListContainersAsync(It.IsAny<ContainersListParameters>(), It.IsAny<CancellationToken>()))
+                            .Returns(() => Task.FromResult(containerList as IList<ContainerListResponse>));
+
+            dockerContainer.Setup(
+                call => call.InspectContainerAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                            .Returns(
+                                (string a, CancellationToken b) =>
+                                {
+                                    if (a.Equals(nonExistingContainer))
+                                    {
+                                        return Task.FromException<ContainerInspectResponse>(new DockerContainerNotFoundException(0, null));
+                                    }
+                                    else
+                                    {
+                                        return Task.FromResult(new ContainerInspectResponse()
+                                        {
+                                            Name = a,
+                                            Config = new Config() { Image = "dummy:latest" },
+                                            State = new ContainerState() { Status = "running" }
+                                        });
+                                    }
+                                });
+
+            dockerSystem.Setup(
+                call => call.GetSystemInfoAsync(It.IsAny<CancellationToken>()))
+                            .Returns(() => Task.FromResult(systemInfoResponse));
+
+            return dockerClient.Object;
+        }
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Option.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Option.cs
@@ -202,6 +202,25 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
     public static class Option
     {
+        public static IEnumerable<T> FilterMap<T>(this IEnumerable<Option<T>> source, Func<T, bool> predicate)
+        {
+            Preconditions.CheckNotNull(source, nameof(source));
+            Preconditions.CheckNotNull(predicate, nameof(predicate));
+
+            foreach (var item in source)
+                if (item.Filter(predicate).HasValue)
+                    yield return item.OrDefault();
+        }
+
+        public static IEnumerable<T> FilterMap<T>(this IEnumerable<Option<T>> source)
+        {
+            Preconditions.CheckNotNull(source, nameof(source));
+
+            foreach (var item in source)
+                if (item.HasValue)
+                    yield return item.OrDefault();
+        }
+
         /// <summary>
         /// Creates an <c>Option &lt;T&gt;</c> with <paramref name="value"/> and marks
         /// the option object as having a value, i.e., <c>Option&lt;T&gt;.HasValue == true</c>.

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Option.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Option.cs
@@ -208,8 +208,12 @@ namespace Microsoft.Azure.Devices.Edge.Util
             Preconditions.CheckNotNull(predicate, nameof(predicate));
 
             foreach (var item in source)
+            {
                 if (item.Filter(predicate).HasValue)
+                {
                     yield return item.OrDefault();
+                }
+            }
         }
 
         public static IEnumerable<T> FilterMap<T>(this IEnumerable<Option<T>> source)
@@ -217,8 +221,12 @@ namespace Microsoft.Azure.Devices.Edge.Util
             Preconditions.CheckNotNull(source, nameof(source));
 
             foreach (var item in source)
+            {
                 if (item.HasValue)
+                {
                     yield return item.OrDefault();
+                }
+            }
         }
 
         /// <summary>

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/TaskEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/TaskEx.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Util
 {
     using System;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -246,6 +247,24 @@ namespace Microsoft.Azure.Devices.Edge.Util
             catch (AggregateException ae)
             {
                 throw ae.GetBaseException();
+            }
+        }
+
+        public static Task<Option<T>> MayThrow<T>(this Task<T> source, params Type[] allowedExceptions)
+        {
+            return MayThrow(source, _ => Option.None<T>(), allowedExceptions);
+        }
+
+        public static async Task<Option<T>> MayThrow<T>(this Task<T> source, Func<Exception, Option<T>> alternativeMaker, params Type[] allowedExceptions)
+        {
+            try
+            {
+                var result = await source;
+                return Option.Some(result);
+            }
+            catch (Exception e) when (allowedExceptions.Contains(e.GetType()))
+            {
+                return alternativeMaker(e);
             }
         }
 

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/OptionTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/OptionTest.cs
@@ -259,5 +259,43 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 });
             Assert.Equal(2, i);
         }
+
+        [Fact]
+        [Unit]
+        public void TestFilterMap_NoPredicate_DropsNones()
+        {
+            var values = new Option<int> []
+                         {
+                            Option.Some(1),
+                            Option.Some(2),
+                            Option.None<int>(),
+                            Option.Some(3),
+                            Option.None<int>(),
+                         };
+
+            var result = values.FilterMap().ToList();
+
+            Assert.Equal(new[] { 1, 2, 3 }, result);
+        }
+
+        [Fact]
+        [Unit]
+        public void TestFilterMap_PredicateFilters_and_DropsNones()
+        {
+            var values = new Option<int>[]
+                         {
+                            Option.Some(1),
+                            Option.Some(2),
+                            Option.None<int>(),
+                            Option.Some(3),
+                            Option.None<int>(),
+                            Option.Some(4)
+                         };
+
+            var result = values.FilterMap(x => x%2 == 0).ToList();
+
+            Assert.Equal(new[] { 2, 4 }, result);
+        }
+
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/OptionTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/OptionTest.cs
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
         [Unit]
         public void TestFilterMap_NoPredicate_DropsNones()
         {
-            var values = new Option<int> []
+            var values = new Option<int>[]
                          {
                             Option.Some(1),
                             Option.Some(2),
@@ -292,10 +292,9 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                             Option.Some(4)
                          };
 
-            var result = values.FilterMap(x => x%2 == 0).ToList();
+            var result = values.FilterMap(x => x % 2 == 0).ToList();
 
             Assert.Equal(new[] { 2, 4 }, result);
         }
-
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/TaskExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/TaskExTest.cs
@@ -234,12 +234,19 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                         var result = await Task.Factory
                                             .StartNew<int>(() => throw new UnexpectedException())
                                             .MayThrow(typeof(ExpectedException1));
-                    }
-                );
+                    });
         }
 
-        private class ExpectedException1 : Exception { };
-        private class ExpectedException2 : Exception { };
-        private class UnexpectedException : Exception { };
+        private class ExpectedException1 : Exception
+        {
+        }
+
+        private class ExpectedException2 : Exception
+        {
+        }
+
+        private class UnexpectedException : Exception
+        {
+        }
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/TaskExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/TaskExTest.cs
@@ -200,5 +200,46 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             Task completedTask = await Task.WhenAny(assertTask, delayTask);
             Assert.Equal(assertTask, completedTask);
         }
+
+        [Fact]
+        [Unit]
+        public async Task MayThrow_ConvertsToSome_When_NoException()
+        {
+            var value = 10;
+            var result = await Task.Factory
+                                  .StartNew(() => value)
+                                  .MayThrow(typeof(ExpectedException1), typeof(ExpectedException2));
+
+            Assert.Equal(Option.Some(value), result);
+        }
+
+        [Fact]
+        [Unit]
+        public async Task MayThrow_ConvertsToNone_When_ExpectedException()
+        {
+            var result = await Task.Factory
+                                  .StartNew<int>(() => throw new ExpectedException2())
+                                  .MayThrow(typeof(ExpectedException1), typeof(ExpectedException2));
+
+            Assert.Equal(Option.None<int>(), result);
+        }
+
+        [Fact]
+        [Unit]
+        public async Task MayThrow_LetsExceptionThrough_When_NotExpected()
+        {
+            await Assert.ThrowsAsync<UnexpectedException>(
+                    async () =>
+                    {
+                        var result = await Task.Factory
+                                            .StartNew<int>(() => throw new UnexpectedException())
+                                            .MayThrow(typeof(ExpectedException1));
+                    }
+                );
+        }
+
+        private class ExpectedException1 : Exception { };
+        private class ExpectedException2 : Exception { };
+        private class UnexpectedException : Exception { };
     }
 }


### PR DESCRIPTION
causing parallel unit tests failing. Modified RuntimeInfoProvider to handle exceptions caused by requesting information about removed modules.