### PR TITLE
Longhaul/Stress: Remove unused env var from analyzer

### DIFF
--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -267,17 +267,11 @@
               "ConsumerGroupId": {
                 "value": "<Analyzer.ConsumerGroupId>"
               },
-              "LogAnalyticsEnabled": {
-                "value": "<Analyzer.LogAnalyticsEnabled>"
-              },
               "LogAnalyticsWorkspaceId": {
                 "value": "<LogAnalyticsWorkspaceId>"
               },
               "LogAnalyticsSharedKey": {
                 "value": "<LogAnalyticsSharedKey>"
-              },
-              "LogAnalyticsLogType": {
-                "value": "<Analyzer.LogAnalyticsLogType>"
               },
               "Logging:LogLevel:Microsoft": {
                 "value": "Error"

--- a/e2e_deployment_files/long_haul_deployment.template.windows.json
+++ b/e2e_deployment_files/long_haul_deployment.template.windows.json
@@ -270,17 +270,11 @@
               "ConsumerGroupId": {
                 "value": "<Analyzer.ConsumerGroupId>"
               },
-              "LogAnalyticsEnabled": {
-                "value": "<Analyzer.LogAnalyticsEnabled>"
-              },
               "LogAnalyticsWorkspaceId": {
                 "value": "<LogAnalyticsWorkspaceId>"
               },
               "LogAnalyticsSharedKey": {
                 "value": "<LogAnalyticsSharedKey>"
-              },
-              "LogAnalyticsLogType": {
-                "value": "<Analyzer.LogAnalyticsLogType>"
               },
               "Logging:LogLevel:Microsoft": {
                 "value": "Error"

--- a/e2e_deployment_files/stress_deployment.template.json
+++ b/e2e_deployment_files/stress_deployment.template.json
@@ -291,17 +291,11 @@
               "ConsumerGroupId": {
                 "value": "<Analyzer.ConsumerGroupId>"
               }, 
-              "LogAnalyticsEnabled": {
-                "value": "<Analyzer.LogAnalyticsEnabled>"
-              },
               "LogAnalyticsWorkspaceId": {
                 "value": "<LogAnalyticsWorkspaceId>"
               },
               "LogAnalyticsSharedKey": {
                 "value": "<LogAnalyticsSharedKey>"
-              },
-              "LogAnalyticsLogType": {
-                "value": "<Analyzer.LogAnalyticsLogType>"
               },
               "Logging:LogLevel:Microsoft": {
                 "value": "Error"

--- a/e2e_deployment_files/stress_deployment.template.windows.json
+++ b/e2e_deployment_files/stress_deployment.template.windows.json
@@ -294,17 +294,11 @@
               "ConsumerGroupId": {
                 "value": "<Analyzer.ConsumerGroupId>"
               }, 
-              "LogAnalyticsEnabled": {
-                "value": "<Analyzer.LogAnalyticsEnabled>"
-              },
               "LogAnalyticsWorkspaceId": {
                 "value": "<LogAnalyticsWorkspaceId>"
               },
               "LogAnalyticsSharedKey": {
                 "value": "<LogAnalyticsSharedKey>"
-              },
-              "LogAnalyticsLogType": {
-                "value": "<Analyzer.LogAnalyticsLogType>"
               },
               "Logging:LogLevel:Microsoft": {
                 "value": "Error"


### PR DESCRIPTION
There is an unused env var in our deployment templates.