### PR TITLE
Refresh SAS token for CI tests

### DIFF
--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TokenHelper.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TokenHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Common
     public static class TokenHelper
     {
         public static string CreateSasToken(string resourceUri, string key = null, bool expired = false) =>
-            CreateSasToken(resourceUri, expired ? new DateTime(2010, 1, 1) : new DateTime(2050, 1, 1), key);
+            CreateSasToken(resourceUri, expired ? new DateTime(2010, 1, 1) : new DateTime(2025, 1, 1), key);
 
         public static string CreateSasToken(string resourceUri, DateTime expiryTime, string key = null)
         {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TokenHelper.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/TokenHelper.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Common
     public static class TokenHelper
     {
         public static string CreateSasToken(string resourceUri, string key = null, bool expired = false) =>
-            CreateSasToken(resourceUri, expired ? new DateTime(2010, 1, 1) : new DateTime(2020, 1, 1), key);
+            CreateSasToken(resourceUri, expired ? new DateTime(2010, 1, 1) : new DateTime(2050, 1, 1), key);
 
         public static string CreateSasToken(string resourceUri, DateTime expiryTime, string key = null)
         {


### PR DESCRIPTION
Our CI tests fail because the token expires 1/1/2020. I increased the expiry date to 2025.