### PR TITLE
IoTEdgeDevOps Dashboard: Fix vsts upload and analyzer status reporting

### DIFF
--- a/test/modules/TestAnalyzer/AggregateCloudOperationReport.cs
+++ b/test/modules/TestAnalyzer/AggregateCloudOperationReport.cs
@@ -33,7 +33,7 @@ namespace TestAnalyzer
 
         public IDictionary<string, string> TestInfo { get; }
 
-        public bool IsPassed => this.StatusCodes.All(x => x.StatusCode.StartsWith("200"));
+        public bool IsPassed => this.StatusCodes.All(x => x.StatusCode.StartsWith("200") || x.StatusCode.Equals("OK"));
 
         public override string ToString()
         {

--- a/tools/IoTEdgeDevOps/DevOpsLib/IoTEdgeReleaseDeployment.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/IoTEdgeReleaseDeployment.cs
@@ -18,6 +18,7 @@ namespace DevOpsLib
         {
             ValidationUtil.ThrowIfNonPositive(id, nameof(id));
             ValidationUtil.ThrowIfNonPositive(attempt, nameof(attempt));
+            ValidationUtil.ThrowIfNull(tasks, nameof(tasks));
 
             this.id = id;
             this.attempt = attempt;
@@ -37,7 +38,7 @@ namespace DevOpsLib
         public HashSet<IoTEdgePipelineTask> Tasks => this.tasks;
 
         public static IoTEdgeReleaseDeployment Create(VstsReleaseDeployment vstsReleaseDeployment)
-            => new IoTEdgeReleaseDeployment(vstsReleaseDeployment.Id, vstsReleaseDeployment.Attempt, vstsReleaseDeployment.Status, vstsReleaseDeployment.LastModifiedOn, vstsReleaseDeployment.Tasks?.Select(IoTEdgePipelineTask.Create).ToHashSet());
+            => new IoTEdgeReleaseDeployment(vstsReleaseDeployment.Id, vstsReleaseDeployment.Attempt, vstsReleaseDeployment.Status, vstsReleaseDeployment.LastModifiedOn, vstsReleaseDeployment.Tasks?.Select(IoTEdgePipelineTask.Create).ToHashSet() ?? new HashSet<IoTEdgePipelineTask>());
 
         public bool Equals(IoTEdgeReleaseDeployment other)
         {

--- a/tools/IoTEdgeDevOps/DevOpsLib/IoTEdgeReleaseDeployment.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/IoTEdgeReleaseDeployment.cs
@@ -18,7 +18,6 @@ namespace DevOpsLib
         {
             ValidationUtil.ThrowIfNonPositive(id, nameof(id));
             ValidationUtil.ThrowIfNonPositive(attempt, nameof(attempt));
-            ValidationUtil.ThrowIfNull(tasks, nameof(tasks));
 
             this.id = id;
             this.attempt = attempt;
@@ -38,7 +37,7 @@ namespace DevOpsLib
         public HashSet<IoTEdgePipelineTask> Tasks => this.tasks;
 
         public static IoTEdgeReleaseDeployment Create(VstsReleaseDeployment vstsReleaseDeployment)
-            => new IoTEdgeReleaseDeployment(vstsReleaseDeployment.Id, vstsReleaseDeployment.Attempt, vstsReleaseDeployment.Status, vstsReleaseDeployment.LastModifiedOn, vstsReleaseDeployment.Tasks.Select(IoTEdgePipelineTask.Create).ToHashSet());
+            => new IoTEdgeReleaseDeployment(vstsReleaseDeployment.Id, vstsReleaseDeployment.Attempt, vstsReleaseDeployment.Status, vstsReleaseDeployment.LastModifiedOn, vstsReleaseDeployment.Tasks?.Select(IoTEdgePipelineTask.Create).ToHashSet());
 
         public bool Equals(IoTEdgeReleaseDeployment other)
         {


### PR DESCRIPTION
We previously made the assumption that release environment pipeline tasks would not be null for an existing deployment. Apparently this is not the case, as the current implementation started throws an argument exception.