### PR TITLE
Prevent new dependencies that pull in winapi 0.2 from being added

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -101,6 +101,8 @@ jobs:
         displayName: Test
       - powershell: edgelet/build/windows/clippy.ps1
         displayName: Clippy
+      - powershell: edgelet/build/windows/check-arm32-patch.ps1
+        displayName: Sanity-check that ARM32 build won't break
 
 ################################################################################
   - job: style_check

--- a/edgelet/build/windows/check-arm32-patch.ps1
+++ b/edgelet/build/windows/check-arm32-patch.ps1
@@ -1,0 +1,37 @@
+# Copyright (c) Microsoft. All rights reserved.
+
+
+# The Windows ARM32 build requires all uses of winapi 0.2 to be removed,
+# since that crate does not build for the Windows ARM32 target.
+# Some mio / tokio crates depend on winapi 0.2, so the build
+# `[patch]`es them to versions that depend on winapi 0.3 instead.
+# See `function PatchRustForArm` for details.
+#
+# This script runs just the patch step of the actual Windows ARM32 build,
+# and ensures that winapi 0.2 is removed from the lockfile.
+#
+# For checkin jobs this helps prevent someone from adding a new dependency
+# that pulls in winapi 0.2.
+#
+# A proper build would also catch this, and other errors, but takes more time
+# than we'd like for a checkin job.
+
+
+# Bring in util functions
+$util = Join-Path -Path $PSScriptRoot -ChildPath 'util.ps1'
+. $util
+
+# Note: We're not passing in `-Arm` here because we don't need the Windows ARM32 Rust toolchain,
+#       which in turn is because we're just patching the manifest, not doing a full build.
+Assert-Rust
+
+# Note: This is destructive since it modifies the manifest and lockfile.
+#       Ensure that no new x86_64-pc-windows-msvc builds happen after this script runs.
+PatchRustForArm
+
+if (Select-String '"winapi 0.2' (Join-Path (Get-EdgeletFolder) -ChildPath 'Cargo.lock')) {
+	throw (
+		'Cargo.lock still references winapi 0.2 after patching. ' +
+		'Ensure that there are no new dependencies that depend on winapi 0.2'
+	)
+}

--- a/edgelet/build/windows/check-arm32-patch.ps1
+++ b/edgelet/build/windows/check-arm32-patch.ps1
@@ -21,12 +21,9 @@
 $util = Join-Path -Path $PSScriptRoot -ChildPath 'util.ps1'
 . $util
 
-# Note: We're not passing in `-Arm` here because we don't need the Windows ARM32 Rust toolchain,
-#       which in turn is because we're just patching the manifest, not doing a full build.
-Assert-Rust
-
-# Note: This is destructive since it modifies the manifest and lockfile.
+# Note: This is destructive since it modifies the manifest, lockfile and environment.
 #       Ensure that no new x86_64-pc-windows-msvc builds happen after this script runs.
+Assert-Rust -Arm
 PatchRustForArm
 
 if (Select-String '"winapi 0.2' (Join-Path (Get-EdgeletFolder) -ChildPath 'Cargo.lock')) {


### PR DESCRIPTION
This change adds a sanity check script for the checkin gates.
It performs the same patching that the Windows ARM32 build does to remove
all known uses of winapi 0.2, then asserts that winapi 0.2 is really gone
from the lockfile.