### PR TITLE
Changing dash to plus in connectivityTest.sh script

### DIFF
--- a/test/connectivity/scripts/connectivityTest.sh
+++ b/test/connectivity/scripts/connectivityTest.sh
@@ -304,7 +304,7 @@ function run_connectivity_test() {
     test_setup && funcRet=$? || funcRet=$?
     if [ $funcRet -ne 0 ]; then return $funcRet; fi
 
-    local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-connect-$(get_hash 8)"
+    local device_id="$RELEASE_LABEL+Linux+$image_architecture_label+connect+$(get_hash 8)"
 
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run connectivity test with -d '$device_id' started at $test_start_time"


### PR DESCRIPTION
Getting an error when running C2D tests. When adding DeviceId into the connection string, the connection string can't be parsed because we are using dashes in the deviceId name. 

This is the error: "System.FormatException: The input is not a valid Base-64 string as it contains a non-base 64 character"

This change replaces the dashes with pluses (as recommended here: https://stackoverflow.com/questions/50524665/convert-frombase64string-throws-invalid-base-64-string-error)