### PR TITLE
Increase delay/retry for flaky test in CI build

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     {
         static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
 
-        static readonly int EventHubMessageReceivedRetry = 5;
+        static readonly int EventHubMessageReceivedRetry = 10;
 
         [Fact]
         [TestPriority(401)]
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var eventHubReceiver = new EventHubReceiver(eventHubConnectionString);
             var cloudMessages = new List<EventData>();
             bool messagesFound = false;
-            // Add retry mechanism to make sure all the messages sent reached Event Hub. Retry 3 times.
+            // Add retry mechanism to make sure all the messages sent reached Event Hub.
             for (int i = 0; i < EventHubMessageReceivedRetry; i++)
             {
                 cloudMessages.AddRange(await eventHubReceiver.GetMessagesFromAllPartitions(startTime));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/BackupAndRestoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/BackupAndRestoreTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             string edgeDeviceConnectionString = await SecretsHelper.GetSecretFromConfigKey("edgeCapableDeviceConnStrKey");
             IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(edgeDeviceConnectionString);
             RegistryManager rm = RegistryManager.CreateFromConnectionString(edgeDeviceConnectionString);
-            Func<int, TimeSpan> waitTimeComputer = (numberOfMessages) => TimeSpan.FromMinutes(Math.Ceiling(numberOfMessages / 2000d) + 1);
+            Func<int, TimeSpan> waitTimeComputer = (numberOfMessages) => TimeSpan.FromMinutes(Math.Ceiling(numberOfMessages / 2000d) + 2);
 
             try
             {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 receiver = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "receiver1", transportSettings);
                 await receiver.SetupReceiveMessageHandler();
 
-                await Task.Delay(TimeSpan.FromSeconds(20));
+                await Task.Delay(TimeSpan.FromSeconds(60));
                 ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
 
                 Assert.Equal(messagesCount, receivedMessages.Count);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TwinDiffE2ETest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TwinDiffE2ETest.cs
@@ -424,7 +424,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             Twin updatedCloudTwin = await deviceClient.GetTwinAsync();
 
             // replicate the patch operation locally
-            var delayTask = Task.Delay(TimeSpan.FromSeconds(10));
+            var delayTask = Task.Delay(TimeSpan.FromSeconds(60));
             while (!desiredPropertiesUpdateCallbackTriggered && !delayTask.IsCompleted)
             {
                 await Task.Delay(TimeSpan.FromMilliseconds(500));


### PR DESCRIPTION
Recently there are some flaky tests reported failure randomly.  Therefore increase delay/retry for short term fix; if this happens again, we should move these tests to e2e tests or take them out from CI build.