### PR TITLE
[1.0.9] Limit the RocksDb LOG file size

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -105,6 +105,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string StorageMaxTotalWalSize = "RocksDB_MaxTotalWalSize";
 
+        public const string StorageMaxLogFileNum = "Storage_MaxLogFileNum";
+
+        public const string StorageMaxLogFileSize = "Storage_MaxLogFileSize";
+
         public const string WorkloadApiVersion = "2019-01-30";
 
         public static class Labels

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/AgentModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/AgentModule.cs
@@ -31,9 +31,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly string moduleId;
         readonly Option<string> moduleGenerationId;
         readonly Option<ulong> storageTotalMaxWalSize;
+        readonly Option<ulong> storageMaxLogFileNum;
+        readonly Option<ulong> storageMaxLogFileSize;
 
-        public AgentModule(int maxRestartCount, TimeSpan intensiveCareTime, int coolOffTimeUnitInSeconds, bool usePersistentStorage, string storagePath, Option<ulong> storageTotalMaxWalSize)
-            : this(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.None<Uri>(), Option.None<string>(), Constants.EdgeAgentModuleIdentityName, Option.None<string>(), storageTotalMaxWalSize)
+        public AgentModule(int maxRestartCount, TimeSpan intensiveCareTime, int coolOffTimeUnitInSeconds, bool usePersistentStorage, string storagePath, Option<ulong> storageTotalMaxWalSize, Option<ulong> storageMaxLogFileNum, Option<ulong> storageMaxLogFileSize)
+            : this(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.None<Uri>(), Option.None<string>(), Constants.EdgeAgentModuleIdentityName, Option.None<string>(), storageTotalMaxWalSize, storageMaxLogFileNum, storageMaxLogFileSize)
         {
         }
 
@@ -47,7 +49,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             Option<string> workloadApiVersion,
             string moduleId,
             Option<string> moduleGenerationId,
-            Option<ulong> storageTotalMaxWalSize)
+            Option<ulong> storageTotalMaxWalSize,
+            Option<ulong> storageMaxLogFileNum,
+            Option<ulong> storageMaxLogFileSize)
         {
             this.maxRestartCount = maxRestartCount;
             this.intensiveCareTime = intensiveCareTime;
@@ -59,6 +63,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.moduleId = moduleId;
             this.moduleGenerationId = moduleGenerationId;
             this.storageTotalMaxWalSize = storageTotalMaxWalSize;
+            this.storageMaxLogFileNum = storageMaxLogFileNum;
+            this.storageMaxLogFileSize = storageMaxLogFileSize;
         }
 
         static Dictionary<Type, IDictionary<string, Type>> DeploymentConfigTypeMapping
@@ -135,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
 
             // IRocksDbOptionsProvider
             // For EdgeAgent, we don't need high performance from RocksDb, so always turn off optimizeForPerformance
-            builder.Register(c => new RocksDbOptionsProvider(c.Resolve<ISystemEnvironment>(), false, this.storageTotalMaxWalSize))
+            builder.Register(c => new RocksDbOptionsProvider(c.Resolve<ISystemEnvironment>(), false, this.storageTotalMaxWalSize, this.storageMaxLogFileNum, this.storageMaxLogFileSize))
                 .As<IRocksDbOptionsProvider>()
                 .SingleInstance();
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
@@ -28,6 +28,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             public const string EdgeHubDevTrustBundleFile = "EdgeHubDevTrustBundleFile";
             public const string EdgeHubClientCertAuthEnabled = "ClientCertAuthEnabled";
             public const string StorageMaxTotalWalSize = "RocksDB_MaxTotalWalSize";
+            public const string StorageMaxLogFileNum = "Storage_MaxLogFileNum";
+            public const string StorageMaxLogFileSize = "Storage_MaxLogFileSize";
         }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly string proxy;
         readonly MetricsConfig metricsConfig;
         readonly Option<ulong> storageMaxTotalWalSize;
+        readonly Option<ulong> storageMaxLogFileNum;
+        readonly Option<ulong> storageMaxLogFileSize;
 
         public CommonModule(
             string productInfo,
@@ -63,7 +65,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             IList<X509Certificate2> trustBundle,
             string proxy,
             MetricsConfig metricsConfig,
-            Option<ulong> storageMaxTotalWalSize)
+            Option<ulong> storageMaxTotalWalSize,
+            Option<ulong> storageMaxLogFileNum,
+            Option<ulong> storageMaxLogFileSize)
         {
             this.productInfo = productInfo;
             this.iothubHostName = Preconditions.CheckNonWhiteSpace(iothubHostName, nameof(iothubHostName));
@@ -84,6 +88,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.proxy = Preconditions.CheckNotNull(proxy, nameof(proxy));
             this.metricsConfig = Preconditions.CheckNotNull(metricsConfig, nameof(metricsConfig));
             this.storageMaxTotalWalSize = storageMaxTotalWalSize;
+            this.storageMaxLogFileNum = storageMaxLogFileNum;
+            this.storageMaxLogFileSize = storageMaxLogFileSize;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -135,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                 .SingleInstance();
 
             // DataBase options
-            builder.Register(c => new RocksDbOptionsProvider(c.Resolve<ISystemEnvironment>(), this.optimizeForPerformance, this.storageMaxTotalWalSize))
+            builder.Register(c => new RocksDbOptionsProvider(c.Resolve<ISystemEnvironment>(), this.optimizeForPerformance, this.storageMaxTotalWalSize, this.storageMaxLogFileNum, this.storageMaxLogFileSize))
                 .As<IRocksDbOptionsProvider>()
                 .SingleInstance();
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -122,6 +122,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     this.trustBundle,
                     string.Empty,
                     metricsConfig,
+                    Option.None<ulong>(),
+                    Option.None<ulong>(),
                     Option.None<ulong>()));
 
             builder.RegisterModule(

--- a/edge-modules/TestAnalyzer/TestStatusStorage.cs
+++ b/edge-modules/TestAnalyzer/TestStatusStorage.cs
@@ -29,7 +29,7 @@ namespace TestAnalyzer
             {
                 var partitionsList = new List<string> { "messages", "directMethods", "twins" };
                 IDbStoreProvider dbStoreprovider = DbStoreProvider.Create(
-                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance, Option.None<ulong>()),
+                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>()),
                     this.GetStoragePath(storagePath),
                     partitionsList);
 

