### PR TITLE
E2E setup on Windows should install, not deploy

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
                     properties = properties.Append(p).ToArray();
                 });
 
-            string installCommand = $"Deploy-IoTEdge -ContainerOs Windows";
+            string installCommand = $"Install-IoTEdge -ContainerOs Windows -Manual -DeviceConnectionString 'tbd'";
             packagesPath.ForEach(p => installCommand += $" -OfflineInstallationPath '{p}'");
             proxy.ForEach(
                 p => installCommand += $" -InvokeWebRequestParameters @{{ '-Proxy' = '{p}' }}");
@@ -53,11 +53,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
                     string[] output =
                         await Process.RunAsync("powershell", string.Join(";", commands), token);
                     Log.Verbose(string.Join("\n", output));
-
-                    const string suffix = @"\iotedge\config.yaml";
-                    File.Copy(
-                        Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles) + suffix,
-                        Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData) + suffix);
                 },
                 message,
                 properties);


### PR DESCRIPTION
Call `Install-IoTEdge` instead of `Deploy-IoTEdge` in Windows installer script, so that internal changes to the script don't impact the end-to-end tests. The downside is that the Windows implementation of `IEdgeDaemon.InstallAsync` will both install and configure, but it's not really any different from what Linux install does. In both cases, iotedged starts up and fails because config.yaml hasn't been fully configured yet, but the tests know how to handle that.

This change fixes errors in the end-to-end tests that look like this:
```
  X QuickstartCerts [< 1ms]
  Error Message:
   OneTimeSetUp: System.IO.DirectoryNotFoundException : Could not find a part of the path 'C:\ProgramData\iotedge\config.yaml'.
```