### PR TITLE
Configurable 'Consumer Group' for MessageAnalyzer

### DIFF
--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -198,6 +198,9 @@
               },
               "DeviceId": {
                 "value": "<Analyzer.DeviceID>"
+              },
+              "ConsumerGroupId": {
+                "value": "<Analyzer.ConsumerGroupId>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/long_haul_deployment.template.windows.json
+++ b/e2e_deployment_files/long_haul_deployment.template.windows.json
@@ -201,6 +201,9 @@
               },
               "DeviceId": {
                 "value": "<Analyzer.DeviceID>"
+              },
+              "ConsumerGroupId": {
+                "value": "<Analyzer.ConsumerGroupId>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.json
+++ b/e2e_deployment_files/stress_deployment.template.json
@@ -168,6 +168,9 @@
               },
               "DeviceId": {
                 "value": "<Analyzer.DeviceID>"
+              },
+              "ConsumerGroupId": {
+                "value": "<Analyzer.ConsumerGroupId>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.windows.json
+++ b/e2e_deployment_files/stress_deployment.template.windows.json
@@ -171,6 +171,9 @@
               },
               "DeviceId": {
                 "value": "<Analyzer.DeviceID>"
+              },
+              "ConsumerGroupId": {
+                "value": "<Analyzer.ConsumerGroupId>"
               }
             },
             "settings": {

--- a/edge-modules/MessagesAnalyzer/Program.cs
+++ b/edge-modules/MessagesAnalyzer/Program.cs
@@ -46,7 +46,7 @@ namespace MessagesAnalyzer
                 EventHubClient.CreateFromConnectionString(builder.ToString());
 
             PartitionReceiver eventHubReceiver = eventHubClient.CreateReceiver(
-                "$Default",
+                Settings.Current.ConsumerGroupId,
                 EventHubPartitionKeyResolver.ResolveToPartition(Settings.Current.DeviceId, (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
                 EventPosition.FromEnqueuedTime(DateTime.UtcNow));
 

--- a/edge-modules/MessagesAnalyzer/Settings.cs
+++ b/edge-modules/MessagesAnalyzer/Settings.cs
@@ -11,9 +11,11 @@ namespace MessagesAnalyzer
         const string ExcludeModulesIdsPropertyName = "ExcludeModules:Ids";
         const string EventHubConnectionStringPropertyValue = "eventHubConnectionString";
         const string DeviceIdPropertyName = "DeviceId";
+        const string ConsumerGroupIdPropertyName = "ConsumerGroupId";
         const string WebhostPortPropertyName = "WebhostPort";
         const string ToleranceInMillisecondsPropertyName = "ToleranceInMilliseconds";
         const string DefaultDeviceId = "device1";
+        const string DefaultConsumerGroupId = "$Default";
         const string DefaultWebhostPort = "5001";
         const double DefaultToleranceInMilliseconds = 1000 * 60;
 
@@ -30,15 +32,17 @@ namespace MessagesAnalyzer
 
                 return new Settings(
                     configuration.GetValue<string>(EventHubConnectionStringPropertyValue),
+                    configuration.GetValue(ConsumerGroupIdPropertyName, DefaultConsumerGroupId),
                     configuration.GetValue(DeviceIdPropertyName, DefaultDeviceId),
                     excludedModules,
                     configuration.GetValue(WebhostPortPropertyName, DefaultWebhostPort),
                     configuration.GetValue(ToleranceInMillisecondsPropertyName, DefaultToleranceInMilliseconds));
             });
 
-        Settings(string eventHubCs, string deviceId, IList<string> excludedModuleIds, string webhostPort, double tolerance)
+        Settings(string eventHubCs, string consumerGroupId, string deviceId, IList<string> excludedModuleIds, string webhostPort, double tolerance)
         {
             this.EventHubConnectionString = eventHubCs;
+            this.ConsumerGroupId = consumerGroupId;
             this.ExcludedModuleIds = excludedModuleIds;
             this.DeviceId = deviceId;
             this.WebhostPort = webhostPort;
@@ -48,6 +52,8 @@ namespace MessagesAnalyzer
         public static Settings Current => Setting.Value;
 
         public string EventHubConnectionString { get; }
+
+        public string ConsumerGroupId { get; }
 
         public IList<string> ExcludedModuleIds { get; }
 

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -945,7 +945,7 @@ function usage() {
     echo ' -containerRegistryPassword      Password of given username for container registory.'
     echo ' -iotHubConnectionString         IoT hub connection string for creating edge device.'
     echo ' -eventHubConnectionString       Event hub connection string for receive D2C messages.'
-	echo ' -eventHubConsumerGroup          An existing consumer group id for D2C messages.'
+    echo ' -eventHubConsumerGroup          An existing consumer group id for D2C messages.'
     echo ' -loadGenMessageFrequency        Frequency to send messages in LoadGen module for long haul and stress test. Default is 00.00.01 for long haul and 00:00:00.03 for stress test.'
     echo ' -snitchAlertUrl                 Alert Url pointing to Azure Logic App for email preparation and sending for long haul and stress test.'
     echo ' -snitchBuildNumber              Build number for snitcher docker image for long haul and stress test. Default is 1.1.'

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -170,6 +170,7 @@ function prepare_test_from_artifacts() {
                 local escapedSnitchAlertUrl
                 local escapedBuildId
                 sed -i -e "s@<Analyzer.EventHubConnectionString>@$EVENTHUB_CONNECTION_STRING@g" "$deployment_working_file"
+                sed -i -e "s@<Analyzer.ConsumerGroupId>@${EVENT_HUB_CONSUMER_GROUP:-\$Default}@g" "$deployment_working_file"
                 sed -i -e "s@<LoadGen.MessageFrequency>@$LOADGEN_MESSAGE_FREQUENCY@g" "$deployment_working_file"
                 escapedSnitchAlertUrl="${SNITCH_ALERT_URL//&/\\&}"
                 escapedBuildId="${ARTIFACT_IMAGE_BUILD_NUMBER//./}"
@@ -348,7 +349,7 @@ function process_args() {
         elif [ $saveNextArg -eq 28 ]; then
             DPS_MASTER_SYMMETRIC_KEY="$arg"
             saveNextArg=0
-		elif [ $saveNextArg -eq 29 ]; then
+        elif [ $saveNextArg -eq 29 ]; then
             EVENT_HUB_CONSUMER_GROUP="$arg"
             saveNextArg=0
         else
@@ -621,7 +622,6 @@ function run_longhaul_test() {
     local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-longhaul"
 
     sed -i -e "s@<Analyzer.DeviceID>@$device_id@g" "$deployment_working_file"
-	sed -i -e "s@<Analyzer.ConsumerGroupId>@${EVENT_HUB_CONSUMER_GROUP:-\$Default}@g" "$deployment_working_file"
 
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run Long Haul test with -d '$device_id' started at $test_start_time"
@@ -700,7 +700,6 @@ function run_stress_test() {
     local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-stress"
 
     sed -i -e "s@<Analyzer.DeviceID>@$device_id@g" "$deployment_working_file"
-	sed -i -e "s@<Analyzer.ConsumerGroupId>@${EVENT_HUB_CONSUMER_GROUP:-\$Default}@g" "$deployment_working_file"
 
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run Stress test with -d '$device_id' started at $test_start_time"

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -383,7 +383,7 @@ function process_args() {
                 '-installRootCAKeyPassword' ) saveNextArg=26;;
                 '-dpsScopeId' ) saveNextArg=27;;
                 '-dpsMasterSymmetricKey' ) saveNextArg=28;;
-				'-eventHubConsumerGroup' ) saveNextArg=29;;
+                '-eventHubConsumerGroup' ) saveNextArg=29;;
                 '-cleanAll' ) CLEAN_ALL=1;;
                 * ) usage;;
             esac

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -348,6 +348,9 @@ function process_args() {
         elif [ $saveNextArg -eq 28 ]; then
             DPS_MASTER_SYMMETRIC_KEY="$arg"
             saveNextArg=0
+		elif [ $saveNextArg -eq 29 ]; then
+            EVENT_HUB_CONSUMER_GROUP="$arg"
+            saveNextArg=0
         else
             case "$arg" in
                 '-h' | '--help' ) usage;;
@@ -379,6 +382,7 @@ function process_args() {
                 '-installRootCAKeyPassword' ) saveNextArg=26;;
                 '-dpsScopeId' ) saveNextArg=27;;
                 '-dpsMasterSymmetricKey' ) saveNextArg=28;;
