### PR TITLE
Remove sysinfo for windows build

### DIFF
--- a/edgelet/iotedge/Cargo.toml
+++ b/edgelet/iotedge/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 
 [dependencies]
 atty = "0.2"
-byte-unit = "3.0.3"
 bytes = "0.4"
 chrono = { version = "0.4.7", features = ["serde"] }
 chrono-humanize = "0.0.11"
@@ -25,7 +24,6 @@ regex = "0.2"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sysinfo = "0.9.5"
 tabwriter = "1.0"
 termcolor = "0.3"
 tokio = "0.1"
@@ -41,7 +39,9 @@ management = { path = "../management" }
 mini-sntp = { path = "../mini-sntp" }
 
 [target.'cfg(unix)'.dependencies]
+byte-unit = "3.0.3"
 libc = "0.2"
+sysinfo = "0.9.5"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["ntdef", "ntstatus", "winnt", "winsock2"] }

--- a/edgelet/iotedge/src/check/additional_info.rs
+++ b/edgelet/iotedge/src/check/additional_info.rs
@@ -213,14 +213,14 @@ impl SystemInfo {
         {
             let mut system = sysinfo::System::new();
             system.refresh_all();
-            return SystemInfo {
+            SystemInfo {
                 total_ram: pretty_kbyte(system.get_total_memory()),
                 used_ram: pretty_kbyte(system.get_used_memory()),
                 total_swap: pretty_kbyte(system.get_total_swap()),
                 used_swap: pretty_kbyte(system.get_used_swap()),
 
                 disks: system.get_disks().iter().map(DiskInfo::new).collect(),
-            };
+            }
         }
 
         #[cfg(not(unix))]

--- a/edgelet/iotedge/src/check/additional_info.rs
+++ b/edgelet/iotedge/src/check/additional_info.rs
@@ -1,7 +1,9 @@
 use std::env::consts::ARCH;
 use std::str;
 
+#[cfg(unix)]
 use byte_unit::{Byte, ByteUnit};
+#[cfg(unix)]
 use sysinfo::{DiskExt, SystemExt};
 
 /// Additional info for the JSON output of `iotedge check`
@@ -195,7 +197,7 @@ pub(super) fn os_version() -> Result<
         ))
     }
 }
-#[derive(Clone, Debug, serde_derive::Serialize)]
+#[derive(Clone, Debug, Default, serde_derive::Serialize)]
 struct SystemInfo {
     used_ram: String,
     total_ram: String,
@@ -207,21 +209,26 @@ struct SystemInfo {
 
 impl SystemInfo {
     fn new() -> Self {
-        let mut system = sysinfo::System::new();
-        system.refresh_all();
+        #[cfg(unix)]
+        {
+            let mut system = sysinfo::System::new();
+            system.refresh_all();
+            return SystemInfo {
+                total_ram: pretty_kbyte(system.get_total_memory()),
+                used_ram: pretty_kbyte(system.get_used_memory()),
+                total_swap: pretty_kbyte(system.get_total_swap()),
+                used_swap: pretty_kbyte(system.get_used_swap()),
 
-        SystemInfo {
-            total_ram: pretty_kbyte(system.get_total_memory()),
-            used_ram: pretty_kbyte(system.get_used_memory()),
-            total_swap: pretty_kbyte(system.get_total_swap()),
-            used_swap: pretty_kbyte(system.get_used_swap()),
-
-            disks: system.get_disks().iter().map(DiskInfo::new).collect(),
+                disks: system.get_disks().iter().map(DiskInfo::new).collect(),
+            };
         }
+
+        #[cfg(not(unix))]
+        return SystemInfo::default();
     }
 }
 
-#[derive(Clone, Debug, serde_derive::Serialize)]
+#[derive(Clone, Debug, Default, serde_derive::Serialize)]
 struct DiskInfo {
     name: String,
     percent_free: String,
@@ -231,6 +238,7 @@ struct DiskInfo {
     file_type: String,
 }
 
+#[cfg(unix)]
 impl DiskInfo {
     fn new<T>(disk: &T) -> Self
     where
@@ -259,6 +267,7 @@ impl DiskInfo {
     }
 }
 
+#[cfg(unix)]
 fn pretty_kbyte(bytes: u64) -> String {
     #[allow(clippy::cast_precision_loss)]
     match Byte::from_unit(bytes as f64, ByteUnit::KiB) {


### PR DESCRIPTION
The system information additions to iotedge check don't work on windows iot core b/c its missing the pdh and psapi dlls. for now windows builds will have null for that information