### PR TITLE
Create [EndToEnd] test category

### DIFF
--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.4.0" />
+    <PackageReference Include="nunit" Version="3.11.0" />
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.5" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="15.9.0" />

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/nunit/EndToEndAttribute.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/nunit/EndToEndAttribute.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit
+{
+    using System;
+    using global::NUnit.Framework;
+
+    [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
+    public class EndToEndAttribute : CategoryAttribute
+    { }
+}

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/nunit/EndToEndAttribute.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/nunit/EndToEndAttribute.cs
@@ -6,5 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit
 
     [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method, AllowMultiple = true)]
     public class EndToEndAttribute : CategoryAttribute
-    { }
+    {
+    }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
@@ -9,8 +9,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
+    [EndToEnd]
     class Device : SasManualProvisioningFixture
     {
         [Test]

--- a/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft. All rights reserved.
+// Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Test
 {
     using System;
@@ -8,8 +8,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
+    [EndToEnd]
     class DeviceWithCustomCertificates : CustomCertificatesFixture
     {
         [Test]

--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -10,9 +10,11 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using Newtonsoft.Json;
     using NUnit.Framework;
 
+    [EndToEnd]
     public class Metrics : SasManualProvisioningFixture
     {
         const string ModuleName = "MetricsValidator";

--- a/test/Microsoft.Azure.Devices.Edge.Test/Microsoft.Azure.Devices.Edge.Test.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Microsoft.Azure.Devices.Edge.Test.csproj
@@ -40,6 +40,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\edge-util\src\Microsoft.Azure.Devices.Edge.Util\Microsoft.Azure.Devices.Edge.Util.csproj" />
+    <ProjectReference Include="..\..\edge-util\test\Microsoft.Azure.Devices.Edge.Util.Test.Common\Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj" />
     <ProjectReference Include="..\Microsoft.Azure.Devices.Edge.Test.Common\Microsoft.Azure.Devices.Edge.Test.Common.csproj" />
   </ItemGroup>
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -8,8 +8,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
+    [EndToEnd]
     public class Module : SasManualProvisioningFixture
     {
         private sealed class TempSensorModule

--- a/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
@@ -11,8 +11,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Certs;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
+    [EndToEnd]
     public class Provisioning : DeviceProvisioningFixture
     {
         protected readonly IotHub iotHub;

--- a/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
@@ -9,8 +9,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
+    [EndToEnd]
     class X509Device : X509ManualProvisioningFixture
     {
         [Test]


### PR DESCRIPTION
While not strictly necessary, people have asked that end-to-end tests be organized in their own category. This change adds the NUnit `EndToEnd` attribute, and adds it to all the existing end-to-end tests.