### PR TITLE
Wrap exceptions before returning to the SDK

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceAuthentication.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceAuthentication.cs
@@ -4,7 +4,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
     using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Edged;
 
     public class DeviceAuthentication : DeviceAuthenticationWithTokenRefresh
     {
@@ -16,7 +18,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             this.tokenProvider = Preconditions.CheckNotNull(tokenProvider);
         }
 
-        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive) =>
-            this.tokenProvider.GetTokenAsync(Option.Some(TimeSpan.FromSeconds(suggestedTimeToLive)));
+        protected override Task<string> SafeCreateNewToken(string iotHub, int suggestedTimeToLive)
+        {
+            try
+            {
+                return this.tokenProvider.GetTokenAsync(Option.Some(TimeSpan.FromSeconds(suggestedTimeToLive)));
+            }
+            catch (HttpHsmCommunicationException ex)
+            {
+                // DeviceAuthentication plugs into the device SDK, and we don't
+                // want to leak our internal exceptions into the device SDK
+                throw new IotHubCommunicationException(ex.Message, ex);
+            }
+        }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceAuthentication.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceAuthentication.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Edged;
 
     public class DeviceAuthentication : DeviceAuthenticationWithTokenRefresh
     {
@@ -24,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             {
                 return this.tokenProvider.GetTokenAsync(Option.Some(TimeSpan.FromSeconds(suggestedTimeToLive)));
             }
-            catch (HttpHsmCommunicationException ex)
+            catch (TokenProviderException ex)
             {
                 // DeviceAuthentication plugs into the device SDK, and we don't
                 // want to leak our internal exceptions into the device SDK

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleAuthentication.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleAuthentication.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             {
                 return this.tokenProvider.GetTokenAsync(Option.Some(TimeSpan.FromSeconds(suggestedTimeToLive)));
             }
-            catch(HttpHsmCommunicationException ex)
+            catch (HttpHsmCommunicationException ex)
             {
                 // ModuleAuthentication plugs into the device SDK, and we don't
                 // want to leak our internal exceptions into the device SDK

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleAuthentication.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleAuthentication.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Edged;
 
     public class ModuleAuthentication : ModuleAuthenticationWithTokenRefresh
     {
@@ -24,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             {
                 return this.tokenProvider.GetTokenAsync(Option.Some(TimeSpan.FromSeconds(suggestedTimeToLive)));
             }
-            catch (HttpHsmCommunicationException ex)
+            catch (TokenProviderException ex)
             {
                 // ModuleAuthentication plugs into the device SDK, and we don't
                 // want to leak our internal exceptions into the device SDK

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/AuthenticationWithTokenRefreshTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/AuthenticationWithTokenRefreshTest.cs
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft. All rights reserved.
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Client.Exceptions;
+using Microsoft.Azure.Devices.Edge.Util;
+using Microsoft.Azure.Devices.Edge.Util.Edged;
+using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+using Xunit;
+
+namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
+{
+    using ObjectUnderTestFn = Func<ITokenProvider, AuthenticationWithTokenRefresh>;
+
+    [Unit]
+    public class AuthenticationWithTokenRefreshTest
+    {
+        public static IEnumerable<object[]> GetObjectUnderTest()
+        {
+            yield return new ObjectUnderTestFn[] {
+                p => new DeviceAuthentication(p, "d")
+            };
+            yield return new ObjectUnderTestFn[] {
+                p => new ModuleAuthentication(p, "d", "m")
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(GetObjectUnderTest))]
+        public async Task SafeCreateNewTokenReturnsAToken(ObjectUnderTestFn get)
+        {
+            var auth = get(new TestTokenProvider());
+            Assert.NotEmpty(await auth.GetTokenAsync("iothub"));
+        }
+
+        [Theory]
+        [MemberData(nameof(GetObjectUnderTest))]
+        public async Task SafeCreateNewTokenWrapsHsmExceptions(ObjectUnderTestFn get)
+        {
+            var src = new HttpHsmCommunicationException("hello", 123);
+            var auth = get(new ThrowingTestTokenProvider(src));
+
+            var dst = await Assert.ThrowsAnyAsync<IotHubCommunicationException>(
+                () => auth.GetTokenAsync("iothub"));
+            Assert.Equal(src.Message, dst.Message);
+        }
+    }
+
+    class TestTokenProvider : ITokenProvider
+    {
+        public Task<string> GetTokenAsync(Option<TimeSpan> ttl)
+        {
+            var builder = new SharedAccessSignatureBuilder
+            {
+                Key = Convert.ToBase64String(Encoding.UTF8.GetBytes("hello")),
+                TimeToLive = ttl.GetOrElse(TimeSpan.FromHours(1))
+            };
+
+            return Task.FromResult(builder.ToSignature());
+        }
+    }
+
+    class ThrowingTestTokenProvider : ITokenProvider
+    {
+        HttpHsmCommunicationException e;
+
+        public ThrowingTestTokenProvider(HttpHsmCommunicationException e)
+        {
+            this.e = e;
+        }
+
+        public Task<string> GetTokenAsync(Option<TimeSpan> ttl)
+        {
+            throw e;
+        }
+    }
+}

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/AuthenticationWithTokenRefreshTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/AuthenticationWithTokenRefreshTest.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
         [Theory]
         [MemberData(nameof(GetObjectUnderTest))]
-        public async Task SafeCreateNewTokenWrapsHsmExceptions(ObjectUnderTestFn get)
+        public async Task SafeCreateNewTokenWrapsTokenExceptions(ObjectUnderTestFn get)
         {
-            var src = new HttpHsmCommunicationException("hello", 123);
+            var src = new TokenProviderException(new Exception("hello"));
             var auth = get(new ThrowingTestTokenProvider(src));
 
             var dst = await Assert.ThrowsAnyAsync<IotHubCommunicationException>(
@@ -68,9 +68,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
     class ThrowingTestTokenProvider : ITokenProvider
     {
-        HttpHsmCommunicationException e;
+        TokenProviderException e;
 
-        public ThrowingTestTokenProvider(HttpHsmCommunicationException e)
+        public ThrowingTestTokenProvider(TokenProviderException e)
         {
             this.e = e;
         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/AuthenticationWithTokenRefreshTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/AuthenticationWithTokenRefreshTest.cs
@@ -1,28 +1,32 @@
 // Copyright (c) Microsoft. All rights reserved.
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.Azure.Devices.Client;
-using Microsoft.Azure.Devices.Client.Exceptions;
-using Microsoft.Azure.Devices.Edge.Util;
-using Microsoft.Azure.Devices.Edge.Util.Edged;
-using Microsoft.Azure.Devices.Edge.Util.Test.Common;
-using Xunit;
-
 namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 {
-    using ObjectUnderTestFn = Func<ITokenProvider, AuthenticationWithTokenRefresh>;
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Client.Exceptions;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Edged;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Xunit;
+
+    using ObjectUnderTestFn = System.Func<
+        Microsoft.Azure.Devices.Edge.Util.ITokenProvider,
+        Microsoft.Azure.Devices.Client.AuthenticationWithTokenRefresh>;
 
     [Unit]
     public class AuthenticationWithTokenRefreshTest
     {
         public static IEnumerable<object[]> GetObjectUnderTest()
         {
-            yield return new ObjectUnderTestFn[] {
+            yield return new ObjectUnderTestFn[]
+            {
                 p => new DeviceAuthentication(p, "d")
             };
-            yield return new ObjectUnderTestFn[] {
+            yield return new ObjectUnderTestFn[]
+            {
                 p => new ModuleAuthentication(p, "d", "m")
             };
         }
@@ -73,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
         public Task<string> GetTokenAsync(Option<TimeSpan> ttl)
         {
-            throw e;
+            throw this.e;
         }
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
@@ -50,9 +50,15 @@ namespace Microsoft.Azure.Devices.Edge.Util
                     audience,
                     expiresOn
                 });
-            string signature = await this.signatureProvider.SignAsync(data);
-
-            return SasTokenHelper.BuildSasToken(audience, signature, expiresOn);
+            try
+            {
+                string signature = await this.signatureProvider.SignAsync(data);
+                return SasTokenHelper.BuildSasToken(audience, signature, expiresOn);
+            }
+            catch (SignatureProviderException e)
+            {
+                throw new TokenProviderException(e);
+            }
         }
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SignatureProviderException.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SignatureProviderException.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when a signature provider fails to sign data.
+    /// </summary>
+    public class SignatureProviderException : Exception
+    {
+        public SignatureProviderException(Exception inner)
+            : base(inner.Message, inner)
+        {
+        }
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/TokenProviderException.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/TokenProviderException.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+
+    /// <summary>
+    /// The exception that is thrown when a token provider fails to get a token.
+    /// </summary>
+    public class TokenProviderException : Exception
+    {
+        public TokenProviderException(Exception inner)
+            : base(inner.Message, inner)
+        {
+        }
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/HttpHsmSignatureProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/HttpHsmSignatureProvider.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged
                 switch (ex)
                 {
                     case WorkloadCommunicationException errorResponseException:
-                        throw new HttpHsmCommunicationException(errorResponseException.Message, errorResponseException.StatusCode);
+                        throw new SignatureProviderException(
+                            new HttpHsmCommunicationException(errorResponseException.Message, errorResponseException.StatusCode));
                     default:
                         throw;
                 }


### PR DESCRIPTION
Fixes #1738.

We have some classes that plug into the SDK to refresh tokens. The SDK calls into these classes and allows any thrown exceptions to bubble up, _except_ for `IotHubCommunicationException`, which is simply logged. We want the second behavior so we need to make sure we don't leak our custom exception to the SDK; wrap it in an `IotHubCommunicationException` instead.