### PR TITLE
Fix ReportTestResultAsync Method in tests

### DIFF
--- a/test/modules/DirectMethodReceiver/src/DirectMethodReceiver.cs
+++ b/test/modules/DirectMethodReceiver/src/DirectMethodReceiver.cs
@@ -3,6 +3,7 @@ namespace DirectMethodReceiver
 {
     using System;
     using System.Net;
+    using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
@@ -43,10 +44,18 @@ namespace DirectMethodReceiver
 
         async Task<MethodResponse> HelloWorldMethodAsync(MethodRequest methodRequest, object userContext)
         {
-            this.logger.LogInformation($"Received direct method call: {methodRequest.DataAsJson}");
-            JToken payload = JToken.Parse(methodRequest.DataAsJson);
-            // Send the report to Test Result Coordinator
-            await this.ReportTestResult(payload["DirectMethodCount"].ToString());
+            try
+            {
+                this.logger.LogInformation($"Received direct method call: {methodRequest.DataAsJson}");
+                JToken payload = JToken.Parse(methodRequest.DataAsJson);
+                // Send the report to Test Result Coordinator
+                await this.ReportTestResult(payload["DirectMethodCount"].ToString());
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, $"Exception thrown from {nameof(this.HelloWorldMethodAsync)} method");
+            }
+
             return new MethodResponse((int)HttpStatusCode.OK);
         }
 

--- a/test/modules/ModuleLib/ModuleUtil.cs
+++ b/test/modules/ModuleLib/ModuleUtil.cs
@@ -57,16 +57,9 @@ namespace Microsoft.Azure.Devices.Edge.ModuleUtil
         }
 
         public static async Task ReportTestResultAsync(TestResultReportingClient apiClient, ILogger logger, TestResultBase testResult)
-        {
-            try
-            {
-                logger.LogInformation($"Sending test result: Source={testResult.Source}, Type={testResult.ResultType}, CreatedAt={testResult.CreatedAt}, Result={testResult.GetFormattedResult()}");
-                await apiClient.ReportResultAsync(testResult.ToTestOperationResultDto());
-            }
-            catch (Exception e)
-            {
-                logger.LogError(e, "Failed call to report status to TestResultCoordinator");
-            }
+        {            
+            logger.LogInformation($"Sending test result: Source={testResult.Source}, Type={testResult.ResultType}, CreatedAt={testResult.CreatedAt}, Result={testResult.GetFormattedResult()}");
+            await apiClient.ReportResultAsync(testResult.ToTestOperationResultDto());
         }
 
         static async Task<ModuleClient> InitializeModuleClientAsync(TransportType transportType, ILogger logger)

--- a/test/modules/Relayer/Program.cs
+++ b/test/modules/Relayer/Program.cs
@@ -120,7 +120,7 @@ namespace Relayer
             }
             catch (Exception ex)
             {
-                Logger.LogError(ex, "Error in ProcessAndSendMessageAsync");
+                Logger.LogError(ex, $"Error in {nameof(ProcessAndSendMessageAsync)} method");
             }
 
             return MessageResponse.Completed;


### PR DESCRIPTION
Remove try-catch in ModuleUtil.ReportTestResultAsync method; and catch in caller code.

1. Update network controller and DM receiver to log error if that method throw exception. 
2. all other usages will catch exception in the program.MainAsync method.
3. for twintester, just let it throw to the top and crash the program for fail-fast.