### PR TITLE
Bug 5588683: If two modules reference the same volume name, edge agent gets into a crash loop

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
     using System.Collections.Generic;
     using System.Collections.Immutable;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
+    using Microsoft.Azure.Devices.Edge.Agent.Docker.Models;
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
 
@@ -81,6 +82,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         public virtual bool Equals(IModule other) => this.Equals(other as KubernetesModule);
 
         public bool Equals(IModule<KubernetesConfig> other) => this.Equals(other as KubernetesModule);
+
+        public static string PvcName(KubernetesModule module, Mount mount)
+        {
+            return KubeUtils.SanitizeK8sValue($"{module.Name}-{mount.Source}");
+        }
 
         public bool Equals(KubernetesModule other)
         {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
             // Volume name will be customer defined name or modulename + mount.source
             if (this.persistentVolumeName.HasValue)
             {
-                this.persistentVolumeName.ForEach(pvVolumeName => volumeName = pvVolumeName);
+                volumeName = this.persistentVolumeName.OrDefault();
                 return new V1Volume(volumeName, persistentVolumeClaim: new V1PersistentVolumeClaimVolumeSource(pvcName, mount.ReadOnly));
             }
             else if (this.storageClassName.HasValue)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -235,13 +235,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
                 .FlatMap(config => Option.Maybe(config.Mounts))
                 .Map(mounts => mounts.Where(mount => mount.Type.Equals("volume", StringComparison.InvariantCultureIgnoreCase)).ToList());
 
-            volumeMounts.Map(mounts => mounts.Select(this.GetVolume))
+            volumeMounts.Map(mounts => mounts.Select(mount => this.GetVolume(module, mount)))
                 .ForEach(volumes => volumeList.AddRange(volumes));
 
             volumeMounts.Map(mounts => mounts.Select(mount => new V1VolumeMount(mount.Target, KubeUtils.SanitizeDNSValue(mount.Source), readOnlyProperty: mount.ReadOnly)))
                 .ForEach(mounts => volumeMountList.AddRange(mounts));
 
-            // collect volume and volume mounts from CreateOption.Volumes section
+            // collect volume and volume mounts from CreateOption.Volumes section @kubernetes extended feature
             module.Config.CreateOptions.Volumes
                 .Map(volumes => volumes.Select(volume => volume.Volume).FilterMap())
                 .ForEach(volumes => volumeList.AddRange(volumes));
@@ -301,14 +301,27 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
             return proxyLevel;
         }
 
-        V1Volume GetVolume(Mount mount)
+        V1Volume GetVolume(KubernetesModule module, Mount mount)
         {
-            string name = KubeUtils.SanitizeDNSValue(mount.Source);
-            return this.ShouldUsePvc()
-                ? new V1Volume(name, persistentVolumeClaim: new V1PersistentVolumeClaimVolumeSource(name, mount.ReadOnly))
-                : new V1Volume(name, emptyDir: new V1EmptyDirVolumeSource());
-        }
+            string name = KubeUtils.SanitizeK8sValue(mount.Source);
+            string pvcName = KubeUtils.SanitizeK8sValue(module.Name) + name;
 
-        bool ShouldUsePvc() => this.persistentVolumeName.HasValue || this.storageClassName.HasValue;
+            // PVC name will be modulename + volume name
+            // Volume name will be customer defined name or modulename + mount.source
+            if (this.persistentVolumeName.HasValue)
+            {
+                this.persistentVolumeName.ForEach(volumeName => name = volumeName);
+                return new V1Volume(name, persistentVolumeClaim: new V1PersistentVolumeClaimVolumeSource(pvcName, mount.ReadOnly));
+            }
+            else if (this.storageClassName.HasValue)
+            {
+                return new V1Volume(pvcName, persistentVolumeClaim: new V1PersistentVolumeClaimVolumeSource(pvcName, mount.ReadOnly));
+            }
+            else
+            {
+                return new V1Volume(name, emptyDir: new V1EmptyDirVolumeSource());
+            }
+           
+        }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -303,15 +303,15 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
 
         V1Volume GetVolume(KubernetesModule module, Mount mount)
         {
-            string name = KubeUtils.SanitizeK8sValue(mount.Source);
+            string volumeName = KubeUtils.SanitizeK8sValue(mount.Source);
             string pvcName = KubernetesModule.PvcName(module, mount);
 
             // PVC name will be modulename + volume name
             // Volume name will be customer defined name or modulename + mount.source
             if (this.persistentVolumeName.HasValue)
             {
-                this.persistentVolumeName.ForEach(volumeName => name = volumeName);
-                return new V1Volume(name, persistentVolumeClaim: new V1PersistentVolumeClaimVolumeSource(pvcName, mount.ReadOnly));
+                this.persistentVolumeName.ForEach(pvVolumeName => volumeName = pvVolumeName);
+                return new V1Volume(volumeName, persistentVolumeClaim: new V1PersistentVolumeClaimVolumeSource(pvcName, mount.ReadOnly));
             }
             else if (this.storageClassName.HasValue)
             {
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
             }
             else
             {
-                return new V1Volume(name, emptyDir: new V1EmptyDirVolumeSource());
+                return new V1Volume(volumeName, emptyDir: new V1EmptyDirVolumeSource());
             }
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -304,7 +304,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
         V1Volume GetVolume(KubernetesModule module, Mount mount)
         {
             string name = KubeUtils.SanitizeK8sValue(mount.Source);
-            string pvcName = KubeUtils.SanitizeK8sValue(module.Name) + name;
+            string pvcName = KubernetesModule.PvcName(module, mount);
 
             // PVC name will be modulename + volume name
             // Volume name will be customer defined name or modulename + mount.source
@@ -321,7 +321,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
             {
                 return new V1Volume(name, emptyDir: new V1EmptyDirVolumeSource());
             }
-           
         }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
         public Option<List<V1PersistentVolumeClaim>> CreatePersistentVolumeClaims(KubernetesModule module, IDictionary<string, string> labels) =>
             module.Config.CreateOptions.HostConfig
                 .FlatMap(hostConfig => Option.Maybe(hostConfig.Mounts))
-                .Map(mounts => mounts.Where(this.ShouldCreatePvc).Select(mount => this.ExtractPvc(mount, labels)).ToList())
+                .Map(mounts => mounts.Where(this.ShouldCreatePvc).Select(mount => this.ExtractPvc(module.Name, mount, labels)).ToList())
                 .Filter(mounts => mounts.Any());
 
         bool ShouldCreatePvc(Mount mount)
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
             return this.storageClassName.HasValue || this.persistentVolumeName.HasValue;
         }
 
