### PR TITLE
Longhaul / Stress: Add testinfo

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -105,6 +105,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'linux_amd64_moby'
 
 ################################################################################
   - job: linux_arm32v7_moby
@@ -180,6 +181,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'linux_arm32v7_moby'
 
 ################################################################################
   - job: linux_arm64v8_docker
@@ -255,6 +257,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'linux_arm64v8_docker'
           
 ################################################################################
   - job: windows_amd64_moby
@@ -332,6 +335,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'windows_amd64_moby'
 
 ################################################################################
   - job: windows_servercore_amd64_moby
@@ -409,6 +413,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'windows_servercore_amd64_moby'
 
 ################################################################################
   - job: iotuap_amd64_moby
@@ -485,3 +490,4 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'iotuap_amd64_moby'

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -83,6 +83,11 @@ jobs:
       - template: templates/longhaul-deploy.yaml
         parameters:
           release.label: 'lh$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -159,6 +164,11 @@ jobs:
       - template: templates/longhaul-deploy.yaml
         parameters:
           release.label: 'lh$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -235,6 +245,11 @@ jobs:
       - template: templates/longhaul-deploy.yaml
         parameters:
           release.label: 'lh$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -313,6 +328,11 @@ jobs:
       - template: templates/longhaul-deploy-windows.yaml
         parameters:
           release.label: 'winpro-lh$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'
@@ -391,6 +411,11 @@ jobs:
       - template: templates/longhaul-deploy-windows.yaml
         parameters:
           release.label: 'servercore-lh$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'
@@ -468,6 +493,11 @@ jobs:
         parameters:
           testName: 'LongHaul'
           release.label: 'iotuap-lh$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -13,8 +13,6 @@ variables:
   #pool.name: ''
   #container.registry: ''
   #snitch.storage.account: ''
-  #analyzer.logAnalytics.enabled  
-  #analyzer.logAnalytics.logType
   # Variables settable at queue time
   #edgelet.package.branchName
   #images.branchName
@@ -103,8 +101,6 @@ jobs:
           longHaul.desiredModulesToRestartCSV: '$(longHaul.desiredModulesToRestartCSV)'
           longHaul.restartIntervalInMins: '$(longHaul.restartIntervalInMins)'
           analyzer.consumerGroupId: 'longhaul_linux_amd64'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -184,8 +180,6 @@ jobs:
           longHaul.desiredModulesToRestartCSV: '$(longHaul.desiredModulesToRestartCSV)'
           longHaul.restartIntervalInMins: '$(longHaul.restartIntervalInMins)'
           analyzer.consumerGroupId: 'longhaul_linux_arm32v7'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -265,8 +259,6 @@ jobs:
           longHaul.desiredModulesToRestartCSV: '$(longHaul.desiredModulesToRestartCSV)'
           longHaul.restartIntervalInMins: '$(longHaul.restartIntervalInMins)'
           analyzer.consumerGroupId: 'longhaul_linux_arm64v8'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -348,8 +340,6 @@ jobs:
           longHaul.desiredModulesToRestartCSV: '$(longHaul.desiredModulesToRestartCSV)'
           longHaul.restartIntervalInMins: '$(longHaul.restartIntervalInMins)'
           analyzer.consumerGroupId: 'longhaul_windows_amd64'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -431,8 +421,6 @@ jobs:
           longHaul.desiredModulesToRestartCSV: '$(longHaul.desiredModulesToRestartCSV)'
           longHaul.restartIntervalInMins: '$(longHaul.restartIntervalInMins)'
           analyzer.consumerGroupId: 'longhaul_windows_servercore_amd64'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -513,8 +501,6 @@ jobs:
           longHaul.desiredModulesToRestartCSV: '$(longHaul.desiredModulesToRestartCSV)'
           longHaul.restartIntervalInMins: '$(longHaul.restartIntervalInMins)'
           analyzer.consumerGroupId: 'longhaul_iotuap_amd64'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -102,6 +102,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'linux_amd64_moby'
 
 ################################################################################
   - job: linux_arm32v7_moby
@@ -175,6 +176,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'linux_arm32v7_moby'
 
 ################################################################################
   - job: linux_arm64v8_docker
@@ -248,6 +250,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'linux_arm64v8_docker'
 
 ################################################################################
   - job: windows_amd64_moby
@@ -324,6 +327,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'windows_amd64_moby'
 
 ################################################################################
   - job: windows_servercore_amd64_moby
@@ -399,6 +403,7 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'windows_servercore_amd64_moby'
 
 ################################################################################
   - job: iotuap_amd64_moby
@@ -474,3 +479,4 @@ jobs:
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
           twinTester.twinUpdateFrequency: '$(twinTester.twinUpdateFrequency)'
           twinTester.twinUpdateFailureThreshold: '$(twinTester.twinUpdateFailureThreshold)'
+          hostPlatform: 'iotuap_amd64_moby'

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -82,6 +82,11 @@ jobs:
       - template: templates/stresstest-deploy.yaml
         parameters:
           release.label: 'st$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -156,6 +161,11 @@ jobs:
       - template: templates/stresstest-deploy.yaml
         parameters:
           release.label: 'st$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -230,6 +240,11 @@ jobs:
       - template: templates/stresstest-deploy.yaml
         parameters:
           release.label: 'st$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.linux)'
           container.registry: '$(container.registry)'
@@ -307,6 +322,11 @@ jobs:
       - template: templates/stresstest-deploy-windows.yaml
         parameters:
           release.label: 'winpro-st$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'
@@ -383,6 +403,11 @@ jobs:
       - template: templates/stresstest-deploy-windows.yaml
         parameters:
           release.label: 'servercore-st$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'
@@ -459,6 +484,11 @@ jobs:
         parameters:
           testName: 'Stress'
           release.label: 'iotuap-st$(agent.group)'
+          test.buildNumber: '$(Build.BuildNumber)'
+          test.buildId: '$(Build.BuildId)'
+          build.source.branch: '$(Build.SourceBranchName)'
+          edgelet.source.branch: '$(edgelet.package.branchName)'
+          images.source.branch: '$(images.branchName)'
           edgelet.artifact.name: '$(edgelet.artifact.name)'
           images.artifact.name: '$(images.artifact.name.windows)'
           container.registry: '$(container.registry)'

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -13,8 +13,6 @@ variables:
   #pool.name: ''
   #container.registry: ''
   #snitch.storage.account: ''
-  #analyzer.logAnalytics.enabled
-  #analyzer.logAnalytics.logType
   # Variables settable at queue time
   #edgelet.package.branchName
   #images.branchName
@@ -100,8 +98,6 @@ jobs:
           snitch.storage.masterKey: '$(StorageAccountMasterKeyStress)'
           loadGen.message.frequency: '$(loadGen.message.frequency.amd64)'
           analyzer.consumerGroupId: 'stress_linux_amd64'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -179,8 +175,6 @@ jobs:
           snitch.storage.masterKey: '$(StorageAccountMasterKeyStress)'
           loadGen.message.frequency: $(loadGen.message.frequency.arm32v7)
           analyzer.consumerGroupId: 'stress_linux_arm32v7'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -258,8 +252,6 @@ jobs:
           snitch.storage.masterKey: '$(StorageAccountMasterKeyStress)'
           loadGen.message.frequency: $(loadGen.message.frequency.arm64v8)
           analyzer.consumerGroupId: 'stress_linux_arm64v8'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -340,8 +332,6 @@ jobs:
           snitch.storage.masterKey: '$(StorageAccountMasterKeyStress)'
           loadGen.message.frequency: '$(loadGen.message.frequency.amd64)'
           analyzer.consumerGroupId: 'stress_windows_amd64'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -421,8 +411,6 @@ jobs:
           snitch.storage.masterKey: '$(StorageAccountMasterKeyStress)'
           loadGen.message.frequency: '$(loadGen.message.frequency.amd64)'
           analyzer.consumerGroupId: 'stress_windows_servercore_amd64'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'
