### PR TITLE
Fix test report generation

### DIFF
--- a/test/modules/Modules.Test/TestResultCoordinator/TestReportHelperTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/TestReportHelperTest.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Modules.Test.TestResultCoordinator
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using global::TestResultCoordinator;
+    using global::TestResultCoordinator.Reports;
+    using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Extensions.Logging;
+    using Moq;
+    using Xunit;
+
+    public class TestReportHelperTest
+    {
+        [Fact]
+        public async Task TestGenerateTestResultReportsAsync_MissingTrackingId()
+        {
+            var mockLogger = new Mock<ILogger>();
+            var mockTestReportGeneratorFactory = new Mock<ITestReportGeneratorFactory>();
+
+            ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(() =>
+                 TestReportHelper.GenerateTestResultReportsAsync(
+                     string.Empty,
+                     new List<IReportMetadata>(),
+                     mockTestReportGeneratorFactory.Object,
+                     mockLogger.Object));
+
+            Assert.StartsWith("trackingId", ex.Message, StringComparison.Ordinal);
+        }
+
+        [Fact]
+        public async Task TestGenerateTestResultReportsAsync_NullReportMetadata()
+        {
+            var mockLogger = new Mock<ILogger>();
+            var mockTestReportGeneratorFactory = new Mock<ITestReportGeneratorFactory>();
+
+            ArgumentNullException ex = await Assert.ThrowsAsync<ArgumentNullException>(() =>
+                 TestReportHelper.GenerateTestResultReportsAsync(
+                     "fakeTrackngId",
+                     null,
+                     mockTestReportGeneratorFactory.Object,
+                     mockLogger.Object));
+
+            Assert.Equal("reportMetadatalist", ex.ParamName);
+        }
+
+        [Theory]
+        [InlineData(false, false, false, 3)]
+        [InlineData(true, false, true, 1)]
+        [InlineData(true, false, false, 2)]
+        [InlineData(true, true, true, 0)]
+        public async Task TestGenerateTestResultReportsAsync_ReportGeneration(bool throwExceptionForTestReport1, bool throwExceptionForTestReport2, bool throwExceptionForTestReport3, int expectedReportCount)
+        {
+            var mockLogger = new Mock<ILogger>();
+            var mockTestReportGeneratorFactory = new Mock<ITestReportGeneratorFactory>();
+
+            string trackingId = "fakeTrackingId";
+            var countingReportMetadata = new CountingReportMetadata("CountingExpectedSource", "CountingAcutalSource", TestOperationResultType.Messages, TestReportType.CountingReport);
+            var twinCountingReportMetadata = new TwinCountingReportMetadata("TwinExpectedSource", "TwinActualSource", TestReportType.TwinCountingReport, TwinTestPropertyType.Desired);
+            var deploymentReportMetadata = new DeploymentTestReportMetadata("DeploymentExpectedSource", "DeploymentActualSource");
+
+            var mockTestReportGenerator1 = new Mock<ITestResultReportGenerator>();
+            mockTestReportGenerator1.Setup(g => g.CreateReportAsync()).Returns(this.MockTestResultReport(throwExceptionForTestReport1));
+
+            var mockTestReportGenerator2 = new Mock<ITestResultReportGenerator>();
+            mockTestReportGenerator2.Setup(g => g.CreateReportAsync()).Returns(this.MockTestResultReport(throwExceptionForTestReport2));
+
+            var mockTestReportGenerator3 = new Mock<ITestResultReportGenerator>();
+            mockTestReportGenerator3.Setup(g => g.CreateReportAsync()).Returns(this.MockTestResultReport(throwExceptionForTestReport3));
+
+            mockTestReportGeneratorFactory.Setup(f => f.Create(trackingId, countingReportMetadata)).Returns(mockTestReportGenerator1.Object);
+            mockTestReportGeneratorFactory.Setup(f => f.Create(trackingId, twinCountingReportMetadata)).Returns(mockTestReportGenerator2.Object);
+            mockTestReportGeneratorFactory.Setup(f => f.Create(trackingId, deploymentReportMetadata)).Returns(mockTestReportGenerator3.Object);
+
+            ITestResultReport[] reports = await TestReportHelper.GenerateTestResultReportsAsync(
+                trackingId,
+                new List<IReportMetadata>
+                {
+                    countingReportMetadata,
+                    twinCountingReportMetadata,
+                    deploymentReportMetadata
+                },
+                mockTestReportGeneratorFactory.Object,
+                mockLogger.Object);
+
+            Assert.Equal(expectedReportCount, reports.Length);
+        }
+
+        private Task<ITestResultReport> MockTestResultReport(bool throwException)
+        {
+            if (!throwException)
+            {
+                return Task.FromResult<ITestResultReport>(new CountingReport("mock", "mock", "mock", "mock", 23, 21, 12, new List<TestOperationResult>()));
+            }
+
+            return Task.FromException<ITestResultReport>(new ApplicationException("Inject exception for testing"));
+        }
+    }
+}