+				'-eventHubConsumerGroup' ) saveNextArg=29;;
                 '-cleanAll' ) CLEAN_ALL=1;;
                 * ) usage;;
             esac
@@ -617,6 +621,7 @@ function run_longhaul_test() {
     local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-longhaul"
 
     sed -i -e "s@<Analyzer.DeviceID>@$device_id@g" "$deployment_working_file"
+	sed -i -e "s@<Analyzer.ConsumerGroupId>@${EVENT_HUB_CONSUMER_GROUP:-\$Default}@g" "$deployment_working_file"
 
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run Long Haul test with -d '$device_id' started at $test_start_time"
@@ -695,6 +700,7 @@ function run_stress_test() {
     local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-stress"
 
     sed -i -e "s@<Analyzer.DeviceID>@$device_id@g" "$deployment_working_file"
+	sed -i -e "s@<Analyzer.ConsumerGroupId>@${EVENT_HUB_CONSUMER_GROUP:-\$Default}@g" "$deployment_working_file"
 
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run Stress test with -d '$device_id' started at $test_start_time"
@@ -940,6 +946,7 @@ function usage() {
     echo ' -containerRegistryPassword      Password of given username for container registory.'
     echo ' -iotHubConnectionString         IoT hub connection string for creating edge device.'
     echo ' -eventHubConnectionString       Event hub connection string for receive D2C messages.'
+	echo ' -eventHubConsumerGroup          An existing consumer group id for D2C messages.'
     echo ' -loadGenMessageFrequency        Frequency to send messages in LoadGen module for long haul and stress test. Default is 00.00.01 for long haul and 00:00:00.03 for stress test.'
     echo ' -snitchAlertUrl                 Alert Url pointing to Azure Logic App for email preparation and sending for long haul and stress test.'
     echo ' -snitchBuildNumber              Build number for snitcher docker image for long haul and stress test. Default is 1.1.'


### PR DESCRIPTION
Allows injecting 'Consumer Group' name for MessageAnalyzer to use when processing messages.

Usage is: runE2ETest.sh -eventHubConsumerGroup groupname

If not specified, it will inject $Default, which results in the current working, as MessageAnalyzer uses $Default consumer today.

Before specifying any consumer group name, that group name must be created manually in IotHub to make it existing.