### PR TITLE
Fix missing testInfo in analyzer report for twins/direct-methods

### DIFF
--- a/test/modules/TestAnalyzer/AggregateCloudOperationReport.cs
+++ b/test/modules/TestAnalyzer/AggregateCloudOperationReport.cs
@@ -23,6 +23,7 @@ namespace TestAnalyzer
                     LastReceivedAt = status.Value.Item2
                 });
             }
+            this.TestInfo = testInfo;
         }
 
         public string ModuleId { get; }

--- a/test/modules/TestAnalyzer/AggregateCloudOperationReport.cs
+++ b/test/modules/TestAnalyzer/AggregateCloudOperationReport.cs
@@ -23,6 +23,7 @@ namespace TestAnalyzer
                     LastReceivedAt = status.Value.Item2
                 });
             }
+
             this.TestInfo = testInfo;
         }
 


### PR DESCRIPTION
Twin / Direct methods currently report with no test information context.