### PR TITLE
Getting rid of unused property in NetworkController

### DIFF
--- a/test/connectivity/modules/NetworkController/Program.cs
+++ b/test/connectivity/modules/NetworkController/Program.cs
@@ -76,7 +76,6 @@ namespace NetworkController
             {
                 $"Network Run Profile={Settings.Current.NetworkRunProfile}",
                 $"Network Network Id={Settings.Current.NetworkId}",
-                $"Network Profile Settings={Settings.Current.ProfileSettings.ToString()}",
                 $"Network Frequencies={string.Join(",", Settings.Current.Frequencies.Select(f => $"[offline:{f.OfflineFrequency},Online:{f.OnlineFrequency},Runs:{f.RunsCount}]"))}"
             };
 

--- a/test/connectivity/modules/NetworkController/Settings.cs
+++ b/test/connectivity/modules/NetworkController/Settings.cs
@@ -57,8 +57,6 @@ namespace NetworkController
 
         public NetworkProfile NetworkRunProfile { get; }
 
-        public NetworkProfileSetting ProfileSettings { get; }
-
         public string TrackingId { get; }
 
         public string ModuleId { get; }
@@ -78,7 +76,8 @@ namespace NetworkController
 
             string runProfileName = configuration.GetValue<string>(NetworkControllerRunProfilePropertyName);
             NetworkProfile runProfileSettings = configuration.GetSection($"{DefaultProfilesPropertyName}:{runProfileName}").Get<NetworkProfile>();
-            if (runProfileSettings == null) {
+            if (runProfileSettings == null)
+            {
                 runProfileSettings = NetworkProfile.Online;
             }
 


### PR DESCRIPTION
Unused property in network controller is causing errors in connectivity tests. Getting rid of the property so that the network controller can function properly.