### PR TITLE
[k8s] kube-client should choose which requests should log trace (#2507)

### DIFF
--- a/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           args: ["-c", "/etc/iotedged/config.yaml"]
           env:
           - name: "IOTEDGE_LOG"
-            value: "debug"
+            value: "info"
           {{- if .Values.iotedged.data.httpsProxy }}
           - name: "https_proxy"
             value: {{ .Values.iotedged.data.httpsProxy | quote}}


### PR DESCRIPTION
Two changes - one to code, one to the helm charts.
1. In iotedged, we log debug kube-client client url&status, and log trace the message, but only if "should_log_trace" is true.  That way, even if log trace is turned on, we won't expose secrets or bearer tokens.
2. set log level in iotedged deployment to info.