### PR TITLE
Fix docker stats

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/metrics/MetricsCommandFactory.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/metrics/MetricsCommandFactory.cs
@@ -117,13 +117,13 @@ public class FactoryMetrics
         {
             string commandName = Enum.GetName(typeof(ModuleCommandMetric), command).ToLower();
             return metricsProvider.CreateCounter(
-                $"module_{commandName}_total",
+                $"module_{commandName}",
                 "Command sent to module",
                 new List<string> { "module_name", "module_version", MetricsConstants.MsTelemetry });
         });
 
         this.commandTiming = metricsProvider.CreateDuration(
-            $"command_latency_seconds",
+            $"command_latency",
             "Command sent to module",
             new List<string> { "command", MetricsConstants.MsTelemetry });
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/models/DockerStats.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/models/DockerStats.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Models
     public class DockerStats
     {
         [JsonConstructor]
-        public DockerStats(string name, Dictionary<string, DiskIO[]> block_io_stats, DockerCpuStats cpu_stats, MemoryStats memory_stats, Dictionary<string, NetworkInfo> networks, int? num_procs, PidsStats pids_stats, DateTime? read)
+        public DockerStats(string name, Dictionary<string, DiskIO[]> blkio_stats, DockerCpuStats cpu_stats, MemoryStats memory_stats, Dictionary<string, NetworkInfo> networks, int? num_procs, PidsStats pids_stats, DateTime? read)
         {
             this.Name = Option.Maybe(name);
-            this.BlockIoStats = Option.Maybe(block_io_stats);
+            this.BlockIoStats = Option.Maybe(blkio_stats);
             this.CpuStats = Option.Maybe(cpu_stats);
             this.MemoryStats = Option.Maybe(memory_stats);
             this.Networks = Option.Maybe(networks);


### PR DESCRIPTION
module command and command latency had units twice (command_latency_seconds_seconds)
read/write stats weren't being parsed correctly. 