### PR TITLE
Make auto_generated_cert_lifetime not required (#2356)

### DIFF
--- a/edgelet/edgelet-core/src/settings.rs
+++ b/edgelet/edgelet-core/src/settings.rs
@@ -321,6 +321,7 @@ impl Listen {
 pub struct Certificates {
     #[serde(flatten)]
     device_cert: Option<DeviceCertificate>,
+    #[serde(default = "default_auto_generated_ca_lifetime_days")]
     auto_generated_ca_lifetime_days: u16,
 }
 
@@ -329,6 +330,10 @@ pub struct DeviceCertificate {
     device_ca_cert: String,
     device_ca_pk: String,
     trusted_ca_certs: String,
+}
+
+fn default_auto_generated_ca_lifetime_days() -> u16 {
+    90
 }
 
 fn is_supported_uri(uri: &Url) -> bool {

--- a/edgelet/edgelet-docker/test/linux/sample_settings_default_cert.yaml
+++ b/edgelet/edgelet-docker/test/linux/sample_settings_default_cert.yaml
@@ -1,0 +1,38 @@
+# Configures the provisioning mode
+provisioning:
+  source: "manual"
+  device_connection_string: "HostName=something.something.com;DeviceId=something;SharedAccessKey=QXp1cmUgSW9UIEVkZ2U="
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env:
+    abc: "value1"
+    acd: "value2"
+  config:
+    image: "microsoft/azureiotedge-agent:1.0"
+    auth: {}
+hostname: "localhost"
+
+watchdog:
+  max_retries: 3
+
+certificates:
+  device_ca_cert: "/path/cert_key.pem"
+  device_ca_pk: "/path/cert_key.pem"
+  trusted_ca_certs: "/path/cert_key.pem"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+homedir: "/tmp"
+moby_runtime:
+  uri: "http://localhost:2375"
+  network: "azure-iot-edge"

--- a/edgelet/edgelet-docker/test/windows/sample_settings_default_cert.yaml
+++ b/edgelet/edgelet-docker/test/windows/sample_settings_default_cert.yaml
@@ -1,0 +1,38 @@
+# Configures the provisioning mode
+provisioning:
+  source: "manual"
+  device_connection_string: "HostName=something.something.com;DeviceId=something;SharedAccessKey=QXp1cmUgSW9UIEVkZ2U="
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env:
+    abc: "value1"
+    acd: "value2"
+  config:
+    image: "microsoft/azureiotedge-agent:1.0"
+    auth: {}
+hostname: "localhost"
+
+watchdog:
+  max_retries: 3
+
+certificates:
+  device_ca_cert: "/path/cert_key.pem"
+  device_ca_pk: "/path/cert_key.pem"
+  trusted_ca_certs: "/path/cert_key.pem"
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+homedir: "C:\\Temp"
+moby_runtime:
+  uri: "npipe://./pipe/iotedge_moby_engine"
+  network: "azure-iot-edge"

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -1766,6 +1766,9 @@ mod tests {
     #[cfg(unix)]
     static GOOD_SETTINGS_DPS_DEFAULT: &str =
         "../edgelet-docker/test/linux/sample_settings.dps.default.yaml";
+    #[cfg(unix)]
+    static SETTINGS_DEFAULT_CERT: &str =
+        "../edgelet-docker/test/linux/sample_settings_default_cert.yaml";
 
     #[cfg(windows)]
     static GOOD_SETTINGS: &str = "../edgelet-docker/test/windows/sample_settings.yaml";
@@ -1780,6 +1783,9 @@ mod tests {
     #[cfg(windows)]
     static GOOD_SETTINGS_DPS_DEFAULT: &str =
         "../edgelet-docker/test/windows/sample_settings.dps.default.yaml";
+    #[cfg(windows)]
+    static SETTINGS_DEFAULT_CERT: &str =
+        "../edgelet-docker/test/windows/sample_settings_default_cert.yaml";
 
     #[derive(Clone, Copy, Debug, Fail)]
     pub struct Error;
@@ -1910,6 +1916,17 @@ mod tests {
             ErrorKind::Initialize(InitializeErrorReason::NotConfigured) => (),
             kind => panic!("Expected `NotConfigured` but got {:?}", kind),
         }
+    }
+
+    #[test]
+    fn settings_manual_without_cert_uses_default() {
+        let _guard = LOCK.lock().unwrap();
+
+        let settings = Settings::new(Path::new(SETTINGS_DEFAULT_CERT)).unwrap();
+        assert_eq!(
+            u64::from(DEFAULT_AUTO_GENERATED_CA_LIFETIME_DAYS) * 86_400,
+            settings.certificates().auto_generated_ca_lifetime_seconds()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fix bug: Auto generated certificate lifetime configuration was required which would break updating of Edge deployments.