### PR TITLE
Revert "Make edgeHub metrics go through asp.net (#2351)"

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Hosting.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Hosting.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool clientCertAuthEnabled,
             SslProtocols sslProtocols)
         {
-            int mainPort = configuration.GetValue("httpSettings:port", 443);
-            int metricsPort = configuration.GetValue("httpSettings:metrics_port", 9600);
+            int port = configuration.GetValue("httpSettings:port", 443);
             var certificateMode = clientCertAuthEnabled ? ClientCertificateMode.AllowCertificate : ClientCertificateMode.NoCertificate;
             IWebHostBuilder webHostBuilder = new WebHostBuilder()
                 .UseKestrel(
@@ -40,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     {
                         options.Listen(
                             !Socket.OSSupportsIPv6 ? IPAddress.Any : IPAddress.IPv6Any,
-                            mainPort,
+                            port,
                             listenOptions =>
                             {
                                 listenOptions.UseHttpsExtensions(
@@ -52,8 +51,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                                         SslProtocols = sslProtocols
                                     });
                             });
-
-                        options.Listen(!Socket.OSSupportsIPv6 ? IPAddress.Any : IPAddress.IPv6Any, metricsPort);
                     })
                 .UseSockets()
                 .ConfigureServices(

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.csproj
@@ -42,8 +42,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />
 	<PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.3.1" />
-	<PackageReference Include="prometheus-net" Version="3.4.0" />
-	<PackageReference Include="prometheus-net.AspNetCore" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Metrics;
-    using Microsoft.Azure.Devices.Edge.Util.Metrics.NullMetrics;
     using Microsoft.Azure.Devices.Routing.Core;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
@@ -69,8 +68,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             logger.LogInformation($"OptimizeForPerformance={configuration.GetValue("OptimizeForPerformance", true)}");
             logger.LogInformation("Loaded server certificate with expiration date of {0}", certificates.ServerCertificate.NotAfter.ToString("o"));
 
+            var metricsListener = container.Resolve<IMetricsListener>();
             var metricsProvider = container.Resolve<IMetricsProvider>();
-            Metrics.InitWithAspNet(metricsProvider, logger);
+            Metrics.Init(metricsProvider, metricsListener, logger);
 
             // Init V0 Metrics
             MetricsV0.BuildMetricsCollector(configuration);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
-    using Prometheus;
 
     public class Startup : IStartup
     {
@@ -45,12 +44,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
         public void Configure(IApplicationBuilder app)
         {
-            // Seperate metrics endpoint from https authentication
-            app.Map("/metrics", metricsApp =>
-            {
-                metricsApp.UseMetricServer(string.Empty);
-            });
-
             app.UseWebSockets();
 
             var webSocketListenerRegistry = app.ApplicationServices.GetService(typeof(IWebSocketListenerRegistry)) as IWebSocketListenerRegistry;

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/Metrics.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/Metrics.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics
 
         public static IMetricsListener Listener { get; private set; } = new NullMetricsListener();
 
-        public static void InitWithServer(IMetricsProvider metricsProvider, IMetricsListener metricsListener, ILogger logger)
+        public static void Init(IMetricsProvider metricsProvider, IMetricsListener metricsListener, ILogger logger)
         {
             Preconditions.CheckNotNull(metricsProvider, nameof(metricsProvider));
             Preconditions.CheckNotNull(metricsListener, nameof(metricsListener));
@@ -22,17 +22,6 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics
                 Instance = metricsProvider;
                 Listener = metricsListener;
                 Listener.Start(logger);
-            }
-        }
-
-        public static void InitWithAspNet(IMetricsProvider metricsProvider, ILogger logger)
-        {
-            Preconditions.CheckNotNull(metricsProvider, nameof(metricsProvider));
-
-            lock (StateLock)
-            {
-                logger.LogInformation("Using Asp Net server for metrics");
-                Instance = metricsProvider;
             }
         }
     }


### PR DESCRIPTION
This change breaks in dotnet 3.0, which linux arm64 uses. reverting for now. 