### PR TITLE
Expose port 5001 from TestResultCoordinator

### DIFF
--- a/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
@@ -15,6 +15,9 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
+# Expose HTTP port
+EXPOSE 5001/tcp
+
 # Add an unprivileged user account for running the module
 RUN adduser -Ds /bin/sh moduleuser 
 USER moduleuser

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
+# Expose HTTP port
+EXPOSE 5001/tcp
+
 USER moduleuser
 
 CMD echo "$(date --utc +"[%Y-%m-%d %H:%M:%S %:z]"): Starting Module" && \

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -9,6 +9,9 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
+# Expose HTTP port
+EXPOSE 5001/tcp
+
 USER moduleuser
 
 CMD echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Starting Module" && \

--- a/test/modules/TestResultCoordinator/docker/windows/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/windows/amd64/Dockerfile
@@ -5,6 +5,9 @@ ARG EXE_DIR=.
 
 WORKDIR /app
 
+# Expose HTTP port
+EXPOSE 5001/tcp
+
 COPY $EXE_DIR/ ./
 
 CMD ["dotnet", "TestResultCoordinator.dll"]

--- a/test/modules/TestResultCoordinator/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/windows/arm32v7/Dockerfile
@@ -6,6 +6,9 @@ ARG EXE_DIR=.
 
 WORKDIR /app
 
+# Expose HTTP port
+EXPOSE 5001/tcp
+
 COPY $EXE_DIR/ ./
 
 CMD ["dotnet", "TestResultCoordinator.dll"]


### PR DESCRIPTION
Exposing the http endpoint port from Dockerfile so the networkcontroller which is running on host to be able to access it.