@@ -502,8 +490,6 @@ jobs:
           snitch.storage.masterKey: '$(StorageAccountMasterKeyStress)'
           loadGen.message.frequency: '$(loadGen.message.frequency.amd64)'
           analyzer.consumerGroupId: 'stress_iotuap_amd64'
-          analyzer.logAnalytics.enabled: '$(analyzer.logAnalytics.enabled)'
-          analyzer.logAnalytics.logType: '$(analyzer.logAnalytics.logType)'
           logAnalytics.workspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalytics.sharedKey: '$(kvLogAnalyticSharedKey)'
           twinTester.twinUpdateSize: '$(twinTester.twinUpdateSize)'

--- a/builds/e2e/templates/deploy-iotuap.yaml
+++ b/builds/e2e/templates/deploy-iotuap.yaml
@@ -96,6 +96,7 @@ steps:
         $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
         
         $ArtifactInfo=convertfrom-stringdata (get-content C:\Data\e2etests\artifacts\${{ parameters['images.artifact.name'] }}\artifactInfo.txt -raw)
         C:\Data\e2etests\artifacts\${{ parameters['images.artifact.name'] }}\scripts\windows\test\Run-E2ETest.ps1 `

--- a/builds/e2e/templates/deploy-iotuap.yaml
+++ b/builds/e2e/templates/deploy-iotuap.yaml
@@ -96,7 +96,7 @@ steps:
         $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
-        $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        $testInfo=$testInfo+",HostPlatform=${{ parameters['hostPlatform'] }}"
         $testInfo=$testInfo+",TestName=${{ parameters['testName'] }}"
         
         $ArtifactInfo=convertfrom-stringdata (get-content C:\Data\e2etests\artifacts\${{ parameters['images.artifact.name'] }}\artifactInfo.txt -raw)

--- a/builds/e2e/templates/deploy-iotuap.yaml
+++ b/builds/e2e/templates/deploy-iotuap.yaml
@@ -1,6 +1,11 @@
 parameters:
   testName: ''
   release.label: ''
+  test.buildNumber: ''
+  test.buildId: ''
+  build.source.branch: ''
+  edgelet.source.branch: ''
+  images.source.branch: ''
   edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''
@@ -76,6 +81,22 @@ steps:
       UserPassword: '$(iotuap-x64-password)'
       InlineScript: |
         #Requires -RunAsAdministrator
+        If ("${{ parameters['testName'] }}" -eq "Stress")
+        {
+          # schedule a task to stop iotedge service (terminate the test) in 4:30h
+          $ScheduleDatetime = [DateTime]::Now.AddMinutes(270)
+          $ScheduleDate=$ScheduleDatetime.ToString("MM/dd/yyyy")
+          $ScheduleTime=$ScheduleDatetime.ToString("HH:mm")
+          Write-Host "Schedule to stop iotedge service at $ScheduleDate $ScheduleTime"
+          SchTasks.exe /Create /RU "SYSTEM" /SC ONCE /TN “StopStressTest” /TR "net stop iotedge" /SD $ScheduleDate /ST $ScheduleTime /F
+        }
+        
+        $testInfo="TestBuildNumber=${{ parameters['test.buildNumber'] }}"
+        $testInfo=$testInfo+",TestBuildId=${{ parameters['test.buildId'] }}"
+        $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
+        $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
+        $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        
         $ArtifactInfo=convertfrom-stringdata (get-content C:\Data\e2etests\artifacts\${{ parameters['images.artifact.name'] }}\artifactInfo.txt -raw)
         C:\Data\e2etests\artifacts\${{ parameters['images.artifact.name'] }}\scripts\windows\test\Run-E2ETest.ps1 `
           -E2ETestFolder "C:\Data\e2etests" `
@@ -107,5 +128,6 @@ steps:
           -TwinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" `
           -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
           -HostPlatform "${{ parameters['hostPlatform'] }}" `
+          -TestInfo "$testInfo" `
           -BypassEdgeInstallation
       CommunicationProtocol: Http

--- a/builds/e2e/templates/deploy-iotuap.yaml
+++ b/builds/e2e/templates/deploy-iotuap.yaml
@@ -27,6 +27,7 @@ parameters:
   twinTester.twinUpdateSize: ''
   twinTester.twinUpdateFrequency: ''
   twinTester.twinUpdateFailureThreshold: ''
+  hostPlatform: ''
 
 steps:
   - task: CopyFiles@2
@@ -105,5 +106,6 @@ steps:
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `
           -TwinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" `
           -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
+          -HostPlatform "${{ parameters['hostPlatform'] }}" `
           -BypassEdgeInstallation
       CommunicationProtocol: Http

--- a/builds/e2e/templates/deploy-iotuap.yaml
+++ b/builds/e2e/templates/deploy-iotuap.yaml
@@ -97,6 +97,7 @@ steps:
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
         $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        $testInfo=$testInfo+",TestName=${{ parameters['testName'] }}"
         
         $ArtifactInfo=convertfrom-stringdata (get-content C:\Data\e2etests\artifacts\${{ parameters['images.artifact.name'] }}\artifactInfo.txt -raw)
         C:\Data\e2etests\artifacts\${{ parameters['images.artifact.name'] }}\scripts\windows\test\Run-E2ETest.ps1 `

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -80,6 +80,5 @@ steps:
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `
           -TwinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" `
           -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
-          -HostPlatform "${{ parameters['hostPlatform'] }}" `
           -TestInfo "$testInfo"
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -20,8 +20,6 @@ parameters:
   longHaul.desiredModulesToRestartCSV: ''
   longHaul.restartIntervalInMins: ''
   analyzer.consumerGroupId: ''
-  analyzer.logAnalytics.enabled: ''
-  analyzer.logAnalytics.logType: ''
   logAnalytics.workspaceId: ''
   logAnalytics.sharedKey: ''
   twinTester.twinUpdateSize: ''
@@ -75,8 +73,6 @@ steps:
           -EventHubConsumerGroupId "${{ parameters['analyzer.consumerGroupId'] }}" `
           -DesiredModulesToRestartCSV "${{ parameters['longHaul.desiredModulesToRestartCSV'] }}" `
           -RestartIntervalInMins "${{ parameters['longHaul.restartIntervalInMins'] }}" `
-          -LogAnalyticsEnabled "${{ parameters['analyzer.logAnalytics.enabled'] }}" `
-          -LogAnalyticsLogType "${{ parameters['analyzer.logAnalytics.logType'] }}" `
           -LogAnalyticsWorkspaceId "${{ parameters['logAnalytics.workspaceId'] }}" `
           -LogAnalyticsSharedKey "${{ parameters['logAnalytics.sharedKey'] }}" `
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -54,6 +54,7 @@ steps:
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
         $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        $testInfo=$testInfo+",TestName=$testName"
         
         $ArtifactInfo=convertfrom-stringdata (get-content $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt -raw)
         $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/windows/test/Run-E2ETest.ps1 `

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -22,6 +22,7 @@ parameters:
   twinTester.twinUpdateSize: ''
   twinTester.twinUpdateFrequency: ''
   twinTester.twinUpdateFailureThreshold: ''
+  hostPlatform: ''
 
 steps:
   - task: CopyFiles@2
@@ -68,5 +69,6 @@ steps:
           -LogAnalyticsSharedKey "${{ parameters['logAnalytics.sharedKey'] }}" `
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `
           -TwinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" `
-          -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}"
+          -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
+          -HostPlatform "${{ parameters['hostPlatform'] }}"
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -1,5 +1,10 @@
 parameters:
   release.label: ''
+  test.buildNumber: ''
+  test.buildId: ''
+  build.source.branch: ''
+  edgelet.source.branch: ''
+  images.source.branch: ''
   edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''
@@ -44,6 +49,13 @@ steps:
       script: |
         #Requires -RunAsAdministrator
         $testName="LongHaul"
