### PR TITLE
Adding SettingRule before disabling any rules

### DIFF
--- a/test/connectivity/modules/NetworkController/Program.cs
+++ b/test/connectivity/modules/NetworkController/Program.cs
@@ -91,6 +91,7 @@ namespace NetworkController
         static async Task RemoveAllControllingRules(IList<INetworkController> controllerList, CancellationToken cancellationToken)
         {
             var reporter = new NetworkStatusReporter(Settings.Current.TestResultCoordinatorEndpoint, Settings.Current.ModuleId, Settings.Current.TrackingId);
+            await reporter.ReportNetworkStatusAsync(NetworkControllerOperation.SettingRule, NetworkControllerStatus.Disabled, NetworkControllerType.All, true);
 
             foreach (var controller in controllerList)
             {

--- a/test/connectivity/modules/NetworkController/Program.cs
+++ b/test/connectivity/modules/NetworkController/Program.cs
@@ -91,7 +91,7 @@ namespace NetworkController
         static async Task RemoveAllControllingRules(IList<INetworkController> controllerList, CancellationToken cancellationToken)
         {
             var reporter = new NetworkStatusReporter(Settings.Current.TestResultCoordinatorEndpoint, Settings.Current.ModuleId, Settings.Current.TrackingId);
-            await reporter.ReportNetworkStatusAsync(NetworkControllerOperation.SettingRule, NetworkControllerStatus.Disabled, NetworkControllerType.All, true);
+            await reporter.ReportNetworkStatusAsync(NetworkControllerOperation.SettingRule, NetworkControllerStatus.Disabled, NetworkControllerType.All);
 
             foreach (var controller in controllerList)
             {


### PR DESCRIPTION
Currently NetworkController only sends RuleSet Disabled at startup time. Adding SettingRule to the first time NetworkController starts up to keep consistent with the idea of sending SettingRule before any RuleSet.