### PR TITLE
[k8s] Implement proxy container readiness check in Agent

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEventIds.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEventIds.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         public const int KubernetesEnvironmentOperator = EventIdStart + 500;
         public const int KubernetesExperimentalCreateOptions = EventIdStart + 600;
         public const int KubernetesModelValidation = EventIdStart + 700;
-        public const int KubernetesServiceBuilder = EventIdStart + 800;
+        public const int KubernetesProxyHealthProbe = EventIdStart + 800;
         public const int SecretBackup = EventIdStart + 900;
         const int EventIdStart = 200000;
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/ProxyReadinessProbe.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/ProxyReadinessProbe.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
+{
+    using System;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
+
+    public class ProxyReadinessProbe
+    {
+        readonly string apiVersion;
+
+        readonly HttpClient client;
+
+        public ProxyReadinessProbe(Uri url, string apiVersion)
+        {
+            this.apiVersion = apiVersion;
+            this.client = new HttpClient { BaseAddress = url };
+        }
+
+        async Task<ProxyReadiness> CheckAsync(CancellationToken token)
+        {
+            try
+            {
+                HttpResponseMessage response = await this.client.GetAsync($"/systeminfo?api-version={this.apiVersion}", token);
+                return response.StatusCode == HttpStatusCode.OK ? ProxyReadiness.Ready : ProxyReadiness.Failed;
+            }
+            catch (OperationCanceledException)
+            {
+                return ProxyReadiness.NotReady;
+            }
+        }
+
+        public async Task WaitUntilProxyIsReady()
+        {
+            while (true)
+            {
+                CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+                ProxyReadiness readiness = await this.CheckAsync(tokenSource.Token);
+                Events.CheckHealth(readiness);
+
+                if (readiness == ProxyReadiness.Ready)
+                {
+                    break;
+                }
+            }
+        }
+
+        enum ProxyReadiness
+        {
+            Ready,
+            NotReady,
+            Failed
+        }
+
+        static class Events
+        {
+            const int IdStart = KubernetesEventIds.KubernetesProxyHealthProbe;
+            static readonly ILogger Log = Logger.Factory.CreateLogger<ProxyReadinessProbe>();
+
+            enum EventIds
+            {
+                CheckHealth = IdStart,
+            }
+
+            internal static void CheckHealth(ProxyReadiness readiness)
+                => Log.LogDebug((int)EventIds.CheckHealth, $"Proxy container readiness state: {readiness}");
+        }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/ProxyReadinessProbe.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/ProxyReadinessProbe.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
                 HttpResponseMessage response = await this.client.GetAsync($"/systeminfo?api-version={this.apiVersion}", token);
                 return response.StatusCode == HttpStatusCode.OK ? ProxyReadiness.Ready : ProxyReadiness.Failed;
             }
-            catch (OperationCanceledException)
+            catch
             {
                 return ProxyReadiness.NotReady;
             }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -285,7 +285,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 string managementUri = configuration.GetValue<string>(Constants.EdgeletManagementUriVariableName);
                 string apiVersion = configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
                 ProxyReadinessProbe probe = new ProxyReadinessProbe(new Uri(managementUri), apiVersion);
-                await probe.WaitUntilProxyIsReady();
+
+                CancellationTokenSource tokenSource = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+                await probe.WaitUntilProxyIsReady(tokenSource.Token);
 
                 // Start environment operator
                 IKubernetesEnvironmentOperator environmentOperator = container.Resolve<IKubernetesEnvironmentOperator>();

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -4,7 +4,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Linq;
     using System.Net;
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;
@@ -28,7 +27,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
     using Constants = Microsoft.Azure.Devices.Edge.Agent.Core.Constants;
     using K8sConstants = Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Constants;
     using KubernetesModule = Microsoft.Azure.Devices.Edge.Agent.Service.Modules.KubernetesModule;
-    using MetricsListener = Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net.MetricsListener;
 
     public class Program
     {
@@ -202,36 +200,37 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         bool runAsNonRoot = configuration.GetValue<bool>(K8sConstants.RunAsNonRootKey);
 
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize));
-                        builder.RegisterModule(new KubernetesModule(
-                            iothubHostname,
-                            deviceId,
-                            edgeDeviceHostName,
-                            proxyImage,
-                            proxyImagePullSecretName,
-                            proxyConfigPath,
-                            proxyConfigVolumeName,
-                            proxyConfigMapName,
-                            proxyTrustBundlePath,
-                            proxyTrustBundleVolumeName,
-                            proxyTrustBundleConfigMapName,
-                            apiVersion,
-                            deviceNamespace,
-                            new Uri(managementUri),
-                            new Uri(workloadUri),
-                            dockerAuthConfig,
-                            upstreamProtocol,
-                            Option.Some(productInfo),
-                            mappedServiceDefault,
-                            enableServiceCallTracing,
-                            persistentVolumeName,
-                            storageClassName,
-                            persistentVolumeClaimDefaultSizeMb,
-                            proxy,
-                            closeOnIdleTimeout,
-                            idleTimeout,
-                            kubernetesExperimentalFeatures,
-                            moduleOwner,
-                            runAsNonRoot));
+                        builder.RegisterModule(
+                            new KubernetesModule(
+                                iothubHostname,
+                                deviceId,
+                                edgeDeviceHostName,
+                                proxyImage,
+                                proxyImagePullSecretName,
+                                proxyConfigPath,
+                                proxyConfigVolumeName,
+                                proxyConfigMapName,
+                                proxyTrustBundlePath,
+                                proxyTrustBundleVolumeName,
+                                proxyTrustBundleConfigMapName,
+                                apiVersion,
+                                deviceNamespace,
+                                new Uri(managementUri),
+                                new Uri(workloadUri),
+                                dockerAuthConfig,
+                                upstreamProtocol,
+                                Option.Some(productInfo),
+                                mappedServiceDefault,
+                                enableServiceCallTracing,
+                                persistentVolumeName,
+                                storageClassName,
+                                persistentVolumeClaimDefaultSizeMb,
+                                proxy,
+                                closeOnIdleTimeout,
+                                idleTimeout,
+                                kubernetesExperimentalFeatures,
+                                moduleOwner,
+                                runAsNonRoot));
 
                         break;
 
