### PR TITLE
[k8s] Make Docker volume declarations work as anticipated (#2498)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcByValueEqualityComparer.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcByValueEqualityComparer.cs
@@ -56,13 +56,35 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
         {
             unchecked
             {
-                int hashCode = obj.Spec?.AccessModes != null ? obj.Spec.AccessModes.GetHashCode() : 0;
+                int hashCode = obj.Spec?.AccessModes != null ? this.GetAccessHash(obj.Spec.AccessModes) : 0;
                 hashCode = (hashCode * 397) ^ (obj.Metadata?.Name != null ? obj.Metadata.Name.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (obj.Metadata?.Labels != null ? obj.Metadata.Labels.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ (obj.Spec?.Resources != null ? obj.Spec.Resources.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ (obj.Metadata?.Labels != null ? this.GetLabelHash(obj.Metadata.Labels) : 0);
                 hashCode = (hashCode * 397) ^ (obj.Spec?.StorageClassName != null ? obj.Spec.StorageClassName.GetHashCode() : 0);
                 hashCode = (hashCode * 397) ^ (obj.Spec?.VolumeName != null ? obj.Spec.VolumeName.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ this.GetStorage(obj).GetHashCode();
                 return hashCode;
+            }
+        }
+
+        int GetAccessHash(IList<string> access)
+        {
+            unchecked
+            {
+                return access.Aggregate(0, (current, item) => (current * 397) ^ (item != null ? item.GetHashCode() : 0));
+            }
+        }
+
+        int GetLabelHash(IDictionary<string, string> labels)
+        {
+            unchecked
+            {
+                return labels.Aggregate(0, (current, item) =>
+                {
+                    int itemHash = current;
+                    itemHash = (itemHash * 397) ^ item.Key.GetHashCode();
+                    itemHash = (itemHash * 397) ^ ((item.Value != null) ? item.Value.GetHashCode() : 0);
+                    return itemHash;
+                });
             }
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
         V1PersistentVolumeClaim ExtractPvc(KubernetesModule module, Mount mount, IDictionary<string, string> labels)
         {
             string volumeName = KubeUtils.SanitizeK8sValue(mount.Source);
-            string pvcName = KubernetesModule.PvcName(module, mount);
+            string pvcName = volumeName;
             bool readOnly = mount.ReadOnly;
 
             var persistentVolumeClaimSpec = new V1PersistentVolumeClaimSpec()
@@ -61,12 +61,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
             if (this.persistentVolumeName.HasValue)
             {
                 string pvName = this.persistentVolumeName.OrDefault();
-                if (pvName != volumeName)
-                {
-                    throw new InvalidModuleException(string.Format("The mount name {0} has to be the same as the PV name {1}", volumeName, pvName));
-                }
-
-                persistentVolumeClaimSpec.VolumeName = volumeName;
+                pvcName = KubeUtils.SanitizeK8sValue(pvName);
+                persistentVolumeClaimSpec.VolumeName = pvcName;
             }
 
             if (this.storageClassName.HasValue)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -177,25 +177,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.True(pod != null);
             var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal("a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
             Assert.True(podVolumeMount.ReadOnlyProperty);
-        }
-
-        [Fact]
-        public void InvalidPvcMappingForVolumeNameVolume()
-        {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "ModuleId", Mock.Of<ICredentials>());
-            var labels = new Dictionary<string, string>();
-            var hostConfig = VolumeMountHostConfig;
-            var config = new KubernetesConfig("image", CreatePodParameters.Create(labels: labels, hostConfig: hostConfig), Option.None<AuthConfig>());
-            var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, DefaultConfigurationInfo, EnvVarsDict);
-            var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
-            var mapper = CreateMapper("elephant", null);
-
-            Assert.Throws<InvalidModuleException>(() => mapper.CreateDeployment(identity, module, labels));
         }
 
         [Fact]
@@ -216,7 +202,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.True(pod != null);
             var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal("a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
@@ -240,7 +226,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.True(pod != null);
             var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal("a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);
@@ -264,7 +250,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.True(pod != null);
             var podVolume = pod.Spec.Volumes.Single(v => v.Name == "a-volume");
             Assert.NotNull(podVolume.PersistentVolumeClaim);
-            Assert.Equal("module1-a-volume", podVolume.PersistentVolumeClaim.ClaimName);
+            Assert.Equal("a-volume", podVolume.PersistentVolumeClaim.ClaimName);
             Assert.True(podVolume.PersistentVolumeClaim.ReadOnlyProperty);
             var podVolumeMount = pod.Spec.Containers.Single(p => p.Name != "proxy").VolumeMounts.Single(vm => vm.Name == "a-volume");
             Assert.Equal("/tmp/volume", podVolumeMount.MountPath);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcByValueComparerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcByValueComparerTest.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
 {
     using System.Collections.Generic;
+    using System.Linq;
     using k8s.Models;
     using Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
@@ -139,39 +140,18 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
         [Fact]
         public void SuccessComparisonTest()
         {
-            var x = new V1PersistentVolumeClaim
-            {
-                Metadata = new V1ObjectMeta(
-                    name: "pvc1",
-                    labels: new Dictionary<string, string>
-                    {
-                        [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
-                    }),
-                Spec = new V1PersistentVolumeClaimSpec
-                {
-                    VolumeName = "steve",
-                    AccessModes = new List<string> { "ReadOnce" },
-                    Resources = new V1ResourceRequirements { Requests = new Dictionary<string, ResourceQuantity> { ["storage"] = new ResourceQuantity("10M") } }
-                }
-            };
-            var y = new V1PersistentVolumeClaim
-            {
-                Metadata = new V1ObjectMeta(
-                    name: "pvc1",
-                    labels: new Dictionary<string, string>
-                    {
-                        [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
-                    }),
-                Spec = new V1PersistentVolumeClaimSpec
-                {
-                    VolumeName = "steve",
-                    AccessModes = new List<string> { "ReadOnce" },
-                    Resources = new V1ResourceRequirements { Requests = new Dictionary<string, ResourceQuantity> { ["storage"] = new ResourceQuantity("10M") } }
-                }
-            };
+            var (x, y) = MakeIdenticalPVCs();
             Assert.True(Comparer.Equals(x, y));
+        }
+
+        [Fact]
+        public void DistictionTest()
+        {
+            var (x, y) = MakeIdenticalPVCs();
+            var claims = new List<V1PersistentVolumeClaim> { x, y };
+            var distinct = claims.Distinct(Comparer);
+
+            Assert.Equal(1, distinct.LongCount());
         }
 
         [Fact]
@@ -212,6 +192,43 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                 }
             };
             Assert.False(Comparer.Equals(pvcWithOwnerRefMetadata, pvcWithoutOwnerRefMetadata));
+        }
+
+        static (V1PersistentVolumeClaim, V1PersistentVolumeClaim) MakeIdenticalPVCs()
+        {
+            var x = new V1PersistentVolumeClaim
+            {
+                Metadata = new V1ObjectMeta(
+                    name: "pvc1",
+                    labels: new Dictionary<string, string>
+                    {
+                        [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
+                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
+                    }),
+                Spec = new V1PersistentVolumeClaimSpec
+                {
+                    VolumeName = "steve",
+                    AccessModes = new List<string> { "ReadOnce" },
+                    Resources = new V1ResourceRequirements { Requests = new Dictionary<string, ResourceQuantity> { ["storage"] = new ResourceQuantity("10M") } }
+                }
+            };
+            var y = new V1PersistentVolumeClaim
+            {
+                Metadata = new V1ObjectMeta(
+                    name: "pvc1",
+                    labels: new Dictionary<string, string>
+                    {
+                        [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
+                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
+                    }),
+                Spec = new V1PersistentVolumeClaimSpec
+                {
+                    VolumeName = "steve",
+                    AccessModes = new List<string> { "ReadOnce" },
+                    Resources = new V1ResourceRequirements { Requests = new Dictionary<string, ResourceQuantity> { ["storage"] = new ResourceQuantity("10M") } }
+                }
+            };
+            return (x, y);
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcMapperTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.VolumeName);
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
             Assert.Equal(V1Deployment.KubeKind, aVolumeClaim.Metadata.OwnerReferences[0].Kind);
             Assert.Equal(EdgeletModuleOwner.Name, aVolumeClaim.Metadata.OwnerReferences[0].Name);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.VolumeName);
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(aVolumeClaim.Spec.VolumeName);
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
             Assert.Equal(V1Deployment.KubeKind, aVolumeClaim.Metadata.OwnerReferences[0].Kind);
             Assert.Equal(EdgeletModuleOwner.Name, aVolumeClaim.Metadata.OwnerReferences[0].Name);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-b-volume");
+            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "b-volume");
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
             Assert.Null(bVolumeClaim.Spec.VolumeName);
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
             var config = new KubernetesConfig("image", CreatePodParameters.Create(hostConfig: VolumeMountHostConfig), Option.None<AuthConfig>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, DefaultConfigurationInfo, EnvVarsDict);
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
-            var mapper = new KubernetesPvcMapper(null, "default", 37);
+            var mapper = new KubernetesPvcMapper("pvname", "storage-class", 37);
             var resourceQuantity = new ResourceQuantity("37Mi");
 
             var pvcs = mapper.CreatePersistentVolumeClaims(module, DefaultLabels);
@@ -215,37 +215,27 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Equal(2, pvcList.Count);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-a-volume");
+            var aVolumeClaim = pvcList[0];
+            Assert.Equal("pvname", aVolumeClaim.Metadata.Name);
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
-            Assert.Equal("default", aVolumeClaim.Spec.StorageClassName);
-            Assert.Null(aVolumeClaim.Spec.VolumeName);
+            Assert.Equal("storage-class", aVolumeClaim.Spec.StorageClassName);
+            Assert.Equal("pvname", aVolumeClaim.Spec.VolumeName);
             Assert.Equal(resourceQuantity, aVolumeClaim.Spec.Resources.Requests["storage"]);
             Assert.Equal(1, aVolumeClaim.Metadata.OwnerReferences.Count);
             Assert.Equal(V1Deployment.KubeKind, aVolumeClaim.Metadata.OwnerReferences[0].Kind);
             Assert.Equal(EdgeletModuleOwner.Name, aVolumeClaim.Metadata.OwnerReferences[0].Name);
 
-            var bVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == module.Name + "-b-volume");
+            var bVolumeClaim = pvcList[1];
+            Assert.Equal("pvname", bVolumeClaim.Metadata.Name);
             Assert.True(bVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadWriteMany", bVolumeClaim.Spec.AccessModes[0]);
-            Assert.Equal("default", bVolumeClaim.Spec.StorageClassName);
-            Assert.Null(bVolumeClaim.Spec.VolumeName);
+            Assert.Equal("storage-class", bVolumeClaim.Spec.StorageClassName);
+            Assert.Equal("pvname", bVolumeClaim.Spec.VolumeName);
             Assert.Equal(resourceQuantity, bVolumeClaim.Spec.Resources.Requests["storage"]);
             Assert.Equal(1, bVolumeClaim.Metadata.OwnerReferences.Count);
             Assert.Equal(V1Deployment.KubeKind, bVolumeClaim.Metadata.OwnerReferences[0].Kind);
             Assert.Equal(EdgeletModuleOwner.Name, bVolumeClaim.Metadata.OwnerReferences[0].Name);
-        }
-
-        [Fact]
-        public void InvalidPreferVolumeNameMappingForVolume()
-        {
-            var config = new KubernetesConfig("image", CreatePodParameters.Create(hostConfig: VolumeMountHostConfig), Option.None<AuthConfig>());
-            var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, DefaultConfigurationInfo, EnvVarsDict);
-            var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
-            var mapper = new KubernetesPvcMapper("a-volume", "storageclass", 1);
-            var resourceQuantity = new ResourceQuantity("1Mi");
-
-            Assert.Throws<InvalidModuleException>(() => mapper.CreatePersistentVolumeClaims(module, DefaultLabels));
         }
 
         [Fact]
@@ -264,7 +254,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
             Assert.True(pvcList.Any());
             Assert.Single(pvcList);
 
-            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "module1-a-volume");
+            var aVolumeClaim = pvcList.Single(pvc => pvc.Metadata.Name == "a-volume");
             Assert.True(aVolumeClaim.Metadata.Labels.SequenceEqual(DefaultLabels));
             Assert.Equal("ReadOnlyMany", aVolumeClaim.Spec.AccessModes[0]);
             Assert.Equal("storageclass", aVolumeClaim.Spec.StorageClassName);

--- a/kubernetes/doc/edge-deployment-to-k8s-translations.md
+++ b/kubernetes/doc/edge-deployment-to-k8s-translations.md
@@ -168,7 +168,7 @@ Each IoT Edge Module will create one Deployment. This will run the module's spec
         - persistentVolumeClaim is always assigned
             - if edge runtime is started with `persistentVolumeName` or `storageClassName` set it will create a [Persistent Volume Claim](#PersistentVolumeClaim)
             - if neither is set Pod will be created but stuck in `Pending` phase not been able to make any progress
-            - claimName = module name + mount.Source
+            - claimName = persistentVolumeName if `persistentVolumeName` is set, mount.Source otherwise.
             - readOnlyProperty = mount.ReadOnly
     - volume mounts from `settings.k8s-extensions.volumes[*].volume`. Placed in spec as provided.
 - **serviceAccountName** = The module name, sanitized to be a K8s identifier. See [Module Authentication](rbac.md#module-authentication) for details.
@@ -223,7 +223,7 @@ gives the IoT Edge Runtime a default claim size as this is not provided by `crea
 
 ### metadata
 
-- **name**        = mount.Source from `settings.createOptions.HostConfig.Mounts`.
+- **name**        = persistentVolumeName if `persistentVolumeName` is set, else mount.Source from `settings.createOptions.HostConfig.Mounts`.
 - **namespace**   = The given namespace.
 - **labels**      = Default label set.
 


### PR DESCRIPTION
Recent testing revealed how Edge on k8s was handling Docker volumes wrong.

We also noticed that there is only a 1:1 mapping between PVCs and PVs - you can only bind one PVC to a PV, and we had expected you could do more than one.  I also discovered that if the user mounts the same volume twice in a container, this will also cause trouble in the Edge on k8s  deployment.

In docker (single node) mode, if a user mounts the same volume in 2 modules, they will expect that the modules will access the same directory. This PR fixes this problem.

This PR does the following:
- If user starts runtime with PersistentVolume name, all volume mounts get the same PVC mount.
- If user starts runtime with a StorageClass name only, each volume is a unique PVC mount.
- If the user starts runtime with neither, each volume is a unique PVC mount - users are expected to provide PVC for each volume.

With specifying a PV name, there is a caveat that all modules will be given that same file share to access - because the user gave only one file share to use.

This will break existing public preview deployments, since it will tear down existing PVCs and replace them with new PVCs.