+        
+        $testInfo="TestBuildNumber=${{ parameters['test.buildNumber'] }}"
+        $testInfo=$testInfo+",TestBuildId=${{ parameters['test.buildId'] }}"
+        $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
+        $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
+        $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        
         $ArtifactInfo=convertfrom-stringdata (get-content $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt -raw)
         $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/windows/test/Run-E2ETest.ps1 `
           -E2ETestFolder "$(Agent.HomeDirectory)/.." `
@@ -70,5 +82,6 @@ steps:
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `
           -TwinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" `
           -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
-          -HostPlatform "${{ parameters['hostPlatform'] }}"
+          -HostPlatform "${{ parameters['hostPlatform'] }}" `
+          -TestInfo "$testInfo"
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -53,6 +53,7 @@ steps:
         $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
         
         $ArtifactInfo=convertfrom-stringdata (get-content $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt -raw)
         $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/windows/test/Run-E2ETest.ps1 `

--- a/builds/e2e/templates/longhaul-deploy-windows.yaml
+++ b/builds/e2e/templates/longhaul-deploy-windows.yaml
@@ -53,7 +53,7 @@ steps:
         $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
-        $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        $testInfo=$testInfo+",HostPlatform=${{ parameters['hostPlatform'] }}"
         $testInfo=$testInfo+",TestName=$testName"
         
         $ArtifactInfo=convertfrom-stringdata (get-content $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt -raw)

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -53,6 +53,7 @@ steps:
         testInfo="$testInfo,BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
         
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -20,8 +20,6 @@ parameters:
   longHaul.desiredModulesToRestartCSV: ''
   longHaul.restartIntervalInMins: ''
   analyzer.consumerGroupId: ''
-  analyzer.logAnalytics.enabled: ''
-  analyzer.logAnalytics.logType: ''
   logAnalytics.workspaceId: ''
   logAnalytics.sharedKey: ''
   twinTester.twinUpdateSize: ''
@@ -76,8 +74,6 @@ steps:
           -eventHubConsumerGroupId "${{ parameters['analyzer.consumerGroupId'] }}" \
           -desiredModulesToRestartCSV "${{ parameters['longHaul.desiredModulesToRestartCSV'] }}" \
           -restartIntervalInMins "${{ parameters['longHaul.restartIntervalInMins'] }}" \
-          -logAnalyticsEnabled "${{ parameters['analyzer.logAnalytics.enabled'] }}" \
-          -logAnalyticsLogType "${{ parameters['analyzer.logAnalytics.logType'] }}" \
           -logAnalyticsWorkspaceId "${{ parameters['logAnalytics.workspaceId'] }}" \
           -logAnalyticsSharedKey "${{ parameters['logAnalytics.sharedKey'] }}" \
           -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -22,6 +22,7 @@ parameters:
   twinTester.twinUpdateSize: ''
   twinTester.twinUpdateFrequency: ''
   twinTester.twinUpdateFailureThreshold: ''
+  hostPlatform: ''
 
 steps:
   - task: CopyFiles@2
@@ -70,5 +71,6 @@ steps:
           -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \
           -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
           -twinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" \
+          -hostPlatform "${{ parameters['hostPlatform'] }}" \
           -cleanAll
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -54,6 +54,7 @@ steps:
         testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
         testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        testInfo="$testInfo,TestName=$testName"
         
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -53,7 +53,7 @@ steps:
         testInfo="$testInfo,BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
-        testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        testInfo="$testInfo,HostPlatform=${{ parameters['hostPlatform'] }}"
         testInfo="$testInfo,TestName=$testName"
         
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -81,7 +81,6 @@ steps:
           -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \
           -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
           -twinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" \
-          -hostPlatform "${{ parameters['hostPlatform'] }}" \
           -testInfo "$testInfo" \
           -cleanAll
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -1,5 +1,10 @@
 parameters:
   release.label: ''
+  test.buildNumber: ''
+  test.buildId: ''
+  build.source.branch: ''
+  edgelet.source.branch: ''
+  images.source.branch: ''
   edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''
@@ -44,6 +49,13 @@ steps:
       script: |
         declare -a cnreg=( ${{ parameters['container.registry.credential'] }} )
         testName="LongHaul"
+        
+        testInfo="TestBuildNumber=${{ parameters['test.buildNumber'] }}"
+        testInfo="$testInfo,TestBuildId=${{ parameters['test.buildId'] }}"
+        testInfo="$testInfo,BuildSourceBranch=${{ parameters['build.source.branch'] }}"
+        testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
+        testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh
         sudo $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh \
@@ -72,5 +84,6 @@ steps:
           -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
           -twinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" \
           -hostPlatform "${{ parameters['hostPlatform'] }}" \
+          -testInfo "$testInfo" \
           -cleanAll
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -58,6 +58,7 @@ steps:
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
         $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        $testInfo=$testInfo+",TestName=$testName"
         
         $ArtifactInfo=convertfrom-stringdata (get-content $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt -raw)
         $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/windows/test/Run-E2ETest.ps1 `

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -57,6 +57,7 @@ steps:
         $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
         
         $ArtifactInfo=convertfrom-stringdata (get-content $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt -raw)
         $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/windows/test/Run-E2ETest.ps1 `

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -57,7 +57,7 @@ steps:
         $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
-        $testInfo=$testInfo+",HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        $testInfo=$testInfo+",HostPlatform=${{ parameters['hostPlatform'] }}"
         $testInfo=$testInfo+",TestName=$testName"
         
         $ArtifactInfo=convertfrom-stringdata (get-content $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt -raw)

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -24,8 +24,6 @@ parameters:
   transportType3: 'Mqtt_Tcp_Only'
   transportType4: 'Mqtt_Tcp_Only'
   analyzer.consumerGroupId: ''
-  analyzer.logAnalytics.enabled: ''
-  analyzer.logAnalytics.logType: ''
   logAnalytics.workspaceId: ''
   logAnalytics.sharedKey: ''
   twinTester.twinUpdateSize: ''
@@ -83,8 +81,6 @@ steps:
           -MqttSettingsEnabled "${{ parameters['mqtt.settings.enabled'] }}" `
           -LoadGenMessageFrequency "${{ parameters['loadGen.message.frequency'] }}" `
           -EventHubConsumerGroupId "${{ parameters['analyzer.consumerGroupId'] }}" `
-          -LogAnalyticsEnabled "${{ parameters['analyzer.logAnalytics.enabled'] }}" `
-          -LogAnalyticsLogType "${{ parameters['analyzer.logAnalytics.logType'] }}" `
           -LogAnalyticsWorkspaceId "${{ parameters['logAnalytics.workspaceId'] }}" `
           -LogAnalyticsSharedKey "${{ parameters['logAnalytics.sharedKey'] }}" `
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -88,7 +88,6 @@ steps:
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `
           -TwinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" `
           -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
-          -HostPlatform "${{ parameters['hostPlatform'] }}" `
           -TestInfo "$testInfo"
         # schedule a task to stop iotedge service (terminate the test) in 4:30h
         $ScheduleDatetime = [DateTime]::Now.AddMinutes(270)

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -1,5 +1,10 @@
 parameters:
   release.label: ''
+  test.buildNumber: ''
+  test.buildId: ''
+  build.source.branch: ''
+  edgelet.source.branch: ''
+  images.source.branch: ''
   edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''
@@ -48,6 +53,13 @@ steps:
       script: |
         #Requires -RunAsAdministrator
         $testName="Stress"
+        
+        $testInfo="TestBuildNumber=${{ parameters['test.buildNumber'] }}"
+        $testInfo=$testInfo+",TestBuildId=${{ parameters['test.buildId'] }}"
+        $testInfo=$testInfo+",BuildSourceBranch=${{ parameters['build.source.branch'] }}"
+        $testInfo=$testInfo+",EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
+        $testInfo=$testInfo+",ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        
         $ArtifactInfo=convertfrom-stringdata (get-content $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt -raw)
         $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/windows/test/Run-E2ETest.ps1 `
           -E2ETestFolder "$(Agent.HomeDirectory)/.." `
@@ -78,7 +90,8 @@ steps:
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `
           -TwinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" `
           -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
