### PR TITLE
Refactoring storage on top of service changes for TestResultCoordinator

### DIFF
--- a/test/modules/TestResultCoordinator/Controllers/TestOperationResultController.cs
+++ b/test/modules/TestResultCoordinator/Controllers/TestOperationResultController.cs
@@ -7,7 +7,9 @@ namespace TestResultCoordinator.Controllers
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
+    using TestResultCoordinator.Storage;
     using TestOperationResult = TestResultCoordinator.TestOperationResult;
 
     [Route("api/[controller]")]
@@ -15,6 +17,12 @@ namespace TestResultCoordinator.Controllers
     public class TestOperationResultController : Controller
     {
         static readonly ILogger Logger = ModuleUtil.CreateLogger(nameof(TestOperationResultController));
+        readonly ITestOperationResultStorage storage;
+
+        public TestOperationResultController(ITestOperationResultStorage storage)
+        {
+            this.storage = Preconditions.CheckNotNull(storage);
+        }
 
         // POST api/TestOperationResult
         [HttpPost]
@@ -22,7 +30,7 @@ namespace TestResultCoordinator.Controllers
         {
             try
             {
-                bool success = await TestOperationResultStorage.AddResultAsync(result);
+                bool success = await this.storage.AddResultAsync(result);
                 Logger.LogDebug($"Received test result: {result.Source}, {result.Type}, {success}");
                 return success ? this.StatusCode((int)HttpStatusCode.NoContent) : this.StatusCode((int)HttpStatusCode.BadRequest);
             }

--- a/test/modules/TestResultCoordinator/Program.cs
+++ b/test/modules/TestResultCoordinator/Program.cs
@@ -20,9 +20,6 @@ namespace TestResultCoordinator
 
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(TimeSpan.FromSeconds(5), Logger);
 
-            await TestOperationResultStorage.InitAsync(Settings.Current.StoragePath, new SystemEnvironment(), Settings.Current.OptimizeForPerformance, Settings.Current.ResultSources);
-            Logger.LogInformation("TestOperationResultStorage created successfully");
-
             Logger.LogInformation("Creating WebHostBuilder...");
             Task webHost = CreateWebHostBuilder(args).Build().RunAsync(cts.Token);
 

--- a/test/modules/TestResultCoordinator/Startup.cs
+++ b/test/modules/TestResultCoordinator/Startup.cs
@@ -3,9 +3,11 @@ namespace TestResultCoordinator
 {
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using TestResultCoordinator.Service;
+    using TestResultCoordinator.Storage;
 
     public class Startup
     {
@@ -17,11 +19,16 @@ namespace TestResultCoordinator
         public IConfiguration Configuration { get; }
 
         // This method gets called by the runtime. Use this method to add services to the container.
-        public void ConfigureServices(IServiceCollection services)
+        public async void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
             services.AddHostedService<TestResultReportingService>();
             services.AddHostedService<TestResultEventReceivingService>();
+            services.AddSingleton<ITestOperationResultStorage>(await TestOperationResultStorage.Create(
+                Settings.Current.StoragePath,
+                new SystemEnvironment(),
+                Settings.Current.OptimizeForPerformance,
+                Settings.Current.ResultSources));
         }
 
         // TODO: Remove warning disable for Obsolete when project is moved to dotnetcore 3.0

--- a/test/modules/TestResultCoordinator/Startup.cs
+++ b/test/modules/TestResultCoordinator/Startup.cs
@@ -1,16 +1,24 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace TestResultCoordinator
 {
+    using System;
+    using System.IO;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Azure.Devices.Edge.Storage;
+    using Microsoft.Azure.Devices.Edge.Storage.RocksDb;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using TestResultCoordinator.Service;
     using TestResultCoordinator.Storage;
 
     public class Startup
     {
+        static readonly ILogger Logger = ModuleUtil.CreateLogger(nameof(Startup));
+
         public Startup(IConfiguration configuration)
         {
             this.Configuration = configuration;
@@ -22,13 +30,30 @@ namespace TestResultCoordinator
         public async void ConfigureServices(IServiceCollection services)
         {
             services.AddMvc();
+            IStoreProvider storeProvider;
+            try
+            {
+                IDbStoreProvider dbStoreprovider = DbStoreProvider.Create(
+                    new RocksDbOptionsProvider(
+                        new SystemEnvironment(),
+                        Settings.Current.OptimizeForPerformance,
+                        Option.None<ulong>()),
+                    this.GetStoragePath(Settings.Current.StoragePath),
+                    Settings.Current.ResultSources);
+
+                storeProvider = new StoreProvider(dbStoreprovider);
+            }
+            catch (Exception ex) when (!ExceptionEx.IsFatal(ex))
+            {
+                Logger.LogError(ex, "Error creating RocksDB store. Falling back to in-memory store.");
+                storeProvider = new StoreProvider(new InMemoryDbStoreProvider());
+            }
+
+            services.AddSingleton<ITestOperationResultStorage>(await TestOperationResultStorage.Create(
+                storeProvider,
+                Settings.Current.ResultSources));
             services.AddHostedService<TestResultReportingService>();
             services.AddHostedService<TestResultEventReceivingService>();
-            services.AddSingleton<ITestOperationResultStorage>(await TestOperationResultStorage.Create(
-                Settings.Current.StoragePath,
-                new SystemEnvironment(),
-                Settings.Current.OptimizeForPerformance,
-                Settings.Current.ResultSources));
         }
 
         // TODO: Remove warning disable for Obsolete when project is moved to dotnetcore 3.0
@@ -44,5 +69,17 @@ namespace TestResultCoordinator
             app.UseMvc();
         }
 #pragma warning restore 612, 618
+
+        string GetStoragePath(string baseStoragePath)
+        {
+            if (string.IsNullOrWhiteSpace(baseStoragePath) || !Directory.Exists(baseStoragePath))
+            {
+                baseStoragePath = Path.GetTempPath();
+            }
+
+            string storagePath = Path.Combine(baseStoragePath, "TestResultCoordinator");
+            Directory.CreateDirectory(storagePath);
+            return storagePath;
+        }
     }
 }

--- a/test/modules/TestResultCoordinator/report/ITestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/report/ITestReportGeneratorFactory.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace TestResultCoordinator.Report
 {
+    using TestResultCoordinator.Storage;
+
     /// <summary>
     /// This is used to create an instance of test report generator based on given report-related parameters.
     /// </summary>
@@ -8,6 +10,7 @@ namespace TestResultCoordinator.Report
     {
         ITestResultReportGenerator Create(
             string trackingId,
-            IReportMetadata reportMetadata);
+            IReportMetadata reportMetadata,
+            ITestOperationResultStorage storage);
     }
 }

--- a/test/modules/TestResultCoordinator/report/ITestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/report/ITestReportGeneratorFactory.cs
@@ -10,7 +10,6 @@ namespace TestResultCoordinator.Report
     {
         ITestResultReportGenerator Create(
             string trackingId,
-            IReportMetadata reportMetadata,
-            ITestOperationResultStorage storage);
+            IReportMetadata reportMetadata);
     }
 }

