### PR TITLE
Twin tester use target module id to update twin

### DIFF
--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/TwinCountingReportGeneratorTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/TwinCountingReportGeneratorTest.cs
@@ -251,7 +251,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
 
             Assert.Equal(expectedTotalExpectedCount, report.TotalExpectCount);
             Assert.Equal(expectedTotalMatchCount, report.TotalMatchCount);
-            Assert.Equal(expectedTotalPatches, report.TotalPatches);
+            Assert.Equal(expectedTotalPatches, report.TotalPatchesCount);
             Assert.Equal(expectedMissingResultsCount, report.UnmatchedResults.Count);
         }
 

--- a/test/modules/TestResultCoordinator/Reports/CloudTwinTestResultCollection.cs
+++ b/test/modules/TestResultCoordinator/Reports/CloudTwinTestResultCollection.cs
@@ -66,6 +66,8 @@ namespace TestResultCoordinator.Reports
                     return null;
                 }
 
+                Logger.LogDebug($"Twin reported properties from cloud {twin.Properties.Reported}");
+
                 return new TwinTestResult(this.source, twin.LastActivityTime.HasValue ? twin.LastActivityTime.Value : DateTime.UtcNow)
                 {
                     TrackingId = this.trackingId,

--- a/test/modules/TestResultCoordinator/Reports/TestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/Reports/TestReportGeneratorFactory.cs
@@ -94,7 +94,7 @@ namespace TestResultCoordinator.Reports
                 throw new NotSupportedException($"Report type {reportMetadata.TestReportType} requires TwinReportMetadata instead of {reportMetadata.GetType()}");
             }
 
-            if (twinMetadata.TwinTestPropertyType == TwinTestPropertyType.Reported)
+            if (twinMetadata.TwinTestPropertyType == TwinTestPropertyType.Desired)
             {
                 return this.GetExpectedResults(reportMetadata);
             }

--- a/test/modules/TestResultCoordinator/Reports/TwinCountingReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/TwinCountingReport.cs
@@ -5,12 +5,13 @@ namespace TestResultCoordinator.Reports
 
     class TwinCountingReport : TestResultReportBase
     {
-        public TwinCountingReport(string trackingId, string expectedSource, string actualSource, string resultType, ulong totalExpectCount, ulong totalMatchCount, ulong totalPatches, ReadOnlyCollection<string> unmatchedResults)
+        public TwinCountingReport(string trackingId, string expectedSource, string actualSource, string resultType, ulong totalExpectCount, ulong totalMatchCount, ulong totalPatches, ulong totalDuplicates, ReadOnlyCollection<string> unmatchedResults)
             : base(trackingId, expectedSource, actualSource, resultType)
         {
             this.TotalExpectCount = totalExpectCount;
             this.TotalMatchCount = totalMatchCount;
-            this.TotalPatches = totalPatches;
+            this.TotalPatchesCount = totalPatches;
+            this.TotalDuplicateResultCount = totalDuplicates;
             this.UnmatchedResults = unmatchedResults;
         }
 
@@ -18,7 +19,9 @@ namespace TestResultCoordinator.Reports
 
         public ulong TotalMatchCount { get; }
 
-        public ulong TotalPatches { get; }
+        public ulong TotalPatchesCount { get; }
+
+        public ulong TotalDuplicateResultCount { get; }
 
         public ReadOnlyCollection<string> UnmatchedResults { get; }
 

--- a/test/modules/TestResultCoordinator/Reports/TwinCountingReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/Reports/TwinCountingReportGenerator.cs
@@ -54,7 +54,6 @@ namespace TestResultCoordinator.Reports
                     {
                         foreach (var prop in r.Properties)
                         {
-                            Logger.LogDebug($"Add {expectedSource} {prop.ToString()}");
                             propertiesUpdated.TryAdd(prop.ToString(), this.expectedTestResults.Current.CreatedAt);
                         }
                     });
