### PR TITLE
Backport CentOS fixes to 1.0.9

### DIFF
--- a/builds/misc/packages.slow.yaml
+++ b/builds/misc/packages.slow.yaml
@@ -1,0 +1,71 @@
+# This is like packages.yaml, but for packages that are much slower to build.
+# This runs independently of the packages.yaml job so that it does not impact other jobs that use the packages.yaml artifacts, like E2E test runs.
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - master
+pr: none
+variables:
+  REVISION: '1'
+jobs:
+
+################################################################################
+  - job: linux
+################################################################################
+    displayName: Linux
+    timeoutInMinutes: 180 # Observed to take just under 2h30m, so round up
+    pool:
+      # qemu on ubuntu-16.04 is too old to support some syscalls used by CentOS 7 containers, so ensure this is ubuntu-18.04 or newer.
+      vmImage: 'ubuntu-18.04'
+    strategy:
+      matrix:
+        Centos75-arm32v7:
+          arch: arm32v7
+          os: centos7
+          target.iotedged: edgelet/target/rpmbuild/RPMS/armv7hl
+        Centos75-aarch64:
+          arch: aarch64
+          os: centos7
+          target.iotedged: edgelet/target/rpmbuild/RPMS/aarch64
+    steps:
+      # Ensure any changes here are replicated in packages.yaml
+
+      - bash: |
+          BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+          VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
+          echo "##vso[task.setvariable variable=VERSION;]$VERSION"
+
+          echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
+          echo "##vso[task.setvariable variable=PACKAGE_OS;]$(os)"
+        displayName: Set Version
+      - bash: |
+          sudo apt-get update &&
+          sudo apt-get install qemu-user-static
+        displayName: Install qemu-arm-static and qemu-aarch64-static for CentOS7 builds
+        condition: and(succeeded(), eq(variables.os, 'centos7'), ne(variables.arch, 'amd64'))
+      - script: edgelet/build/linux/package.sh
+        displayName: Create libiothsm and iotedged packages
+      - task: CopyFiles@2
+        displayName: Copy libiothsm Files to Artifact Staging
+        inputs:
+          SourceFolder: edgelet/target/hsm
+          Contents: |
+            *.deb
+            *.rpm
+          TargetFolder: '$(build.artifactstagingdirectory)'
+      - task: CopyFiles@2
+        displayName: Copy iotedged Files to Artifact Staging
+        inputs:
+          SourceFolder: $(target.iotedged)
+          Contents: |
+            *.deb
+            *.rpm
+          TargetFolder: '$(build.artifactstagingdirectory)'
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts
+        inputs:
+          PathtoPublish: '$(build.artifactstagingdirectory)'
+          ArtifactName: 'iotedged-$(os)-$(arch)'
+        condition: succeededOrFailed()

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -22,14 +22,7 @@ jobs:
           arch: amd64
           os: centos7
           target.iotedged: edgelet/target/rpmbuild/RPMS/x86_64
-        Centos75-arm32v7:
-          arch: arm32v7
-          os: centos7
-          target.iotedged: edgelet/target/rpmbuild/RPMS/armv7hl
-        Centos75-aarch64:
-          arch: aarch64
-          os: centos7
-          target.iotedged: edgelet/target/rpmbuild/RPMS/aarch64
+        # Centos75-arm32v7 and Centos75-aarch64 are built in packages.slow.yaml
 
         Debian8-amd64:
           os: debian8
@@ -97,6 +90,8 @@ jobs:
           arch: aarch64
           target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
     steps:
+      # Ensure any changes here are replicated in packages.slow.yaml
+
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"

--- a/edgelet/build/linux/package.sh
+++ b/edgelet/build/linux/package.sh
@@ -13,7 +13,7 @@ REVISION="${REVISION:-1}"
 DEFAULT_VERSION="$(cat "$PROJECT_ROOT/version.txt")"
 VERSION="${VERSION:-$DEFAULT_VERSION}"
 
-CMAKE_ARGS='-DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1 -DCMAKE_BUILD_TYPE=Release'
+CMAKE_ARGS='-DCMAKE_BUILD_TYPE=Release'
 CMAKE_ARGS="$CMAKE_ARGS -DBUILD_SHARED=On -Drun_unittests=Off -Duse_default_uuid=On -Duse_emulator=Off -Duse_http=Off"
 
 DOCKER_VOLUME_MOUNTS=''
