### PR TITLE
Add twin tester to deployment

### DIFF
--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -297,6 +297,138 @@
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"5001/tcp\": [{\"HostPort\": \"5001\"}]}}}"
             }
           },
+          "twinTester1": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "trackingId": {
+                "value": "<TrackingId>"
+              },
+              "TestResultCoordinatorUrl": {
+                "value": "http://localhost:5001"
+              },
+              "TwinTestMode": {
+                "value": "TwinCloudOperations"
+              },
+              "TestStartDelay": {
+                "value": "<TestStartDelay>"
+              },
+              "TestDuration": {
+                "value": "<TestDuration>"
+              },
+              "ServiceClientConnectionString": {
+                "value": "<ServiceClientConnectionString>"
+              },
+              "TargetModuleId": {
+                "value": "twinTester2"
+              }
+            },
+            "settings": {
+              "image": "<Container_Registry>/microsoft/azureiotedge-twin-tester:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": "{\"HostConfig\":{\"NetworkMode\":\"host\"},\"NetworkingConfig\":{\"EndpointsConfig\":{\"host\":{}}}}"
+            }
+          },
+          "twinTester2": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "trackingId": {
+                "value": "<TrackingId>"
+              },
+              "TestResultCoordinatorUrl": {
+                "value": "http://testResultCoordinator:5001"
+              },
+              "TwinTestMode": {
+                "value": "TwinEdgeOperations"
+              },
+              "TestStartDelay": {
+                "value": "<TestStartDelay>"
+              },
+              "TestDuration": {
+                "value": "<TestDuration>"
+              },
+              "ServiceClientConnectionString": {
+                "value": "<ServiceClientConnectionString>"
+              },
+              "TransportType" : {
+                "value": "Amqp"
+              }
+            },
+            "settings": {
+              "image": "<Container_Registry>/microsoft/azureiotedge-twin-tester:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            }
+          },
+          "twinTester3": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "trackingId": {
+                "value": "<TrackingId>"
+              },
+              "TestResultCoordinatorUrl": {
+                "value": "http://localhost:5001"
+              },
+              "TwinTestMode": {
+                "value": "TwinCloudOperations"
+              },
+              "TestStartDelay": {
+                "value": "<TestStartDelay>"
+              },
+              "TestDuration": {
+                "value": "<TestDuration>"
+              },
+              "ServiceClientConnectionString": {
+                "value": "<ServiceClientConnectionString>"
+              },
+              "TargetModuleId": {
+                "value": "twinTester4"
+              }
+            },
+            "settings": {
+              "image": "<Container_Registry>/microsoft/azureiotedge-twin-tester:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": "{\"HostConfig\":{\"NetworkMode\":\"host\"},\"NetworkingConfig\":{\"EndpointsConfig\":{\"host\":{}}}}"
+            }
+          },
+          "twinTester4": {
+            "version": "1.0",
+            "type": "docker",
+            "status": "running",
+            "restartPolicy": "always",
+            "env": {
+              "trackingId": {
+                "value": "<TrackingId>"
+              },
+              "TestResultCoordinatorUrl": {
+                "value": "http://testResultCoordinator:5001"
+              },
+              "TwinTestMode": {
+                "value": "TwinEdgeOperations"
+              },
+              "TestStartDelay": {
+                "value": "<TestStartDelay>"
+              },
+              "TestDuration": {
+                "value": "<TestDuration>"
+              },
+              "ServiceClientConnectionString": {
+                "value": "<ServiceClientConnectionString>"
+              },
+              "TransportType" : {
+                "value": "Mqtt"
+              }
+            },
+            "settings": {
+              "image": "<Container_Registry>/microsoft/azureiotedge-twin-tester:<Build.BuildNumber>-linux-<Architecture>",
+              "createOptions": ""
+            }
+          },
           "networkController": {
             "version": "1.0",
             "type": "docker",

--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -290,6 +290,9 @@
               },
               "logAnalyticsLogType": {
                 "value": "<TestResultCoordinator.LogAnalyticsLogType>"
+              },
+              "ServiceClientConnectionString": {
+                "value": "<ServiceClientConnectionString>"
               }
             },
             "settings": {


### PR DESCRIPTION
Added twin tester modules to connectivity deployment:
twinTester1 sends to cloud twin desired properties update for twinTester2.
twinTester2 connects to edgeHub with AMQP, subscribes to desired properties updates and sends reported properties.
twinTester3 sends to cloud twin desired properties update for twinTester4.
twinTester4 connects to edgeHub with MQTT, subscribes to desired properties updates and sends reported properties.
twinTester1 and twinTester3 are running on Host network, 
twinTester2 and twinTester4 running on iot-edge-network
