### PR TITLE
Set max total wal size for RocksDB to 512M (#1704)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -93,6 +93,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string IoTEdgeAgentProductInfoIdentifier = "EdgeAgent";
 
+        public const string StorageMaxTotalWalSize = "RocksDB_MaxTotalWalSize";
+
         public static class Labels
         {
             public const string Version = "net.azure-devices.edge.version";

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -435,7 +435,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             IDbStoreProvider dbStoreProvider = await container.Resolve<Task<IDbStoreProvider>>();
             await dbStoreProvider.CloseAsync();
         }
-        
+
         static Option<ulong> GetStorageMaxTotalWalSizeIfExists(IConfiguration configuration)
         {
             ulong storageMaxTotalWalSize = 0;

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                             configuration.GetValue<string>(K8sConstants.EdgeK8sObjectOwnerUidKey));
                         bool runAsNonRoot = configuration.GetValue<bool>(K8sConstants.RunAsNonRootKey);
 
-                        builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath));
+                        builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize));
                         builder.RegisterModule(new KubernetesModule(
                             iothubHostname,
                             deviceId,

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -135,6 +135,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 int idleTimeoutSecs = configuration.GetValue(Constants.IdleTimeoutSecs, 300);
                 TimeSpan idleTimeout = TimeSpan.FromSeconds(idleTimeoutSecs);
                 experimentalFeatures = ExperimentalFeatures.Create(configuration.GetSection("experimentalFeatures"), logger);
+                Option<ulong> storageTotalMaxWalSize = GetStorageMaxTotalWalSizeIfExists(configuration);
                 string iothubHostname;
                 string deviceId;
                 string apiVersion = "2018-06-28";
@@ -147,7 +148,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         IotHubConnectionStringBuilder connectionStringParser = IotHubConnectionStringBuilder.Create(deviceConnectionString);
                         deviceId = connectionStringParser.DeviceId;
                         iothubHostname = connectionStringParser.HostName;
-                        builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, enableNonPersistentStorageBackup, storageBackupPath));
+                        builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize));
                         builder.RegisterModule(new DockerModule(deviceConnectionString, edgeDeviceHostName, dockerUri, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout));
                         break;
 
@@ -159,7 +160,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         string moduleId = configuration.GetValue(Constants.ModuleIdVariableName, Constants.EdgeAgentModuleIdentityName);
                         string moduleGenerationId = configuration.GetValue<string>(Constants.EdgeletModuleGenerationIdVariableName);
                         apiVersion = configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
-                        builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath));
+                        builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize));
                         builder.RegisterModule(new EdgeletModule(iothubHostname, edgeDeviceHostName, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout));
                         break;
 
@@ -433,6 +434,21 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
         {
             IDbStoreProvider dbStoreProvider = await container.Resolve<Task<IDbStoreProvider>>();
             await dbStoreProvider.CloseAsync();
+        }
+        
+        static Option<ulong> GetStorageMaxTotalWalSizeIfExists(IConfiguration configuration)
+        {
+            ulong storageMaxTotalWalSize = 0;
+            try
+            {
+                storageMaxTotalWalSize = configuration.GetValue<ulong>(Constants.StorageMaxTotalWalSize);
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return storageMaxTotalWalSize <= 0 ? Option.None<ulong>() : Option.Some(storageMaxTotalWalSize);
         }
 
         static void LogLogo(ILogger logger)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/AgentModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/AgentModule.cs
@@ -32,9 +32,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly Option<string> moduleGenerationId;
         readonly bool useBackupAndRestore;
         readonly Option<string> storageBackupPath;
+        readonly Option<ulong> storageTotalMaxWalSize;
 
-        public AgentModule(int maxRestartCount, TimeSpan intensiveCareTime, int coolOffTimeUnitInSeconds, bool usePersistentStorage, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath)
-            : this(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.None<Uri>(), Option.None<string>(), Constants.EdgeAgentModuleIdentityName, Option.None<string>(), useBackupAndRestore, storageBackupPath)
+        public AgentModule(int maxRestartCount, TimeSpan intensiveCareTime, int coolOffTimeUnitInSeconds, bool usePersistentStorage, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath, Option<ulong> storageTotalMaxWalSize)
+            : this(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.None<Uri>(), Option.None<string>(), Constants.EdgeAgentModuleIdentityName, Option.None<string>(), useBackupAndRestore, storageBackupPath, storageTotalMaxWalSize)
         {
         }
 
@@ -49,7 +50,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             string moduleId,
             Option<string> moduleGenerationId,
             bool useBackupAndRestore,
-            Option<string> storageBackupPath)
+            Option<string> storageBackupPath,
+            Option<ulong> storageTotalMaxWalSize)
         {
             this.maxRestartCount = maxRestartCount;
             this.intensiveCareTime = intensiveCareTime;
@@ -62,6 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.moduleGenerationId = moduleGenerationId;
             this.useBackupAndRestore = useBackupAndRestore;
             this.storageBackupPath = storageBackupPath;
+            this.storageTotalMaxWalSize = storageTotalMaxWalSize;
         }
 
         static Dictionary<Type, IDictionary<string, Type>> DeploymentConfigTypeMapping
