### PR TITLE
Remove upload target for metrics collector

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -78,7 +78,6 @@ jobs:
           testResultCoordinator.verificationDelay: '$(testResultCoordinator.verificationDelay)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: linux_arm32v7_moby
@@ -153,4 +152,3 @@ jobs:
           testResultCoordinator.verificationDelay: '$(testResultCoordinator.verificationDelay)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -32,7 +32,6 @@ variables:
   #twinTester.twinUpdateFailureThreshold: 'xx:xx:xx.xx'
   #metricsCollector.metricsEndpointsCSV
   #metricsCollector.scrapeFrequencyInSecs: 'xx:xx:xx.xx'
-  #metricsCollector.uploadTarget
 
 jobs:
 ################################################################################
@@ -110,7 +109,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: linux_arm32v7_moby
@@ -188,7 +186,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: linux_arm64v8_docker
@@ -266,7 +263,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
           
 ################################################################################
   - job: windows_amd64_moby
@@ -346,7 +342,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: windows_servercore_amd64_moby
@@ -426,7 +421,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: iotuap_amd64_moby
@@ -505,4 +499,3 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -31,7 +31,6 @@ variables:
   #twinTester.twinUpdateFailureThreshold: 'xx:xx:xx.xx'
   #metricsCollector.metricsEndpointsCSV
   #metricsCollector.scrapeFrequencyInSecs: 'xx:xx:xx.xx'
-  #metricsCollector.uploadTarget
 
 jobs:
 ################################################################################
@@ -107,7 +106,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: linux_arm32v7_moby
@@ -183,7 +181,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: linux_arm64v8_docker
@@ -259,7 +256,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: windows_amd64_moby
@@ -337,7 +333,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: windows_servercore_amd64_moby
@@ -415,7 +410,6 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'
 
 ################################################################################
   - job: iotuap_amd64_moby
@@ -492,4 +486,3 @@ jobs:
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
           metricsCollector.metricsEndpointsCSV: '$(metricsCollector.metricsEndpointsCSV)'
           metricsCollector.scrapeFrequencyInSecs: '$(metricsCollector.scrapeFrequencyInSecs)'
-          metricsCollector.uploadTarget: '$(metricsCollector.uploadTarget)'

--- a/builds/e2e/templates/connectivity-deploy.yaml
+++ b/builds/e2e/templates/connectivity-deploy.yaml
@@ -17,7 +17,6 @@ parameters:
   testResultCoordinator.verificationDelay: ''
   metricsCollector.metricsEndpointsCSV: ''
   metricsCollector.scrapeFrequencyInSecs: ''
-  metricsCollector.uploadTarget: ''
 
 steps:
   - task: CopyFiles@2
@@ -62,7 +61,6 @@ steps:
           -verificationDelay "${{ parameters['testResultCoordinator.verificationDelay'] }}" \
           -metricsEndpointsCSV "${{ parameters['metricsCollector.metricsEndpointsCSV'] }}" \
           -metricsScrapeFrequencyInSecs "${{ parameters['metricsCollector.scrapeFrequencyInSecs'] }}" \
-          -metricsUploadTarget "${{ parameters['metricsCollector.uploadTarget'] }}" \
           -waitForTestComplete \
           -cleanAll
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -24,7 +24,6 @@ parameters:
   twinTester.twinUpdateFailureThreshold: ''
   metricsCollector.metricsEndpointsCSV: ''
   metricsCollector.scrapeFrequencyInSecs: ''
-  metricsCollector.uploadTarget: ''
 
 steps:
   - task: CopyFiles@2
@@ -74,5 +73,4 @@ steps:
           -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
           -MetricsEndpointsCSV "${{ parameters['metricsCollector.metricsEndpointsCSV'] }}" `
           -MetricsScrapeFrequencyInSecs "${{ parameters['metricsCollector.scrapeFrequencyInSecs'] }}" `
-          -MetricsUploadTarget "${{ parameters['metricsCollector.uploadTarget'] }}"
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -24,7 +24,6 @@ parameters:
   twinTester.twinUpdateFailureThreshold: ''
   metricsCollector.metricsEndpointsCSV: ''
   metricsCollector.scrapeFrequencyInSecs: ''
-  metricsCollector.uploadTarget: ''
 
 steps:
   - task: CopyFiles@2
