### PR TITLE
Changed CloudEndpoint to fail subsequent batches after a transient error

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/ModuleEndpoint.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/ModuleEndpoint.cs
@@ -161,8 +161,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                     IMessage message = this.moduleEndpoint.messageConverter.ToMessage(routingMessage);
                     try
                     {
-                        await dp.SendMessageAsync(message, this.moduleEndpoint.Input);
-                        succeeded.Add(routingMessage);
+                        if (failed.Count == 0)
+                        {
+                            await dp.SendMessageAsync(message, this.moduleEndpoint.Input);
+                            succeeded.Add(routingMessage);
+                        }
+                        else
+                        {
+                            // if one failed, fail the rest, so retry will keep message order
+                            failed.Add(routingMessage);
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudMessageProcessorTests.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/CloudMessageProcessorTests.cs
@@ -347,7 +347,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             string cloudEndpointId = Guid.NewGuid().ToString();
 
             var cloudProxy = ThrowingCloudProxy
-                                .CreateWithResponses(30, ThrowingCloudProxy.Success())
+                                .Create()
+                                .WithBatchSize(batchSize)
+                                .WithReportSuccessfulBatch(3)
                                 .Build();
 
             Task<Option<ICloudProxy>> GetCloudProxy(string id) => Task.FromResult(Option.Some(cloudProxy));
@@ -366,17 +368,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
         [Fact]
         [Unit]
-        public async Task ErrorInFirstBatch_ErrorDetailsReturned()
+        public async Task TransientErrorInFirstBatch_FastFailsRest()
         {
             var batchSize = 10;
             Core.IMessageConverter<IRoutingMessage> routingMessageConverter = new RoutingMessageConverter();
             string cloudEndpointId = Guid.NewGuid().ToString();
 
             var cloudProxy = ThrowingCloudProxy
-                                .CreateWithResponses(3, ThrowingCloudProxy.Success())
-                                .Then(ThrowingCloudProxy.Throw<Client.Exceptions.IotHubException>())
-                                .ThenMany(batchSize - 4, ThrowingCloudProxy.Success()) // first batch ends here (3 success + 1 fail -> 10 - 4 to go)
-                                .ThenMany(2 * batchSize, ThrowingCloudProxy.Success())
+                                .Create()
+                                .WithBatchSize(batchSize)
+                                .WithReportErrorInBatch(ThrowingCloudProxy.Throw<Client.Exceptions.IotHubException>())
+                                .WithReportSuccessfulBatch(2)
                                 .Build();
 
             Task<Option<ICloudProxy>> GetCloudProxy(string id) => Task.FromResult(Option.Some(cloudProxy));
@@ -386,9 +388,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
             var sinkResult = await cloudMessageProcessor.ProcessAsync(GetMessages("device1", 3 * batchSize), CancellationToken.None);
 
+            // although the test is setup to succeed with batch 2 and 3, they will fast fail because of the first one
             Assert.False(sinkResult.IsSuccessful);
-            Assert.Equal(2 * batchSize, sinkResult.Succeeded.Count);
-            Assert.Equal(1 * batchSize, sinkResult.Failed.Count);
+            Assert.Equal(0, sinkResult.Succeeded.Count);
+            Assert.Equal(30, sinkResult.Failed.Count);
             Assert.Equal(0, sinkResult.InvalidDetailsList.Count);
             Assert.True(sinkResult.SendFailureDetails.HasValue);
             Assert.Equal(FailureKind.Transient, sinkResult.SendFailureDetails.Expect(() => new Exception()).FailureKind);
@@ -396,20 +399,48 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
 
         [Fact]
         [Unit]
-        public async Task TransientErrorInFirstBatch_FailureDetailsDoesNotGetOverwritten()
+        public async Task NonTransientErrorInFirstBatch_LetsTryTheRest_ButReportsSendFailure()
         {
             var batchSize = 10;
             Core.IMessageConverter<IRoutingMessage> routingMessageConverter = new RoutingMessageConverter();
             string cloudEndpointId = Guid.NewGuid().ToString();
 
             var cloudProxy = ThrowingCloudProxy
-                                .CreateWithResponses(3, ThrowingCloudProxy.Success())
-                                .Then(ThrowingCloudProxy.Throw<Client.Exceptions.IotHubException>()) // transient error
-                                .ThenMany(batchSize - 4, ThrowingCloudProxy.Success()) // first batch ends here (3 success + 1 fail -> 10 - 4 to go)
-                                .ThenMany(3, ThrowingCloudProxy.Success())
-                                .Then(ThrowingCloudProxy.Throw<Exception>()) // non-transient error
-                                .ThenMany(batchSize - 4, ThrowingCloudProxy.Success()) // second batch ends here
-                                .ThenMany(1 * batchSize, ThrowingCloudProxy.Success())
+                                .Create()
+                                .WithBatchSize(batchSize)
+                                .WithReportErrorInBatch(ThrowingCloudProxy.Throw<Exception>())
+                                .WithReportSuccessfulBatch(2)
+                                .Build();
+
+            Task<Option<ICloudProxy>> GetCloudProxy(string id) => Task.FromResult(Option.Some(cloudProxy));
+
+            var cloudEndpoint = new CloudEndpoint(cloudEndpointId, GetCloudProxy, routingMessageConverter);
+            IProcessor cloudMessageProcessor = cloudEndpoint.CreateProcessor();
+
+            var sinkResult = await cloudMessageProcessor.ProcessAsync(GetMessages("device1", 3 * batchSize), CancellationToken.None);
+
+            Assert.True(sinkResult.IsSuccessful); // non-transient errors are ignored, but reported in SendFailureDetails
+            Assert.Equal(2 * batchSize, sinkResult.Succeeded.Count);
+            Assert.Equal(0, sinkResult.Failed.Count);
+            Assert.Equal(batchSize, sinkResult.InvalidDetailsList.Count);
+            Assert.True(sinkResult.SendFailureDetails.HasValue);
+            Assert.Equal(FailureKind.InvalidInput, sinkResult.SendFailureDetails.Expect(() => new Exception()).FailureKind);
+        }
+
+        [Fact]
+        [Unit]
+        public async Task TransientErrorInSecondBatch_FastFailsRest_OverwritesNonTransientResult()
+        {
+            var batchSize = 10;
+            Core.IMessageConverter<IRoutingMessage> routingMessageConverter = new RoutingMessageConverter();
+            string cloudEndpointId = Guid.NewGuid().ToString();
+
+            var cloudProxy = ThrowingCloudProxy
+                                .Create()
+                                .WithBatchSize(batchSize)
+                                .WithReportErrorInBatch(ThrowingCloudProxy.Throw<Exception>())
+                                .WithReportErrorInBatch(ThrowingCloudProxy.Throw<Client.Exceptions.IotHubException>())
+                                .WithReportSuccessfulBatch()
                                 .Build();
 
             Task<Option<ICloudProxy>> GetCloudProxy(string id) => Task.FromResult(Option.Some(cloudProxy));
@@ -420,42 +451,52 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             var sinkResult = await cloudMessageProcessor.ProcessAsync(GetMessages("device1", 3 * batchSize), CancellationToken.None);
 
             Assert.False(sinkResult.IsSuccessful);
-            Assert.Equal(batchSize, sinkResult.Succeeded.Count);
-            Assert.Equal(batchSize, sinkResult.Failed.Count);
-            Assert.Equal(batchSize, sinkResult.InvalidDetailsList.Count);
+            Assert.Equal(0, sinkResult.Succeeded.Count);
+            Assert.Equal(2 * batchSize, sinkResult.Failed.Count);
+            Assert.Equal(1 * batchSize, sinkResult.InvalidDetailsList.Count);
             Assert.True(sinkResult.SendFailureDetails.HasValue);
             Assert.Equal(FailureKind.Transient, sinkResult.SendFailureDetails.Expect(() => new Exception()).FailureKind);
         }
 
         [Fact]
         [Unit]
-        public async Task TransientErrorInSecondBatch_OverwritesNonTransientFailureDetails()
+        public async Task TransientErrorOfFirstIdentity_DoesNotFastFailsSecondIdentity_ButReportsError()
         {
             var batchSize = 10;
             Core.IMessageConverter<IRoutingMessage> routingMessageConverter = new RoutingMessageConverter();
             string cloudEndpointId = Guid.NewGuid().ToString();
 
-            var cloudProxy = ThrowingCloudProxy
-                                .CreateWithResponses(3, ThrowingCloudProxy.Success())
-                                .Then(ThrowingCloudProxy.Throw<Exception>()) // non-transient error
-                                .ThenMany(batchSize - 4, ThrowingCloudProxy.Success()) // first batch ends here (3 success + 1 fail -> 10 - 4 to go)
-                                .ThenMany(3, ThrowingCloudProxy.Success())
-                                .Then(ThrowingCloudProxy.Throw<Client.Exceptions.IotHubException>()) // transient error
-                                .ThenMany(batchSize - 4, ThrowingCloudProxy.Success()) // second batch ends here
-                                .ThenMany(1 * batchSize, ThrowingCloudProxy.Success())
+            // this wont fast fail
+            var cloudProxy1 = ThrowingCloudProxy
+                                .Create()
+                                .WithBatchSize(batchSize)
+                                .WithReportSuccessfulBatch(3)
                                 .Build();
 
-            Task<Option<ICloudProxy>> GetCloudProxy(string id) => Task.FromResult(Option.Some(cloudProxy));
+            // this will fast fail after a batch (skipping the second and the third)
+            var cloudProxy2 = ThrowingCloudProxy
+                                .Create()
+                                .WithBatchSize(batchSize)
+                                .WithReportSuccessfulBatch()
+                                .WithReportErrorInBatch(ThrowingCloudProxy.Throw<Client.Exceptions.IotHubException>())
+                                .WithReportSuccessfulBatch()
+                                .Build();
+
+            var proxyMap = new Dictionary<string, ICloudProxy> { ["device1"] = cloudProxy1, ["device2"] = cloudProxy2 };
+
+            Task<Option<ICloudProxy>> GetCloudProxy(string id) => Task.FromResult(Option.Some(proxyMap[id]));
 
             var cloudEndpoint = new CloudEndpoint(cloudEndpointId, GetCloudProxy, routingMessageConverter);
-            IProcessor cloudMessageProcessor = cloudEndpoint.CreateProcessor();
+            var cloudMessageProcessor = cloudEndpoint.CreateProcessor();
 
-            var sinkResult = await cloudMessageProcessor.ProcessAsync(GetMessages("device1", 3 * batchSize), CancellationToken.None);
+            var random = new Random(35325);
+            var messages = GetMessages("device1", 3 * batchSize).Concat(GetMessages("device2", 3 * batchSize)).OrderBy(order => random.Next()).ToList();
+            var sinkResult = await cloudMessageProcessor.ProcessAsync(messages, CancellationToken.None);
 
-            Assert.False(sinkResult.IsSuccessful);
-            Assert.Equal(batchSize, sinkResult.Succeeded.Count);
-            Assert.Equal(batchSize, sinkResult.Failed.Count);
-            Assert.Equal(batchSize, sinkResult.InvalidDetailsList.Count);
+            Assert.False(sinkResult.IsSuccessful); // one batch went wrong, should report here
+            Assert.Equal(3 * batchSize + 1 * batchSize, sinkResult.Succeeded.Count);  // dev1 all good, dev2 1st good
+            Assert.Equal(2 * batchSize, sinkResult.Failed.Count);
+            Assert.Equal(0, sinkResult.InvalidDetailsList.Count);
             Assert.True(sinkResult.SendFailureDetails.HasValue);
             Assert.Equal(FailureKind.Transient, sinkResult.SendFailureDetails.Expect(() => new Exception()).FailureKind);
         }
@@ -492,12 +533,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             var systemProperties = new Dictionary<string, string>
             {
                 { SystemProperties.DeviceId, id }
-            };
-
-            var cancelProperties = new Dictionary<string, string>()
-            {
-                { "Delay", "true" },
-                { "Prop2", "Val2" }
             };
 
             var message = new RoutingMessage(TelemetryMessageSource.Instance, messageBody, properties, systemProperties);
@@ -558,27 +593,48 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             return () => Task.FromException(new T());
         }
 
-        internal static CloudProxyBuilder CreateWithResponses(int count, Func<Task> action)
+        internal static CloudProxyBuilder Create()
         {
-            var result = new CloudProxyBuilder();
-            result.ThenMany(count, action);
-
-            return result;
+            return new CloudProxyBuilder();
         }
 
         internal class CloudProxyBuilder
         {
+            private Random random = new Random(834793);
             private List<(int, Func<Task>)> callResponses = new List<(int, Func<Task>)>();
+            private int batchSize = 10;
+            private Func<Task> successAction = ThrowingCloudProxy.Success();
 
-            internal CloudProxyBuilder Then(Func<Task> action)
+            internal CloudProxyBuilder WithBatchSize(int batchSize)
             {
-                this.callResponses.Add((1, action));
+                this.batchSize = batchSize;
                 return this;
             }
 
-            internal CloudProxyBuilder ThenMany(int count, Func<Task> action)
+            internal CloudProxyBuilder WithSuccessAction(Func<Task> successAction)
             {
-                this.callResponses.Add((count, action));
+                this.successAction = successAction;
+                return this;
+            }
+
+            internal CloudProxyBuilder WithReportSuccessfulBatch(int batchCount = 1)
+            {
+                this.callResponses.Add((batchCount * this.batchSize, this.successAction));
+                return this;
+            }
+
+            internal CloudProxyBuilder WithReportErrorInBatch(Func<Task> errorAction)
+            {
+                var index = this.random.Next(this.batchSize);
+
+                if (index > 0)
+                    this.callResponses.Add((index, this.successAction));
+
+                this.callResponses.Add((1, errorAction));
+
+                if (index + 1 != this.batchSize)
+                    this.callResponses.Add((this.batchSize - (index + 1), this.successAction));
+
                 return this;
             }
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CollectionEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CollectionEx.cs
@@ -143,6 +143,8 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
         public static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> list, int batchSize)
         {
+            Preconditions.CheckArgument(batchSize > 0, "BatchSize should be > 0");
+
             var current = new List<T>();
             foreach (T item in list)
             {


### PR DESCRIPTION
Cherry pick #1845

* Changed CloudEndpoint to fail subsequent batches after a transient error
* Changed ModuleEndpoint, so after a failed message it fails all subsequent in order to keep message order for retry