### PR TITLE
Fix Y2038 bug with certificate expiry for platforms with 64-bit `time_t`

### DIFF
--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ut/certificate_info_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ut/certificate_info_ut.c
@@ -1076,6 +1076,20 @@ BEGIN_TEST_SUITE(certificate_info_ut)
         //cleanup
     }
 
+    TEST_FUNCTION(get_utc_time_from_asn_string_success_test_y2038)
+    {
+        //arrange
+        time_t test_time;
+
+        //act
+        test_time = get_utc_time_from_asn_string((unsigned char*)"491231235959Z", 13);
+
+        //assert
+        ASSERT_ARE_EQUAL(int64_t, 2524607999, test_time);
+
+        //cleanup
+    }
+
     TEST_FUNCTION(get_common_name_NULL_param_fails)
     {
         //arrange


### PR DESCRIPTION
Before this change, the code to convert `struct tm` to `time_t`
did arithmetic in `int` (the type of the fields of `struct tm`)
before assigning the result to `time_t`. So platforms that have 64-bit `time_t`
to solve the Y2038 problem and 32-bit `int` (Linux glibc amd64,
Windows MSVCRT amd64, Windows MSVCRT arm32) were still unable to make use of
certs with not-after after 2038.

As discussed in https://github.com/Azure/iotedge/issues/1960 , the fix is to
ensure the intermediates of the calculation are themselves in `time_t.
This change does that.

As mentioned in #1960, another bug in this code was that it used -1 to signal
an invalid `time_t`, whereas the caller used 0 for that. Thus even if the time
did overflow, the -1 result would make it all the way to iotedged
before being rejected as a cert that expired in 1969. This change fixes that.

Lastly, to clarify, this change still does *not* make it possible for platforms
with 32-bit `time_t` (Linux glibc arm32) to use certificates that expire
past 2038. These platforms will still have the Y2038 problem until their libc
starts using 64-bit `time_t`

Aside: There is still a Y2050 problem even after this change. That is because
the code asserts that the times use the ASN1_UTCTIME type; this type uses
the format YYMMDDHHMMSS where 0 <= YY < 50 implies 20YY and
50 <= YY < 100 implies 19YY, and the code parses the string accordingly.
For years past 2050, openssl switches to ASN1_GENERALIZEDTIME which has
a four-digit YYYY.

Rather than try to support both formats, we should stop parsing this structure
ourselves and just use `ASN1_TIME_to_tm`. We can't do this today because
the function does not exist before openssl 1.1.1, but hopefully that will
stop being an issue by the time supporting certs with expiry past 2050
becomes important.