@@ -72,7 +71,6 @@ namespace TestResultCoordinator.Reports
                     {
                         foreach (var prop in r.Properties)
                         {
-                            Logger.LogDebug($"Add {actualSource} {prop.ToString()}");
                             bool added = propertiesReceived.TryAdd(prop.ToString(), this.actualTestResults.Current.CreatedAt);
                             if (!added)
                             {
@@ -125,7 +123,6 @@ namespace TestResultCoordinator.Reports
                 Option.None<TwinTestResult>();
             }
 
-            Logger.LogDebug($"Deserializing for source {current.Source} result: {current.Result} {current.Type}");
             TwinTestResult twinTestResult = JsonConvert.DeserializeObject<TwinTestResult>(current.Result);
             return Option.Some(twinTestResult);
         }

--- a/test/modules/TestResultCoordinator/Reports/TwinCountingReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/Reports/TwinCountingReportGenerator.cs
@@ -33,11 +33,12 @@ namespace TestResultCoordinator.Reports
 
         public async Task<ITestResultReport> CreateReportAsync()
         {
-            Logger.LogInformation($"Start to generate report by {nameof(TwinCountingReportGenerator)} for Sources [{this.expectedTestResults}] and [{this.actualSource}]");
+            Logger.LogInformation($"Start to generate report by {nameof(TwinCountingReportGenerator)} for Sources [{this.expectedSource}] and [{this.actualSource}]");
 
             ulong totalExpectCount = 0;
             ulong totalMatchCount = 0;
             ulong totalPatches = 0;
+            ulong totalDuplicates = 0;
             List<string> unmatchedResults = new List<string>();
 
             Dictionary<string, DateTime> propertiesUpdated = new Dictionary<string, DateTime>();
@@ -46,13 +47,15 @@ namespace TestResultCoordinator.Reports
             while (await this.expectedTestResults.MoveNextAsync())
             {
                 Option<TwinTestResult> twinTestResult = this.GetTwinTestResult(this.expectedTestResults.Current);
+                Logger.LogDebug($"Expected test results {twinTestResult}");
 
                 twinTestResult.ForEach(
                     r =>
                     {
                         foreach (var prop in r.Properties)
                         {
-                            propertiesUpdated.Add(prop.ToString(), this.expectedTestResults.Current.CreatedAt);
+                            Logger.LogDebug($"Add {expectedSource} {prop.ToString()}");
+                            propertiesUpdated.TryAdd(prop.ToString(), this.expectedTestResults.Current.CreatedAt);
                         }
                     });
             }
@@ -62,12 +65,20 @@ namespace TestResultCoordinator.Reports
                 totalPatches++;
 
                 Option<TwinTestResult> twinTestResult = this.GetTwinTestResult(this.actualTestResults.Current);
+                Logger.LogDebug($"Actual test results {twinTestResult}");
+
                 twinTestResult.ForEach(
                     r =>
                     {
                         foreach (var prop in r.Properties)
                         {
-                            propertiesReceived.Add(prop.ToString(), this.actualTestResults.Current.CreatedAt);
+                            Logger.LogDebug($"Add {actualSource} {prop.ToString()}");
+                            bool added = propertiesReceived.TryAdd(prop.ToString(), this.actualTestResults.Current.CreatedAt);
+                            if (!added)
+                            {
+                                Logger.LogDebug($"Duplicate for {actualSource} {prop.ToString()}");
+                                totalDuplicates++;
+                            }
                         }
                     });
             }
@@ -103,6 +114,7 @@ namespace TestResultCoordinator.Reports
                 totalExpectCount,
                 totalMatchCount,
                 totalPatches,
+                totalDuplicates,
                 unmatchedResults.AsReadOnly());
         }
 

--- a/test/modules/TestResultCoordinator/Settings.cs
+++ b/test/modules/TestResultCoordinator/Settings.cs
@@ -147,10 +147,10 @@ namespace TestResultCoordinator
                 new CountingReportMetadata("directMethodSender1.send", "directMethodReceiver1.receive", TestOperationResultType.DirectMethod, TestReportType.CountingReport),
                 new CountingReportMetadata("directMethodSender2.send", "directMethodReceiver2.receive", TestOperationResultType.DirectMethod, TestReportType.CountingReport),
                 new TwinCountingReportMetadata("twinTester1.desiredUpdated", "twinTester2.desiredReceived", TestReportType.TwinCountingReport, TwinTestPropertyType.Desired),
-                new TwinCountingReportMetadata("twinTester2.reportedUpdated", "twinTester2.reportedReceived", TestReportType.TwinCountingReport, TwinTestPropertyType.Reported),
+                new TwinCountingReportMetadata("twinTester2.reportedReceived", "twinTester2.reportedUpdated", TestReportType.TwinCountingReport, TwinTestPropertyType.Reported),
                 new TwinCountingReportMetadata("twinTester3.desiredUpdated", "twinTester4.desiredReceived", TestReportType.TwinCountingReport, TwinTestPropertyType.Desired),
-                new TwinCountingReportMetadata("twinTester4.reportedUpdated", "twinTester4.reportedReceived", TestReportType.TwinCountingReport, TwinTestPropertyType.Reported),
-                new DeploymentTestReportMetadata("deploymentTester1.send",  "deploymentTester2.receive"),
+                new TwinCountingReportMetadata("twinTester4.reportedReceived", "twinTester4.reportedUpdated", TestReportType.TwinCountingReport, TwinTestPropertyType.Reported),
+                new DeploymentTestReportMetadata("deploymentTester1.send",  "deploymentTester2.receive")
             };
         }
 

