### PR TITLE
Port CI / E2E fixes from master

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -28,13 +28,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         const string Device2ConnStrKey = "device2ConnStrKey";
         const string Device3ConnStrKey = "device3ConnStrKey";
         static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
-<<<<<<< HEAD
-
-        static readonly int EventHubMessageReceivedRetry = 5;
-=======
         static readonly int EventHubMessageReceivedRetry = 10;
         static readonly ILogger logger = Logger.Factory.CreateLogger(nameof(CloudProxyTest));
->>>>>>> d7a74bfe... Fix flaky CI tests - Overloaded consumer group partitions (#2114)
 
         [Fact]
         [TestPriority(401)]
@@ -258,13 +253,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var receivedMessagesByPartition = new Dictionary<string, List<EventData>>();
 
             bool messagesFound = false;
-<<<<<<< HEAD
-            // Add retry mechanism to make sure all the messages sent reached Event Hub. Retry 3 times.
-            for (int i = 0; i < EventHubMessageReceivedRetry; i++)
-=======
             // If this test becomes flaky, use PartitionReceiver as a background Task to continuously retrieve messages.
             for (int i = 0; i < EventHubMessageReceivedRetry; i++) // Retry for event hub being slow to process messages.
->>>>>>> d7a74bfe... Fix flaky CI tests - Overloaded consumer group partitions (#2114)
             {
                 foreach (string deviceId in sentMessagesByDevice.Keys)
                 {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Azure.EventHubs;
+    using Microsoft.Extensions.Logging;
     using Moq;
     using Newtonsoft.Json.Linq;
     using Xunit;
@@ -24,22 +25,37 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     [TestCaseOrderer("Microsoft.Azure.Devices.Edge.Util.Test.PriorityOrderer", "Microsoft.Azure.Devices.Edge.Util.Test")]
     public class CloudProxyTest
     {
+        const string Device2ConnStrKey = "device2ConnStrKey";
+        const string Device3ConnStrKey = "device3ConnStrKey";
         static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(5);
+<<<<<<< HEAD
 
         static readonly int EventHubMessageReceivedRetry = 5;
+=======
+        static readonly int EventHubMessageReceivedRetry = 10;
+        static readonly ILogger logger = Logger.Factory.CreateLogger(nameof(CloudProxyTest));
+>>>>>>> d7a74bfe... Fix flaky CI tests - Overloaded consumer group partitions (#2114)
 
         [Fact]
         [TestPriority(401)]
         public async Task SendMessageTest()
         {
+            string device2ConnectionString = await SecretsHelper.GetSecretFromConfigKey(Device2ConnStrKey);
+            string deviceId2 = IotHubConnectionStringBuilder.Create(device2ConnectionString).DeviceId;
+
             IMessage message = MessageHelper.GenerateMessages(1)[0];
             DateTime startTime = DateTime.UtcNow.Subtract(ClockSkew);
-            ICloudProxy cloudProxy = await this.GetCloudProxyWithConnectionStringKey("device2ConnStrKey");
+            ICloudProxy cloudProxy = await this.GetCloudProxyFromConnectionStringKey(Device2ConnStrKey);
             await cloudProxy.SendMessageAsync(message);
+
+            Dictionary<string, IList<IMessage>> sentMessagesByDevice = new Dictionary<string, IList<IMessage>>();
+            sentMessagesByDevice.Add(deviceId2, new List<IMessage>());
+            sentMessagesByDevice[deviceId2].Add(message);
+
             bool disconnectResult = await cloudProxy.CloseAsync();
             Assert.True(disconnectResult);
 
-            await CheckMessageInEventHub(new List<IMessage> { message }, startTime);
+            await CheckMessageInEventHub(sentMessagesByDevice, startTime);
         }
 
         [Fact]
@@ -49,43 +65,64 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             IList<IMessage> messages = MessageHelper.GenerateMessages(4);
             DateTime startTime = DateTime.UtcNow.Subtract(ClockSkew);
 
-            ICloudProxy cloudProxy1 = await this.GetCloudProxyWithConnectionStringKey("device2ConnStrKey");
+            string device2ConnectionString = await SecretsHelper.GetSecretFromConfigKey(Device2ConnStrKey);
+            string device3ConnectionString = await SecretsHelper.GetSecretFromConfigKey(Device3ConnStrKey);
+            string deviceId2 = IotHubConnectionStringBuilder.Create(device2ConnectionString).DeviceId;
+            string deviceId3 = IotHubConnectionStringBuilder.Create(device3ConnectionString).DeviceId;
 
-            ICloudProxy cloudProxy2 = await this.GetCloudProxyWithConnectionStringKey("device3ConnStrKey");
+            ICloudProxy cloudProxy2 = await this.GetCloudProxyFromConnectionStringKey(Device2ConnStrKey);
+            ICloudProxy cloudProxy3 = await this.GetCloudProxyFromConnectionStringKey(Device3ConnStrKey);
+
+            Dictionary<string, IList<IMessage>> sentMessagesByDevice = new Dictionary<string, IList<IMessage>>();
+            sentMessagesByDevice.Add(deviceId2, new List<IMessage>());
+            sentMessagesByDevice.Add(deviceId3, new List<IMessage>());
 
             for (int i = 0; i < messages.Count; i = i + 2)
             {
-                await cloudProxy1.SendMessageAsync(messages[i]);
-                await cloudProxy2.SendMessageAsync(messages[i + 1]);
+                IMessage device2Message = messages[i];
+                IMessage device3Message = messages[i + 1];
+
+                await cloudProxy2.SendMessageAsync(device2Message);
+                await cloudProxy3.SendMessageAsync(device3Message);
+
+                sentMessagesByDevice[deviceId2].Add(device2Message);
+                sentMessagesByDevice[deviceId3].Add(device3Message);
             }
 
-            bool disconnectResult = await cloudProxy1.CloseAsync();
+            bool disconnectResult = await cloudProxy2.CloseAsync();
             Assert.True(disconnectResult);
-            disconnectResult = await cloudProxy2.CloseAsync();
+            disconnectResult = await cloudProxy3.CloseAsync();
             Assert.True(disconnectResult);
 
-            await CheckMessageInEventHub(messages, startTime);
+            await CheckMessageInEventHub(sentMessagesByDevice, startTime);
         }
 
         [Fact]
         [TestPriority(403)]
         public async Task SendMessageBatchTest()
         {
+            string device2ConnectionString = await SecretsHelper.GetSecretFromConfigKey(Device2ConnStrKey);
+            string deviceId2 = IotHubConnectionStringBuilder.Create(device2ConnectionString).DeviceId;
+
             IList<IMessage> messages = MessageHelper.GenerateMessages(4);
             DateTime startTime = DateTime.UtcNow.Subtract(ClockSkew);
-            ICloudProxy cloudProxy = await this.GetCloudProxyWithConnectionStringKey("device2ConnStrKey");
+            ICloudProxy cloudProxy = await this.GetCloudProxyFromConnectionStringKey(Device2ConnStrKey);
             await cloudProxy.SendMessageBatchAsync(messages);
+
+            Dictionary<string, IList<IMessage>> sentMessagesByDevice = new Dictionary<string, IList<IMessage>>();
+            sentMessagesByDevice.Add(deviceId2, messages);
+
             bool disconnectResult = await cloudProxy.CloseAsync();
             Assert.True(disconnectResult);
 
-            await CheckMessageInEventHub(messages, startTime);
+            await CheckMessageInEventHub(sentMessagesByDevice, startTime);
         }
 
         [Fact]
         [TestPriority(404)]
         public async Task CanGetTwin()
         {
-            ICloudProxy cloudProxy = await this.GetCloudProxyWithConnectionStringKey("device2ConnStrKey");
+            ICloudProxy cloudProxy = await this.GetCloudProxyFromConnectionStringKey(Device2ConnStrKey);
             IMessage result = await cloudProxy.GetTwinAsync();
             string actualString = Encoding.UTF8.GetString(result.Body);
             Assert.StartsWith("{", actualString);
@@ -97,7 +134,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         [TestPriority(405)]
         public async Task CanUpdateReportedProperties()
         {
-            ICloudProxy cloudProxy = await this.GetCloudProxyWithConnectionStringKey("device2ConnStrKey");
+            ICloudProxy cloudProxy = await this.GetCloudProxyFromConnectionStringKey(Device2ConnStrKey);
             IMessage message = await cloudProxy.GetTwinAsync();
 
             JObject twin = JObject.Parse(Encoding.UTF8.GetString(message.Body));
@@ -125,12 +162,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         {
             var update = new TaskCompletionSource<IMessage>();
             var edgeHub = new Mock<IEdgeHub>();
-            string deviceConnectionStringKey = "device2ConnStrKey";
             edgeHub.Setup(x => x.UpdateDesiredPropertiesAsync(It.IsAny<string>(), It.IsAny<IMessage>()))
                 .Callback((string _, IMessage m) => update.TrySetResult(m))
                 .Returns(TaskEx.Done);
 
-            ICloudProxy cloudProxy = await this.GetCloudProxyWithConnectionStringKey(deviceConnectionStringKey, edgeHub.Object);
+            ICloudProxy cloudProxy = await this.GetCloudProxyFromConnectionStringKey(Device2ConnStrKey, edgeHub.Object);
 
             await cloudProxy.SetupDesiredPropertyUpdatesAsync();
 
@@ -139,7 +175,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 ["desiredPropertyTest"] = Guid.NewGuid().ToString()
             };
 
-            await UpdateDesiredProperty(ConnectionStringHelper.GetDeviceId(await SecretsHelper.GetSecretFromConfigKey(deviceConnectionStringKey)), desired);
+            await UpdateDesiredProperty(ConnectionStringHelper.GetDeviceId(await SecretsHelper.GetSecretFromConfigKey(Device2ConnStrKey)), desired);
             await update.Task;
             await cloudProxy.RemoveDesiredPropertyUpdatesAsync();
 
@@ -158,8 +194,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         public async Task CloudProxyNullReceiverTest()
         {
             // Arrange
-            string deviceConnectionStringKey = "device2ConnStrKey";
-            ICloudProxy cloudProxy = await this.GetCloudProxyWithConnectionStringKey(deviceConnectionStringKey);
+            ICloudProxy cloudProxy = await this.GetCloudProxyFromConnectionStringKey(Device2ConnStrKey);
 
             // Act/assert
             // Without setting up the CloudListener, the following methods should not throw.
@@ -216,28 +251,46 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             client.VerifyAll();
         }
 
-        static async Task CheckMessageInEventHub(IList<IMessage> sentMessages, DateTime startTime)
+        static async Task CheckMessageInEventHub(Dictionary<string, IList<IMessage>> sentMessagesByDevice, DateTime startTime)
         {
             string eventHubConnectionString = await SecretsHelper.GetSecretFromConfigKey("eventHubConnStrKey");
             var eventHubReceiver = new EventHubReceiver(eventHubConnectionString);
-            var cloudMessages = new List<EventData>();
+            var receivedMessagesByPartition = new Dictionary<string, List<EventData>>();
+
             bool messagesFound = false;
+<<<<<<< HEAD
             // Add retry mechanism to make sure all the messages sent reached Event Hub. Retry 3 times.
             for (int i = 0; i < EventHubMessageReceivedRetry; i++)
+=======
+            // If this test becomes flaky, use PartitionReceiver as a background Task to continuously retrieve messages.
+            for (int i = 0; i < EventHubMessageReceivedRetry; i++) // Retry for event hub being slow to process messages.
+>>>>>>> d7a74bfe... Fix flaky CI tests - Overloaded consumer group partitions (#2114)
             {
-                cloudMessages.AddRange(await eventHubReceiver.GetMessagesFromAllPartitions(startTime));
-                messagesFound = MessageHelper.CompareMessagesAndEventData(sentMessages, cloudMessages);
+                foreach (string deviceId in sentMessagesByDevice.Keys)
+                {
+                    receivedMessagesByPartition[deviceId] = await eventHubReceiver.GetMessagesForDevice(deviceId, startTime);
+                }
+
+                messagesFound = MessageHelper.ValidateSentMessagesWereReceived(sentMessagesByDevice, receivedMessagesByPartition);
+
                 if (messagesFound)
                 {
                     break;
+                }
+                else
+                {
+                    logger.LogInformation($"Messages not found in event hub for attempt {i}");
                 }
 
                 await Task.Delay(TimeSpan.FromSeconds(20));
             }
 
-            await eventHubReceiver.Close();
-            Assert.NotNull(cloudMessages);
-            Assert.NotEmpty(cloudMessages);
+            foreach (string device in receivedMessagesByPartition.Keys)
+            {
+                Assert.NotNull(receivedMessagesByPartition[device]);
+                Assert.NotEmpty(receivedMessagesByPartition[device]);
+            }
+
             Assert.True(messagesFound);
         }
 
@@ -251,10 +304,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             desired["$version"] = twin.Properties.Desired.Version;
         }
 
-        Task<ICloudProxy> GetCloudProxyWithConnectionStringKey(string connectionStringConfigKey) =>
-            this.GetCloudProxyWithConnectionStringKey(connectionStringConfigKey, Mock.Of<IEdgeHub>());
+        Task<ICloudProxy> GetCloudProxyFromConnectionStringKey(string connectionStringConfigKey) =>
+            this.GetCloudProxyFromConnectionStringKey(connectionStringConfigKey, Mock.Of<IEdgeHub>());
 
-        async Task<ICloudProxy> GetCloudProxyWithConnectionStringKey(string connectionStringConfigKey, IEdgeHub edgeHub)
+        async Task<ICloudProxy> GetCloudProxyFromConnectionStringKey(string connectionStringConfigKey, IEdgeHub edgeHub)
         {
             const int ConnectionPoolSize = 10;
             string deviceConnectionString = await SecretsHelper.GetSecretFromConfigKey(connectionStringConfigKey);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/EventHubReceiver.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/EventHubReceiver.cs
@@ -4,52 +4,48 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     using System;
     using System.Collections.Generic;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Common;
     using Microsoft.Azure.EventHubs;
 
     public class EventHubReceiver
     {
-        readonly EventHubClient eventHubClient;
+        const string EventHubConsumerGroup = "ci-tests";
+        readonly string eventHubConnectionString;
 
         public EventHubReceiver(string eventHubConnectionString)
         {
-            this.eventHubClient = EventHubClient.CreateFromConnectionString(eventHubConnectionString);
+            this.eventHubConnectionString = eventHubConnectionString;
         }
 
-        public async Task<IList<EventData>> GetMessagesFromAllPartitions(DateTime startTime, int maxPerPartition = 10, int waitTimeSecs = 5)
+        public async Task<List<EventData>> GetMessagesForDevice(string deviceId, DateTime startTime, int maxPerPartition = 100, int waitTimeSecs = 5)
         {
             var messages = new List<EventData>();
-            EventHubRuntimeInformation rtInfo = await this.eventHubClient.GetRuntimeInformationAsync();
-            foreach (string partition in rtInfo.PartitionIds)
+
+            EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(this.eventHubConnectionString);
+            PartitionReceiver partitionReceiver = eventHubClient.CreateReceiver(
+                EventHubConsumerGroup,
+                EventHubPartitionKeyResolver.ResolveToPartition(deviceId, (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
+                EventPosition.FromEnqueuedTime(startTime));
+
+            // Retry a few times due to weird behavior with ReceiveAsync() not returning all messages available
+            for (int i = 0; i < 3; i++)
             {
-                PartitionReceiver partitionReceiver = this.eventHubClient.CreateReceiver(
-                    PartitionReceiver.DefaultConsumerGroupName,
-                    partition,
-                    EventPosition.FromEnqueuedTime(startTime));
-
-                // Retry a few times to make sure we get all expected messages.
-                for (int i = 0; i < 3; i++)
+                IEnumerable<EventData> events = await partitionReceiver.ReceiveAsync(maxPerPartition, TimeSpan.FromSeconds(waitTimeSecs));
+                if (events != null)
                 {
-                    IEnumerable<EventData> events = await partitionReceiver.ReceiveAsync(maxPerPartition, TimeSpan.FromSeconds(waitTimeSecs));
-                    if (events != null)
-                    {
-                        messages.AddRange(events);
-                    }
-
-                    if (i < 3)
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(5));
-                    }
+                    messages.AddRange(events);
                 }
 
-                await partitionReceiver.CloseAsync();
+                if (i < 3)
+                {
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
             }
 
-            return messages;
-        }
+            await partitionReceiver.CloseAsync();
+            await eventHubClient.CloseAsync();
 
-        public async Task Close()
-        {
-            await this.eventHubClient.CloseAsync();
+            return messages;
         }
     }
 }

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -363,8 +363,9 @@ namespace IotEdgeQuickstart.Details
                     (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
                 EventPosition.FromEnd());
 
+            // TODO: [Improvement] should verify test results without using event hub, which introduce latency.
             var result = new TaskCompletionSource<bool>();
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed in case event hub is slow to process messages
             {
                 using (cts.Token.Register(() => result.TrySetCanceled()))
                 {

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -277,7 +277,7 @@ namespace IotEdgeQuickstart.Details
         protected async Task VerifyEdgeAgentIsConnectedToIotHub()
         {
             Console.WriteLine("Verifying if edge is connected to IoThub");
-            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(300)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(600))) // Long timeout is needed because registry manager takes a while for the device identity to be usable
             {
                 Exception savedException = null;
 
@@ -289,7 +289,7 @@ namespace IotEdgeQuickstart.Details
                     ServiceClient serviceClient =
                         ServiceClient.CreateFromConnectionString(this.context.IotHubConnectionString, this.serviceClientTransportType, settings);
 
-                    while (true)
+                    while (!cts.IsCancellationRequested)
                     {
                         await Task.Delay(TimeSpan.FromSeconds(10), cts.Token);
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -95,7 +95,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed for resource constrained devices pulling the large tempFilterFunctions image
             {
                 string errorMessage = null;
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -55,7 +55,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed for resource constrained devices pulling the large tempFilterFunctions image
             {
                 try
                 {


### PR DESCRIPTION
[2114](https://github.com/Azure/iotedge/pull/2114) - CloudProxyTest overloaded partitions within consumer group

[2163](https://github.com/Azure/iotedge/pull/2163) - TempFilterFunc image download and direct method testing timeout increases

[2173](https://github.com/Azure/iotedge/pull/2173) - Increase timeouts for slow registry manager device creation