### PR TITLE
Fix Windows build to compile against openssl 1.1.1

### DIFF
--- a/edgelet/build/windows/iotedge.wm.xml
+++ b/edgelet/build/windows/iotedge.wm.xml
@@ -14,8 +14,8 @@
     <file source="$(_REPO_ROOT)\edgelet\target\$(_Arch)\release\iotedged.pdb" destinationDir="$(runtime.programFiles)\iotedge" />
     <file source="$(_REPO_ROOT)\edgelet\target\$(_Arch)\release\iotedged_eventlog_messages.dll" destinationDir="$(runtime.programFiles)\iotedge" />
     <file source="$(_REPO_ROOT)\edgelet\hsm-sys\azure-iot-hsm-c\build\Release\iothsm.dll" destinationDir="$(runtime.programFiles)\iotedge" />
-    <file source="$(_OPENSSL_ROOT_DIR)\bin\libeay32.dll" destinationDir="$(runtime.programFiles)\iotedge" />
-    <file source="$(_OPENSSL_ROOT_DIR)\bin\ssleay32.dll" destinationDir="$(runtime.programFiles)\iotedge" />
+    <file source="$(_OPENSSL_ROOT_DIR)\bin\libcrypto-1_1-$(_OPENSSL_DLL_SUFFIX).dll" destinationDir="$(runtime.programFiles)\iotedge" />
+    <file source="$(_OPENSSL_ROOT_DIR)\bin\libssl-1_1-$(_OPENSSL_DLL_SUFFIX).dll" destinationDir="$(runtime.programFiles)\iotedge" />
     <file source="$(_REPO_ROOT)\edgelet\contrib\docs\LICENSE" destinationDir="$(runtime.programFiles)\iotedge\LICENSE" />
     <file source="$(_REPO_ROOT)\edgelet\contrib\docs\ThirdPartyNotices" destinationDir="$(runtime.programFiles)\iotedge\LICENSE" />
     <file source="$(_REPO_ROOT)\edgelet\contrib\docs\trademark" destinationDir="$(runtime.programFiles)\iotedge\LICENSE" />

--- a/edgelet/build/windows/openssl.ps1
+++ b/edgelet/build/windows/openssl.ps1
@@ -36,10 +36,6 @@ function Get-OpenSSL
         New-Item -Type Directory "$env:HOMEDRIVE\vcpkg\Downloads" | Out-Null
     }
 
-    $strawberryPerlUri = "https://edgebuild.blob.core.windows.net/strawberry-perl/strawberry-perl-5.24.1.1-32bit-portable.zip"
-    $strawberryPerlPath = "$env:HOMEDRIVE\vcpkg\Downloads\strawberry-perl-5.24.1.1-32bit-portable.zip"
-    Invoke-WebRequest -Uri $strawberryPerlUri -OutFile $strawberryPerlPath
-
     Write-Host "Installing OpenSSL for $(if ($Arm) { 'arm' } else { 'x64' })..."
     & $env:HOMEDRIVE\vcpkg\vcpkg.exe install $(if ($Arm) { 'openssl-windows:arm-windows' } else { 'openssl:x64-windows' } )
     if ($LastExitCode)

--- a/edgelet/build/windows/package.ps1
+++ b/edgelet/build/windows/package.ps1
@@ -90,7 +90,11 @@ Function New-Package([string] $Name, [string] $Version)
         Write-Host $(Get-Command makecat.exe).Path
     }
 
-    Invoke-Expression "& '$pkggen' $manifest /universalbsp /variables:'_REPO_ROOT=..\..\..;_OPENSSL_ROOT_DIR=$env:OPENSSL_ROOT_DIR;_Arch=$(if ($Arm) { 'thumbv7a-pc-windows-msvc' } else { '' })' /cpu:$(if ($Arm) { 'arm' } else { 'amd64' }) /version:$Version"
+    $pkggenVariables = '_REPO_ROOT=..\..\..'
+    $pkggenVariables += ";_OPENSSL_ROOT_DIR=$env:OPENSSL_ROOT_DIR"
+    $pkggenVariables += ";_OPENSSL_DLL_SUFFIX=$(if ($Arm) { 'arm' } else { 'x64' })"
+    $pkggenVariables += ";_Arch=$(if ($Arm) { 'thumbv7a-pc-windows-msvc' } else { '' })"
+    & $pkggen $manifest /universalbsp "/variables:$pkggenVariables" "/cpu:$(if ($Arm) { 'arm' } else { 'amd64' })" "/version:$Version"
     if ($LASTEXITCODE) {
         Throw "Failed to package cab"
     }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
@@ -137,7 +137,7 @@ if (save_ut)
 endif(save_ut)
 
 if(WIN32)
