### PR TITLE
fix deployment status update

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public async Task ReconcileAsync(CancellationToken token)
         {
-            Option<DeploymentStatus> status = Option.None<DeploymentStatus>();
+            DeploymentStatus status = DeploymentStatus.Unknown;
             ModuleSet moduleSetToReport = null;
             using (await this.reconcileLock.LockAsync(token))
             {
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                                 await this.UpdateCurrentConfig(deploymentConfigInfo);
                                 if (result)
                                 {
-                                    status = Option.Some(DeploymentStatus.Success);
+                                    status = DeploymentStatus.Success;
                                 }
                             }
                             catch (Exception ex) when (!ex.IsFatal())
@@ -147,12 +147,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                         }
                         else
                         {
-                            status = Option.Some(DeploymentStatus.Success);
+                            status = DeploymentStatus.Success;
                         }
                     }
                     else
                     {
-                        status = Option.Some(DeploymentStatus.Success);
+                        status = DeploymentStatus.Success;
                     }
                 }
                 catch (Exception ex) when (!ex.IsFatal())
@@ -160,22 +160,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                     switch (ex)
                     {
                         case ConfigEmptyException _:
-                            status = Option.Some(new DeploymentStatus(DeploymentStatusCode.ConfigEmptyError, ex.Message));
+                            status = new DeploymentStatus(DeploymentStatusCode.ConfigEmptyError, ex.Message);
                             Events.EmptyConfig(ex);
                             break;
 
                         case InvalidSchemaVersionException _:
-                            status = Option.Some(new DeploymentStatus(DeploymentStatusCode.InvalidSchemaVersion, ex.Message));
+                            status = new DeploymentStatus(DeploymentStatusCode.InvalidSchemaVersion, ex.Message);
                             Events.InvalidSchemaVersion(ex);
                             break;
 
                         case ConfigFormatException _:
-                            status = Option.Some(new DeploymentStatus(DeploymentStatusCode.ConfigFormatError, ex.Message));
+                            status = new DeploymentStatus(DeploymentStatusCode.ConfigFormatError, ex.Message);
                             Events.InvalidConfigFormat(ex);
                             break;
 
                         default:
-                            status = Option.Some(new DeploymentStatus(DeploymentStatusCode.Failed, ex.Message));
+                            status = new DeploymentStatus(DeploymentStatusCode.Failed, ex.Message);
                             Events.UnknownFailure(ex);
                             break;
                     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
@@ -145,6 +145,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                                 throw;
                             }
                         }
+                        else
+                        {
+                            status = Option.Some(DeploymentStatus.Success);
+                        }
                     }
                     else
                     {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
@@ -127,7 +127,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                         // But that required ModuleSet.Diff to be updated to include modules updated by deployment, and modules updated by state change.
                         IImmutableDictionary<string, IModuleIdentity> identities = await this.moduleIdentityLifecycleManager.GetModuleIdentitiesAsync(desiredModuleSet, current);
                         Plan plan = await this.planner.PlanAsync(desiredModuleSet, current, deploymentConfig.Runtime, identities);
-                        if (!plan.IsEmpty)
+                        if (plan.IsEmpty)
+                        {
+                            status = DeploymentStatus.Success;
+                        }
+                        else
                         {
                             try
                             {
@@ -144,10 +148,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                                 await this.UpdateCurrentConfig(deploymentConfigInfo);
                                 throw;
                             }
-                        }
-                        else
-                        {
-                            status = DeploymentStatus.Success;
                         }
                     }
                     else

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IReporter.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IReporter.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
     public interface IReporter
     {
-        Task ReportAsync(CancellationToken token, ModuleSet moduleSet, IRuntimeInfo runtimeInfo, long version, Option<DeploymentStatus> status);
+        Task ReportAsync(CancellationToken token, ModuleSet moduleSet, IRuntimeInfo runtimeInfo, long version, DeploymentStatus status);
 
         Task ReportShutdown(DeploymentStatus status, CancellationToken token);
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/reporters/NullReporter.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/reporters/NullReporter.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Reporters
 
         public static NullReporter Instance { get; } = new NullReporter();
 
-        public Task ReportAsync(CancellationToken token, ModuleSet moduleSet, IRuntimeInfo runtimeInfo, long version, Option<DeploymentStatus> status) => Task.CompletedTask;
+        public Task ReportAsync(CancellationToken token, ModuleSet moduleSet, IRuntimeInfo runtimeInfo, long version,DeploymentStatus status) => Task.CompletedTask;
 
         public Task ReportShutdown(DeploymentStatus status, CancellationToken token) => Task.CompletedTask;
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/reporters/IoTHubReporter.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/reporters/IoTHubReporter.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Reporters
             this.reportedState = Option.None<AgentState>();
         }
 
