### PR TITLE
Add new layered deployment integration tests

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -520,7 +520,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
 
                 ISerde<DeploymentConfig> serde = new TypeSpecificSerDe<DeploymentConfig>(deserializerTypes);
                 IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
-                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers, DefaultRequestTimeout));
+                var deviceManager = new Mock<IDeviceManager>();
+                IEdgeAgentConnection edgeAgentConnection = new EdgeAgentConnection(moduleClientProvider, serde, new RequestManager(requestHandlers, DefaultRequestTimeout), deviceManager.Object);
                 await Task.Delay(TimeSpan.FromSeconds(20));
 
                 Option<DeploymentConfigInfo> deploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                     { "App", "Mongo" }
                 },
                 Content = GetBaseConfigurationContent(),
-                Priority = priority + 1,
+                Priority = priority,
                 TargetCondition = targetCondition
             };
 
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                     { "Addon", "Stream Analytics" }
                 },
                 Content = GetAddOnConfigurationContent(),
-                Priority = priority,
+                Priority = priority + 1,
                 TargetCondition = targetCondition
             };
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -37,9 +37,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             {
                 Labels = new Dictionary<string, string>
                 {
-                    { "App", "Stream Analytics" }
+                    { "App", "Mongo" }
                 },
-                Content = GetDefaultConfigurationContent(),
+                Content = GetBaseConfigurationContent(),
                 Priority = priority,
                 TargetCondition = targetCondition
             };
@@ -135,32 +135,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
 
             string patch = JsonConvert.SerializeObject(reportedProperties);
             return new TwinCollection(patch);
-        }
-
-        public static ConfigurationContent GetDefaultConfigurationContent()
-        {
-            return new ConfigurationContent
-            {
-                ModulesContent = new Dictionary<string, IDictionary<string, object>>
-                {
-                    ["$edgeAgent"] = new Dictionary<string, object>
-                    {
-                        ["properties.desired"] = GetEdgeAgentConfiguration()
-                    },
-                    ["$edgeHub"] = new Dictionary<string, object>
-                    {
-                        ["properties.desired"] = GetEdgeHubConfiguration()
-                    },
-                    ["mongoserver"] = new Dictionary<string, object>
-                    {
-                        ["properties.desired"] = GetTwinConfiguration("mongoserver")
-                    },
-                    ["asa"] = new Dictionary<string, object>
-                    {
-                        ["properties.desired"] = GetTwinConfiguration("asa")
-                    }
-                }
-            };
         }
 
         public static ConfigurationContent GetBaseConfigurationContent()
@@ -405,9 +379,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 Assert.NotNull(deploymentConfig.Runtime);
                 Assert.NotNull(deploymentConfig.SystemModules);
                 Assert.Equal(EdgeAgentConnection.ExpectedSchemaVersion.ToString(), deploymentConfig.SchemaVersion);
-                Assert.Equal(2, deploymentConfig.Modules.Count);
+                Assert.Equal(1, deploymentConfig.Modules.Count);
                 Assert.NotNull(deploymentConfig.Modules["mongoserver"]);
-                Assert.NotNull(deploymentConfig.Modules["asa"]);
 
                 TwinCollection reportedPatch = GetEdgeAgentReportedProperties(deploymentConfigInfo.OrDefault());
                 await edgeAgentConnection.UpdateReportedPropertiesAsync(reportedPatch);


### PR DESCRIPTION
Add a new integration test that composes a base and add-on deployment, deploys it to a fresh Edge device and validates reporting via ADM deployment metrics functionality