-          -HostPlatform "${{ parameters['hostPlatform'] }}"
+          -HostPlatform "${{ parameters['hostPlatform'] }}" `
+          -TestInfo "$testInfo"
         # schedule a task to stop iotedge service (terminate the test) in 4:30h
         $ScheduleDatetime = [DateTime]::Now.AddMinutes(270)
         $ScheduleDate=$ScheduleDatetime.ToString("MM/dd/yyyy")

--- a/builds/e2e/templates/stresstest-deploy-windows.yaml
+++ b/builds/e2e/templates/stresstest-deploy-windows.yaml
@@ -26,6 +26,7 @@ parameters:
   twinTester.twinUpdateSize: ''
   twinTester.twinUpdateFrequency: ''
   twinTester.twinUpdateFailureThreshold: ''
+  hostPlatform: ''
 
 steps:
   - task: CopyFiles@2
@@ -76,7 +77,8 @@ steps:
           -LogAnalyticsSharedKey "${{ parameters['logAnalytics.sharedKey'] }}" `
           -TwinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" `
           -TwinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" `
-          -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}"
+          -TwinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" `
+          -HostPlatform "${{ parameters['hostPlatform'] }}"
         # schedule a task to stop iotedge service (terminate the test) in 4:30h
         $ScheduleDatetime = [DateTime]::Now.AddMinutes(270)
         $ScheduleDate=$ScheduleDatetime.ToString("MM/dd/yyyy")

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -91,7 +91,6 @@ steps:
           -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \
           -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
           -twinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" \
-          -hostPlatform "${{ parameters['hostPlatform'] }}" \
           -testInfo "$testInfo" \
           -cleanAll
         #Remove all pending jobs

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -58,6 +58,7 @@ steps:
         testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
         testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        testInfo="$testInfo,TestName=$testName"
         
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         echo "snitcher duration in mins=$(snitcher.test.duration.in.mins)"

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -57,6 +57,7 @@ steps:
         testInfo="$testInfo,BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
         
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         echo "snitcher duration in mins=$(snitcher.test.duration.in.mins)"

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -26,6 +26,7 @@ parameters:
   twinTester.twinUpdateSize: ''
   twinTester.twinUpdateFrequency: ''
   twinTester.twinUpdateFailureThreshold: ''
+  hostPlatform: ''
 
 steps:
   - task: CopyFiles@2
@@ -80,6 +81,7 @@ steps:
           -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \
           -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
           -twinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" \
+          -hostPlatform "${{ parameters['hostPlatform'] }}" \
           -cleanAll
         #Remove all pending jobs
         atrm $(atq | cut -f1)

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -1,5 +1,10 @@
 parameters:
   release.label: ''
+  test.buildNumber: ''
+  test.buildId: ''
+  build.source.branch: ''
+  edgelet.source.branch: ''
+  images.source.branch: ''
   edgelet.artifact.name: ''
   images.artifact.name: ''
   container.registry: ''
@@ -48,6 +53,13 @@ steps:
       script: |
         declare -a cnreg=( ${{ parameters['container.registry.credential'] }} )
         testName="Stress"
+        
+        testInfo="TestBuildNumber=${{ parameters['test.buildNumber'] }}"
+        testInfo="$testInfo,TestBuildId=${{ parameters['test.buildId'] }}"
+        testInfo="$testInfo,BuildSourceBranch=${{ parameters['build.source.branch'] }}"
+        testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
+        testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
+        
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         echo "snitcher duration in mins=$(snitcher.test.duration.in.mins)"
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh
@@ -82,6 +94,7 @@ steps:
           -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
           -twinUpdateFailureThreshold "${{ parameters['twinTester.twinUpdateFailureThreshold'] }}" \
           -hostPlatform "${{ parameters['hostPlatform'] }}" \
+          -testInfo "$testInfo" \
           -cleanAll
         #Remove all pending jobs
         atrm $(atq | cut -f1)

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -24,8 +24,6 @@ parameters:
   transportType3: 'Mqtt_Tcp_Only'
   transportType4: 'Mqtt_WebSocket_Only'
   analyzer.consumerGroupId: ''
-  analyzer.logAnalytics.enabled: ''
-  analyzer.logAnalytics.logType: ''
   logAnalytics.workspaceId: ''
   logAnalytics.sharedKey: ''
   twinTester.twinUpdateSize: ''
@@ -86,8 +84,6 @@ steps:
           -loadGenMessageFrequency "${{ parameters['loadGen.message.frequency'] }}" \
           -snitchTestDurationInSecs "$(($(snitcher.test.duration.in.mins)*60))" \
           -eventHubConsumerGroupId "${{ parameters['analyzer.consumerGroupId'] }}" \
-          -logAnalyticsEnabled "${{ parameters['analyzer.logAnalytics.enabled'] }}" \
-          -logAnalyticsLogType "${{ parameters['analyzer.logAnalytics.logType'] }}" \
           -logAnalyticsWorkspaceId "${{ parameters['logAnalytics.workspaceId'] }}" \
           -logAnalyticsSharedKey "${{ parameters['logAnalytics.sharedKey'] }}" \
           -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \

--- a/builds/e2e/templates/stresstest-deploy.yaml
+++ b/builds/e2e/templates/stresstest-deploy.yaml
@@ -57,7 +57,7 @@ steps:
         testInfo="$testInfo,BuildSourceBranch=${{ parameters['build.source.branch'] }}"
         testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
-        testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
+        testInfo="$testInfo,HostPlatform=${{ parameters['hostPlatform'] }}"
         testInfo="$testInfo,TestName=$testName"
         
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt

