### PR TITLE
Removing unused property ConnectionIdleTimeout

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
     public class CloudConnectionProvider : ICloudConnectionProvider
     {
-        // Minimum value allowed by the SDK for Connection Idle timeout for AMQP Multiplexed connections.
-        static readonly TimeSpan MinAmqpConnectionMuxIdleTimeout = TimeSpan.FromSeconds(5);
         static readonly TimeSpan HeartbeatTimeout = TimeSpan.FromSeconds(60);
 
         readonly ITransportSettings[] transportSettings;
@@ -180,7 +178,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 {
                     Pooling = true,
                     MaxPoolSize = (uint)connectionPoolSize,
-                    ConnectionIdleTimeout = MinAmqpConnectionMuxIdleTimeout
                 }
             };
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         {
                             Pooling = true,
                             MaxPoolSize = 20,
-                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                         },
                         IdleTimeout = TimeSpan.FromSeconds(0)
                     }
@@ -66,7 +65,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         {
                             Pooling = true,
                             MaxPoolSize = 30,
-                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                         },
                         Proxy = new WebProxy(ProxyUri),
                         IdleTimeout = TimeSpan.FromSeconds(60)
@@ -88,7 +86,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         {
                             Pooling = true,
                             MaxPoolSize = 50,
-                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                         },
                         Proxy = new WebProxy(ProxyUri)
                     }


### PR DESCRIPTION
Removing unused property ConnectionIdleTimeout that was causing a build error with the new SDK