### PR TITLE
[k8s] Fix RequestType display implementation that lead to crash with stack overflow

### DIFF
--- a/edgelet/kube-client/src/error.rs
+++ b/edgelet/kube-client/src/error.rs
@@ -155,6 +155,6 @@ pub enum RequestType {
 
 impl Display for RequestType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:#}", self)
+        write!(f, "{:?}", self)
     }
 }


### PR DESCRIPTION
There was an error when iotedged tries to log an error with RequestType in context it calls display method via write!() macros that causes the stack to be overflown.