### PR TITLE
fix cross Mac build when FORCE_NO_UNITTEST is enabled

### DIFF
--- a/edgelet/Cross.toml
+++ b/edgelet/Cross.toml
@@ -3,6 +3,7 @@ passthrough = [
     "BUILD_SOURCEVERSION",
     "VERSION",
     "IOTEDGE_HOMEDIR",
+    "FORCE_NO_UNITTEST"
 ]
 
 [target.x86_64-unknown-linux-gnu]

--- a/edgelet/Cross.toml
+++ b/edgelet/Cross.toml
@@ -3,7 +3,7 @@ passthrough = [
     "BUILD_SOURCEVERSION",
     "VERSION",
     "IOTEDGE_HOMEDIR",
-    "FORCE_NO_UNITTEST"
+    "FORCE_NO_UNITTEST",
 ]
 
 [target.x86_64-unknown-linux-gnu]


### PR DESCRIPTION
If the project is built on a Mac, the FORCE_NO_UNITTEST variable isn't passed down into cross unless it is part of the build.env.passthrough
I receive a failure on the hsm-sys project build with the follow log - 

$ scripts/linux/buildEdgelet.sh -P iotedged -i azureiotedge-iotedged -n microsoft
Project:      /Users/m/iotedge_massand_clion/edgelet/iotedged
Arch:         amd64
Toolchain:    x86_64-unknown-linux-gnu
Image:        azureiotedge-iotedged
Namespace:    microsoft
Dockerfile:   /Users/m/iotedge_massand_clion/edgelet/iotedged/docker/linux/amd64/Dockerfile

$ cross build -p iotedged --manifest-path=iotedged/Cargo.toml --no-default-features --features runtime-kubernetes --release --target x86_64-unknown-linux-gnu
   Compiling hsm-sys v0.1.0 (/project/hsm-sys)
error: failed to run custom build command for `hsm-sys v0.1.0 (/project/hsm-sys)`

Caused by:
  process didn't exit successfully: `/target/release/build/hsm-sys-049bf4c5bb48f4b9/build-script-build` (exit code: 101)
--- stdout
#Start Update C-Shared Utilities
#Done Updating C-Shared Utilities
#Start building shared utilities
detected home dir change, cleaning out entire build directory
running: "cmake" "/project/hsm-sys/azure-iot-hsm-c/deps/c-shared" "-Duse_openssl=ON" "-DCMAKE_BUILD_TYPE=Release" "-Drun_unittests=OFF" "-Duse_default_uuid=ON" "-Duse_http=OFF" "-Dskip_samples=ON" "-Drun_valgrind=OFF" "-Duse_emulator=OFF" "-Drun_valgrind=OFF" "-DCMAKE_INSTALL_PREFIX=/target/x86_64-unknown-linux-gnu/release/build/hsm-sys-0480751faab8b30c/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++"

[snipped for brevity]

