### PR TITLE
New-E2E tempFilter flake - send more messages to resolve flaky test

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 builder =>
                 {
                     builder.AddModule(tempSensorModule.Name, tempSensorModule.Image)
-                        .WithEnvironment(new[] { ("MessageCount", "1") });
+                        .WithEnvironment(new[] { ("MessageCount", "100") });
                     builder.AddModule(filterModuleName, filterImage)
                         .WithEnvironment(new[] { ("TemperatureThreshold", "19") });
                     builder.GetModule("$edgeHub")
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 builder =>
                 {
                     builder.AddModule(tempSensorModule.Name, tempSensorModule.Image)
-                        .WithEnvironment(new[] { ("MessageCount", "1") });
+                        .WithEnvironment(new[] { ("MessageCount", "100") });
                     builder.AddModule(filterFuncModuleName, filterFunc)
                         .WithEnvironment(new[] { ("AZURE_FUNCTIONS_ENVIRONMENT", "Development") });
                     builder.GetModule("$edgeHub")


### PR DESCRIPTION
I believe the test fails currently as EdgeHub does not come up within the SDK retry threshold.