### PR TITLE
Fix Ensure Metrics Ordering

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             // Initialize metric uploading
             if (diagnosticConfig.Enabled)
             {
-                MetricsWorker worker = container.Resolve<MetricsWorker>();
+                MetricsWorker worker = await container.Resolve<Task<MetricsWorker>>();
                 worker.Start(diagnosticConfig.ScrapeInterval, diagnosticConfig.UploadInterval);
                 Console.WriteLine($"Scraping frequency: {diagnosticConfig.ScrapeInterval}\nUpload Frequency: {diagnosticConfig.UploadInterval}");
             }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/AgentModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/AgentModule.cs
@@ -203,8 +203,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             // IEntityStore<string, ModuleState>
             builder.Register(async c =>
                 {
-                IStoreProvider storeProvider = await c.Resolve<Task<IStoreProvider>>();
-                return storeProvider.GetEntityStore<string, ModuleState>("moduleState");
+                    IStoreProvider storeProvider = await c.Resolve<Task<IStoreProvider>>();
+                    return storeProvider.GetEntityStore<string, ModuleState>("moduleState");
                 })
                 .As<Task<IEntityStore<string, ModuleState>>>()
                 .SingleInstance();
@@ -212,8 +212,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             // IEntityStore<string, DeploymentConfigInfo>
             builder.Register(async c =>
                 {
-                IStoreProvider storeProvider = await c.Resolve<Task<IStoreProvider>>();
-                return storeProvider.GetEntityStore<string, string>("deploymentConfig");
+                    IStoreProvider storeProvider = await c.Resolve<Task<IStoreProvider>>();
+                    return storeProvider.GetEntityStore<string, string>("deploymentConfig");
                 })
                 .As<Task<IEntityStore<string, string>>>()
                 .SingleInstance();
@@ -225,11 +225,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
 
             // IPlanner
             builder.Register(
-                    async c => new HealthRestartPlanner(
-                        await c.Resolve<Task<ICommandFactory>>(),
-                        await c.Resolve<Task<IEntityStore<string, ModuleState>>>(),
-                        this.intensiveCareTime,
-                        c.Resolve<IRestartPolicyManager>()) as IPlanner)
+                    async c =>
+                    {
+                        var commandFactory = c.Resolve<Task<ICommandFactory>>();
+                        var entityStore = c.Resolve<Task<IEntityStore<string, ModuleState>>>();
+                        var policyManager = c.Resolve<IRestartPolicyManager>();
+
+                        return new HealthRestartPlanner(await commandFactory, await entityStore, this.intensiveCareTime, policyManager) as IPlanner;
+                    })
                 .As<Task<IPlanner>>()
                 .SingleInstance();
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DiagnosticsModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DiagnosticsModule.cs
@@ -47,12 +47,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             // Task<MetricsWorker>
             builder.Register(async c =>
                 {
-                    // Note: for some reason, the synchronous resolves must happen before the async resolve.
                     IMetricsScraper scraper = c.Resolve<IMetricsScraper>();
-                    IMetricsPublisher publisher = c.Resolve<IMetricsPublisher>(); 
-                    IMetricsStorage storage = await c.Resolve<Task<IMetricsStorage>>();
+                    IMetricsPublisher publisher = c.Resolve<IMetricsPublisher>();
+                    Task<IMetricsStorage> storage = c.Resolve<Task<IMetricsStorage>>();
 
-                    return new MetricsWorker(scraper, storage, publisher);
+                    return new MetricsWorker(scraper, await storage, publisher);
                 })
                 .As<Task<MetricsWorker>>()
                 .SingleInstance();


### PR DESCRIPTION
This fixes #2167, which had issues with autofac. The change made some of the metrics worker's dependencies async. For some reason, autofac broke if the async dependencies were resolved before the synchronous ones. 

This PR reverts #2187 and makes the needed changes to autofac.

The actual changes for this pr are the second commit: https://github.com/Azure/iotedge/commit/816e35fe08ca927b83c87f2ec6f717b891e22639