--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -267,6 +267,9 @@
               },
               "LogAnalyticsLogType": {
                 "value": "<Analyzer.LogAnalyticsLogType>"
+              },
+              "TestInfo": {
+                "value": "<Analyzer.TestInfo>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/long_haul_deployment.template.windows.json
+++ b/e2e_deployment_files/long_haul_deployment.template.windows.json
@@ -270,6 +270,9 @@
               },
               "LogAnalyticsLogType": {
                 "value": "<Analyzer.LogAnalyticsLogType>"
+              },
+              "TestInfo": {
+                "value": "<Analyzer.TestInfo>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.json
+++ b/e2e_deployment_files/stress_deployment.template.json
@@ -291,6 +291,9 @@
               },
               "LogAnalyticsLogType": {
                 "value": "<Analyzer.LogAnalyticsLogType>"
+              },
+              "TestInfo": {
+                "value": "<Analyzer.TestInfo>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/stress_deployment.template.windows.json
+++ b/e2e_deployment_files/stress_deployment.template.windows.json
@@ -294,6 +294,9 @@
               },
               "LogAnalyticsLogType": {
                 "value": "<Analyzer.LogAnalyticsLogType>"
+              },
+              "TestInfo": {
+                "value": "<Analyzer.TestInfo>"
               }
             },
             "settings": {

--- a/edge-modules/TestAnalyzer/AggregateCloudOperationReport.cs
+++ b/edge-modules/TestAnalyzer/AggregateCloudOperationReport.cs
@@ -33,7 +33,7 @@ namespace TestAnalyzer
 
         public IDictionary<string, string> TestInfo { get; }
 
-        public bool IsPassed => this.StatusCodes.All(x => x.StatusCode.Equals("200"));
+        public bool IsPassed => this.StatusCodes.All(x => x.StatusCode.StartsWith("200"));
 
         public override string ToString()
         {

--- a/edge-modules/TestAnalyzer/AggregateCloudOperationReport.cs
+++ b/edge-modules/TestAnalyzer/AggregateCloudOperationReport.cs
@@ -3,13 +3,14 @@ namespace TestAnalyzer
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Serialization;
 
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     class AggregateCloudOperationReport
     {
-        public AggregateCloudOperationReport(string moduleId, IDictionary<string, Tuple<int, DateTime>> statusCodes)
+        public AggregateCloudOperationReport(string moduleId, IDictionary<string, Tuple<int, DateTime>> statusCodes, IDictionary<string, string> testInfo)
         {
             this.ModuleId = moduleId;
             this.StatusCodes = new List<CloudOperationReport>();
@@ -27,6 +28,10 @@ namespace TestAnalyzer
         public string ModuleId { get; }
 
         public IList<CloudOperationReport> StatusCodes { get; }
+
+        public IDictionary<string, string> TestInfo { get; }
+
+        public bool IsPassed => this.StatusCodes.All(x => x.StatusCode.Equals("200"));
 
         public override string ToString()
         {

--- a/edge-modules/TestAnalyzer/AggregateCloudOperationReport.cs
+++ b/edge-modules/TestAnalyzer/AggregateCloudOperationReport.cs
@@ -23,6 +23,8 @@ namespace TestAnalyzer
                     LastReceivedAt = status.Value.Item2
                 });
             }
+
+            this.TestInfo = testInfo;
         }
 
         public string ModuleId { get; }

--- a/edge-modules/TestAnalyzer/Controllers/ReportController.cs
+++ b/edge-modules/TestAnalyzer/Controllers/ReportController.cs
@@ -20,10 +20,7 @@ namespace TestAnalyzer.Controllers
         public async Task<ContentResult> GetReport()
         {
             TestResultAnalysis deviceAnalysis = TestResultReporter.GetDeviceReport(Settings.Current.ToleranceInMilliseconds);
-            if (Settings.Current.LogAnalyticsEnabled)
-            {
-                await this.PublishToLogAnalyticsAsync(deviceAnalysis);
-            }
+            await this.PublishToLogAnalyticsAsync(deviceAnalysis);
 
             return new ContentResult { Content = deviceAnalysis.ToString() };
         }
@@ -33,10 +30,7 @@ namespace TestAnalyzer.Controllers
         public async Task<ContentResult> GetMessagesAsync()
         {
             TestResultAnalysis deviceAnalysis = TestResultReporter.GetDeviceReport(Settings.Current.ToleranceInMilliseconds);
-            if (Settings.Current.LogAnalyticsEnabled)
-            {
-                await this.PublishToLogAnalyticsAsync(deviceAnalysis);
-            }
+            await this.PublishToLogAnalyticsAsync(deviceAnalysis);
 
             return new ContentResult { Content = JsonConvert.SerializeObject(deviceAnalysis.MessagesReport, Formatting.Indented) }; // explicit serialization needed due to the wrapping list
         }
@@ -49,7 +43,6 @@ namespace TestAnalyzer.Controllers
 
             string workspaceId = Settings.Current.LogAnalyticsWorkspaceId;
             string sharedKey = Settings.Current.LogAnalyticsSharedKey;
-            string logType = Settings.Current.LogAnalyticsLogType;
 
             // Upload the data to Log Analytics for our dashboards
             try
@@ -58,19 +51,19 @@ namespace TestAnalyzer.Controllers
                     workspaceId,
                     sharedKey,
                     messagesJson,
-                    logType);
+                    "messagingReportsLonghaulStress");
 
                 await AzureLogAnalytics.Instance.PostAsync(
                     workspaceId,
                     sharedKey,
                     twinsJson,
-                    logType);
+                    "twinReportsLonghaulStress");
 
                 await AzureLogAnalytics.Instance.PostAsync(
                     workspaceId,
                     sharedKey,
                     directMethodsJson,
-                    logType);
+                    "directMethodReportsLonghaulStress");
             }
             catch (Exception e)
             {

--- a/edge-modules/TestAnalyzer/ModuleMessagesReport.cs
+++ b/edge-modules/TestAnalyzer/ModuleMessagesReport.cs
@@ -9,17 +9,17 @@ namespace TestAnalyzer
     [JsonObject(NamingStrategyType = typeof(CamelCaseNamingStrategy))]
     class ModuleMessagesReport
     {
-        public ModuleMessagesReport(string moduleId, StatusCode statusCode, long receivedMessagesCount, string statusMessage)
-            : this(moduleId, statusCode, receivedMessagesCount, statusMessage, DateTime.MinValue, new List<MissedMessagesDetails>())
+        public ModuleMessagesReport(string moduleId, StatusCode statusCode, long receivedMessagesCount, string statusMessage, IDictionary<string, string> testInfo)
+            : this(moduleId, statusCode, receivedMessagesCount, statusMessage, DateTime.MinValue, new List<MissedMessagesDetails>(), testInfo)
         {
         }
 
-        public ModuleMessagesReport(string moduleId, StatusCode statusCode, long receivedMessagesCount, string statusMessage, DateTime lastMessageReceivedAt)
-            : this(moduleId, statusCode, receivedMessagesCount, statusMessage, lastMessageReceivedAt, new List<MissedMessagesDetails>())
+        public ModuleMessagesReport(string moduleId, StatusCode statusCode, long receivedMessagesCount, string statusMessage, DateTime lastMessageReceivedAt, IDictionary<string, string> testInfo)
+            : this(moduleId, statusCode, receivedMessagesCount, statusMessage, lastMessageReceivedAt, new List<MissedMessagesDetails>(), testInfo)
         {
         }
 
-        public ModuleMessagesReport(string moduleId, StatusCode statusCode, long receivedMessagesCount, string statusMessage, DateTime lastMessageReceivedAt, IList<MissedMessagesDetails> missedMessages)
+        public ModuleMessagesReport(string moduleId, StatusCode statusCode, long receivedMessagesCount, string statusMessage, DateTime lastMessageReceivedAt, IList<MissedMessagesDetails> missedMessages, IDictionary<string, string> testInfo)
         {
             this.ModuleId = moduleId;
             this.StatusCode = statusCode;
@@ -27,6 +27,7 @@ namespace TestAnalyzer
             this.StatusMessage = statusMessage;
             this.MissedMessages = missedMessages;
             this.LastMessageReceivedAt = lastMessageReceivedAt;
+            this.TestInfo = testInfo;
         }
 
         public string ModuleId { get; }
@@ -40,6 +41,10 @@ namespace TestAnalyzer
         public DateTime LastMessageReceivedAt { get; }
 
         public IList<MissedMessagesDetails> MissedMessages { get; }
+
+        public bool IsPassed => this.StatusCode == StatusCode.AllMessages;
+
+        public IDictionary<string, string> TestInfo { get; }
 
         public override string ToString()
         {

--- a/edge-modules/TestAnalyzer/Settings.cs
+++ b/edge-modules/TestAnalyzer/Settings.cs
@@ -36,10 +36,8 @@ namespace TestAnalyzer
                     excludedModules,
                     configuration.GetValue("WebhostPort", DefaultWebhostPort),
                     configuration.GetValue("ToleranceInMilliseconds", DefaultToleranceInMilliseconds),
-                    configuration.GetValue<bool>("LogAnalyticsEnabled"),
                     configuration.GetValue<string>("LogAnalyticsWorkspaceId"),
                     configuration.GetValue<string>("LogAnalyticsSharedKey"),
-                    configuration.GetValue<string>("LogAnalyticsLogType"),
                     configuration.GetValue<string>("storagePath", DefaultStoragePath),
                     configuration.GetValue<bool>("StorageOptimizeForPerformance", true),
                     configuration.GetValue<string>("TestInfo"));
@@ -52,10 +50,8 @@ namespace TestAnalyzer
             IList<string> excludedModuleIds,
             string webhostPort,
             double tolerance,
-            bool logAnalyticsEnabled,
             string logAnalyticsWorkspaceIdName,
             string logAnalyticsSharedKeyName,
-            string logAnalyticsLogTypeName,
             string storagePath,
             bool storageOptimizeForPerformance,
             string testInfo)
@@ -76,10 +72,8 @@ namespace TestAnalyzer
                                     x => x.KeyAndValue.Substring(0, x.SplitIndex),
                                     x => x.KeyAndValue.Substring(x.SplitIndex + 1, x.KeyAndValue.Length - x.SplitIndex - 1));
             this.OptimizeForPerformance = Preconditions.CheckNotNull(storageOptimizeForPerformance);