-        public async Task ReportAsync(CancellationToken token, ModuleSet moduleSet, IRuntimeInfo runtimeInfo, long version, Option<DeploymentStatus> updatedStatus)
+        public async Task ReportAsync(CancellationToken token, ModuleSet moduleSet, IRuntimeInfo runtimeInfo, long version, DeploymentStatus updatedStatus)
         {
             Option<AgentState> agentState = Option.None<AgentState>();
             using (await this.sync.LockAsync(token))
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Reporters
                     await agentState.ForEachAsync(
                         async rs =>
                         {
-                            AgentState currentState = this.BuildCurrentState(moduleSet, runtimeInfo, version > 0 ? version : rs.LastDesiredVersion, updatedStatus.GetOrElse(rs.LastDesiredStatus));
+                            AgentState currentState = this.BuildCurrentState(moduleSet, runtimeInfo, version > 0 ? version : rs.LastDesiredVersion, updatedStatus);
                             // diff, prepare patch and report
                             await this.DiffAndReportAsync(currentState, rs);
                         });

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 
             mockEnvironment.Verify(env => env.GetModulesAsync(token), Times.Once);
             mockPlanner.Verify(pl => pl.PlanAsync(It.Is<ModuleSet>(ms => ms.Equals(desiredModuleSet)), currentModuleSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty), Times.Once);
-            mockReporter.Verify(r => r.ReportAsync(token, currentModuleSet, runtimeInfo, DeploymentConfigInfo.Empty.Version, Option.Some(DeploymentStatus.Success)), Times.Once);
+            mockReporter.Verify(r => r.ReportAsync(token, currentModuleSet, runtimeInfo, DeploymentConfigInfo.Empty.Version, DeploymentStatus.Success), Times.Once);
             mockPlanRunner.Verify(r => r.ExecuteAsync(1, Plan.Empty, token), Times.Never);
         }
 
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             mockConfigSource.Setup(cs => cs.GetDeploymentConfigInfoAsync()).Throws<InvalidOperationException>();
             mockEnvironment.Setup(env => env.GetModulesAsync(token))
                 .ReturnsAsync(currentSet);
-            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<Option<DeploymentStatus>>(s => s.HasValue && s.OrDefault().Code == DeploymentStatusCode.Failed)))
+            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<DeploymentStatus>(s => s.Code == DeploymentStatusCode.Failed)))
                 .Returns(Task.CompletedTask);
 
             var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider, mockPlanner.Object, mockPlanRunner.Object, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider);
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 .ReturnsAsync(deploymentConfigInfo);
             mockEnvironment.Setup(env => env.GetModulesAsync(token))
                 .ReturnsAsync(currentSet);
-            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<Option<DeploymentStatus>>(s => s.HasValue && s.OrDefault().Code == statusCode)))
+            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<DeploymentStatus>(s => s.Code == statusCode)))
                 .Returns(Task.CompletedTask);
 
             var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider, mockPlanner.Object, mockPlanRunner.Object, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider);
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             mockConfigSource.Setup(cs => cs.GetDeploymentConfigInfoAsync())
                 .ReturnsAsync(deploymentConfigInfo);
             mockEnvironment.Setup(env => env.GetModulesAsync(token)).Throws<InvalidOperationException>();
