### PR TITLE
Revert added header to analyzer report

### DIFF
--- a/edge-modules/TestAnalyzer/Controllers/ReportController.cs
+++ b/edge-modules/TestAnalyzer/Controllers/ReportController.cs
@@ -38,15 +38,7 @@ namespace TestAnalyzer.Controllers
                 await this.PublishToLogAnalyticsAsync(deviceAnalysis);
             }
 
-            return new ContentResult
-            {
-                Content = this.AddManualRunReportingHeading(JsonConvert.SerializeObject(deviceAnalysis.MessagesReport, Formatting.Indented)) // explicit serialization needed due to the wrapping list
-            };
-        }
-
-        string AddManualRunReportingHeading(string reportContent)
-        {
-            return $"Run manually at {DateTime.UtcNow}{Environment.NewLine}Report result is not complete as testing is still running.{Environment.NewLine}{reportContent}";
+            return new ContentResult { Content = JsonConvert.SerializeObject(deviceAnalysis.MessagesReport, Formatting.Indented) }; // explicit serialization needed due to the wrapping list
         }
 
         async Task PublishToLogAnalyticsAsync(TestResultAnalysis deviceAnalysis)

--- a/test/modules/TestResultCoordinator/Controllers/ReportController.cs
+++ b/test/modules/TestResultCoordinator/Controllers/ReportController.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace TestResultCoordinator.Controllers
 {
+    using System;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
@@ -33,7 +34,15 @@ namespace TestResultCoordinator.Controllers
                 return new ContentResult { Content = "No test report generated" };
             }
 
-            return new ContentResult { Content = JsonConvert.SerializeObject(testResultReports, Formatting.Indented) };
+            return new ContentResult
+            {
+                Content = this.AddManualRunReportingHeading(JsonConvert.SerializeObject(testResultReports, Formatting.Indented)) // explicit serialization needed due to the wrapping list
+            };
+        }
+
+        string AddManualRunReportingHeading(string reportContent)
+        {
+            return $"Run manually at {DateTime.UtcNow}{Environment.NewLine}Report result is not complete as testing is still running.{Environment.NewLine}{reportContent}";
         }
     }
 }


### PR DESCRIPTION
There was a header added to the analyzer report which cannot be parsed by the snitcher. I don't think we need this so I am removing.