### PR TITLE
E2E test improvement: Don't eat bad exceptions

### DIFF
--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -11,6 +11,7 @@ namespace IotEdgeQuickstart.Details
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Common;
+    using Microsoft.Azure.Devices.Common.Exceptions;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Azure.EventHubs;
@@ -305,7 +306,7 @@ namespace IotEdgeQuickstart.Details
                                 break;
                             }
                         }
-                        catch (Exception e)
+                        catch (DeviceNotFoundException e)
                         {
                             savedException = e;
                         }
@@ -365,7 +366,7 @@ namespace IotEdgeQuickstart.Details
 
             // TODO: [Improvement] should verify test results without using event hub, which introduce latency.
             var result = new TaskCompletionSource<bool>();
-            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed in case event hub is slow to process messages
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(20))) // This long timeout is needed in case event hub's partition receive handler is slow to process messages
             {
                 using (cts.Token.Register(() => result.TrySetCanceled()))
                 {

--- a/smoke/LeafDevice/details/Details.cs
+++ b/smoke/LeafDevice/details/Details.cs
@@ -16,6 +16,7 @@ namespace LeafDeviceTest
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Transport.Mqtt;
     using Microsoft.Azure.Devices.Common;
+    using Microsoft.Azure.Devices.Common.Exceptions;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Azure.EventHubs;
@@ -178,7 +179,7 @@ namespace LeafDeviceTest
                             Console.WriteLine("Direct method callback is set.");
                             break;
                         }
-                        catch (Exception e)
+                        catch (DeviceNotFoundException e)
                         {
                             savedException = e;
                         }


### PR DESCRIPTION
Currently, we catch every exception type when using service client or device client.

For ServiceClient the expected failure case throws exception of type AggregateException, but we can catch the underlying exception type of DeviceNotFoundException (tested in Console App).

For DeviceClient, this was hard to reproduce. I might investigate but I think it is better to merge and fix if there is an issue down the line. Eating exceptions like this could potentially mask SDK problems.