### PR TITLE
Fix Twin property 4K length validation (#1786)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/TwinManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/TwinManager.cs
@@ -103,6 +103,36 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         internal static void ValidateTwinProperties(JToken properties) => ValidateTwinProperties(properties, 1);
 
+        // TODO: Move to a Twin helper class (along with Twin manager update).
+        internal static string EncodeTwinKey(string key)
+        {
+            Preconditions.CheckNonWhiteSpace(key, nameof(key));
+            var sb = new StringBuilder();
+            foreach (char ch in key)
+            {
+                switch (ch)
+                {
+                    case '.':
+                        sb.Append("%2E");
+                        break;
+
+                    case '$':
+                        sb.Append("%24");
+                        break;
+
+                    case ' ':
+                        sb.Append("%20");
+                        break;
+
+                    default:
+                        sb.Append(ch);
+                        break;
+                }
+            }
+
+            return sb.ToString();
+        }
+
         internal void ConnectionEstablishedCallback(object sender, IIdentity identity)
         {
             Events.ConnectionEstablished(identity.Id);
@@ -271,15 +301,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
                 ValidateValueType(kvp.Name, kvp.Value);
 
-                string s = kvp.Value.ToString();
-                ValidatePropertyValueLength(kvp.Name, s);
-
-                if ((kvp.Value is JValue) && (kvp.Value.Type is JTokenType.Integer))
+                if (kvp.Value is JValue)
                 {
-                    ValidateIntegerValue(kvp.Name, (long)kvp.Value);
+                    if (kvp.Value.Type is JTokenType.Integer)
+                    {
+                        ValidateIntegerValue(kvp.Name, (long)kvp.Value);
+                    }
+                    else
+                    {
+                        string s = kvp.Value.ToString();
+                        ValidatePropertyValueLength(kvp.Name, s);
+                    }
                 }
 
-                if ((kvp.Value != null) && (kvp.Value is JObject))
+                if (kvp.Value != null && kvp.Value is JObject)
                 {
                     if (currentDepth > TwinPropertyMaxDepth)
                     {
@@ -617,36 +652,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             }
 
             await cloudProxy.ForEachAsync(cp => cp.UpdateReportedPropertiesAsync(reported));
-        }
-
-        // TODO: Move to a Twin helper class (along with Twin manager update).
-        internal static string EncodeTwinKey(string key)
-        {
-            Preconditions.CheckNonWhiteSpace(key, nameof(key));
-            var sb = new StringBuilder();
-            foreach (char ch in key)
-            {
-                switch (ch)
-                {
-                    case '.':
-                        sb.Append("%2E");
-                        break;
-
-                    case '$':
-                        sb.Append("%24");
-                        break;
-
-                    case ' ':
-                        sb.Append("%20");
-                        break;
-
-                    default:
-                        sb.Append(ch);
-                        break;
-                }
-            }
-
-            return sb.ToString();
         }
 
         static class Events

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/ReportedPropertiesValidator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/ReportedPropertiesValidator.cs
@@ -32,15 +32,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
 
                 ValidateValueType(kvp.Name, kvp.Value);
 
-                string s = kvp.Value.ToString();
-                ValidatePropertyValueLength(kvp.Name, s);
-
-                if ((kvp.Value is JValue) && (kvp.Value.Type is JTokenType.Integer))
+                if (kvp.Value is JValue)
                 {
-                    ValidateIntegerValue(kvp.Name, (long)kvp.Value);
+                    if (kvp.Value.Type is JTokenType.Integer)
+                    {
+                        ValidateIntegerValue(kvp.Name, (long)kvp.Value);
+                    }
+                    else
+                    {
+                        string s = kvp.Value.ToString();
+                        ValidatePropertyValueLength(kvp.Name, s);
+                    }
                 }
 
-                if ((kvp.Value != null) && (kvp.Value is JObject))
+                if (kvp.Value != null && kvp.Value is JObject)
                 {
                     if (currentDepth > TwinPropertyMaxDepth)
                     {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/TwinManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/TwinManagerTest.cs
@@ -33,6 +33,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             this.twinMessageConverter = new TwinMessageConverter();
         }
 
+        public static IEnumerable<object[]> GetTwinKeyData()
+        {
+            yield return new object[] { "key1", "key1" };
+
+            yield return new object[] { "123", "123" };
+
+            yield return new object[] { "a.b$c d", "a%2Eb%24c%20d" };
+
+            yield return new object[] { "a.b.c.d", "a%2Eb%2Ec%2Ed" };
+        }
+
         [Fact]
         public void TwinManagerConstructorVerifiesArguments()
         {
@@ -1511,7 +1522,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         }
 
         [Fact]
-        public void ValidateTwinPropertiesSuccess()
+        public void ValidateTwinPropertiesWithLongName()
         {
             string tooLong = Enumerable.Repeat("A", 5000).Aggregate((sum, next) => sum + next);
             var reported = new Dictionary<string, string>
@@ -1519,50 +1530,68 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 [tooLong] = "wrong"
             };
 
-            Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported)));
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported)));
+            Assert.Equal("Length of property name AAAAAAAAAA.. exceeds maximum length of 4096", ex.Message);
+        }
 
