### PR TITLE
Updating Test Certificate for local E2E and integration tests

### DIFF
--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/settings/base.json
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/settings/base.json
@@ -2,7 +2,7 @@
   "keyVault": {
     "baseUrl": "https://edgebuildkv.vault.azure.net/",
     "clientId": "668cc883-59f1-4a11-9d4d-bdf18563d672",
-    "clientCertificateThumbprint": "3c79dc82703923b48866c3ce294e0b06f5e2578e"
+    "clientCertificateThumbprint": "bd76a78e183714a37a13f855ccd97e15c50f3894"
   },
   "iotHubConnStrKey": "IotHubConnStr2",
   "device1ConnStrKey": "IotDevice1ConnStr2",


### PR DESCRIPTION
The certificate for accessing the key vault for local E2E and Integration tests has expired. 
The certificate has been updated to a new version in Azure portal, and we need to use its new thumbprint. This change adds that thumbprint to the test config.