### PR TITLE
[k8s] Runtime now only gets node info if it has cluster RBAC permissi…

### DIFF
--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -417,7 +417,7 @@ pub trait MakeModuleRuntime {
     fn make_runtime(
         settings: Self::Settings,
         provisioning_result: Self::ProvisioningResult,
-        crypto: impl GetTrustBundle + 'static,
+        crypto: impl GetTrustBundle + Send + 'static,
     ) -> Self::Future;
 }
 

--- a/edgelet/edgelet-kube/src/module/trust_bundle.rs
+++ b/edgelet/edgelet-kube/src/module/trust_bundle.rs
@@ -12,9 +12,10 @@ use kube_client::TokenSource;
 use crate::convert::trust_bundle_to_config_map;
 use crate::{Error, ErrorKind, KubeModuleRuntime};
 
+#[allow(clippy::needless_pass_by_value)]
 pub fn init_trust_bundle<T, S>(
     runtime: &KubeModuleRuntime<T, S>,
-    crypto: &impl GetTrustBundle,
+    crypto: impl GetTrustBundle,
 ) -> impl Future<Item = (), Error = Error>
 where
     T: TokenSource,
@@ -116,7 +117,7 @@ mod tests {
         let crypto = TestHsm::default().with_fail_call(true);
 
         let runtime = create_runtime(settings, service);
-        let task = init_trust_bundle(&runtime, &crypto);
+        let task = init_trust_bundle(&runtime, crypto);
 
         let mut runtime = Runtime::new().unwrap();
         let err = runtime.block_on(task).unwrap_err();
@@ -141,7 +142,7 @@ mod tests {
         let crypto = TestHsm::default().with_cert(cert);
 
         let runtime = create_runtime(settings, service);
-        let task = init_trust_bundle(&runtime, &crypto);
+        let task = init_trust_bundle(&runtime, crypto);
 
         let mut runtime = Runtime::new().unwrap();
         let err = runtime.block_on(task).unwrap_err();
@@ -166,7 +167,7 @@ mod tests {
         let crypto = TestHsm::default().with_cert(cert);
 
         let runtime = create_runtime(settings, service);
-        let task = init_trust_bundle(&runtime, &crypto);
+        let task = init_trust_bundle(&runtime, crypto);
 
         let mut runtime = Runtime::new().unwrap();
         let err = runtime.block_on(task).unwrap_err();
@@ -196,7 +197,7 @@ mod tests {
         let cert = TestCert::default().with_cert(b"secret_cert".to_vec());
         let crypto = TestHsm::default().with_cert(cert);
 
-        let task = init_trust_bundle(&runtime, &crypto);
+        let task = init_trust_bundle(&runtime, crypto);
 
         let mut runtime = Runtime::new().unwrap();
         runtime.block_on(task).unwrap();
@@ -217,7 +218,7 @@ mod tests {
         let cert = TestCert::default().with_cert(b"secret_cert".to_vec());
         let crypto = TestHsm::default().with_cert(cert);
 
-        let task = init_trust_bundle(&runtime, &crypto);
+        let task = init_trust_bundle(&runtime, crypto);
 
         let mut runtime = Runtime::new().unwrap();
         runtime.block_on(task).unwrap();

--- a/edgelet/edgelet-kube/src/runtime.rs
+++ b/edgelet/edgelet-kube/src/runtime.rs
@@ -105,16 +105,23 @@ impl MakeModuleRuntime
     fn make_runtime(
         settings: Self::Settings,
         provisioning_result: Self::ProvisioningResult,
-        crypto: impl GetTrustBundle + 'static,
+        crypto: impl GetTrustBundle + Send + 'static,
     ) -> Self::Future {
         let settings = settings
             .with_device_id(provisioning_result.device_id())
             .with_iot_hub_hostname(provisioning_result.hub_name());
 
         let fut = get_config()
-            .map(|config| KubeModuleRuntime::new(KubeClient::new(config), settings))
+            .map(|config| (config.clone(), KubeClient::new(config)))
             .map_err(|err| Error::from(err.context(ErrorKind::Initialization)))
-            .map(|runtime| init_trust_bundle(&runtime, &crypto).map(|_| runtime))
+            .map(|(config, mut client)| {
+                client
+                    .is_subject_allowed(Some("nodes".to_string()), Some("list".to_string()))
+                    .map(|is_allowed| settings.with_nodes_rbac(is_allowed))
+                    .map_err(|err| Error::from(err.context(ErrorKind::Initialization)))
+                    .map(|settings| KubeModuleRuntime::new(KubeClient::new(config), settings))
+                    .and_then(move |runtime| init_trust_bundle(&runtime, crypto).map(|_| runtime))
+            })
             .into_future()
             .flatten();
 
@@ -183,46 +190,55 @@ where
             name: String,
             nodes_count: u32,
         };
-
-        let fut = self
-            .client
-            .lock()
-            .expect("Unexpected lock error")
-            .borrow_mut()
-            .list_nodes()
-            .map_err(|err| {
-                Error::from(err.context(ErrorKind::RuntimeOperation(RuntimeOperation::SystemInfo)))
-            })
-            .map(|nodes| {
-                // Accumulate the architectures and their node counts into a map
-                let architectures = nodes
-                    .items
-                    .into_iter()
-                    .filter_map(|node| {
-                        node.status
-                            .and_then(|status| status.node_info.map(|info| info.architecture))
+        let fut = if self.settings.has_nodes_rbac() {
+            future::Either::A(
+                self.client
+                    .lock()
+                    .expect("Unexpected lock error")
+                    .borrow_mut()
+                    .list_nodes()
+                    .map_err(|err| {
+                        Error::from(
+                            err.context(ErrorKind::RuntimeOperation(RuntimeOperation::SystemInfo)),
+                        )
                     })
-                    .fold(HashMap::new(), |mut architectures, current_arch| {
-                        let count = architectures.entry(current_arch).or_insert(0);
-                        *count += 1;
-                        architectures
-                    });
+                    .map(|nodes| {
+                        // Accumulate the architectures and their node counts into a map
+                        let architectures = nodes
+                            .items
+                            .into_iter()
+                            .filter_map(|node| {
+                                node.status.and_then(|status| {
+                                    status.node_info.map(|info| info.architecture)
+                                })
+                            })
+                            .fold(HashMap::new(), |mut architectures, current_arch| {
+                                let count = architectures.entry(current_arch).or_insert(0);
+                                *count += 1;
+                                architectures
+                            });
 
-                // Convert a map to a list of architectures
-                let architectures = architectures
-                    .into_iter()
-                    .map(|(name, count)| Architecture {
-                        name,
-                        nodes_count: count,
-                    })
-                    .collect::<Vec<Architecture>>();
+                        // Convert a map to a list of architectures
+                        let architectures = architectures
+                            .into_iter()
+                            .map(|(name, count)| Architecture {
+                                name,
+                                nodes_count: count,
+                            })
+                            .collect::<Vec<Architecture>>();
 
-                SystemInfo::new(
-                    "Kubernetes".to_string(),
-                    serde_json::to_string(&architectures).unwrap(),
-                )
-            });
-
+                        SystemInfo::new(
+                            "Kubernetes".to_string(),
+                            serde_json::to_string(&architectures).unwrap(),
+                        )
+                    }),
+            )
+        } else {
+            future::Either::B(future::ok(SystemInfo::new(
+                "Kubernetes".to_string(),
+                "Kubernetes".to_string(),
+            )))
+        };
         Box::new(fut)
     }
 
@@ -362,6 +378,51 @@ mod tests {
     fn runtime_get_system_info() {
         let settings = make_settings(None);
 
+        let dispatch_table = routes!(
+            GET "/api/v1/nodes" => list_node_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+
+        let task = runtime.system_info();
+
+        let mut runtime = Runtime::new().unwrap();
+        let info = runtime.block_on(task).unwrap();
+
+        assert_eq!(
+            info.architecture(),
+            "[{\"name\":\"amd64\",\"nodes_count\":2}]"
+        );
+    }
+
+    #[test]
+    fn runtime_get_system_info_no_rbac() {
+        let more_settings = json!({"has_nodes_rbac" : "false"});
+        let settings = make_settings(Option::Some(more_settings));
+        assert_eq!(settings.has_nodes_rbac(), false);
+        let dispatch_table = routes!(
+            GET "/api/v1/nodes" => list_node_handler(),
+        );
+
+        let handler = make_req_dispatcher(dispatch_table, Box::new(not_found_handler));
+        let service = service_fn(handler);
+        let runtime = create_runtime(settings, service);
+
+        let task = runtime.system_info();
+
+        let mut runtime = Runtime::new().unwrap();
+        let info = runtime.block_on(task).unwrap();
+
+        assert_eq!(info.architecture(), "Kubernetes");
+    }
+
+    #[test]
+    fn runtime_get_system_info_rbac_set() {
+        let more_settings = json!({"has_nodes_rbac" : "true"});
+        let settings = make_settings(Option::Some(more_settings));
+        assert_eq!(settings.has_nodes_rbac(), true);
         let dispatch_table = routes!(
             GET "/api/v1/nodes" => list_node_handler(),
         );

--- a/edgelet/edgelet-kube/src/runtime.rs
+++ b/edgelet/edgelet-kube/src/runtime.rs
@@ -116,8 +116,10 @@ impl MakeModuleRuntime
             .map_err(|err| Error::from(err.context(ErrorKind::Initialization)))
             .map(|(config, mut client)| {
                 client
-                    .is_subject_allowed(Some("nodes".to_string()), Some("list".to_string()))
-                    .map(|is_allowed| settings.with_nodes_rbac(is_allowed))
+                    .is_subject_allowed("nodes".to_string(), "list".to_string())
+                    .map(|subject_review_status| {
+                        settings.with_nodes_rbac(subject_review_status.allowed)
+                    })
                     .map_err(|err| Error::from(err.context(ErrorKind::Initialization)))
                     .map(|settings| KubeModuleRuntime::new(KubeClient::new(config), settings))
                     .and_then(move |runtime| init_trust_bundle(&runtime, crypto).map(|_| runtime))

--- a/edgelet/edgelet-kube/src/settings.rs
+++ b/edgelet/edgelet-kube/src/settings.rs
@@ -87,7 +87,7 @@ impl Settings {
         self.has_nodes_rbac
     }
 
-    pub fn default_nodes_rbac() -> bool {
+    fn default_nodes_rbac() -> bool {
         true
     }
 }

--- a/edgelet/edgelet-kube/src/settings.rs
+++ b/edgelet/edgelet-kube/src/settings.rs
@@ -24,6 +24,8 @@ pub struct Settings {
     device_id: Option<String>,
     device_hub_selector: String,
     proxy: ProxySettings,
+    #[serde(default = "Settings::default_nodes_rbac")]
+    has_nodes_rbac: bool,
 }
 
 impl Settings {
@@ -56,6 +58,11 @@ impl Settings {
         self
     }
 
+    pub fn with_nodes_rbac(mut self, has_nodes_rbac: bool) -> Self {
+        self.has_nodes_rbac = has_nodes_rbac;
+        self
+    }
+
     pub fn namespace(&self) -> &str {
         &self.namespace
     }
@@ -74,6 +81,14 @@ impl Settings {
 
     pub fn device_hub_selector(&self) -> &str {
         &self.device_hub_selector
+    }
+
+    pub fn has_nodes_rbac(&self) -> bool {
+        self.has_nodes_rbac
+    }
+
+    pub fn default_nodes_rbac() -> bool {
+        true
     }
 }
 

--- a/edgelet/kube-client/src/error.rs
+++ b/edgelet/kube-client/src/error.rs
@@ -143,6 +143,7 @@ pub enum RequestType {
     SecretCreate,
     SecretReplace,
     TokenReview,
+    SelfSubjectAccessReviewCreate,
     ServiceAccountList,
     ServiceAccountCreate,
     ServiceAccountReplace,

--- a/kubernetes/charts/edge-kubernetes/templates/edge-rbac.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/edge-rbac.yaml
@@ -25,6 +25,7 @@ subjects:
     namespace: {{ include "edge-kubernetes.namespace" . | quote }}
 ...
 ---
+{{- if .Values.iotedged.data.enableGetNodesRBAC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -39,6 +40,7 @@ subjects:
     name: iotedged
     namespace: {{ include "edge-kubernetes.namespace" . | quote }}
 ...
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -55,6 +57,7 @@ subjects:
     namespace: {{ include "edge-kubernetes.namespace" . | quote }}
 ...
 ---
+{{- if .Values.iotedged.data.enableGetNodesRBAC }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -64,6 +67,7 @@ rules:
     resources: ["nodes"]
     verbs: ["list", "watch", "get"]
 ...
+{{ end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -13,6 +13,7 @@ iotedged:
     management: 35000
     workload: 35001
   data:
+    enableGetNodesRBAC: true
     targetPath: /var/lib/iotedge
     # In order to benefit from HA, at a minimum the data location for iotedged
     # should be backed by a persistent volume. Please setup a persistent volume


### PR DESCRIPTION
…ons. (#2058)

* Runtime now only gets node info if it has cluster RBAC permissions.

* Use a serde default, so `has_nodes_rbac` does not need to be optional.

* At startup, have module runtime check "list nodes"
access before attempting to list nodes.

* Changed "enable Cluster RBAC" to "enable get nodes RBAC"