### PR TITLE
Fixing a bug, changing values to match IoTHub adding missing tests (#1932)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/ReportedPropertiesValidator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/ReportedPropertiesValidator.cs
@@ -10,11 +10,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
 
     public class ReportedPropertiesValidator : IValidator<TwinCollection>
     {
-        const int TwinPropertyMaxDepth = 5; // taken from IoTHub
+        const int TwinPropertyMaxDepth = 10; // taken from IoTHub
         const int TwinPropertyValueMaxLength = 4096; // bytes. taken from IoTHub
+        const int TwinPropertyNameMaxLength = 1024; // taken from IoTHub
         const long TwinPropertyMaxSafeValue = 4503599627370495; // (2^52) - 1. taken from IoTHub
         const long TwinPropertyMinSafeValue = -4503599627370496; // -2^52. taken from IoTHub
-        const int TwinPropertyDocMaxLength = 8 * 1024; // 8K bytes. taken from IoTHub
+        const int TwinPropertyDocMaxLength = 32 * 1024; // 32KB. taken from IoTHub
 
         public void Validate(TwinCollection reportedProperties)
         {
@@ -65,10 +66,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
                 throw new ArgumentNullException(nameof(name));
             }
 
-            if (Encoding.UTF8.GetByteCount(name) > TwinPropertyValueMaxLength)
+            if (Encoding.UTF8.GetByteCount(name) > TwinPropertyNameMaxLength)
             {
                 string truncated = name.Substring(0, 10);
-                throw new InvalidOperationException($"Length of property name {truncated}.. exceeds maximum length of {TwinPropertyValueMaxLength}");
+                throw new InvalidOperationException($"Length of property name {truncated}.. exceeds maximum length of {TwinPropertyNameMaxLength}");
             }
 
             for (int index = 0; index < name.Length; index++)

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.Shared;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
     using Xunit;
 
     public class ReportedPropertiesValidatorTest
@@ -29,7 +28,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                             {
                                 level4 = new
                                 {
-                                    level5 = new { }
+                                    level5 = new
+                                    {
+                                        level6 = new
+                                        {
+                                            level7 = new
+                                            {
+                                                level8 = new
+                                                {
+                                                    level9 = new
+                                                    {
+                                                        level10 = new { }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -81,7 +95,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                                 {
                                     level5 = new
                                     {
-                                        level6 = new { }
+                                        level6 = new
+                                        {
+                                            level7 = new
+                                             {
+                                                level8 = new
+                                                {
+                                                    level9 = new
+                                                    {
+                                                        level10 = new
+                                                        {
+                                                            level11 = new { }
+                                                        }
+                                                    }
+                                                }
+                                             }
+                                        }
                                     }
                                 }
                             }
@@ -89,7 +118,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                     }
                 })),
                 typeof(InvalidOperationException),
-                "Nested depth of twin property exceeds 5"
+                "Nested depth of twin property exceeds 10"
             };
 
             yield return new object[]
@@ -131,6 +160,38 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                 new TwinCollection("{ \"ok\":\"good\", \"level1\": { \"field1\": null } }"),
                 null,
                 string.Empty
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection("{ \"o#k\":\"good\", \"level1\": { \"field1\": null } }"),
+                typeof(InvalidOperationException),
+                "Property name o#k contains invalid character '#'"
+            };
+
+            yield return new object[]
+           {
+                new TwinCollection($"{{ \"{longString} \":\"good\", \"level1\":{{ \"field1\": null }} }}"),
+                typeof(InvalidOperationException),
+                "Length of property name **********.. exceeds maximum length of 1024"
+           };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
+                {
+                    LargeByteArray = new byte[3000],
+                    LargeByteArray2 = new byte[3000],
+                    LargeByteArray3 = new byte[3000],
+                    LargeByteArray4 = new byte[3000],
+                    LargeByteArray5 = new byte[3000],
+                    LargeByteArray6 = new byte[3000],
+                    LargeByteArray7 = new byte[3000],
+                    LargeByteArray8 = new byte[3000],
+                    LargeByteArray9 = new byte[3000]
+                } )),
+                typeof(InvalidOperationException),
+                "Twin properties size 36189 exceeds maximum 32768"
             };
         }
 


### PR DESCRIPTION

* Fixing a bug, changing values to match IoTHub, and adding missing test cases

* Fixing a bug, changing values to match IoTHub, and adding missing test cases

* Formatting

* Putting test to limit of 10 levels

IoTHub changed their validation limits. This update reflects those changes in EdgeHub. It also fixes a bug where Property name and value shared the same max value.
Also adds tests for the changes and a test that was missing originally.