### PR TITLE
Increase build timeout

### DIFF
--- a/builds/ci/edgelet.yaml
+++ b/builds/ci/edgelet.yaml
@@ -37,6 +37,7 @@ jobs:
   - job: linux_arm32v7
 ################################################################################
     displayName: Linux arm32v7
+    timeoutInMinutes: 90
     pool:
       vmImage: 'ubuntu-16.04'
     steps:


### PR DESCRIPTION
increase build timeout for edgelet CI arm32 to avoid build fail due to timeout limit.