-            this.LogAnalyticsEnabled = logAnalyticsEnabled;
             this.LogAnalyticsWorkspaceId = logAnalyticsWorkspaceIdName;
             this.LogAnalyticsSharedKey = logAnalyticsSharedKeyName;
-            this.LogAnalyticsLogType = logAnalyticsLogTypeName;
         }
 
         public static Settings Current => Setting.Value;
@@ -103,14 +97,10 @@ namespace TestAnalyzer
 
         public bool OptimizeForPerformance { get; }
 
-        public bool LogAnalyticsEnabled { get; }
-
         public string LogAnalyticsWorkspaceId { get; }
 
         [JsonIgnore]
         public string LogAnalyticsSharedKey { get; }
-
-        public string LogAnalyticsLogType { get; }
 
         public override string ToString()
         {

--- a/edge-modules/TestAnalyzer/Settings.cs
+++ b/edge-modules/TestAnalyzer/Settings.cs
@@ -4,6 +4,7 @@ namespace TestAnalyzer
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Configuration;
     using Newtonsoft.Json;
@@ -68,7 +69,12 @@ namespace TestAnalyzer
             this.WebhostPort = Preconditions.CheckNonWhiteSpace(webhostPort, nameof(webhostPort));
             this.ToleranceInMilliseconds = Preconditions.CheckRange(tolerance, 0);
             this.StoragePath = storagePath;
-            this.TestInfo = testInfo.Split(",", StringSplitOptions.RemoveEmptyEntries);
+            this.TestInfo = testInfo.Split(",", StringSplitOptions.RemoveEmptyEntries)
+                                .Select(x => (KeyAndValue: x, SplitIndex: x.IndexOf('=')))
+                                .Where(x => x.SplitIndex >= 1)
+                                .ToDictionary(
+                                    x => x.KeyAndValue.Substring(0, x.SplitIndex),
+                                    x => x.KeyAndValue.Substring(x.SplitIndex + 1, x.KeyAndValue.Length - x.SplitIndex - 1));
             this.OptimizeForPerformance = Preconditions.CheckNotNull(storageOptimizeForPerformance);
             this.LogAnalyticsEnabled = logAnalyticsEnabled;
             this.LogAnalyticsWorkspaceId = logAnalyticsWorkspaceIdName;
@@ -93,7 +99,7 @@ namespace TestAnalyzer
 
         public string StoragePath { get; }
 
-        public string[] TestInfo { get; }
+        public Dictionary<string, string> TestInfo { get; }
 
         public bool OptimizeForPerformance { get; }
 

--- a/edge-modules/TestAnalyzer/Settings.cs
+++ b/edge-modules/TestAnalyzer/Settings.cs
@@ -40,11 +40,27 @@ namespace TestAnalyzer
                     configuration.GetValue<string>("LogAnalyticsSharedKey"),
                     configuration.GetValue<string>("LogAnalyticsLogType"),
                     configuration.GetValue<string>("storagePath", DefaultStoragePath),
-                    configuration.GetValue<bool>("StorageOptimizeForPerformance", true));
+                    configuration.GetValue<bool>("StorageOptimizeForPerformance", true),
+                    configuration.GetValue<string>("TestInfo"));
             });
 
-        Settings(string eventHubConnectionString, string consumerGroupId, string deviceId, IList<string> excludedModuleIds, string webhostPort, double tolerance, bool logAnalyticsEnabled, string logAnalyticsWorkspaceIdName, string logAnalyticsSharedKeyName, string logAnalyticsLogTypeName, string storagePath, bool storageOptimizeForPerformance)
+        Settings(
+            string eventHubConnectionString,
+            string consumerGroupId,
+            string deviceId,
+            IList<string> excludedModuleIds,
+            string webhostPort,
+            double tolerance,
+            bool logAnalyticsEnabled,
+            string logAnalyticsWorkspaceIdName,
+            string logAnalyticsSharedKeyName,
+            string logAnalyticsLogTypeName,
+            string storagePath,
+            bool storageOptimizeForPerformance,
+            string testInfo)
         {
+            Preconditions.CheckNonWhiteSpace(testInfo, nameof(testInfo));
+
             this.EventHubConnectionString = Preconditions.CheckNonWhiteSpace(eventHubConnectionString, nameof(eventHubConnectionString));
             this.ConsumerGroupId = Preconditions.CheckNonWhiteSpace(consumerGroupId, nameof(consumerGroupId));
             this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
@@ -52,6 +68,7 @@ namespace TestAnalyzer
             this.WebhostPort = Preconditions.CheckNonWhiteSpace(webhostPort, nameof(webhostPort));
             this.ToleranceInMilliseconds = Preconditions.CheckRange(tolerance, 0);
             this.StoragePath = storagePath;
+            this.TestInfo = testInfo.Split(",", StringSplitOptions.RemoveEmptyEntries);
             this.OptimizeForPerformance = Preconditions.CheckNotNull(storageOptimizeForPerformance);
             this.LogAnalyticsEnabled = logAnalyticsEnabled;
             this.LogAnalyticsWorkspaceId = logAnalyticsWorkspaceIdName;
@@ -75,6 +92,8 @@ namespace TestAnalyzer
         public double ToleranceInMilliseconds { get; }
 
         public string StoragePath { get; }
+
+        public string[] TestInfo { get; }
 
         public bool OptimizeForPerformance { get; }
 

--- a/edge-modules/TestAnalyzer/TestResultReporter.cs
+++ b/edge-modules/TestAnalyzer/TestResultReporter.cs
@@ -37,7 +37,7 @@ namespace TestAnalyzer
             foreach (KeyValuePair<string, IDictionary<string, Tuple<int, DateTime>>> obj in cache)
             {
                 Logger.LogInformation($"{reportDescription} {obj.Key}");
-                report.Add(new AggregateCloudOperationReport(obj.Key, obj.Value));
+                report.Add(new AggregateCloudOperationReport(obj.Key, obj.Value, Settings.Current.TestInfo));
             }
 
             return report;
@@ -67,7 +67,7 @@ namespace TestAnalyzer
 
             if (batchesSnapshot.Count == 0)
             {
-                return new ModuleMessagesReport(moduleId, StatusCode.NoMessages, totalMessagesCounter, "No messages received for module");
+                return new ModuleMessagesReport(moduleId, StatusCode.NoMessages, totalMessagesCounter, "No messages received for module", Settings.Current.TestInfo);
             }
 
             DateTime lastMessageDateTime = DateTime.MinValue;
@@ -105,12 +105,12 @@ namespace TestAnalyzer
             if (DateTime.Compare(lastMessageDateTime.AddMilliseconds(toleranceInMilliseconds), endDateTime) < 0)
             {
                 Logger.LogInformation($"Module {moduleId}: last message datetime={lastMessageDateTime} and end datetime={endDateTime}");
-                return new ModuleMessagesReport(moduleId, StatusCode.OldMessages, totalMessagesCounter, $"Missing messages: {missingCounter}. No messages received for the past {toleranceInMilliseconds} milliseconds.", lastMessageDateTime, missedMessages);
+                return new ModuleMessagesReport(moduleId, StatusCode.OldMessages, totalMessagesCounter, $"Missing messages: {missingCounter}. No messages received for the past {toleranceInMilliseconds} milliseconds.", lastMessageDateTime, missedMessages, Settings.Current.TestInfo);
             }
 
             return missingCounter > 0
-                ? new ModuleMessagesReport(moduleId, StatusCode.SkippedMessages, totalMessagesCounter, $"Missing messages: {missingCounter}.", lastMessageDateTime, missedMessages)
-                : new ModuleMessagesReport(moduleId, StatusCode.AllMessages, totalMessagesCounter, "All messages received.", lastMessageDateTime);
+                ? new ModuleMessagesReport(moduleId, StatusCode.SkippedMessages, totalMessagesCounter, $"Missing messages: {missingCounter}.", lastMessageDateTime, missedMessages, Settings.Current.TestInfo)
+                : new ModuleMessagesReport(moduleId, StatusCode.AllMessages, totalMessagesCounter, "All messages received.", lastMessageDateTime, Settings.Current.TestInfo);
         }
     }
 }

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -176,6 +176,7 @@ function prepare_test_from_artifacts() {
                 sed -i -e "s@<Analyzer.EventHubConnectionString>@$EVENTHUB_CONNECTION_STRING@g" "$deployment_working_file"
                 sed -i -e "s@<Analyzer.LogAnalyticsEnabled>@$LOG_ANALYTICS_ENABLED@g" "$deployment_working_file"
                 sed -i -e "s@<Analyzer.LogAnalyticsLogType>@$LOG_ANALYTICS_LOG_TYPE@g" "$deployment_working_file"
+                sed -i -e "s@<Analyzer.TestInfo>@$TEST_INFO@g" "$deployment_working_file"
                 sed -i -e "s@<LogAnalyticsWorkspaceId>@$LOG_ANALYTICS_WORKSPACE_ID@g" "$deployment_working_file"
                 sed -i -e "s@<LogAnalyticsSharedKey>@$LOG_ANALYTICS_SHARED_KEY@g" "$deployment_working_file"
                 sed -i -e "s@<LoadGen.MessageFrequency>@$LOADGEN_MESSAGE_FREQUENCY@g" "$deployment_working_file"
@@ -390,6 +391,9 @@ function process_args() {
         elif [ $saveNextArg -eq 38 ]; then
             TWIN_UPDATE_FAILURE_THRESHOLD="$arg"
             saveNextArg=0;
+        elif [ $saveNextArg -eq 39 ]; then
+            TEST_INFO="$arg"
+            saveNextArg=0
         else
             case "$arg" in
                 '-h' | '--help' ) usage;;
@@ -431,6 +435,7 @@ function process_args() {
                 '-twinUpdateSize' ) saveNextArg=36;;
                 '-twinUpdateFrequency' ) saveNextArg=37;;
                 '-twinUpdateFailureThreshold' ) saveNextArg=38;;