@@ -260,6 +260,10 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
             echo \'[target.armv7-unknown-linux-gnueabihf]\' > ~/.cargo/config &&
             echo \'linker = "arm-linux-gnueabihf-gcc"\' >> ~/.cargo/config &&
         '
+
+        # Indicate to cmake that we're cross-compiling
+        CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1"
+
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_SYSROOT=/toolchain/arm-linux-gnueabihf/libc"
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_C_COMPILER=/toolchain/bin/arm-linux-gnueabihf-gcc"
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_CXX_COMPILER=/toolchain/bin/arm-linux-gnueabihf-g++"
@@ -282,6 +286,10 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
             export ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_LIB_DIR=/usr/lib/arm-linux-gnueabihf &&
             export ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR=/usr/include &&
         '
+
+        # Indicate to cmake that we're cross-compiling
+        CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1"
+
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc"
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++"
         ;;
@@ -303,6 +311,10 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
             export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu &&
             export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR=/usr/include &&
         '
+
+        # Indicate to cmake that we're cross-compiling
+        CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1"
+
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc"
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++"
         ;;
@@ -360,6 +372,9 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
             export ARMV7_UNKNOWN_LINUX_GNUEABIHF_OPENSSL_INCLUDE_DIR=/usr/include &&
         "
 
+        # Indicate to cmake that we're cross-compiling
+        CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1"
+
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc"
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++"
         ;;
@@ -405,6 +420,10 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
             export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu &&
             export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR=/usr/include &&
         "
+
+        # Indicate to cmake that we're cross-compiling
+        CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_SYSTEM_NAME=Linux -DCMAKE_SYSTEM_VERSION=1"
+
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc"
         CMAKE_ARGS="$CMAKE_ARGS -DCMAKE_CXX_COMPILER=aarch64-linux-gnu-g++"
         ;;
@@ -472,8 +491,6 @@ esac
 
 
 mkdir -p "$LIBIOTHSM_BUILD_DIR"
-
-echo "$DOCKER_VOLUME_MOUNTS"
 
 docker run --rm \
     --user root \

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -30,9 +30,18 @@ The packages are built inside a Docker container, so no build dependencies are i
 
 Note that the script must be run on an `amd64` device. The `PACKAGE_ARCH=arm32v7` and `PACKAGE_ARCH=aarch64` builds are done using a cross-compiler.
 
-Once the packages are built, they will be found somewhere under the `edgelet/target/` directory. (The exact path under that directory depends on the combination of `PACKAGE_OS` and `PACKAGE_ARCH`. See `builds/misc/packages.yaml` for the exact paths.)
+Once the packages are built, they will be found somewhere under the `edgelet/target/` directory. (The exact path under that directory depends on the combination of `PACKAGE_OS` and `PACKAGE_ARCH`. See `builds/misc/packages.yaml` and `builds/misc/packages.slow.yaml` for the exact paths.)
 
 If you want to run another build for a different combination of `PACKAGE_OS` and `PACKAGE_ARCH`, make sure to clean the repository first with `sudo git clean -xffd` so that artifacts from the previous build don't get reused for the next one.
+
+Note: For the following targets, `qemu-user-static` must be installed on the host and registered with `binfmt`:
+
+- `PACKAGE_OS=centos7 PACKAGE_ARCH=arm32v7`
+- `PACKAGE_OS=centos7 PACKAGE_ARCH=aarch64`
+
+If that has not been done, `package.sh` prints an error message explaining how to do that.
+
+This is because these targets do not have functional cross-compilers, so their builds are done as native builds emulated using qemu. Be aware that these builds are much slower - where a native build might take 15m, a qemu build might take 2h30m.
 
 
 ### Windows

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -1,163 +1,269 @@
 # IoT Edge Security Daemon - Dev Guide
 