--- a/test/modules/TwinTester/DesiredPropertiesValidator.cs
+++ b/test/modules/TwinTester/DesiredPropertiesValidator.cs
@@ -85,7 +85,7 @@ namespace TwinTester
                     continue;
                 }
 
-                await this.HandleReportStatusAsync(Settings.Current.ModuleId, status);
+                await this.HandleReportStatusAsync(status);
                 propertiesToRemoveFromTwin.Add(desiredPropertyUpdate.Key, null); // will later be serialized as a twin update
             }
 
@@ -113,7 +113,7 @@ namespace TwinTester
             try
             {
                 string patch = $"{{ properties: {{ desired: {JsonConvert.SerializeObject(propertiesToRemoveFromTwin)} }}";
-                Twin newTwin = await this.registryManager.UpdateTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId, patch, this.twinState.TwinETag);
+                Twin newTwin = await this.registryManager.UpdateTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, patch, this.twinState.TwinETag);
                 this.twinState.TwinETag = newTwin.ETag;
             }
             catch (Exception e)
@@ -128,7 +128,7 @@ namespace TwinTester
             return DateTime.UtcNow - comparisonPoint > Settings.Current.TwinUpdateFailureThreshold;
         }
 
-        async Task HandleReportStatusAsync(string moduleId, string status)
+        async Task HandleReportStatusAsync(string status)
         {
             await this.resultHandler.HandleTwinValidationStatusAsync(status);
         }

--- a/test/modules/TwinTester/DesiredPropertyReceiver.cs
+++ b/test/modules/TwinTester/DesiredPropertyReceiver.cs
@@ -11,13 +11,11 @@ namespace TwinTester
     class DesiredPropertyReceiver : ITwinOperation
     {
         static readonly ILogger Logger = ModuleUtil.CreateLogger(nameof(DesiredPropertyReceiver));
-        readonly RegistryManager registryManager;
         readonly ModuleClient moduleClient;
         readonly ITwinTestResultHandler resultHandler;
 
-        public DesiredPropertyReceiver(RegistryManager registryManager, ModuleClient moduleClient, ITwinTestResultHandler resultHandler)
+        public DesiredPropertyReceiver(ModuleClient moduleClient, ITwinTestResultHandler resultHandler)
         {
-            this.registryManager = registryManager;
             this.moduleClient = moduleClient;
             this.resultHandler = resultHandler;
         }

--- a/test/modules/TwinTester/DesiredPropertyUpdater.cs
+++ b/test/modules/TwinTester/DesiredPropertyUpdater.cs
@@ -38,7 +38,7 @@ namespace TwinTester
 
                 Logger.LogInformation($"Desired property updated {propertyKey}");
 
-                await this.Report(propertyKey);
+                await this.Report(propertyKey, desiredPropertyUpdateValue);
             }
             catch (Exception e)
             {
@@ -46,11 +46,11 @@ namespace TwinTester
             }
         }
 
-        async Task Report(string propertyKey)
+        async Task Report(string propertyKey, string value)
         {
             try
             {
-                await this.resultHandler.HandleDesiredPropertyUpdateAsync(propertyKey);
+                await this.resultHandler.HandleDesiredPropertyUpdateAsync(propertyKey, value);
                 this.twinState.DesiredPropertyUpdateCounter += 1;
             }
             catch (Exception e)

--- a/test/modules/TwinTester/ITwinTestInitializer.cs
+++ b/test/modules/TwinTester/ITwinTestInitializer.cs
@@ -5,8 +5,10 @@ namespace TwinTester
     using System.Threading;
     using System.Threading.Tasks;
 
-    interface ITwinTestInitializer : IDisposable
+    interface ITwinTestInitializer
     {
         Task StartAsync(CancellationToken cancellationToken);
+
+        void Stop();
     }
 }

--- a/test/modules/TwinTester/ITwinTestInitializer.cs
+++ b/test/modules/TwinTester/ITwinTestInitializer.cs
@@ -2,10 +2,11 @@
 namespace TwinTester
 {
     using System;
+    using System.Threading;
     using System.Threading.Tasks;
 
     interface ITwinTestInitializer : IDisposable
     {
-        Task Start();
+        Task StartAsync(CancellationToken cancellationToken);
     }
 }

