### PR TITLE
Log Edge Hub experimental features

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 this.GetStoreAndForwardConfiguration();
 
             IConfiguration configuration = this.configuration.GetSection("experimentalFeatures");
-            ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Create(configuration);
+            ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Create(configuration, Logger.Factory.CreateLogger("EdgeHub"));
 
             MetricsListenerConfig listenerConfig = experimentalFeatures.EnableMetrics
                 ? MetricsListenerConfig.Create(this.configuration.GetSection("metrics:listener"))

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Hub.Service
 {
+    using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
 
     public class ExperimentalFeatures
     {
@@ -13,13 +15,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             this.EnableMetrics = enableMetrics;
         }
 
-        public static ExperimentalFeatures Create(IConfiguration experimentalFeaturesConfig)
+        public static ExperimentalFeatures Create(IConfiguration experimentalFeaturesConfig, ILogger logger)
         {
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
             bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("disableConnectivityCheck", false);
             bool enableMetrics = enabled && experimentalFeaturesConfig.GetValue("enableMetrics", false);
-            return new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableMetrics);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableMetrics);
+            logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
+            return experimentalFeatures;
         }
 
         public bool Enabled { get; }


### PR DESCRIPTION
Edge Agent already logs the configuration of experimental features when it first starts; this change adds similar logic to Edge Hub. The result looks like this, near the top of Edge Hub's log:

```
<6> 2020-02-27 12:33:02.941 -08:00 [INF] [EdgeHub] - Experimental features configuration: {"Enabled":true,"DisableCloudSubscriptions":false,"DisableConnectivityCheck":false,"EnableMetrics":true}
```