--- a/test/modules/TestResultCoordinator/report/TestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/report/TestReportGeneratorFactory.cs
@@ -6,14 +6,16 @@ namespace TestResultCoordinator.Report
 
     class TestReportGeneratorFactory : ITestReportGeneratorFactory
     {
-        public TestReportGeneratorFactory()
+        ITestOperationResultStorage storage;
+
+        public TestReportGeneratorFactory(ITestOperationResultStorage storage)
         {
+            this.storage = storage;
         }
 
         public ITestResultReportGenerator Create(
             string trackingId,
-            IReportMetadata reportMetadata,
-            ITestOperationResultStorage storage)
+            IReportMetadata reportMetadata)
         {
             switch (reportMetadata.TestReportType)
             {
@@ -22,9 +24,9 @@ namespace TestResultCoordinator.Report
                         return new CountingReportGenerator(
                             trackingId,
                             reportMetadata.ExpectedSource,
-                            storage.GetStoreFromSource(reportMetadata.ExpectedSource),
+                            this.storage.GetStoreFromSource(reportMetadata.ExpectedSource),
                             reportMetadata.ActualSource,
-                            storage.GetStoreFromSource(reportMetadata.ActualSource),
+                            this.storage.GetStoreFromSource(reportMetadata.ActualSource),
                             reportMetadata.TestOperationResultType.ToString(),
                             new SimpleTestOperationResultComparer());
                 }

--- a/test/modules/TestResultCoordinator/report/TestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/report/TestReportGeneratorFactory.cs
@@ -2,6 +2,8 @@
 namespace TestResultCoordinator.Report
 {
     using System;
+    using TestResultCoordinator.Storage;
+
     class TestReportGeneratorFactory : ITestReportGeneratorFactory
     {
         public TestReportGeneratorFactory()
@@ -10,7 +12,8 @@ namespace TestResultCoordinator.Report
 
         public ITestResultReportGenerator Create(
             string trackingId,
-            IReportMetadata reportMetadata)
+            IReportMetadata reportMetadata,
+            ITestOperationResultStorage storage)
         {
             switch (reportMetadata.TestReportType)
             {
@@ -19,10 +22,9 @@ namespace TestResultCoordinator.Report
                         return new CountingReportGenerator(
                             trackingId,
                             reportMetadata.ExpectedSource,
-                            // TODO: Change the storage to be passed in when it becomes non-static
-                            TestOperationResultStorage.GetStoreFromSource(reportMetadata.ExpectedSource),
+                            storage.GetStoreFromSource(reportMetadata.ExpectedSource),
                             reportMetadata.ActualSource,
-                            TestOperationResultStorage.GetStoreFromSource(reportMetadata.ActualSource),
+                            storage.GetStoreFromSource(reportMetadata.ActualSource),
                             reportMetadata.TestOperationResultType.ToString(),
                             new SimpleTestOperationResultComparer());
                 }

--- a/test/modules/TestResultCoordinator/report/TestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/report/TestReportGeneratorFactory.cs
@@ -2,6 +2,7 @@
 namespace TestResultCoordinator.Report
 {
     using System;
+    using Microsoft.Azure.Devices.Edge.Util;
     using TestResultCoordinator.Storage;
 
     class TestReportGeneratorFactory : ITestReportGeneratorFactory
@@ -10,7 +11,7 @@ namespace TestResultCoordinator.Report
 
         public TestReportGeneratorFactory(ITestOperationResultStorage storage)
         {
-            this.storage = storage;
+            this.storage = Preconditions.CheckNotNull(storage, nameof(storage));
         }
 
         public ITestResultReportGenerator Create(

--- a/test/modules/TestResultCoordinator/service/PartitionReceiverHandler.cs
+++ b/test/modules/TestResultCoordinator/service/PartitionReceiverHandler.cs
@@ -8,6 +8,7 @@ namespace TestResultCoordinator.Service
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.EventHubs;
     using Microsoft.Extensions.Logging;
+    using TestResultCoordinator.Storage;
     using TestOperationResult = TestResultCoordinator.TestOperationResult;
 
     class PartitionReceiveHandler : IPartitionReceiveHandler
@@ -20,11 +21,13 @@ namespace TestResultCoordinator.Service
 
         readonly string deviceId;
         readonly string trackingId;
+        readonly ITestOperationResultStorage storage;
 
-        public PartitionReceiveHandler(string trackingId, string deviceId)
+        public PartitionReceiveHandler(string trackingId, string deviceId, ITestOperationResultStorage storage)
         {
             this.trackingId = Preconditions.CheckNonWhiteSpace(trackingId, nameof(trackingId));
             this.deviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
+            this.storage = Preconditions.CheckNotNull(storage);
         }
 
         public int MaxBatchSize { get; set; }
@@ -70,7 +73,7 @@ namespace TestResultCoordinator.Service
                                         (string)batchIdFromEvent,
                                         (string)sequenceNumberFromEvent),
                                     enqueuedtime);
-                                await TestOperationResultStorage.AddResultAsync(result);
+                                await this.storage.AddResultAsync(result);
                             }
                             else
                             {

--- a/test/modules/TestResultCoordinator/service/PartitionReceiverHandler.cs
+++ b/test/modules/TestResultCoordinator/service/PartitionReceiverHandler.cs
@@ -27,7 +27,7 @@ namespace TestResultCoordinator.Service
         {
             this.trackingId = Preconditions.CheckNonWhiteSpace(trackingId, nameof(trackingId));
             this.deviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
-            this.storage = Preconditions.CheckNotNull(storage);
+            this.storage = Preconditions.CheckNotNull(storage, nameof(storage));
         }
 
         public int MaxBatchSize { get; set; }

--- a/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
@@ -10,10 +10,17 @@ namespace TestResultCoordinator.Service
     using Microsoft.Azure.EventHubs;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
+    using TestResultCoordinator.Storage;
 
     class TestResultEventReceivingService : BackgroundService
     {
         readonly ILogger logger = ModuleUtil.CreateLogger(nameof(TestResultEventReceivingService));
+        readonly ITestOperationResultStorage storage;
+
+        public TestResultEventReceivingService(ITestOperationResultStorage storage)
+        {
+            this.storage = Preconditions.CheckNotNull(storage);
+        }
 
         public override async Task StopAsync(CancellationToken stoppingToken)
         {
@@ -35,7 +42,7 @@ namespace TestResultCoordinator.Service
                 Settings.Current.ConsumerGroupName,
                 EventHubPartitionKeyResolver.ResolveToPartition(Settings.Current.DeviceId, (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
                 EventPosition.FromEnqueuedTime(eventEnqueuedFrom));
-            eventHubReceiver.SetReceiveHandler(new PartitionReceiveHandler(Settings.Current.TrackingId, Settings.Current.DeviceId));
+            eventHubReceiver.SetReceiveHandler(new PartitionReceiveHandler(Settings.Current.TrackingId, Settings.Current.DeviceId, this.storage));
 
             await cancellationToken.WhenCanceled();
 

--- a/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultEventReceivingService.cs
@@ -19,7 +19,7 @@ namespace TestResultCoordinator.Service
 
         public TestResultEventReceivingService(ITestOperationResultStorage storage)
         {
-            this.storage = Preconditions.CheckNotNull(storage);
+            this.storage = Preconditions.CheckNotNull(storage, nameof(storage));
         }
 
         public override async Task StopAsync(CancellationToken stoppingToken)

--- a/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
@@ -25,8 +25,8 @@ namespace TestResultCoordinator.Service
 
         public TestResultReportingService(ITestOperationResultStorage storage)
         {
-            this.delayBeforeWork = Settings.Current.TestStartDelay + Settings.Current.TestDuration + Settings.Current.DurationBeforeVerification;
             this.storage = Preconditions.CheckNotNull(storage, nameof(storage));
+            this.delayBeforeWork = Settings.Current.TestStartDelay + Settings.Current.TestDuration + Settings.Current.DurationBeforeVerification;
         }
 
         public Task StartAsync(CancellationToken ct)

--- a/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
@@ -6,6 +6,7 @@ namespace TestResultCoordinator.Service
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.AzureLogAnalytics;
     using Microsoft.Extensions.Hosting;
     using Microsoft.Extensions.Logging;
@@ -25,7 +26,7 @@ namespace TestResultCoordinator.Service
         public TestResultReportingService(ITestOperationResultStorage storage)
         {
             this.delayBeforeWork = Settings.Current.TestStartDelay + Settings.Current.TestDuration + Settings.Current.DurationBeforeVerification;
-            this.storage = storage;
+            this.storage = Preconditions.CheckNotNull(storage);
         }
 
         public Task StartAsync(CancellationToken ct)

--- a/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
+++ b/test/modules/TestResultCoordinator/service/TestResultReportingService.cs
@@ -26,7 +26,7 @@ namespace TestResultCoordinator.Service
         public TestResultReportingService(ITestOperationResultStorage storage)
         {
             this.delayBeforeWork = Settings.Current.TestStartDelay + Settings.Current.TestDuration + Settings.Current.DurationBeforeVerification;
-            this.storage = Preconditions.CheckNotNull(storage);
+            this.storage = Preconditions.CheckNotNull(storage, nameof(storage));
         }
 
         public Task StartAsync(CancellationToken ct)
@@ -63,11 +63,11 @@ namespace TestResultCoordinator.Service
 
             try
             {
-                var testReportGeneratorFactory = new TestReportGeneratorFactory();
+                var testReportGeneratorFactory = new TestReportGeneratorFactory(this.storage);
                 var testResultReportList = new List<Task<ITestResultReport>>();
                 foreach (IReportMetadata reportMetadata in Settings.Current.ReportMetadataList)
                 {
-                    ITestResultReportGenerator testResultReportGenerator = testReportGeneratorFactory.Create(Settings.Current.TrackingId, reportMetadata, this.storage);
+                    ITestResultReportGenerator testResultReportGenerator = testReportGeneratorFactory.Create(Settings.Current.TrackingId, reportMetadata);
                     testResultReportList.Add(testResultReportGenerator.CreateReportAsync());
                 }
 

--- a/test/modules/TestResultCoordinator/storage/ITestOperationResultStorage.cs
+++ b/test/modules/TestResultCoordinator/storage/ITestOperationResultStorage.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace TestResultCoordinator.Storage
+{
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Storage;
+    public interface ITestOperationResultStorage
+    {
+        ISequentialStore<TestOperationResult> GetStoreFromSource(string source);
+
+        Task<bool> AddResultAsync(TestOperationResult testOperationResult);
+    }
+}

--- a/test/modules/TestResultCoordinator/storage/TestOperationResultStorage.cs
+++ b/test/modules/TestResultCoordinator/storage/TestOperationResultStorage.cs
@@ -17,7 +17,7 @@ namespace TestResultCoordinator.Storage
         public static async Task<TestOperationResultStorage> Create(IStoreProvider storeProvider, List<string> resultSources)
         {
             Preconditions.CheckNotNull(storeProvider, nameof(storeProvider));
-            Dictionary<string, ISequentialStore<TestOperationResult>> resultSourcesToStores = new Dictionary<string, ISequentialStore<TestOperationResult>>();
+            var resultSourcesToStores = new Dictionary<string, ISequentialStore<TestOperationResult>>();
             foreach (string resultSource in resultSources)
             {
                 resultSourcesToStores.Add(resultSource, await storeProvider.GetSequentialStore<TestOperationResult>(resultSource));
@@ -34,31 +34,6 @@ namespace TestResultCoordinator.Storage
         public ISequentialStore<TestOperationResult> GetStoreFromSource(string source)
         {
             return this.resultStores.TryGetValue(source, out ISequentialStore<TestOperationResult> store) ? store : throw new InvalidDataException($"Source {source} not found.");
-        }
-
-        static async Task<Dictionary<string, ISequentialStore<TestOperationResult>>> InitializeStoresAsync(StoreProvider storeProvider, List<string> resultSources)
-        {
-            Preconditions.CheckNotNull(storeProvider);
-            Preconditions.CheckNotNull(resultSources);
-            Dictionary<string, ISequentialStore<TestOperationResult>> resultSourcesToStores = new Dictionary<string, ISequentialStore<TestOperationResult>>();
-            foreach (string resultSource in resultSources)
-            {
-                resultSourcesToStores.Add(resultSource, await storeProvider.GetSequentialStore<TestOperationResult>(resultSource));
-            }
-
-            return resultSourcesToStores;
-        }
-
-        static string GetStoragePath(string baseStoragePath)
-        {
-            if (string.IsNullOrWhiteSpace(baseStoragePath) || !Directory.Exists(baseStoragePath))
-            {
-                baseStoragePath = Path.GetTempPath();
-            }
-
-            string storagePath = Path.Combine(baseStoragePath, "TestResultCoordinator");
-            Directory.CreateDirectory(storagePath);
-            return storagePath;
         }
 
         public async Task<bool> AddResultAsync(TestOperationResult testOperationResult)

--- a/test/modules/TestResultCoordinator/storage/TestOperationResultStorage.cs
+++ b/test/modules/TestResultCoordinator/storage/TestOperationResultStorage.cs
@@ -6,47 +6,34 @@ namespace TestResultCoordinator.Storage
     using System.IO;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Storage;
-    using Microsoft.Azure.Devices.Edge.Storage.RocksDb;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
 
     public class TestOperationResultStorage : ITestOperationResultStorage
     {
         static readonly ILogger Logger = Microsoft.Azure.Devices.Edge.ModuleUtil.ModuleUtil.CreateLogger(nameof(TestOperationResultStorage));
-        private Dictionary<string, ISequentialStore<TestOperationResult>> ResultStores { get; set; }
+        private Dictionary<string, ISequentialStore<TestOperationResult>> resultStores;
 
-        public static async Task<TestOperationResultStorage> Create(string storagePath, ISystemEnvironment systemEnvironment, bool optimizeForPerformance, List<string> resultSources)
+        public static async Task<TestOperationResultStorage> Create(IStoreProvider storeProvider, List<string> resultSources)
         {
-            StoreProvider storeProvider;
-            Preconditions.CheckNotNull(systemEnvironment);
-            Preconditions.CheckNotNull(optimizeForPerformance);
-            Preconditions.CheckNotNull(resultSources);
-            try
+            Preconditions.CheckNotNull(storeProvider, nameof(storeProvider));
+            Dictionary<string, ISequentialStore<TestOperationResult>> resultSourcesToStores = new Dictionary<string, ISequentialStore<TestOperationResult>>();
+            foreach (string resultSource in resultSources)
             {
-                IDbStoreProvider dbStoreprovider = DbStoreProvider.Create(
-                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance, Option.None<ulong>()),
-                    GetStoragePath(storagePath),
-                    resultSources);
-
-                storeProvider = new StoreProvider(dbStoreprovider);
-            }
-            catch (Exception ex) when (!ExceptionEx.IsFatal(ex))
-            {
-                Logger.LogError(ex, "Error creating RocksDB store. Falling back to in-memory store.");
-                storeProvider = new StoreProvider(new InMemoryDbStoreProvider());
+                resultSourcesToStores.Add(resultSource, await storeProvider.GetSequentialStore<TestOperationResult>(resultSource));
             }
 
-            return new TestOperationResultStorage(await InitializeStoresAsync(storeProvider, resultSources));
+            return new TestOperationResultStorage(resultSourcesToStores);
         }
 
         private TestOperationResultStorage(Dictionary<string, ISequentialStore<TestOperationResult>> resultStores)
         {
-            this.ResultStores = resultStores;
+            this.resultStores = resultStores;
         }
 
         public ISequentialStore<TestOperationResult> GetStoreFromSource(string source)
         {
-            return this.ResultStores.TryGetValue(source, out ISequentialStore<TestOperationResult> store) ? store : throw new InvalidDataException($"Source {source} not found.");
+            return this.resultStores.TryGetValue(source, out ISequentialStore<TestOperationResult> store) ? store : throw new InvalidDataException($"Source {source} not found.");
         }
 
         static async Task<Dictionary<string, ISequentialStore<TestOperationResult>>> InitializeStoresAsync(StoreProvider storeProvider, List<string> resultSources)
@@ -84,7 +71,7 @@ namespace TestResultCoordinator.Storage
                     return false;
                 }
 
-                if (!this.ResultStores.TryGetValue(testOperationResult.Source, out ISequentialStore<TestOperationResult> resultStore))
+                if (!this.resultStores.TryGetValue(testOperationResult.Source, out ISequentialStore<TestOperationResult> resultStore))
                 {
                     string message = $"Source {testOperationResult.Source} is not valid.";
                     Logger.LogError(message);


### PR DESCRIPTION
Changing Storage from static to an instance that is injected as a Singleton in webhost services for TestResultCoordinator

Now we make the storage in the Startup file and leverage existing framework to inject the storage object in the services where we need it (send and receive services).

I made this new PR because it was easier than dealing with a ton of merge conflicts - and I accidentally closed the other one :). Old PR with comments and responses here: https://github.com/Azure/iotedge/pull/2126