### PR TITLE
Refactor and fix test reports

### DIFF
--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportTest.cs
@@ -28,7 +28,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
 
             Assert.Equal("trackingId123", report.TrackingId);
             Assert.Equal("actualSource", report.ActualSource);
-            Assert.Equal("expectedSource", report.ExpectSource);
+            Assert.Equal("expectedSource", report.ExpectedSource);
             Assert.Equal("resultType1", report.ResultType);
             Assert.Equal(945UL, report.TotalExpectCount);
             Assert.Equal(923UL, report.TotalMatchCount);

--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/DeploymentTestReportTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/DeploymentTestReportTest.cs
@@ -33,7 +33,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
 
             Assert.Equal("trackingId123", report.TrackingId);
             Assert.Equal("actualSource", report.ActualSource);
-            Assert.Equal("expectedSource", report.ExpectSource);
+            Assert.Equal("expectedSource", report.ExpectedSource);
             Assert.Equal("resultType1", report.ResultType);
             Assert.Equal(15UL, report.TotalExpectedDeployments);
             Assert.Equal(10UL, report.TotalActualDeployments);

--- a/test/modules/Modules.Test/TestResultCoordinator/TestReportHelperTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/TestReportHelperTest.cs
@@ -22,7 +22,7 @@ namespace Modules.Test.TestResultCoordinator
             ArgumentException ex = await Assert.ThrowsAsync<ArgumentException>(() =>
                  TestReportHelper.GenerateTestResultReportsAsync(
                      string.Empty,
-                     new List<IReportMetadata>(),
+                     new List<ITestReportMetadata>(),
                      mockTestReportGeneratorFactory.Object,
                      mockLogger.Object));
 
@@ -75,7 +75,7 @@ namespace Modules.Test.TestResultCoordinator
 
             ITestResultReport[] reports = await TestReportHelper.GenerateTestResultReportsAsync(
                 trackingId,
-                new List<IReportMetadata>
+                new List<ITestReportMetadata>
                 {
                     countingReportMetadata,
                     twinCountingReportMetadata,

--- a/test/modules/TestResultCoordinator/Reports/CountingReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/CountingReport.cs
@@ -3,6 +3,7 @@ namespace TestResultCoordinator.Reports
 {
     using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Azure.Devices.Edge.Util;
 
     /// <summary>
     /// This is a counting report to show test result counts, e.g. expect and match counts; and contains a list of unmatched test results.
@@ -18,13 +19,19 @@ namespace TestResultCoordinator.Reports
             ulong totalMatchCount,
             ulong totalDuplicateResultCount,
             IReadOnlyList<TestOperationResult> unmatchedResults)
-            : base(trackingId, expectedSource, actualSource, resultType)
+            : base(trackingId, resultType)
         {
+            this.ExpectedSource = Preconditions.CheckNonWhiteSpace(expectedSource, nameof(expectedSource));
+            this.ActualSource = Preconditions.CheckNonWhiteSpace(actualSource, nameof(actualSource));
             this.TotalExpectCount = totalExpectCount;
             this.TotalMatchCount = totalMatchCount;
             this.TotalDuplicateResultCount = totalDuplicateResultCount;
             this.UnmatchedResults = unmatchedResults ?? new List<TestOperationResult>();
         }
+
+        public string ExpectedSource { get; }
+
+        public string ActualSource { get; }
 
         public ulong TotalExpectCount { get; }
 
@@ -35,5 +42,7 @@ namespace TestResultCoordinator.Reports
         public IReadOnlyList<TestOperationResult> UnmatchedResults { get; }
 
         public override bool IsPassed => this.TotalExpectCount == this.TotalMatchCount;
+
+        public override string Title => $"Counting Report ({this.ResultType}) between [{this.ExpectedSource}] and [{this.ActualSource}]";
     }
 }