-            mockReporter.Setup(r => r.ReportAsync(token, null, It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<Option<DeploymentStatus>>(s => s.HasValue && s.OrDefault().Code == DeploymentStatusCode.Failed)))
+            mockReporter.Setup(r => r.ReportAsync(token, null, It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<DeploymentStatus>(s => s.Code == DeploymentStatusCode.Failed)))
                 .Returns(Task.CompletedTask);
 
             var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider, mockPlanner.Object, mockPlanRunner.Object, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider);
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 .ReturnsAsync(ModuleSet.Empty);
             mockModuleIdentityLifecycleManager.Setup(m => m.GetModuleIdentitiesAsync(It.Is<ModuleSet>(ms => ms.Equals(desiredModuleSet)), ModuleSet.Empty))
                 .Throws<InvalidOperationException>();
-            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<Option<DeploymentStatus>>(s => s.HasValue && s.OrDefault().Code == DeploymentStatusCode.Failed)))
+            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<DeploymentStatus>(s => s.Code == DeploymentStatusCode.Failed)))
                 .Returns(Task.CompletedTask);
 
             var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider, mockPlanner.Object, mockPlanRunner.Object, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider);
@@ -341,7 +341,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 
             // Assert
             mockPlanner.Verify(p => p.PlanAsync(It.IsAny<ModuleSet>(), It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<ImmutableDictionary<string, IModuleIdentity>>()), Times.Once);
-            mockReporter.Verify(r => r.ReportAsync(It.IsAny<CancellationToken>(), It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), 0, Option.Some(new DeploymentStatus(DeploymentStatusCode.Failed, "failed"))));
+            mockReporter.Verify(r => r.ReportAsync(It.IsAny<CancellationToken>(), It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), 0, new DeploymentStatus(DeploymentStatusCode.Failed, "failed")));
             mockPlanRunner.Verify(r => r.ExecuteAsync(0, It.IsAny<Plan>(), token), Times.Once);
             encryptionDecryptionProvider.Verify(ep => ep.EncryptAsync(It.IsAny<string>()), Times.Exactly(2));
         }
@@ -393,7 +393,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 .Returns(Task.FromResult(testPlan));
             mockModuleIdentityLifecycleManager.Setup(m => m.GetModuleIdentitiesAsync(It.IsAny<ModuleSet>(), currentSet))
                 .Returns(Task.FromResult((IImmutableDictionary<string, IModuleIdentity>)ImmutableDictionary<string, IModuleIdentity>.Empty));
-            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), Option.Some(DeploymentStatus.Success)))
+            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), DeploymentStatus.Success))
                 .Returns(Task.CompletedTask);
 
             var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider, mockPlanner.Object, planRunner, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider);
@@ -440,7 +440,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 .ReturnsAsync(ImmutableDictionary<string, IModuleIdentity>.Empty);
             mockPlanner.Setup(pl => pl.PlanAsync(It.IsAny<ModuleSet>(), currentSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty))
                 .Returns(Task.FromResult(testPlan));
-            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), Option.Some(DeploymentStatus.Success)))
+            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), DeploymentStatus.Success))
                 .Returns(Task.CompletedTask);
 
             var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider, mockPlanner.Object, planRunner, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider);
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 
             mockEnvironment.Verify(env => env.GetModulesAsync(token), Times.Exactly(1));
             mockPlanner.Verify(pl => pl.PlanAsync(It.IsAny<ModuleSet>(), currentSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty), Times.Once);
-            mockReporter.Verify(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), Option.Some(DeploymentStatus.Success)), Times.Once);
+            mockReporter.Verify(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), DeploymentStatus.Success), Times.Once);
         }
 
         [Fact]
@@ -480,7 +480,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             await agent.ReconcileAsync(token);
 
             // Assert
-            mockReporter.Verify(r => r.ReportAsync(token, null, It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<Option<DeploymentStatus>>(s => s.HasValue && s.OrDefault().Code == DeploymentStatusCode.Failed)));
+            mockReporter.Verify(r => r.ReportAsync(token, null, It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<DeploymentStatus>(s => s.Code == DeploymentStatusCode.Failed)));
             mockPlanRunner.Verify(r => r.ExecuteAsync(1, It.IsAny<Plan>(), token), Times.Never);
         }
 
