### PR TITLE
Fix twin tests offline detection

### DIFF
--- a/edge-modules/TwinTester/ReportedPropertyOperation.cs
+++ b/edge-modules/TwinTester/ReportedPropertyOperation.cs
@@ -6,7 +6,7 @@ namespace TwinTester
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices;
     using Microsoft.Azure.Devices.Client;
-    using Microsoft.Azure.Devices.Client.Exceptions;
+    using Microsoft.Azure.Devices.Common.Exceptions;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Logging;


### PR DESCRIPTION

Since we are using the Service SDK (RegistryManager), we need to catch the correct IoTHubCommunicationException