+                '-testInfo' ) saveNextArg=39;;
                 '-cleanAll' ) CLEAN_ALL=1;;
                 * ) usage;;
             esac
@@ -976,6 +981,11 @@ function validate_test_parameters() {
             print_error "Required snitch storage master key."
             ((error++))
         fi
+        
+        if [[ -z "$TEST_INFO" ]]; then
+            print_error "Required test info."
+            ((error++))
+        fi
     fi
 
     if (( error > 0 )); then
@@ -1030,6 +1040,7 @@ function usage() {
     echo ' -twinUpdateSize                   Specifies the char count (i.e. size) of each twin update. Default is 1 for long haul and 100 for stress test.'
     echo ' -twinUpdateFrequency              Frequency to make twin updates. This should be specified in DateTime format. Default is 00:00:15 for long haul and 00:00:05 for stress test.'
     echo ' -twinUpdateFailureThreshold       Specifies the longest period of time a twin update can take before being marked as a failure. This should be specified in DateTime format. Default is 00:01:00'
+    echo ' -testInfo                         Contains comma delimiter test information, e.g. build number and id, source branches of build, edgelet and images.' 
     exit 1;
 }
 

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -174,8 +174,6 @@ function prepare_test_from_artifacts() {
                 local escapedBuildId
                 sed -i -e "s@<Analyzer.ConsumerGroupId>@$EVENT_HUB_CONSUMER_GROUP_ID@g" "$deployment_working_file"
                 sed -i -e "s@<Analyzer.EventHubConnectionString>@$EVENTHUB_CONNECTION_STRING@g" "$deployment_working_file"
-                sed -i -e "s@<Analyzer.LogAnalyticsEnabled>@$LOG_ANALYTICS_ENABLED@g" "$deployment_working_file"
-                sed -i -e "s@<Analyzer.LogAnalyticsLogType>@$LOG_ANALYTICS_LOG_TYPE@g" "$deployment_working_file"
                 sed -i -e "s@<Analyzer.TestInfo>@$TEST_INFO@g" "$deployment_working_file"
                 sed -i -e "s@<LogAnalyticsWorkspaceId>@$LOG_ANALYTICS_WORKSPACE_ID@g" "$deployment_working_file"
                 sed -i -e "s@<LogAnalyticsSharedKey>@$LOG_ANALYTICS_SHARED_KEY@g" "$deployment_working_file"
@@ -371,27 +369,21 @@ function process_args() {
             RESTART_INTERVAL_IN_MINS="$arg"
             saveNextArg=0;
         elif [ $saveNextArg -eq 32 ]; then
-            LOG_ANALYTICS_ENABLED="$arg"
-            saveNextArg=0
-        elif [ $saveNextArg -eq 33 ]; then
             LOG_ANALYTICS_WORKSPACE_ID="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 34 ]; then
+        elif [ $saveNextArg -eq 33 ]; then
             LOG_ANALYTICS_SHARED_KEY="$arg"
             saveNextArg=0
-        elif [ $saveNextArg -eq 35 ]; then
-            LOG_ANALYTICS_LOG_TYPE="$arg"
-            saveNextArg=0
-        elif [ $saveNextArg -eq 36 ]; then
+        elif [ $saveNextArg -eq 34 ]; then
             TWIN_UPDATE_SIZE="$arg"
             saveNextArg=0;
-        elif [ $saveNextArg -eq 37 ]; then
+        elif [ $saveNextArg -eq 35 ]; then
             TWIN_UPDATE_FREQUENCY="$arg"
             saveNextArg=0;
-        elif [ $saveNextArg -eq 38 ]; then
+        elif [ $saveNextArg -eq 36 ]; then
             TWIN_UPDATE_FAILURE_THRESHOLD="$arg"
             saveNextArg=0;
-        elif [ $saveNextArg -eq 39 ]; then
+        elif [ $saveNextArg -eq 37 ]; then
             TEST_INFO="$arg"
             saveNextArg=0
         else
@@ -428,14 +420,12 @@ function process_args() {
                 '-eventHubConsumerGroupId' ) saveNextArg=29;;
                 '-desiredModulesToRestartCSV' ) saveNextArg=30;;
                 '-restartIntervalInMins' ) saveNextArg=31;;
-                '-logAnalyticsEnabled' ) saveNextArg=32;;
-                '-logAnalyticsWorkspaceId' ) saveNextArg=33;;
-                '-logAnalyticsSharedKey' ) saveNextArg=34;;
-                '-logAnalyticsLogType' ) saveNextArg=35;;
-                '-twinUpdateSize' ) saveNextArg=36;;
-                '-twinUpdateFrequency' ) saveNextArg=37;;
-                '-twinUpdateFailureThreshold' ) saveNextArg=38;;
-                '-testInfo' ) saveNextArg=39;;
+                '-logAnalyticsWorkspaceId' ) saveNextArg=32;;
+                '-logAnalyticsSharedKey' ) saveNextArg=33;;
+                '-twinUpdateSize' ) saveNextArg=34;;
+                '-twinUpdateFrequency' ) saveNextArg=35;;
+                '-twinUpdateFailureThreshold' ) saveNextArg=36;;
+                '-testInfo' ) saveNextArg=37;;
                 '-cleanAll' ) CLEAN_ALL=1;;
                 * ) usage;;
             esac
