### PR TITLE
Adding Relayer initial logic for connectivity tests

### DIFF
--- a/Microsoft.Azure.Devices.Edge.sln
+++ b/Microsoft.Azure.Devices.Edge.sln
@@ -191,6 +191,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Devices.Edg
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest", "edge-agent\test\Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest\Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest.csproj", "{79540E35-45EA-4568-9AB7-C1CC0BFF73EE}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Relayer", "edge-modules\Relayer\Relayer.csproj", "{61500583-6040-416F-A639-7BDC171E56A7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CheckInBuild|Any CPU = CheckInBuild|Any CPU
@@ -607,6 +609,14 @@ Global
 		{79540E35-45EA-4568-9AB7-C1CC0BFF73EE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{79540E35-45EA-4568-9AB7-C1CC0BFF73EE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{79540E35-45EA-4568-9AB7-C1CC0BFF73EE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{61500583-6040-416F-A639-7BDC171E56A7}.CheckInBuild|Any CPU.ActiveCfg = CheckInBuild|Any CPU
+		{61500583-6040-416F-A639-7BDC171E56A7}.CheckInBuild|Any CPU.Build.0 = CheckInBuild|Any CPU
+		{61500583-6040-416F-A639-7BDC171E56A7}.CodeCoverage|Any CPU.ActiveCfg = CheckInBuild|Any CPU
+		{61500583-6040-416F-A639-7BDC171E56A7}.CodeCoverage|Any CPU.Build.0 = CheckInBuild|Any CPU
+		{61500583-6040-416F-A639-7BDC171E56A7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{61500583-6040-416F-A639-7BDC171E56A7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{61500583-6040-416F-A639-7BDC171E56A7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{61500583-6040-416F-A639-7BDC171E56A7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -680,6 +690,7 @@ Global
 		{A5DFFB52-D8EA-4E1A-BF4F-8B9665C7DAFE} = {F5E37327-3AA9-4CC2-9FE3-B28271ADB5E3}
 		{08986FED-9283-47F1-B938-86D9C6E753E1} = {2300ED4C-1D5A-460F-8691-7C85E1162E0C}
 		{79540E35-45EA-4568-9AB7-C1CC0BFF73EE} = {F5E37327-3AA9-4CC2-9FE3-B28271ADB5E3}
+		{61500583-6040-416F-A639-7BDC171E56A7} = {578D5330-2F72-44C6-9DB5-C93B3F42C473}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {D71830F5-3AF5-46B4-8A9E-1DCE4F2253AC}

--- a/edge-modules/Relayer/Program.cs
+++ b/edge-modules/Relayer/Program.cs
@@ -20,7 +20,6 @@ namespace Relayer
             Logger.LogInformation($"Starting Relayer with the following settings: \r\n{Settings.Current}");
             try
             {
-                // Create moduleClient
                 ModuleClient moduleClient = await ModuleUtil.CreateModuleClientAsync(
                     Settings.Current.TransportType,
                     ModuleUtil.DefaultTimeoutErrorDetectionStrategy,

--- a/edge-modules/Relayer/Program.cs
+++ b/edge-modules/Relayer/Program.cs
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Relayer
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
+    /*
+     * Module for relaying messages. It receives a message and passes it on.
+     */
+    class Program
+    {
+        static readonly ILogger Logger = ModuleUtil.CreateLogger("Relayer");
+
+        static async Task Main(string[] args)
+        {
+            Logger.LogInformation($"Starting Relayer with the following settings: \r\n{Settings.Current}");
+            try
+            {
+                // Create moduleClient
+                ModuleClient moduleClient = await ModuleUtil.CreateModuleClientAsync(
+                    Settings.Current.TransportType,
+                    ModuleUtil.DefaultTimeoutErrorDetectionStrategy,
+                    ModuleUtil.DefaultTransientRetryStrategy,
+                    Logger);
+
+                (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(TimeSpan.FromSeconds(5), Logger);
+
+                // Receive a message and call ProcessAndSendMessageAsync to send it on its way
+                await moduleClient.SetInputMessageHandlerAsync("input1", ProcessAndSendMessageAsync, moduleClient);
+
+                await cts.Token.WhenCanceled();
+                completed.Set();
+                handler.ForEach(h => GC.KeepAlive(h));
+                Logger.LogInformation("Relayer Main() finished.");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Error occurred during Relayer.\r\n{ex}");
+            }
+        }
+
+        static async Task<MessageResponse> ProcessAndSendMessageAsync(Message message, object userContext)
+        {
+            try
+            {
+                if (!(userContext is ModuleClient moduleClient))
+                {
+                    throw new InvalidOperationException("UserContext doesn't contain expected value");
+                }
+
+                await moduleClient.SendEventAsync(Settings.Current.OutputName, message);
+                Logger.LogInformation("Successfully sent a message");
+            }
+            catch (Exception ex)
+            {
+                Logger.LogError($"Error in ProcessAndSendMessageAsync: {ex}");
+            }
+
+            return MessageResponse.Completed;
+        }
+    }
+}

--- a/edge-modules/Relayer/Relayer.csproj
+++ b/edge-modules/Relayer/Relayer.csproj
@@ -1,0 +1,51 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <LangVersion>latest</LangVersion>
+    <Configurations>Debug;Release;CheckInBuild</Configurations>
+    <HighEntropyVA>true</HighEntropyVA>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="docker*/**/*.*" CopyToPublishDirectory="Always" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.20.3-asc-edge" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\edge-util\src\Microsoft.Azure.Devices.Edge.Util\Microsoft.Azure.Devices.Edge.Util.csproj" />
+    <ProjectReference Include="..\ModuleLib\Microsoft.Azure.Devices.Edge.ModuleUtil.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <AdditionalFiles Include="..\..\stylecop.json" Link="stylecop.json" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="config/settings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <PropertyGroup>
+    <CodeAnalysisRuleSet>..\..\stylecop.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+  <Import Project="..\..\stylecop.props" />
+</Project>

--- a/edge-modules/Relayer/Settings.cs
+++ b/edge-modules/Relayer/Settings.cs
@@ -4,6 +4,7 @@ namespace Relayer
     using System;
     using System.IO;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Configuration;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
@@ -30,8 +31,8 @@ namespace Relayer
             TransportType transportType,
             string outputName)
         {
-            this.TransportType = transportType;
-            this.OutputName = outputName;
+            this.TransportType = Preconditions.CheckNotNull(transportType);
+            this.OutputName = Preconditions.CheckNonWhiteSpace(outputName, nameof(outputName));
         }
 
         public static Settings Current => DefaultSettings.Value;

--- a/edge-modules/Relayer/Settings.cs
+++ b/edge-modules/Relayer/Settings.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Relayer
+{
+    using System;
+    using System.IO;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Extensions.Configuration;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using Newtonsoft.Json.Serialization;
+
+    [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
+    public class Settings
+    {
+        static readonly Lazy<Settings> DefaultSettings = new Lazy<Settings>(
+            () =>
+            {
+                IConfiguration configuration = new ConfigurationBuilder()
+                    .SetBasePath(Directory.GetCurrentDirectory())
+                    .AddJsonFile("config/settings.json", optional: true)
+                    .AddEnvironmentVariables()
+                    .Build();
+
+                return new Settings(
+                    configuration.GetValue("transportType", TransportType.Amqp_Tcp_Only),
+                    configuration.GetValue("outputName", "output1"));
+            });
+
+        Settings(
+            TransportType transportType,
+            string outputName)
+        {
+            this.TransportType = transportType;
+            this.OutputName = outputName;
+        }
+
+        public static Settings Current => DefaultSettings.Value;
+
+        [JsonConverter(typeof(StringEnumConverter))]
+        public TransportType TransportType { get; }
+
+        public string OutputName { get; }
+
+        public override string ToString() => JsonConvert.SerializeObject(this, Formatting.Indented);
+    }
+}

--- a/edge-modules/Relayer/config/settings.json
+++ b/edge-modules/Relayer/config/settings.json
@@ -1,0 +1,4 @@
+{
+  "transportType": "amqp",
+  "outputName": "output1"
+}


### PR DESCRIPTION
Adding initial logic for Relayer. This is just baseline logic. This module will be added to later once we finalize the design of the connectivity tests.

The Relayer simply receives a message and relays it onward. It is very similar to TemperatureFilter with the temperature logic removed.