### PR TITLE
[k8s] Put IDeploymentBackupSource back in k8s module.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -227,6 +227,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .As<IRuntimeInfoSource>()
                 .SingleInstance();
 
+            // Task<IBackupSource>
+            builder.Register(
+                c =>
+                {
+                    var serde = c.Resolve<ISerde<DeploymentConfigInfo>>();
+                    IDeploymentBackupSource backupSource = new DeploymentSecretBackup(Constants.EdgeAgentBackupName, this.deviceNamespace, this.moduleOwner, serde, c.Resolve<IKubernetes>());
+                    return Task.FromResult(backupSource);
+                })
+                .As<Task<IDeploymentBackupSource>>()
+                .SingleInstance();
+
             // KubernetesDeploymentProvider
             builder.Register(
                     c => new KubernetesDeploymentMapper(

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .As<IRuntimeInfoSource>()
                 .SingleInstance();
 
-            // Task<IBackupSource>
+            // Task<IDeploymentBackupSource>
             builder.Register(
                 c =>
                 {


### PR DESCRIPTION
We lost registration of IDeploymentBackupSource  in a recent merge, this puts it back.