### PR TITLE
Turn microsoft asp.net logging to Error level

### DIFF
--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -161,6 +161,9 @@
             "status": "running",
             "restartPolicy": "always",
             "env": {
+              "Logging:LogLevel:Microsoft": {
+                "value": "Error"
+              },            
               "trackingId": {
                 "value": "<TrackingId>"
               },


### PR DESCRIPTION
Turn microsoft asp.net logging to Error level to reduce the volume of log in TRC.