### PR TITLE
[k8s] iotedged: Generate image pull secret for both proxy and edgeagent

### DIFF
--- a/edgelet/edgelet-kube/src/constants.rs
+++ b/edgelet/edgelet-kube/src/constants.rs
@@ -37,6 +37,8 @@ pub mod env {
 
     pub const PROXY_TRUST_BUNDLE_PATH_KEY: &str = "ProxyTrustBundlePath";
 
+    pub const PROXY_IMAGE_PULL_SECRET_NAME_KEY: &str = "ProxyImagePullSecretName";
+
     pub const NAMESPACE_KEY: &str = "K8sNamespace";
 
     pub const EDGE_NETWORK_ID_KEY: &str = "NetworkId";

--- a/edgelet/edgelet-kube/src/convert/named_secret.rs
+++ b/edgelet/edgelet-kube/src/convert/named_secret.rs
@@ -25,10 +25,10 @@ impl NamedSecret {
     }
 }
 
-impl<'a> TryFrom<(&str, &ImagePullSecret<'a>)> for NamedSecret {
+impl<'a> TryFrom<(&str, ImagePullSecret<'a>)> for NamedSecret {
     type Error = crate::error::Error;
 
-    fn try_from((namespace, image_pull_secret): (&str, &ImagePullSecret<'a>)) -> Result<Self> {
+    fn try_from((namespace, image_pull_secret): (&str, ImagePullSecret<'a>)) -> Result<Self> {
         let secret_name = image_pull_secret
             .name()
             .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthName))?;

--- a/edgelet/edgelet-kube/src/convert/named_secret.rs
+++ b/edgelet/edgelet-kube/src/convert/named_secret.rs
@@ -25,10 +25,10 @@ impl NamedSecret {
     }
 }
 
-impl<'a> TryFrom<(&str, ImagePullSecret<'a>)> for NamedSecret {
+impl<'a> TryFrom<(&str, &ImagePullSecret<'a>)> for NamedSecret {
     type Error = crate::error::Error;
 
-    fn try_from((namespace, image_pull_secret): (&str, ImagePullSecret<'a>)) -> Result<Self> {
+    fn try_from((namespace, image_pull_secret): (&str, &ImagePullSecret<'a>)) -> Result<Self> {
         let secret_name = image_pull_secret
             .name()
             .ok_or_else(|| ErrorKind::PullImage(PullImageErrorReason::AuthName))?;

--- a/edgelet/edgelet-kube/src/convert/to_k8s.rs
+++ b/edgelet/edgelet-kube/src/convert/to_k8s.rs
@@ -59,16 +59,16 @@ fn spec_to_podspec(
     if EDGE_EDGE_AGENT_NAME == module_label_value {
         env_vars.push(env(EDGE_NETWORK_ID_KEY, ""));
         env_vars.push(env(NAMESPACE_KEY, settings.namespace()));
-        env_vars.push(env(PROXY_IMAGE_KEY, settings.proxy_image()));
+        env_vars.push(env(PROXY_IMAGE_KEY, settings.proxy().image()));
         env_vars.push(env(PROXY_CONFIG_VOLUME_KEY, PROXY_CONFIG_VOLUME_NAME));
         env_vars.push(env(
             PROXY_CONFIG_MAP_NAME_KEY,
-            settings.proxy_config_map_name(),
+            settings.proxy().config_map_name(),
         ));
-        env_vars.push(env(PROXY_CONFIG_PATH_KEY, settings.proxy_config_path()));
+        env_vars.push(env(PROXY_CONFIG_PATH_KEY, settings.proxy().config_path()));
         env_vars.push(env(
             PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME_KEY,
-            settings.proxy_trust_bundle_config_map_name(),
+            settings.proxy().trust_bundle_config_map_name(),
         ));
         env_vars.push(env(
             PROXY_TRUST_BUNDLE_VOLUME_KEY,
@@ -76,14 +76,14 @@ fn spec_to_podspec(
         ));
         env_vars.push(env(
             PROXY_TRUST_BUNDLE_PATH_KEY,
-            settings.proxy_trust_bundle_path(),
+            settings.proxy().trust_bundle_path(),
         ));
     }
 
     // Bind/volume mounts
     // ConfigMap volume name is fixed: "config-volume"
     let proxy_config_volume_source = api_core::ConfigMapVolumeSource {
-        name: Some(settings.proxy_config_map_name().to_string()),
+        name: Some(settings.proxy().config_map_name().to_string()),
         ..api_core::ConfigMapVolumeSource::default()
     };
     // Volume entry for proxy's config map
@@ -95,7 +95,7 @@ fn spec_to_podspec(
 
     // trust bundle ConfigMap volume name is fixed: "trust-bundle-volume"
     let trust_bundle_config_volume_source = api_core::ConfigMapVolumeSource {
-        name: Some(settings.proxy_trust_bundle_config_map_name().to_string()),
+        name: Some(settings.proxy().trust_bundle_config_map_name().to_string()),
         ..api_core::ConfigMapVolumeSource::default()
     };
     // Volume entry for proxy's trust bundle config map
@@ -109,7 +109,7 @@ fn spec_to_podspec(
 
     // Where to mount proxy config map
     let proxy_volume_mount = api_core::VolumeMount {
-        mount_path: settings.proxy_config_path().to_string(),
+        mount_path: settings.proxy().config_path().to_string(),
         name: PROXY_CONFIG_VOLUME_NAME.to_string(),
         read_only: Some(true),
         ..api_core::VolumeMount::default()
@@ -117,7 +117,7 @@ fn spec_to_podspec(
 
     // Where to mount proxy trust bundle config map
     let trust_bundle_volume_mount = api_core::VolumeMount {
-        mount_path: settings.proxy_trust_bundle_path().to_string(),
+        mount_path: settings.proxy().trust_bundle_path().to_string(),
         name: PROXY_TRUST_BUNDLE_VOLUME_NAME.to_string(),
         read_only: Some(true),
         ..api_core::VolumeMount::default()
@@ -251,7 +251,7 @@ fn spec_to_podspec(
                 name: module_label_value.clone(),
                 env: Some(env_vars.clone()),
                 image: Some(module_image),
-                image_pull_policy: Some(settings.image_pull_policy().to_string()),
+                image_pull_policy: Some(settings.proxy().image_pull_policy().to_string()), //todo user edgeagent imagepullpolicy instead
                 security_context: security,
                 volume_mounts: Some(volume_mounts),
                 ..api_core::Container::default()
@@ -260,8 +260,8 @@ fn spec_to_podspec(
             api_core::Container {
                 name: PROXY_CONTAINER_NAME.to_string(),
                 env: Some(env_vars),
-                image: Some(settings.proxy_image().to_string()),
-                image_pull_policy: Some(settings.image_pull_policy().to_string()),
+                image: Some(settings.proxy().image().to_string()),
+                image_pull_policy: Some(settings.proxy().image_pull_policy().to_string()),
                 volume_mounts: Some(proxy_volume_mounts),
                 ..api_core::Container::default()
             },
@@ -464,7 +464,7 @@ pub fn trust_bundle_to_config_map(
 
     let mut data = BTreeMap::new();
     data.insert(PROXY_TRUST_BUNDLE_FILENAME.to_string(), cert.to_string());
-    let config_map_name = settings.proxy_trust_bundle_config_map_name().to_string();
+    let config_map_name = settings.proxy().trust_bundle_config_map_name().to_string();
 
     let config_map = api_core::ConfigMap {
         metadata: Some(api_meta::ObjectMeta {

--- a/edgelet/edgelet-kube/src/lib.rs
+++ b/edgelet/edgelet-kube/src/lib.rs
@@ -72,13 +72,16 @@ mod tests {
             "namespace": "default",
             "iot_hub_hostname": "iotHub",
             "device_id": "device1",
-            "proxy_image": "proxy:latest",
-            "proxy_config_path": "/etc/traefik",
-            "proxy_config_map_name": PROXY_CONFIG_MAP_NAME,
-            "proxy_trust_bundle_path": "/etc/trust-bundle",
-            "proxy_trust_bundle_config_map_name": PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME,
-            "image_pull_policy": "IfNotPresent",
             "device_hub_selector": "",
+            "proxy": {
+               "image": "proxy:latest",
+               "image_pull_policy": "IfNotPresent",
+               "auth": {},
+               "config_path": "/etc/traefik",
+               "config_map_name": PROXY_CONFIG_MAP_NAME,
+               "trust_bundle_path": "/etc/trust-bundle",
+               "trust_bundle_config_map_name": PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME,
+            },
         });
 
         if let Some(merge_json) = merge_json {

--- a/edgelet/edgelet-kube/src/module/trust_bundle.rs
+++ b/edgelet/edgelet-kube/src/module/trust_bundle.rs
@@ -186,7 +186,7 @@ mod tests {
 
         let dispatch_table = routes!(
             GET format!("/api/v1/namespaces/{}/configmaps", settings.namespace()) => config_map_list(),
-            PUT format!("/api/v1/namespaces/{}/configmaps/{}", settings.namespace(), settings.proxy_trust_bundle_config_map_name()) => update_config_map(),
+            PUT format!("/api/v1/namespaces/{}/configmaps/{}", settings.namespace(), settings.proxy().trust_bundle_config_map_name()) => update_config_map(),
         );
 
         let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));

--- a/edgelet/edgelet-kube/src/registry/mod.rs
+++ b/edgelet/edgelet-kube/src/registry/mod.rs
@@ -1,5 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 mod image_pull_secret;
+mod pull;
 
 pub use image_pull_secret::ImagePullSecret;
+pub use pull::create_image_pull_secrets;

--- a/edgelet/edgelet-kube/src/registry/pull.rs
+++ b/edgelet/edgelet-kube/src/registry/pull.rs
@@ -1,0 +1,113 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+use std::collections::hash_map::Values;
+use std::collections::HashMap;
+use std::convert::TryFrom;
+
+use failure::Fail;
+use futures::future::Either;
+use futures::prelude::*;
+use futures::{future, Future, Stream};
+use hyper::service::Service;
+use hyper::Body;
+
+use edgelet_docker::DockerConfig;
+use kube_client::TokenSource;
+
+use crate::convert::NamedSecret;
+use crate::error::{Error, ErrorKind};
+use crate::registry::ImagePullSecret;
+use crate::KubeModuleRuntime;
+
+pub fn create_image_pull_secrets<T, S>(
+    runtime: &KubeModuleRuntime<T, S>,
+    config: &DockerConfig,
+) -> impl Future<Item = (), Error = Error>
+where
+    T: TokenSource + Send + 'static,
+    S: Service + Send + 'static,
+    S::ReqBody: From<Vec<u8>>,
+    S::ResBody: Stream,
+    Body: From<S::ResBody>,
+    S::Error: Fail,
+    S::Future: Send,
+{
+    let image_pull_secrets = vec![config.auth(), runtime.settings().proxy().auth()]
+        .into_iter()
+        .filter_map(|auth| auth.and_then(|auth| ImagePullSecret::from_auth(&auth)))
+        .map(|secret| (secret.name(), secret))
+        .collect::<HashMap<_, _>>();
+
+    create_or_update_image_pull_secret(runtime, image_pull_secrets.values())
+        .map_err(|err| Error::from(err.context(ErrorKind::RegistryOperation)))
+}
+
+fn create_or_update_image_pull_secret<T, S>(
+    runtime: &KubeModuleRuntime<T, S>,
+    image_pull_secrets: Values<'_, Option<String>, ImagePullSecret<'_>>,
+) -> impl Future<Item = (), Error = Error> + 'static
+where
+    T: TokenSource + Send + 'static,
+    S: Service + Send + 'static,
+    S::ReqBody: From<Vec<u8>>,
+    S::ResBody: Stream,
+    Body: From<S::ResBody>,
+    S::Error: Fail,
+    S::Future: Send,
+{
+    let client_copy = runtime.client().clone();
+    let namespace_copy = runtime.settings().namespace().to_owned();
+
+    let named_secrets: Vec<_> = image_pull_secrets
+        .into_iter()
+        .map(|secret| NamedSecret::try_from((runtime.settings().namespace(), secret)))
+        .collect();
+
+    runtime
+        .client()
+        .lock()
+        .expect("Unexpected lock error")
+        .borrow_mut()
+        .list_secrets(runtime.settings().namespace(), None)
+        .map_err(|err| Error::from(err.context(ErrorKind::KubeClient)))
+        .and_then(move |secrets| {
+            let existing_names: Vec<_> = secrets
+                .items
+                .into_iter()
+                .filter_map(|secret| secret.metadata.and_then(|metadata| metadata.name))
+                .collect();
+
+            let futures = named_secrets.into_iter().map(move |pull_secret| {
+                pull_secret
+                    .map(|pull_secret| {
+                        if existing_names.iter().any(|name| name == pull_secret.name()) {
+                            let f = client_copy
+                                .lock()
+                                .expect("Unexpected lock error")
+                                .borrow_mut()
+                                .replace_secret(
+                                    namespace_copy.as_str(),
+                                    pull_secret.name(),
+                                    pull_secret.secret(),
+                                )
+                                .map_err(|err| Error::from(err.context(ErrorKind::KubeClient)))
+                                .map(|_| ());
+                            Either::A(f)
+                        } else {
+                            let f = client_copy
+                                .lock()
+                                .expect("Unexpected lock error")
+                                .borrow_mut()
+                                .create_secret(namespace_copy.as_str(), pull_secret.secret())
+                                .map_err(|err| Error::from(err.context(ErrorKind::KubeClient)))
+                                .map(|_| ());
+                            Either::B(f)
+                        }
+                    })
+                    .into_future()
+                    .flatten()
+            });
+
+            future::join_all(futures).map(|_| ())
+        })
+}

--- a/edgelet/edgelet-kube/src/registry/pull.rs
+++ b/edgelet/edgelet-kube/src/registry/pull.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use std::collections::hash_map::Values;
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
@@ -34,17 +33,22 @@ where
 {
     let image_pull_secrets = vec![config.auth(), runtime.settings().proxy().auth()]
         .into_iter()
-        .filter_map(|auth| auth.and_then(|auth| ImagePullSecret::from_auth(&auth)))
-        .map(|secret| (secret.name(), secret))
-        .collect::<HashMap<_, _>>();
+        .filter_map(|auth| {
+            auth.and_then(|auth| ImagePullSecret::from_auth(&auth))
+                .map(|secret| (secret.name(), secret))
+        })
+        .collect::<HashMap<_, _>>()
+        .drain()
+        .map(|(_, secret)| secret)
+        .collect::<Vec<_>>();
 
-    create_or_update_image_pull_secret(runtime, image_pull_secrets.values())
+    create_or_update_image_pull_secrets(runtime, image_pull_secrets)
         .map_err(|err| Error::from(err.context(ErrorKind::RegistryOperation)))
 }
 
-fn create_or_update_image_pull_secret<T, S>(
+fn create_or_update_image_pull_secrets<T, S>(
     runtime: &KubeModuleRuntime<T, S>,
-    image_pull_secrets: Values<'_, Option<String>, ImagePullSecret<'_>>,
+    image_pull_secrets: Vec<ImagePullSecret<'_>>,
 ) -> impl Future<Item = (), Error = Error> + 'static
 where
     T: TokenSource + Send + 'static,
@@ -110,4 +114,249 @@ where
 
             future::join_all(futures).map(|_| ())
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use hyper::service::service_fn;
+    use hyper::{Body, Method, Request, StatusCode};
+    use maplit::btreemap;
+    use serde_json::json;
+    use tokio::runtime::Runtime;
+
+    use docker::models::{AuthConfig, ContainerCreateBody};
+    use edgelet_docker::DockerConfig;
+    use edgelet_test_utils::routes;
+    use edgelet_test_utils::web::{
+        make_req_dispatcher, HttpMethod, RequestHandler, RequestPath, ResponseFuture,
+    };
+
+    use crate::error::PullImageErrorReason;
+    use crate::registry::pull::create_or_update_image_pull_secrets;
+    use crate::registry::{create_image_pull_secrets, ImagePullSecret};
+    use crate::tests::{create_runtime, make_settings, not_found_handler, response};
+    use crate::ErrorKind;
+
+    #[test]
+    fn it_creates_image_pull_secret_if_it_does_not_exist() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/secrets", settings.namespace()) => empty_secret_list_handler(),
+            POST format!("/api/v1/namespaces/{}/secrets", settings.namespace()) => create_secret_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+
+        let image_pull_secrets = vec![ImagePullSecret::default()
+            .with_registry("REGISTRY")
+            .with_username("USER")
+            .with_password("PASSWORD")];
+
+        let task = create_or_update_image_pull_secrets(&runtime, image_pull_secrets);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn it_updates_image_pull_secret_if_it_exists() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/secrets", settings.namespace()) => secret_list_handler(),
+            PUT format!("/api/v1/namespaces/{}/secrets/user-registry", settings.namespace(), ) => replace_secret_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+
+        let image_pull_secrets = vec![ImagePullSecret::default()
+            .with_registry("REGISTRY")
+            .with_username("USER")
+            .with_password("PASSWORD")];
+
+        let task = create_or_update_image_pull_secrets(&runtime, image_pull_secrets);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn it_returns_an_error_when_image_pull_secret_is_invalid() {
+        let settings = make_settings(None);
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/secrets", settings.namespace()) => secret_list_handler(),
+            PUT format!("/api/v1/namespaces/{}/secrets/user-registry", settings.namespace(), ) => replace_secret_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+
+        let image_pull_secrets = vec![ImagePullSecret::default()];
+
+        let task = create_or_update_image_pull_secrets(&runtime, image_pull_secrets);
+
+        let mut runtime = Runtime::new().unwrap();
+        let err = runtime.block_on(task).unwrap_err();
+        assert_eq!(
+            err.kind(),
+            &ErrorKind::PullImage(PullImageErrorReason::AuthName)
+        )
+    }
+
+    #[test]
+    fn it_updates_image_pull_secrets_for_both_module_and_proxy() {
+        let settings = make_settings(Some(json!({
+            "proxy": {
+                "auth": {
+                    "username": "user",
+                    "password": "password",
+                    "serveraddress": "registry2"
+                },
+            },
+        })));
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/secrets", settings.namespace()) => secret_list_handler(),
+            PUT format!("/api/v1/namespaces/{}/secrets/user-registry", settings.namespace()) => replace_secret_handler(),
+            PUT format!("/api/v1/namespaces/{}/secrets/user-registry2", settings.namespace()) => replace_secret_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+
+        let auth_config = AuthConfig::new()
+            .with_password(String::from("PASSWORD"))
+            .with_username(String::from("USER"))
+            .with_serveraddress(String::from("REGISTRY"));
+
+        let config = DockerConfig::new(
+            "my-image:v1.0".to_string(),
+            ContainerCreateBody::new(),
+            Some(auth_config),
+        )
+        .unwrap();
+
+        let task = create_image_pull_secrets(&runtime, &config);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    #[test]
+    fn it_creates_image_pull_secret_only_once_if_both_module_and_proxy_stored_in_the_same_repo() {
+        let settings = make_settings(Some(json!({
+            "proxy": {
+                "auth": {
+                    "username": "user",
+                    "password": "password",
+                    "serveraddress": "registry"
+                },
+            },
+        })));
+
+        let dispatch_table = routes!(
+            GET format!("/api/v1/namespaces/{}/secrets", settings.namespace()) => secret_list_handler(),
+            PUT format!("/api/v1/namespaces/{}/secrets/user-registry", settings.namespace()) => replace_secret_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+
+        let auth_config = AuthConfig::new()
+            .with_password(String::from("PASSWORD"))
+            .with_username(String::from("USER"))
+            .with_serveraddress(String::from("REGISTRY"));
+
+        let config = DockerConfig::new(
+            "my-image:v1.0".to_string(),
+            ContainerCreateBody::new(),
+            Some(auth_config),
+        )
+        .unwrap();
+
+        let task = create_image_pull_secrets(&runtime, &config);
+
+        let mut runtime = Runtime::new().unwrap();
+        runtime.block_on(task).unwrap();
+    }
+
+    fn empty_secret_list_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "SecretList",
+                    "apiVersion": "v1",
+                    "items": []
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn secret_list_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                   "kind": "SecretList",
+                    "apiVersion": "v1",
+                    "items": [
+                        {
+                            "metadata": {
+                                "name": "user-registry",
+                                "namespace": "my-namespace",
+                            }
+                        },
+                        {
+                            "metadata": {
+                                "name": "user-registry2",
+                                "namespace": "my-namespace",
+                            }
+                        }
+                    ]
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn create_secret_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::CREATED, || {
+                json!({
+                    "kind": "Secret",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": "user-registry",
+                        "namespace": "my-namespace",
+                    },
+                })
+                .to_string()
+            })
+        }
+    }
+
+    fn replace_secret_handler() -> impl Fn(Request<Body>) -> ResponseFuture + Clone {
+        move |_| {
+            response(StatusCode::OK, || {
+                json!({
+                    "kind": "Secret",
+                    "apiVersion": "v1",
+                    "metadata": {
+                        "name": "user-registry",
+                        "namespace": "my-namespace",
+                    },
+                })
+                .to_string()
+            })
+        }
+    }
 }

--- a/edgelet/edgelet-kube/src/settings.rs
+++ b/edgelet/edgelet-kube/src/settings.rs
@@ -13,6 +13,7 @@ use failure::ResultExt;
 
 use crate::error::Error;
 use crate::ErrorKind;
+use docker::models::AuthConfig;
 
 #[derive(Clone, Debug, serde_derive::Deserialize, serde_derive::Serialize)]
 pub struct Settings {
@@ -21,13 +22,8 @@ pub struct Settings {
     namespace: String,
     iot_hub_hostname: Option<String>,
     device_id: Option<String>,
-    proxy_image: String,
-    proxy_config_path: String,
-    proxy_config_map_name: String,
-    proxy_trust_bundle_path: String,
-    proxy_trust_bundle_config_map_name: String,
-    image_pull_policy: String,
     device_hub_selector: String,
+    proxy: ProxySettings,
 }
 
 impl Settings {
@@ -68,32 +64,12 @@ impl Settings {
         self.iot_hub_hostname.as_ref().map(String::as_str)
     }
 
+    pub fn proxy(&self) -> &ProxySettings {
+        &self.proxy
+    }
+
     pub fn device_id(&self) -> Option<&str> {
         self.device_id.as_ref().map(String::as_str)
-    }
-
-    pub fn proxy_image(&self) -> &str {
-        &self.proxy_image
-    }
-
-    pub fn proxy_config_path(&self) -> &str {
-        &self.proxy_config_path
-    }
-
-    pub fn proxy_config_map_name(&self) -> &str {
-        &self.proxy_config_map_name
-    }
-
-    pub fn proxy_trust_bundle_path(&self) -> &str {
-        &self.proxy_trust_bundle_path
-    }
-
-    pub fn proxy_trust_bundle_config_map_name(&self) -> &str {
-        &self.proxy_trust_bundle_config_map_name
-    }
-
-    pub fn image_pull_policy(&self) -> &str {
-        &self.image_pull_policy
     }
 
     pub fn device_hub_selector(&self) -> &str {
@@ -138,5 +114,46 @@ impl RuntimeSettings for Settings {
 
     fn watchdog(&self) -> &WatchdogSettings {
         self.base.watchdog()
+    }
+}
+
+#[derive(Clone, Debug, serde_derive::Deserialize, serde_derive::Serialize)]
+pub struct ProxySettings {
+    auth: Option<AuthConfig>,
+    image: String,
+    image_pull_policy: String,
+    config_path: String,
+    config_map_name: String,
+    trust_bundle_path: String,
+    trust_bundle_config_map_name: String,
+}
+
+impl ProxySettings {
+    pub fn auth(&self) -> Option<&AuthConfig> {
+        self.auth.as_ref()
+    }
+
+    pub fn image(&self) -> &str {
+        &self.image
+    }
+
+    pub fn config_path(&self) -> &str {
+        &self.config_path
+    }
+
+    pub fn config_map_name(&self) -> &str {
+        &self.config_map_name
+    }
+
+    pub fn trust_bundle_path(&self) -> &str {
+        &self.trust_bundle_path
+    }
+
+    pub fn trust_bundle_config_map_name(&self) -> &str {
+        &self.trust_bundle_config_map_name
+    }
+
+    pub fn image_pull_policy(&self) -> &str {
+        &self.image_pull_policy
     }
 }

--- a/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
+++ b/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
@@ -61,7 +61,7 @@ agent:
   {{ end }}
   config:
     image: "{{ .Values.edgeAgent.image.repository }}:{{ .Values.edgeAgent.image.tag }}"
-  {{- if .Values.edgeAgent.registryCredentials }}
+    {{- if .Values.edgeAgent.registryCredentials }}
     auth:
       username: {{ .Values.edgeAgent.registryCredentials.username | quote }}
       password: {{ .Values.edgeAgent.registryCredentials.password | quote }}
@@ -78,13 +78,22 @@ listen:
   workload_uri: "https://0.0.0.0:{{ .Values.iotedged.ports.workload }}"
 homedir: {{ .Values.iotedged.data.targetPath | quote }}
 namespace: {{ .Release.Namespace | quote }}
-proxy_image:  "{{.Values.iotedgedProxy.image.repository}}:{{.Values.iotedgedProxy.image.tag}}"
-proxy_config_path: "/etc/iotedge-proxy"
-proxy_config_map_name: "iotedged-proxy-config"
-proxy_trust_bundle_path: "/etc/trust-bundle"
-proxy_trust_bundle_config_map_name: "iotedged-proxy-trust-bundle"
-image_pull_policy: {{ .Values.iotedgedProxy.image.pullPolicy | quote }}
 device_hub_selector: ""
+proxy:
+  image: "{{.Values.iotedgedProxy.image.repository}}:{{.Values.iotedgedProxy.image.tag}}"
+  image_pull_policy: {{ .Values.iotedgedProxy.image.pullPolicy | quote }}
+  {{- if .Values.edgeAgent.registryCredentials }}
+  auth:
+    username: {{ .Values.edgeAgent.registryCredentials.username | quote }}
+    password: {{ .Values.edgeAgent.registryCredentials.password | quote }}
+    serveraddress: {{ .Values.edgeAgent.registryCredentials.serveraddress | quote }}
+  {{ else }}
+  auth: {}
+  {{ end }}
+  config_map_name: "iotedged-proxy-config"
+  config_path: "/etc/iotedge-proxy"
+  trust_bundle_config_map_name: "iotedged-proxy-trust-bundle"
+  trust_bundle_path: "/etc/trust-bundle"
 {{ end }}
 
 {{/* Template for rendering registry credentials. */}}

--- a/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
+++ b/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
@@ -82,11 +82,11 @@ device_hub_selector: ""
 proxy:
   image: "{{.Values.iotedgedProxy.image.repository}}:{{.Values.iotedgedProxy.image.tag}}"
   image_pull_policy: {{ .Values.iotedgedProxy.image.pullPolicy | quote }}
-  {{- if .Values.edgeAgent.registryCredentials }}
+  {{- if .Values.iotedgedProxy.registryCredentials }}
   auth:
-    username: {{ .Values.edgeAgent.registryCredentials.username | quote }}
-    password: {{ .Values.edgeAgent.registryCredentials.password | quote }}
-    serveraddress: {{ .Values.edgeAgent.registryCredentials.serveraddress | quote }}
+    username: {{ .Values.iotedgedProxy.registryCredentials.username | quote }}
+    password: {{ .Values.iotedgedProxy.registryCredentials.password | quote }}
+    serveraddress: {{ .Values.iotedgedProxy.registryCredentials.serveraddress | quote }}
   {{ else }}
   auth: {}
   {{ end }}


### PR DESCRIPTION
Initially, we assume that proxy will live in the public container registry that maybe not the case for some customers. So edge should be able to provide all credentials for k8s to pull and run proxy as a sidecar container.
- Refactor `config.yaml` file structure to support proxy settings
- Generate image pull secret for both EdgeAgent and Proxy
- Pass proxy image pull secret to EdgeAgent in order for other modules to have proxy pulled
