### PR TITLE
Removing null from Option ForEachAsync overload

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Option.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Option.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
         public Task ForEachAsync(Func<T, Task> action) => this.HasValue ? action(this.Value) : Task.CompletedTask;
 
-        public Task ForEachAsync(Func<T, Task> action, Func<Task> none = null) => this.HasValue ? action(this.Value) : none?.Invoke();
+        public Task ForEachAsync(Func<T, Task> action, Func<Task> none) => this.HasValue ? action(this.Value) : none();
 
         /// <summary>
         /// If this option has a value then it transforms it into a new option instance by


### PR DESCRIPTION
Missed a null when I was adding this commit: https://github.com/Azure/iotedge/commit/25be39c96837e50cf9bad866deba90676898cec4

Fixing the mistake.