--- a/edge-modules/TwinTester/TwinEventStorage.cs
+++ b/edge-modules/TwinTester/TwinEventStorage.cs
@@ -28,7 +28,7 @@ namespace TwinTester
             {
                 var partitionsList = new List<string> { "desiredPropertyUpdated", "desiredPropertyReceived", "reportedPropertyUpdated" };
                 IDbStoreProvider dbStoreprovider = DbStoreProvider.Create(
-                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance, Option.None<ulong>()),
+                    new RocksDbOptionsProvider(systemEnvironment, optimizeForPerformance, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>()),
                     this.GetStoragePath(storagePath),
                     partitionsList);
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/RocksDbOptionsProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/RocksDbOptionsProvider.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
         // column families whose memtables are backed by the oldest live WAL file
         const ulong DefaultMaxTotalWalSize = 512 * 1024 * 1024;
         // Logging to ONE file as a default
-        const ulong DefaultMaxLogFileNum = 0;
+        const ulong DefaultMaxLogFileNum = 1;
         // Do not log anything to the ONE log file
         const ulong DefaultMaxLogFileSize = 0;
 

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/DbStoreProviderTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/DbStoreProviderTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         [Fact]
         public void CreateTestAsync()
         {
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>());
 
             var partitionsList1 = new[]
             {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/RockDbWrapperTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/RockDbWrapperTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         {
             // Arrange
             ICollection<string> partitions = new List<string>();
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>());
             // Act
             // Assert
             Assert.Throws<ArgumentException>(() => RocksDbWrapper.Create(options, null, partitions));
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         public void CreateWithNullPartitionsPathThrowsAsync()
         {
             // Arrange
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>());
 
             // Act
             // Assert

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/RocksDbOptionsProviderTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/RocksDbOptionsProviderTest.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
         [Fact]
         public void RocksDbOptionsProviderCreateTest()
         {
-            Assert.Throws<ArgumentNullException>(() => new RocksDbOptionsProvider(null, true, Option.None<ulong>()));
+            Assert.Throws<ArgumentNullException>(() => new RocksDbOptionsProvider(null, true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>()));
         }
 
         [Fact]
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
             env64.SetupGet(s => s.Is32BitProcess)
                             .Returns(() => false);
-            var provider32 = new RocksDbOptionsProvider(env32.Object, true, Option.None<ulong>());
-            var provider64 = new RocksDbOptionsProvider(env64.Object, true, Option.None<ulong>());
+            var provider32 = new RocksDbOptionsProvider(env32.Object, true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>());
+            var provider64 = new RocksDbOptionsProvider(env64.Object, true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>());
 
             // act
             DbOptions newOptions32 = provider32.GetDbOptions();
@@ -52,8 +52,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
             env64.SetupGet(s => s.Is32BitProcess)
                             .Returns(() => false);
-            var provider32 = new RocksDbOptionsProvider(env32.Object, true, Option.None<ulong>());
-            var provider64 = new RocksDbOptionsProvider(env64.Object, true, Option.None<ulong>());
+            var provider32 = new RocksDbOptionsProvider(env32.Object, true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>());
+            var provider64 = new RocksDbOptionsProvider(env64.Object, true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>());
 
             // act
             ColumnFamilyOptions newOptions32 = provider32.GetColumnFamilyOptions();

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
         public TestRocksDbStoreProvider()
         {
-            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>());
+            var options = new RocksDbOptionsProvider(new SystemEnvironment(), true, Option.None<ulong>(), Option.None<ulong>(), Option.None<ulong>());
             string tempFolder = Path.GetTempPath();
             this.rocksDbFolder = Path.Combine(tempFolder, $"edgeTestDb{Guid.NewGuid()}");
             if (Directory.Exists(this.rocksDbFolder))


### PR DESCRIPTION
- Limit Rocks DB Log file size
- Set the default RocksDB's default log file to be 1 file, 0 MB
- Make the maximum number of log files and the size of the log file configurable from the module (EdgeAgent & EdgeHub).