### PR TITLE
contentTrust Add repo root key to AuthConfig

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/CombinedDockerConfigProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/CombinedDockerConfigProvider.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
 
             // Convert registry credentials from config to AuthConfig objects
             List<AuthConfig> deploymentAuthConfigs = dockerRuntimeConfig.Config.RegistryCredentials
-                .Select(c => new AuthConfig { ServerAddress = c.Value.Address, Username = c.Value.Username, Password = c.Value.Password })
+                .Select(c => new AuthConfig { ServerAddress = c.Value.Address, Username = c.Value.Username, Password = c.Value.Password, RegistryToken = c.Value.RootKey})
                 .ToList();
 
             // First try to get matching auth config from the runtime info. If no match is found,

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RegistryCredentials.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RegistryCredentials.cs
@@ -15,6 +15,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             this.Password = Preconditions.CheckNonWhiteSpace(password, nameof(password));
         }
 
+        public RegistryCredentials(string address, string username, string password, string rootKey)
+        {
+            this.Address = Preconditions.CheckNonWhiteSpace(address, nameof(address));
+            this.Username = Preconditions.CheckNonWhiteSpace(username, nameof(username));
+            this.Password = Preconditions.CheckNonWhiteSpace(password, nameof(password));
+            this.RootKey = Preconditions.CheckNonWhiteSpace(rootKey, nameof(rootKey));
+        }
+
         [JsonProperty(Required = Required.Always, PropertyName = "address")]
         public string Address { get; }
 
@@ -23,6 +31,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
 
         [JsonProperty(Required = Required.Always, PropertyName = "password")]
         public string Password { get; }
+
+        [JsonProperty(PropertyName = "rootKey")]
+        public string RootKey { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as RegistryCredentials);
 


### PR DESCRIPTION
This is based on the design which we think the root key will be put into registryCredntial. The code enable the ability to get root key into CombinedDockerConfig in PlanAsync