### PR TITLE
Fix E2E flake - Increase timeouts

### DIFF
--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -364,7 +364,7 @@ namespace IotEdgeQuickstart.Details
                 EventPosition.FromEnd());
 
             var result = new TaskCompletionSource<bool>();
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20)))
             {
                 using (cts.Token.Register(() => result.TrySetCanceled()))
                 {

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -364,7 +364,7 @@ namespace IotEdgeQuickstart.Details
                 EventPosition.FromEnd());
 
             var result = new TaskCompletionSource<bool>();
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed in case event hub is slow to process messages
             {
                 using (cts.Token.Register(() => result.TrySetCanceled()))
                 {

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -363,6 +363,7 @@ namespace IotEdgeQuickstart.Details
                     (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
                 EventPosition.FromEnd());
 
+            // TODO: Don't rely on eventhub to verify module to module direct methods. The module sending the direct method should report success / failure directly.
             var result = new TaskCompletionSource<bool>();
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed in case event hub is slow to process messages
             {

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -363,7 +363,7 @@ namespace IotEdgeQuickstart.Details
                     (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
                 EventPosition.FromEnd());
 
-            // TODO: Don't rely on eventhub to verify module to module direct methods. The module sending the direct method should report success / failure directly.
+            // TODO: [Improvement] should verify test results without using event hub, which introduce latency.
             var result = new TaskCompletionSource<bool>();
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed in case event hub is slow to process messages
             {

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -95,7 +95,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed for resource constrained devices pulling the large tempFilterFunctions image
             {
                 string errorMessage = null;
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -95,7 +95,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20)))
             {
                 string errorMessage = null;
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -55,7 +55,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed for resource constrained devices pulling the large tempFilterFunctions image
             {
                 try
                 {

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -55,7 +55,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20)))
             {
                 try
                 {


### PR DESCRIPTION
TempFilterFunctions is a large image which takes a long time to download, so we need to increase the timeout.

Our direct method tests rely on a message sent through event hub which serves as a signal that the direct method was successful. We should change this logic to have the direct method sender module report status directly rather than relying on eventHub