### PR TITLE
Fixing max device queue length bug

### DIFF
--- a/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageReceiver.cs
+++ b/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageReceiver.cs
@@ -90,6 +90,7 @@ namespace CloudToDeviceMessageTester
                             $"batchId: {message.Properties[TestConstants.Message.BatchIdPropertyName]}, " +
                             $"trackingId: {message.Properties[TestConstants.Message.TrackingIdPropertyName]}.");
                         await this.ReportTestResult(message);
+                        await this.deviceClient.CompleteAsync(message);
                     }
                     catch (Exception ex)
                     {


### PR DESCRIPTION
Adding CompleteAsync for C2DReceiver once we are done processing a message. This will delete the message from the device queue. Otherwise we get a max queue length hit error message.