### PR TITLE
Add agent to custom network 

### DIFF
--- a/doc/IPv6Configuration.md
+++ b/doc/IPv6Configuration.md
@@ -1,17 +1,12 @@
 # IPv6 support in IoT Edge (Linux only)
 
-IoT Edge can be configured to work on Linux devices that are on IPv6 networks. On Linux devices, IoT Edge creates modules in two different docker networks:
-
-1. Default 'bridge' network: This network is created by docker. The Edge Agent module is deployed to this network.
-
-2. Custom 'azure-iot-edge' network: This network is created by `iotedged`. All user defined modules along with Edge Hub are deployed to this network.
+IoT Edge can be configured to work on Linux devices that are on IPv6 networks. On Linux devices, a user-defined network named 'azure-iot-edge' is created by `iotedged`. All modules, including Edge Agent and Edge Hub, are deployed to this network.
 
 To learn more about IoT Edge networking, please refer to the [networking](./networking.md) documentation.
 
 # Device specific configuration
 
-Firstly, to configure docker to create container networks with IPv4/IPv6 dual-stack enabled, the following changes are required on the device:
-(The following steps are based on the [Docker IPv6][1] documentation. Please refer to it for guidance)
+Firstly, to configure docker to create container networks with IPv4/IPv6 dual-stack enabled, the following changes are required on the device (see the [Docker IPv6][1] documentation for further guidance):
 
 ## Configure docker for IPv4/IPv6 dual-stack support
 
@@ -33,13 +28,13 @@ IPv4/IPv6 dual stack support can be enabled on docker using either of the follow
 dockerd --ipv6 --fixed-cidr-v6 "2021:ffff:e0:3b1:0::/80" --dns ["2021:ffff:0:4:fe::6464","10.55.40.50"]
 ```
 
-The value of fixed-cidr-v6 defines the subnet for the docker0 bridge network that gets created on the device. The Edge Agent module is deployed to the bridge network. This subnet can be obtained from your IaaS provider.
+The value of fixed-cidr-v6 defines the subnet for the docker0 bridge network that gets created on the device. This subnet can be obtained from your IaaS provider.
 
 ## Configure the public network interface
 
 As per the [docker IPv6 documentation][1]:
 
-* IPv6 forwarding may interfere with your existing IPv6 configuration. If you are using Router Advertisements to get IPv6 settings for your host’s interfaces, set accept_ra to 2. Otherwise IPv6 enabled forwarding will result in rejecting Router Advertisements. To enable router advertisements, execute the following command:
+* IPv6 forwarding may interfere with your existing IPv6 configuration. If you are using Router Advertisements to get IPv6 settings for your host's interfaces, set accept_ra to 2. Otherwise IPv6 enabled forwarding will result in rejecting router advertisements. To enable router advertisements, execute the following command:
 
 ```bash
 sysctl -w net.ipv6.conf.eth0.accept_ra=2
@@ -78,11 +73,7 @@ This can be achieved by either of the following two methods:
       sudo apt-get install ndppd
       ```
 
-   * Create /etc/ndppd.conf. You will need to define two rule sections for the eth0 network interface (or the public network interface on your device) for the two subnets:
-
-      a. 'docker0' bridge network: This is the network with subnet defined in the daemon.json file.
-
-      b. 'azure-iot-edge' user defined network: The subnet configuration for this network is specified in the config.yaml file of IoT Edge later.
+   * Create /etc/ndppd.conf:
 
       ```conf
       route-ttl 5000

--- a/doc/networking.md
+++ b/doc/networking.md
@@ -4,51 +4,28 @@ IoT Edge uses the networking capabilities of the Moby runtime to connect to IoT 
 In a basic IoT Edge setup, the default configuration should be sufficient.
 However, if there are additional requirements for firewalls or network topology, it is helpful to understand IoT Edge's network setup and dependencies.
 
-On Windows, all containers are started on the Moby [nat network][3]. The only requirement for IoT Edge is that this nat network has outbound internet connectivity to IoT Hub, a container registry, and optionally the Device Provisioning Service.
-
 # Default Topology
 
 ![IoT Edge network][network]
 
 # Networks
 
-By default, IoT Edge uses two networks for connectivity between containers.
-This allows an additional form of isolation between the host network, the Edge Agent, and application containers.
+By default, IoT Edge places modules on a Docker network rather than the host network.
+This allows an additional form of isolation between the host network and application containers.
 
