### PR TITLE
Analyzer - Fix device id default to device1 if not set 

### DIFF
--- a/edge-modules/DirectMethodCloudSender/src/Program.cs
+++ b/edge-modules/DirectMethodCloudSender/src/Program.cs
@@ -34,7 +34,7 @@ namespace DirectMethodCloudSender
                 .AddEnvironmentVariables()
                 .Build();
 
-            string serviceClientConnectionString = Preconditions.CheckNonWhiteSpace(configuration.GetValue<string>("ServiceClientConnectionString"), "ServiceClientConnectionString");
+            string serviceClientConnectionString = Preconditions.CheckNonWhiteSpace(configuration.GetValue<string>("ServiceClientConnectionString"), nameof(serviceClientConnectionString));
             // Get device id of this device, exposed as a system variable by the iot edge runtime
             string targetDeviceId = configuration.GetValue<string>("IOTEDGE_DEVICEID");
             string targetModuleId = configuration.GetValue("TargetModuleId", "DirectMethodReceiver");

--- a/edge-modules/MessagesAnalyzer/Settings.cs
+++ b/edge-modules/MessagesAnalyzer/Settings.cs
@@ -10,14 +10,13 @@ namespace MessagesAnalyzer
     {
         const string ExcludeModulesIdsPropertyName = "ExcludeModules:Ids";
         const string EventHubConnectionStringPropertyValue = "eventHubConnectionString";
-        const string DeviceIdPropertyName = "DeviceId";
+        const string DeviceIdPropertyName = "IOTEDGE_DEVICEID";
         const string ConsumerGroupIdPropertyName = "ConsumerGroupId";
         const string WebhostPortPropertyName = "WebhostPort";
         const string ToleranceInMillisecondsPropertyName = "ToleranceInMilliseconds";
         const string DefaultConsumerGroupId = "$Default";
         const string DefaultWebhostPort = "5001";
         const double DefaultToleranceInMilliseconds = 1000 * 60;
-        static readonly string DefaultDeviceId = Environment.GetEnvironmentVariable("IOTEDGE_DEVICEID");
 
         static readonly Lazy<Settings> Setting = new Lazy<Settings>(
             () =>
@@ -33,7 +32,7 @@ namespace MessagesAnalyzer
                 return new Settings(
                     configuration.GetValue<string>(EventHubConnectionStringPropertyValue),
                     configuration.GetValue(ConsumerGroupIdPropertyName, DefaultConsumerGroupId),
-                    configuration.GetValue(DeviceIdPropertyName, DefaultDeviceId),
+                    configuration.GetValue(DeviceIdPropertyName, string.Empty),
                     excludedModules,
                     configuration.GetValue(WebhostPortPropertyName, DefaultWebhostPort),
                     configuration.GetValue(ToleranceInMillisecondsPropertyName, DefaultToleranceInMilliseconds));

--- a/edge-modules/MessagesAnalyzer/Settings.cs
+++ b/edge-modules/MessagesAnalyzer/Settings.cs
@@ -4,6 +4,7 @@ namespace MessagesAnalyzer
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Configuration;
 
     class Settings
@@ -31,21 +32,21 @@ namespace MessagesAnalyzer
 
                 return new Settings(
                     configuration.GetValue<string>(EventHubConnectionStringPropertyValue),
-                    configuration.GetValue(ConsumerGroupIdPropertyName, DefaultConsumerGroupId),
-                    configuration.GetValue(DeviceIdPropertyName, string.Empty),
+                    configuration.GetValue<string>(ConsumerGroupIdPropertyName, DefaultConsumerGroupId),
+                    configuration.GetValue<string>(DeviceIdPropertyName),
                     excludedModules,
-                    configuration.GetValue(WebhostPortPropertyName, DefaultWebhostPort),
-                    configuration.GetValue(ToleranceInMillisecondsPropertyName, DefaultToleranceInMilliseconds));
+                    configuration.GetValue<string>(WebhostPortPropertyName, DefaultWebhostPort),
+                    configuration.GetValue<double>(ToleranceInMillisecondsPropertyName, DefaultToleranceInMilliseconds));
             });
 