-            var reported1 = new
+        [Fact]
+        public void ValidateTwinPropertiesWithLongValue()
+        {
+            string tooLong = Enumerable.Repeat("A", 5000).Aggregate((sum, next) => sum + next);
+            var reported = new
             {
                 ok = "ok",
-                level = new
-                {
-                    ok = "ok",
-                    s = tooLong
-                }
-            };
-
-            Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported1)));
-
-            var reported2 = new
-            {
-                level = new
-                {
-                    number = -4503599627370497
-                }
-            };
-
-            Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported2)));
-
-            var reported3 = new
-            {
                 level1 = new
                 {
+                    ok = "ok",
                     level2 = new
                     {
-                        level3 = new
-                        {
-                            level4 = new
-                            {
-                                level5 = new { }
-                            }
-                        }
+                        propertyWithBigValue = tooLong
                     }
                 }
             };
 
-            TwinManager.ValidateTwinProperties(JToken.FromObject(reported3));
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported)));
+            Assert.Equal("Value associated with property name propertyWithBigValue has length 5000 that exceeds maximum length of 4096", ex.Message);
+        }
 
-            var reported4 = new
+        [Fact]
+        public void ValidateTwinPropertiesWithNullValue()
+        {
+            var reportedObj = new
+            {
+                ok = "ok",
+                level1 = new
+                {
+                    ok = null as string
+                }
+            };
+
+            string reportedJson = "{ \"ok\":\"good\", \"level1\": { \"field1\": null } }";
+
+            TwinManager.ValidateTwinProperties(JToken.FromObject(reportedObj));
+            TwinManager.ValidateTwinProperties(JToken.Parse(reportedJson));
+        }
+
+        [Fact]
+        public void ValidateTwinPropertiesWithInvalidNumber()
+        {
+            var reported = new
+            {
+                level = new
+                {
+                    invalidNumber = -4503599627370497
+                }
+            };
+
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported)));
+            Assert.Equal("Property invalidNumber has an out of bound value. Valid values are between -4503599627370496 and 4503599627370495", ex.Message);
+        }
+
+        [Fact]
+        public void ValidateTwinPropertiesWithTooManyLevel()
+        {
+            var reported = new
             {
                 level1 = new
                 {
@@ -1582,21 +1611,55 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 }
             };
 
-            Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported4)));
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported)));
+            Assert.Equal("Nested depth of twin property exceeds 5", ex.Message);
+        }
 
-            var reported5 = new
+        [Fact]
+        public void ValidateTwinPropertiesWithArray()
+        {
+            var reported = new
             {
                 array = new[] { 0, 1, 2 }
             };
 
-            Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported5)));
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported)));
+            Assert.Equal("Property array has a value of unsupported type. Valid types are integer, float, string, bool, null and nested object", ex.Message);
+        }
 