@@ -138,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
 
             // IRocksDbOptionsProvider
             // For EdgeAgent, we don't need high performance from RocksDb, so always turn off optimizeForPerformance
-            builder.Register(c => new RocksDbOptionsProvider(c.Resolve<ISystemEnvironment>(), false))
+            builder.Register(c => new RocksDbOptionsProvider(c.Resolve<ISystemEnvironment>(), false, this.storageTotalMaxWalSize))
                 .As<IRocksDbOptionsProvider>()
                 .SingleInstance();
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             public const string EdgeHubDevTrustBundleFile = "EdgeHubDevTrustBundleFile";
             public const string EdgeHubClientCertAuthEnabled = "ClientCertAuthEnabled";
             public const string SslProtocols = "SslProtocols";
+            public const string StorageMaxTotalWalSize = "RocksDB_MaxTotalWalSize";
         }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     proxy,
                     metricsConfig,
                     storeAndForward.useBackupAndRestore,
-                    storeAndForward.storageBackupPath));
+                    storeAndForward.storageBackupPath,
                     storeAndForward.storageMaxTotalWalSize));
         }
 
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             }
 
             var storeAndForwardConfiguration = new StoreAndForwardConfiguration(timeToLiveSecs);
-            return (storeAndForwardEnabled, usePersistentStorage, storeAndForwardConfiguration, storagePath, storageMaxTotalWalSize, storageBackupPath);
+            return (storeAndForwardEnabled, usePersistentStorage, storeAndForwardConfiguration, storagePath, useBackupAndRestore, storageBackupPath, storageMaxTotalWalSize);
         }
 
         Option<ulong> GetStorageMaxTotalWalSizeIfExists()

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 });
 
             bool optimizeForPerformance = this.configuration.GetValue("OptimizeForPerformance", true);
-            (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath) storeAndForward =
+            (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath, Option<ulong> storageMaxTotalWalSize) storeAndForward =
                 this.GetStoreAndForwardConfiguration();
 
             IConfiguration configuration = this.configuration.GetSection("experimentalFeatures");
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             builder.RegisterModule(new AmqpModule(amqpSettings["scheme"], amqpSettings.GetValue<ushort>("port"), this.serverCertificate, this.iotHubHostname, clientCertAuthEnabled, this.sslProtocols));
         }
 
-        void RegisterMqttModule(ContainerBuilder builder, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath) storeAndForward, bool optimizeForPerformance)
+        void RegisterMqttModule(ContainerBuilder builder, (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath, Option<ulong> storageMaxTotalWalSize) storeAndForward, bool optimizeForPerformance)
         {
             var topics = new MessageAddressConversionConfiguration(
                 this.configuration.GetSection(Constants.TopicNameConversionSectionName + ":InboundTemplates").Get<List<string>>(),
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
         void RegisterRoutingModule(
             ContainerBuilder builder,
-            (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath) storeAndForward,
+            (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath, Option<ulong> storageMaxTotalWalSize) storeAndForward,
             ExperimentalFeatures experimentalFeatures)
         {
             var routes = this.configuration.GetSection("routes").Get<Dictionary<string, string>>();
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         void RegisterCommonModule(
             ContainerBuilder builder,
             bool optimizeForPerformance,
-            (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath) storeAndForward,
+            (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath, Option<ulong> storageMaxTotalWalSize) storeAndForward,
             MetricsConfig metricsConfig)
         {
             bool cacheTokens = this.configuration.GetValue("CacheTokens", false);
@@ -225,6 +225,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     metricsConfig,
                     storeAndForward.useBackupAndRestore,
                     storeAndForward.storageBackupPath));
+                    storeAndForward.storageMaxTotalWalSize));
         }
 
         static string GetProductInfo()
@@ -234,7 +235,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             return productInfo;
         }
 
