### PR TITLE
[k8s] Start users' modules with a respect of RunAsNonRoot env

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Constants.cs
@@ -76,5 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         public const string EdgeK8sObjectOwnerNameKey = "EdgeK8sObjectOwnerName";
 
         public const string EdgeK8sObjectOwnerUidKey = "EdgeK8sObjectOwnerUid";
+
+        public const string RunAsNonRootKey = "RunAsNonRoot";
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModuleOwner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModuleOwner.cs
@@ -1,19 +1,18 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 {
-    using System;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Serialization;
 
     public class KubernetesModuleOwner
     {
         [JsonConstructor]
         public KubernetesModuleOwner(string apiVersion, string kind, string name, string uid)
         {
-            this.ApiVersion = apiVersion;
-            this.Kind = kind;
-            this.Name = name;
-            this.Uid = uid;
+            this.ApiVersion = Preconditions.CheckNonWhiteSpace(apiVersion, nameof(apiVersion));
+            this.Kind = Preconditions.CheckNonWhiteSpace(kind, nameof(kind));
+            this.Name = Preconditions.CheckNonWhiteSpace(name, nameof(name));
+            this.Uid = Preconditions.CheckNonWhiteSpace(uid, nameof(uid));
         }
 
         [JsonProperty(PropertyName = "apiVersion")]

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -190,10 +190,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         uint persistentVolumeClaimDefaultSizeMb = configuration.GetValue<uint>(K8sConstants.PersistentVolumeClaimDefaultSizeInMbKey);
                         string deviceNamespace = configuration.GetValue<string>(K8sConstants.K8sNamespaceKey);
                         var kubernetesExperimentalFeatures = KubernetesExperimentalFeatures.Create(configuration.GetSection("experimentalFeatures"), logger);
-                        string edgeK8sObjectOwnerApiVersion = configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerApiVersionKey);
-                        string edgeK8sObjectOwnerKind = configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerKindKey);
-                        string edgeK8sObjectOwnerName = configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerNameKey);
-                        string edgeK8sObjectOwnerUid = configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerUidKey);
+                        var moduleOwner = new KubernetesModuleOwner(
+                            configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerApiVersionKey),
+                            configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerKindKey),
+                            configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerNameKey),
+                            configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerUidKey));
+                        bool runAsNonRoot = configuration.GetValue<bool>(K8sConstants.RunAsNonRootKey);
 
                         builder.RegisterInstance(metricsConfig.Enabled
                                  ? new MetricsProvider("edgeagent", iothubHostname, deviceId)
@@ -227,11 +229,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                             closeOnIdleTimeout,
                             idleTimeout,
                             kubernetesExperimentalFeatures,
-                            new KubernetesModuleOwner(
-                                edgeK8sObjectOwnerApiVersion,
-                                edgeK8sObjectOwnerKind,
-                                edgeK8sObjectOwnerName,
-                                edgeK8sObjectOwnerUid)));
+                            moduleOwner,
+                            runAsNonRoot));
 
                         break;
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly TimeSpan idleTimeout;
         readonly KubernetesExperimentalFeatures experimentalFeatures;
         readonly KubernetesModuleOwner moduleOwner;
+        readonly bool runAsNonRoot;
 
         public KubernetesModule(
             string iotHubHostname,
@@ -89,7 +90,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             bool closeOnIdleTimeout,
             TimeSpan idleTimeout,
             KubernetesExperimentalFeatures experimentalFeatures,
-            KubernetesModuleOwner moduleOwner)
+            KubernetesModuleOwner moduleOwner,
+            bool runAsNonRoot)
         {
             this.resourceName = new ResourceName(iotHubHostname, deviceId);
             this.edgeDeviceHostName = Preconditions.CheckNonWhiteSpace(edgeDeviceHostName, nameof(edgeDeviceHostName));
@@ -118,6 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.idleTimeout = idleTimeout;
             this.experimentalFeatures = experimentalFeatures;
             this.moduleOwner = moduleOwner;
+            this.runAsNonRoot = runAsNonRoot;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -237,7 +240,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                             this.storageClassName,
                             this.apiVersion,
                             this.workloadUri,
-                            this.managementUri))
+                            this.managementUri,
+                            this.runAsNonRoot))
                 .As<IKubernetesDeploymentMapper>();
 
             // KubernetesServiceMapper

--- a/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
+++ b/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
@@ -56,6 +56,9 @@ agent:
     {{- if .Values.edgeAgent.env.enableK8sExtensions }}
     ExperimentalFeatures__EnableK8SExtensions: {{ .Values.edgeAgent.env.enableK8sExtensions | quote }}
     {{- end }}
+    {{- if .Values.edgeAgent.env.runAsNonRoot }}
+    RunAsNonRoot: {{ .Values.edgeAgent.env.runAsNonRoot | quote }}
+    {{- end }}
   {{ else }}
   env: {}
   {{ end }}

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -99,6 +99,11 @@ edgeAgent:
     # must be set to "true".
     # enableK8sExtensions: true
 
+    # Configure default pod security context rule. If set true, it will allow kubernetes to run only non-root containers
+    # under the user with uid(1000).
+    # false dy default.
+    # runAsNonRoot: false
+
 # Optional registry credentials for module images
 # registryCredentials:
 #   <SERVER ADDRESS>:


### PR DESCRIPTION
Add additional env for EdgeAgent that determines whether users' modules should run with default pod security context. When `RunAsNonRoot` env is set EdgeAgent should add pod security context with `RunAsNonRoot = true` and `RunAsUser = 1000`.