--- a/test/modules/TwinTester/ITwinTestResultHandler.cs
+++ b/test/modules/TwinTester/ITwinTestResultHandler.cs
@@ -6,13 +6,13 @@ namespace TwinTester
 
     interface ITwinTestResultHandler
     {
-        Task HandleDesiredPropertyUpdateAsync(string propertyKey);
+        Task HandleDesiredPropertyUpdateAsync(string propertyKey, string value);
 
         Task HandleDesiredPropertyReceivedAsync(TwinCollection properties);
 
         Task HandleTwinValidationStatusAsync(string status);
 
-        Task HandleReportedPropertyUpdateAsync(string propertyKey);
+        Task HandleReportedPropertyUpdateAsync(string propertyKey, string value);
 
         Task HandleReportedPropertyUpdateExceptionAsync(string failureStatus);
     }

--- a/test/modules/TwinTester/Program.cs
+++ b/test/modules/TwinTester/Program.cs
@@ -20,11 +20,12 @@ namespace TwinTester
 
             Logger.LogInformation($"Starting twin tester with the following settings:\r\n{Settings.Current}");
 
+            ITwinTestInitializer twinOperator = null;
             try
             {
                 using (RegistryManager registryManager = RegistryManager.CreateFromConnectionString(Settings.Current.ServiceClientConnectionString))
                 {
-                    ITwinTestInitializer twinOperator = await GetTwinOperatorAsync(registryManager);
+                    twinOperator = await GetTwinOperatorAsync(registryManager);
                     await twinOperator.StartAsync(cts.Token);
                     await Task.Delay(Settings.Current.TestDuration, cts.Token);
 
@@ -40,6 +41,7 @@ namespace TwinTester
             catch (Exception ex)
             {
                 Logger.LogError(ex, $"Error occurred during twin test setup.");
+                twinOperator?.Stop();
             }
         }
 

--- a/test/modules/TwinTester/Program.cs
+++ b/test/modules/TwinTester/Program.cs
@@ -22,13 +22,11 @@ namespace TwinTester
 
             try
             {
-                await Task.Delay(Settings.Current.TestStartDelay);
-
                 RegistryManager registryManager = RegistryManager.CreateFromConnectionString(Settings.Current.ServiceClientConnectionString);
 
                 using (ITwinTestInitializer twinOperator = await GetTwinOperatorAsync(registryManager))
                 {
-                    await twinOperator.Start();
+                    await twinOperator.StartAsync(cts.Token);
                     await Task.Delay(Settings.Current.TestDuration, cts.Token);
                 }
 

--- a/test/modules/TwinTester/Program.cs
+++ b/test/modules/TwinTester/Program.cs
@@ -24,11 +24,12 @@ namespace TwinTester
             {
                 RegistryManager registryManager = RegistryManager.CreateFromConnectionString(Settings.Current.ServiceClientConnectionString);
 
-                using (ITwinTestInitializer twinOperator = await GetTwinOperatorAsync(registryManager))
-                {
-                    await twinOperator.StartAsync(cts.Token);
-                    await Task.Delay(Settings.Current.TestDuration, cts.Token);
-                }
+                ITwinTestInitializer twinOperator = await GetTwinOperatorAsync(registryManager);
+                await twinOperator.StartAsync(cts.Token);
+                await Task.Delay(Settings.Current.TestDuration, cts.Token);
+
+                Logger.LogInformation($"Test run completed after {Settings.Current.TestDuration}");
+                twinOperator.Stop();
 
                 await cts.Token.WhenCanceled();
                 completed.Set();

--- a/test/modules/TwinTester/ReportedPropertiesValidator.cs
+++ b/test/modules/TwinTester/ReportedPropertiesValidator.cs
@@ -34,7 +34,7 @@ namespace TwinTester
             Twin receivedTwin;
             try
             {
-                receivedTwin = await this.registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId);
+                receivedTwin = await this.registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
                 this.twinState.TwinETag = receivedTwin.ETag;
             }
             catch (Exception e)
@@ -119,7 +119,7 @@ namespace TwinTester
                 }
 
                 propertiesToRemoveFromTwin[reportedPropertyUpdate.Key] = null; // will later be serialized as a twin update
-                await this.HandleReportStatusAsync(Settings.Current.ModuleId, status);
+                await this.HandleReportStatusAsync(status);
             }
 
             return propertiesToRemoveFromTwin;
@@ -131,7 +131,7 @@ namespace TwinTester
             return DateTime.UtcNow - comparisonPoint > Settings.Current.TwinUpdateFailureThreshold;
         }
 
-        async Task HandleReportStatusAsync(string moduleId, string status)
+        async Task HandleReportStatusAsync(string status)
         {
             await this.reporter.HandleTwinValidationStatusAsync(status);
         }