-        (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath) GetStoreAndForwardConfiguration()
+        (bool isEnabled, bool usePersistentStorage, StoreAndForwardConfiguration config, string storagePath, bool useBackupAndRestore, Option<string> storageBackupPath, Option<ulong> storageMaxTotalWalSize) GetStoreAndForwardConfiguration()
         {
             int defaultTtl = -1;
             bool usePersistentStorage = this.configuration.GetValue<bool>("usePersistentStorage");
@@ -243,6 +244,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             // Note: Keep in sync with iotedge-check's edge-hub-storage-mounted-from-host check (edgelet/iotedge/src/check/checks/storage_mounted_from_host.rs)
             string storagePath = GetOrCreateDirectoryPath(this.configuration.GetValue<string>("StorageFolder"), Constants.EdgeHubStorageFolder);
             bool storeAndForwardEnabled = this.configuration.GetValue<bool>("storeAndForwardEnabled");
+            Option<ulong> storageMaxTotalWalSize = this.GetStorageMaxTotalWalSizeIfExists();
+
             if (storeAndForwardEnabled)
             {
                 IConfiguration storeAndForwardConfigurationSection = this.configuration.GetSection("storeAndForward");
@@ -257,7 +260,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             }
 
             var storeAndForwardConfiguration = new StoreAndForwardConfiguration(timeToLiveSecs);
-            return (storeAndForwardEnabled, usePersistentStorage, storeAndForwardConfiguration, storagePath, useBackupAndRestore, storageBackupPath);
+            return (storeAndForwardEnabled, usePersistentStorage, storeAndForwardConfiguration, storagePath, storageMaxTotalWalSize, storageBackupPath);
+        }
+
+        Option<ulong> GetStorageMaxTotalWalSizeIfExists()
+        {
+            ulong storageMaxTotalWalSize = 0;
+            try
+            {
+                storageMaxTotalWalSize = this.configuration.GetValue<ulong>(Constants.ConfigKey.StorageMaxTotalWalSize);
+            }
+            catch
+            {
+                // ignored
+            }
+
+            return storageMaxTotalWalSize <= 0 ? Option.None<ulong>() : Option.Some(storageMaxTotalWalSize);
         }
 
         static string GetOrCreateDirectoryPath(string baseDirectoryPath, string directoryName)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly MetricsConfig metricsConfig;
         readonly bool useBackupAndRestore;
         readonly Option<string> storageBackupPath;
