### PR TITLE
Updating SDK

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Microsoft.Azure.Devices.Edge.Hub.Amqp.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Microsoft.Azure.Devices.Edge.Hub.Amqp.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.4.2" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
     public class CloudConnectionProvider : ICloudConnectionProvider
     {
-        // Minimum value allowed by the SDK for Connection Idle timeout for AMQP Multiplexed connections.
-        static readonly TimeSpan MinAmqpConnectionMuxIdleTimeout = TimeSpan.FromSeconds(5);
         static readonly TimeSpan HeartbeatTimeout = TimeSpan.FromSeconds(60);
 
         readonly ITransportSettings[] transportSettings;
@@ -180,7 +178,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 {
                     Pooling = true,
                     MaxPoolSize = (uint)connectionPoolSize,
-                    ConnectionIdleTimeout = MinAmqpConnectionMuxIdleTimeout
                 }
             };
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
     <PackageReference Include="Stateless" Version="4.0.0" />
   </ItemGroup>
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -17,7 +17,7 @@
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="3.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/Microsoft.Azure.Devices.Edge.Hub.Http.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/Microsoft.Azure.Devices.Edge.Hub.Http.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.WebSockets" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
@@ -45,7 +45,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         {
                             Pooling = true,
                             MaxPoolSize = 20,
-                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                         },
                         IdleTimeout = TimeSpan.FromSeconds(0)
                     }
@@ -66,7 +65,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         {
                             Pooling = true,
                             MaxPoolSize = 30,
-                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                         },
                         Proxy = new WebProxy(ProxyUri),
                         IdleTimeout = TimeSpan.FromSeconds(60)
@@ -88,7 +86,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         {
                             Pooling = true,
                             MaxPoolSize = 50,
-                            ConnectionIdleTimeout = TimeSpan.FromSeconds(5)
                         },
                         Proxy = new WebProxy(ProxyUri)
                     }

--- a/edge-modules/MetricsCollector/MetricsCollector.csproj
+++ b/edge-modules/MetricsCollector/MetricsCollector.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
+++ b/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
@@ -23,7 +23,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
   </ItemGroup>
 

--- a/smoke/IotEdgeQuickstart/IotEdgeQuickstart.csproj
+++ b/smoke/IotEdgeQuickstart/IotEdgeQuickstart.csproj
@@ -16,7 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0" />

--- a/smoke/LeafDevice/LeafDevice.csproj
+++ b/smoke/LeafDevice/LeafDevice.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />
     <PackageReference Include="YamlDotNet" Version="5.4.0" />

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />

--- a/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageTester.csproj
+++ b/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageTester.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/DeploymentTester/DeploymentTester.csproj
+++ b/test/modules/DeploymentTester/DeploymentTester.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/DirectMethodReceiver/DirectMethodReceiver.csproj
+++ b/test/modules/DirectMethodReceiver/DirectMethodReceiver.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/DirectMethodSender/DirectMethodSender.csproj
+++ b/test/modules/DirectMethodSender/DirectMethodSender.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/EdgeHubRestartTester/EdgeHubRestartTester.csproj
+++ b/test/modules/EdgeHubRestartTester/EdgeHubRestartTester.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.2" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/MetricsValidator/MetricsValidator.csproj
+++ b/test/modules/MetricsValidator/MetricsValidator.csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
+++ b/test/modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/modules/ModuleRestarter/ModuleRestarter.csproj
+++ b/test/modules/ModuleRestarter/ModuleRestarter.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/Relayer/Relayer.csproj
+++ b/test/modules/Relayer/Relayer.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/TemperatureFilter/TemperatureFilter.csproj
+++ b/test/modules/TemperatureFilter/TemperatureFilter.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />

--- a/test/modules/TestAnalyzer/TestAnalyzer.csproj
+++ b/test/modules/TestAnalyzer/TestAnalyzer.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Features" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />

--- a/test/modules/TestResultCoordinator/TestResultCoordinator.csproj
+++ b/test/modules/TestResultCoordinator/TestResultCoordinator.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.2.0" />
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore" Version="2.1.1" />

--- a/test/modules/TwinTester/TwinTester.csproj
+++ b/test/modules/TwinTester/TwinTester.csproj
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices" Version="1.18.4" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/test/modules/load-gen/load-gen.csproj
+++ b/test/modules/load-gen/load-gen.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.22.0" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />


### PR DESCRIPTION
Updating SDK
Microsoft.Azure.Devices 1.18.4 -> 1.19.0
Microsoft.Azure.Devices 1.22.0 -> 1.23.0

And removing unused property that causes build error with new SDK