-        Settings(string eventHubCs, string consumerGroupId, string deviceId, IList<string> excludedModuleIds, string webhostPort, double tolerance)
+        Settings(string eventHubConnectionString, string consumerGroupId, string deviceId, IList<string> excludedModuleIds, string webhostPort, double tolerance)
         {
-            this.EventHubConnectionString = eventHubCs;
-            this.ConsumerGroupId = consumerGroupId;
+            this.EventHubConnectionString = Preconditions.CheckNonWhiteSpace(eventHubConnectionString, "eventHubConnectionString");
+            this.ConsumerGroupId = Preconditions.CheckNonWhiteSpace(consumerGroupId, "consumerGroupId");
             this.ExcludedModuleIds = excludedModuleIds;
-            this.DeviceId = deviceId;
-            this.WebhostPort = webhostPort;
-            this.ToleranceInMilliseconds = tolerance;
+            this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, "deviceId");
+            this.WebhostPort = Preconditions.CheckNonWhiteSpace(webhostPort, "webhostPort");
+            this.ToleranceInMilliseconds = Preconditions.CheckRange(tolerance, 0);
         }
 
         public static Settings Current => Setting.Value;

--- a/edge-modules/MessagesAnalyzer/Settings.cs
+++ b/edge-modules/MessagesAnalyzer/Settings.cs
@@ -41,11 +41,11 @@ namespace MessagesAnalyzer
 
         Settings(string eventHubConnectionString, string consumerGroupId, string deviceId, IList<string> excludedModuleIds, string webhostPort, double tolerance)
         {
-            this.EventHubConnectionString = Preconditions.CheckNonWhiteSpace(eventHubConnectionString, "eventHubConnectionString");
-            this.ConsumerGroupId = Preconditions.CheckNonWhiteSpace(consumerGroupId, "consumerGroupId");
+            this.EventHubConnectionString = Preconditions.CheckNonWhiteSpace(eventHubConnectionString, nameof(eventHubConnectionString));
+            this.ConsumerGroupId = Preconditions.CheckNonWhiteSpace(consumerGroupId, nameof(consumerGroupId));
             this.ExcludedModuleIds = excludedModuleIds;
-            this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, "deviceId");
-            this.WebhostPort = Preconditions.CheckNonWhiteSpace(webhostPort, "webhostPort");
+            this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
+            this.WebhostPort = Preconditions.CheckNonWhiteSpace(webhostPort, nameof(webhostPort));
             this.ToleranceInMilliseconds = Preconditions.CheckRange(tolerance, 0);
         }
 

--- a/edge-modules/MessagesAnalyzer/config/settings.json
+++ b/edge-modules/MessagesAnalyzer/config/settings.json
@@ -1,5 +1,5 @@
 {
-  "DeviceId": "device1",
+  "DeviceId": "",
   "ExcludeModules": {
     "Ids": [
       "$edgeAgent",

--- a/edge-modules/MessagesAnalyzer/config/settings.json
+++ b/edge-modules/MessagesAnalyzer/config/settings.json
@@ -1,5 +1,4 @@
 {
-  "DeviceId": "",
   "ExcludeModules": {
     "Ids": [
       "$edgeAgent",

--- a/edge-modules/ModuleRestarter/src/Settings.cs
+++ b/edge-modules/ModuleRestarter/src/Settings.cs
@@ -35,8 +35,8 @@ namespace ModuleRestarter
             string desiredModulesToRestartCSV,
             int restartIntervalInMins)
         {
-            this.ServiceClientConnectionString = Preconditions.CheckNonWhiteSpace(serviceClientConnectionString, "ServiceClientConnectionString");
-            this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, "DeviceId");
+            this.ServiceClientConnectionString = Preconditions.CheckNonWhiteSpace(serviceClientConnectionString, nameof(serviceClientConnectionString));
+            this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
             this.RestartIntervalInMins = Preconditions.CheckRange(restartIntervalInMins, 0);
 
             // mitigate unintended repeated commas


### PR DESCRIPTION
If device id was not set, the analyzer would take it's value from the settings.json. 

The environment variable IOTEDGE_DEVICEID will always be set within a module, so we don't have to look at the settings config.