#Start building HSM dev-mode library
detected home dir change, cleaning out entire build directory
running: "cmake" "/project/hsm-sys/azure-iot-hsm-c" "-Duse_openssl=ON" "-DCMAKE_BUILD_TYPE=Release" "-Drun_unittests=ON" "-Duse_default_uuid=ON" "-Duse_http=OFF" "-Dskip_samples=ON" "-Drun_valgrind=OFF" "-Duse_emulator=OFF" "-DBUILD_SHARED=ON" "-DUSE_TEST_TPM_INTERFACE_IN_MEM=OFF" "-DCMAKE_INSTALL_PREFIX=/target/x86_64-unknown-linux-gnu/release/build/hsm-sys-0480751faab8b30c/out" "-DCMAKE_C_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_C_COMPILER=/usr/bin/cc" "-DCMAKE_CXX_FLAGS= -ffunction-sections -fdata-sections -fPIC -m64" "-DCMAKE_CXX_COMPILER=/usr/bin/c++"
-- The C compiler identification is GNU 6.3.0
-- The CXX compiler identification is GNU 6.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found OpenSSL: /usr/lib/x86_64-linux-gnu/libcrypto.so (found version "1.0.2l")
-- Looking for include file stdint.h
-- Looking for include file stdint.h - found
-- Looking for include file stdbool.h
-- Looking for include file stdbool.h - found
-- target architecture: x86_64
-- Performing Test CXX_FLAG_CXX11
-- Performing Test CXX_FLAG_CXX11 - Success
-- target architecture: x86_64
-- Configuring done
-- Generating done
-- Build files have been written to: /target/x86_64-unknown-linux-gnu/release/build/hsm-sys-0480751faab8b30c/out/build
running: "cmake" "--build" "." "--target" "install" "--config" "Release" "--"
Scanning dependencies of target testrunnerswitcher
Scanning dependencies of target ctest
[  0%] Building C object tests/c-shared/testtools/ctest/CMakeFiles/ctest.dir/src/ctest.c.o
[  1%] Building C object tests/c-shared/testtools/testrunner/CMakeFiles/testrunnerswitcher.dir/src/testmutex.c.o
[  1%] Building C object tests/c-shared/testtools/testrunner/CMakeFiles/testrunnerswitcher.dir/src/ctrs_sprintf.c.o
[  2%] Linking C static library libtestrunnerswitcher.a
[  3%] Linking C static library libctest.a
[  3%] Built target testrunnerswitcher
Scanning dependencies of target umock_c
[  3%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umock_c.c.o
[  3%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umock_c_negative_tests.c.o
[  3%] Built target ctest
[  4%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umockalloc.c.o
[  4%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umockcall.c.o
[  5%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umockcallrecorder.c.o
[  5%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umocktypename.c.o
[  6%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umocktypes.c.o
[  6%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umocktypes_bool.c.o
[  6%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umocktypes_c.c.o
[  7%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umocktypes_stdint.c.o
[  7%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umocktypes_charptr.c.o
[  8%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umockcallpairs.c.o
[  8%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umockstring.c.o
[  9%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umockautoignoreargs.c.o
[  9%] Building C object deps/c-shared/deps/umock-c/CMakeFiles/umock_c.dir/src/umock_log.c.o
[  9%] Linking C static library libumock_c.a
[  9%] Built target umock_c
Scanning dependencies of target hsm_tpm_select_ut_exe
Scanning dependencies of target certificate_info_ut_exe
[  9%] Building C object tests/hsm_tpm_select_ut/CMakeFiles/hsm_tpm_select_ut_exe.dir/hsm_tpm_select_ut.c.o
[  9%] Building C object tests/certificate_info_ut/CMakeFiles/certificate_info_ut_exe.dir/certificate_info_ut.c.o
Scanning dependencies of target hsm_certificate_props_ut_exe
[  9%] Building C object tests/hsm_certificate_props_ut/CMakeFiles/hsm_certificate_props_ut_exe.dir/hsm_certificate_props_ut.c.o
Scanning dependencies of target aziotsharedutil
[  9%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/azure_base32.c.o
[  9%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/azure_base64.c.o
[ 10%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/buffer.c.o
[ 10%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/constbuffer_array.c.o
[ 11%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/connection_string_parser.c.o
[ 11%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/constbuffer.c.o
[ 12%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/consolelogger.c.o
[ 12%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/crt_abstractions.c.o
[ 12%] Building C object tests/hsm_tpm_select_ut/CMakeFiles/hsm_tpm_select_ut_exe.dir/__/__/src/hsm_client_tpm_select.c.o
[ 12%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/constmap.c.o
[ 13%] Building C object tests/hsm_tpm_select_ut/CMakeFiles/hsm_tpm_select_ut_exe.dir/__/__/src/hsm_log.c.o
[ 13%] Building C object tests/hsm_tpm_select_ut/CMakeFiles/hsm_tpm_select_ut_exe.dir/__/__/src/constants.c.o
[ 14%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/doublylinkedlist.c.o
[ 15%] Building C object tests/hsm_tpm_select_ut/CMakeFiles/hsm_tpm_select_ut_exe.dir/main.c.o
[ 15%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/gballoc.c.o
[ 15%] Linking C executable hsm_tpm_select_ut_exe
[ 16%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/gbnetwork.c.o
[ 17%] Building C object tests/hsm_certificate_props_ut/CMakeFiles/hsm_certificate_props_ut_exe.dir/__/__/src/hsm_certificate_props.c.o
[ 17%] Built target hsm_tpm_select_ut_exe
[ 17%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/gb_stdio.c.o
[ 18%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/gb_time.c.o
[ 18%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/gb_rand.c.o
[ 18%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/hmac.c.o
[ 19%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/hmacsha256.c.o
[ 19%] Building C object tests/hsm_certificate_props_ut/CMakeFiles/hsm_certificate_props_ut_exe.dir/__/__/deps/c-shared/src/xlogging.c.o
[ 19%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/xio.c.o
Scanning dependencies of target edge_hsm_tpm_ut_exe
[ 19%] Building C object tests/edge_hsm_tpm_ut/CMakeFiles/edge_hsm_tpm_ut_exe.dir/__/__/src/hsm_client_tpm_in_mem.c.o
[ 20%] Building C object tests/hsm_certificate_props_ut/CMakeFiles/hsm_certificate_props_ut_exe.dir/__/__/deps/c-shared/src/consolelogger.c.o
[ 21%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/singlylinkedlist.c.o
[ 22%] Building C object tests/edge_hsm_tpm_ut/CMakeFiles/edge_hsm_tpm_ut_exe.dir/__/__/src/hsm_log.c.o
[ 22%] Building C object tests/hsm_certificate_props_ut/CMakeFiles/hsm_certificate_props_ut_exe.dir/__/__/deps/c-shared/tests/real_test_files/real_crt_abstractions.c.o
[ 22%] Building C object tests/edge_hsm_tpm_ut/CMakeFiles/edge_hsm_tpm_ut_exe.dir/__/__/src/constants.c.o
[ 22%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/map.c.o
[ 23%] Building C object tests/edge_hsm_tpm_ut/CMakeFiles/edge_hsm_tpm_ut_exe.dir/edge_hsm_tpm_ut.c.o
[ 24%] Building C object tests/hsm_certificate_props_ut/CMakeFiles/hsm_certificate_props_ut_exe.dir/main.c.o
[ 25%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/sastoken.c.o
[ 25%] Linking C executable hsm_certificate_props_ut_exe
[ 25%] Building C object tests/certificate_info_ut/CMakeFiles/certificate_info_ut_exe.dir/pki_mocked.c.o
[ 25%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/sha1.c.o
[ 25%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/sha224.c.o
[ 25%] Built target hsm_certificate_props_ut_exe
[ 26%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/sha384-512.c.o
[ 27%] Building C object tests/certificate_info_ut/CMakeFiles/certificate_info_ut_exe.dir/__/__/src/hsm_log.c.o
[ 27%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/strings.c.o
[ 27%] Building C object tests/certificate_info_ut/CMakeFiles/certificate_info_ut_exe.dir/main.c.o
[ 28%] Linking C executable certificate_info_ut_exe
Scanning dependencies of target edge_hsm_key_intf_sas_ut_exe
[ 29%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/string_token.c.o
[ 30%] Building C object tests/edge_hsm_key_intf_sas_ut/CMakeFiles/edge_hsm_key_intf_sas_ut_exe.dir/__/__/src/edge_hsm_key_interface.c.o
[ 30%] Building C object tests/edge_hsm_key_intf_sas_ut/CMakeFiles/edge_hsm_key_intf_sas_ut_exe.dir/__/__/src/edge_sas_perform_sign_with_key.c.o
[ 30%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/string_tokenizer.c.o
[ 30%] Building C object tests/edge_hsm_key_intf_sas_ut/CMakeFiles/edge_hsm_key_intf_sas_ut_exe.dir/__/__/src/edge_sas_key.c.o
[ 31%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/uuid.c.o
[ 31%] Built target certificate_info_ut_exe
[ 31%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/urlencode.c.o
[ 32%] Building C object tests/edge_hsm_key_intf_sas_ut/CMakeFiles/edge_hsm_key_intf_sas_ut_exe.dir/__/__/src/hsm_log.c.o
[ 32%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/usha.c.o
[ 32%] Building C object tests/edge_hsm_key_intf_sas_ut/CMakeFiles/edge_hsm_key_intf_sas_ut_exe.dir/__/__/src/constants.c.o
[ 33%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/vector.c.o
[ 34%] Building C object tests/edge_hsm_key_intf_sas_ut/CMakeFiles/edge_hsm_key_intf_sas_ut_exe.dir/edge_hsm_key_intf_sas_ut.c.o
Scanning dependencies of target edge_hsm_crypto_ut_exe
[ 34%] Building C object tests/edge_hsm_crypto_ut/CMakeFiles/edge_hsm_crypto_ut_exe.dir/__/__/src/edge_hsm_client_crypto.c.o
[ 34%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/xlogging.c.o
[ 35%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/optionhandler.c.o
[ 35%] Building C object tests/edge_hsm_crypto_ut/CMakeFiles/edge_hsm_crypto_ut_exe.dir/__/__/src/hsm_log.c.o
[ 35%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/memory_data.c.o
[ 36%] Building C object tests/edge_hsm_crypto_ut/CMakeFiles/edge_hsm_crypto_ut_exe.dir/__/__/src/constants.c.o
[ 36%] Building C object tests/edge_hsm_crypto_ut/CMakeFiles/edge_hsm_crypto_ut_exe.dir/edge_hsm_crypto_ut.c.o
[ 37%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/agenttime.c.o
[ 37%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/condition_pthreads.c.o
[ 37%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/lock_pthreads.c.o
[ 38%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/platform_linux.c.o
[ 38%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/socketio_berkeley.c.o
[ 39%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/tickcounter_linux.c.o
[ 39%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/threadapi_pthreads.c.o
[ 40%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/uniqueid_stub.c.o
[ 40%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/envvariable.c.o
[ 40%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/linux_time.c.o
[ 41%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/http_proxy_io.c.o
[ 41%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/tlsio_openssl.c.o
[ 42%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/adapters/x509_openssl.c.o
[ 42%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/wsio.c.o
[ 43%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/uws_client.c.o
[ 43%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/uws_frame_encoder.c.o
[ 43%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/utf8_checker.c.o
[ 44%] Building C object deps/c-shared/CMakeFiles/aziotsharedutil.dir/src/ws_url.c.o
[ 44%] Linking C static library libaziotsharedutil.a
[ 44%] Built target aziotsharedutil
[ 45%] Building C object tests/edge_hsm_crypto_ut/CMakeFiles/edge_hsm_crypto_ut_exe.dir/main.c.o
[ 45%] Building C object tests/edge_hsm_tpm_ut/CMakeFiles/edge_hsm_tpm_ut_exe.dir/main.c.o
[ 45%] Building C object tests/edge_hsm_key_intf_sas_ut/CMakeFiles/edge_hsm_key_intf_sas_ut_exe.dir/main.c.o
[ 45%] Linking C executable edge_hsm_tpm_ut_exe
Scanning dependencies of target edge_openssl_common_ut_exe
[ 45%] Building C object tests/edge_openssl_common_ut/CMakeFiles/edge_openssl_common_ut_exe.dir/edge_openssl_common_ut.c.o
[ 46%] Linking C executable edge_hsm_key_intf_sas_ut_exe
[ 46%] Built target edge_hsm_tpm_ut_exe
[ 46%] Built target edge_hsm_key_intf_sas_ut_exe
Scanning dependencies of target edge_openssl_pki_ut_exe
[ 46%] Building C object tests/edge_openssl_pki_ut/CMakeFiles/edge_openssl_pki_ut_exe.dir/edge_openssl_pki_ut.c.o
Scanning dependencies of target hsm_client_tpm_ut_exe
[ 46%] Building C object tests/hsm_client_tpm_ut/CMakeFiles/hsm_client_tpm_ut_exe.dir/hsm_client_tpm_ut.c.o
[ 46%] Building C object tests/edge_openssl_common_ut/CMakeFiles/edge_openssl_common_ut_exe.dir/openssl_mocked.c.o
[ 47%] Building C object tests/edge_openssl_common_ut/CMakeFiles/edge_openssl_common_ut_exe.dir/main.c.o
[ 47%] Linking C executable edge_openssl_common_ut_exe
[ 47%] Built target edge_openssl_common_ut_exe
Scanning dependencies of target edge_openssl_enc_ut_exe
[ 47%] Building C object tests/edge_openssl_enc_ut/CMakeFiles/edge_openssl_enc_ut_exe.dir/__/__/src/edge_enc_openssl_key.c.o
[ 48%] Building C object tests/edge_openssl_enc_ut/CMakeFiles/edge_openssl_enc_ut_exe.dir/__/__/src/hsm_log.c.o
[ 48%] Building C object tests/edge_openssl_enc_ut/CMakeFiles/edge_openssl_enc_ut_exe.dir/edge_openssl_enc_ut.c.o
[ 48%] Linking C executable edge_hsm_crypto_ut_exe
[ 48%] Built target edge_hsm_crypto_ut_exe
Scanning dependencies of target edge_hsm_x509_ut_exe
[ 48%] Building C object tests/edge_hsm_x509_ut/CMakeFiles/edge_hsm_x509_ut_exe.dir/__/__/src/edge_hsm_client_x509.c.o
[ 49%] Building C object tests/edge_hsm_x509_ut/CMakeFiles/edge_hsm_x509_ut_exe.dir/__/__/src/hsm_log.c.o
[ 49%] Building C object tests/edge_hsm_x509_ut/CMakeFiles/edge_hsm_x509_ut_exe.dir/__/__/src/constants.c.o
[ 50%] Building C object tests/edge_hsm_x509_ut/CMakeFiles/edge_hsm_x509_ut_exe.dir/edge_hsm_x509_ut.c.o
[ 50%] Building C object tests/edge_openssl_enc_ut/CMakeFiles/edge_openssl_enc_ut_exe.dir/main.c.o
tests/hsm_client_tpm_ut/CMakeFiles/hsm_client_tpm_ut_exe.dir/build.make:62: recipe for target 'tests/hsm_client_tpm_ut/CMakeFiles/hsm_client_tpm_ut_exe.dir/hsm_client_tpm_ut.c.o' failed
CMakeFiles/Makefile2:2291: recipe for target 'tests/hsm_client_tpm_ut/CMakeFiles/hsm_client_tpm_ut_exe.dir/all' failed
[ 52%] Building C object tests/edge_openssl_pki_ut/CMakeFiles/edge_openssl_pki_ut_exe.dir/pki_mocked.c.o
[ 52%] Linking C executable edge_openssl_enc_ut_exe
[ 52%] Built target edge_openssl_enc_ut_exe
[ 52%] Building C object tests/edge_hsm_x509_ut/CMakeFiles/edge_hsm_x509_ut_exe.dir/main.c.o
[ 52%] Building C object tests/edge_openssl_pki_ut/CMakeFiles/edge_openssl_pki_ut_exe.dir/__/__/src/hsm_log.c.o
[ 52%] Building C object tests/edge_openssl_pki_ut/CMakeFiles/edge_openssl_pki_ut_exe.dir/main.c.o
[ 53%] Linking C executable edge_hsm_x509_ut_exe
[ 53%] Built target edge_hsm_x509_ut_exe
[ 54%] Linking C executable edge_openssl_pki_ut_exe
[ 54%] Built target edge_openssl_pki_ut_exe
Makefile:162: recipe for target 'all' failed

--- stderr
CMake Warning:
  Manually-specified variables were not used by the project:

    use_emulator


cc: internal compiler error: Killed (program cc1)
Please submit a full bug report,
with preprocessed source if appropriate.
See <file:///usr/share/doc/gcc-6/README.Bugs> for instructions.
make[2]: *** [tests/hsm_client_tpm_ut/CMakeFiles/hsm_client_tpm_ut_exe.dir/hsm_client_tpm_ut.c.o] Error 4
make[1]: *** [tests/hsm_client_tpm_ut/CMakeFiles/hsm_client_tpm_ut_exe.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [all] Error 2
thread 'main' panicked at '
command did not execute successfully, got: exit code: 2

build script failed, must exit now', /cargo/registry/src/github.com-1ecc6299db9ec823/cmake-0.1.40/src/lib.rs:832:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.