--- a/test/modules/TwinTester/TwinAllOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinAllOperationsInitializer.cs
@@ -112,7 +112,7 @@ namespace TwinTester
             }
         }
 
-        public void Dispose()
+        public void Stop()
         {
             this.periodicValidation.Dispose();
             this.periodicUpdate.Dispose();

--- a/test/modules/TwinTester/TwinAllOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinAllOperationsInitializer.cs
@@ -114,7 +114,6 @@ namespace TwinTester
         {
             this.periodicValidation?.Dispose();
             this.periodicUpdate?.Dispose();
-            this.periodicUpdate.Dispose();
         }
 
         static int GetNewPropertyCounter(Dictionary<string, DateTime> properties)

--- a/test/modules/TwinTester/TwinAllOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinAllOperationsInitializer.cs
@@ -52,9 +52,7 @@ namespace TwinTester
                     // reset desired properties
                     Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, new Twin(), twin.ETag);
 
-                    // reset reported properties
-                    TwinCollection eraseReportedProperties = TwinTesterUtil.GetResetedReportedPropertiesTwin(desiredPropertyResetTwin);
-                    await moduleClient.UpdateReportedPropertiesAsync(eraseReportedProperties);
+                    await TwinTesterUtil.ResetTwinReportedPropertiesAsync(moduleClient, desiredPropertyResetTwin);
 
                     await Task.Delay(TimeSpan.FromSeconds(10)); // give enough time for reported properties reset to reach cloud
                     twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);

--- a/test/modules/TwinTester/TwinAllOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinAllOperationsInitializer.cs
@@ -39,7 +39,7 @@ namespace TwinTester
             try
             {
                 TwinState initializedState;
-                Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId);
+                Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
                 Dictionary<string, DateTime> reportedPropertyUpdates = await storage.GetAllReportedPropertiesUpdatedAsync();
                 Dictionary<string, DateTime> desiredPropertyUpdates = await storage.GetAllDesiredPropertiesUpdatedAsync();
 
@@ -50,14 +50,14 @@ namespace TwinTester
                     Logger.LogInformation("No existing storage detected. Initializing new module twin for fresh run.");
 
                     // reset desired properties
-                    Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId, new Twin(), twin.ETag);
+                    Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, new Twin(), twin.ETag);
 
                     // reset reported properties
                     TwinCollection eraseReportedProperties = GetReportedPropertiesResetTwin(desiredPropertyResetTwin);
                     await moduleClient.UpdateReportedPropertiesAsync(eraseReportedProperties);
 
                     await Task.Delay(TimeSpan.FromSeconds(10)); // give enough time for reported properties reset to reach cloud
-                    twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId);
+                    twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
                     initializedState = new TwinState { ReportedPropertyUpdateCounter = 0, DesiredPropertyUpdateCounter = 0, TwinETag = twin.ETag, LastTimeOffline = DateTime.MinValue };
                 }
                 else

--- a/test/modules/TwinTester/TwinAllOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinAllOperationsInitializer.cs
@@ -112,7 +112,8 @@ namespace TwinTester
 
         public void Stop()
         {
-            this.periodicValidation.Dispose();
+            this.periodicValidation?.Dispose();
+            this.periodicUpdate?.Dispose();
             this.periodicUpdate.Dispose();
         }
 

--- a/test/modules/TwinTester/TwinAllOperationsResultHandler.cs
+++ b/test/modules/TwinTester/TwinAllOperationsResultHandler.cs
@@ -38,7 +38,7 @@ namespace TwinTester
             }
         }
 
-        public async Task HandleDesiredPropertyUpdateAsync(string status)
+        public async Task HandleDesiredPropertyUpdateAsync(string status, string value)
         {
             try
             {
@@ -50,7 +50,7 @@ namespace TwinTester
             }
         }
 
-        public async Task HandleReportedPropertyUpdateAsync(string status)
+        public async Task HandleReportedPropertyUpdateAsync(string status, string value)
         {
             try
             {

--- a/test/modules/TwinTester/TwinCloudOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinCloudOperationsInitializer.cs
@@ -58,7 +58,7 @@ namespace TwinTester
 
         public void Stop()
         {
-            this.periodicUpdate.Dispose();
+            this.periodicUpdate?.Dispose();
         }
     }
 }

--- a/test/modules/TwinTester/TwinCloudOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinCloudOperationsInitializer.cs
@@ -2,6 +2,7 @@
 namespace TwinTester
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices;
@@ -30,10 +31,12 @@ namespace TwinTester
                 Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
 
                 // reset desired properties
