### PR TITLE
Reduce log level in test analyzer

### DIFF
--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -278,6 +278,9 @@
               },
               "LogAnalyticsLogType": {
                 "value": "<Analyzer.LogAnalyticsLogType>"
+              },
+              "Logging:LogLevel:Microsoft": {
+                "value": "Error"
               }
             },
             "settings": {

--- a/e2e_deployment_files/long_haul_deployment.template.windows.json
+++ b/e2e_deployment_files/long_haul_deployment.template.windows.json
@@ -281,6 +281,9 @@
               },
               "LogAnalyticsLogType": {
                 "value": "<Analyzer.LogAnalyticsLogType>"
+              },
+              "Logging:LogLevel:Microsoft": {
+                "value": "Error"
               }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.json
+++ b/e2e_deployment_files/stress_deployment.template.json
@@ -302,6 +302,9 @@
               },
               "LogAnalyticsLogType": {
                 "value": "<Analyzer.LogAnalyticsLogType>"
+              },
+              "Logging:LogLevel:Microsoft": {
+                "value": "Error"
               }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.windows.json
+++ b/e2e_deployment_files/stress_deployment.template.windows.json
@@ -305,6 +305,9 @@
               },
               "LogAnalyticsLogType": {
                 "value": "<Analyzer.LogAnalyticsLogType>"
+              },
+              "Logging:LogLevel:Microsoft": {
+                "value": "Error"
               }
             },
             "settings": {


### PR DESCRIPTION
The snitcher will eventually have trouble allocating enough memory for the analyzer's logs after around 5 days. This can be solved by reducing the log level in the test analyzer.