### PR TITLE
Update dotnet task in image build

### DIFF
--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -31,7 +31,7 @@ jobs:
             IotDevice3ConnStr2,
             IotHubConnStr2,
             IotHubMqttHeadCert
-      - task: DotNetCoreInstaller@0
+      - task: UseDotNet@2
         displayName: Install .NET Core
         inputs:
           packageType: sdk
@@ -110,7 +110,7 @@ jobs:
             IotDevice3ConnStr2,
             IotHubConnStr2,
             IotHubMqttHeadCert
-      - task: DotNetCoreInstaller@0
+      - task: UseDotNet@2
         displayName: Install .NET Core
         inputs:
           packageType: sdk

--- a/builds/misc/templates/install-dotnet3.yaml
+++ b/builds/misc/templates/install-dotnet3.yaml
@@ -1,6 +1,6 @@
 steps:
-  - task: DotNetCoreInstaller@0
-    displayName: Install .NET Core
+  - task: UseDotNet@2
+    displayName: Install .NET Core sdk
     inputs:
       packageType: sdk
       version: 3.0.100


### PR DESCRIPTION
Update dotnet 3.0 to use latest .net core task in image build pipeline.