### PR TITLE
Fix test result coordinator

### DIFF
--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -45,7 +45,7 @@
               "messageFrequency": {
                 "value": "<LoadGen.MessageFrequency>"
               },
-              "testRunDuration": {
+              "testDuration": {
                 "value": "<TestDuration>"
               },
               "testStartDelay": {
@@ -78,7 +78,7 @@
               "messageFrequency": {
                 "value": "<LoadGen.MessageFrequency>"
               },
-              "testRunDuration": {
+              "testDuration": {
                 "value": "<TestDuration>"
               },
               "testStartDelay": {

--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -114,6 +114,9 @@
               "inputName": {
                 "value": "input1"
               },
+              "outputName": {
+                "value": "output1"
+              },
               "testResultCoordinatorUrl": {
                 "value": "http://testResultCoordinator:5001"
               }
@@ -135,6 +138,9 @@
               "inputName": {
                 "value": "input2"
               },
+              "outputName": {
+                "value": "output2"
+              },
               "testResultCoordinatorUrl": {
                 "value": "http://testResultCoordinator:5001"
               }
@@ -152,6 +158,9 @@
             "env": {
               "trackingId": {
                 "value": "<TrackingId>"
+              },
+              "testStartDelay": {
+                "value": "<TestStartDelay>"
               },
               "testDuration": {
                 "value": "<TestDuration>"

--- a/edge-modules/load-gen/Program.cs
+++ b/edge-modules/load-gen/Program.cs
@@ -80,6 +80,7 @@ namespace LoadGen
                     }
                 }
 
+                Logger.LogInformation("Finish sending messages.");
                 await cts.Token.WhenCanceled();
                 completed.Set();
                 handler.ForEach(h => GC.KeepAlive(h));

--- a/edge-modules/load-gen/Program.cs
+++ b/edge-modules/load-gen/Program.cs
@@ -80,6 +80,7 @@ namespace LoadGen
                     }
                 }
 
+                await cts.Token.WhenCanceled();
                 completed.Set();
                 handler.ForEach(h => GC.KeepAlive(h));
             }

--- a/test/modules/Modules.Test/TestResultCoordinator/CountingReportGeneratorTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/CountingReportGeneratorTest.cs
@@ -6,6 +6,7 @@ namespace Modules.Test.TestResultCoordinator
     using System.Linq;
     using System.Threading.Tasks;
     using global::TestResultCoordinator;
+    using global::TestResultCoordinator.Report;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Moq;
     using Xunit;

--- a/test/modules/Modules.Test/TestResultCoordinator/CountingReportTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/CountingReportTest.cs
@@ -4,6 +4,7 @@ namespace Modules.Test.TestResultCoordinator
     using System;
     using System.Collections.Generic;
     using global::TestResultCoordinator;
+    using global::TestResultCoordinator.Report;
     using Xunit;
 
     public class CountingReportTest

--- a/test/modules/Modules.Test/TestResultCoordinator/SimpleTestOperationResultComparerTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/SimpleTestOperationResultComparerTest.cs
@@ -4,6 +4,7 @@ namespace Modules.Test.TestResultCoordinator
     using System;
     using System.Collections.Generic;
     using global::TestResultCoordinator;
+    using global::TestResultCoordinator.Report;
     using Xunit;
 
     public class SimpleTestOperationResultComparerTest

--- a/test/modules/TestResultCoordinator/Controllers/TestOperationResultController.cs
+++ b/test/modules/TestResultCoordinator/Controllers/TestOperationResultController.cs
@@ -23,7 +23,7 @@ namespace TestResultCoordinator.Controllers
             try
             {
                 bool success = await TestOperationResultStorage.AddResultAsync(result);
-                Logger.LogInformation($"Received test result: {result.Source}, {result.Type}, {success}");
+                Logger.LogDebug($"Received test result: {result.Source}, {result.Type}, {success}");
                 return success ? this.StatusCode((int)HttpStatusCode.NoContent) : this.StatusCode((int)HttpStatusCode.BadRequest);
             }
             catch (Exception)

--- a/test/modules/TestResultCoordinator/Controllers/TestOperationResultController.cs
+++ b/test/modules/TestResultCoordinator/Controllers/TestOperationResultController.cs
@@ -6,11 +6,16 @@ namespace TestResultCoordinator.Controllers
     using System.Net;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Extensions.Logging;
+    using TestOperationResult = TestResultCoordinator.TestOperationResult;
 
     [Route("api/[controller]")]
     [ApiController]
     public class TestOperationResultController : Controller
     {
+        static readonly ILogger Logger = ModuleUtil.CreateLogger(nameof(TestOperationResultController));
+
         // POST api/TestOperationResult
         [HttpPost]
         public async Task<StatusCodeResult> PostAsync(TestOperationResult result)
@@ -18,6 +23,7 @@ namespace TestResultCoordinator.Controllers
             try
             {
                 bool success = await TestOperationResultStorage.AddResultAsync(result);
+                Logger.LogInformation($"Received test result: {result.Source}, {result.Type}, {success}");
                 return success ? this.StatusCode((int)HttpStatusCode.NoContent) : this.StatusCode((int)HttpStatusCode.BadRequest);
             }
             catch (Exception)

--- a/test/modules/TestResultCoordinator/PartitionReceiverHandler.cs
+++ b/test/modules/TestResultCoordinator/PartitionReceiverHandler.cs
@@ -30,6 +30,8 @@ namespace TestResultCoordinator
 
         public async Task ProcessEventsAsync(IEnumerable<EventData> events)
         {
+            Logger.LogInformation("Processing events from event hub.");
+
             if (events != null)
             {
                 foreach (EventData eventData in events)
@@ -52,17 +54,18 @@ namespace TestResultCoordinator
                         {
                             if (long.TryParse(sequenceNumberFromEvent.ToString(), out long sequenceNumber))
                             {
+                                Logger.LogInformation($"Recieved event hub event: tracking Id={(string)trackingIdFromEvent}, deviceId={(string)deviceIdFromEvent}, moduleId={(string)moduleIdFromEvent}");
                                 DateTime enqueuedtime = GetEnqueuedTime(deviceIdFromEvent.ToString(), moduleIdFromEvent.ToString(), eventData);
 
                                 // TODO: remove hardcoded eventHub string in next line
-                                TestOperationResult result = new TestOperationResult(
-                                    moduleIdFromEvent.ToString() + ".eventHub",
+                                var result = new TestOperationResult(
+                                    (string)moduleIdFromEvent + ".eventHub",
                                     "Messages",
                                     ModuleUtil.FormatTestResultValue(
                                         (string)trackingIdFromEvent,
                                         (string)batchIdFromEvent,
                                         (string)sequenceNumberFromEvent),
-                                    DateTime.UtcNow);
+                                    enqueuedtime);
                                 await TestOperationResultStorage.AddResultAsync(result);
                             }
                             else

--- a/test/modules/TestResultCoordinator/PartitionReceiverHandler.cs
+++ b/test/modules/TestResultCoordinator/PartitionReceiverHandler.cs
@@ -40,6 +40,8 @@ namespace TestResultCoordinator
                     eventData.SystemProperties.TryGetValue(DeviceIdPropertyName, out object deviceIdFromEvent);
                     eventData.SystemProperties.TryGetValue(ModuleIdPropertyName, out object moduleIdFromEvent);
 
+                    Logger.LogInformation($"Received event from Event Hub: trackingId={(string)trackingIdFromEvent}, deviceId={(string)deviceIdFromEvent}, moduleId={(string)moduleIdFromEvent}");
+
                     if (!string.IsNullOrWhiteSpace((string)trackingIdFromEvent) &&
                         string.Equals(trackingIdFromEvent.ToString(), this.trackingId, StringComparison.OrdinalIgnoreCase) &&
                         !string.IsNullOrWhiteSpace((string)deviceIdFromEvent) &&
@@ -49,12 +51,13 @@ namespace TestResultCoordinator
                         eventData.Properties.TryGetValue(TestConstants.Message.SequenceNumberPropertyName, out object sequenceNumberFromEvent);
                         eventData.Properties.TryGetValue(TestConstants.Message.BatchIdPropertyName, out object batchIdFromEvent);
 
+                        Logger.LogInformation($"Recieved event from Event Hub: sequenceNumber={(string)sequenceNumberFromEvent}, batchId={(string)batchIdFromEvent}");
+
                         if (!string.IsNullOrWhiteSpace((string)sequenceNumberFromEvent) &&
                             !string.IsNullOrWhiteSpace((string)batchIdFromEvent))
                         {
                             if (long.TryParse(sequenceNumberFromEvent.ToString(), out long sequenceNumber))
                             {
-                                Logger.LogInformation($"Recieved event hub event: tracking Id={(string)trackingIdFromEvent}, deviceId={(string)deviceIdFromEvent}, moduleId={(string)moduleIdFromEvent}");
                                 DateTime enqueuedtime = GetEnqueuedTime(deviceIdFromEvent.ToString(), moduleIdFromEvent.ToString(), eventData);
 
                                 // TODO: remove hardcoded eventHub string in next line

--- a/test/modules/TestResultCoordinator/PartitionReceiverHandler.cs
+++ b/test/modules/TestResultCoordinator/PartitionReceiverHandler.cs
@@ -36,7 +36,7 @@ namespace TestResultCoordinator
             {
                 foreach (EventData eventData in events)
                 {
-                    eventData.SystemProperties.TryGetValue(TestConstants.Message.TrackingIdPropertyName, out object trackingIdFromEvent);
+                    eventData.Properties.TryGetValue(TestConstants.Message.TrackingIdPropertyName, out object trackingIdFromEvent);
                     eventData.SystemProperties.TryGetValue(DeviceIdPropertyName, out object deviceIdFromEvent);
                     eventData.SystemProperties.TryGetValue(ModuleIdPropertyName, out object moduleIdFromEvent);
 

--- a/test/modules/TestResultCoordinator/Program.cs
+++ b/test/modules/TestResultCoordinator/Program.cs
@@ -27,53 +27,17 @@ namespace TestResultCoordinator
 
             await SetupEventReceiveHandlerAsync(Settings.Current, DateTime.UtcNow);
 
-            // Continue after delay to report test results
-            Task.Delay(Settings.Current.TestDuration + Settings.Current.DurationBeforeVerification, cts.Token)
-                .ContinueWith(async _ => await ReportTestResultsAsync(), cts.Token);
-
             await TestOperationResultStorage.InitAsync(Settings.Current.StoragePath, new SystemEnvironment(), Settings.Current.OptimizeForPerformance, Settings.Current.ResultSources);
             Logger.LogInformation("TestOperationResultStorage created successfully");
-            Logger.LogInformation("Creating WebHostBuilder...");
-            await CreateWebHostBuilder(args).Build().RunAsync(cts.Token);
 
-            await cts.Token.WhenCanceled();
+            Logger.LogInformation("Creating WebHostBuilder...");
+            Task webHost = CreateWebHostBuilder(args).Build().RunAsync(cts.Token);
+
+            await Task.WhenAny(cts.Token.WhenCanceled(), webHost);
+
             completed.Set();
             handler.ForEach(h => GC.KeepAlive(h));
-            Console.WriteLine("TestResultCoordinator Main() exited.");
-        }
-
-        static async Task ReportTestResultsAsync()
-        {
-            Logger.LogInformation($"Starting report generation for {Settings.Current.ReportMetadataList.Count} reports");
-            try
-            {
-                TestReportGeneratorFactory testReportGeneratorFactory = new TestReportGeneratorFactory();
-                List<Task<ITestResultReport>> testResultReportList = new List<Task<ITestResultReport>>();
-                foreach (IReportMetadata reportMetadata in Settings.Current.ReportMetadataList)
-                {
-                    ITestResultReportGenerator testResultReportGenerator = testReportGeneratorFactory.Create(Settings.Current.TrackingId, reportMetadata);
-                    testResultReportList.Add(testResultReportGenerator.CreateReportAsync());
-                }
-
-                ITestResultReport[] testResultReports = await Task.WhenAll(testResultReportList);
-
-                Logger.LogInformation("Successfully generated all reports");
-
-                string reportsContent = JsonConvert.SerializeObject(testResultReports);
-                Logger.LogInformation(reportsContent);
-
-                await AzureLogAnalytics.Instance.PostAsync(
-                    Settings.Current.LogAnalyticsWorkspaceId,
-                    Settings.Current.LogAnalyticsSharedKey,
-                    reportsContent,
-                    Settings.Current.LogAnalyticsLogType);
-
-                Logger.LogInformation("Successfully send reports to LogAnalytics");
-            }
-            catch (Exception ex)
-            {
-                Logger.LogError("TestResultCoordinator failed during report generation", ex);
-            }
+            Logger.LogInformation("TestResultCoordinator Main() exited.");
         }
 
         static IWebHostBuilder CreateWebHostBuilder(string[] args) =>

--- a/test/modules/TestResultCoordinator/Program.cs
+++ b/test/modules/TestResultCoordinator/Program.cs
@@ -2,7 +2,6 @@
 namespace TestResultCoordinator
 {
     using System;
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore;
@@ -10,10 +9,8 @@ namespace TestResultCoordinator
     using Microsoft.Azure.Devices.Common;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.AzureLogAnalytics;
     using Microsoft.Azure.EventHubs;
     using Microsoft.Extensions.Logging;
-    using Newtonsoft.Json;
 
     class Program
     {
@@ -24,8 +21,6 @@ namespace TestResultCoordinator
             Logger.LogInformation($"Starting TestResultCoordinator with the following settings:\r\n{Settings.Current}");
 
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(TimeSpan.FromSeconds(5), Logger);
-
-            await SetupEventReceiveHandlerAsync(Settings.Current, DateTime.UtcNow);
 
             await TestOperationResultStorage.InitAsync(Settings.Current.StoragePath, new SystemEnvironment(), Settings.Current.OptimizeForPerformance, Settings.Current.ResultSources);
             Logger.LogInformation("TestOperationResultStorage created successfully");
@@ -44,20 +39,5 @@ namespace TestResultCoordinator
             WebHost.CreateDefaultBuilder(args)
                 .UseUrls($"http://*:{Settings.Current.WebHostPort}")
                 .UseStartup<Startup>();
-
-        static async Task SetupEventReceiveHandlerAsync(Settings settings, DateTime eventEnqueuedFrom)
-        {
-            var builder = new EventHubsConnectionStringBuilder(settings.EventHubConnectionString);
-            Logger.LogInformation($"Receiving events from device '{settings.DeviceId}' on Event Hub '{builder.EntityPath}' enqueued at or after {eventEnqueuedFrom}");
-
-            EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
-
-            PartitionReceiver eventHubReceiver = eventHubClient.CreateReceiver(
-                settings.ConsumerGroupName,
-                EventHubPartitionKeyResolver.ResolveToPartition(settings.DeviceId, (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
-                EventPosition.FromEnqueuedTime(eventEnqueuedFrom));
-
-            eventHubReceiver.SetReceiveHandler(new PartitionReceiveHandler(settings.TrackingId, settings.DeviceId));
-        }
     }
 }

--- a/test/modules/TestResultCoordinator/Program.cs
+++ b/test/modules/TestResultCoordinator/Program.cs
@@ -6,10 +6,8 @@ namespace TestResultCoordinator
     using System.Threading.Tasks;
     using Microsoft.AspNetCore;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.Azure.Devices.Common;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.EventHubs;
     using Microsoft.Extensions.Logging;
 
     class Program

--- a/test/modules/TestResultCoordinator/Settings.cs
+++ b/test/modules/TestResultCoordinator/Settings.cs
@@ -37,6 +37,7 @@ namespace TestResultCoordinator
                     configuration.GetValue<string>("logAnalyticsLogType"),
                     configuration.GetValue("storagePath", DefaultStoragePath),
                     configuration.GetValue<bool>("optimizeForPerformance", true),
+                    configuration.GetValue("testStartDelay", TimeSpan.FromMinutes(2)),
                     configuration.GetValue("testDuration", TimeSpan.FromHours(1)),
                     configuration.GetValue("verificationDelay", TimeSpan.FromMinutes(15)));
             });
@@ -51,6 +52,7 @@ namespace TestResultCoordinator
             string logAnalyticsLogType,
             string storagePath,
             bool optimizeForPerformance,
+            TimeSpan testStartDelay,
             TimeSpan testDuration,
             TimeSpan verificationDelay)
         {
@@ -66,6 +68,7 @@ namespace TestResultCoordinator
             this.StoragePath = storagePath;
             this.OptimizeForPerformance = Preconditions.CheckNotNull(optimizeForPerformance);
             this.TestDuration = testDuration;
+            this.TestStartDelay = testStartDelay;
             this.ResultSources = this.GetResultSources();
             this.DurationBeforeVerification = verificationDelay;
             this.ConsumerGroupName = "$Default";
@@ -106,6 +109,8 @@ namespace TestResultCoordinator
 
         public TimeSpan TestDuration { get; }
 
+        public TimeSpan TestStartDelay { get; }
+
         public List<string> ResultSources { get; }
 
         public TimeSpan DurationBeforeVerification { get; }
@@ -124,6 +129,7 @@ namespace TestResultCoordinator
                 { nameof(this.WebHostPort), this.WebHostPort.ToString() },
                 { nameof(this.StoragePath), this.StoragePath },
                 { nameof(this.OptimizeForPerformance), this.OptimizeForPerformance.ToString() },
+                { nameof(this.TestStartDelay), this.TestDuration.ToString() },
                 { nameof(this.TestDuration), this.TestDuration.ToString() },
                 { nameof(this.ResultSources), string.Join("\n", this.ResultSources) },
                 { nameof(this.DurationBeforeVerification), this.DurationBeforeVerification.ToString() },

--- a/test/modules/TestResultCoordinator/Settings.cs
+++ b/test/modules/TestResultCoordinator/Settings.cs
@@ -10,6 +10,7 @@ namespace TestResultCoordinator
     using Microsoft.Extensions.Configuration;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
+    using TestResultCoordinator.Report;
 
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     class Settings

--- a/test/modules/TestResultCoordinator/Startup.cs
+++ b/test/modules/TestResultCoordinator/Startup.cs
@@ -5,6 +5,7 @@ namespace TestResultCoordinator
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using TestResultCoordinator.Service;
 
     public class Startup
     {
@@ -20,6 +21,7 @@ namespace TestResultCoordinator
         {
             services.AddMvc();
             services.AddHostedService<TestResultReportingService>();
+            services.AddHostedService<TestResultEventReceivingService>();
         }
 
         // TODO: Remove warning disable for Obsolete when project is moved to dotnetcore 3.0

--- a/test/modules/TestResultCoordinator/Startup.cs
+++ b/test/modules/TestResultCoordinator/Startup.cs
@@ -19,6 +19,7 @@ namespace TestResultCoordinator
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
+            services.AddHostedService<TestResultReportingService>();
         }
 
         // TODO: Remove warning disable for Obsolete when project is moved to dotnetcore 3.0

--- a/test/modules/TestResultCoordinator/TestResultReportingService.cs
+++ b/test/modules/TestResultCoordinator/TestResultReportingService.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace TestResultCoordinator
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Azure.Devices.Edge.Util.AzureLogAnalytics;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using Newtonsoft.Json;
+
+    // Reference from https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-3.1&tabs=visual-studio
+    class TestResultReportingService : IHostedService, IDisposable
+    {
+        readonly ILogger logger = ModuleUtil.CreateLogger(nameof(TestResultReportingService));
+        readonly TimeSpan delayBeforeWork;
+        Timer timer;
+
+        public TestResultReportingService()
+        {
+            this.delayBeforeWork = Settings.Current.TestDuration + Settings.Current.DurationBeforeVerification;
+        }
+
+        public Task StartAsync(CancellationToken ct)
+        {
+            this.logger.LogInformation("Test Result Reporting Service running.");
+
+            // Specify -1 ms to disable periodic run
+            this.timer = new Timer(
+                this.DoWorkAsync,
+                null,
+                this.delayBeforeWork,
+                TimeSpan.FromMilliseconds(-1));
+
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken stoppingToken)
+        {
+            this.logger.LogInformation("Test Result Reporting Service is stopping.");
+
+            this.timer?.Change(Timeout.Infinite, 0);
+
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            this.timer?.Dispose();
+        }
+
+        async void DoWorkAsync(object state)
+        {
+            this.logger.LogInformation($"Starting report generation for {Settings.Current.ReportMetadataList.Count} reports");
+
+            try
+            {
+                var testReportGeneratorFactory = new TestReportGeneratorFactory();
+                var testResultReportList = new List<Task<ITestResultReport>>();
+                foreach (IReportMetadata reportMetadata in Settings.Current.ReportMetadataList)
+                {
+                    ITestResultReportGenerator testResultReportGenerator = testReportGeneratorFactory.Create(Settings.Current.TrackingId, reportMetadata);
+                    testResultReportList.Add(testResultReportGenerator.CreateReportAsync());
+                }
+
+                ITestResultReport[] testResultReports = await Task.WhenAll(testResultReportList);
+
+                this.logger.LogInformation("Successfully generated all reports");
+
+                string reportsContent = JsonConvert.SerializeObject(testResultReports);
+                this.logger.LogInformation(reportsContent);
+
+                await AzureLogAnalytics.Instance.PostAsync(
+                    Settings.Current.LogAnalyticsWorkspaceId,
+                    Settings.Current.LogAnalyticsSharedKey,
+                    reportsContent,
+                    Settings.Current.LogAnalyticsLogType);
+
+                this.logger.LogInformation("Successfully send reports to LogAnalytics");
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError("TestResultCoordinator failed during report generation", ex);
+            }
+        }
+    }
+}

--- a/test/modules/TestResultCoordinator/report/CountingReport.cs
+++ b/test/modules/TestResultCoordinator/report/CountingReport.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     using System.Collections.Generic;
 

--- a/test/modules/TestResultCoordinator/report/CountingReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/report/CountingReportGenerator.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     using System;
     using System.Collections.Generic;
@@ -10,6 +10,7 @@ namespace TestResultCoordinator
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
+    using TestOperationResult = TestResultCoordinator.TestOperationResult;
 
     /// <summary>
     /// This is used to create counting report based on 2 different sources/stores; it will use given test result comparer to determine whether it matches or not.

--- a/test/modules/TestResultCoordinator/report/CountingReportMetadata.cs
+++ b/test/modules/TestResultCoordinator/report/CountingReportMetadata.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
 

--- a/test/modules/TestResultCoordinator/report/IReportMetadata.cs
+++ b/test/modules/TestResultCoordinator/report/IReportMetadata.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
     interface IReportMetadata

--- a/test/modules/TestResultCoordinator/report/ITestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/report/ITestReportGeneratorFactory.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     /// <summary>
     /// This is used to create an instance of test report generator based on given report-related parameters.

--- a/test/modules/TestResultCoordinator/report/ITestResultComparer.cs
+++ b/test/modules/TestResultCoordinator/report/ITestResultComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     /// <summary>
     /// It is used to compare 2 test results whether they matches or not.

--- a/test/modules/TestResultCoordinator/report/ITestResultReport.cs
+++ b/test/modules/TestResultCoordinator/report/ITestResultReport.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     /// <summary>
     /// This defines the basic properties of a test result report.

--- a/test/modules/TestResultCoordinator/report/ITestResultReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/report/ITestResultReportGenerator.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     using System.Threading.Tasks;
 

--- a/test/modules/TestResultCoordinator/report/SimpleTestOperationResultComparer.cs
+++ b/test/modules/TestResultCoordinator/report/SimpleTestOperationResultComparer.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     using System;
 

--- a/test/modules/TestResultCoordinator/report/TestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/report/TestReportGeneratorFactory.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     using System;
     class TestReportGeneratorFactory : ITestReportGeneratorFactory

--- a/test/modules/TestResultCoordinator/report/TestReportType.cs
+++ b/test/modules/TestResultCoordinator/report/TestReportType.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     enum TestReportType
     {

--- a/test/modules/TestResultCoordinator/report/TestResultReportBase.cs
+++ b/test/modules/TestResultCoordinator/report/TestResultReportBase.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Report
 {
     using Microsoft.Azure.Devices.Edge.Util;
 

--- a/test/modules/TestResultCoordinator/service/PartitionReceiverHandler.cs
+++ b/test/modules/TestResultCoordinator/service/PartitionReceiverHandler.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Service
 {
     using System;
     using System.Collections.Generic;
@@ -8,6 +8,7 @@ namespace TestResultCoordinator
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.EventHubs;
     using Microsoft.Extensions.Logging;
+    using TestOperationResult = TestResultCoordinator.TestOperationResult;
 
     class PartitionReceiveHandler : IPartitionReceiveHandler
     {

--- a/test/modules/TestResultCoordinator/service/PartitionReceiverHandler.cs
+++ b/test/modules/TestResultCoordinator/service/PartitionReceiverHandler.cs
@@ -52,7 +52,7 @@ namespace TestResultCoordinator.Service
                         eventData.Properties.TryGetValue(TestConstants.Message.SequenceNumberPropertyName, out object sequenceNumberFromEvent);
                         eventData.Properties.TryGetValue(TestConstants.Message.BatchIdPropertyName, out object batchIdFromEvent);
 
-                        Logger.LogInformation($"Recieved event from Event Hub: sequenceNumber={(string)sequenceNumberFromEvent}, batchId={(string)batchIdFromEvent}");
+                        Logger.LogInformation($"Received event from Event Hub: sequenceNumber={(string)sequenceNumberFromEvent}, batchId={(string)batchIdFromEvent}");
 
                         if (!string.IsNullOrWhiteSpace((string)sequenceNumberFromEvent) &&
                             !string.IsNullOrWhiteSpace((string)batchIdFromEvent))

--- a/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
@@ -6,7 +6,6 @@ namespace TestResultCoordinator.Service
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Common;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
-    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.EventHubs;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
@@ -37,7 +36,12 @@ namespace TestResultCoordinator.Service
                 EventPosition.FromEnqueuedTime(eventEnqueuedFrom));
             eventHubReceiver.SetReceiveHandler(new PartitionReceiveHandler(Settings.Current.TrackingId, Settings.Current.DeviceId));
 
-            await stoppingToken.WhenCanceled();
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                await Task.Delay(TimeSpan.FromMilliseconds(5), stoppingToken);
+            }
+
+            this.logger.LogInformation($"Finish ExecuteAsync method in {nameof(TestResultEventReceivingService)}");
         }
     }
 }

--- a/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
@@ -6,6 +6,7 @@ namespace TestResultCoordinator.Service
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Common;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.EventHubs;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
@@ -36,10 +37,7 @@ namespace TestResultCoordinator.Service
                 EventPosition.FromEnqueuedTime(eventEnqueuedFrom));
             eventHubReceiver.SetReceiveHandler(new PartitionReceiveHandler(Settings.Current.TrackingId, Settings.Current.DeviceId));
 
-            while (!stoppingToken.IsCancellationRequested)
-            {
-                await Task.Delay(TimeSpan.FromMilliseconds(5), stoppingToken);
-            }
+            await stoppingToken.WhenCanceled();
 
             this.logger.LogInformation($"Finish ExecuteAsync method in {nameof(TestResultEventReceivingService)}");
         }

--- a/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace TestResultCoordinator.Service
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Common;
+    using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.EventHubs;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+
+    class TestResultEventReceivingService : BackgroundService
+    {
+        readonly ILogger logger = ModuleUtil.CreateLogger(nameof(TestResultEventReceivingService));
+
+        public override async Task StopAsync(CancellationToken stoppingToken)
+        {
+            this.logger.LogInformation("Test Result Event Receiving Service is stopping.");
+
+            await Task.CompletedTask;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            this.logger.LogInformation("Test Result Event Receiving Service running.");
+
+            DateTime eventEnqueuedFrom = DateTime.UtcNow;
+            var builder = new EventHubsConnectionStringBuilder(Settings.Current.EventHubConnectionString);
+            this.logger.LogInformation($"Receiving events from device '{Settings.Current.DeviceId}' on Event Hub '{builder.EntityPath}' enqueued at or after {eventEnqueuedFrom}");
+
+            EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
+            PartitionReceiver eventHubReceiver = eventHubClient.CreateReceiver(
+                Settings.Current.ConsumerGroupName,
+                EventHubPartitionKeyResolver.ResolveToPartition(Settings.Current.DeviceId, (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
+                EventPosition.FromEnqueuedTime(eventEnqueuedFrom));
+            eventHubReceiver.SetReceiveHandler(new PartitionReceiveHandler(Settings.Current.TrackingId, Settings.Current.DeviceId));
+
+            await stoppingToken.WhenCanceled();
+        }
+    }
+}

--- a/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
@@ -22,13 +22,13 @@ namespace TestResultCoordinator.Service
             await Task.CompletedTask;
         }
 
-        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken cancellationToken)
         {
             this.logger.LogInformation("Test Result Event Receiving Service running.");
 
             DateTime eventEnqueuedFrom = DateTime.UtcNow;
             var builder = new EventHubsConnectionStringBuilder(Settings.Current.EventHubConnectionString);
-            this.logger.LogInformation($"Receiving events from device '{Settings.Current.DeviceId}' on Event Hub '{builder.EntityPath}' enqueued at or after {eventEnqueuedFrom}");
+            this.logger.LogDebug($"Receiving events from device '{Settings.Current.DeviceId}' on Event Hub '{builder.EntityPath}' enqueued on or after {eventEnqueuedFrom}");
 
             EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());
             PartitionReceiver eventHubReceiver = eventHubClient.CreateReceiver(
@@ -37,7 +37,7 @@ namespace TestResultCoordinator.Service
                 EventPosition.FromEnqueuedTime(eventEnqueuedFrom));
             eventHubReceiver.SetReceiveHandler(new PartitionReceiveHandler(Settings.Current.TrackingId, Settings.Current.DeviceId));
 
-            await stoppingToken.WhenCanceled();
+            await cancellationToken.WhenCanceled();
 
             this.logger.LogInformation($"Finish ExecuteAsync method in {nameof(TestResultEventReceivingService)}");
         }

--- a/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
@@ -21,7 +21,7 @@ namespace TestResultCoordinator.Service
 
         public TestResultReportingService()
         {
-            this.delayBeforeWork = Settings.Current.TestDuration + Settings.Current.DurationBeforeVerification;
+            this.delayBeforeWork = Settings.Current.TestStartDelay + Settings.Current.TestDuration + Settings.Current.DurationBeforeVerification;
         }
 
         public Task StartAsync(CancellationToken ct)

--- a/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
@@ -12,7 +12,8 @@ namespace TestResultCoordinator.Service
     using Newtonsoft.Json;
     using TestResultCoordinator.Report;
 
-    // Reference from https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-3.1&tabs=visual-studio
+    // This class implementation is copied from https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-3.1&tabs=visual-studio
+    // And then implement our own DoWorkAsync for reporting generation.
     class TestResultReportingService : IHostedService, IDisposable
     {
         readonly ILogger logger = ModuleUtil.CreateLogger(nameof(TestResultReportingService));

--- a/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace TestResultCoordinator
+namespace TestResultCoordinator.Service
 {
     using System;
     using System.Collections.Generic;
@@ -10,6 +10,7 @@ namespace TestResultCoordinator
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
+    using TestResultCoordinator.Report;
 
     // Reference from https://docs.microsoft.com/en-us/aspnet/core/fundamentals/host/hosted-services?view=aspnetcore-3.1&tabs=visual-studio
     class TestResultReportingService : IHostedService, IDisposable


### PR DESCRIPTION
Use task.Run to wrap task delay to ensure running on different thread; therefore web host can start processing requests and save result to store.