### PR TITLE
Change DPS provisioning check error to warning

### DIFF
--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -162,9 +162,8 @@ provisioning:
 #                                       Defaults to 90 days.
 #
 # Note:
-# The values of all of these fields can be specified either as a
-# "file" scheme URI such as "file:///path/cert_key.pem" or a
-#  file path such as "/path/cert_key.pem"
+# The values of all of these fields must be specified as a
+# "file" scheme URI such as "file:///path/cert_key.pem"
 ###############################################################################
 
 # certificates:

--- a/edgelet/contrib/config/linux/debian/config.yaml
+++ b/edgelet/contrib/config/linux/debian/config.yaml
@@ -158,9 +158,8 @@ provisioning:
 #                        Optionally can be specified as a file path.
 #
 # Note:
-# The values of all of these fields can be specified either as a
-# "file" scheme URI such as "file:///path/cert_key.pem" or a
-#  file path such as "/path/cert_key.pem"
+# The values of all of these fields must be specified as a
+# "file" scheme URI such as "file:///path/cert_key.pem"
 ###############################################################################
 
 # certificates:

--- a/edgelet/contrib/config/windows/config.yaml
+++ b/edgelet/contrib/config/windows/config.yaml
@@ -162,9 +162,8 @@ provisioning:
 #                                       Defaults to 90 days.
 #
 # Note:
-# The values of all of these fields can be specified either as a
-# "file" scheme URI such as "file:///C:/cert_key.pem" or a
-#  file path such as "C:\\cert_key.pem"
+# The values of all of these fields must be specified as a
+# "file" scheme URI such as "file:///path/cert_key.pem"
 ###############################################################################
 
 # certificates:

--- a/edgelet/iotedge/src/check/checks/well_formed_connection_string.rs
+++ b/edgelet/iotedge/src/check/checks/well_formed_connection_string.rs
@@ -53,8 +53,6 @@ impl WellFormedConnectionString {
                             To run connectivity checks in this configuration please specify the backing IoT Hub name using --iothub-hostname switch if you have that information.\n\
                             If no hostname is provided, all hub connectivity tests will be skipped.";
             return Ok(CheckResult::Warning(Context::new(warning).into()));
-        } else {
-            return Ok(CheckResult::Skipped);
         }
 
         Ok(CheckResult::Ok)

--- a/edgelet/iotedge/src/check/checks/well_formed_connection_string.rs
+++ b/edgelet/iotedge/src/check/checks/well_formed_connection_string.rs
@@ -49,8 +49,11 @@ impl WellFormedConnectionString {
             check.iothub_hostname = Some(hub);
             self.iothub_hostname = check.iothub_hostname.clone();
         } else if check.iothub_hostname.is_none() {
-            return Err(Context::new("Device is not using manual provisioning, so Azure IoT Hub hostname needs to be specified with --iothub-hostname").into());
-        };
+            let warning = "Device is configured with automatic provisioning, in this configuration 'iotedge check' is not able to discover the device's backing IoT Hub. To run connectivity checks in this configuration please specify the backing IoT Hub name using --iothub-hostname switch if you have that information.";
+            return Ok(CheckResult::Warning(Context::new(warning).into()));
+        } else {
+            return Ok(CheckResult::Skipped);
+        }
 
         Ok(CheckResult::Ok)
     }

--- a/edgelet/iotedge/src/check/checks/well_formed_connection_string.rs
+++ b/edgelet/iotedge/src/check/checks/well_formed_connection_string.rs
@@ -49,7 +49,9 @@ impl WellFormedConnectionString {
             check.iothub_hostname = Some(hub);
             self.iothub_hostname = check.iothub_hostname.clone();
         } else if check.iothub_hostname.is_none() {
-            let warning = "Device is configured with automatic provisioning, in this configuration 'iotedge check' is not able to discover the device's backing IoT Hub. To run connectivity checks in this configuration please specify the backing IoT Hub name using --iothub-hostname switch if you have that information.";
+            let warning = "Device is configured with automatic provisioning, in this configuration 'iotedge check' is not able to discover the device's backing IoT Hub.\n\
+                            To run connectivity checks in this configuration please specify the backing IoT Hub name using --iothub-hostname switch if you have that information.\n\
+                            If no hostname is provided, all hub connectivity tests will be skipped.";
             return Ok(CheckResult::Warning(Context::new(warning).into()));
         } else {
             return Ok(CheckResult::Skipped);

--- a/edgelet/iotedge/src/check/checks/well_formed_connection_string.rs
+++ b/edgelet/iotedge/src/check/checks/well_formed_connection_string.rs
@@ -49,7 +49,7 @@ impl WellFormedConnectionString {
             check.iothub_hostname = Some(hub);
             self.iothub_hostname = check.iothub_hostname.clone();
         } else if check.iothub_hostname.is_none() {
-            let warning = "Device is configured with automatic provisioning, in this configuration 'iotedge check' is not able to discover the device's backing IoT Hub.\n\
+            let warning = "Device not configured with manual provisioning, in this configuration 'iotedge check' is not able to discover the device's backing IoT Hub.\n\
                             To run connectivity checks in this configuration please specify the backing IoT Hub name using --iothub-hostname switch if you have that information.\n\
                             If no hostname is provided, all hub connectivity tests will be skipped.";
             return Ok(CheckResult::Warning(Context::new(warning).into()));

--- a/edgelet/iotedge/src/check/mod.rs
+++ b/edgelet/iotedge/src/check/mod.rs
@@ -817,7 +817,7 @@ mod tests {
         }
 
         match WellFormedConnectionString::default().execute(&mut check) {
-            CheckResult::Failed(err) => assert!(err.to_string().contains("Device is not using manual provisioning, so Azure IoT Hub hostname needs to be specified with --iothub-hostname")),
+            CheckResult::Warning(err) => assert!(err.to_string().contains("Device not configured with manual provisioning, in this configuration 'iotedge check' is not able to discover the device's backing IoT Hub.")),
             check_result => panic!(
                 "checking connection string in {} returned {:?}",
                 filename, check_result


### PR DESCRIPTION
In the context of https://github.com/Azure/iotedge/issues/2313 

Users often find that particular error and message a bit jarring/confusing. I propose downgrading this to a warning and updating the warning message to be more descriptive:
```Device is configured with automatic provisioning, in this configuration 'iotedge check' is not able to discover the device's backing IoT Hub. To run connectivity checks in this configuration please specify the backing IoT Hub name using --iothub-hostname switch if you have that information.​```

It also changes the documentation for certs in the config yaml. While file paths still work, we want users to only use uris for consistency with the new x509. 
