### PR TITLE
Use PodStatus instead of ContainerStatus to create ModuleStatus

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/PodExtensions.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/PodExtensions.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
     using k8s.Models;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Org.BouncyCastle.Security;
     using AgentDocker = Microsoft.Azure.Devices.Edge.Agent.Docker;
     using KubernetesConstants = Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Constants;
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/PodExtensions.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/PodExtensions.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
                         default:
                             throw new InvalidOperationException($"Invalid pod status {status.Phase}");
                     }
-                }).GetOrElse(() => throw new InvalidParameterException("No pod status"));
+                }).GetOrElse(() => new ReportedModuleStatus(ModuleStatus.Failed, "Unable to get pod status"));
         }
 
         static RuntimeData GetRuntimeData(V1ContainerStatus status)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesRuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesRuntimeInfoProviderTest.cs
@@ -146,11 +146,21 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             }
 
             Dictionary<string, V1Pod> modified = BuildPodList();
-            modified["edgeagent"].Status.ContainerStatuses[0].State.Running = null;
-            modified["edgeagent"].Status.ContainerStatuses[0].State.Terminated = new V1ContainerStateTerminated(139, finishedAt: DateTime.Parse("2019-06-12T16:13:07Z"), startedAt: DateTime.Parse("2019-06-12T16:11:22Z"));
-            modified["edgehub"].Status.ContainerStatuses[0].State.Running = null;
-            modified["edgehub"].Status.ContainerStatuses[1].State.Waiting = new V1ContainerStateWaiting("waiting", "reason");
+
+            DateTime agentStartTime = new DateTime(2019, 6, 11);
+            modified["edgeagent"].Status.Phase = "Running";
+            modified["edgeagent"].Status.StartTime = agentStartTime;
+
+            string pendingDescription = "0/1 node available";
+            modified["edgehub"].Status.Phase = "Pending";
+            modified["edgehub"].Status.Reason = pendingDescription;
+
+            string finishedDescription = "Pod finished";
+            modified["simulatedtemperaturesensor"].Status.Phase = "Succeeded";
+            modified["simulatedtemperaturesensor"].Status.Reason = finishedDescription;
             modified["simulatedtemperaturesensor"].Status.ContainerStatuses[1].State.Running = null;
+            modified["simulatedtemperaturesensor"].Status.ContainerStatuses[1].State.Terminated = new V1ContainerStateTerminated(139, finishedAt: DateTime.Parse("2019-06-12T16:13:07Z"), startedAt: DateTime.Parse("2019-06-12T16:11:22Z"));
+
             foreach ((string podName, var pod) in modified)
             {
                 runtimeInfo.CreateOrUpdateAddPodInfo(podName, pod);
@@ -161,24 +171,27 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.Equal(3, modules.Count);
             foreach (var i in modules)
             {
-                if (!string.Equals("edgeAgent", i.Name))
+                if (string.Equals("edgeAgent", i.Name))
                 {
-                    Assert.Equal(ModuleStatus.Unknown, i.ModuleStatus);
+                    Assert.Equal(ModuleStatus.Running, i.ModuleStatus);
+                    Assert.Equal($"Started at {agentStartTime.ToString()}", i.Description);
                 }
-                else
+                else if (string.Equals("edgeHub", i.Name))
                 {
                     Assert.Equal(ModuleStatus.Failed, i.ModuleStatus);
-                }
-
-                if (string.Equals("edgeHub", i.Name))
-                {
+                    Assert.Equal(pendingDescription, i.Description);
                     Assert.Equal(Option.None<DateTime>(), i.ExitTime);
-                    Assert.Equal(Option.None<DateTime>(), i.StartTime);
+                }
+                else if (string.Equals("SimulatedTemperatureSensor", i.Name))
+                {
+                    Assert.Equal(ModuleStatus.Stopped, i.ModuleStatus);
+                    Assert.Equal(finishedDescription, i.Description);
+                    Assert.Equal(new DateTime(2019, 6, 12), i.StartTime.OrDefault().Date);
+                    Assert.Equal(new DateTime(2019, 6, 12), i.ExitTime.OrDefault().Date);
                 }
                 else
                 {
-                    Assert.Equal(new DateTime(2019, 6, 12), i.StartTime.OrDefault().Date);
-                    Assert.Equal(new DateTime(2019, 6, 12), i.ExitTime.OrDefault().Date);
+                    Assert.True(false, $"Missing module {i.Name} in validation");
                 }
 
                 if (i is ModuleRuntimeInfo<DockerReportedConfig> d)


### PR DESCRIPTION
ContainerStatus doesn't have a concept of "pending", as that happens at the pod level.  So pending pods end up with an unknown module status, which is not well-handled throughout the rest of the codebase.

This change makes it so that we base the module status off the pod phase, which is arguably more correct conceptually.