### PR TITLE
[k8s][Helm] Big numbers make Helm convert to scientific notation, (#2456)

### DIFF
--- a/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
+++ b/kubernetes/charts/edge-kubernetes/templates/_helpers.tpl
@@ -73,7 +73,8 @@ agent:
     RuntimeLogLevel: {{ .Values.edgeAgent.env.runtimeLogLevel | quote }}
     {{- end }}
     {{- if .Values.edgeAgent.env.persistentVolumeClaimDefaultSizeInMb}}
-    PersistentVolumeClaimDefaultSizeInMb: {{ .Values.edgeAgent.env.persistentVolumeClaimDefaultSizeInMb | quote }}
+    {{- $sizeInMb :=  .Values.edgeAgent.env.persistentVolumeClaimDefaultSizeInMb }}
+    PersistentVolumeClaimDefaultSizeInMb: {{- if kindIs "float64" $sizeInMb }} {{ printf "%.0f" $sizeInMb | quote }} {{- else }} {{ $sizeInMb | quote }} {{end}}
     {{- end }}
     {{- if .Values.edgeAgent.env.upstreamProtocol}}
     UpstreamProtocol: {{ .Values.edgeAgent.env.upstreamProtocol | quote }}


### PR DESCRIPTION
and autofac didn't like that much.
Quick fix is to force Helm to print float64 in decimal format.

Merge to master PR.