### PR TITLE
[k8s] Treat empty auth config section as no section at all

### DIFF
--- a/edgelet/edgelet-kube/src/constants.rs
+++ b/edgelet/edgelet-kube/src/constants.rs
@@ -25,8 +25,6 @@ pub const PULL_SECRET_DATA_TYPE: &str = "kubernetes.io/dockerconfigjson";
 pub const EDGE_AGENT_MODE: &str = "kubernetes";
 
 pub mod env {
-    pub const USE_PERSISTENT_VOLUME_KEY: &str = "USE_PERSISTENT_VOLUMES";
-
     pub const EDGE_AGENT_MODE_KEY: &str = "Mode";
 
     pub const PROXY_IMAGE_KEY: &str = "ProxyImage";

--- a/edgelet/edgelet-kube/src/constants.rs
+++ b/edgelet/edgelet-kube/src/constants.rs
@@ -43,5 +43,5 @@ pub mod env {
 
     pub const NAMESPACE_KEY: &str = "K8sNamespace";
 
-    pub const EDGE_NETWORKID_KEY: &str = "NetworkId";
+    pub const EDGE_NETWORK_ID_KEY: &str = "NetworkId";
 }

--- a/edgelet/edgelet-kube/src/convert/mod.rs
+++ b/edgelet/edgelet-kube/src/convert/mod.rs
@@ -3,13 +3,14 @@
 use crate::error::{ErrorKind, Result};
 use edgelet_utils::sanitize_dns_label;
 
+mod named_secret;
 mod to_docker;
 mod to_k8s;
 
-pub use self::to_docker::pod_to_module;
-pub use self::to_k8s::{
-    auth_to_image_pull_secret, spec_to_deployment, spec_to_role_binding, spec_to_service_account,
-    trust_bundle_to_config_map,
+pub use named_secret::NamedSecret;
+pub use to_docker::pod_to_module;
+pub use to_k8s::{
+    spec_to_deployment, spec_to_role_binding, spec_to_service_account, trust_bundle_to_config_map,
 };
 
 const DNS_DOMAIN_MAX_SIZE: usize = 253;

--- a/edgelet/edgelet-kube/src/convert/named_secret.rs
+++ b/edgelet/edgelet-kube/src/convert/named_secret.rs
@@ -1,0 +1,131 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+
+use k8s_openapi::api::core::v1 as api_core;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1 as api_meta;
+
+use crate::constants::{PULL_SECRET_DATA_NAME, PULL_SECRET_DATA_TYPE};
+use crate::error::PullImageErrorReason;
+use crate::error::Result;
+use crate::registry::ImagePullSecret;
+use crate::ErrorKind;
+
+#[derive(Debug, PartialEq)]
+pub struct NamedSecret(String, api_core::Secret);
+
+impl NamedSecret {
+    pub fn name(&self) -> &str {
+        &self.0
+    }
+
+    pub fn secret(&self) -> &api_core::Secret {
+        &self.1
+    }
+}
+
+impl<'a> TryFrom<(&str, ImagePullSecret<'a>)> for NamedSecret {
+    type Error = crate::error::Error;
+
+    fn try_from((namespace, image_pull_secret): (&str, ImagePullSecret<'a>)) -> Result<Self> {
+        let secret_name = image_pull_secret
+            .name()
+            .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthName))?;
+
+        let mut secret_data = BTreeMap::new();
+        secret_data.insert(PULL_SECRET_DATA_NAME.to_string(), image_pull_secret.data()?);
+
+        Ok(NamedSecret(
+            secret_name.to_string(),
+            api_core::Secret {
+                data: Some(secret_data),
+                metadata: Some(api_meta::ObjectMeta {
+                    name: Some(secret_name.to_string()),
+                    namespace: Some(namespace.to_string()),
+                    ..api_meta::ObjectMeta::default()
+                }),
+                type_: Some(PULL_SECRET_DATA_TYPE.to_string()),
+                ..api_core::Secret::default()
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::convert::TryFrom;
+
+    use serde_json::{json, Value};
+
+    use crate::constants::PULL_SECRET_DATA_TYPE;
+    use crate::convert::named_secret::NamedSecret;
+    use crate::error::PullImageErrorReason;
+    use crate::registry::ImagePullSecret;
+    use crate::ErrorKind;
+
+    #[test]
+    fn it_converts_to_named_secret() {
+        let image_pull_secret = ImagePullSecret::default()
+            .with_registry("REGISTRY")
+            .with_username("USER")
+            .with_password("PASSWORD");
+
+        let pull_secret = NamedSecret::try_from(("namespace", image_pull_secret)).unwrap();
+
+        assert_eq!(pull_secret.name(), "user-registry".to_string());
+
+        assert_eq!(
+            pull_secret.secret().type_,
+            Some(PULL_SECRET_DATA_TYPE.to_string())
+        );
+        assert!(pull_secret.secret().metadata.is_some());
+        if let Some(meta) = pull_secret.secret().metadata.as_ref() {
+            assert_eq!(meta.name, Some("user-registry".to_string()));
+            assert_eq!(meta.namespace, Some("namespace".to_string()));
+        }
+
+        let json_data = json!({
+            "auths": {
+                "REGISTRY": {
+                    "username":"USER",
+                    "password":"PASSWORD",
+                    "auth":"VVNFUjpQQVNTV09SRA=="
+                }
+            }
+        });
+        let actual_data: Value = serde_json::from_slice(
+            pull_secret.secret().data.as_ref().unwrap()[".dockerconfigjson"]
+                .0
+                .as_slice(),
+        )
+        .unwrap();
+        assert_eq!(actual_data, json_data);
+    }
+
+    #[test]
+    fn it_fails_to_convert_to_named_secret_if_unable_generate_a_name_or_data() {
+        let image_pull_secrets = vec![
+            (
+                ImagePullSecret::default(),
+                ErrorKind::PullImage(PullImageErrorReason::AuthName),
+            ),
+            (
+                ImagePullSecret::default().with_registry("REGISTRY"),
+                ErrorKind::PullImage(PullImageErrorReason::AuthName),
+            ),
+            (
+                ImagePullSecret::default()
+                    .with_registry("REGISTRY")
+                    .with_username("USER"),
+                ErrorKind::PullImage(PullImageErrorReason::AuthPassword),
+            ),
+        ];
+
+        for (image_pull_secret, cause) in image_pull_secrets {
+            let err = NamedSecret::try_from(("namespace", image_pull_secret)).unwrap_err();
+
+            assert_eq!(err.kind(), &cause);
+        }
+    }
+}

--- a/edgelet/edgelet-kube/src/convert/to_k8s.rs
+++ b/edgelet/edgelet-kube/src/convert/to_k8s.rs
@@ -55,9 +55,9 @@ fn spec_to_podspec(
             ..api_core::EnvVar::default()
         })
         .collect();
-    // Pass along "USE_PERSISTENT_VOLUMES" to EdgeAgent
+
     if EDGE_EDGE_AGENT_NAME == module_label_value {
-        env_vars.push(env(EDGE_NETWORKID_KEY, ""));
+        env_vars.push(env(EDGE_NETWORK_ID_KEY, ""));
         env_vars.push(env(NAMESPACE_KEY, settings.namespace()));
         env_vars.push(env(EDGE_AGENT_MODE_KEY, EDGE_AGENT_MODE));
         env_vars.push(env(PROXY_IMAGE_KEY, settings.proxy_image()));

--- a/edgelet/edgelet-kube/src/convert/to_k8s.rs
+++ b/edgelet/edgelet-kube/src/convert/to_k8s.rs
@@ -3,8 +3,7 @@
 use std::collections::BTreeMap;
 use std::str;
 
-use base64;
-use docker::models::{AuthConfig, HostConfig};
+use docker::models::HostConfig;
 use edgelet_core::{Certificate, ModuleSpec};
 use edgelet_docker::DockerConfig;
 use failure::ResultExt;
@@ -12,119 +11,14 @@ use k8s_openapi::api::apps::v1 as api_apps;
 use k8s_openapi::api::core::v1 as api_core;
 use k8s_openapi::api::rbac::v1 as api_rbac;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as api_meta;
-use k8s_openapi::ByteString;
 use log::warn;
-use serde_json;
 
 use crate::constants::env::*;
 use crate::constants::*;
 use crate::convert::{sanitize_dns_domain, sanitize_dns_value};
-use crate::error::{ErrorKind, PullImageErrorReason, Result};
+use crate::error::{ErrorKind, Result};
+use crate::registry::ImagePullSecret;
 use crate::settings::Settings;
-
-// Use username and server from Docker AuthConfig to construct an image pull secret name.
-fn auth_to_pull_secret_name(auth: &AuthConfig) -> Option<String> {
-    match (auth.username(), auth.serveraddress()) {
-        (Some(user), Some(server)) => {
-            Some(format!("{}-{}", user.to_lowercase(), server.to_lowercase()))
-        }
-        _ => None,
-    }
-}
-
-// AuthEntry models the JSON string needed for entryies in the image pull secrets.
-#[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
-struct AuthEntry {
-    pub username: String,
-    pub password: String,
-    pub auth: String,
-}
-
-impl AuthEntry {
-    pub fn new(username: String, password: String) -> AuthEntry {
-        let auth = base64::encode(&format!("{}:{}", username, password));
-        AuthEntry {
-            username,
-            password,
-            auth,
-        }
-    }
-}
-
-// Auth represents the JSON string needed for image pull secrets.
-// JSON struct is
-// { "auths":
-//   {"<registry>" :
-//      { "username":"<user>",
-//        "password":"<password>",
-//        "email":"<email>" (not needed)
-//        "auth":"<base64 of '<user>:<password>'>"
-//       }
-//   }
-// }
-#[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
-struct Auth {
-    pub auths: BTreeMap<String, AuthEntry>,
-}
-
-impl Auth {
-    pub fn new(auths: BTreeMap<String, AuthEntry>) -> Auth {
-        Auth { auths }
-    }
-
-    pub fn secret_data(&self) -> Result<ByteString> {
-        let data =
-            serde_json::to_vec(self).context(ErrorKind::PullImage(PullImageErrorReason::Json))?;
-        Ok(ByteString(data))
-    }
-}
-
-/// Converts Docker `AuthConfig` to a K8s image pull secret.
-pub fn auth_to_image_pull_secret(
-    namespace: &str,
-    auth: &AuthConfig,
-) -> Result<(String, api_core::Secret)> {
-    let secret_name = auth_to_pull_secret_name(auth)
-        .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthName))?;
-
-    let registry = auth
-        .serveraddress()
-        .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthServerAddress))?;
-
-    let user = auth
-        .username()
-        .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthUser))?;
-
-    let password = auth
-        .password()
-        .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthPassword))?;
-
-    let mut auths = BTreeMap::new();
-    auths.insert(
-        registry.to_string(),
-        AuthEntry::new(user.to_string(), password.to_string()),
-    );
-
-    // construct a JSON string from "auths" structure
-    let auth_string = Auth::new(auths).secret_data()?;
-
-    // create a pull secret from auths string.
-    let mut secret_data = BTreeMap::new();
-    secret_data.insert(PULL_SECRET_DATA_NAME.to_string(), auth_string);
-    Ok((
-        secret_name.clone(),
-        api_core::Secret {
-            data: Some(secret_data),
-            metadata: Some(api_meta::ObjectMeta {
-                name: Some(secret_name),
-                namespace: Some(namespace.to_string()),
-                ..api_meta::ObjectMeta::default()
-            }),
-            type_: Some(PULL_SECRET_DATA_TYPE.to_string()),
-            ..api_core::Secret::default()
-        },
-    ))
-}
 
 /// Converts Docker `ModuleSpec` to K8s `PodSpec`
 fn spec_to_podspec(
@@ -163,10 +57,6 @@ fn spec_to_podspec(
         .collect();
     // Pass along "USE_PERSISTENT_VOLUMES" to EdgeAgent
     if EDGE_EDGE_AGENT_NAME == module_label_value {
-        if settings.use_pvc() {
-            env_vars.push(env(USE_PERSISTENT_VOLUME_KEY, "True"));
-        }
-
         env_vars.push(env(EDGE_NETWORKID_KEY, ""));
         env_vars.push(env(NAMESPACE_KEY, settings.namespace()));
         env_vars.push(env(EDGE_AGENT_MODE_KEY, EDGE_AGENT_MODE));
@@ -325,23 +215,10 @@ fn spec_to_podspec(
                     if let (Some(source), Some(target)) = (mount.source(), mount.target()) {
                         let volume_name = sanitize_dns_value(source)?;
 
-                        let volume = if settings.use_pvc() {
-                            api_core::Volume {
-                                name: volume_name.clone(),
-                                persistent_volume_claim: Some(
-                                    api_core::PersistentVolumeClaimVolumeSource {
-                                        claim_name: volume_name.clone(),
-                                        read_only: mount.read_only().cloned(),
-                                    },
-                                ),
-                                ..api_core::Volume::default()
-                            }
-                        } else {
-                            api_core::Volume {
-                                name: volume_name.clone(),
-                                empty_dir: Some(api_core::EmptyDirVolumeSource::default()),
-                                ..api_core::Volume::default()
-                            }
+                        let volume = api_core::Volume {
+                            name: volume_name.clone(),
+                            empty_dir: Some(api_core::EmptyDirVolumeSource::default()),
+                            ..api_core::Volume::default()
                         };
                         let volume_mount = api_core::VolumeMount {
                             mount_path: target.to_string(),
@@ -362,11 +239,15 @@ fn spec_to_podspec(
         }
     };
     //pull secrets
-    let image_pull_secrets = spec.config().auth().and_then(|auth| {
-        Some(vec![api_core::LocalObjectReference {
-            name: auth_to_pull_secret_name(auth),
-        }])
-    });
+    let image_pull_secrets = spec
+        .config()
+        .auth()
+        .and_then(|auth| ImagePullSecret::from_auth(&auth))
+        .map(|image_pull_secret| {
+            vec![api_core::LocalObjectReference {
+                name: image_pull_secret.name(),
+            }]
+        });
 
     Ok(api_core::PodSpec {
         containers: vec![
@@ -605,7 +486,7 @@ pub fn trust_bundle_to_config_map(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::{BTreeMap, HashMap};
+    use std::collections::HashMap;
     use std::str;
 
     use k8s_openapi::api::core::v1 as api_core;
@@ -621,10 +502,9 @@ mod tests {
 
     use crate::constants::env::*;
     use crate::constants::*;
-    use crate::convert::to_k8s::{Auth, AuthEntry};
     use crate::convert::{
-        auth_to_image_pull_secret, spec_to_deployment, spec_to_role_binding,
-        spec_to_service_account, trust_bundle_to_config_map,
+        spec_to_deployment, spec_to_role_binding, spec_to_service_account,
+        trust_bundle_to_config_map,
     };
     use crate::tests::{make_settings, PROXY_CONFIG_MAP_NAME, PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME};
     use crate::ErrorKind;
@@ -750,21 +630,20 @@ mod tests {
     }
 
     fn validate_container_env(env: &[api_core::EnvVar]) {
-        assert_eq!(env.len(), 13);
+        assert_eq!(env.len(), 12);
         assert!(env.contains(&super::env("a", "b")));
         assert!(env.contains(&super::env("C", "D")));
-        assert!(env.contains(&super::env(USE_PERSISTENT_VOLUME_KEY, "True")));
         assert!(env.contains(&super::env(NAMESPACE_KEY, "default")));
         assert!(env.contains(&super::env(EDGE_AGENT_MODE_KEY, EDGE_AGENT_MODE)));
         assert!(env.contains(&super::env(PROXY_IMAGE_KEY, "proxy:latest")));
         assert!(env.contains(&super::env(
             PROXY_CONFIG_VOLUME_KEY,
-            PROXY_CONFIG_VOLUME_NAME
+            PROXY_CONFIG_VOLUME_NAME,
         )));
         assert!(env.contains(&super::env(PROXY_CONFIG_PATH_KEY, "/etc/traefik")));
         assert!(env.contains(&super::env(
             PROXY_CONFIG_MAP_NAME_KEY,
-            PROXY_CONFIG_MAP_NAME
+            PROXY_CONFIG_MAP_NAME,
         )));
         assert!(env.contains(&super::env(
             PROXY_TRUST_BUNDLE_VOLUME_KEY,
@@ -772,58 +651,12 @@ mod tests {
         )));
         assert!(env.contains(&super::env(
             &PROXY_TRUST_BUNDLE_PATH_KEY,
-            "/etc/trust-bundle"
+            "/etc/trust-bundle",
         )));
         assert!(env.contains(&super::env(
             &PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME_KEY,
-            PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME
+            PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME,
         )));
-    }
-
-    #[test]
-    fn auth_to_image_pull_secret_success() {
-        let mut auths = BTreeMap::new();
-        auths.insert(
-            "REGISTRY".to_string(),
-            AuthEntry::new("USER".to_string(), "a password".to_string()),
-        );
-        let json_data = serde_json::to_string(&Auth::new(auths)).unwrap();
-        let auth_config = AuthConfig::new()
-            .with_password(String::from("a password"))
-            .with_username(String::from("USER"))
-            .with_serveraddress(String::from("REGISTRY"));
-        let (name, secret) = auth_to_image_pull_secret("namespace", &auth_config).unwrap();
-        assert_eq!(name, "user-registry");
-
-        assert_eq!(secret.type_, Some(PULL_SECRET_DATA_TYPE.to_string()));
-        assert!(secret.metadata.is_some());
-        if let Some(meta) = secret.metadata.as_ref() {
-            assert_eq!(meta.name, Some(name));
-            assert_eq!(meta.namespace, Some("namespace".to_string()));
-        }
-        assert_eq!(
-            str::from_utf8(secret.data.unwrap()[".dockerconfigjson"].0.as_slice()).unwrap(),
-            json_data
-        );
-    }
-
-    #[test]
-    fn auth_to_image_pull_secret_failure() {
-        let auths = vec![
-            AuthConfig::new()
-                .with_username(String::from("USER"))
-                .with_serveraddress(String::from("REGISTRY")),
-            AuthConfig::new()
-                .with_password(String::from("a password"))
-                .with_serveraddress(String::from("REGISTRY")),
-            AuthConfig::new()
-                .with_password(String::from("a password"))
-                .with_username(String::from("USER")),
-        ];
-        for auth in auths {
-            let result = auth_to_image_pull_secret("namespace", &auth);
-            assert!(result.is_err());
-        }
     }
 
     #[test]

--- a/edgelet/edgelet-kube/src/lib.rs
+++ b/edgelet/edgelet-kube/src/lib.rs
@@ -13,6 +13,7 @@ mod constants;
 mod convert;
 mod error;
 mod module;
+mod registry;
 mod runtime;
 mod settings;
 

--- a/edgelet/edgelet-kube/src/registry/image_pull_secret.rs
+++ b/edgelet/edgelet-kube/src/registry/image_pull_secret.rs
@@ -1,0 +1,253 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use std::collections::BTreeMap;
+use std::str;
+
+use base64;
+use docker::models::AuthConfig;
+use failure::ResultExt;
+use k8s_openapi::ByteString;
+use serde_json;
+
+use crate::error::{ErrorKind, PullImageErrorReason, Result};
+
+#[derive(Debug, PartialEq, Default)]
+pub struct ImagePullSecret<'a> {
+    registry: Option<&'a str>,
+    username: Option<&'a str>,
+    password: Option<&'a str>,
+}
+
+impl<'a> ImagePullSecret<'a> {
+    pub fn from_auth(auth: &'a AuthConfig) -> Option<Self> {
+        if let (None, None, None) = (auth.serveraddress(), auth.username(), auth.password()) {
+            None
+        } else {
+            Some(Self {
+                registry: auth.serveraddress(),
+                username: auth.username(),
+                password: auth.password(),
+            })
+        }
+    }
+
+    #[cfg(test)]
+    pub fn with_registry(mut self, registry: &'a str) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_username(mut self, username: &'a str) -> Self {
+        self.username = Some(username);
+        self
+    }
+
+    #[cfg(test)]
+    pub fn with_password(mut self, password: &'a str) -> Self {
+        self.password = Some(password);
+        self
+    }
+
+    pub fn name(&self) -> Option<String> {
+        match (self.username, self.registry) {
+            (Some(user), Some(registry)) => Some(format!(
+                "{}-{}",
+                user.to_lowercase(),
+                registry.to_lowercase()
+            )),
+            _ => None,
+        }
+    }
+
+    pub fn data(&self) -> Result<ByteString> {
+        let registry = self
+            .registry
+            .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthServerAddress))?;
+
+        let user = self
+            .username
+            .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthUser))?;
+
+        let password = self
+            .password
+            .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthPassword))?;
+
+        let mut auths = BTreeMap::new();
+        auths.insert(
+            registry.to_string(),
+            AuthEntry::new(user.to_string(), password.to_string()),
+        );
+
+        Auth::new(auths).secret_data()
+    }
+}
+
+// AuthEntry models the JSON string needed for entryies in the image pull secrets.
+#[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
+struct AuthEntry {
+    pub username: String,
+    pub password: String,
+    pub auth: String,
+}
+
+impl AuthEntry {
+    pub fn new(username: String, password: String) -> AuthEntry {
+        let auth = base64::encode(&format!("{}:{}", username, password));
+        AuthEntry {
+            username,
+            password,
+            auth,
+        }
+    }
+}
+
+// Auth represents the JSON string needed for image pull secrets.
+// JSON struct is
+// { "auths":
+//   {"<registry>" :
+//      { "username":"<user>",
+//        "password":"<password>",
+//        "email":"<email>" (not needed)
+//        "auth":"<base64 of '<user>:<password>'>"
+//       }
+//   }
+// }
+#[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
+struct Auth {
+    pub auths: BTreeMap<String, AuthEntry>,
+}
+
+impl Auth {
+    pub fn new(auths: BTreeMap<String, AuthEntry>) -> Auth {
+        Auth { auths }
+    }
+
+    pub fn secret_data(&self) -> Result<ByteString> {
+        let data =
+            serde_json::to_vec(self).context(ErrorKind::PullImage(PullImageErrorReason::Json))?;
+        Ok(ByteString(data))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use docker::models::AuthConfig;
+    use serde_json::{json, Value};
+
+    use crate::error::PullImageErrorReason;
+    use crate::registry::ImagePullSecret;
+    use crate::ErrorKind;
+
+    #[test]
+    fn it_converts_to_image_pull_secret_none_when_all_data_missing() {
+        let auth = AuthConfig::new();
+
+        let image_pull_secret = ImagePullSecret::from_auth(&auth);
+
+        assert!(image_pull_secret.is_none());
+    }
+
+    #[test]
+    fn it_converts_to_image_pull_secret_some_if_any_data_exist() {
+        let auths = vec![
+            AuthConfig::new()
+                .with_username(String::from("USER"))
+                .with_serveraddress(String::from("REGISTRY")),
+            AuthConfig::new()
+                .with_password(String::from("a password"))
+                .with_serveraddress(String::from("REGISTRY")),
+            AuthConfig::new()
+                .with_password(String::from("a password"))
+                .with_username(String::from("USER")),
+        ];
+
+        for auth in auths {
+            let image_pull_secret = ImagePullSecret::from_auth(&auth);
+            assert!(image_pull_secret.is_some());
+        }
+    }
+
+    #[test]
+    fn it_returns_some_secret_name() {
+        let image_pull_secret = ImagePullSecret::default()
+            .with_registry("REGISTRY")
+            .with_username("USER");
+
+        let name = image_pull_secret.name();
+
+        assert_eq!(name, Some("user-registry".to_string()));
+    }
+
+    #[test]
+    fn it_returns_none_secret_name_when_username_or_registry_missing() {
+        let image_pull_secrets = vec![
+            ImagePullSecret::default().with_registry("REGISTRY"),
+            ImagePullSecret::default().with_username("USER"),
+            ImagePullSecret::default(),
+        ];
+
+        for image_pull_secret in image_pull_secrets {
+            let name = image_pull_secret.name();
+
+            assert_eq!(name, None);
+        }
+    }
+
+    #[test]
+    fn it_returns_none_secret_name_when_registry_missing() {
+        let image_pull_secret = ImagePullSecret::default().with_username("USER");
+
+        let name = image_pull_secret.name();
+
+        assert_eq!(name, None);
+    }
+
+    #[test]
+    fn it_generates_secret_data() {
+        let image_pull_secret = ImagePullSecret::default()
+            .with_registry("REGISTRY")
+            .with_username("USER")
+            .with_password("PASSWORD");
+
+        let data = image_pull_secret.data();
+
+        let expected = json!({
+            "auths": {
+                "REGISTRY": {
+                    "username":"USER",
+                    "password":"PASSWORD",
+                    "auth":"VVNFUjpQQVNTV09SRA=="
+                }
+            }
+        });
+        let actual: Value = serde_json::from_slice(data.unwrap().0.as_slice()).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn it_fails_to_generate_secret_data() {
+        let image_pull_secrets = vec![
+            (
+                ImagePullSecret::default(),
+                ErrorKind::PullImage(PullImageErrorReason::AuthServerAddress),
+            ),
+            (
+                ImagePullSecret::default().with_registry("REGISTRY"),
+                ErrorKind::PullImage(PullImageErrorReason::AuthUser),
+            ),
+            (
+                ImagePullSecret::default()
+                    .with_registry("REGISTRY")
+                    .with_username("USER"),
+                ErrorKind::PullImage(PullImageErrorReason::AuthPassword),
+            ),
+        ];
+
+        for (image_pull_secret, cause) in image_pull_secrets {
+            let data = image_pull_secret.data();
+
+            assert_eq!(data.unwrap_err().kind(), &cause);
+        }
+    }
+}

--- a/edgelet/edgelet-kube/src/registry/mod.rs
+++ b/edgelet/edgelet-kube/src/registry/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+mod image_pull_secret;
+
+pub use image_pull_secret::ImagePullSecret;

--- a/edgelet/edgelet-kube/src/settings.rs
+++ b/edgelet/edgelet-kube/src/settings.rs
@@ -19,7 +19,6 @@ pub struct Settings {
     #[serde(flatten)]
     base: BaseSettings<DockerConfig>,
     namespace: String,
-    use_pvc: bool,
     iot_hub_hostname: Option<String>,
     device_id: Option<String>,
     proxy_image: String,
@@ -63,10 +62,6 @@ impl Settings {
 
     pub fn namespace(&self) -> &str {
         &self.namespace
-    }
-
-    pub fn use_pvc(&self) -> bool {
-        self.use_pvc
     }
 
     pub fn iot_hub_hostname(&self) -> Option<&str> {

--- a/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
+++ b/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
@@ -75,7 +75,6 @@ listen:
   workload_uri: "https://0.0.0.0:{{ .Values.iotedged.ports.workload }}"
 homedir: {{ .Values.iotedged.data.targetPath | quote }}
 namespace: {{ .Release.Namespace | quote }}
-use_pvc: False
 proxy_image:  "{{.Values.iotedgedProxy.image.repository}}:{{.Values.iotedgedProxy.image.tag}}"
 proxy_config_path: "/etc/iotedge-proxy"
 proxy_config_map_name: "iotedged-proxy-config"


### PR DESCRIPTION
* Remove unused `use_pvc` config parameter
* Treat empty auth config section as no section at all
* Refactored big `to_k8s` module to make image pull secret conversion clean and simple