--- a/test/modules/TestResultCoordinator/Controllers/ReportController.cs
+++ b/test/modules/TestResultCoordinator/Controllers/ReportController.cs
@@ -27,7 +27,8 @@ namespace TestResultCoordinator.Controllers
         [HttpGet]
         public async Task<ContentResult> GetReportsAsync()
         {
-            ITestResultReport[] testResultReports = await TestReportHelper.GenerateTestResultReports(this.storage, Logger);
+            var testReportGeneratorFactory = new TestReportGeneratorFactory(this.storage);
+            ITestResultReport[] testResultReports = await TestReportHelper.GenerateTestResultReportsAsync(Settings.Current.TrackingId, Settings.Current.GetReportMetadataList(), testReportGeneratorFactory, Logger);
 
             if (testResultReports.Length == 0)
             {

--- a/test/modules/TestResultCoordinator/Reports/IReportMetadata.cs
+++ b/test/modules/TestResultCoordinator/Reports/IReportMetadata.cs
@@ -3,7 +3,7 @@ namespace TestResultCoordinator.Reports
 {
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
 
-    interface IReportMetadata
+    public interface IReportMetadata
     {
         string ExpectedSource { get; }
 

--- a/test/modules/TestResultCoordinator/Reports/ITestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/Reports/ITestReportGeneratorFactory.cs
@@ -4,7 +4,7 @@ namespace TestResultCoordinator.Reports
     /// <summary>
     /// This is used to create an instance of test report generator based on given report-related parameters.
     /// </summary>
-    interface ITestReportGeneratorFactory
+    public interface ITestReportGeneratorFactory
     {
         ITestResultReportGenerator Create(
             string trackingId,

--- a/test/modules/TestResultCoordinator/Reports/ITestResultReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/ITestResultReport.cs
@@ -4,7 +4,7 @@ namespace TestResultCoordinator.Reports
     /// <summary>
     /// This defines the basic properties of a test result report.
     /// </summary>
-    interface ITestResultReport
+    public interface ITestResultReport
     {
         string TrackingId { get; }
 

--- a/test/modules/TestResultCoordinator/Reports/ITestResultReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/Reports/ITestResultReportGenerator.cs
@@ -6,7 +6,7 @@ namespace TestResultCoordinator.Reports
     /// <summary>
     /// This defines methods for a test result report generator.
     /// </summary>
-    interface ITestResultReportGenerator
+    public interface ITestResultReportGenerator
     {
         Task<ITestResultReport> CreateReportAsync();
     }

--- a/test/modules/TestResultCoordinator/Reports/TestReportType.cs
+++ b/test/modules/TestResultCoordinator/Reports/TestReportType.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace TestResultCoordinator.Reports
 {
-    enum TestReportType
+    public enum TestReportType
     {
         CountingReport,
         TwinCountingReport,

--- a/test/modules/TestResultCoordinator/Services/TestResultReportingService.cs
+++ b/test/modules/TestResultCoordinator/Services/TestResultReportingService.cs
@@ -58,7 +58,8 @@ namespace TestResultCoordinator.Services
 
         async void DoWorkAsync(object state)
         {
-            ITestResultReport[] testResultReports = await TestReportHelper.GenerateTestResultReports(this.storage, this.logger);
+            var tesReportGeneratorFactory = new TestReportGeneratorFactory(this.storage);
+            ITestResultReport[] testResultReports = await TestReportHelper.GenerateTestResultReportsAsync(Settings.Current.TrackingId, Settings.Current.GetReportMetadataList(), tesReportGeneratorFactory, this.logger);
 
             if (testResultReports.Length == 0)
             {

--- a/test/modules/TestResultCoordinator/Startup.cs
+++ b/test/modules/TestResultCoordinator/Startup.cs
@@ -53,7 +53,7 @@ namespace TestResultCoordinator
             }
 
             services.AddSingleton<ITestOperationResultStorage>(
-                TestOperationResultStorage.Create(
+                TestOperationResultStorage.CreateAsync(
                     storeProvider,
                     Settings.Current.GetResultSources()).Result);
 

--- a/test/modules/TestResultCoordinator/TwinTestPropertyType.cs
+++ b/test/modules/TestResultCoordinator/TwinTestPropertyType.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace TestResultCoordinator
 {
-    enum TwinTestPropertyType
+    public enum TwinTestPropertyType
     {
         Desired,
         Reported

--- a/test/modules/TestResultCoordinator/storage/TestOperationResultStorage.cs
+++ b/test/modules/TestResultCoordinator/storage/TestOperationResultStorage.cs
@@ -20,7 +20,7 @@ namespace TestResultCoordinator.Storage
             this.resultStores = resultStores;
         }
 
-        public static async Task<TestOperationResultStorage> Create(IStoreProvider storeProvider, HashSet<string> resultSources)
+        public static async Task<TestOperationResultStorage> CreateAsync(IStoreProvider storeProvider, HashSet<string> resultSources)
         {
             Preconditions.CheckNotNull(storeProvider, nameof(storeProvider));
             var resultSourcesToStores = new Dictionary<string, ISequentialStore<TestOperationResult>>();


### PR DESCRIPTION
Return completely generated reports and log errors for any report generation errors.  Add unit tests.