+        readonly Option<ulong> storageMaxTotalWalSize;
 
         public CommonModule(
             string productInfo,
@@ -65,7 +66,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             string proxy,
             MetricsConfig metricsConfig,
             bool useBackupAndRestore,
-            Option<string> storageBackupPath)
+            Option<string> storageBackupPath,
+            Option<ulong> storageMaxTotalWalSize)
         {
             this.productInfo = productInfo;
             this.iothubHostName = Preconditions.CheckNonWhiteSpace(iothubHostName, nameof(iothubHostName));
@@ -87,6 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.metricsConfig = Preconditions.CheckNotNull(metricsConfig, nameof(metricsConfig));
             this.useBackupAndRestore = useBackupAndRestore;
             this.storageBackupPath = storageBackupPath;
+            this.storageMaxTotalWalSize = storageMaxTotalWalSize;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -138,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                 .SingleInstance();
 
             // DataBase options
-            builder.Register(c => new RocksDbOptionsProvider(c.Resolve<ISystemEnvironment>(), this.optimizeForPerformance))
+            builder.Register(c => new RocksDbOptionsProvider(c.Resolve<ISystemEnvironment>(), this.optimizeForPerformance, this.storageMaxTotalWalSize))
                 .As<IRocksDbOptionsProvider>()
                 .SingleInstance();
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -160,7 +160,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     string.Empty,
                     metricsConfig,
                     enableNonPersistentStorageBackup,
-                    backupFolder));
+                    backupFolder,
+                    Option.None<ulong>()));
 
             builder.RegisterModule(
                 new RoutingModule(

--- a/edge-modules/TestAnalyzer/TestStatusStorage.cs
+++ b/edge-modules/TestAnalyzer/TestStatusStorage.cs
@@ -29,7 +29,7 @@ namespace TestAnalyzer
             {
                 var partitionsList = new List<string> { "messages", "directMethods", "twins" };
                 IDbStoreProvider dbStoreprovider = DbStoreProvider.Create(
-                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance),
+                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance, Option.None<ulong>()),
                     this.GetStoragePath(storagePath),
                     partitionsList);
 

--- a/edge-modules/TwinTester/TwinEventStorage.cs
+++ b/edge-modules/TwinTester/TwinEventStorage.cs
@@ -28,7 +28,7 @@ namespace TwinTester
             {
                 var partitionsList = new List<string> { "desiredPropertyUpdated", "desiredPropertyReceived", "reportedPropertyUpdated" };
                 IDbStoreProvider dbStoreprovider = DbStoreProvider.Create(
-                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance),
+                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance, Option.None<ulong>()),
                     this.GetStoragePath(storagePath),
                     partitionsList);
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/RocksDbOptionsProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/RocksDbOptionsProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
 {
+    using System;
     using Microsoft.Azure.Devices.Edge.Util;
     using RocksDbSharp;
 
@@ -40,13 +41,19 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
         // Set to a limit less than a 32 bit #
         const ulong HardPendingCompactionBytes = 1024UL * 1024UL * 1024UL;
 
+        // Once write-ahead logs exceed this size, we will start forcing the flush of
+        // column families whose memtables are backed by the oldest live WAL file
+        const ulong DefaultMaxTotalWalSize = 512 * 1024 * 1024;
+
         readonly ISystemEnvironment env;
         readonly bool optimizeForPerformance;
+        readonly ulong maxTotalWalSize;
 
-        public RocksDbOptionsProvider(ISystemEnvironment env, bool optimizeForPerformance)
+        public RocksDbOptionsProvider(ISystemEnvironment env, bool optimizeForPerformance, Option<ulong> maxTotalWalsize)
         {
             this.env = Preconditions.CheckNotNull(env);
             this.optimizeForPerformance = optimizeForPerformance;
+            this.maxTotalWalSize = maxTotalWalsize.GetOrElse(DefaultMaxTotalWalSize);
         }
 
         public DbOptions GetDbOptions()
@@ -54,6 +61,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
             DbOptions options = new DbOptions()
                 .SetCreateIfMissing()
                 .SetCreateMissingColumnFamilies();
+
+            options.SetMaxTotalWalSize(this.maxTotalWalSize);
 
             if (this.env.Is32BitProcess || !this.optimizeForPerformance)
             {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/DbStoreProviderTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/DbStoreProviderTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         [Fact]
         public async Task GetRemoveDefaultPartitionTestAsync()
         {
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true);
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
 
             var partitionsList = new[]
             {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/DbStoreProviderTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/DbStoreProviderTest.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         [Fact]
         public void CreateTest()
         {
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true);
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
 
             var partitionsList1 = new[]
             {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/RockDbWrapperTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/RockDbWrapperTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         {
             // Arrange
             ICollection<string> partitions = new List<string>();
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true);
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
             // Act
             // Assert
             Assert.Throws<ArgumentException>(() => RocksDbWrapper.Create(options, null, partitions));
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         public void CreateWithNullPartitionsPathThrowsAsync()
         {
             // Arrange
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true);
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
 
             // Act
             // Assert

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/RocksDbOptionsProviderTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/RocksDbOptionsProviderTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         [Fact]
         public void RocksDbOptionsProviderCreateTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new RocksDbOptionsProvider(null, true));
+            Assert.Throws<ArgumentNullException>(() => new RocksDbOptionsProvider(null, true, Option.None<ulong>()));
         }
 
         [Fact]
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
             env64.SetupGet(s => s.Is32BitProcess)
                             .Returns(() => false);
-            var provider32 = new RocksDbOptionsProvider(env32.Object, true);
-            var provider64 = new RocksDbOptionsProvider(env64.Object, true);
+            var provider32 = new RocksDbOptionsProvider(env32.Object, true, Option.None<ulong>());
+            var provider64 = new RocksDbOptionsProvider(env64.Object, true, Option.None<ulong>());
 
             // act
             DbOptions newOptions32 = provider32.GetDbOptions();
@@ -52,8 +52,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
             env64.SetupGet(s => s.Is32BitProcess)
                             .Returns(() => false);
-            var provider32 = new RocksDbOptionsProvider(env32.Object, true);
-            var provider64 = new RocksDbOptionsProvider(env64.Object, true);
+            var provider32 = new RocksDbOptionsProvider(env32.Object, true, Option.None<ulong>());
+            var provider64 = new RocksDbOptionsProvider(env64.Object, true, Option.None<ulong>());
 
             // act
             ColumnFamilyOptions newOptions32 = provider32.GetColumnFamilyOptions();

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
         public TestRocksDbStoreProvider()
         {
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true);
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
             string tempFolder = Path.GetTempPath();
             this.rocksDbFolder = Path.Combine(tempFolder, $"edgeTestDb{Guid.NewGuid()}");
             if (Directory.Exists(this.rocksDbFolder))

--- a/test/modules/TestResultCoordinator/TestOperationResultStorage.cs
+++ b/test/modules/TestResultCoordinator/TestOperationResultStorage.cs
@@ -26,7 +26,7 @@ namespace TestResultCoordinator
             try
             {
                 IDbStoreProvider dbStoreprovider = DbStoreProvider.Create(
-                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance),
+                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance, Option.None<ulong>()),
                     GetStoragePath(storagePath),
                     resultSources);
 


### PR DESCRIPTION
* Set max total wal size to 512M port from 1.0.8 fix