### PR TITLE
Fix Windows build by downgrading openssl to 1.0.2

### DIFF
--- a/edgelet/build/windows/openssl.ps1
+++ b/edgelet/build/windows/openssl.ps1
@@ -8,10 +8,14 @@ function Get-OpenSSL
 
     $ErrorActionPreference = 'Continue'
 
-    if (!((Test-Path -Path $env:HOMEDRIVE\vcpkg) -and ((Test-Path -Path $env:HOMEDRIVE\vcpkg\vcpkg.exe))))
+    # Override vcpkg directory from the default $env:HOMEDRIVE\vcpkg that VSTS CI machines have.
+    # See TODO below for the reason.
+    $vcpkgDirectory = "$env:HOMEDRIVE\vcpkg-2"
+
+    if (!((Test-Path -Path $vcpkgDirectory) -and ((Test-Path -Path $vcpkgDirectory\vcpkg.exe))))
     {
         Write-Host "Installing vcpkg from github..."
-        git clone https://github.com/Microsoft/vcpkg $env:HOMEDRIVE\vcpkg
+        git clone https://github.com/Microsoft/vcpkg $vcpkgDirectory
         if ($LastExitCode)
         {
             Throw "Failed to clone vcpkg repo with exit code $LastExitCode"
@@ -20,18 +24,18 @@ function Get-OpenSSL
         # TODO: vcpkg updated openssl from 1.0.2 to 1.1.1, but some of our libiothsm tests fail with it.
         #       Revert to the version of vcpkg before that commit to fix our build for now,
         #       until we fix the tests to work with 1.1.1.
-        Push-Location $env:HOMEDRIVE\vcpkg
+        Push-Location $vcpkgDirectory
         git checkout 'bdae0904c41a0ee2c5204d6449038d3b5d551726~1'
         Pop-Location
 
         Write-Host "Bootstrapping vcpkg..."
-        & "$env:HOMEDRIVE\vcpkg\bootstrap-vcpkg.bat"
+        & "$vcpkgDirectory\bootstrap-vcpkg.bat"
         if ($LastExitCode)
         {
             Throw "Failed to bootstrap vcpkg with exit code $LastExitCode"
         }
         Write-Host "Installing vcpkg..."
-        & $env:HOMEDRIVE\\vcpkg\\vcpkg.exe integrate install
+        & $vcpkgDirectory\vcpkg.exe integrate install
         if ($LastExitCode)
         {
             Throw "Failed to install vcpkg with exit code $LastExitCode"
@@ -39,17 +43,17 @@ function Get-OpenSSL
     }
 
     Write-Host "Downloading strawberry perl"
-    if (!(Test-Path -Path $env:HOMEDRIVE\vcpkg\Downloads))
+    if (!(Test-Path -Path $vcpkgDirectory\Downloads))
     {
-        New-Item -Type Directory "$env:HOMEDRIVE\vcpkg\Downloads" | Out-Null
+        New-Item -Type Directory "$vcpkgDirectory\Downloads" | Out-Null
     }
 
     $strawberryPerlUri = "https://edgebuild.blob.core.windows.net/strawberry-perl/strawberry-perl-5.24.1.1-32bit-portable.zip"
-    $strawberryPerlPath = "$env:HOMEDRIVE\vcpkg\Downloads\strawberry-perl-5.24.1.1-32bit-portable.zip"
+    $strawberryPerlPath = "$vcpkgDirectory\Downloads\strawberry-perl-5.24.1.1-32bit-portable.zip"
     Invoke-WebRequest -Uri $strawberryPerlUri -OutFile $strawberryPerlPath
 
     Write-Host "Installing OpenSSL for $(if ($Arm) { 'arm' } else { 'x64' })..."
-    & $env:HOMEDRIVE\vcpkg\vcpkg.exe install $(if ($Arm) { 'openssl-windows:arm-windows' } else { 'openssl:x64-windows' } )
+    & $vcpkgDirectory\vcpkg.exe install $(if ($Arm) { 'openssl-windows:arm-windows' } else { 'openssl:x64-windows' } )
     if ($LastExitCode)
     {
         Throw "Failed to install openssl vcpkg with exit code $LastExitCode"
@@ -61,16 +65,16 @@ function Get-OpenSSL
         # When executing within TF (VSTS) environment, install the env variable
         # such that all follow up build tasks have visibility of the env variable
         Write-Host "VSTS installation detected"
-        Write-Host "##vso[task.setvariable variable=OPENSSL_ROOT_DIR;]$env:HOMEDRIVE\vcpkg\installed\$(if ($Arm){ 'arm' } else { 'x64' })-windows"
+        Write-Host "##vso[task.setvariable variable=OPENSSL_ROOT_DIR;]$vcpkgDirectory\installed\$(if ($Arm){ 'arm' } else { 'x64' })-windows"
         # Rust's openssl-sys crate needs this environment set.
-        Write-Host "##vso[task.setvariable variable=OPENSSL_DIR;]$env:HOMEDRIVE\vcpkg\installed\$(if ($Arm){ 'arm' } else { 'x64' })-windows"
+        Write-Host "##vso[task.setvariable variable=OPENSSL_DIR;]$vcpkgDirectory\installed\$(if ($Arm){ 'arm' } else { 'x64' })-windows"
     }
     else
     {
         # for local installation, set the env variable within the USER scope
         Write-Host "Local installation detected"
-        [System.Environment]::SetEnvironmentVariable("OPENSSL_ROOT_DIR", "$env:HOMEDRIVE\vcpkg\installed\$(if ($Arm) { 'arm' } else { 'x64' })-windows", [System.EnvironmentVariableTarget]::User)
-        [System.Environment]::SetEnvironmentVariable("OPENSSL_DIR", "$env:HOMEDRIVE\vcpkg\installed\$(if ($Arm) { 'arm' } else { 'x64' })-windows", [System.EnvironmentVariableTarget]::User)
+        [System.Environment]::SetEnvironmentVariable("OPENSSL_ROOT_DIR", "$vcpkgDirectory\installed\$(if ($Arm) { 'arm' } else { 'x64' })-windows", [System.EnvironmentVariableTarget]::User)
+        [System.Environment]::SetEnvironmentVariable("OPENSSL_DIR", "$vcpkgDirectory\installed\$(if ($Arm) { 'arm' } else { 'x64' })-windows", [System.EnvironmentVariableTarget]::User)
     }
 
     $ErrorActionPreference = 'Stop'

--- a/edgelet/build/windows/openssl.ps1
+++ b/edgelet/build/windows/openssl.ps1
@@ -16,6 +16,14 @@ function Get-OpenSSL
         {
             Throw "Failed to clone vcpkg repo with exit code $LastExitCode"
         }
+
+        # TODO: vcpkg updated openssl from 1.0.2 to 1.1.1, but some of our libiothsm tests fail with it.
+        #       Revert to the version of vcpkg before that commit to fix our build for now,
+        #       until we fix the tests to work with 1.1.1.
+        Push-Location $env:HOMEDRIVE\vcpkg
+        git checkout 'bdae0904c41a0ee2c5204d6449038d3b5d551726~1'
+        Pop-Location
+
         Write-Host "Bootstrapping vcpkg..."
         & "$env:HOMEDRIVE\vcpkg\bootstrap-vcpkg.bat"
         if ($LastExitCode)


### PR DESCRIPTION
Our build always uses latest vcpkg to install openssl.
vcpkg updated openssl from 1.0.2 to 1.1.1, which breaks our build:

- We've hard-coded the names of libssl and libcrypto import libs and DLLs in
  a few cmake files and the CAB package manifest file. These names are
  different in 1.1.1

- Some of our libiothsm tests fail with 1.1.1. This appears to be benign -
  the tests expect a PEM blob to contain Unix newlines, but they actually
  contain Windows newlines. (This is also why the tests are fine on Linux.)

Fixing the latter will take some time to investigate, so for now, this commit
unbreaks the Windows build by forcing vcpkg to a commit right before it updated
openssl to 1.1.1