### PR TITLE
Fix flaky BackupAndRestoreTest

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/BackupAndRestoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/BackupAndRestoreTest.cs
@@ -177,10 +177,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 // Send more messages after the receiver is registered.
                 Task<int> task2 = sender.SendMessagesByCountAsync("output1", beforeBackupMessageCount, afterBackupMessageCount, TimeSpan.FromMinutes(2));
                 sentMessagesCount = await task2;
-                Assert.Equal(afterBackupMessageCount, sentMessagesCount);
 
                 waitTime = waitTimeComputer(expectedMessageCountAfterRestore);
                 Console.WriteLine($"Waiting {waitTime.TotalSeconds} seconds before validating receipt of messages.");
+                Assert.Equal(afterBackupMessageCount, sentMessagesCount);
 
                 // Validate that all the messages were received (both sent earlier and the new messages).
                 await Task.Delay(waitTime);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/BackupAndRestoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/BackupAndRestoreTest.cs
@@ -180,12 +180,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
 
                 waitTime = waitTimeComputer(expectedMessageCountAfterRestore);
                 Console.WriteLine($"Waiting {waitTime.TotalSeconds} seconds before validating receipt of messages.");
-                Assert.Equal(afterBackupMessageCount, sentMessagesCount);
 
                 // Validate that all the messages were received (both sent earlier and the new messages).
                 await Task.Delay(waitTime);
                 ISet<int> receivedMessages = receiver.GetReceivedMessageIndices();
 
+                Assert.Equal(afterBackupMessageCount, sentMessagesCount);
                 Assert.Equal(expectedMessageCountAfterRestore, receivedMessages.Count);
             }
             finally


### PR DESCRIPTION
There is an Assert before a needed wait that will cause an amqp error if Assert fails (execution immediately jumps into finally without waiting).