@@ -279,6 +278,24 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 return 1;
             }
 
+            // TODO move this code to Agent
+            if (mode.ToLowerInvariant().Equals(Constants.KubernetesMode))
+            {
+                // Block agent startup routine until proxy sidecar container is ready
+                string managementUri = configuration.GetValue<string>(Constants.EdgeletManagementUriVariableName);
+                string apiVersion = configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
+                ProxyReadinessProbe probe = new ProxyReadinessProbe(new Uri(managementUri), apiVersion);
+                await probe.WaitUntilProxyIsReady();
+
+                // Start environment operator
+                IKubernetesEnvironmentOperator environmentOperator = container.Resolve<IKubernetesEnvironmentOperator>();
+                environmentOperator.Start();
+
+                // Start the edge deployment operator
+                IEdgeDeploymentOperator edgeDeploymentOperator = container.Resolve<IEdgeDeploymentOperator>();
+                edgeDeploymentOperator.Start();
+            }
+
             // Initialize metrics
             if (metricsConfig.Enabled)
             {
@@ -292,18 +309,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 MetricsWorker worker = await container.Resolve<Task<MetricsWorker>>();
                 worker.Start(diagnosticConfig.ScrapeInterval, diagnosticConfig.UploadInterval);
                 Console.WriteLine($"Scraping frequency: {diagnosticConfig.ScrapeInterval}\nUpload Frequency: {diagnosticConfig.UploadInterval}");
-            }
-
-            // TODO move this code to Agent
-            if (mode.ToLowerInvariant().Equals(Constants.KubernetesMode))
-            {
-                // Start environment operator
-                IKubernetesEnvironmentOperator environmentOperator = container.Resolve<IKubernetesEnvironmentOperator>();
-                environmentOperator.Start();
-
-                // Start the edge deployment operator
-                IEdgeDeploymentOperator edgeDeploymentOperator = container.Resolve<IEdgeDeploymentOperator>();
-                edgeDeploymentOperator.Start();
             }
 
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler)


### PR DESCRIPTION
Query iotedged systeminfo endpoint in a loop before run Agent routine in Kubernetes mode. This way we ensure Agent will not be stuck during first call to iotedged because the proxy container has not been ready to serve responses.