@@ -75,6 +74,5 @@ steps:
           -twinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" \
           -metricsEndpointsCSV "${{ parameters['metricsCollector.metricsEndpointsCSV'] }}" \
           -metricsScrapeFrequencyInSecs "${{ parameters['metricsCollector.scrapeFrequencyInSecs'] }}" \
-          -metricsUploadTarget "${{ parameters['metricsCollector.uploadTarget'] }}" \
           -cleanAll
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -28,7 +28,6 @@ parameters:
   twinTester.twinUpdateFailureThreshold: ''
   metricsCollector.metricsEndpointsCSV: ''
   metricsCollector.scrapeFrequencyInSecs: ''
-  metricsCollector.uploadTarget: ''
 
 steps:
   - task: CopyFiles@2
@@ -82,7 +81,6 @@ steps:
           -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
           -MetricsEndpointsCSV "${{ parameters['metricsCollector.metricsEndpointsCSV'] }}" `
           -MetricsScrapeFrequencyInSecs "${{ parameters['metricsCollector.scrapeFrequencyInSecs'] }}" `
-          -MetricsUploadTarget "${{ parameters['metricsCollector.uploadTarget'] }}"
         # schedule a task to stop iotedge service (terminate the test) in 4:30h
         $ScheduleDatetime = [DateTime]::Now.AddMinutes(270)
         $ScheduleDate=$ScheduleDatetime.ToString("MM/dd/yyyy")

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -28,7 +28,6 @@ parameters:
   twinTester.twinUpdateFailureThreshold: ''
   metricsCollector.metricsEndpointsCSV: ''
   metricsCollector.scrapeFrequencyInSecs: ''
-  metricsCollector.uploadTarget: ''
 
 steps:
   - task: CopyFiles@2
@@ -85,7 +84,6 @@ steps:
           -twinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" \
           -metricsEndpointsCSV "${{ parameters['metricsCollector.metricsEndpointsCSV'] }}" \
           -metricsScrapeFrequencyInSecs "${{ parameters['metricsCollector.scrapeFrequencyInSecs'] }}" \
-          -metricsUploadTarget "${{ parameters['metricsCollector.uploadTarget'] }}" \
           -cleanAll
         #Remove all pending jobs
         atrm $(atq | cut -f1)

--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -617,9 +617,6 @@
                 },
                 "ScrapeFrequencyInSecs": {
                     "value": "<MetricsCollector.ScrapeFrequencyInSecs>"
-                },
-                "UploadTarget": {
-                  "value": "<MetricsCollector.UploadTarget>"
                 }
             },
             "settings": {

--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -408,9 +408,6 @@
                 },
                 "ScrapeFrequencyInSecs": {
                     "value": "<MetricsCollector.ScrapeFrequencyInSecs>"
-                },
-                "UploadTarget": {
-                  "value": "<MetricsCollector.UploadTarget>"
                 }
             },
             "settings": {

--- a/e2e_deployment_files/long_haul_deployment.template.windows.json
+++ b/e2e_deployment_files/long_haul_deployment.template.windows.json
@@ -411,9 +411,6 @@
                 },
                 "ScrapeFrequencyInSecs": {
                     "value": "<MetricsCollector.ScrapeFrequencyInSecs>"
-                },
-                "UploadTarget": {
-                  "value": "<MetricsCollector.UploadTarget>"
                 }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.json
+++ b/e2e_deployment_files/stress_deployment.template.json
@@ -332,9 +332,6 @@
                 },
                 "ScrapeFrequencyInSecs": {
                     "value": "<MetricsCollector.ScrapeFrequencyInSecs>"
-                },
-                "UploadTarget": {
-                  "value": "<MetricsCollector.UploadTarget>"
                 }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.windows.json
