### PR TITLE
[k8s] Make default volume mount as emptyDir

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using k8s.Models;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
@@ -359,39 +360,23 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
         V1Volume GetVolume(KubernetesModule module, Mount mount)
         {
             string volumeName = KubeUtils.SanitizeK8sValue(mount.Source);
+
+            // verify PV name is the same as desired volume name
+            this.persistentVolumeName.ForEach(
+                pvName =>
+                {
+                    if (pvName != volumeName)
+                    {
+                        throw new InvalidModuleException($"The mount name {volumeName} has to be the same as the PV name {pvName}");
+                    }
+                });
+
+            // PVC name will be module name + volume name
             string pvcName = KubernetesModule.PvcName(module, mount);
-
-            // PVC name will be modulename + volume name
-            // Volume name will be customer defined name or modulename + mount.source
-            if (this.persistentVolumeName.HasValue)
-            {
-                string pvName = this.persistentVolumeName.OrDefault();
-
-                if (pvName != volumeName)
-                {
-                    throw new InvalidModuleException(string.Format("The mount name {0} has to be the same as the PV name {1}", volumeName, pvName));
-                }
-
-                return new V1Volume
-                {
-                    Name = volumeName,
-                    PersistentVolumeClaim = new V1PersistentVolumeClaimVolumeSource(pvcName, mount.ReadOnly)
-                };
-            }
-
-            if (this.storageClassName.HasValue)
-            {
-                return new V1Volume
-                {
-                    Name = volumeName,
-                    PersistentVolumeClaim = new V1PersistentVolumeClaimVolumeSource(pvcName, mount.ReadOnly)
-                };
-            }
-
             return new V1Volume
             {
                 Name = volumeName,
-                EmptyDir = new V1EmptyDirVolumeSource()
+                PersistentVolumeClaim = new V1PersistentVolumeClaimVolumeSource(pvcName, mount.ReadOnly)
             };
         }
     }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         }
 
         [Fact]
-        public void EmptyDirMappingForVolume()
+        public void PvcMappingByDefault()
         {
             var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "ModuleId", Mock.Of<ICredentials>());
             var labels = new Dictionary<string, string>();
@@ -176,7 +176,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
 
             Assert.True(pod != null);
             var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
-            Assert.NotNull(podVolume.EmptyDir);
+            Assert.NotNull(podVolume.PersistentVolumeClaim);
+            Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
             Assert.True(podVolumeMount.ReadOnlyProperty);
@@ -214,7 +216,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.True(pod != null);
             var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-
             Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
@@ -280,23 +281,23 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var experimental = new Dictionary<string, JToken>
             {
                 ["k8s-experimental"] = JToken.Parse(
-                    @"{ 
+                    @"{
                         ""volumes"": [
                           {
                             ""volume"": {
                               ""name"": ""module-config"",
                             },
-                         
+
                           ""volumeMounts"": [
                             {
                               ""name"": ""module-config"",
                               ""mountPath"": ""/etc/module"",
                               ""mountPropagation"": ""None"",
                               ""readOnly"": ""true"",
-                              ""subPath"": """" 
+                              ""subPath"": """"
                             }
                           ]
-                        }  
+                        }
                     ]}")
             };
 

--- a/kubernetes/doc/edge-deployment-to-k8s-translations.md
+++ b/kubernetes/doc/edge-deployment-to-k8s-translations.md
@@ -165,11 +165,11 @@ Each IoT Edge Module will create one Deployment. This will run the module's spec
             - type = "DirectoryOrCreate".
     - volume mounts from `settings.createOptions.HostConfig.Mounts`
         - name = mount.Source
-        - persistentVolumeClaim is assigned if edge runtime is started with `persistentVolumeName` 
-          or `storageClassName` set.
+        - persistentVolumeClaim is always assigned
+            - if edge runtime is started with `persistentVolumeName` or `storageClassName` set it will create a [Persistent Volume Claim](#PersistentVolumeClaim)
+            - if neither is set Pod will be created but stuck in `Pending` phase not been able to make any progress
             - claimName = module name + mount.Source
             - readOnlyProperty = mount.ReadOnly
-        - emptyDir is assigned otherwise.
     - volume mounts from `settings.k8s-extensions.volumes[*].volume`. Placed in spec as provided.
 - **serviceAccountName** = The module name, sanitized to be a K8s identifier. See [Module Authentication](rbac.md#module-authentication) for details.
 - **nodeSelector** = `settings.k8s-extensions.nodeSelector` Placed in spec as provided.


### PR DESCRIPTION
When a user specifies a volume for a module and didn't specify `persistentVolumeClaim` or `storageClass` option during installation it used to be mapping to emptyDir by default. It violates promise of storing data after container/pod restart as for edge on single-node case.

There are changes to use PVC even if `persistentVolumeClaim` or `storageClass` was not specified. In this case, Kubernetes scheduler will make an attempt to create a pod for a module, but it will not reach `Ready` state. Proper module status also should be reported to Device Twin.