-            var reported6 = new
+        [Fact]
+        public void ValidateTwinPropertiesWithBtyeValue()
+        {
+            var reported = new
             {
                 tooBig = new byte[10 * 1024]
             };
 
-            Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported6)));
+            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported)));
+            Assert.Equal("Property tooBig has a value of unsupported type. Valid types are integer, float, string, bool, null and nested object", ex.Message);
+        }
+
+        [Fact]
+        public void ValidateTwinPropertiesSuccess()
+        {
+            var reported = new
+            {
+                level1 = new
+                {
+                    level2 = new
+                    {
+                        level3 = new
+                        {
+                            level4 = new
+                            {
+                                level5 = new { }
+                            }
+                        }
+                    }
+                }
+            };
+
+            TwinManager.ValidateTwinProperties(JToken.FromObject(reported));
         }
 
         [Theory]
@@ -1605,17 +1668,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             string result = TwinManager.EncodeTwinKey(input);
             Assert.Equal(expectedResult, result);
-        }
-
-        public static IEnumerable<object[]> GetTwinKeyData()
-        {
-            yield return new object[] { "key1", "key1" };
-
-            yield return new object[] { "123", "123" };
-
-            yield return new object[] { "a.b$c d", "a%2Eb%24c%20d" };
-
-            yield return new object[] { "a.b.c.d", "a%2Eb%2Ec%2Ed" };
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.Shared;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using Xunit;
 
     public class ReportedPropertiesValidatorTest
@@ -34,7 +35,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                         }
                     }
                 })),
-                null
+                null,
+                string.Empty
             };
 
             yield return new object[]
@@ -45,10 +47,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                     level = new
                     {
                         ok = "ok",
-                        s = longString
+                        propertyWithBigValue = longString
                     }
                 })),
-                typeof(InvalidOperationException)
+                typeof(InvalidOperationException),
+                "Value associated with property name propertyWithBigValue has length 5000 that exceeds maximum length of 4096"
             };
 
             yield return new object[]
@@ -57,10 +60,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                 {
                     level = new
                     {
-                        number = -4503599627370497
+                        invalidNumber = -4503599627370497
                     }
                 })),
-                typeof(InvalidOperationException)
+                typeof(InvalidOperationException),
+                "Property invalidNumber has an out of bound value. Valid values are between -4503599627370496 and 4503599627370495"
             };
 
             yield return new object[]
@@ -84,7 +88,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                         }
                     }
                 })),
-                typeof(InvalidOperationException)
+                typeof(InvalidOperationException),
+                "Nested depth of twin property exceeds 5"
             };
 
             yield return new object[]
@@ -93,23 +98,46 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                 {
                     array = new[] { 0, 1, 2 }
                 })),
-                typeof(InvalidOperationException)
+                typeof(InvalidOperationException),
+                "Property array has a value of unsupported type. Valid types are integer, float, string, bool, null and nested object"
             };
 
             yield return new object[]
             {
                 new TwinCollection(JsonConvert.SerializeObject(new
                 {
-                    tooBig = new byte[10 * 1024]
+                    tooBig = longString
                 })),
-                typeof(InvalidOperationException)
+                typeof(InvalidOperationException),
+                "Value associated with property name tooBig has length 5000 that exceeds maximum length of 4096"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
+                {
+                    ok = "ok",
+                    level1 = new
+                    {
+                        ok = null as string
+                    }
+                })),
+                null,
+                string.Empty
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection("{ \"ok\":\"good\", \"level1\": { \"field1\": null } }"),
+                null,
+                string.Empty
             };
         }
 
         [Unit]
         [Theory]
         [MemberData(nameof(GetTwinCollections))]
-        public void ValidateReportedPropertiesTest(TwinCollection twinCollection, Type expectedExceptionType)
+        public void ValidateReportedPropertiesTest(TwinCollection twinCollection, Type expectedExceptionType, string expectedExceptionMessage)
         {
             // Arrange
             var reportedPropertiesValidator = new ReportedPropertiesValidator();
@@ -121,7 +149,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
             }
             else
             {
-                Assert.Throws(expectedExceptionType, () => reportedPropertiesValidator.Validate(twinCollection));
+                Exception ex = Assert.Throws(expectedExceptionType, () => reportedPropertiesValidator.Validate(twinCollection));
+                Assert.Equal(expectedExceptionMessage, ex.Message);
             }
         }
     }


### PR DESCRIPTION
* Update Twin property value validation to apply 4K length limit on JValue type only.
* Add test to check twin property having null value.
* Fix ReportedPropertiesValidator for TwinManager V2.