@@ -510,7 +510,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             await agent.ReconcileAsync(token);
 
             // Assert
-            mockReporter.Verify(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<Option<DeploymentStatus>>(s => s.HasValue && s.OrDefault().Code == DeploymentStatusCode.Failed)));
+            mockReporter.Verify(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.Is<DeploymentStatus>(s => s.Code == DeploymentStatusCode.Failed)));
             mockPlanRunner.Verify(r => r.ExecuteAsync(1, It.IsAny<Plan>(), token), Times.Never);
         }
 
@@ -591,7 +591,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                         It.IsAny<ModuleSet>(),
                         It.IsAny<IRuntimeInfo>(),
                         It.IsAny<long>(),
-                        It.IsAny<Option<DeploymentStatus>>()))
+                        It.IsAny<DeploymentStatus>()))
                 .Returns(Task.Delay(TimeSpan.FromSeconds(5)));
 
             var mockModuleIdentityLifecycleManager = new Mock<IModuleIdentityLifecycleManager>();

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/reporters/IoTHubReporterTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/reporters/IoTHubReporterTest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
-                await reporter.ReportAsync(cts.Token, ModuleSet.Empty, Mock.Of<IRuntimeInfo>(), 0, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, ModuleSet.Empty, Mock.Of<IRuntimeInfo>(), 0, DeploymentStatus.Success);
 
                 // Assert
                 edgeAgentConnection.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Never);
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Assert
                 Assert.Equal(2, patches.Count);
@@ -362,7 +362,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Assert
                 Assert.NotNull(patch);
@@ -541,7 +541,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Assert
                 Assert.NotNull(patch);
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                 patch = null;
 
                 // Act
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.None<DeploymentStatus>());
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Assert
                 Assert.Null(patch);
@@ -735,7 +735,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, deploymentConfigInfo.Version, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, deploymentConfigInfo.Version, DeploymentStatus.Success);
 
                 // Assert
                 Assert.NotNull(patch);
@@ -913,7 +913,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
 
                 // this should cause "extra_mod" to get deleted and "mod1" and "mod2" to get updated
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // now change "current" so that "mod1" fails
                 currentModuleSet = ModuleSet.Create(
@@ -947,7 +947,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         ModuleStatus.Running));
 
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Assert
                 Assert.NotNull(patch);
@@ -1084,10 +1084,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
 
                 // this should cause a patch to get generated
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // since nothing changed, this call should not cause a patch to be generated
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Assert
                 edgeAgentConnection.Verify(c => c.UpdateReportedPropertiesAsync(It.IsAny<TwinCollection>()), Times.Once);
@@ -1212,7 +1212,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Assert
                 Assert.NotNull(patch);
@@ -1300,7 +1300,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
-                await reporter.ReportAsync(cts.Token, null, null, -1, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, null, null, -1, DeploymentStatus.Success);
 
                 // Assert
                 // Assert
@@ -1447,7 +1447,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
 
                 // this should cause all modules to be updated.
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Now use the last reported configuration to report a shutdown
                 await reporter.ReportShutdown(DeploymentStatus.Success, cts.Token);
@@ -1561,7 +1561,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
 
                 // this should cause all modules to be updated.
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Now use the last reported configuration to report a shutdown
                 await reporter.ReportShutdown(DeploymentStatus.Success, cts.Token);
@@ -1718,7 +1718,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
-                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, Option.Some(DeploymentStatus.Success));
+                await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
                 // Assert
                 Assert.NotNull(patch);


### PR DESCRIPTION
Update deployment status to success even there is no deployment change. We got IcM incident that we find when any exception happened during edge agent reconciliation, it will report 500 failed deployment status. If it is a transient exception (timeout exception when calling to management endpoint to get container list) and there is no change in deployment, the next reconciliation doesn't detect any change and doesn't assign any deployment status. Therefore it doesn't update deployment status back to 200 OK.