-    target_link_libraries(iothsm aziotsharedutil utpm $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(iothsm aziotsharedutil utpm $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
     target_link_libraries(iothsm aziotsharedutil utpm ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/src/edge_pki_openssl.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/src/edge_pki_openssl.c
@@ -506,7 +506,7 @@ static void destroy_evp_key(EVP_PKEY *evp_key)
 static X509* load_certificate_file(const char* cert_file_name)
 {
     X509* x509_cert;
-    BIO* cert_file = BIO_new_file(cert_file_name, "r");
+    BIO* cert_file = BIO_new_file(cert_file_name, "rb");
     if (cert_file == NULL)
     {
         LOG_ERROR("Failure to open certificate file %s", cert_file_name);
@@ -577,7 +577,7 @@ static int write_certificate_file
     int result;
 
 #if defined __WINDOWS__ || defined _WIN32 || defined _WIN64 || defined _Windows
-    BIO* cert_file = BIO_new_file(cert_file_name, "w");
+    BIO* cert_file = BIO_new_file(cert_file_name, "wb");
     if (cert_file == NULL)
     {
         LOG_ERROR("Failure opening cert file for writing for %s", cert_file_name);
@@ -644,7 +644,7 @@ static int write_certificate_file
 static EVP_PKEY* load_private_key_file(const char* key_file_name)
 {
     EVP_PKEY* evp_key;
-    BIO* key_file = BIO_new_file(key_file_name, "r");
+    BIO* key_file = BIO_new_file(key_file_name, "rb");
     if (key_file == NULL)
     {
         LOG_ERROR("Failure to open key file %s", key_file_name);
@@ -668,7 +668,7 @@ static int write_private_key_file(EVP_PKEY* evp_key, const char* key_file_name)
     int result;
 
 #if defined __WINDOWS__ || defined _WIN32 || defined _WIN64 || defined _Windows
-    BIO* key_file = BIO_new_file(key_file_name, "w");
+    BIO* key_file = BIO_new_file(key_file_name, "wb");
     if (key_file == NULL)
     {
         LOG_ERROR("Failure opening key file for writing for %s", key_file_name);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ft/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ft/CMakeLists.txt
@@ -29,7 +29,7 @@ set(${theseTestsName}_h_files
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
 
 if(WIN32)
-    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
      target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_client_x509_int/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_client_x509_int/CMakeLists.txt
@@ -35,7 +35,7 @@ set(${theseTestsName}_h_files
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
 
 if(WIN32)
-    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
      target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_int/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_int/CMakeLists.txt
@@ -34,7 +34,7 @@ set(${theseTestsName}_h_files
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
 
 if(WIN32)
-    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
      target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_sas_auth_int/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_sas_auth_int/CMakeLists.txt
@@ -24,7 +24,7 @@ set(${theseTestsName}_h_files
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
 
 if(WIN32)
-    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
      target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_int/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_int/CMakeLists.txt
@@ -38,7 +38,7 @@ set(${theseTestsName}_h_files
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
 
 if(WIN32)
-    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
      target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_util_int/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_util_int/CMakeLists.txt
@@ -26,7 +26,7 @@ set(${theseTestsName}_h_files
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
 
 if(WIN32)
-    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
      target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_int/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_int/CMakeLists.txt
@@ -28,7 +28,7 @@ set(${theseTestsName}_h_files
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
 
 if(WIN32)
-    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
      target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_int/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_int/CMakeLists.txt
@@ -29,7 +29,7 @@ set(${theseTestsName}_h_files
 build_c_test_artifacts(${theseTestsName} ON "tests/azure_c_shared_utility_tests")
 
 if(WIN32)
-    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/ssleay32.lib $ENV{OPENSSL_ROOT_DIR}/lib/libeay32.lib)
+    target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil $ENV{OPENSSL_ROOT_DIR}/lib/libssl.lib $ENV{OPENSSL_ROOT_DIR}/lib/libcrypto.lib)
 else()
      target_link_libraries(${theseTestsName}_exe iothsm aziotsharedutil ${OPENSSL_LIBRARIES})
 endif(WIN32)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_int/edge_openssl_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_int/edge_openssl_int.c
@@ -369,7 +369,7 @@ void test_helper_server_chain_validator(const PKI_KEY_PROPS *key_props)
 
 static X509* test_helper_load_certificate_file(const char* cert_file_name)
 {
-    BIO* cert_file = BIO_new_file(cert_file_name, "r");
+    BIO* cert_file = BIO_new_file(cert_file_name, "rb");
     ASSERT_IS_NOT_NULL(cert_file, "Line:" TOSTRING(__LINE__));
     X509* x509_cert = PEM_read_bio_X509(cert_file, NULL, NULL, NULL);
     // make sure the file is closed before asserting below

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
@@ -1399,7 +1399,7 @@ static void test_helper_cert_create_with_subject
 
     if (!is_self_signed)
     {
-        STRICT_EXPECTED_CALL(BIO_new_file(TEST_ISSUER_CERT_FILE, "r"));
+        STRICT_EXPECTED_CALL(BIO_new_file(TEST_ISSUER_CERT_FILE, "rb"));
         ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
@@ -1411,7 +1411,7 @@ static void test_helper_cert_create_with_subject
         ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         i++;
 
-        STRICT_EXPECTED_CALL(BIO_new_file(TEST_ISSUER_KEY_FILE, "r"));
+        STRICT_EXPECTED_CALL(BIO_new_file(TEST_ISSUER_KEY_FILE, "rb"));
         ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
@@ -1450,7 +1450,7 @@ static void test_helper_cert_create_with_subject
 
     if (test_helper_is_windows())
     {
-        STRICT_EXPECTED_CALL(BIO_new_file(TEST_KEY_FILE, "w")).SetReturn(TEST_BIO_WRITE_KEY);
+        STRICT_EXPECTED_CALL(BIO_new_file(TEST_KEY_FILE, "wb")).SetReturn(TEST_BIO_WRITE_KEY);
         ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
@@ -1829,7 +1829,7 @@ static void test_helper_cert_create_with_subject
 
     if (test_helper_is_windows())
     {
-        STRICT_EXPECTED_CALL(BIO_new_file(TEST_CERT_FILE, "w")).SetReturn(TEST_BIO_WRITE_CERT);
+        STRICT_EXPECTED_CALL(BIO_new_file(TEST_CERT_FILE, "wb")).SetReturn(TEST_BIO_WRITE_CERT);
         ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
@@ -1920,7 +1920,7 @@ static void test_helper_load_cert_file
 {
     size_t i = *index;
 
-    STRICT_EXPECTED_CALL(BIO_new_file(file, "r"));
+    STRICT_EXPECTED_CALL(BIO_new_file(file, "rb"));
     ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
@@ -2070,7 +2070,7 @@ static void test_helper_create_cert_key
     ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     i++;
 
-    STRICT_EXPECTED_CALL(BIO_new_file(TEST_KEY_FILE, "r"));
+    STRICT_EXPECTED_CALL(BIO_new_file(TEST_KEY_FILE, "rb"));
     ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 

--- a/edgelet/hsm-sys/build.rs
+++ b/edgelet/hsm-sys/build.rs
@@ -177,8 +177,8 @@ fn build_libiothsm() {
             "cargo:rustc-link-search=native={}/lib",
             env::var("OPENSSL_ROOT_DIR").unwrap()
         );
-        println!("cargo:rustc-link-lib=libeay32");
-        println!("cargo:rustc-link-lib=ssleay32");
+        println!("cargo:rustc-link-lib=libssl");
+        println!("cargo:rustc-link-lib=libcrypto");
     }
 
     #[cfg(target_os = "macos")]


### PR DESCRIPTION
Cherry-pick from master of c173ff16317157aa48cd90bb00f3ec946b13082b

Our build always uses latest vcpkg to install openssl.
vcpkg updated openssl from 1.0.2 to 1.1.1, which broke the Windows build:

- We've hard-coded the names of libssl and libcrypto import libs and DLLs in
  a few cmake files and the CAB package manifest file. These names are
  different in 1.1.1. This change updates the files to use the new names.

  This in turn means that we can no longer compile with 1.0.2,
  but we don't need to. If we do need that, we can always revert
  this change.

- Some of our libiothsm tests failed with 1.1.1. The tests expected a PEM blob
  to contain Unix newlines, but it actually contained Windows newlines.

  `read_file_into_buffer_impl` on Windows opens files for reading
  using win32 `CreateFile`, as opposed to POSIX `fopen`. This means the files
  would be read without newline translation, ie the equivalent of `rb` mode
  instead of `r`.

  However the code that used openssl BIOs, such as `write_certificate_file`,
  used `BIO_new_file` with modes like `r` and `w` that get passed down to
  `fopen` unchanged. This means these files would get opened
  with newline translation.

  The end result was that the code ended up writing a file with
  Windows newlines but believed it had not, which broke some tests
  that asserted one against the other.

  This change makes all calls to `BIO_new_file` specify `b` in the mode.

This change also removes the strawberry perl download from the Windows script
that installs openssl. We'd seen in the past that our build would break
because the original host that vcpkg pulled this file from from went down,
so we'd mirrored the file to our infra. However vcpkg has since started
using a new version of strawberry perl, so the one we downloaded ourselves
was being ignored and just wasting build time.