-        V1PersistentVolumeClaim ExtractPvc(Mount mount, IDictionary<string, string> labels)
+        V1PersistentVolumeClaim ExtractPvc(string moduleName, Mount mount, IDictionary<string, string> labels)
         {
-            string name = KubeUtils.SanitizeK8sValue(mount.Source);
+            string name = KubeUtils.SanitizeK8sValue(moduleName) + KubeUtils.SanitizeK8sValue(mount.Source); 
             bool readOnly = mount.ReadOnly;
             var persistentVolumeClaimSpec = new V1PersistentVolumeClaimSpec()
             {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
             }
             else if (this.storageClassName.HasValue)
             {
-                this.storageClassName.ForEach(storageClass => persistentVolumeClaimSpec.StorageClassName = storageClass);
+                persistentVolumeClaimSpec.StorageClassName = this.storageClassName.OrDefault();
             }
 
             return new V1PersistentVolumeClaim(metadata: new V1ObjectMeta(name: volumeName, labels: labels), spec: persistentVolumeClaimSpec);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
 
         V1PersistentVolumeClaim ExtractPvc(KubernetesModule module, Mount mount, IDictionary<string, string> labels)
         {
-            string name = KubernetesModule.PvcName(module, mount);
+            string volumeName = KubernetesModule.PvcName(module, mount);
             bool readOnly = mount.ReadOnly;
             var persistentVolumeClaimSpec = new V1PersistentVolumeClaimSpec()
             {
@@ -60,14 +60,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
             // prefer persistent volume name to storage class name, if both are set.
             if (this.persistentVolumeName.HasValue)
             {
-                this.persistentVolumeName.ForEach(volumeName => persistentVolumeClaimSpec.VolumeName = volumeName);
+                persistentVolumeClaimSpec.VolumeName = this.persistentVolumeName.OrDefault();
             }
             else if (this.storageClassName.HasValue)
             {
                 this.storageClassName.ForEach(storageClass => persistentVolumeClaimSpec.StorageClassName = storageClass);
             }
 
-            return new V1PersistentVolumeClaim(metadata: new V1ObjectMeta(name: name, labels: labels), spec: persistentVolumeClaimSpec);
+            return new V1PersistentVolumeClaim(metadata: new V1ObjectMeta(name: volumeName, labels: labels), spec: persistentVolumeClaimSpec);
         }
 
         public void UpdatePersistentVolumeClaim(V1PersistentVolumeClaim to, V1PersistentVolumeClaim from)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -158,15 +158,15 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var config = new KubernetesConfig("image", CreatePodParameters.Create(labels: labels, hostConfig: hostConfig), Option.None<AuthConfig>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, DefaultConfigurationInfo, EnvVarsDict);
             var module = new KubernetesModule(docker, config);
-            var mapper = new KubernetesDeploymentMapper("namespace", "edgehub", "proxy", "configPath", "configVolumeName", "configMapName", "trustBundlePAth", "trustBundleVolumeName", "trustBundleConfigMapName", "elephant", string.Empty, "apiVersion", new Uri("http://workload"), new Uri("http://management"));
+            var mapper = new KubernetesDeploymentMapper("namespace", "edgehub", "proxy", "configPath", "configVolumeName", "configMapName", "trustBundlePAth", "trustBundleVolumeName", "trustBundleConfigMapName", "elephant", null, "apiVersion", new Uri("http://workload"), new Uri("http://management"));
 
             var deployment = mapper.CreateDeployment(identity, module, labels);
             var pod = deployment.Spec.Template;
 
             Assert.True(pod != null);
-            var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
+            var podVolume = pod.Spec.Volumes.Single(v => v.Name == "elephant");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal("a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal(module.Name + "a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
@@ -188,9 +188,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var pod = deployment.Spec.Template;
 
             Assert.True(pod != null);
-            var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
+            var podVolume = pod.Spec.Volumes.Single(v => v.Name == module.Name + "a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal("a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal(module.Name + "a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
@@ -212,9 +212,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var pod = deployment.Spec.Template;
 
             Assert.True(pod != null);
-            var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
+            var podVolume = pod.Spec.Volumes.Single(v => v.Name == module.Name + "a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal("a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal(module.Name + "a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -166,7 +166,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.True(pod != null);
             var podVolume = pod.Spec.Volumes.Single(v => v.Name == "elephant");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal(module.Name + "a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+
+            Assert.Equal(module.Name + "-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
@@ -188,9 +189,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var pod = deployment.Spec.Template;
 
             Assert.True(pod != null);
-            var podVolume = pod.Spec.Volumes.Single(v => v.Name == module.Name + "a-volume");
+            var podVolume = pod.Spec.Volumes.Single(v => v.Name == module.Name + "-a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal(module.Name + "a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal(module.Name + "-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
@@ -212,9 +213,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var pod = deployment.Spec.Template;
 
             Assert.True(pod != null);
-            var podVolume = pod.Spec.Volumes.Single(v => v.Name == module.Name + "a-volume");
+            var podVolume = pod.Spec.Volumes.Single(v => v.Name == module.Name + "-a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal(module.Name + "a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal(module.Name + "-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var podVolume = pod.Spec.Volumes.Single(v => v.Name == "elephant");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
 
-            Assert.Equal(module.Name + "-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
@@ -189,9 +189,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var pod = deployment.Spec.Template;
 
             Assert.True(pod != null);
-            var podVolume = pod.Spec.Volumes.Single(v => v.Name == module.Name + "-a-volume");
+            var podVolume = pod.Spec.Volumes.Single(v => v.Name == "module1-a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal(module.Name + "-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
@@ -213,9 +213,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var pod = deployment.Spec.Template;
 
             Assert.True(pod != null);
-            var podVolume = pod.Spec.Volumes.Single(v => v.Name == module.Name + "-a-volume");
+            var podVolume = pod.Spec.Volumes.Single(v => v.Name == "module1-a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal(module.Name + "-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcMapperTest.cs
@@ -122,14 +122,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Edgedeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.VolumeName);
             Assert.Equal(string.Empty, aVolumeClaim.Spec.StorageClassName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.VolumeName);
@@ -153,14 +153,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Edgedeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.VolumeName);
             Assert.Equal("default", aVolumeClaim.Spec.StorageClassName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.VolumeName);
@@ -184,14 +184,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Edgedeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.StorageClassName);
             Assert.Equal("a-pvc-name", aVolumeClaim.Spec.VolumeName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.StorageClassName);
@@ -215,14 +215,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Edgedeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.StorageClassName);
             Assert.Equal("a-pvc-name", aVolumeClaim.Spec.VolumeName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.StorageClassName);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcMapperTest.cs
@@ -122,14 +122,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Edgedeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.VolumeName);
             Assert.Equal(string.Empty, aVolumeClaim.Spec.StorageClassName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.VolumeName);
@@ -153,14 +153,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Edgedeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.VolumeName);
             Assert.Equal("default", aVolumeClaim.Spec.StorageClassName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.VolumeName);
@@ -184,14 +184,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Edgedeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.StorageClassName);
             Assert.Equal("a-pvc-name", aVolumeClaim.Spec.VolumeName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.StorageClassName);
@@ -215,14 +215,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Edgedeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.StorageClassName);
             Assert.Equal("a-pvc-name", aVolumeClaim.Spec.VolumeName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.StorageClassName);


### PR DESCRIPTION
Currently customers can specify volume mount through the createoption; and can also add k8s style PV/storageclass in the extended feature section. The -v and k8s can both be specified or either of them. 

For above, we create PVCs and then let k8s to schedule the right PV. PV will be created in case of stroageclass or the use what customer specified. 

The root cause of the crash is that customer specify two modules mouting to the same volume. Our code creates PVC using the mount.source. When adding to the dictionary of the PVC list, the name crashes. 

The change is to 
- Include module name in PVC to prevent conflict
- Make sure using the PV name customer specified otherwise use mount.source
- Allow volume share
- mount to the name customer specified. 