+++ b/e2e_deployment_files/stress_deployment.template.windows.json
@@ -335,9 +335,6 @@
                 },
                 "ScrapeFrequencyInSecs": {
                     "value": "<MetricsCollector.ScrapeFrequencyInSecs>"
-                },
-                "UploadTarget": {
-                  "value": "<MetricsCollector.UploadTarget>"
                 }
             },
             "settings": {

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -180,7 +180,6 @@ function prepare_test_from_artifacts() {
                 sed -i -e "s@<LogAnalyticsWorkspaceId>@$LOG_ANALYTICS_WORKSPACE_ID@g" "$deployment_working_file"
                 sed -i -e "s@<MetricsCollector.MetricsEndpointsCSV>@$METRICS_ENDPOINTS_CSV@g" "$deployment_working_file"
                 sed -i -e "s@<MetricsCollector.ScrapeFrequencyInSecs>@$METRICS_SCRAPE_FREQUENCY_IN_SECS@g" "$deployment_working_file"
-                sed -i -e "s@<MetricsCollector.UploadTarget>@$METRICS_UPLOAD_TARGET@g" "$deployment_working_file"
                 escapedSnitchAlertUrl="${SNITCH_ALERT_URL//&/\\&}"
                 escapedBuildId="${ARTIFACT_IMAGE_BUILD_NUMBER//./}"
                 sed -i -e "s@<ServiceClientConnectionString>@$IOTHUB_CONNECTION_STRING@g" "$deployment_working_file"
@@ -399,9 +398,6 @@ function process_args() {
         elif [ $saveNextArg -eq 40 ]; then
             METRICS_SCRAPE_FREQUENCY_IN_SECS="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 41 ]; then
-            METRICS_UPLOAD_TARGET="$arg"
-            saveNextArg=0
         else
             case "$arg" in
                 '-h' | '--help' ) usage;;
@@ -445,7 +441,6 @@ function process_args() {
                 '-twinUpdateFailureThreshold' ) saveNextArg=38;;
                 '-metricsEndpointsCSV' ) saveNextArg=39;;
                 '-metricsScrapeFrequencyInSecs' ) saveNextArg=40;;
-                '-metricsUploadTarget' ) saveNextArg=41;;
                 '-cleanAll' ) CLEAN_ALL=1;;
                 * ) usage;;
             esac
@@ -1039,7 +1034,6 @@ function usage() {
     echo ' -twinUpdateFailureThreshold       Specifies the longest period of time a twin update can take before being marked as a failure. This should be specified in DateTime format. Default is 00:01:00'
     echo ' -metricsEndpointsCSV              Optional csv of exposed endpoints for which to scrape metrics.'
     echo ' -metricsScrapeFrequencyInSecs     Optional frequency at which the MetricsCollector module will scrape metrics from the exposed metrics endpoints. Default is 300 seconds.'
-    echo ' -metricsUploadTarget              Optional upload target for metrics. Valid values are AzureLogAnalytics or IoTHub. Default is AzureLogAnalytics.'
     exit 1;
 }
 
@@ -1055,7 +1049,6 @@ TRANSPORT_TYPE_3="${TRANSPORT_TYPE_3:-mqtt}"
 TRANSPORT_TYPE_4="${TRANSPORT_TYPE_4:-mqtt}"
 TWIN_UPDATE_FAILURE_THRESHOLD="${TWIN_UPDATE_FAILURE_THRESHOLD:-00:01:00}"
 METRICS_SCRAPE_FREQUENCY_IN_SECS="${METRICS_SCRAPE_FREQUENCY_IN_SECS:-300}"
-METRICS_UPLOAD_TARGET="${METRICS_UPLOAD_TARGET:-AzureLogAnalytics}"
 if [[ "${TEST_NAME,,}" == "longhaul" ]]; then
     DESIRED_MODULES_TO_RESTART_CSV="${DESIRED_MODULES_TO_RESTART_CSV:-,}"
     LOADGEN_MESSAGE_FREQUENCY="${LOADGEN_MESSAGE_FREQUENCY:-00:00:01}"

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -128,9 +128,6 @@
     .PARAMETER MetricsScrapeFrequencyInSecs
         Optional frequency at which the MetricsCollector module will scrape metrics from the exposed metrics endpoints. Default is 300 seconds. 
 
-    .PARAMETER MetricsUploadTarget
-        Optional upload target for metrics. Valid values are AzureLogAnalytics or IoTHub. Default is AzureLogAnalytics. 
-
     .EXAMPLE
         .\Run-E2ETest.ps1
             -E2ETestFolder "C:\Data\e2etests"
@@ -264,8 +261,6 @@ Param (
     [string] $MetricsEndpointsCSV = $null,
 
     [string] $MetricsScrapeFrequencyInSecs = $null,
-
-    [string] $MetricsUploadTarget = $null,
 
     [ValidateScript({($_ -as [System.Uri]).AbsoluteUri -ne $null})]
     [string] $ProxyUri = $null,
@@ -507,7 +502,6 @@ Function PrepareTestFromArtifacts
                 (Get-Content $DeploymentWorkingFilePath).replace('<ServiceClientConnectionString>',$IoTHubConnectionString) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<MetricsCollector.MetricsEndpointsCSV>',$MetricsEndpointsCSV) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<MetricsCollector.ScrapeFrequencyInSecs>',$MetricsScrapeFrequencyInSecs) | Set-Content $DeploymentWorkingFilePath
