### PR TITLE
use job strategy in connectivity test

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -11,6 +11,14 @@ jobs:
 ################################################################################
     displayName: Linux AMD64 Moby
     condition: and(eq(variables['run.linux.amd64.moby'], 'true'), ne(variables['agent.group'], ''))
+    strategy:
+      matrix:
+        setting1:
+          setting.Param1: 'setting1 param value1'
+          setting.Param2: 'setting1 param value2'
+        setting2:
+          setting.Param1: 'setting2 param value1'
+          setting.Param2: 'setting2 param value2'
     timeoutInMinutes: 120
     pool:
       name: $(pool.name)
@@ -79,6 +87,8 @@ jobs:
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
           metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
+          setting.param1: '$(setting.Param1)'
+          setting.param2: '$(setting.Param2)'
 
 ################################################################################
   - job: linux_arm32v7_moby

--- a/builds/e2e/templates/connectivity-deploy.yaml
+++ b/builds/e2e/templates/connectivity-deploy.yaml
@@ -18,6 +18,8 @@ parameters:
   metricsCollector.metricsEndpointsCSV: ''
   metricsCollector.scrapeFrequencyInSecs: ''
   metricsCollector.uploadTarget: ''
+  setting.param1: ''
+  setting.param2: ''
 
 steps:
   - task: CopyFiles@2
@@ -63,6 +65,8 @@ steps:
           -metricsEndpointsCSV "${{ parameters['metricsCollector.metricsEndpointsCSV'] }}" \
           -metricsScrapeFrequencyInSecs "${{ parameters['metricsCollector.scrapeFrequencyInSecs'] }}" \
           -metricsUploadTarget "${{ parameters['metricsCollector.uploadTarget'] }}" \
+          -settingParam1 "${{ parameters['setting.param1'] }}" \
+          -settingParam2 "${{ parameters['setting.param2'] }}" \
           -waitForTestComplete \
           -cleanAll
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/test/connectivity/scripts/connectivityTest.sh
+++ b/test/connectivity/scripts/connectivityTest.sh
@@ -217,6 +217,12 @@ function process_args() {
         elif [ $saveNextArg -eq 24 ]; then
             METRICS_UPLOAD_TARGET="$arg"
             saveNextArg=0
+        elif [ $saveNextArg -eq 25 ]; then
+            SETTING_PARAM1="$arg"
+            saveNextArg=0
+        elif [ $saveNextArg -eq 26 ]; then
+            SETTING_PARAM2="$arg"
+            saveNextArg=0
         else
             case "$arg" in
                 '-h' | '--help' ) usage;;
@@ -244,8 +250,10 @@ function process_args() {
                 '-metricsEndpointsCSV' ) saveNextArg=22;;
                 '-metricsScrapeFrequencyInSecs' ) saveNextArg=23;;
                 '-metricsUploadTarget' ) saveNextArg=24;;
+                '-settingParam1' ) saveNextArg=25;;
+                '-settingParam2' ) saveNextArg=26;;
+                
                 '-waitForTestComplete' ) WAIT_FOR_TEST_COMPLETE=1;;
-
                 '-cleanAll' ) CLEAN_ALL=1;;
                 * ) usage;;
             esac
@@ -419,6 +427,11 @@ function usage() {
 }
 
 process_args "$@"
+
+echo
+echo "Setting Param1=$SETTING_PARAM1"
+echo "Setting Param2=$SETTING_PARAM2"
+echo
 
 CONTAINER_REGISTRY="${CONTAINER_REGISTRY:-edgebuilds.azurecr.io}"
 E2E_TEST_DIR="${E2E_TEST_DIR:-$(pwd)}"


### PR DESCRIPTION
testing to use job strategy in connectivity test; in order to run different settings/external environment parameters.