### PR TITLE
Fix E2E: Pass edge agent base image name to IoTEdgeSecurityDaemon.ps1

### DIFF
--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -259,7 +259,7 @@ namespace IotEdgeQuickstart.Details
 
                     return new DeviceProvisioningMethod(connectionString);
                 });
-            return this.bootstrapper.Configure(method, this.EdgeAgentImage(), this.hostname, this.deviceCaCert, this.deviceCaPk, this.deviceCaCerts, this.runtimeLogLevel);
+            return this.bootstrapper.Configure(method, this.PredeploymentEdgeAgentImage(), this.hostname, this.deviceCaCert, this.deviceCaPk, this.deviceCaCerts, this.runtimeLogLevel);
         }
 
         protected Task StartBootstrapper()

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -259,7 +259,7 @@ namespace IotEdgeQuickstart.Details
 
                     return new DeviceProvisioningMethod(connectionString);
                 });
-            return this.bootstrapper.Configure(method, this.hostname, this.deviceCaCert, this.deviceCaPk, this.deviceCaCerts, this.runtimeLogLevel);
+            return this.bootstrapper.Configure(method, this.EdgeAgentImage(), this.hostname, this.deviceCaCert, this.deviceCaPk, this.deviceCaCerts, this.runtimeLogLevel);
         }
 
         protected Task StartBootstrapper()
@@ -511,25 +511,37 @@ namespace IotEdgeQuickstart.Details
             this.context = new DeviceContext(device, builder.ToString(), rm, true);
         }
 
+        string PredeploymentEdgeAgentImage()
+        {
+            return this.BuildImageName("azureiotedge-agent", true);
+        }
+
         string EdgeAgentImage()
         {
-            return this.BuildImageName("azureiotedge-agent");
+            return this.BuildImageName("azureiotedge-agent", false);
         }
 
         string EdgeHubImage()
         {
-            return this.BuildImageName("azureiotedge-hub");
+            return this.BuildImageName("azureiotedge-hub", false);
         }
 
         string TempSensorImage()
         {
-            return this.BuildImageName("azureiotedge-simulated-temperature-sensor");
+            return this.BuildImageName("azureiotedge-simulated-temperature-sensor", false);
         }
 
-        string BuildImageName(string name)
+        string BuildImageName(string name, bool isPredeploymentImage)
         {
             string prefix = this.credentials.Match(c => $"{c.Address}/microsoft", () => "mcr.microsoft.com");
-            return $"{prefix}/{name}:{this.imageTag}";
+            if (isPredeploymentImage)
+            {
+                return $"{prefix}/{name}:1.0";
+            }
+            else
+            {
+                return $"{prefix}/{name}:{this.imageTag}";
+            }
         }
 
         (string, string[]) DeploymentJson()

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -513,36 +513,28 @@ namespace IotEdgeQuickstart.Details
 
         string PredeploymentEdgeAgentImage()
         {
-            return this.BuildImageName("azureiotedge-agent", true);
+            return this.BuildImageName("azureiotedge-agent", "1.0");
         }
 
         string EdgeAgentImage()
         {
-            return this.BuildImageName("azureiotedge-agent", false);
+            return this.BuildImageName("azureiotedge-agent", this.imageTag);
         }
 
         string EdgeHubImage()
         {
-            return this.BuildImageName("azureiotedge-hub", false);
+            return this.BuildImageName("azureiotedge-hub", this.imageTag);
         }
 
         string TempSensorImage()
         {
-            return this.BuildImageName("azureiotedge-simulated-temperature-sensor", false);
+            return this.BuildImageName("azureiotedge-simulated-temperature-sensor", this.imageTag);
         }
 
-        string BuildImageName(string name, bool isPredeploymentImage)
+        string BuildImageName(string name, string customImageTag)
         {
             string prefix = this.credentials.Match(c => $"{c.Address}/microsoft", () => "mcr.microsoft.com");
-            string nameWithoutTag = $"{prefix}/{name}";
-            if (isPredeploymentImage)
-            {
-                return nameWithoutTag + ":1.0";
-            }
-            else
-            {
-                return nameWithoutTag + $":{this.imageTag}";
-            }
+            return $"{prefix}/{name}:{customImageTag}";
         }
 
         (string, string[]) DeploymentJson()

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -534,13 +534,14 @@ namespace IotEdgeQuickstart.Details
         string BuildImageName(string name, bool isPredeploymentImage)
         {
             string prefix = this.credentials.Match(c => $"{c.Address}/microsoft", () => "mcr.microsoft.com");
+            string nameWithoutTag = $"{prefix}/{name}";
             if (isPredeploymentImage)
             {
-                return $"{prefix}/{name}:1.0";
+                return nameWithoutTag + ":1.0";
             }
             else
             {
-                return $"{prefix}/{name}:{this.imageTag}";
+                return nameWithoutTag + $":{this.imageTag}";
             }
         }
 

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -531,10 +531,10 @@ namespace IotEdgeQuickstart.Details
             return this.BuildImageName("azureiotedge-simulated-temperature-sensor", this.imageTag);
         }
 