@@ -450,11 +440,6 @@ function process_args() {
     [[ -z "$CONTAINER_REGISTRY_PASSWORD" ]] && { print_error 'Container registry password is required'; exit 1; }
     [[ -z "$IOTHUB_CONNECTION_STRING" ]] && { print_error 'IoT hub connection string is required'; exit 1; }
     [[ -z "$EVENTHUB_CONNECTION_STRING" ]] && { print_error 'Event hub connection string is required'; exit 1; }
-    [[ -z "$LOG_ANALYTICS_ENABLED" ]] && { LOG_ANALYTICS_ENABLED="false"; }
-    [[ "$LOG_ANALYTICS_ENABLED" == true ]] && \
-    {  [[ -z "$LOG_ANALYTICS_WORKSPACE_ID" ]] && { print_error 'Log Analytics Workspace ID is required'; exit 1; }; \
-       [[ -z "$LOG_ANALYTICS_SHARED_KEY" ]] && { print_error 'Log Analytics secret is required'; exit 1; }; \
-       [[ -z "$LOG_ANALYTICS_LOG_TYPE" ]] && { print_error 'Log Analytics Log Type is required'; exit 1; }; }
 
     echo 'Required parameters are provided'
 }
@@ -986,6 +971,16 @@ function validate_test_parameters() {
             print_error "Required test info."
             ((error++))
         fi
+
+        if [[ -z "$LOG_ANALYTICS_WORKSPACE_ID" ]]; then
+            print_error "Required log analytics workspace id"
+            ((error++))
+        fi
+
+        if [[ -z "$LOG_ANALYTICS_SHARED_KEY" ]]; then
+            print_error "Required log analytics shared key"
+            ((error++))
+        fi
     fi
 
     if (( error > 0 )); then
@@ -1033,10 +1028,8 @@ function usage() {
     echo ' -installRootCAKeyPassword         Optional password to access the root CA certificate private key to be used for certificate generation'
     echo ' -desiredModulesToRestartCSV       Optional CSV string of module names for long haul specifying what modules to restart. If specified, then "restartIntervalInMins" must be specified as well.'
     echo ' -restartIntervalInMins            Optional value for long haul specifying how often a random module will restart. If specified, then "desiredModulesToRestartCSV" must be specified as well.'
-    echo ' -logAnalyticsEnabled              Optional Log Analytics enable string for the Analyzer module. If logAnalyticsEnabled is set to enable (true), the rest of Log Analytics parameters must be provided.'
     echo ' -logAnalyticsWorkspaceId          Optional Log Analytics workspace ID for metrics collection and reporting.'
     echo ' -logAnalyticsSharedKey            Optional Log Analytics shared key for metrics collection and reporting.'
-    echo ' -logAnalyticsLogType              Optional Log Analytics log type for the Analyzer module.'
     echo ' -twinUpdateSize                   Specifies the char count (i.e. size) of each twin update. Default is 1 for long haul and 100 for stress test.'
     echo ' -twinUpdateFrequency              Frequency to make twin updates. This should be specified in DateTime format. Default is 00:00:15 for long haul and 00:00:05 for stress test.'
     echo ' -twinUpdateFailureThreshold       Specifies the longest period of time a twin update can take before being marked as a failure. This should be specified in DateTime format. Default is 00:01:00'

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -100,18 +100,12 @@
 
     .PARAMETER DpsMasterSymmetricKey
         DPS master symmetric key. Required only when using DPS symmetric key to provision the Edge device.
-    
-    .PARAMETER LogAnalyticsEnabled
-        Optional Log Analytics enable string for the Analyzer module. If LogAnalyticsEnabled is set to enable (true), the rest of Log Analytics parameters must be provided.
 
     .PARAMETER LogAnalyticsWorkspaceId
         Optional Log Analytics workspace ID for metrics collection and reporting.
 
     .PARAMETER LogAnalyticsSharedKey
         Optional Log Analytics shared key for metrics collection and reporting.
-
-    .PARAMETER LogAnalyticsLogType
-        Optional Log Analytics log type for the Analyzer module.
 
     .PARAMETER TwinUpdateSize
         Specifies the char count (i.e. size) of each twin update. Default is 1 for long haul and 100 for stress test.
@@ -286,14 +280,9 @@ Param (
     [ValidateSet("true", "false")]
     [string] $MqttSettingsEnabled = "true",
 
-    [ValidateSet("true", "false")]
-    [string] $LogAnalyticsEnabled = "false",
-
     [string] $LogAnalyticsWorkspaceId = $null,
 
     [string] $LogAnalyticsSharedKey = $null,
-
-    [string] $LogAnalyticsLogType = $null,
 
     [string] $TwinUpdateSize = $null,
 
@@ -485,8 +474,6 @@ Function PrepareTestFromArtifacts
 
                 (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.ConsumerGroupId>',$EventHubConsumerGroupId) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.EventHubConnectionString>',$EventHubConnectionString) | Set-Content $DeploymentWorkingFilePath
-                (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.LogAnalyticsEnabled>',$LogAnalyticsEnabled) | Set-Content $DeploymentWorkingFilePath
-                (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.LogAnalyticsLogType>',$LogAnalyticsLogType) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.TestInfo>',$TestInfo) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<LogAnalyticsWorkspaceId>',$LogAnalyticsWorkspaceId) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<LogAnalyticsSharedKey>',$LogAnalyticsSharedKey) | Set-Content $DeploymentWorkingFilePath
@@ -1490,6 +1477,8 @@ Function ValidateTestParameters
         If ([string]::IsNullOrEmpty($SnitchStorageMasterKey)) {Throw "Required snitch storage master key."}
         If ($ProxyUri) {Throw "Proxy not supported for $TestName test"}
         If ([string]::IsNullOrEmpty($TestInfo)) {Throw "Required test info."}
+        If ([string]::IsNullOrEmpty($LogAnalyticsWorkspaceId)) {Throw "Required log analytics workspace id."}
+        If ([string]::IsNullOrEmpty($LogAnalyticsSharedKey)) {Throw "Required log analytics shared key."}
     }
 }
 

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -301,6 +301,8 @@ Param (
 
     [string] $TwinUpdateFailureThreshold = $null,
 
+    [string] $TestInfo = $null,
+
     [switch] $BypassEdgeInstallation
 )
 
@@ -485,6 +487,7 @@ Function PrepareTestFromArtifacts
                 (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.EventHubConnectionString>',$EventHubConnectionString) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.LogAnalyticsEnabled>',$LogAnalyticsEnabled) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.LogAnalyticsLogType>',$LogAnalyticsLogType) | Set-Content $DeploymentWorkingFilePath
+                (Get-Content $DeploymentWorkingFilePath).replace('<Analyzer.TestInfo>',$TestInfo) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<LogAnalyticsWorkspaceId>',$LogAnalyticsWorkspaceId) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<LogAnalyticsSharedKey>',$LogAnalyticsSharedKey) | Set-Content $DeploymentWorkingFilePath
                 (Get-Content $DeploymentWorkingFilePath).replace('<LoadGen.MessageFrequency>',$LoadGenMessageFrequency) | Set-Content $DeploymentWorkingFilePath
@@ -1486,6 +1489,7 @@ Function ValidateTestParameters
         If ([string]::IsNullOrEmpty($SnitchStorageAccount)) {Throw "Required snitch storage account."}
         If ([string]::IsNullOrEmpty($SnitchStorageMasterKey)) {Throw "Required snitch storage master key."}
         If ($ProxyUri) {Throw "Proxy not supported for $TestName test"}
+        If ([string]::IsNullOrEmpty($TestInfo)) {Throw "Required test info."}
     }
 }
 


### PR DESCRIPTION
We need to see the contextual longhaul / stress test information in the dashboard.

Cherry picking the following commits from master:
#2359 
#2564 
#2571
#2585 
#2574 
#2589 
#2598 
#2595 