### PR TITLE
[k8s] Sanitize helm chart name

### DIFF
--- a/kubernetes/charts/edge-kubernetes/templates/edge-rbac.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/edge-rbac.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: {{.Release.Service | quote }}
     app.kubernetes.io/instance: {{.Release.Name | quote }}
-    helm.sh/chart: "{{.Chart.Name}}-{{.Chart.Version}}"
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 ...
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/kubernetes/charts/edge-kubernetes/templates/edge-rbac.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/edge-rbac.yaml
@@ -15,6 +15,10 @@ kind: ClusterRoleBinding
 metadata:
   name: iotedge:{{ .Release.Name }}:auth-delegator
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -31,6 +35,10 @@ kind: ClusterRoleBinding
 metadata:
   name: iotedge:{{ .Release.Name }}:node-observer
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -47,6 +55,10 @@ kind: RoleBinding
 metadata:
   name: iotedged
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -62,6 +74,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: iotedge:{{ .Release.Name }}:node-observer
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -74,6 +90,10 @@ kind: Role
 metadata:
   name: iotedged
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
@@ -109,6 +129,10 @@ kind: Role
 metadata:
   name: edgeagent
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 rules:
   - apiGroups: [""]
     resources: ["pods", "pods/log"]

--- a/kubernetes/charts/edge-kubernetes/templates/iotedged-config-secret.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/iotedged-config-secret.yaml
@@ -5,6 +5,10 @@ kind: Secret
 metadata:
   name: iotedged-config
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 type: Opaque
 data:
     config.yaml: |-
@@ -18,6 +22,10 @@ kind: Secret
 metadata:
   name: regcreds
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 type: kubernetes.io/dockerconfigjson
 data:
   {{- /*
@@ -41,6 +49,10 @@ kind: Secret
 metadata:
   name: edgecerts
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 type: Opaque
 data:
   device_ca_cert: |-

--- a/kubernetes/charts/edge-kubernetes/templates/iotedged-pvc.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/iotedged-pvc.yaml
@@ -4,6 +4,10 @@ kind: PersistentVolumeClaim
 metadata:
   name: {{ .Values.iotedged.data.persistentVolumeClaim.name | quote }}
   namespace: {{ include "edge-kubernetes.namespace" . | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{.Release.Service | quote }}
+    app.kubernetes.io/instance: {{.Release.Name | quote }}
+    helm.sh/chart: {{ include "edge-kubernetes.chart" . }}
 spec:
   resources:
     requests:


### PR DESCRIPTION
Fix leftover of helm chart refactoring
Convenient command to check whether everything was deleted by helm
```bash
$ kubectl api-resources --verbs=list --namespaced -o name | xargs -n 1 kubectl get --show-kind --ignore-not-found -n <your namespace>
```