### PR TITLE
[k8s][helm] Update helm charts to include all config.yaml changes. (#2353)

### DIFF
--- a/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             value: "debug"
           {{- if .Values.iotedged.data.httpsProxy }}
           - name: "https_proxy"
-            value: {{ .Values.iotedged.data.targetPath | quote}}
+            value: {{ .Values.iotedged.data.httpsProxy | quote}}
           {{end}}
           volumeMounts:
           - name: config

--- a/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
@@ -29,17 +29,37 @@ spec:
           env:
           - name: "IOTEDGE_LOG"
             value: "debug"
+          {{- if .Values.iotedged.data.httpsProxy }}
+          - name: "https_proxy"
+            value: {{ .Values.iotedged.data.targetPath | quote}}
+          {{end}}
           volumeMounts:
           - name: config
             mountPath: "/etc/iotedged"
             readOnly: true
           - name: edge-home
             mountPath: {{ .Values.iotedged.data.targetPath | quote }}
-          {{- if .Values.iotedged.certificates }}
+          {{- with .Values.iotedged.certificates }}
+          {{- if .secret }}
           - name: edge-certs
             mountPath: "/etc/edgecerts"
             readOnly: true
-          {{end}}
+          {{- end}}
+          {{- end}}
+          {{- with .Values.provisioning.authentication }}
+          {{- if .identitySecret }}
+          - name: edge-authentication
+            mountPath: "/etc/edge-authentication"
+            readOnly: true
+          {{- end}}
+          {{- end}}
+          {{- with .Values.provisioning.attestation }}
+          {{- if .identitySecret }}
+          - name: edge-attestation
+            mountPath: "/etc/edge-attestation"
+            readOnly: true
+          {{- end}}
+          {{- end}}
           ports:
             - name: management
               containerPort: {{ .Values.iotedged.ports.management }}
@@ -70,27 +90,59 @@ spec:
       - name: config
         secret:
           secretName: iotedged-config
-      {{- if .Values.iotedged.certificates }}
+      {{- with .Values.provisioning.authentication }}
+      {{- if .identitySecret }}
+      {{- /*
+      NOTE: This sets up iotedged with a volume "/etc/edge-authentication" populated with authentication certs.
+    */}}
+      - name: edge-authentication
+        secret:
+          secretName: {{ .identitySecret }}
+          items:
+          - key: {{ .identityCert | default "identity_certificate.pem" }}
+            path: identity_cert
+          - key: {{ .identityPk | default "identity_key.pem" }}
+            path: identity_pk
+      {{- end}}
+      {{- end}}
+      {{- with .Values.provisioning.attestation }}
+      {{- if .identitySecret }}
+      {{- /*
+      NOTE: This sets up iotedged with a volume "/etc/edge-attestation" populated with the attestation certs.
+    */}}
+      - name: edge-attestation
+        secret:
+          secretName: {{ .identitySecret }}
+          items:
+          - key: {{ .identityCert | default "identity_certificate.pem" }}
+            path: identity_cert
+          - key: {{ .identityPk | default "identity_key.pem" }}
+            path: identity_pk
+      {{- end}}
+      {{- end}}
+      {{- with .Values.iotedged.certificates }}
+      {{- if .secret }}
       {{- /*
         NOTE: This sets up iotedged with a volume "/etc/edgecerts" populated with the given CA certs.
       */}}
       - name: edge-certs
         secret:
-          secretName: {{ .Values.iotedged.certificates.secret }}
+          secretName: {{ .secret }}
           items:
-          - key: {{ .Values.iotedged.certificates.device_ca_cert | default "device_ca_cert" }}
+          - key: {{ .device_ca_cert | default "device_ca_cert" }}
             path: device_ca_cert
-          - key: {{ .Values.iotedged.certificates.device_ca_pk | default "device_ca_pk" }}
+          - key: {{ .device_ca_pk | default "device_ca_pk" }}
             path: device_ca_pk
-          - key: {{ .Values.iotedged.certificates.trusted_ca_certs | default "trusted_ca_certs" }}
+          - key: {{ .trusted_ca_certs | default "trusted_ca_certs" }}
             path: trusted_ca_certs
-      {{else}}
+      {{- end}}
+      {{- else}}
       {{- /*
         NOTE: This sets up iotedged in the "quickstart" mode which is NOT meant
         for production use. For PoCs though, its wonderful! For production, this
         volume should probably be populated with proper CA certs.
       */}}
-      {{end}}
+      {{- end}}
       - name: edge-home
         {{- if .Values.iotedged.data.persistentVolumeClaim }}
         persistentVolumeClaim:

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -26,6 +26,37 @@ iotedged:
     #   name: <CLAIM NAME HERE>
     #   storageClassName: <STORAGE CLASS NAME HERE>
     #   size: 100Mi
+    #
+    ###############################################################################
+    # Proxy settings
+    ###############################################################################
+    # Set the following if an HTTPS proxy is needed
+    # httpsProxy: "<proxy URL>"
+    ###############################################################################
+    # Watchdog settings
+    ###############################################################################
+    #
+    # The IoT edge daemon has a watchdog that periodically checks the health of the
+    # Edge Agent module and restarts it if it's down.
+    #
+    # maxRetries - Configures the number of retry attempts that the IoT edge daemon
+    #               should make for failed operations before failing with a fatal error.
+    #
+    #               If this configuration is not specified, the daemon keeps retrying
+    #               on errors and doesn't fail fatally.
+    #
+    #               On a fatal failure, the daemon returns an exit code which
+    #               signifies the kind of error encountered. Currently, the following
+    #               error codes are returned by the daemon -
+    #
+    #               150 - Invalid Device ID specified.
+    #               151 - Invalid IoT hub configuration.
+    #               152 - Invalid SAS token used to call IoT hub.
+    #                     This could signal an invalid SAS key.
+    #               1 - All other errors.
+    ###############################################################################
+    #  maxRetries: 2
+
   ###############################################################################
   # Certificate settings
   ###############################################################################
@@ -52,6 +83,7 @@ iotedged:
   #   device_ca_cert: "<ADD SECRET ITEM NAME FOR DEVICE CA CERTIFICATE HERE>"
   #   device_ca_pk: "<ADD SECRET ITEM NAME FOR CA PRIVATE KEY HERE>"
   #   trusted_ca_certs: "<ADD SECRET ITEM NAME FOR CA CERTIFICATES HERE>"
+  #   auto_generated_ca_lifetime_days: <value>
 
 iotedgedProxy:
   image:
@@ -60,6 +92,12 @@ iotedgedProxy:
     pullPolicy: Always
 
 # Edge Agent image configuration
+# Settings:
+#     containerName  - name of the edge agent module. Expected to be "edgeAgent".
+#     image          - Image tag and image pull policy
+#     env            - Any environment variable that needs to be set for edge agent module.
+#                      Some environment variables affect how Edge Agent creates modules in the
+#                      cluster see the descriptions below.
 edgeAgent:
   containerName: edgeagent
   image:
@@ -126,9 +164,127 @@ edgeAgent:
 #     username: '<USERNAME>'
 #     password: '<PASSWORD>'
 
+###############################################################################
+# Provisioning mode and settings
+###############################################################################
+#
+# Configures the identity provisioning mode of the daemon.
+#
+# Supported modes:
+#     manual   - using an iothub connection string or an X.509 identity certificate
+#     dps      - using dps for provisioning
+#     external - the device has been provisioned externally.
+#                Uses an external provisioning endpoint to get device specific information.
+#
+# Manual settings when using IoT Hub connection string
+#     deviceConnectionString - Required. The Edge device connection string
+#                                when using SharedAccessKey authentication mode.
+#                                Ex. "HostName=<hub-name>.azure-devices.net;DeviceId=<device-id>;SharedAccessKey=<key>
+#
+# Manual authentication settings when using an X.509 identity certificate
+#   Please create a secret containing 2 items, the Edge device identity X.509 certificate, and the 
+#   Edge device identity private key. Then give the chart the secret name and the item names. 
+#   For example, if a secret is created like this:
+#   `kubectl create secret generic -n device-namespace edge-authentication --from-file=certs/identity_certificate.pem --from-file=private/identity_key.pem
+#   The YAML would look like:
+#     identitySecret: "edge-authentication"
+#     identityCert: "identity_certificate.pem"
+#     identityPk: "identity_key.pem"
+#
+#     iothubHostname - Required. The Azure Iot Hub hostname.
+#                       Ex. <hub-name>.azure-devices.net
+#     deviceId       - Required. The Edge device id.
+#     identitySecret - Required. The secret name.
+#     identityCert   - Required. The secret item name for Edge device identity X.509 certificate.
+#     identityPk     - Required. The secret item name forEdge device identity private key.
+#
+# DPS Settings
+#   If configuring for configured for X.509 authentication, please create a secret containing 2 
+#   items, the Edge device identity X.509 certificate, and the Edge device identity private key. 
+#   Then give the chart the secret name and the item names. For example, if a secret is created like 
+#   this:
+#   `kubectl create secret generic -n device-namespace edge-authentication --from-file=certs/identity_certificate.pem --from-file=private/identity_key.pem
+#   The YAML would look like:
+#     identitySecret: "edge-authentication"
+#     identityCert: "identity_certificate.pem"
+#     identityPk: "identity_key.pem"
+#
+#     scopeId        - Required. Value of a specific DPS instance's ID scope
+#     registrationId - Required for TPM and symmetric key provisioning flows.
+#                       Optional for X.509 provisioning. Registration ID of a
+#                       specific device in DPS.
+#                       For more information regarding DPS registration ids
+#                       please see https://docs.microsoft.com/en-us/azure/iot-dps/concepts-device#registration-id
+#     symmetricKey   - Optional. This entry should only be specified when
+#                       provisioning devices configured for symmetric key
+#                       attestation. Device specific symmetric key.
+#     identitySecret - Optional. The secret name.
+#     identityCert   - Optional. The secret item name for Edge device identity X.509 certificate.
+#     identityPk     - Optional. The secret item name forEdge device identity private key.
+#
+# External Settings
+#     endpoint - Required. Value of the endpoint used to retrieve device specific
+#                information such as its IoT hub connection information.
+#
+# Dynamic Re-provisioning Settings
+#     dynamicReprovisioning - Optional. A flag to opt-in to the dynamic re-provisioning 
+#                              feature. If enabled, IoT Edge on detecting a possible 
+#                              device re-provisioning event will shut down the daemon.
+#                              This is so that on the next daemon startup, the device is 
+#                              set up with the new provisioning information of the device in 
+#                              in IoT Hub.
+#                              For the external provisioning mode specifically, the daemon 
+#                              will notify the external provisioning endpoint about the
+#                              re-provisioning event before shutting down.
+###############################################################################
+# Manual provisioning configuration using a connection string
+provisioning:
+  source: "manual"
+  #deviceConnectionString: "<ADD DEVICE CONNECTION STRING HERE>"
+  dynamicReprovisioning: false
+
+# Manual provisioning configuration using an X.509 identity certificate
+# provisioning:
+#   source: "manual"
+#   authentication:
+#     method: "x509"
+#     iothubHostname: "<REQUIRED IOTHUB HOSTNAME>"
+#     deviceId: "<REQUIRED DEVICE ID PROVISIONED IN IOTHUB>"
+#     identitySecret: "<REQUIRED SECRET CONTAINING IDENTITY CERTIFICATE>"
+#     identityCert: "<REQUIRED SECRET ITEM NAME FOR DEVICE IDENTITY CERTIFICATE>"
+#     identityPk: "<REQUIRED SECRET ITEM NAME FOR DEVICE IDENTITY PRIVATE KEY>"
+#   dynamicReprovisioning: false
+
+# DPS symmetric key provisioning configuration
+# provisioning:
+#   source: "dps"
+#   globalEndpoint: "https://global.azure-devices-provisioning.net"
+#   scopeId: "{scope_id}"
+#   attestation:
+#     method: "symmetric_key"
+#     registrationId: "{registration_id}"
+#     symmetricKey: "{symmetric_key}"
+#   dynamicReprovisioning: false
+
+# DPS X.509 provisioning configuration
+# provisioning:
+#   source: "dps"
+#   globalEndpoint: "https://global.azure-devices-provisioning.net"
+#   scopeId: "{scope_id}"
+#   attestation:
+#     method: "x509"
+#     registrationId: "<OPTIONAL REGISTRATION ID. IF UNSPECIFIED CAN BE OBTAINED FROM CN OF identity_cert"
+#     identitySecret: "<REQUIRED SECRET CONTAINING IDENTITY CERTIFICATE>"
+#     identityCert: "<REQUIRED SECRET ITEM NAME FOR DEVICE IDENTITY CERTIFICATE>"
+#     identityPk: "<REQUIRED SECRET ITEM NAME FOR DEVICE IDENTITY PRIVATE KEY>"
+#   dynamicReprovisioning: false
+
+# External provisioning configuration
+# provisioning:
+#   source: "external"
+#   endpoint: "http://localhost:9999"
+#   dynamicReprovisioning: false
+
 # TODO: Re-enable edge-deployment-crd dependency when namespace specific CRD is supported in Helm
 edge-kubernetes-crd:
   enabled: false
-
-# Azure IoT Hub device connection string
-deviceConnectionString: '<ADD DEVICE CONNECTION STRING HERE>'


### PR DESCRIPTION
Cherry-pick helm changes into edge on k8s public preview branch.

* First step: pull in all new settings into values.yaml

* Remove a test value.

* Removed TPM for k8s in values.yaml

* certs are secrets and are mounted.

* Add httpsProxy

* Slightly less unpleasant from of the same logic using "with".

* Moved edge-kubernetes-crd to end of file.

* In the certificate section, the certificate is optional,
auto_generated_ca_lifetime_days is independent
of the other cert settings.