-        string BuildImageName(string name, string customImageTag)
+        string BuildImageName(string name, string imageTag)
         {
             string prefix = this.credentials.Match(c => $"{c.Address}/microsoft", () => "mcr.microsoft.com");
-            return $"{prefix}/{name}:{customImageTag}";
+            return $"{prefix}/{name}:{imageTag}";
         }
 
         (string, string[]) DeploymentJson()

--- a/smoke/IotEdgeQuickstart/details/IBootstrapper.cs
+++ b/smoke/IotEdgeQuickstart/details/IBootstrapper.cs
@@ -13,7 +13,7 @@ namespace IotEdgeQuickstart.Details
 
         Task Install();
 
-        Task Configure(DeviceProvisioningMethod method, string hostname, string deviceCaCert, string deviceCaPk, string deviceCaCerts, LogLevel runtimeLogLevel);
+        Task Configure(DeviceProvisioningMethod method, string image, string hostname, string deviceCaCert, string deviceCaPk, string deviceCaCerts, LogLevel runtimeLogLevel);
 
         Task Start();
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -176,7 +176,7 @@ namespace IotEdgeQuickstart.Details
 
         public async Task Configure(DeviceProvisioningMethod method, string image, string hostname, string deviceCaCert, string deviceCaPk, string deviceCaCerts, LogLevel runtimeLogLevel)
         {
-            Console.WriteLine($"Setting up iotedged with agent image '{image}'");
+            Console.WriteLine($"Setting up iotedged with agent image 1.0");
 
             const string YamlPath = "/etc/iotedge/config.yaml";
             Task<string> text = File.ReadAllTextAsync(YamlPath);

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -174,9 +174,9 @@ namespace IotEdgeQuickstart.Details
                 300); // 5 min timeout because install can be slow on raspberry pi
         }
 
-        public async Task Configure(DeviceProvisioningMethod method, string hostname, string deviceCaCert, string deviceCaPk, string deviceCaCerts, LogLevel runtimeLogLevel)
+        public async Task Configure(DeviceProvisioningMethod method, string image, string hostname, string deviceCaCert, string deviceCaPk, string deviceCaCerts, LogLevel runtimeLogLevel)
         {
-            Console.WriteLine($"Setting up iotedged with agent image 1.0");
+            Console.WriteLine($"Setting up iotedged with agent image '{image}'");
 
             const string YamlPath = "/etc/iotedge/config.yaml";
             Task<string> text = File.ReadAllTextAsync(YamlPath);
@@ -221,6 +221,7 @@ namespace IotEdgeQuickstart.Details
                     dps.RegistrationId.ForEach(id => { doc.ReplaceOrAdd("provisioning.attestation.registration_id", id); });
                 });
 
+            doc.ReplaceOrAdd("agent.config.image", image);
             doc.ReplaceOrAdd("hostname", hostname);
 
             foreach (RegistryCredentials c in this.credentials)

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -115,7 +115,7 @@ namespace IotEdgeQuickstart.Details
         {
             const string HidePowerShellProgressBar = "$ProgressPreference='SilentlyContinue'";
 
-            Console.WriteLine($"Setting up iotedged with agent image '{image}'");
+            Console.WriteLine($"Setting up iotedged with agent image 1.0");
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
             {

--- a/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedWindows.cs
@@ -111,11 +111,11 @@ namespace IotEdgeQuickstart.Details
             return Task.CompletedTask;
         }
 
-        public async Task Configure(DeviceProvisioningMethod method, string hostname, string deviceCaCert, string deviceCaPk, string deviceCaCerts, LogLevel runtimeLogLevel)
+        public async Task Configure(DeviceProvisioningMethod method, string image, string hostname, string deviceCaCert, string deviceCaPk, string deviceCaCerts, LogLevel runtimeLogLevel)
         {
             const string HidePowerShellProgressBar = "$ProgressPreference='SilentlyContinue'";
 
-            Console.WriteLine($"Setting up iotedged with agent image 1.0");
+            Console.WriteLine($"Setting up iotedged with agent image '{image}'");
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5)))
             {
@@ -139,7 +139,7 @@ namespace IotEdgeQuickstart.Details
                 {
                     Console.WriteLine("Installing iotedge...");
                     args = $". {this.scriptDir}\\IotEdgeSecurityDaemon.ps1; Install-SecurityDaemon " +
-                           $"-ContainerOs Windows";
+                           $"-ContainerOs Windows -AgentImage '{image}'";
 
                     this.proxy.ForEach(proxy => { args += $" -Proxy '{proxy}'"; });
 
@@ -152,7 +152,7 @@ namespace IotEdgeQuickstart.Details
                 {
                     Console.WriteLine("Initializing iotedge...");
                     args = $". {this.scriptDir}\\IotEdgeSecurityDaemon.ps1; Initialize-IoTEdge " +
-                           $"-ContainerOs Windows";
+                           $"-ContainerOs Windows -AgentImage '{image}'";
                 }
 
                 args += method.Dps.Map(


### PR DESCRIPTION
I accidentally broke E2E because I didn't catch the fact that IoTEdgeSecurityDaemon.ps1 needs an agent image passed in. I fix this by passing edge agent 1.0.