### PR TITLE
Fix twin tests offline detection

### DIFF
--- a/test/modules/TwinTester/ReportedPropertiesValidator.cs
+++ b/test/modules/TwinTester/ReportedPropertiesValidator.cs
@@ -6,7 +6,7 @@ namespace TwinTester
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Client;
-    using Microsoft.Azure.Devices.Client.Exceptions;
+    using Microsoft.Azure.Devices.Common.Exceptions;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;


### PR DESCRIPTION
The twin tests running in long haul are supposed to detect offline states and postpone validation of in-flight updates until back online. This is not working currently as we catch the wrong variation of IoTHubCommunicationException.

Link to bug with stack traces from twinTester / edgeHub:
https://msazure.visualstudio.com/One/_sprints/taskboard/IoT-Platform-Edge/One/IoT/2001?workitem=6006371