### PR TITLE
Rename to report url in TwinTester

### DIFF
--- a/test/modules/TwinTester/Program.cs
+++ b/test/modules/TwinTester/Program.cs
@@ -61,7 +61,7 @@ namespace TwinTester
             }
         }
 
-        static async Task<ITwinTestInitializer> GetTwinAllOperationsInitializer(RegistryManager registryManager, Uri analyzerClientUri)
+        static async Task<ITwinTestInitializer> GetTwinAllOperationsInitializer(RegistryManager registryManager, Uri reportUrl)
         {
             ModuleClient moduleClient = await ModuleUtil.CreateModuleClientAsync(
                 Settings.Current.TransportType,
@@ -71,7 +71,7 @@ namespace TwinTester
 
             TwinEventStorage storage = new TwinEventStorage();
             storage.Init(Settings.Current.StoragePath, new SystemEnvironment(), Settings.Current.StorageOptimizeForPerformance);
-            var resultHandler = new TwinAllOperationsResultHandler(analyzerClientUri, storage, Settings.Current.ModuleId);
+            var resultHandler = new TwinAllOperationsResultHandler(reportUrl, storage, Settings.Current.ModuleId);
             return await TwinAllOperationsInitializer.CreateAsync(registryManager, moduleClient, resultHandler, storage);
         }
     }

--- a/test/modules/TwinTester/TwinAllOperationsResultHandler.cs
+++ b/test/modules/TwinTester/TwinAllOperationsResultHandler.cs
@@ -15,9 +15,9 @@ namespace TwinTester
         readonly string moduleId;
         readonly TwinEventStorage storage;
 
-        public TwinAllOperationsResultHandler(Uri analyzerClientUri, TwinEventStorage storage, string moduleId)
+        public TwinAllOperationsResultHandler(Uri reportUrl, TwinEventStorage storage, string moduleId)
         {
-            this.testResultReportingClient = new TestResultReportingClient { BaseUrl = analyzerClientUri.AbsoluteUri };
+            this.testResultReportingClient = new TestResultReportingClient { BaseUrl = reportUrl.AbsoluteUri };
             this.moduleId = moduleId;
             this.storage = storage;
         }

--- a/test/modules/TwinTester/TwinEdgeOperationsResultHandler.cs
+++ b/test/modules/TwinTester/TwinEdgeOperationsResultHandler.cs
@@ -15,9 +15,9 @@ namespace TwinTester
         readonly string moduleId;
         readonly string trackingId;
 
-        public TwinEdgeOperationsResultHandler(Uri reporterUri, string moduleId, Option<string> trackingId)
+        public TwinEdgeOperationsResultHandler(Uri reportUrl, string moduleId, Option<string> trackingId)
         {
-            this.testResultReportingClient = new TestResultReportingClient { BaseUrl = reporterUri.AbsoluteUri };
+            this.testResultReportingClient = new TestResultReportingClient { BaseUrl = reportUrl.AbsoluteUri };
             this.moduleId = moduleId;
             this.trackingId = trackingId.Expect(() => new ArgumentNullException(nameof(trackingId)));
         }


### PR DESCRIPTION
fix naming of report url in Twin Tester.