-The Edge Agent attaches to the [default docker network][1] (name and type are `bridge` on Linux, `nat` on Windows).
-Inside a Linux container, this default network device shows up as `docker0` when running `ifconfig`.
+## Nat Network (Windows only)
 
-On Linux, the remaining containers, including the Edge Hub, are placed on a [user-defined network][2] named `azure-iot-edge` . Like the default network, this network's type is `bridge` on Linux, `nat` on Windows.
-
-## Default Network
-
-The Edge Agent is started by `iotedged` and is started without any explicit networking configuration.
-By default, the Moby runtime places all containers without a defined network configuration on the default network (named `bridge` on Linux, `nat` on Windows).
-
-The Edge Agent requires outbound internet connectivity to IoT Hub to function properly.
-This means that a route from the default docker subnet to the internet must exist, no firewall rules are setup to block traffic, and IP forwarding is enabled.
-All three of these conditions are met in the standard Moby installation.
-
-### Configuring the Default Network
-
-The Moby Engine creates and configures the default network.
-Changing this configuration is done at the Moby Engine level, by modifying the `daemon.json` config file and restarting the Moby Engine.
-This file is normally located at `/etc/docker/daemon.json` on Linux.
-
-Reasons for changing this configuration include:
-* Modifying the IP block used for assigning IPs to containers
-* Changing the MTU
-* Changing the gateway address
-* Enabling IPv4/IPv6 dual-stack support
-
-The usual reason for modifying this configuration is that some other subnet on the network clashes with the default docker subnet.
+On Windows, all containers are started on the Moby [nat network][3].
+The only requirement for IoT Edge is that this nat network has outbound internet connectivity to IoT Hub, a container registry, and optionally the Device Provisioning Service.
 
 ## User-defined Network (Linux only)
 
-On Linux, all modules (containers), including the Edge Hub, are started by the Edge Agent and placed on a user-defined network named `azure-iot-edge`.
-This network is created when the `iotedged` boots for the first time.
+On Linux, `iotedged` creates a [user-defined network][2] named `azure-iot-edge` when it boots for the first time.
+It also starts the Edge Agent and places it on the `azure-iot-edge` network.
 
-The Edge Hub requires outbound internet connectivity to IoT Hub to function properly.
+All other modules (containers), including the Edge Hub, are started by the Edge Agent and placed on the `azure-iot-edge` network.
+
+Edge Agent and Edge Hub require outbound internet connectivity to IoT Hub to function properly.
 This means that a route from the `azure-iot-edge` subnet to the internet must exist and no firewall rules are set up to block traffic.
 
 ### Configuring `azure-iot-edge`

--- a/edgelet/docker-rs/src/models/container_create_body.rs
+++ b/edgelet/docker-rs/src/models/container_create_body.rs
@@ -112,8 +112,8 @@ pub struct ContainerCreateBody {
     // shell: Option<Vec<String>>,
     #[serde(rename = "HostConfig", skip_serializing_if = "Option::is_none")]
     host_config: Option<crate::models::HostConfig>,
-    // #[serde(rename = "NetworkingConfig", skip_serializing_if = "Option::is_none")]
-    // networking_config: Option<crate::models::ContainerCreateBodyNetworkingConfig>,
+    #[serde(rename = "NetworkingConfig", skip_serializing_if = "Option::is_none")]
+    networking_config: Option<crate::models::ContainerCreateBodyNetworkingConfig>,
     #[serde(flatten)]
     other_properties: std::collections::HashMap<String, serde_json::Value>,
 }
@@ -147,7 +147,7 @@ impl ContainerCreateBody {
             // stop_timeout: None,
             // shell: None,
             host_config: None,
-            // networking_config: None,
+            networking_config: None,
             other_properties: Default::default(),
         }
     }
@@ -597,26 +597,26 @@ impl ContainerCreateBody {
         self.host_config = None;
     }
 
-    // pub fn set_networking_config(
-    //     &mut self,
-    //     networking_config: crate::models::ContainerCreateBodyNetworkingConfig,
-    // ) {
-    //     self.networking_config = Some(networking_config);
-    // }
+    pub fn set_networking_config(
+        &mut self,
+        networking_config: crate::models::ContainerCreateBodyNetworkingConfig,
+    ) {
+        self.networking_config = Some(networking_config);
+    }
 
-    // pub fn with_networking_config(
-    //     mut self,
-    //     networking_config: crate::models::ContainerCreateBodyNetworkingConfig,
-    // ) -> Self {
-    //     self.networking_config = Some(networking_config);
-    //     self
-    // }
+    pub fn with_networking_config(
+        mut self,
+        networking_config: crate::models::ContainerCreateBodyNetworkingConfig,
+    ) -> Self {
+        self.networking_config = Some(networking_config);
+        self
+    }
 