-                Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, new Twin(), twin.ETag);
+                twin.Properties.Desired = null;
+                Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, twin, twin.ETag);
+
                 initializedState = new TwinState { TwinETag = desiredPropertyResetTwin.ETag };
 
-                Logger.LogInformation($"Start state of module twin: {JsonConvert.SerializeObject(twin, Formatting.Indented)}");
+                Logger.LogInformation($"Start state of module twin: {JsonConvert.SerializeObject(desiredPropertyResetTwin, Formatting.Indented)}");
                 return new TwinCloudOperationsInitializer(registryManager, resultHandler, initializedState);
             }
             catch (Exception e)
@@ -42,10 +45,10 @@ namespace TwinTester
             }
         }
 
-        public Task Start()
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
+            await Task.Delay(Settings.Current.TestStartDelay, cancellationToken);
             this.periodicUpdate = new PeriodicTask(this.UpdateAsync, Settings.Current.TwinUpdateFrequency, Settings.Current.TwinUpdateFrequency, Logger, "TwinDesiredPropertiesUpdate");
-            return Task.CompletedTask;
         }
 
         public async Task UpdateAsync(CancellationToken cancellationToken)

--- a/test/modules/TwinTester/TwinCloudOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinCloudOperationsInitializer.cs
@@ -27,10 +27,10 @@ namespace TwinTester
             try
             {
                 TwinState initializedState;
-                Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId);
+                Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
 
                 // reset desired properties
-                Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId, new Twin(), twin.ETag);
+                Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, new Twin(), twin.ETag);
                 initializedState = new TwinState { TwinETag = desiredPropertyResetTwin.ETag };
 
                 Logger.LogInformation($"Start state of module twin: {JsonConvert.SerializeObject(twin, Formatting.Indented)}");

--- a/test/modules/TwinTester/TwinCloudOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinCloudOperationsInitializer.cs
@@ -56,7 +56,7 @@ namespace TwinTester
             await this.desiredPropertyUpdater.UpdateAsync();
         }
 
-        public void Dispose()
+        public void Stop()
         {
             this.periodicUpdate.Dispose();
         }

--- a/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
@@ -49,12 +49,12 @@ namespace TwinTester
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             await Task.Delay(Settings.Current.TestStartDelay, cancellationToken);
-            await DisplayInitialTwin();
+            await this.DisplayInitialTwin();
             this.periodicUpdate = new PeriodicTask(this.UpdateAsync, Settings.Current.TwinUpdateFrequency, Settings.Current.TwinUpdateFrequency, Logger, "TwinReportedPropertiesUpdate");
             await this.desiredPropertiesReceiver.UpdateAsync();
         }
 
-        private async Task DisplayInitialTwin()
+        async Task DisplayInitialTwin()
         {
             try
             {
@@ -67,7 +67,7 @@ namespace TwinTester
             }
         }
 
-        public void Dispose()
+        public void Stop()
         {
             this.periodicUpdate.Dispose();
         }

--- a/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
@@ -54,7 +54,7 @@ namespace TwinTester
             await this.desiredPropertiesReceiver.UpdateAsync();
         }
 
-        async Task DisplayInitialTwin()
+        async Task LogEdgeDeviceTwin()
         {
             try
             {

--- a/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
@@ -35,8 +35,8 @@ namespace TwinTester
                 Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
 
                 // reset reported properties
-                TwinCollection resetProperties = TwinTesterUtil.GetResetedReportedPropertiesTwin(twin);
-                await moduleClient.UpdateReportedPropertiesAsync(resetProperties);
+                await TwinTesterUtil.ResetTwinReportedPropertiesAsync(moduleClient, twin);
+                
 
                 return new TwinEdgeOperationsInitializer(registryManager, moduleClient, reporter, 0);
             }
@@ -49,7 +49,7 @@ namespace TwinTester
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             await Task.Delay(Settings.Current.TestStartDelay, cancellationToken);
-            await this.DisplayInitialTwin();
+            await this.LogEdgeDeviceTwin();
             this.periodicUpdate = new PeriodicTask(this.UpdateAsync, Settings.Current.TwinUpdateFrequency, Settings.Current.TwinUpdateFrequency, Logger, "TwinReportedPropertiesUpdate");
             await this.desiredPropertiesReceiver.UpdateAsync();
         }

--- a/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
@@ -2,6 +2,7 @@
 namespace TwinTester
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices;
@@ -17,27 +18,27 @@ namespace TwinTester
         static readonly ILogger Logger = ModuleUtil.CreateLogger(nameof(TwinCloudOperationsInitializer));
         readonly ReportedPropertyUpdater reportedPropertyUpdater;
         readonly DesiredPropertyReceiver desiredPropertiesReceiver;
