### PR TITLE
Fix E2E flake - Increase timeouts (#2163)

### DIFF
--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -363,8 +363,9 @@ namespace IotEdgeQuickstart.Details
                     (await eventHubClient.GetRuntimeInformationAsync()).PartitionCount),
                 EventPosition.FromEnd());
 
+            // TODO: [Improvement] should verify test results without using event hub, which introduce latency.
             var result = new TaskCompletionSource<bool>();
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed in case event hub is slow to process messages
             {
                 using (cts.Token.Register(() => result.TrySetCanceled()))
                 {

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -95,7 +95,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(10)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed for resource constrained devices pulling the large tempFilterFunctions image
             {
                 string errorMessage = null;
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -55,7 +55,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task VerifyModuleIsRunning(string name)
         {
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed for resource constrained devices pulling the large tempFilterFunctions image
             {
                 try
                 {


### PR DESCRIPTION
Cherry pick of #2163
* increase timeout for tempFilterFunctions
* increase timeout for direct methods