-    // pub fn networking_config(&self) -> Option<&crate::models::ContainerCreateBodyNetworkingConfig> {
-    //     self.networking_config.as_ref()
-    // }
+    pub fn networking_config(&self) -> Option<&crate::models::ContainerCreateBodyNetworkingConfig> {
+        self.networking_config.as_ref()
+    }
 
-    // pub fn reset_networking_config(&mut self) {
-    //     self.networking_config = None;
-    // }
+    pub fn reset_networking_config(&mut self) {
+        self.networking_config = None;
+    }
 }

--- a/edgelet/docker-rs/src/models/container_create_body_networking_config.rs
+++ b/edgelet/docker-rs/src/models/container_create_body_networking_config.rs
@@ -13,11 +13,34 @@
 #[allow(unused_imports)]
 use serde_json::Value;
 
+// DEVNOTE: Why is most of this type commented out?
+//
+// We do not want to restrict the properties that the user can set in their create options, because future versions of Docker can add new properties
+// that we don't define here.
+//
+// So this type has a `#[serde(flatten)] HashMap` field to collect all the extra properties that we don't have a struct field for.
+//
+// But if an existing field references another type under `crate::models::`, then that would still be parsed lossily, so we would have to also add
+// a `#[serde(flatten)] HashMap` field there. And if that type has fields that reference types under `crate::models::` ...
+//
+// To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
+//
+// ---
+//
+// If you need to access a commented out field, uncomment it.
+//
+// - If it's a simple built-in type, then that is all you need to do.
+//
+// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] HashMap` property
+//   and is commented out as much as possible. Also copy this devnote there for future readers.
+
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
 pub struct ContainerCreateBodyNetworkingConfig {
     /// A mapping of network name to endpoint configuration for that network.
     #[serde(rename = "EndpointsConfig", skip_serializing_if = "Option::is_none")]
     endpoints_config: Option<::std::collections::HashMap<String, crate::models::EndpointSettings>>,
+    #[serde(flatten)]
+    other_properties: std::collections::HashMap<String, serde_json::Value>,
 }
 
 impl ContainerCreateBodyNetworkingConfig {
@@ -25,6 +48,7 @@ impl ContainerCreateBodyNetworkingConfig {
     pub fn new() -> Self {
         ContainerCreateBodyNetworkingConfig {
             endpoints_config: None,
+            other_properties: Default::default(),
         }
     }
 

--- a/edgelet/docker-rs/src/models/endpoint_settings.rs
+++ b/edgelet/docker-rs/src/models/endpoint_settings.rs
@@ -13,119 +13,143 @@
 #[allow(unused_imports)]
 use serde_json::Value;
 
+// DEVNOTE: Why is most of this type commented out?
+//
+// We do not want to restrict the properties that the user can set in their create options, because future versions of Docker can add new properties
+// that we don't define here.
+//
+// So this type has a `#[serde(flatten)] HashMap` field to collect all the extra properties that we don't have a struct field for.
+//
+// But if an existing field references another type under `crate::models::`, then that would still be parsed lossily, so we would have to also add
+// a `#[serde(flatten)] HashMap` field there. And if that type has fields that reference types under `crate::models::` ...
+//
+// To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
+//
+// ---
+//
+// If you need to access a commented out field, uncomment it.
+//
+// - If it's a simple built-in type, then that is all you need to do.
+//
+// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] HashMap` property
+//   and is commented out as much as possible. Also copy this devnote there for future readers.
+
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
 pub struct EndpointSettings {
-    #[serde(rename = "IPAMConfig", skip_serializing_if = "Option::is_none")]
-    ipam_config: Option<crate::models::EndpointIpamConfig>,
-    #[serde(rename = "Links", skip_serializing_if = "Option::is_none")]
-    links: Option<Vec<String>>,
-    #[serde(rename = "Aliases", skip_serializing_if = "Option::is_none")]
-    aliases: Option<Vec<String>>,
+    // #[serde(rename = "IPAMConfig", skip_serializing_if = "Option::is_none")]
+    // ipam_config: Option<crate::models::EndpointIpamConfig>,
+    // #[serde(rename = "Links", skip_serializing_if = "Option::is_none")]
+    // links: Option<Vec<String>>,
+    // #[serde(rename = "Aliases", skip_serializing_if = "Option::is_none")]
+    // aliases: Option<Vec<String>>,
     /// Unique ID of the network.
     #[serde(rename = "NetworkID", skip_serializing_if = "Option::is_none")]
     network_id: Option<String>,
-    /// Unique ID for the service endpoint in a Sandbox.
-    #[serde(rename = "EndpointID", skip_serializing_if = "Option::is_none")]
-    endpoint_id: Option<String>,
-    /// Gateway address for this network.
-    #[serde(rename = "Gateway", skip_serializing_if = "Option::is_none")]
-    gateway: Option<String>,
-    /// IPv4 address.
-    #[serde(rename = "IPAddress", skip_serializing_if = "Option::is_none")]
-    ip_address: Option<String>,
-    /// Mask length of the IPv4 address.
-    #[serde(rename = "IPPrefixLen", skip_serializing_if = "Option::is_none")]
-    ip_prefix_len: Option<i32>,
-    /// IPv6 gateway address.
-    #[serde(rename = "IPv6Gateway", skip_serializing_if = "Option::is_none")]
-    i_pv6_gateway: Option<String>,
-    /// Global IPv6 address.
-    #[serde(rename = "GlobalIPv6Address", skip_serializing_if = "Option::is_none")]
-    global_i_pv6_address: Option<String>,
-    /// Mask length of the global IPv6 address.
-    #[serde(
-        rename = "GlobalIPv6PrefixLen",
-        skip_serializing_if = "Option::is_none"
-    )]
-    global_i_pv6_prefix_len: Option<i64>,
-    /// MAC address for the endpoint on this network.
-    #[serde(rename = "MacAddress", skip_serializing_if = "Option::is_none")]
-    mac_address: Option<String>,
-    /// DriverOpts is a mapping of driver options and values. These options are passed directly to the driver and are driver specific.
-    #[serde(rename = "DriverOpts", skip_serializing_if = "Option::is_none")]
-    driver_opts: Option<::std::collections::HashMap<String, String>>,
+    // /// Unique ID for the service endpoint in a Sandbox.
+    // #[serde(rename = "EndpointID", skip_serializing_if = "Option::is_none")]
+    // endpoint_id: Option<String>,
+    // /// Gateway address for this network.
+    // #[serde(rename = "Gateway", skip_serializing_if = "Option::is_none")]
+    // gateway: Option<String>,
+    // /// IPv4 address.
+    // #[serde(rename = "IPAddress", skip_serializing_if = "Option::is_none")]
+    // ip_address: Option<String>,
+    // /// Mask length of the IPv4 address.
+    // #[serde(rename = "IPPrefixLen", skip_serializing_if = "Option::is_none")]
+    // ip_prefix_len: Option<i32>,
+    // /// IPv6 gateway address.
+    // #[serde(rename = "IPv6Gateway", skip_serializing_if = "Option::is_none")]
+    // i_pv6_gateway: Option<String>,
+    // /// Global IPv6 address.
+    // #[serde(rename = "GlobalIPv6Address", skip_serializing_if = "Option::is_none")]
+    // global_i_pv6_address: Option<String>,
+    // /// Mask length of the global IPv6 address.
+    // #[serde(
+    //     rename = "GlobalIPv6PrefixLen",
+    //     skip_serializing_if = "Option::is_none"
+    // )]
+    // global_i_pv6_prefix_len: Option<i64>,
+    // /// MAC address for the endpoint on this network.
+    // #[serde(rename = "MacAddress", skip_serializing_if = "Option::is_none")]
+    // mac_address: Option<String>,
+    // /// DriverOpts is a mapping of driver options and values. These options are passed directly to the driver and are driver specific.
+    // #[serde(rename = "DriverOpts", skip_serializing_if = "Option::is_none")]
+    // driver_opts: Option<::std::collections::HashMap<String, String>>,
+    #[serde(flatten)]
+    other_properties: std::collections::HashMap<String, serde_json::Value>,
 }
 
 impl EndpointSettings {
     /// Configuration for a network endpoint.
     pub fn new() -> Self {
         EndpointSettings {
-            ipam_config: None,
-            links: None,
-            aliases: None,
+            // ipam_config: None,
+            // links: None,
+            // aliases: None,
             network_id: None,
-            endpoint_id: None,
-            gateway: None,
-            ip_address: None,
-            ip_prefix_len: None,
-            i_pv6_gateway: None,
-            global_i_pv6_address: None,
-            global_i_pv6_prefix_len: None,
-            mac_address: None,
-            driver_opts: None,
+            // endpoint_id: None,
+            // gateway: None,
+            // ip_address: None,
+            // ip_prefix_len: None,
+            // i_pv6_gateway: None,
+            // global_i_pv6_address: None,
+            // global_i_pv6_prefix_len: None,
+            // mac_address: None,
+            // driver_opts: None,
+            other_properties: Default::default(),
         }
     }
 
-    pub fn set_ipam_config(&mut self, ipam_config: crate::models::EndpointIpamConfig) {
-        self.ipam_config = Some(ipam_config);
-    }
+    // pub fn set_ipam_config(&mut self, ipam_config: crate::models::EndpointIpamConfig) {
+    //     self.ipam_config = Some(ipam_config);
+    // }
 
-    pub fn with_ipam_config(mut self, ipam_config: crate::models::EndpointIpamConfig) -> Self {
-        self.ipam_config = Some(ipam_config);
-        self
-    }
+    // pub fn with_ipam_config(mut self, ipam_config: crate::models::EndpointIpamConfig) -> Self {
+    //     self.ipam_config = Some(ipam_config);
+    //     self
+    // }
 
-    pub fn ipam_config(&self) -> Option<&crate::models::EndpointIpamConfig> {
-        self.ipam_config.as_ref()
-    }
+    // pub fn ipam_config(&self) -> Option<&crate::models::EndpointIpamConfig> {
+    //     self.ipam_config.as_ref()
+    // }
 
-    pub fn reset_ipam_config(&mut self) {
-        self.ipam_config = None;
-    }
+    // pub fn reset_ipam_config(&mut self) {
+    //     self.ipam_config = None;
+    // }
 
-    pub fn set_links(&mut self, links: Vec<String>) {
-        self.links = Some(links);
-    }
+    // pub fn set_links(&mut self, links: Vec<String>) {
+    //     self.links = Some(links);
+    // }
 
-    pub fn with_links(mut self, links: Vec<String>) -> Self {
-        self.links = Some(links);
-        self
-    }
+    // pub fn with_links(mut self, links: Vec<String>) -> Self {
+    //     self.links = Some(links);
+    //     self
+    // }
 
-    pub fn links(&self) -> Option<&[String]> {
-        self.links.as_ref().map(AsRef::as_ref)
-    }
+    // pub fn links(&self) -> Option<&[String]> {
+    //     self.links.as_ref().map(AsRef::as_ref)
+    // }
 
-    pub fn reset_links(&mut self) {
-        self.links = None;
-    }
+    // pub fn reset_links(&mut self) {
+    //     self.links = None;
+    // }
 
-    pub fn set_aliases(&mut self, aliases: Vec<String>) {
-        self.aliases = Some(aliases);
-    }
+    // pub fn set_aliases(&mut self, aliases: Vec<String>) {
+    //     self.aliases = Some(aliases);
+    // }
 
-    pub fn with_aliases(mut self, aliases: Vec<String>) -> Self {
-        self.aliases = Some(aliases);
-        self
-    }
+    // pub fn with_aliases(mut self, aliases: Vec<String>) -> Self {
+    //     self.aliases = Some(aliases);
+    //     self
+    // }
 
-    pub fn aliases(&self) -> Option<&[String]> {
-        self.aliases.as_ref().map(AsRef::as_ref)
-    }
+    // pub fn aliases(&self) -> Option<&[String]> {
+    //     self.aliases.as_ref().map(AsRef::as_ref)
+    // }
 
-    pub fn reset_aliases(&mut self) {
-        self.aliases = None;
-    }
+    // pub fn reset_aliases(&mut self) {
+    //     self.aliases = None;
+    // }
 
     pub fn set_network_id(&mut self, network_id: String) {
         self.network_id = Some(network_id);
@@ -144,159 +168,159 @@ impl EndpointSettings {
         self.network_id = None;
     }
 
-    pub fn set_endpoint_id(&mut self, endpoint_id: String) {
-        self.endpoint_id = Some(endpoint_id);
-    }
+    // pub fn set_endpoint_id(&mut self, endpoint_id: String) {
+    //     self.endpoint_id = Some(endpoint_id);
+    // }
 
-    pub fn with_endpoint_id(mut self, endpoint_id: String) -> Self {
-        self.endpoint_id = Some(endpoint_id);
-        self
-    }
+    // pub fn with_endpoint_id(mut self, endpoint_id: String) -> Self {
+    //     self.endpoint_id = Some(endpoint_id);
+    //     self
+    // }
 
-    pub fn endpoint_id(&self) -> Option<&str> {
-        self.endpoint_id.as_ref().map(AsRef::as_ref)
-    }
+    // pub fn endpoint_id(&self) -> Option<&str> {
+    //     self.endpoint_id.as_ref().map(AsRef::as_ref)
+    // }
 
-    pub fn reset_endpoint_id(&mut self) {
-        self.endpoint_id = None;
-    }
+    // pub fn reset_endpoint_id(&mut self) {
+    //     self.endpoint_id = None;
+    // }
 
-    pub fn set_gateway(&mut self, gateway: String) {
-        self.gateway = Some(gateway);
-    }
+    // pub fn set_gateway(&mut self, gateway: String) {
+    //     self.gateway = Some(gateway);
+    // }
 
-    pub fn with_gateway(mut self, gateway: String) -> Self {
-        self.gateway = Some(gateway);
-        self
-    }
+    // pub fn with_gateway(mut self, gateway: String) -> Self {
+    //     self.gateway = Some(gateway);
+    //     self
+    // }
 
-    pub fn gateway(&self) -> Option<&str> {
-        self.gateway.as_ref().map(AsRef::as_ref)
-    }
+    // pub fn gateway(&self) -> Option<&str> {
+    //     self.gateway.as_ref().map(AsRef::as_ref)
+    // }
 
-    pub fn reset_gateway(&mut self) {
-        self.gateway = None;
-    }
+    // pub fn reset_gateway(&mut self) {
+    //     self.gateway = None;
+    // }
 
-    pub fn set_ip_address(&mut self, ip_address: String) {
-        self.ip_address = Some(ip_address);
-    }
+    // pub fn set_ip_address(&mut self, ip_address: String) {
+    //     self.ip_address = Some(ip_address);
+    // }
 
-    pub fn with_ip_address(mut self, ip_address: String) -> Self {
-        self.ip_address = Some(ip_address);
-        self
-    }
+    // pub fn with_ip_address(mut self, ip_address: String) -> Self {
+    //     self.ip_address = Some(ip_address);
+    //     self
+    // }
 
-    pub fn ip_address(&self) -> Option<&str> {
-        self.ip_address.as_ref().map(AsRef::as_ref)
-    }
+    // pub fn ip_address(&self) -> Option<&str> {
+    //     self.ip_address.as_ref().map(AsRef::as_ref)
+    // }
 
-    pub fn reset_ip_address(&mut self) {
-        self.ip_address = None;
-    }
+    // pub fn reset_ip_address(&mut self) {
+    //     self.ip_address = None;
+    // }
 
-    pub fn set_ip_prefix_len(&mut self, ip_prefix_len: i32) {
-        self.ip_prefix_len = Some(ip_prefix_len);
-    }
+    // pub fn set_ip_prefix_len(&mut self, ip_prefix_len: i32) {
+    //     self.ip_prefix_len = Some(ip_prefix_len);
+    // }
 
-    pub fn with_ip_prefix_len(mut self, ip_prefix_len: i32) -> Self {
-        self.ip_prefix_len = Some(ip_prefix_len);
-        self
-    }
+    // pub fn with_ip_prefix_len(mut self, ip_prefix_len: i32) -> Self {
+    //     self.ip_prefix_len = Some(ip_prefix_len);
+    //     self
+    // }
 
-    pub fn ip_prefix_len(&self) -> Option<i32> {
-        self.ip_prefix_len
-    }
+    // pub fn ip_prefix_len(&self) -> Option<i32> {
+    //     self.ip_prefix_len
+    // }
 
-    pub fn reset_ip_prefix_len(&mut self) {
-        self.ip_prefix_len = None;
-    }
+    // pub fn reset_ip_prefix_len(&mut self) {
+    //     self.ip_prefix_len = None;
+    // }
 
-    pub fn set_i_pv6_gateway(&mut self, i_pv6_gateway: String) {
-        self.i_pv6_gateway = Some(i_pv6_gateway);
-    }
+    // pub fn set_i_pv6_gateway(&mut self, i_pv6_gateway: String) {
+    //     self.i_pv6_gateway = Some(i_pv6_gateway);
+    // }
 
-    pub fn with_i_pv6_gateway(mut self, i_pv6_gateway: String) -> Self {
-        self.i_pv6_gateway = Some(i_pv6_gateway);
-        self
-    }
+    // pub fn with_i_pv6_gateway(mut self, i_pv6_gateway: String) -> Self {
+    //     self.i_pv6_gateway = Some(i_pv6_gateway);
+    //     self
+    // }
 
-    pub fn i_pv6_gateway(&self) -> Option<&str> {
-        self.i_pv6_gateway.as_ref().map(AsRef::as_ref)
-    }
+    // pub fn i_pv6_gateway(&self) -> Option<&str> {
+    //     self.i_pv6_gateway.as_ref().map(AsRef::as_ref)
+    // }
 
-    pub fn reset_i_pv6_gateway(&mut self) {
-        self.i_pv6_gateway = None;
-    }
+    // pub fn reset_i_pv6_gateway(&mut self) {
+    //     self.i_pv6_gateway = None;
+    // }
 
-    pub fn set_global_i_pv6_address(&mut self, global_i_pv6_address: String) {
-        self.global_i_pv6_address = Some(global_i_pv6_address);
-    }
+    // pub fn set_global_i_pv6_address(&mut self, global_i_pv6_address: String) {
+    //     self.global_i_pv6_address = Some(global_i_pv6_address);
+    // }
 
-    pub fn with_global_i_pv6_address(mut self, global_i_pv6_address: String) -> Self {
-        self.global_i_pv6_address = Some(global_i_pv6_address);
-        self
-    }
+    // pub fn with_global_i_pv6_address(mut self, global_i_pv6_address: String) -> Self {
+    //     self.global_i_pv6_address = Some(global_i_pv6_address);
+    //     self
+    // }
 
-    pub fn global_i_pv6_address(&self) -> Option<&str> {
-        self.global_i_pv6_address.as_ref().map(AsRef::as_ref)
-    }
+    // pub fn global_i_pv6_address(&self) -> Option<&str> {
+    //     self.global_i_pv6_address.as_ref().map(AsRef::as_ref)
+    // }
 
-    pub fn reset_global_i_pv6_address(&mut self) {
-        self.global_i_pv6_address = None;
-    }
+    // pub fn reset_global_i_pv6_address(&mut self) {
+    //     self.global_i_pv6_address = None;
+    // }
 
-    pub fn set_global_i_pv6_prefix_len(&mut self, global_i_pv6_prefix_len: i64) {
-        self.global_i_pv6_prefix_len = Some(global_i_pv6_prefix_len);
-    }
+    // pub fn set_global_i_pv6_prefix_len(&mut self, global_i_pv6_prefix_len: i64) {
+    //     self.global_i_pv6_prefix_len = Some(global_i_pv6_prefix_len);
+    // }
 
-    pub fn with_global_i_pv6_prefix_len(mut self, global_i_pv6_prefix_len: i64) -> Self {
-        self.global_i_pv6_prefix_len = Some(global_i_pv6_prefix_len);
-        self
-    }
+    // pub fn with_global_i_pv6_prefix_len(mut self, global_i_pv6_prefix_len: i64) -> Self {
+    //     self.global_i_pv6_prefix_len = Some(global_i_pv6_prefix_len);
+    //     self
+    // }
 
-    pub fn global_i_pv6_prefix_len(&self) -> Option<i64> {
-        self.global_i_pv6_prefix_len
-    }
+    // pub fn global_i_pv6_prefix_len(&self) -> Option<i64> {
+    //     self.global_i_pv6_prefix_len
+    // }
 
-    pub fn reset_global_i_pv6_prefix_len(&mut self) {
-        self.global_i_pv6_prefix_len = None;
-    }
+    // pub fn reset_global_i_pv6_prefix_len(&mut self) {
+    //     self.global_i_pv6_prefix_len = None;
+    // }
 
-    pub fn set_mac_address(&mut self, mac_address: String) {
-        self.mac_address = Some(mac_address);
-    }
+    // pub fn set_mac_address(&mut self, mac_address: String) {
+    //     self.mac_address = Some(mac_address);
+    // }
 
-    pub fn with_mac_address(mut self, mac_address: String) -> Self {
-        self.mac_address = Some(mac_address);
-        self
-    }
+    // pub fn with_mac_address(mut self, mac_address: String) -> Self {
+    //     self.mac_address = Some(mac_address);
+    //     self
+    // }
 
-    pub fn mac_address(&self) -> Option<&str> {
-        self.mac_address.as_ref().map(AsRef::as_ref)
-    }
+    // pub fn mac_address(&self) -> Option<&str> {
+    //     self.mac_address.as_ref().map(AsRef::as_ref)
+    // }
 
-    pub fn reset_mac_address(&mut self) {
-        self.mac_address = None;
-    }
+    // pub fn reset_mac_address(&mut self) {
+    //     self.mac_address = None;
+    // }
 
-    pub fn set_driver_opts(&mut self, driver_opts: ::std::collections::HashMap<String, String>) {
-        self.driver_opts = Some(driver_opts);
-    }
+    // pub fn set_driver_opts(&mut self, driver_opts: ::std::collections::HashMap<String, String>) {
+    //     self.driver_opts = Some(driver_opts);
+    // }
 
-    pub fn with_driver_opts(
-        mut self,
-        driver_opts: ::std::collections::HashMap<String, String>,
-    ) -> Self {
-        self.driver_opts = Some(driver_opts);
-        self
-    }
+    // pub fn with_driver_opts(
+    //     mut self,
+    //     driver_opts: ::std::collections::HashMap<String, String>,
+    // ) -> Self {
+    //     self.driver_opts = Some(driver_opts);
+    //     self
+    // }
 
-    pub fn driver_opts(&self) -> Option<&::std::collections::HashMap<String, String>> {
-        self.driver_opts.as_ref()
-    }
+    // pub fn driver_opts(&self) -> Option<&::std::collections::HashMap<String, String>> {
+    //     self.driver_opts.as_ref()
+    // }
 
-    pub fn reset_driver_opts(&mut self) {
-        self.driver_opts = None;
-    }
+    // pub fn reset_driver_opts(&mut self) {
+    //     self.driver_opts = None;
+    // }
 }

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -17,7 +17,10 @@ use url::Url;
 
 use docker::apis::client::APIClient;
 use docker::apis::configuration::Configuration;
-use docker::models::{ContainerCreateBody, ContainerCreateBodyNetworkingConfig, EndpointSettings, InlineResponse200, Ipam, NetworkConfig};
+use docker::models::{
+    ContainerCreateBody, ContainerCreateBodyNetworkingConfig, EndpointSettings, InlineResponse200,
+    Ipam, NetworkConfig,
+};
 use edgelet_core::{
     AuthId, Authenticator, GetTrustBundle, Ipam as CoreIpam, LogOptions, MakeModuleRuntime,
     MobyNetwork, Module, ModuleId, ModuleRegistry, ModuleRuntime, ModuleRuntimeState, ModuleSpec,

--- a/edgelet/edgelet-docker/tests/runtime.rs
+++ b/edgelet/edgelet-docker/tests/runtime.rs
@@ -775,6 +775,13 @@ fn container_create_handler(req: Request<Body>) -> ResponseFuture {
                         .unwrap()
                 );
 
+                assert!(create_options
+                    .networking_config()
+                    .unwrap()
+                    .endpoints_config()
+                    .unwrap()
+                    .contains_key(&"test-network-id".to_string()));
+
                 let volumes = create_options.volumes().unwrap();
                 let mut expected = ::std::collections::HashMap::new();
                 expected.insert("test1".to_string(), json!({}));
@@ -821,6 +828,7 @@ fn container_create_succeeds() {
             env.insert("k1".to_string(), "v1".to_string());
             env.insert("k2".to_string(), "v2".to_string());
             env.insert("k3".to_string(), "v3".to_string());
+            env.insert("NetworkId".to_string(), "test-network-id".to_string());
 
             // add some create options
             let mut port_bindings = HashMap::new();


### PR DESCRIPTION
Currently, when edge agent is started by iotedged for the first time (container doesn't already exist on the host) it is added to the default docker network, e.g., "bridge" on Linux.

When the agent's container is upgraded by the deployment (i.e., the deployment specifies a docker image that doesn't match what was given in config.yaml), it is added to the network specified by config.yaml's `moby_runtime.network[.name]` field, e.g., "azure-iot-edge" by default on Linux.

This behavior was inadvertently introduced a long time ago (see e2006e0a4). The common case seems to be to use the default `mcr.microsoft.com/azureiotedge-agent:1.0` image to bootstrap then change to a specific image in the deployment, so for most people the agent lives in the right network most of the time. And even if it's added to the default network instead, that's usually not a problem, which probably explains why this hasn't been an issue. I ran into it while working on the new diagnostics feature (the agent needs to connect to edge hub's Prometheus endpoint, but it's in a different network so it can't resolve the name).

This change makes the behavior more consistent. Now, when the daemon creates the agent container, it will add it to the custom network--the same network it will live on if it ever gets upgraded by a deployment.