+        readonly RegistryManager registryManager;
         PeriodicTask periodicUpdate;
 
-        TwinEdgeOperationsInitializer(RegistryManager registryManager, ModuleClient moduleClient, ITwinTestResultHandler reporter, TwinState initializedState)
+        TwinEdgeOperationsInitializer(RegistryManager registryManager, ModuleClient moduleClient, ITwinTestResultHandler reporter, int reportedPropertyUpdateCounter)
         {
-            this.reportedPropertyUpdater = new ReportedPropertyUpdater(registryManager, moduleClient, reporter, initializedState);
-            this.desiredPropertiesReceiver = new DesiredPropertyReceiver(registryManager, moduleClient, reporter);
+            this.registryManager = registryManager;
+            this.reportedPropertyUpdater = new ReportedPropertyUpdater(moduleClient, reporter, reportedPropertyUpdateCounter);
+            this.desiredPropertiesReceiver = new DesiredPropertyReceiver(moduleClient, reporter);
         }
 
         public static async Task<TwinEdgeOperationsInitializer> CreateAsync(RegistryManager registryManager, ModuleClient moduleClient, ITwinTestResultHandler reporter)
         {
             try
             {
-                TwinState initializedState;
                 Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
 
-                // reset properties
-                Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, new Twin(), twin.ETag);
-                initializedState = new TwinState { TwinETag = desiredPropertyResetTwin.ETag };
+                // reset reported properties
+                TwinCollection resetProperties = TwinTesterUtil.GetResetedReportedPropertiesTwin(twin);
+                await moduleClient.UpdateReportedPropertiesAsync(resetProperties);
 
-                Logger.LogInformation($"Start state of module twin: {JsonConvert.SerializeObject(twin, Formatting.Indented)}");
-                return new TwinEdgeOperationsInitializer(registryManager, moduleClient, reporter, initializedState);
+                return new TwinEdgeOperationsInitializer(registryManager, moduleClient, reporter, 0);
             }
             catch (Exception e)
             {
@@ -45,10 +46,25 @@ namespace TwinTester
             }
         }
 
-        public async Task Start()
+        public async Task StartAsync(CancellationToken cancellationToken)
         {
+            await Task.Delay(Settings.Current.TestStartDelay, cancellationToken);
+            await DisplayInitialTwin();
             this.periodicUpdate = new PeriodicTask(this.UpdateAsync, Settings.Current.TwinUpdateFrequency, Settings.Current.TwinUpdateFrequency, Logger, "TwinReportedPropertiesUpdate");
             await this.desiredPropertiesReceiver.UpdateAsync();
+        }
+
+        private async Task DisplayInitialTwin()
+        {
+            try
+            {
+                Twin twin = await this.registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
+                Logger.LogInformation($"Start state of module twin: {JsonConvert.SerializeObject(twin, Formatting.Indented)}");
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, $"Failure to get twin");
+            }
         }
 
         public void Dispose()

--- a/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
@@ -30,10 +30,10 @@ namespace TwinTester
             try
             {
                 TwinState initializedState;
-                Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId);
+                Twin twin = await registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId);
 
                 // reset properties
-                Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.ModuleId, new Twin(), twin.ETag);
+                Twin desiredPropertyResetTwin = await registryManager.ReplaceTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, new Twin(), twin.ETag);
                 initializedState = new TwinState { TwinETag = desiredPropertyResetTwin.ETag };
 
                 Logger.LogInformation($"Start state of module twin: {JsonConvert.SerializeObject(twin, Formatting.Indented)}");

--- a/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsInitializer.cs
@@ -69,7 +69,7 @@ namespace TwinTester
 
         public void Stop()
         {
-            this.periodicUpdate.Dispose();
+            this.periodicUpdate?.Dispose();
         }
 
         async Task UpdateAsync(CancellationToken cancellationToken)

--- a/test/modules/TwinTester/TwinEdgeOperationsResultHandler.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsResultHandler.cs
@@ -29,13 +29,13 @@ namespace TwinTester
 
         public Task HandleDesiredPropertyUpdateAsync(string propertyKey, string value)
         {
-            TwinCollection properties = this.GetTwinCollection(propertyKey, value);
+            TwinCollection properties = this.CreateTwinCollection(propertyKey, value);
             return this.SendReportAsync($"{this.moduleId}.desiredUpdated", StatusCode.DesiredPropertyUpdated, properties);
         }
 
         public Task HandleReportedPropertyUpdateAsync(string propertyKey, string value)
         {
-            TwinCollection properties = this.GetTwinCollection(propertyKey, value);
+            TwinCollection properties = this.CreateTwinCollection(propertyKey, value);
             return this.SendReportAsync($"{this.moduleId}.reportedUpdated", StatusCode.ReportedPropertyUpdated, properties);
         }
 
