### PR TITLE
Make Kodiak to add Co-authored-by in commit body for squash merges

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -30,5 +30,8 @@ title = "pull_request_title" # default: "github_default"
 # use body of PR for merge commit.
 body = "pull_request_body" # default: "github_default"
 
+# Add the pull request author as a coauthor of the merge commit using
+include_pull_request_author = true # default: false
+
 # remove html comments to auto remove PR templates.
 strip_html_comments = true # default: false


### PR DESCRIPTION
GitHub API changed recently in a way that Kodiak is shown as an author of the squashed merge commit.
Added config parameter that forces Kodiak to add `Co-authored-by` in a commit body for squash merges.