### PR TITLE
Fix load-gen to not increase sequence number when it fails to send

### DIFF
--- a/edge-modules/load-gen/Program.cs
+++ b/edge-modules/load-gen/Program.cs
@@ -16,35 +16,45 @@ namespace LoadGen
     {
         static readonly ILogger Logger = ModuleUtil.CreateLogger("LoadGen");
 
-        static long messageIdCounter = 0;
-
         static async Task Main()
         {
             Logger.LogInformation($"Starting load gen with the following settings:\r\n{Settings.Current}");
 
+            ModuleClient moduleClient = null;
+
             try
             {
-                ModuleClient moduleClient = await ModuleUtil.CreateModuleClientAsync(
-                    Settings.Current.TransportType,
-                    ModuleUtil.DefaultTimeoutErrorDetectionStrategy,
-                    ModuleUtil.DefaultTransientRetryStrategy,
-                    Logger);
+                (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(TimeSpan.FromSeconds(5), Logger);
 
                 Guid batchId = Guid.NewGuid();
                 Logger.LogInformation($"Batch Id={batchId}");
 
-                (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(TimeSpan.FromSeconds(5), Logger);
+                moduleClient = await ModuleUtil.CreateModuleClientAsync(
+                    Settings.Current.TransportType,
+                    ModuleUtil.DefaultTimeoutErrorDetectionStrategy,
+                    ModuleUtil.DefaultTransientRetryStrategy,
+                    Logger);
+                Logger.LogInformation($"Load gen delay start for {Settings.Current.StartDelay}.");
+                await Task.Delay(Settings.Current.StartDelay);
 
-                // setup the message PeriodicTask
-                using (var messageTask = new PeriodicTask(
-                    () => GenerateMessageAsync(moduleClient, batchId),
-                    Settings.Current.MessageFrequency,
-                    Settings.Current.StartDelay,
-                    Logger,
-                    "Generate message"))
+                long messageIdCounter = 1;
+                while (!cts.IsCancellationRequested)
                 {
-                    Logger.LogInformation("Load gen running.");
-                    await cts.Token.WhenCanceled();
+                    try
+                    {
+                        await SendEventAsync(moduleClient, batchId, messageIdCounter);
+                        messageIdCounter++;
+                        await Task.Delay(Settings.Current.MessageFrequency);
+
+                        if (messageIdCounter % 1000 == 0)
+                        {
+                            Logger.LogInformation($"Sent {messageIdCounter} messages.");
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError(ex, $"[SendEventAsync] Sequence number {messageIdCounter}, BatchId: {batchId.ToString()};");
+                    }
                 }
 
                 Logger.LogInformation("Closing connection to Edge Hub.");
@@ -60,31 +70,23 @@ namespace LoadGen
             }
         }
 
-        static async Task GenerateMessageAsync(ModuleClient client, Guid batchId)
+        static async Task SendEventAsync(ModuleClient client, Guid batchId, long messageId)
         {
             var random = new Random();
             var bufferPool = new BufferPool();
 
-            try
+            using (Buffer data = bufferPool.AllocBuffer(Settings.Current.MessageSizeInBytes))
             {
-                using (Buffer data = bufferPool.AllocBuffer(Settings.Current.MessageSizeInBytes))
-                {
-                    // generate some bytes
-                    random.NextBytes(data.Data);
+                // generate some bytes
+                random.NextBytes(data.Data);
 
-                    // build message
-                    var messageBody = new { data = data.Data };
-                    var message = new Message(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(messageBody)));
-                    messageIdCounter++;
-                    message.Properties.Add("sequenceNumber", messageIdCounter.ToString());
-                    message.Properties.Add("batchId", batchId.ToString());
+                // build message
+                var messageBody = new { data = data.Data };
+                var message = new Message(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(messageBody)));
+                message.Properties.Add("sequenceNumber", messageId.ToString());
+                message.Properties.Add("batchId", batchId.ToString());
 
-                    await client.SendEventAsync(Settings.Current.OutputName, message);
-                }
-            }
-            catch (Exception e)
-            {
-                Logger.LogError($"[GenerateMessageAsync] Sequence number {messageIdCounter}, BatchId: {batchId.ToString()};{Environment.NewLine}{e}");
+                await client.SendEventAsync(Settings.Current.OutputName, message);
             }
         }
     }


### PR DESCRIPTION
LoadGen currently skips sequence numbers when it fails to send (on 1.0.9). 

This causes us to have false negatives in LongHaul when we can't send a message for some reason (connectivity is down for > the SDK timeout period).

With this change, the sequence number won't be updated if load-gen can't send. Thus, we'll get rid of false negatives, and LongHaul can be refocused to only be testing if edgeHub loses messages.

This PR is based on one that went into master a few months ago: https://github.com/Azure/iotedge/commit/1163e055f236b9518c7549e31ff2132adeddf5fd?diff=unified