### PR TITLE
Fix old e2e VM proxy test: Adapt to new service sdk exceptions 

### DIFF
--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -237,9 +237,16 @@ namespace IotEdgeQuickstart.Details
                 Console.WriteLine($"Device '{device.Id}' already registered on IoT hub '{builder.HostName}'");
                 Console.WriteLine($"Clean up Existing device? {this.cleanUpExistingDeviceOnSuccess}");
             }
-            catch (IotHubCommunicationException e)
+            catch (Exception e)
             {
-                Console.WriteLine($"Device '{this.deviceId}' not registered on IoT hub '{builder.HostName}': {e}");
+                if (e is IotHubException || e is IotHubCommunicationException)
+                {
+                    Console.WriteLine($"Device '{this.deviceId}' not registered on IoT hub '{builder.HostName}': {e}");
+                }
+                else
+                {
+                    throw;
+                }
             }
 
             if (device != null)

--- a/smoke/IotEdgeQuickstart/details/Details.cs
+++ b/smoke/IotEdgeQuickstart/details/Details.cs
@@ -224,11 +224,20 @@ namespace IotEdgeQuickstart.Details
             IotHubConnectionStringBuilder builder = IotHubConnectionStringBuilder.Create(this.iothubConnectionString);
             RegistryManager rm = RegistryManager.CreateFromConnectionString(builder.ToString(), settings);
 
-            Device device = await rm.GetDeviceAsync(this.deviceId);
-            if (device != null)
+            Device device = null;
+            try
             {
+                device = await rm.GetDeviceAsync(this.deviceId);
                 Console.WriteLine($"Device '{device.Id}' already registered on IoT hub '{builder.HostName}'");
                 Console.WriteLine($"Clean up Existing device? {this.cleanUpExistingDeviceOnSuccess}");
+            }
+            catch (TimeoutException)
+            {
+                Console.WriteLine($"Device '{this.deviceId}' not registered on IoT hub '{builder.HostName}'");
+            }
+
+            if (device != null)
+            {
                 this.context = new DeviceContext(device, this.iothubConnectionString, rm, this.cleanUpExistingDeviceOnSuccess);
             }
             else


### PR DESCRIPTION
The new service SDK 1.18.4 throws a new exception only when configured with a proxy. I am editing our quickstart application to adjust to this, however will also open a bug noting that this is a breaking change.  