### PR TITLE
Fix CentOS arm32v7 and aarch64 packages to depend on correct openssl sonames

### DIFF
--- a/builds/misc/packages.slow.yaml
+++ b/builds/misc/packages.slow.yaml
@@ -1,0 +1,71 @@
+# This is like packages.yaml, but for packages that are much slower to build.
+# This runs independently of the packages.yaml job so that it does not impact other jobs that use the packages.yaml artifacts, like E2E test runs.
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - master
+pr: none
+variables:
+  REVISION: '1'
+jobs:
+
+################################################################################
+  - job: linux
+################################################################################
+    displayName: Linux
+    timeoutInMinutes: 180 # Observed to take just under 2h30m, so round up
+    pool:
+      # qemu on ubuntu-16.04 is too old to support some syscalls used by CentOS 7 containers, so ensure this is ubuntu-18.04 or newer.
+      vmImage: 'ubuntu-18.04'
+    strategy:
+      matrix:
+        Centos75-arm32v7:
+          arch: arm32v7
+          os: centos7
+          target.iotedged: edgelet/target/rpmbuild/RPMS/armv7hl
+        Centos75-aarch64:
+          arch: aarch64
+          os: centos7
+          target.iotedged: edgelet/target/rpmbuild/RPMS/aarch64
+    steps:
+      # Ensure any changes here are replicated in packages.yaml
+
+      - bash: |
+          BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+          VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
+          echo "##vso[task.setvariable variable=VERSION;]$VERSION"
+
+          echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
+          echo "##vso[task.setvariable variable=PACKAGE_OS;]$(os)"
+        displayName: Set Version
+      - bash: |
+          sudo apt-get update &&
+          sudo apt-get install qemu-user-static
+        displayName: Install qemu-arm-static and qemu-aarch64-static for CentOS7 builds
+        condition: and(succeeded(), eq(variables.os, 'centos7'), ne(variables.arch, 'amd64'))
+      - script: edgelet/build/linux/package.sh
+        displayName: Create libiothsm and iotedged packages
+      - task: CopyFiles@2
+        displayName: Copy libiothsm Files to Artifact Staging
+        inputs:
+          SourceFolder: edgelet/target/hsm
+          Contents: |
+            *.deb
+            *.rpm
+          TargetFolder: '$(build.artifactstagingdirectory)'
+      - task: CopyFiles@2
+        displayName: Copy iotedged Files to Artifact Staging
+        inputs:
+          SourceFolder: $(target.iotedged)
+          Contents: |
+            *.deb
+            *.rpm
+          TargetFolder: '$(build.artifactstagingdirectory)'
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts
+        inputs:
+          PathtoPublish: '$(build.artifactstagingdirectory)'
+          ArtifactName: 'iotedged-$(os)-$(arch)'
+        condition: succeededOrFailed()

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -21,14 +21,7 @@ jobs:
           arch: amd64
           os: centos7
           target.iotedged: edgelet/target/rpmbuild/RPMS/x86_64
-        Centos75-arm32v7:
-          arch: arm32v7
-          os: centos7
-          target.iotedged: edgelet/target/rpmbuild/RPMS/armv7hl
-        Centos75-aarch64:
-          arch: aarch64
-          os: centos7
-          target.iotedged: edgelet/target/rpmbuild/RPMS/aarch64
+        # Centos75-arm32v7 and Centos75-aarch64 are built in packages.slow.yaml
 
         Debian8-amd64:
           os: debian8
@@ -96,6 +89,8 @@ jobs:
           arch: aarch64
           target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
     steps:
+      # Ensure any changes here are replicated in packages.slow.yaml
+
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -30,9 +30,18 @@ The packages are built inside a Docker container, so no build dependencies are i
 
 Note that the script must be run on an `amd64` device. The `PACKAGE_ARCH=arm32v7` and `PACKAGE_ARCH=aarch64` builds are done using a cross-compiler.
 
-Once the packages are built, they will be found somewhere under the `edgelet/target/` directory. (The exact path under that directory depends on the combination of `PACKAGE_OS` and `PACKAGE_ARCH`. See `builds/misc/packages.yaml` for the exact paths.)
+Once the packages are built, they will be found somewhere under the `edgelet/target/` directory. (The exact path under that directory depends on the combination of `PACKAGE_OS` and `PACKAGE_ARCH`. See `builds/misc/packages.yaml` and `builds/misc/packages.slow.yaml` for the exact paths.)
 
 If you want to run another build for a different combination of `PACKAGE_OS` and `PACKAGE_ARCH`, make sure to clean the repository first with `sudo git clean -xffd` so that artifacts from the previous build don't get reused for the next one.
+
+Note: For the following targets, `qemu-user-static` must be installed on the host and registered with `binfmt`:
+
+- `PACKAGE_OS=centos7 PACKAGE_ARCH=arm32v7`
+- `PACKAGE_OS=centos7 PACKAGE_ARCH=aarch64`
+
+If that has not been done, `package.sh` prints an error message explaining how to do that.
+
+This is because these targets do not have functional cross-compilers, so their builds are done as native builds emulated using qemu. Be aware that these builds are much slower - where a native build might take 15m, a qemu build might take 2h30m.
 
 
 ### Windows


### PR DESCRIPTION
Before this change, these two targets were built using Linaro compilers
and against custom-compiled openssl. However the packages built this way
ended up depending on `libcrypto.so.1.0.0` and `libssl.so.1.0.0`,
whereas CentOS's openssl-libs package provides `libcrypto.so.10` and
`libssl.so.10`

Since CentOS 7 does not ship cross-compiler packages and openssl,
this commit changes the build steps to run the native arm32v7 and arm64v8
CentOS Docker containers in qemu instead of cross-compiling.

Since qemu builds are very slow (2h30m instead of 15m), this commit moves them
to a new pipeline job so that it does not block existing downstream jobs like
E2E tests that don't need the CentOS packages.

Lastly, the new job runs on Ubuntu 18.04 hosts instead of Ubuntu 16.04 hosts.
Ubuntu 16.04 supports getrandom, but its qemu is just old enough to
not implement it, which breaks processes inside the container that require it.

Fixes #2398