### PR TITLE
[k8s][public preview] Cherry-pick Add "Cmd", "Entrypoint", and "WorkingDir" translations (#2629)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CreatePodParameters.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CreatePodParameters.cs
@@ -17,8 +17,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             IDictionary<string, EmptyStruct> exposedPorts,
             HostConfig hostConfig,
             string image,
-            IDictionary<string, string> labels)
-            : this(env?.ToList(), exposedPorts, hostConfig, image, labels, null, null, null, null)
+            IDictionary<string, string> labels,
+            IEnumerable<string> cmd,
+            IEnumerable<string> entrypoint,
+            string workingDir)
+            : this(env?.ToList(), exposedPorts, hostConfig, image, labels, cmd?.ToList(), entrypoint?.ToList(), workingDir, null, null, null, null)
         {
         }
 
@@ -29,6 +32,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             HostConfig hostConfig,
             string image,
             IDictionary<string, string> labels,
+            IReadOnlyList<string> cmd,
+            IReadOnlyList<string> entrypoint,
+            string workingDir,
             IDictionary<string, string> nodeSelector,
             V1ResourceRequirements resources,
             IReadOnlyList<KubernetesModuleVolumeSpec> volumes,
@@ -39,6 +45,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             this.HostConfig = Option.Maybe(hostConfig);
             this.Image = Option.Maybe(image);
             this.Labels = Option.Maybe(labels);
+            this.Cmd = Option.Maybe(cmd);
+            this.Entrypoint = Option.Maybe(entrypoint);
+            this.WorkingDir = Option.Maybe(workingDir);
             this.NodeSelector = Option.Maybe(nodeSelector);
             this.Resources = Option.Maybe(resources);
             this.Volumes = Option.Maybe(volumes);
@@ -51,11 +60,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             HostConfig hostConfig = null,
             string image = null,
             IDictionary<string, string> labels = null,
+            IReadOnlyList<string> cmd = null,
+            IReadOnlyList<string> entrypoint = null,
+            string workingDir = null,
             IDictionary<string, string> nodeSelector = null,
             V1ResourceRequirements resources = null,
             IReadOnlyList<KubernetesModuleVolumeSpec> volumes = null,
             V1PodSecurityContext securityContext = null)
-            => new CreatePodParameters(env, exposedPorts, hostConfig, image, labels, nodeSelector, resources, volumes, securityContext);
+            => new CreatePodParameters(env, exposedPorts, hostConfig, image, labels, cmd, entrypoint, workingDir, nodeSelector, resources, volumes, securityContext);
 
         [JsonProperty("env", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<IReadOnlyList<string>>))]
@@ -92,5 +104,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         [JsonProperty("securityContext", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<V1PodSecurityContext>))]
         public Option<V1PodSecurityContext> SecurityContext { get; set; }
+
+        [JsonProperty("cmd", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<IReadOnlyList<string>>))]
+        public Option<IReadOnlyList<string>> Cmd { get; }
+
+        [JsonProperty("entrypoint", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<IReadOnlyList<string>>))]
+        public Option<IReadOnlyList<string>> Entrypoint { get; }
+
+        [JsonProperty("workingDir", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<string>))]
+        public Option<string> WorkingDir { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -180,7 +180,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
                 VolumeMounts = volumeMounts,
                 SecurityContext = securityContext.OrDefault(),
                 Ports = exposedPorts.OrDefault(),
-                Resources = module.Config.CreateOptions.Resources.OrDefault()
+                Resources = module.Config.CreateOptions.Resources.OrDefault(),
+                Command = module.Config.CreateOptions.Entrypoint.Map(list => list.ToList()).OrDefault(),
+                Args = module.Config.CreateOptions.Cmd.Map(list => list.ToList()).OrDefault(),
+                WorkingDir = module.Config.CreateOptions.WorkingDir.OrDefault(),
             };
 
             return (container, volumes);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -562,6 +562,77 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         }
 
         [Fact]
+        public void NoCmdOptionsNoContainerArgs()
+        {
+            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.Some(new AuthConfig("user-registry1")));
+            var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
+            var labels = new Dictionary<string, string>();
+            var mapper = CreateMapper();
+
+            var deployment = mapper.CreateDeployment(identity, module, labels);
+
+            var container = deployment.Spec.Template.Spec.Containers.Single(c => c.Name == "module1");
+            Assert.Null(container.Args);
+            Assert.Null(container.Command);
+            Assert.Null(container.WorkingDir);
+        }
+
+        [Fact]
+        public void CmdOptionsContainerArgs()
+        {
+            var cmd = new List<string> { "argument1", "argument2" };
+            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var config = new KubernetesConfig("image", CreatePodParameters.Create(cmd: cmd), Option.Some(new AuthConfig("user-registry1")));
+            var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
+            var labels = new Dictionary<string, string>();
+            var mapper = CreateMapper();
+
+            var deployment = mapper.CreateDeployment(identity, module, labels);
+
+            var container = deployment.Spec.Template.Spec.Containers.Single(c => c.Name == "module1");
+            Assert.NotNull(container.Args);
+            Assert.Equal(2, container.Args.Count);
+            Assert.Equal("argument1", container.Args[0]);
+            Assert.Equal("argument2", container.Args[1]);
+        }
+
+        [Fact]
+        public void EntrypointOptionsContainerCommands()
+        {
+            var entrypoint = new List<string> { "command", "argument-a" };
+            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var config = new KubernetesConfig("image", CreatePodParameters.Create(entrypoint: entrypoint), Option.Some(new AuthConfig("user-registry1")));
+            var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
+            var labels = new Dictionary<string, string>();
+            var mapper = CreateMapper();
+
+            var deployment = mapper.CreateDeployment(identity, module, labels);
+
+            var container = deployment.Spec.Template.Spec.Containers.Single(c => c.Name == "module1");
+            Assert.NotNull(container.Command);
+            Assert.Equal(2, container.Command.Count);
+            Assert.Equal("command", container.Command[0]);
+            Assert.Equal("argument-a", container.Command[1]);
+        }
+
+        [Fact]
+        public void WorkingDirOptionsContainerWorkingDir()
+        {
+            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var config = new KubernetesConfig("image", CreatePodParameters.Create(workingDir: "/tmp/working"), Option.Some(new AuthConfig("user-registry1")));
+            var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
+            var labels = new Dictionary<string, string>();
+            var mapper = CreateMapper();
+
+            var deployment = mapper.CreateDeployment(identity, module, labels);
+
+            var container = deployment.Spec.Template.Spec.Containers.Single(c => c.Name == "module1");
+            Assert.NotNull(container.WorkingDir);
+            Assert.Equal("/tmp/working", container.WorkingDir);
+        }
+
+        [Fact]
         public void EdgeAgentEnvSettingsHaveLotsOfStuff()
         {
             var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "$edgeAgent", Mock.Of<ICredentials>());


### PR DESCRIPTION
Make  "Cmd", "Entrypoint", and "WorkingDir" of DockerOptions available in CombinedKubernetesConfig, and translate them to k8s options on the module container.