-                (Get-Content $DeploymentWorkingFilePath).replace('<MetricsCollector.UploadTarget>',$MetricsUploadTarget) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.AlertUrl>',$SnitchAlertUrl) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.BuildNumber>',$SnitchBuildNumber) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Snitch.BuildId>',"$ReleaseLabel-$(GetImageArchitectureLabel)-windows-$escapedBuildId") | Set-Content $DeploymentWorkingFilePath
@@ -1572,11 +1566,6 @@ If ([string]::IsNullOrWhiteSpace($TwinUpdateFailureThreshold))
 If ([string]::IsNullOrWhiteSpace($MetricsScrapeFrequencyInSecs))
 {
     $MetricsScrapeFrequencyInSecs=300;
-}
-
-If ([string]::IsNullOrWhiteSpace($MetricsUploadTarget))
-{
-    $MetricsScrapeFrequencyInSecs="AzureLogAnalytics";
 }
 
 If ($TestName -eq "LongHaul")

--- a/test/connectivity/scripts/connectivityTest.sh
+++ b/test/connectivity/scripts/connectivityTest.sh
@@ -68,7 +68,6 @@ function prepare_test_from_artifacts() {
 
     sed -i -e "s@<MetricsCollector.MetricsEndpointsCSV>@$METRICS_ENDPOINTS_CSV@g" "$deployment_working_file"
     sed -i -e "s@<MetricsCollector.ScrapeFrequencyInSecs>@$METRICS_SCRAPE_FREQUENCY_IN_SECS@g" "$deployment_working_file"
-    sed -i -e "s@<MetricsCollector.UploadTarget>@$METRICS_UPLOAD_TARGET@g" "$deployment_working_file"
 }
 
 function print_deployment_logs() {
@@ -214,9 +213,6 @@ function process_args() {
         elif [ $saveNextArg -eq 23 ]; then
             METRICS_SCRAPE_FREQUENCY_IN_SECS="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 24 ]; then
-            METRICS_UPLOAD_TARGET="$arg"
-            saveNextArg=0
         else
             case "$arg" in
                 '-h' | '--help' ) usage;;
@@ -243,7 +239,6 @@ function process_args() {
                 '-timeForReportingGeneration' ) saveNextArg=21;;
                 '-metricsEndpointsCSV' ) saveNextArg=22;;
                 '-metricsScrapeFrequencyInSecs' ) saveNextArg=23;;
-                '-metricsUploadTarget' ) saveNextArg=24;;
                 '-waitForTestComplete' ) WAIT_FOR_TEST_COMPLETE=1;;
 
                 '-cleanAll' ) CLEAN_ALL=1;;
@@ -412,7 +407,6 @@ function usage() {
     echo ' -waitForTestComplete            Wait for test to complete if this parameter is provided.  Otherwise it will finish once deployment is done.'
     echo ' -metricsEndpointsCSV            Optional csv of exposed endpoints for which to scrape metrics.'
     echo ' -metricsScrapeFrequencyInSecs   Optional frequency at which the MetricsCollector module will scrape metrics from the exposed metrics endpoints. Default is 300 seconds.'
-    echo ' -metricsUploadTarget            Optional upload target for metrics. Valid values are AzureLogAnalytics or IoTHub. Default is AzureLogAnalytics.'
 
     echo ' -cleanAll                       Do docker prune for containers, logs and volumes.'
     exit 1;


### PR DESCRIPTION
The metrics collector supports a flow to send metrics in messages through edge hub to event hub. We currently have our test script configured to take an UploadTarget as input, where you can specify to use the event hub flow.

There is confusing behavior where this flow only works if you also supply values for log analytics credentials (which are not needed for the event hub flow). This is because the log analytics env vars are defined in our deployment files, and if no value is passed to our e2e scripts, empty string will be passed. When empty string is passed as an env var, edge agent will fail to start the module.

I elected to remove this upload target as we are not using it in our tests. If we want to add it back later, we need to allow it to work without needing to pass log analytics values.