-## Building
-The daemon is written in [Rust](https://www.rust-lang.org/en-US/). Rust uses two cli tools for its build: rustup and cargo.
+There are two options for building the IoT Edge Security Daemon.
 
-### Rustup
-Rustup is rust's toolchain manager. Rust ships stable, beta, and nightly versions of the compiler and standard library.
-This project uses stable, but some of the tooling uses the nightly compiler. Rustup is used to update the compiler, and
-switch the active toolchain. You will use rustup infrequently.
+1. Build the OS packages. If you just want to build something that you can install on your device, and are not making frequent changes to the daemon's source code, you probably want this option.
 
-To install rustup, visit [https://www.rustup.rs](https://www.rustup.rs/) and follow the instructions.
+1. Build the daemon binaries. If you want to make frequent changes to the daemon's source code and run it without installing it, you probably want this option.
 
-To install or update the compiler:
+
+## Building OS packages
+
+### Linux
+
+Linux packages are built using the `edgelet/build/linux/package.sh` script. Set the following environment variables, then invoke the script:
+
+1. `PACKAGE_OS`: This is the OS on which the resulting packages will be installed. It should be one of `centos7`, `debian8`, `debian9`, `debian10`, `ubuntu16.04` or `ubuntu18.04`
+
+1. `PACKAGE_ARCH`: This is the architecture of the OS on which the resulting packages will be installed. It should be one of `amd64`, `arm32v7` or `aarch64`.
+
+For example:
+
+```sh
+git clone --recurse-submodules 'https://github.com/Azure/iotedge'
+cd iotedge/
+
+PACKAGE_OS='debian10' PACKAGE_ARCH='arm32v7' ./edgelet/build/linux/package.sh
 ```
-rustup update stable
+
+The packages are built inside a Docker container, so no build dependencies are installed on the device running the script. However the user running the script does need to have permissions to invoke the `docker` command.
+
+Note that the script must be run on an `amd64` device. The `PACKAGE_ARCH=arm32v7` and `PACKAGE_ARCH=aarch64` builds are done using a cross-compiler.
+
+Once the packages are built, they will be found somewhere under the `edgelet/target/` directory. (The exact path under that directory depends on the combination of `PACKAGE_OS` and `PACKAGE_ARCH`. See `builds/misc/packages.yaml` for the exact paths.)
+
+If you want to run another build for a different combination of `PACKAGE_OS` and `PACKAGE_ARCH`, make sure to clean the repository first with `sudo git clean -xffd` so that artifacts from the previous build don't get reused for the next one.
+
+
+### Windows
+
+See "Building daemon binaries" below.
+
+
+## Building daemon binaries
+
+### Dependencies
+
+The daemon is written in [Rust,](https://www.rust-lang.org/) so you will need an installation of the Rust compiler. It is recommended to use [`rustup`](https://www.rustup.rs/) to install a Rust toolchain. For Linux, some distributions have their own packages for `rustc` and `cargo`, but these might not match the toolchain used by our code and may fail to build it.
+
+After installing `rustup`, or if you already have it installed, install the toolchain that will be used to build the daemon binaries.
+
+```sh
+rustup self update   # Update rustup itself to the latest version
+
+git clone --recurse-submodules 'https://github.com/Azure/iotedge'
+cd iotedge/edgelet/
+
+rustup update   # Install / update the toolchain used to build the daemon binaries.
+                # This is controlled by the rust-toolchain file in this directory.
+                # For the master branch, this is the latest "stable" toolchain.
+                # For release branches, this is a pinned Rust release.
 ```
 
-### Additional Dependencies
+In addition, building the daemon binaries also requires these dependencies to be installed:
 
-#### Linux
+#### CentOS 7
 
-```bash
-sudo apt-get update
-sudo apt-get install -y git cmake build-essential curl libcurl4-openssl-dev libssl-dev uuid-dev pkg-config
+```sh
+yum update
+yum install \
+    cmake curl git make rpm-build \
+    gcc gcc-c++ \
+    libcurl-devel libuuid-devel openssl-devel
 ```
 
-### macOS
+#### Debian 8-10, Ubuntu 16.04, Ubuntu 18.04
 
-1. Install necessary tools for development using [Homebrew](https://brew.sh/) package manager
-    ```bash
+```sh
+apt-get update
+apt-get install \
+    binutils build-essential ca-certificates curl cmake debhelper dh-systemd file git make \
+    gcc g++ pkg-config \
+    libcurl4-openssl-dev libssl-dev uuid-dev
+```
+
+#### macOS
+
+1. Install the dependencies using [Homebrew](https://brew.sh/) package manager
+
+    ```sh
     brew update
     brew install cmake openssl
     ```
 
-1. Set `OPENSSL_ROOT_DIR`
-    ```bash
-    export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
+1. Set the `OPENSSL_DIR` and `OPENSSL_ROOT_DIR` environment variables to point to the local openssl installation.
+
+    ```sh
     export OPENSSL_DIR=/usr/local/opt/openssl
+    export OPENSSL_ROOT_DIR=/usr/local/opt/openssl
     ```
 
 #### Windows
 
+1. Install Visual Studio 2017 / 2019, or the Build Tools for Visual Studio 2017 / 2019. Ensure the components for building C / C++ are installed.
+
+1. Install `cmake` from <https://cmake.org/> or with [`choco`](https://chocolatey.org/) or [`scoop`.](https://scoop.sh/) Ensure `cmake` is in `PATH` after installation.
+
 1. Install `vcpkg`
 
-	```powershell
-	git clone https://github.com/Microsoft/vcpkg
-	cd vcpkg
-	.\bootstrap-vcpkg.bat
-	```
+    ```powershell
+    git clone https://github.com/Microsoft/vcpkg
+    cd vcpkg
+    .\bootstrap-vcpkg.bat
+    ```
 
-1. Install openssl binaries
+1. Install openssl
 
-	```powershell
-	.\vcpkg install openssl:x64-windows
-	```
+    ```powershell
+    .\vcpkg install openssl:x64-windows
+    ```
 
-1. Set `OPENSSL_ROOT_DIR`
+1. Set the `OPENSSL_DIR` and `OPENSSL_ROOT_DIR` environment variables to point to the local openssl installation.
 
-	```powershell
-	$env:OPENSSL_ROOT_DIR = "$PWD\installed\x64-windows"
-	$env:OPENSSL_DIR = "$PWD\installed\x64-windows"
-	```
+    ```powershell
+    # $PWD is the root of the vcpkg repository
 
-### Cargo
-Cargo is the build tool for rust. You will use cargo frequently. It manages the build of the project, downloading dependencies,
-testing, etc. You can read more about cargo and it's capabilities in the [cargo book](https://doc.rust-lang.org/cargo/).
+    $env:OPENSSL_DIR = "$PWD\installed\x64-windows"
+    $env:OPENSSL_ROOT_DIR = "$PWD\installed\x64-windows"
+    ```
 
-#### Building
+
+### Build
+
 To build the project, use:
-```
-cargo build --all
+
+```sh
+cd edgelet/
+
+cargo build -p iotedged -p iotedge
 ```
 
-#### Testing
-To test the project, use:
-```
+This will create `iotedged` and `iotedge` binaries under `edgelet/target/debug`
+
+
+### Run
+
+To run `iotedged` locally:
+
+1. Create a directory that it will use as its home directory, such as `~/iotedge`
+
+    - Linux / macOS
+
+        ```sh
+        export IOTEDGE_HOMEDIR=~/iotedge
+        mkdir -p "$IOTEDGE_HOMEDIR"
+        ```
+
+    - Windows
+
+        ```powershell
+        $env:IOTEDGE_HOMEDIR = Resolve-Path ~/iotedge
+        New-Item -Type Directory -Force $env:IOTEDGE_HOMEDIR
+        ```
+
+1. Create a `config.yaml`. It's okay to create this under the `IOTEDGE_HOMEDIR` directory.
+
+1. Run the daemon with the `IOTEDGE_HOMEDIR` environment variable set and with the path to the `config.yaml`
+
+    ```sh
+    cargo run -p iotedged -- -c /absolute/path/to/config.yaml
+    ```
+
+
+### Run tests
+
+```sh
 cargo test --all
 ```
 
+
 ### Additional Tools
-Rust has a few tools that help in day to day development.
 
-Note: on older installations of Rust, these components may not be available.  You will need to update rustup, and reinstall the stable toolchain:
-```
-rustup self update
-rustup uninstall stable
-rustup install stable
-```
+- rustfmt
 
-#### Cargo Fmt
-Cargo supports a formatting tool to automatically format the source code.
+    This tool automatically formats the Rust source code. Our checkin gates assert that the code is correctly formatted.
 
-Install it with:
-```
-rustup component add rustfmt
-```
+    Install it with:
 
-Run it with:
-```
-cargo fmt --all
-```
+    ```sh
+    cd edgelet/
 
-By default, this will update the source files with newly formatted source files. Cargo fmt is also run as a checkin
-gate to prevent code from being checked in that doesn't meet the style guidelines.
+    rustup component add rustfmt
+    ```
 
-#### Cargo Clippy
-Clippy is a linting tool for rust. It provides suggestions for more idiomatic rust code.
+    To format the source code, run:
 
-Install it with:
-```
-rustup component add clippy
-```
+    ```sh
+    cargo fmt --all
+    ```
 
-Run it with:
-```
-cargo clippy --all
-cargo clippy --all --tests
-cargo clippy --all --examples
-```
+    To verify the source code is already correctly formatted, run:
 
-Clippy is also run as a checkin gate.
+    ```sh
+    cargo fmt --all -- --check
+    ```
 
-### Swagger
+- clippy
 
-#### Definitions
+    This is a Rust linter. It provides suggestions for more idiomatic Rust code and detects some common mistakes. Our checkin gates assert that clippy raises no warnings or errors when run against the code.
 
-We use YAML for our swagger definitions. You can edit the definitions in VS code, but https://editor.swagger.io is also an invaluable tool for validation, converting YAML -> JSON for code-gen, etc.
+    Install it with:
 
-#### Code generation
+    ```sh
+    cd edgelet/
 
-We use a modified version of `swagger-codegen` to generate code from our swagger definitions. To build the tool:
+    rustup component add clippy
+    ```
 
-```
-git clone -b support-rust-uds  https://github.com/avranju/swagger-codegen.git
-cd swagger-codegen
-mvn clean package
-```
+    Run it with:
 
-To run the tool, for example to update our workload API:
+    ```sh
+    cargo clippy --all
+    cargo clippy --all --tests
+    cargo clippy --all --examples
+    ```
 
-```
-java -jar swagger-codegen-cli.jar generate -i api/workload.yaml -l rust -o {root}/edgelet/workload
-```
+- Swagger
 
-> Note that `cargo fmt` and `cargo clippy` will complain about the code produced by this tool. We like to keep **all** code in our repo clean, so you'll want to run clippy and fmt over the generated code, make the recommended changes, and carefully inspect the diffs of modified files before checking in.
+    Some of our source code is generated from swagger definitions stored as YAML.
 
-## IDE
-VS Code has good support for rust. Consider installing the following extensions:
+    You can edit the definitions in VS code, but https://editor.swagger.io is also an invaluable tool for validation, converting YAML -> JSON for code-gen, etc.
 
-* [Rust](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust) - Syntax highlighting and intellisense support
-* [Better TOML](https://marketplace.visualstudio.com/items?itemName=bungcip.better-toml) - Syntax highlighting for Cargo.toml
-* [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) - Native debugger support
-* [Vim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) - For a more sophisticated editor experience :)
+    We use a modified version of `swagger-codegen` to generate code from the swagger definitions. To build the tool:
 
-There is a `launch.json` configuration in this repo to setup debugging on Windows. This should work out of the box.
+    ```sh
+    git clone -b support-rust-uds https://github.com/avranju/swagger-codegen.git
+    cd swagger-codegen
+    mvn clean package
+    ```
 
-## Test IoT Edge daemon API endpoints on dev machine
+    To run the tool, for example to update our workload API:
+
+    ```sh
+    java -jar swagger-codegen-cli.jar generate -i api/workload.yaml -l rust -o {root}/edgelet/workload
+    ```
+
+    Note that we've manually fixed up the generated code so that it satisfies rustfmt and clippy. As such, if you ever need to run `swagger-codegen-cli` against new definitions, or need to regenerate existing ones, you will want to perform the same fixups manually. Make sure to run clippy and rustfmt against the new code yourself, and inspect the diffs of modified files before checking in.
+
+- IDE
+
+    [VS Code](https://code.visualstudio.com/) has good support for Rust. Consider installing the following extensions:
+
+    * [Rust (rls)](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust) - Syntax highlighting and Intellisense support
+    * [Better TOML](https://marketplace.visualstudio.com/items?itemName=bungcip.better-toml) - Syntax highlighting for `Cargo.toml`
+    * [C/C++](https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools) - Native debugger support
+    * [Vim](https://marketplace.visualstudio.com/items?itemName=vscodevim.vim) - For a more sophisticated editor experience :)
+
+    Alternatively, [IntelliJ IDEA Community Edition](https://www.jetbrains.com/idea/) with the [Rust plugin](https://intellij-rust.github.io/) provides a full IDE experience for programming in Rust.
+
+
+### Test IoT Edge daemon API endpoints
+
 If you would like to know how to test IoT Edge daemon API endpoints on dev machine, please read from [here](testiotedgedapi.md).
 
-## Other
 
-* [The Book](https://doc.rust-lang.org/book/second-edition/index.html) - The Rust Programming Language
-* [RUST Api Guidelines](https://rust-lang-nursery.github.io/api-guidelines/) - Guidelines on naming conventions, organization, etc.
+## References
+
+* [The Rust Programming Language Book](https://doc.rust-lang.org/book/second-edition/index.html)
+
+* [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) - Guidelines on naming conventions, organization, function semantics, etc.


### PR DESCRIPTION
- 20b5f1fbd4aa350f2645d3b717e6ef51908feb8a

    Update edgelet devguide. (#2428)
    
    - Talk about building the packages as an alternative to building the binaries.
    
      Discussed in https://github.com/Azure/iotedge/pull/2301
    
    - Building binaries on Windows requires VS / VSBT and cmake.
    
    - Both `OPENSSL_DIR` and `OPENSSL_ROOT_DIR` need to be set for
      macOS and Windows.
    
    - Take into account that builds don't necessarily use "stable", but whatever
      happens to be in the rust-toolchain file.
    
    - `cargo build --all` spends time building Kubernetes dependencies.
      `cargo build -p iotedged -p iotedge` is sufficient.
    
    - Talk about how to actually run the binaries.
    
    - Update some URLs, such as from the merger of the rust-lang-nursery and
      rust-lang GitHub orgs.

- 958e4b05622a429bed08547f6e7915bc4a25fe0e

    Fix CentOS arm32v7 and aarch64 packages to depend on correct openssl sonames. (#2518)
    
    Before this change, these two targets were built using Linaro compilers
    and against custom-compiled openssl. However the packages built this way
    ended up depending on `libcrypto.so.1.0.0` and `libssl.so.1.0.0`,
    whereas CentOS's openssl-libs package provides `libcrypto.so.10` and
    `libssl.so.10`
    
    Since CentOS 7 does not ship cross-compiler packages and openssl,
    this commit changes the build steps to run the native arm32v7 and arm64v8
    CentOS Docker containers in qemu instead of cross-compiling.
    
    Since qemu builds are very slow (2h30m instead of 15m), this commit moves them
    to a new pipeline job so that it does not block existing downstream jobs like
    E2E tests that don't need the CentOS packages.
    
    Lastly, the new job runs on Ubuntu 18.04 hosts instead of Ubuntu 16.04 hosts.
    Ubuntu 16.04 supports getrandom, but its qemu is just old enough to
    not implement it, which breaks processes inside the container that require it.
    
    Fixes #2398

- fd2dc5a670fc05d2fbc111fd8a3256251869bfe5

    Fix libiothsm-std centos7-amd64 and centos7-aarch64 packages to install to /usr/lib64. (#2625)
    
    c1e2d5e93bf08d5b2ea7e52ab2bd8957652a7e88 defined CMAKE_SYSTEM_NAME and
    CMAKE_SYSTEM_VERSION for all targets, however this breaks
    GNUInstallDirs.cmake's detection of the system architecture, so it doesn't
    realize CentOS amd64's libdir is /usr/lib64. Instead it defaults to /usr/lib,
    which causes the libiothsm-std package to install libiothsm.so to /usr/lib and
    causes iotedged to fail to find it.
    
    Before the package.sh refactoring, `CMAKE_SYSTEM_NAME` and
    `CMAKE_SYSTEM_VERSION` were only defined for arm32 and aarch64 targets,
    via 0dac12c17f03261c2a2979d09457327012e44f91. So this commit restores that
    behavior.
    
    For CentOS specifically, we also don't want to define `CMAKE_SYSTEM_NAME` and
    `CMAKE_SYSTEM_VERSION` for the arm32v7 and aarch64 builds anyway,
    because they're only supposed to be defined when cross-compiling, whereas
    the CentOS arm32v7 and aarch64 builds run natively (via qemu).