### PR TITLE
DevOpsLib: Ingest connectivity, longhaul, stress data into database for test dashboard

### DIFF
--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildDefinitionId.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildDefinitionId.cs
@@ -10,6 +10,7 @@ namespace DevOpsLib
         EdgeletRelease = 31845,
         EndToEndTest = 87020,
         ImageRelease = 31987,
-        LibiohsmCI = 39853
+        LibiohsmCI = 39853,
+        ConnectivityTest = 108949
     }
 }

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildDefinitionId.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildDefinitionId.cs
@@ -12,8 +12,11 @@ namespace DevOpsLib
         ImageRelease = 31987,
         LibiohsmCI = 39853,
         ConnectivityTest = 108949,
-        LonghaulTest = 66429,
-        StressTest = 66357,
-
+        LonghaulTestEnv1 = 66429,
+        LonghaulTestEnv2 = 93654,
+        LonghaulTestEnv3 = 93725,
+        StressTestEnv1 = 66357,
+        StressTestEnv2 = 96102,
+        StressTestEnv3 = 96103,
     }
 }

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildDefinitionId.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildDefinitionId.cs
@@ -11,6 +11,9 @@ namespace DevOpsLib
         EndToEndTest = 87020,
         ImageRelease = 31987,
         LibiohsmCI = 39853,
-        ConnectivityTest = 108949
+        ConnectivityTest = 108949,
+        LonghaulTest = 66429,
+        StressTest = 66357,
+
     }
 }

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildExtension.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildExtension.cs
@@ -36,12 +36,12 @@ namespace DevOpsLib
                 { BuildDefinitionId.ImageRelease, "Image Release" },
                 { BuildDefinitionId.LibiohsmCI, "Libiohsm CI" },
                 { BuildDefinitionId.ConnectivityTest, "Connectivity Test" },
-                { BuildDefinitionId.LonghaulTestEnv1, "Longhaul Test Env 1" },
-                { BuildDefinitionId.LonghaulTestEnv2, "Longhaul Test Env 2" },
-                { BuildDefinitionId.LonghaulTestEnv3, "Longhaul Test Env 3" },
-                { BuildDefinitionId.StressTestEnv1, "Stress Test Env 1" },
-                { BuildDefinitionId.StressTestEnv2, "Stress Test Env 2" },
-                { BuildDefinitionId.StressTestEnv3, "Stress Test Env 3" },
+                { BuildDefinitionId.LonghaulTestEnv1, "Longhaul Test" },
+                { BuildDefinitionId.LonghaulTestEnv2, "Longhaul Test Release Candidate" },
+                { BuildDefinitionId.LonghaulTestEnv3, "Longhaul Test Release" },
+                { BuildDefinitionId.StressTestEnv1, "Stress Test" },
+                { BuildDefinitionId.StressTestEnv2, "Stress Test Release Candidate" },
+                { BuildDefinitionId.StressTestEnv3, "Stress Test Release" },
             };
 
             return definitionIdToDisplayNameMapping.ContainsKey(buildDefinitionId) ? definitionIdToDisplayNameMapping[buildDefinitionId] : buildDefinitionId.ToString();

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildExtension.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildExtension.cs
@@ -15,8 +15,12 @@ namespace DevOpsLib
                 BuildDefinitionId.EdgeletPackages,
                 BuildDefinitionId.EndToEndTest,
                 BuildDefinitionId.ConnectivityTest,
-                BuildDefinitionId.LonghaulTest,
-                BuildDefinitionId.StressTest
+                BuildDefinitionId.LonghaulTestEnv1,
+                BuildDefinitionId.LonghaulTestEnv2,
+                BuildDefinitionId.LonghaulTestEnv3,
+                BuildDefinitionId.StressTestEnv1,
+                BuildDefinitionId.StressTestEnv2,
+                BuildDefinitionId.StressTestEnv3
             };
 
         public static string DisplayName(this BuildDefinitionId buildDefinitionId)
@@ -32,8 +36,12 @@ namespace DevOpsLib
                 { BuildDefinitionId.ImageRelease, "Image Release" },
                 { BuildDefinitionId.LibiohsmCI, "Libiohsm CI" },
                 { BuildDefinitionId.ConnectivityTest, "Connectivity Test" },
-                { BuildDefinitionId.LonghaulTest, "Longhaul Test" },
-                { BuildDefinitionId.StressTest, "Stress Test" },
+                { BuildDefinitionId.LonghaulTestEnv1, "Longhaul Test Env 1" },
+                { BuildDefinitionId.LonghaulTestEnv2, "Longhaul Test Env 2" },
+                { BuildDefinitionId.LonghaulTestEnv3, "Longhaul Test Env 3" },
+                { BuildDefinitionId.StressTestEnv1, "Stress Test Env 1" },
+                { BuildDefinitionId.StressTestEnv2, "Stress Test Env 2" },
+                { BuildDefinitionId.StressTestEnv3, "Stress Test Env 3" },
             };
 
             return definitionIdToDisplayNameMapping.ContainsKey(buildDefinitionId) ? definitionIdToDisplayNameMapping[buildDefinitionId] : buildDefinitionId.ToString();

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildExtension.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildExtension.cs
@@ -13,7 +13,8 @@ namespace DevOpsLib
                 BuildDefinitionId.LibiohsmCI,
                 BuildDefinitionId.BuildImages,
                 BuildDefinitionId.EdgeletPackages,
-                BuildDefinitionId.EndToEndTest
+                BuildDefinitionId.EndToEndTest,
+                BuildDefinitionId.ConnectivityTest
             };
 
         public static string DisplayName(this BuildDefinitionId buildDefinitionId)
@@ -28,6 +29,7 @@ namespace DevOpsLib
                 { BuildDefinitionId.EndToEndTest, "End-to-End Test" },
                 { BuildDefinitionId.ImageRelease, "Image Release" },
                 { BuildDefinitionId.LibiohsmCI, "Libiohsm CI" },
+                { BuildDefinitionId.ConnectivityTest, "Connectivity Test" },
             };
 
             return definitionIdToDisplayNameMapping.ContainsKey(buildDefinitionId) ? definitionIdToDisplayNameMapping[buildDefinitionId] : buildDefinitionId.ToString();

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildExtension.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildExtension.cs
@@ -14,7 +14,9 @@ namespace DevOpsLib
                 BuildDefinitionId.BuildImages,
                 BuildDefinitionId.EdgeletPackages,
                 BuildDefinitionId.EndToEndTest,
-                BuildDefinitionId.ConnectivityTest
+                BuildDefinitionId.ConnectivityTest,
+                BuildDefinitionId.LonghaulTest,
+                BuildDefinitionId.StressTest
             };
 
         public static string DisplayName(this BuildDefinitionId buildDefinitionId)
@@ -30,6 +32,8 @@ namespace DevOpsLib
                 { BuildDefinitionId.ImageRelease, "Image Release" },
                 { BuildDefinitionId.LibiohsmCI, "Libiohsm CI" },
                 { BuildDefinitionId.ConnectivityTest, "Connectivity Test" },
+                { BuildDefinitionId.LonghaulTest, "Longhaul Test" },
+                { BuildDefinitionId.StressTest, "Stress Test" },
             };
 
             return definitionIdToDisplayNameMapping.ContainsKey(buildDefinitionId) ? definitionIdToDisplayNameMapping[buildDefinitionId] : buildDefinitionId.ToString();


### PR DESCRIPTION
We do not currently ingest vsts build api data for our connectivity, longhaul, or stress tests.