### PR TITLE
Increase build timeout for Windows platforms

### DIFF
--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -133,6 +133,7 @@ jobs:
   - job: windows_amd64
 ################################################################################
     displayName: Windows amd64
+    timeoutInMinutes: 90
     pool:
       vmImage: 'vs2017-win2016'
     steps:
@@ -197,6 +198,7 @@ jobs:
   - job: windows_arm32
 ################################################################################
     displayName: Windows arm32
+    timeoutInMinutes: 90
     pool:
       vmImage: 'vs2017-win2016'
     steps:


### PR DESCRIPTION
Increase build timeout for Windows platforms to avoid build failure.