--- a/test/modules/TestResultCoordinator/Reports/CountingReportMetadata.cs
+++ b/test/modules/TestResultCoordinator/Reports/CountingReportMetadata.cs
@@ -3,7 +3,7 @@ namespace TestResultCoordinator.Reports
 {
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
 
-    class CountingReportMetadata : IReportMetadata
+    class CountingReportMetadata : ITestReportMetadata
     {
         public CountingReportMetadata(string expectedSource, string actualSource, TestOperationResultType testOperationResultType, TestReportType testReportType)
         {
@@ -20,6 +20,8 @@ namespace TestResultCoordinator.Reports
         public TestOperationResultType TestOperationResultType { get; }
 
         public TestReportType TestReportType { get; }
+
+        public string[] ResultSources => new string[] { this.ExpectedSource, this.ActualSource };
 
         public override string ToString()
         {

--- a/test/modules/TestResultCoordinator/Reports/DeploymentTestReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/DeploymentTestReport.cs
@@ -20,14 +20,20 @@ namespace TestResultCoordinator.Reports
             ulong totalMatchedDeployments,
             Option<TestOperationResult> lastActualDeploymentTestResult,
             IReadOnlyList<TestOperationResult> unmatchedResults)
-            : base(trackingId, expectedSource, actualSource, resultType)
+            : base(trackingId, resultType)
         {
+            this.ExpectedSource = Preconditions.CheckNonWhiteSpace(expectedSource, nameof(expectedSource));
+            this.ActualSource = Preconditions.CheckNonWhiteSpace(actualSource, nameof(actualSource));
             this.TotalExpectedDeployments = totalExpectedDeployments;
             this.TotalActualDeployments = totalActualDeployments;
             this.TotalMatchedDeployments = totalMatchedDeployments;
             this.LastActualDeploymentTestResult = lastActualDeploymentTestResult;
             this.UnmatchedResults = unmatchedResults ?? new List<TestOperationResult>();
         }
+
+        public string ExpectedSource { get; }
+
+        public string ActualSource { get; }
 
         public ulong TotalExpectedDeployments { get; }
 
@@ -40,5 +46,7 @@ namespace TestResultCoordinator.Reports
         public IReadOnlyList<TestOperationResult> UnmatchedResults { get; }
 
         public override bool IsPassed => this.TotalExpectedDeployments == this.TotalMatchedDeployments;
+
+        public override string Title => $"Deployment Test Report ({this.ResultType}) between [{this.ExpectedSource}] and [{this.ActualSource}]";
     }
 }

--- a/test/modules/TestResultCoordinator/Reports/DeploymentTestReportMetadata.cs
+++ b/test/modules/TestResultCoordinator/Reports/DeploymentTestReportMetadata.cs
@@ -3,7 +3,7 @@ namespace TestResultCoordinator.Reports
 {
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
 
-    class DeploymentTestReportMetadata : IReportMetadata
+    class DeploymentTestReportMetadata : ITestReportMetadata
     {
         public DeploymentTestReportMetadata(string expectedSource, string actualSource)
         {
@@ -18,6 +18,8 @@ namespace TestResultCoordinator.Reports
         public TestReportType TestReportType => TestReportType.DeploymentTestReport;
 
         public TestOperationResultType TestOperationResultType => TestOperationResultType.Deployment;
+
+        public string[] ResultSources => new string[] { this.ExpectedSource, this.ActualSource };
 
         public override string ToString()
         {

--- a/test/modules/TestResultCoordinator/Reports/ITestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/Reports/ITestReportGeneratorFactory.cs
@@ -8,6 +8,6 @@ namespace TestResultCoordinator.Reports
     {
         ITestResultReportGenerator Create(
             string trackingId,
-            IReportMetadata reportMetadata);
+            ITestReportMetadata reportMetadata);
     }
 }

--- a/test/modules/TestResultCoordinator/Reports/ITestReportMetadata.cs
+++ b/test/modules/TestResultCoordinator/Reports/ITestReportMetadata.cs
@@ -3,11 +3,9 @@ namespace TestResultCoordinator.Reports
 {
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
 
-    public interface IReportMetadata
+    public interface ITestReportMetadata
     {
-        string ExpectedSource { get; }
-
-        string ActualSource { get; }
+        string[] ResultSources { get; }
 
         TestReportType TestReportType { get; }
 

--- a/test/modules/TestResultCoordinator/Reports/ITestResultReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/ITestResultReport.cs
@@ -12,10 +12,6 @@ namespace TestResultCoordinator.Reports
 
         string ResultType { get; }
 
-        string ExpectSource { get; }
-
-        string ActualSource { get; }
-
         bool IsPassed { get; }
     }
 }

--- a/test/modules/TestResultCoordinator/Reports/TestReportHelper.cs
+++ b/test/modules/TestResultCoordinator/Reports/TestReportHelper.cs
@@ -6,13 +6,12 @@ namespace TestResultCoordinator.Reports
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
-    using TestResultCoordinator.Storage;
 
     static class TestReportHelper
     {
         internal static async Task<ITestResultReport[]> GenerateTestResultReportsAsync(
             string trackingId,
-            List<IReportMetadata> reportMetadatalist,
+            List<ITestReportMetadata> reportMetadatalist,
             ITestReportGeneratorFactory testReportGeneratorFactory,
             ILogger logger)
         {
@@ -25,7 +24,7 @@ namespace TestResultCoordinator.Reports
 
             try
             {
-                foreach (IReportMetadata reportMetadata in reportMetadatalist)
+                foreach (ITestReportMetadata reportMetadata in reportMetadatalist)
                 {
                     ITestResultReportGenerator testResultReportGenerator = testReportGeneratorFactory.Create(trackingId, reportMetadata);
                     testResultReportTasks.Add(testResultReportGenerator.CreateReportAsync());

--- a/test/modules/TestResultCoordinator/Reports/TestResultReportBase.cs
+++ b/test/modules/TestResultCoordinator/Reports/TestResultReportBase.cs
@@ -8,23 +8,17 @@ namespace TestResultCoordinator.Reports
     /// </summary>
     abstract class TestResultReportBase : ITestResultReport
     {
-        protected TestResultReportBase(string trackingId, string expectedSource, string actualSource, string resultType)
+        protected TestResultReportBase(string trackingId, string resultType)
         {
             this.TrackingId = Preconditions.CheckNonWhiteSpace(trackingId, nameof(trackingId));
-            this.ExpectSource = Preconditions.CheckNonWhiteSpace(expectedSource, nameof(expectedSource));
-            this.ActualSource = Preconditions.CheckNonWhiteSpace(actualSource, nameof(actualSource));
             this.ResultType = Preconditions.CheckNonWhiteSpace(resultType, nameof(resultType));
         }
 
         public string TrackingId { get; }
 
-        public string Title => $"Counting Report ({this.ResultType}) between [{this.ExpectSource}] and [{this.ActualSource}]";
+        public abstract string Title { get; }
 
         public string ResultType { get; }
-
-        public string ExpectSource { get; }
-
-        public string ActualSource { get; }
 
         public abstract bool IsPassed { get; }
     }

--- a/test/modules/TestResultCoordinator/Reports/TwinCountingReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/TwinCountingReport.cs
@@ -2,18 +2,25 @@
 namespace TestResultCoordinator.Reports
 {
     using System.Collections.ObjectModel;
+    using Microsoft.Azure.Devices.Edge.Util;
 
     class TwinCountingReport : TestResultReportBase
     {
         public TwinCountingReport(string trackingId, string expectedSource, string actualSource, string resultType, ulong totalExpectCount, ulong totalMatchCount, ulong totalPatches, ulong totalDuplicates, ReadOnlyCollection<string> unmatchedResults)
-            : base(trackingId, expectedSource, actualSource, resultType)
+            : base(trackingId, resultType)
         {
+            this.ExpectedSource = Preconditions.CheckNonWhiteSpace(expectedSource, nameof(expectedSource));
+            this.ActualSource = Preconditions.CheckNonWhiteSpace(actualSource, nameof(actualSource));
             this.TotalExpectCount = totalExpectCount;
             this.TotalMatchCount = totalMatchCount;
             this.TotalPatchesCount = totalPatches;
             this.TotalDuplicateResultCount = totalDuplicates;
             this.UnmatchedResults = unmatchedResults;
         }
+
+        public string ExpectedSource { get; }
+
+        public string ActualSource { get; }
 
         public ulong TotalExpectCount { get; }
 
@@ -26,5 +33,7 @@ namespace TestResultCoordinator.Reports
         public ReadOnlyCollection<string> UnmatchedResults { get; }
 
         public override bool IsPassed => this.TotalExpectCount == this.TotalMatchCount;
+
+        public override string Title => $"Twin Counting Report ({this.ResultType}) between [{this.ExpectedSource}] and [{this.ActualSource}]";
     }
 }


### PR DESCRIPTION
1. fix missing module id assignment in settings class.
2. update to use IOT_HUB_CONNECTION_STRING as key in setting class.
3. Remove actual and expected source from ITestReportMetadata since not all reports have 2 result sources
4. Remove actual and expected source from ITestResultReport  since not all reports have 2 result sources