### PR TITLE
Calculate health reset from start not exit time

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/RestartPolicyManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/RestartPolicyManager.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                 TimeSpan timeLeft = coolOffPeriod - elapsedTime;
                 Log.LogInformation(
                     (int)EventIds.ScheduledModule,
-                    $"Module '{module.Name}' scheduled to restart after {coolOffPeriod.Humanize()} ({timeLeft.Humanize()} left).");
+                    $">>>\nModule '{module.Name}' scheduled to restart after {coolOffPeriod.Humanize()} ({timeLeft.Humanize()} left).\n<<<");
             }
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/RestartPolicyManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/RestartPolicyManager.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                 TimeSpan timeLeft = coolOffPeriod - elapsedTime;
                 Log.LogInformation(
                     (int)EventIds.ScheduledModule,
-                    $">>>\nModule '{module.Name}' scheduled to restart after {coolOffPeriod.Humanize()} ({timeLeft.Humanize()} left).\n<<<");
+                    $"Module '{module.Name}' scheduled to restart after {coolOffPeriod.Humanize()} ({timeLeft.Humanize()} left).");
             }
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planners/HealthRestartPlanner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planners/HealthRestartPlanner.cs
@@ -305,12 +305,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Planners
                 if (await this.store.Contains(module.Name))
                 {
                     Events.DumpModuleInfo(module);
-                    // this value comes from docker; if this is equal to DateTime.MinValue then the container
-                    // never exited before; if it is anything else then we check if it has been up for "IntensiveCareTime"
-                    // and if yes, then we clear the health stats on it;
+                    // this value comes from docker; if this is equal to DateTime.MinValue then the container was
+                    // created by never started (which shouldn't happen); if it is anything else then we check if
+                    // it has been up for "IntensiveCareTime" and if yes, then we clear the health stats on it;
                     //
                     // the time returned by docker is in UTC timezone
-                    if (module.LastExitTimeUtc != DateTime.MinValue && DateTime.UtcNow - module.LastExitTimeUtc > this.intensiveCareTime)
+                    if (module.LastStartTimeUtc != DateTime.MinValue && DateTime.UtcNow - module.LastStartTimeUtc > this.intensiveCareTime)
                     {
                         // NOTE: This is a "special" command in that it doesn't come from an "ICommandFactory". This
                         // command clears the health stats from the store.

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planners/HealthRestartPlanner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planners/HealthRestartPlanner.cs
@@ -304,9 +304,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Planners
             {
                 if (await this.store.Contains(module.Name))
                 {
-                    Events.DumpModuleInfo(module);
                     // this value comes from docker; if this is equal to DateTime.MinValue then the container was
-                    // created by never started (which shouldn't happen); if it is anything else then we check if
+                    // created but never started (which shouldn't happen); if it is anything else then we check if
                     // it has been up for "IntensiveCareTime" and if yes, then we clear the health stats on it;
                     //
                     // the time returned by docker is in UTC timezone
@@ -408,13 +407,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Planners
                 UnableToUpdateEdgeAgent,
                 UnableToProcessModule,
                 CurrentModuleNotFound,
-                InvalidDesiredState,
-                XxDebugInfoxX
-            }
-
-            public static void DumpModuleInfo(IRuntimeModule module)
-            {
-                Log.LogInformation((int)EventIds.XxDebugInfoxX, $">>>\n{module.ToJson()}\n<<<\n");
+                InvalidDesiredState
             }
 
             public static void PlanCreated(IList<ICommand> commands)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planners/HealthRestartPlanner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planners/HealthRestartPlanner.cs
@@ -304,6 +304,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Planners
             {
                 if (await this.store.Contains(module.Name))
                 {
+                    Events.DumpModuleInfo(module);
                     // this value comes from docker; if this is equal to DateTime.MinValue then the container
                     // never exited before; if it is anything else then we check if it has been up for "IntensiveCareTime"
                     // and if yes, then we clear the health stats on it;
@@ -407,7 +408,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Planners
                 UnableToUpdateEdgeAgent,
                 UnableToProcessModule,
                 CurrentModuleNotFound,
-                InvalidDesiredState
+                InvalidDesiredState,
+                XxDebugInfoxX
+            }
+
+            public static void DumpModuleInfo(IRuntimeModule module)
+            {
+                Log.LogInformation((int)EventIds.XxDebugInfoxX, $">>>\n{module.ToJson()}\n<<<\n");
             }
 
             public static void PlanCreated(IList<ICommand> commands)


### PR DESCRIPTION
If a module keeps exiting there's an increasing back-off period (up to 5 min) before it restarts. Once it restarts and runs for an "intensive care" period (default is 10 min), it should be declared "healthy" and its back-off state should be reset. However, the intensive care period is being calculated incorrectly. The logic is (current time - last exit time), so 10 min actually includes the time the agent spent waiting to restart the module. In the worst case (if the back-off has capped out at 5 min), the module will only run for 5 min before being declared healthy. In other words, less-healthy modules are declared healthy faster than more-healthy modules.

This change updates the calculation logic to use the modules last _start_ time instead of exit time.

I confirmed that a module whose cool-off period has capped out at 5 min will run for a full 10 min before being declared healthy.