### PR TITLE
Fix "storage directories are mounted from host" checks to account for mounts of parent directories

### DIFF
--- a/edgelet/iotedge/src/check/mod.rs
+++ b/edgelet/iotedge/src/check/mod.rs
@@ -1557,7 +1557,7 @@ fn storage_mounted_from_host(
 
     if !mounted_directories
         .chain(volume_directories)
-        .any(|container_directory| container_directory == storage_directory)
+        .any(|container_directory| storage_directory.starts_with(container_directory))
     {
         return Ok(CheckResult::Warning(
             Context::new(format!(


### PR DESCRIPTION
Previously the checks required that the storage directory itself should be
mounted in the container. However it's possible that a parent directory of
the storage directory was mounted instead. This is common for users that
set the `storageFolder` env var on Edge Agent and/or Edge Hub and then mount
this directory from the host.

For example, the user could set `storageFolder` to `/iotedge/storage` and then
mount the host directory `/var/iotedge/storage` to `/iotedge/storage` in
the container. So the storage directories are `/iotedge/storage/edgeAgent`
and `iotedge/storage/edgeHub` but the mount is for `/iotedge/storage`.

Cherry-pick from master of 623d92acd45d6897af56e84954b7ba496062717d