@@ -49,7 +49,7 @@ namespace TwinTester
             return Task.CompletedTask;
         }
 
-        TwinCollection GetTwinCollection(string propertyKey, string value)
+        TwinCollection CreateTwinCollection(string propertyKey, string value)
         {
             var properties = new TwinCollection();
             properties[propertyKey] = value;

--- a/test/modules/TwinTester/TwinEdgeOperationsResultHandler.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsResultHandler.cs
@@ -27,15 +27,15 @@ namespace TwinTester
             return this.SendReportAsync($"{this.moduleId}.desiredReceived", StatusCode.DesiredPropertyReceived, desiredProperties);
         }
 
-        public Task HandleDesiredPropertyUpdateAsync(string propertyKey)
+        public Task HandleDesiredPropertyUpdateAsync(string propertyKey, string value)
         {
-            TwinCollection properties = this.GetTwinCollection(propertyKey);
+            TwinCollection properties = this.GetTwinCollection(propertyKey, value);
             return this.SendReportAsync($"{this.moduleId}.desiredUpdated", StatusCode.DesiredPropertyUpdated, properties);
         }
 
-        public Task HandleReportedPropertyUpdateAsync(string propertyKey)
+        public Task HandleReportedPropertyUpdateAsync(string propertyKey, string value)
         {
-            TwinCollection properties = this.GetTwinCollection(propertyKey);
+            TwinCollection properties = this.GetTwinCollection(propertyKey, value);
             return this.SendReportAsync($"{this.moduleId}.reportedUpdated", StatusCode.ReportedPropertyUpdated, properties);
         }
 
@@ -49,10 +49,10 @@ namespace TwinTester
             return Task.CompletedTask;
         }
 
-        TwinCollection GetTwinCollection(string propertyKey)
+        TwinCollection GetTwinCollection(string propertyKey, string value)
         {
             var properties = new TwinCollection();
-            properties[propertyKey] = propertyKey;
+            properties[propertyKey] = value;
 
             return properties;
         }

--- a/test/modules/TwinTester/TwinTesterUtil.cs
+++ b/test/modules/TwinTester/TwinTesterUtil.cs
@@ -17,6 +17,5 @@ namespace TwinTester
 
             return eraseReportedProperties;
         }
-
     }
 }

--- a/test/modules/TwinTester/TwinTesterUtil.cs
+++ b/test/modules/TwinTester/TwinTesterUtil.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace TwinTester
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Shared;
+
+    static class TwinTesterUtil
+    {
+        public static TwinCollection GetResetedReportedPropertiesTwin(Twin originalTwin)
+        {
+            TwinCollection eraseReportedProperties = new TwinCollection();
+            foreach (dynamic twinUpdate in originalTwin.Properties.Reported)
+            {
+                KeyValuePair<string, object> pair = (KeyValuePair<string, object>)twinUpdate;
+                eraseReportedProperties[pair.Key] = null; // erase twin property by assigning null
+            }
+
+            return eraseReportedProperties;
+        }
+
+    }
+}

--- a/test/modules/TwinTester/TwinTesterUtil.cs
+++ b/test/modules/TwinTester/TwinTesterUtil.cs
@@ -2,20 +2,22 @@
 namespace TwinTester
 {
     using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Shared;
 
     static class TwinTesterUtil
     {
-        public static TwinCollection GetResetedReportedPropertiesTwin(Twin originalTwin)
+        public static Task ResetTwinReportedPropertiesAsync(ModuleClient moduleClient, Twin originalTwin)
         {
-            TwinCollection eraseReportedProperties = new TwinCollection();
+            TwinCollection cleanedReportedProperties = new TwinCollection();
             foreach (dynamic twinUpdate in originalTwin.Properties.Reported)
             {
                 KeyValuePair<string, object> pair = (KeyValuePair<string, object>)twinUpdate;
-                eraseReportedProperties[pair.Key] = null; // erase twin property by assigning null
+                cleanedReportedProperties[pair.Key] = null; // erase twin property by assigning null
             }
 
-            return eraseReportedProperties;
+            return moduleClient.UpdateReportedPropertiesAsync(cleanedReportedProperties);
         }
     }
 }


### PR DESCRIPTION
- Fix twinTester to use targetModuleId. If env variable for targetModuleId is not set it is set to the moduleId value by default.
- Fix twinTester initialization for edge operations mode
- Replaced Dispose with Stop for test initializer to continue receiving desired properties updates after test duration