### PR TITLE
5473107 [k8s] don't update edgeAgent in Public Preview.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IModule.cs
@@ -119,6 +119,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         IDictionary<string, EnvVal> Env { get; }
 
         bool IsOnlyModuleStatusChanged(IModule other);
+
+        [JsonIgnore]
+        bool IsUpdateable { get; set; }
     }
 
     public interface IModule<TConfig> : IModule, IEquatable<IModule<TConfig>>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/ModuleSet.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/ModuleSet.cs
@@ -66,11 +66,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
             // build list of modules that are currently running but the
             // configuration has changed; these are modules that need to
-            // be "updated"
+            // be "updated" and the modules are updateable
             IEnumerable<IModule> updated = this.Modules.Keys
                 .Intersect(other.Modules.Keys)
                 .Except(desiredStatusChanged.Select(m => m.Name))
-                .Where(key => !this.Modules[key].Equals(other.Modules[key]))
+                .Where(key => !this.Modules[key].Equals(other.Modules[key]) && this.Modules[key].IsUpdateable)
                 .Select(key => this.Modules[key]);
 
             return new Diff(created.ToList(), updated.ToList(), desiredStatusChanged, removed.ToList());

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/UnknownModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/UnknownModule.cs
@@ -29,6 +29,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public bool IsOnlyModuleStatusChanged(IModule other) => other is UnknownModule;
 
+        public bool IsUpdateable { get; set; } = true;
+
         public bool Equals(IModule other) => other != null && ReferenceEquals(this, other);
     }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
@@ -97,6 +97,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                 EnvDictionaryComparer.Equals(this.Env, other.Env);
         }
 
+        public bool IsUpdateable { get; set; } = true;
+        
         public override int GetHashCode()
         {
             unchecked

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
@@ -136,6 +136,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
                 EnvDictionaryComparer.Equals(this.Env, other.Env);
         }
 
+        public bool IsUpdateable { get; set; } = true;
+            
         internal class CombinedKubernetesConfigEqualityComparer : IEqualityComparer<KubernetesConfig>
         {
             static readonly AuthConfigEqualityComparer AuthConfigComparer = new AuthConfigEqualityComparer();

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/planners/KubernetesPlanner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/planners/KubernetesPlanner.cs
@@ -63,6 +63,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Planners
                 throw new InvalidModuleException($"Kubernetes deployment currently only handles type={typeof(DockerConfig).FullName}");
             }
 
+            // This is a workaround for K8s public preview refresh
+            // TODO: mark edgeagent module updateable when merging back to main release
+            if (desired.Modules.ContainsKey(Constants.EdgeAgentModuleName)) {
+                desired.Modules[Constants.EdgeAgentModuleName].IsUpdateable = false;
+            }
+
             Diff moduleDifference = desired.Diff(current);
 
             Plan plan;

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
@@ -108,6 +108,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             this.RestartPolicy == other.RestartPolicy &&
             this.ImagePullPolicy == other.ImagePullPolicy;
 
+        public bool IsUpdateable { get; set; } = true;
+
         public override bool Equals(object obj) => this.Equals(obj as TestModuleBase<TConfig>);
 
         public bool Equals(IModule other) => this.Equals(other as TestModuleBase<TConfig>);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Planners
         static readonly ResourceName ResourceName = new ResourceName("hostname", "deviceId");
         static readonly IDictionary<string, EnvVal> EnvVars = new Dictionary<string, EnvVal>();
         static readonly DockerConfig Config1 = new DockerConfig("image1");
+        static readonly DockerConfig Config2 = new DockerConfig("image2");
         static readonly ConfigurationInfo DefaultConfigurationInfo = new ConfigurationInfo("1");
         static readonly IRuntimeInfo RuntimeInfo = Mock.Of<IRuntimeInfo>();
         static readonly IKubernetes DefaultClient = Mock.Of<IKubernetes>();
@@ -61,6 +62,20 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Planners
 
             await Assert.ThrowsAsync<InvalidIdentityException>(
                 () => planner.PlanAsync(addRunning, ModuleSet.Empty, RuntimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty));
+        }
+
+        [Fact]
+        [Unit]
+        public async void KubernetesPlannerNoOverwriteAgentModules()
+        {
+            IModule m1 = new DockerModule(Constants.EdgeAgentModuleName, "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, DefaultConfigurationInfo, EnvVars);
+            IModule m2 = new DockerModule(Constants.EdgeAgentModuleName, "v1", ModuleStatus.Running, RestartPolicy.Always, Config2, ImagePullPolicy.OnCreate, DefaultConfigurationInfo, EnvVars);
+            ModuleSet desired = ModuleSet.Create(m1);
+            ModuleSet current = ModuleSet.Create(m2);
+
+            var planner = new KubernetesPlanner(Namespace, ResourceName, DefaultClient, DefaultCommandFactory, ConfigProvider);
+            var plan = await planner.PlanAsync(desired, current, RuntimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty);
+            Assert.Equal(Plan.Empty, plan);
         }
 
         [Fact]
@@ -149,6 +164,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Planners
             public IDictionary<string, EnvVal> Env { get; }
 
             public bool IsOnlyModuleStatusChanged(IModule other) => throw new NotImplementedException();
+
+            public bool IsUpdateable { get; set; }
 
             public bool Equals(IModule<string> other) => throw new NotImplementedException();
 


### PR DESCRIPTION
This is to disable edgeagent updating itself for the kubernetes case by not creating a deployment. 
It also kind of laying out the long term updateability work. 