### PR TITLE
Improve staged deployments in end-to-end tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -106,8 +106,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         public Task DeployDeviceConfigurationAsync(
             string deviceId,
             ConfigurationContent config,
-            CancellationToken token) => this.RegistryManager.ApplyConfigurationContentOnDeviceAsync(deviceId, config, token);
-
+            CancellationToken token)
+        {
+            Log.Information(">>> DEPLOYING CONFIG:\n{Config}\n=====\n", JsonConvert.SerializeObject(config, Formatting.Indented));
+            return this.RegistryManager.ApplyConfigurationContentOnDeviceAsync(deviceId, config, token);
+        }
         public Task<Twin> GetTwinAsync(
             string deviceId,
             string moduleId,

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -106,11 +106,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         public Task DeployDeviceConfigurationAsync(
             string deviceId,
             ConfigurationContent config,
-            CancellationToken token)
-        {
-            Log.Information(">>> DEPLOYING CONFIG:\n{Config}\n=====\n", JsonConvert.SerializeObject(config, Formatting.Indented));
-            return this.RegistryManager.ApplyConfigurationContentOnDeviceAsync(deviceId, config, token);
-        }
+            CancellationToken token) => this.RegistryManager.ApplyConfigurationContentOnDeviceAsync(deviceId, config, token);
+
         public Task<Twin> GetTwinAsync(
             string deviceId,
             string moduleId,

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/EdgeConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/EdgeConfiguration.cs
@@ -29,6 +29,45 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
                 .ToArray();
         }
 
+        public static EdgeConfiguration Create(string deviceId, List<ModuleConfiguration> modules)
+        {
+            var config = new ConfigurationContent
+            {
+                ModulesContent = new Dictionary<string, IDictionary<string, object>>()
+            };
+
+            var moduleNames = new HashSet<string>();
+            var moduleImages = new HashSet<string>();
+
+            void UpdateConfiguration(ModuleConfiguration module)
+            {
+                moduleNames.Add(module.Name);
+                moduleImages.Add(module.Image);
+
+                if (module.DesiredProperties.Count != 0)
+                {
+                    config.ModulesContent[module.Name] = new Dictionary<string, object>
+                    {
+                        ["properties.desired"] = module.DesiredProperties
+                    };
+                }
+            }
+
+            foreach (ModuleConfiguration module in modules)
+            {
+                UpdateConfiguration(module);
+            }
+
+            return new EdgeConfiguration(
+                deviceId,
+                new List<string>(moduleNames),
+                new List<string>(moduleImages),
+                new ConfigurationContent
+                {
+                    ModulesContent = new Dictionary<string, IDictionary<string, object>>(config.ModulesContent)
+                });
+        }
+
         public Task DeployAsync(IotHub iotHub, CancellationToken token)
         {
             return Profiler.Run(


### PR DESCRIPTION
It turns out #2567 didn't go far enough. Deployments were still duplicated instead of staged because we weren't making a deep copy of the configuration for the 1st stage.

This change makes the following corrections:
- Makes a deep copy of the configuration for each stage, so that the 2nd one won't update the 1st
- Moved some of the configuration creation code into a factory method on `EdgeConfiguration` for readability
- Instead of separating deployments via a hard-coded 10-second delay, wait for the 1st deployment to complete before sending the next