### PR TITLE
EdgeHub to module messages: Make module response timeout configurable

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
@@ -11,18 +11,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     {
         readonly IConnectionManager connectionManager;
         readonly IEdgeHub edgeHub;
-        readonly TimeSpan messageResponseTimeout;
+        readonly TimeSpan messageAckTimeout;
 
-        public ConnectionProvider(IConnectionManager connectionManager, IEdgeHub edgeHub, TimeSpan messageResponseTimeout)
+        public ConnectionProvider(IConnectionManager connectionManager, IEdgeHub edgeHub, TimeSpan messageAckTimeout)
         {
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
             this.edgeHub = Preconditions.CheckNotNull(edgeHub, nameof(edgeHub));
-            this.messageResponseTimeout = Preconditions.CheckNotNull(messageResponseTimeout, nameof(messageResponseTimeout));
+            this.messageAckTimeout = Preconditions.CheckNotNull(messageAckTimeout, nameof(messageAckTimeout));
         }
 
         public Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity)
         {
-            IDeviceListener deviceListener = new DeviceMessageHandler(Preconditions.CheckNotNull(identity, nameof(identity)), this.edgeHub, this.connectionManager, this.messageResponseTimeout);
+            IDeviceListener deviceListener = new DeviceMessageHandler(Preconditions.CheckNotNull(identity, nameof(identity)), this.edgeHub, this.connectionManager, this.messageAckTimeout);
             return Task.FromResult(deviceListener);
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
             this.edgeHub = Preconditions.CheckNotNull(edgeHub, nameof(edgeHub));
-            this.messageAckTimeout = Preconditions.CheckNotNull(messageAckTimeout, nameof(messageAckTimeout));
+            this.messageAckTimeout = messageAckTimeout;
         }
 
         public Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Hub.Core
 {
+    using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
@@ -10,16 +11,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     {
         readonly IConnectionManager connectionManager;
         readonly IEdgeHub edgeHub;
+        readonly TimeSpan messageResponseTimeout;
 
-        public ConnectionProvider(IConnectionManager connectionManager, IEdgeHub edgeHub)
+        public ConnectionProvider(IConnectionManager connectionManager, IEdgeHub edgeHub, TimeSpan messageResponseTimeout)
         {
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
             this.edgeHub = Preconditions.CheckNotNull(edgeHub, nameof(edgeHub));
+            this.messageResponseTimeout = Preconditions.CheckNotNull(messageResponseTimeout, nameof(messageResponseTimeout));
         }
 
         public Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity)
         {
-            IDeviceListener deviceListener = new DeviceMessageHandler(Preconditions.CheckNotNull(identity, nameof(identity)), this.edgeHub, this.connectionManager);
+            IDeviceListener deviceListener = new DeviceMessageHandler(Preconditions.CheckNotNull(identity, nameof(identity)), this.edgeHub, this.connectionManager, this.messageResponseTimeout);
             return Task.FromResult(deviceListener);
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.edgeHub = Preconditions.CheckNotNull(edgeHub, nameof(edgeHub));
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
-            this.messageAckTimeout = Preconditions.CheckNotNull(messageAckTimeout, nameof(messageAckTimeout));
+            this.messageAckTimeout = messageAckTimeout;
         }
 
         public IIdentity Identity { get; }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -24,16 +24,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
 
         readonly IEdgeHub edgeHub;
         readonly IConnectionManager connectionManager;
-        readonly TimeSpan messageResponseTimeout;
+        readonly TimeSpan messageAckTimeout;
         readonly AsyncLock serializeMessagesLock = new AsyncLock();
         IDeviceProxy underlyingProxy;
 
-        public DeviceMessageHandler(IIdentity identity, IEdgeHub edgeHub, IConnectionManager connectionManager, TimeSpan messageResponseTimeout)
+        public DeviceMessageHandler(IIdentity identity, IEdgeHub edgeHub, IConnectionManager connectionManager, TimeSpan messageAckTimeout)
         {
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.edgeHub = Preconditions.CheckNotNull(edgeHub, nameof(edgeHub));
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
-            this.messageResponseTimeout = Preconditions.CheckNotNull(messageResponseTimeout, nameof(messageResponseTimeout));
+            this.messageAckTimeout = Preconditions.CheckNotNull(messageAckTimeout, nameof(messageAckTimeout));
         }
 
         public IIdentity Identity { get; }
@@ -417,7 +417,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
                     Metrics.MessageProcessingLatency(this.Identity, message);
                     await this.underlyingProxy.SendMessageAsync(message, input);
 
-                    Task completedTask = await Task.WhenAny(taskCompletionSource.Task, Task.Delay(this.messageResponseTimeout));
+                    Task completedTask = await Task.WhenAny(taskCompletionSource.Task, Task.Delay(this.messageAckTimeout));
                     if (completedTask != taskCompletionSource.Task)
                     {
                         Events.MessageFeedbackTimedout(this.Identity, lockToken);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
     class DeviceMessageHandler : IDeviceListener, IDeviceProxy
     {
         const int GenericBadRequest = 400000;
-        static readonly TimeSpan MessageResponseTimeout = TimeSpan.FromSeconds(30);
 
         readonly ConcurrentDictionary<string, TaskCompletionSource<DirectMethodResponse>> methodCallTaskCompletionSources = new ConcurrentDictionary<string, TaskCompletionSource<DirectMethodResponse>>();
         readonly ConcurrentDictionary<string, TaskCompletionSource<bool>> messageTaskCompletionSources = new ConcurrentDictionary<string, TaskCompletionSource<bool>>();
@@ -25,14 +24,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
 
         readonly IEdgeHub edgeHub;
         readonly IConnectionManager connectionManager;
+        readonly TimeSpan messageResponseTimeout;
         readonly AsyncLock serializeMessagesLock = new AsyncLock();
         IDeviceProxy underlyingProxy;
 
-        public DeviceMessageHandler(IIdentity identity, IEdgeHub edgeHub, IConnectionManager connectionManager)
+        public DeviceMessageHandler(IIdentity identity, IEdgeHub edgeHub, IConnectionManager connectionManager, TimeSpan messageResponseTimeout)
         {
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.edgeHub = Preconditions.CheckNotNull(edgeHub, nameof(edgeHub));
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
+            this.messageResponseTimeout = Preconditions.CheckNotNull(messageResponseTimeout, nameof(messageResponseTimeout));
         }
 
         public IIdentity Identity { get; }
@@ -416,7 +417,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
                     Metrics.MessageProcessingLatency(this.Identity, message);
                     await this.underlyingProxy.SendMessageAsync(message, input);
 
-                    Task completedTask = await Task.WhenAny(taskCompletionSource.Task, Task.Delay(MessageResponseTimeout));
+                    Task completedTask = await Task.WhenAny(taskCompletionSource.Task, Task.Delay(this.messageResponseTimeout));
                     if (completedTask != taskCompletionSource.Task)
                     {
                         Events.MessageFeedbackTimedout(this.Identity, lockToken);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -131,8 +131,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             TimeSpan connectivityCheckFrequency = connectivityCheckFrequencySecs < 0 ? TimeSpan.MaxValue : TimeSpan.FromSeconds(connectivityCheckFrequencySecs);
             // n Clients + 1 Edgehub
             int maxConnectedClients = this.configuration.GetValue("MaxConnectedClients", 100) + 1;
-            int messageResponseTimeoutSecs = this.configuration.GetValue("MessageResponseTimeoutSecs", 30);
-            TimeSpan messageResponseTimeout = TimeSpan.FromSeconds(messageResponseTimeoutSecs);
+            int messageAckTimeoutSecs = this.configuration.GetValue("MessageAckTimeoutSecs", 30);
+            TimeSpan messageAckTimeout = TimeSpan.FromSeconds(messageAckTimeoutSecs);
             int cloudConnectionIdleTimeoutSecs = this.configuration.GetValue("CloudConnectionIdleTimeoutSecs", 3600);
             TimeSpan cloudConnectionIdleTimeout = TimeSpan.FromSeconds(cloudConnectionIdleTimeoutSecs);
             bool closeCloudConnectionOnIdleTimeout = this.configuration.GetValue("CloseCloudConnectionOnIdleTimeout", true);
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     upstreamProtocolOption,
                     connectivityCheckFrequency,
                     maxConnectedClients,
-                    messageResponseTimeout,
+                    messageAckTimeout,
                     cloudConnectionIdleTimeout,
                     closeCloudConnectionOnIdleTimeout,
                     cloudOperationTimeout,

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -131,6 +131,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             TimeSpan connectivityCheckFrequency = connectivityCheckFrequencySecs < 0 ? TimeSpan.MaxValue : TimeSpan.FromSeconds(connectivityCheckFrequencySecs);
             // n Clients + 1 Edgehub
             int maxConnectedClients = this.configuration.GetValue("MaxConnectedClients", 100) + 1;
+            int messageResponseTimeoutSecs = this.configuration.GetValue("MessageResponseTimeoutSecs", 30);
+            TimeSpan messageResponseTimeout = TimeSpan.FromSeconds(messageResponseTimeoutSecs);
             int cloudConnectionIdleTimeoutSecs = this.configuration.GetValue("CloudConnectionIdleTimeoutSecs", 3600);
             TimeSpan cloudConnectionIdleTimeout = TimeSpan.FromSeconds(cloudConnectionIdleTimeoutSecs);
             bool closeCloudConnectionOnIdleTimeout = this.configuration.GetValue("CloseCloudConnectionOnIdleTimeout", true);
@@ -165,6 +167,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     upstreamProtocolOption,
                     connectivityCheckFrequency,
                     maxConnectedClients,
+                    messageResponseTimeout,
                     cloudConnectionIdleTimeout,
                     closeCloudConnectionOnIdleTimeout,
                     cloudOperationTimeout,

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             LogLogo(logger);
             LogVersionInfo(logger);
             logger.LogInformation($"OptimizeForPerformance={configuration.GetValue("OptimizeForPerformance", true)}");
+            logger.LogInformation($"MessageAckTimeoutSecs={configuration.GetValue("MessageAckTimeoutSecs", 30)}");
             logger.LogInformation("Loaded server certificate with expiration date of {0}", certificates.ServerCertificate.NotAfter.ToString("o"));
 
             var metricsListener = container.Resolve<IMetricsListener>();

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly Option<UpstreamProtocol> upstreamProtocol;
         readonly TimeSpan connectivityCheckFrequency;
         readonly int maxConnectedClients;
-        readonly TimeSpan messageResponseTimeout;
+        readonly TimeSpan messageAckTimeout;
         readonly TimeSpan cloudConnectionIdleTimeout;
         readonly bool closeCloudConnectionOnIdleTimeout;
         readonly TimeSpan operationTimeout;
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             Option<UpstreamProtocol> upstreamProtocol,
             TimeSpan connectivityCheckFrequency,
             int maxConnectedClients,
-            TimeSpan messageResponseTimeout,
+            TimeSpan messageAckTimeout,
             TimeSpan cloudConnectionIdleTimeout,
             bool closeCloudConnectionOnIdleTimeout,
             TimeSpan operationTimeout,
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.upstreamProtocol = upstreamProtocol;
             this.connectivityCheckFrequency = connectivityCheckFrequency;
             this.maxConnectedClients = Preconditions.CheckRange(maxConnectedClients, 1);
-            this.messageResponseTimeout = messageResponseTimeout;
+            this.messageAckTimeout = messageAckTimeout;
             this.cloudConnectionIdleTimeout = cloudConnectionIdleTimeout;
             this.closeCloudConnectionOnIdleTimeout = closeCloudConnectionOnIdleTimeout;
             this.operationTimeout = operationTimeout;
@@ -583,7 +583,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         var edgeHubTask = c.Resolve<Task<IEdgeHub>>();
                         IConnectionManager connectionManager = await connectionManagerTask;
                         IEdgeHub edgeHub = await edgeHubTask;
-                        IConnectionProvider connectionProvider = new ConnectionProvider(connectionManager, edgeHub, this.messageResponseTimeout);
+                        IConnectionProvider connectionProvider = new ConnectionProvider(connectionManager, edgeHub, this.messageAckTimeout);
                         return connectionProvider;
                     })
                 .As<Task<IConnectionProvider>>()

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly Option<UpstreamProtocol> upstreamProtocol;
         readonly TimeSpan connectivityCheckFrequency;
         readonly int maxConnectedClients;
+        readonly TimeSpan messageResponseTimeout;
         readonly TimeSpan cloudConnectionIdleTimeout;
         readonly bool closeCloudConnectionOnIdleTimeout;
         readonly TimeSpan operationTimeout;
@@ -67,6 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             Option<UpstreamProtocol> upstreamProtocol,
             TimeSpan connectivityCheckFrequency,
             int maxConnectedClients,
+            TimeSpan messageResponseTimeout,
             TimeSpan cloudConnectionIdleTimeout,
             bool closeCloudConnectionOnIdleTimeout,
             TimeSpan operationTimeout,
@@ -93,6 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.upstreamProtocol = upstreamProtocol;
             this.connectivityCheckFrequency = connectivityCheckFrequency;
             this.maxConnectedClients = Preconditions.CheckRange(maxConnectedClients, 1);
+            this.messageResponseTimeout = messageResponseTimeout;
             this.cloudConnectionIdleTimeout = cloudConnectionIdleTimeout;
             this.closeCloudConnectionOnIdleTimeout = closeCloudConnectionOnIdleTimeout;
             this.operationTimeout = operationTimeout;
@@ -580,7 +583,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         var edgeHubTask = c.Resolve<Task<IEdgeHub>>();
                         IConnectionManager connectionManager = await connectionManagerTask;
                         IEdgeHub edgeHub = await edgeHubTask;
-                        IConnectionProvider connectionProvider = new ConnectionProvider(connectionManager, edgeHub);
+                        IConnectionProvider connectionProvider = new ConnectionProvider(connectionManager, edgeHub, this.messageResponseTimeout);
                         return connectionProvider;
                     })
                 .As<Task<IConnectionProvider>>()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -266,7 +266,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsManager, GetIdentityProvider(), deviceConnectivityManager);
             Try<ICloudProxy> cloudProxyTry = await connectionManager.CreateCloudConnectionAsync(deviceCredentials);
             Assert.True(cloudProxyTry.Success);
-            var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub.Object, connectionManager);
+            TimeSpan defaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+            var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub.Object, connectionManager, defaultMessageResponseTimeout);
 
             Option<ICloudProxy> cloudProxy = await connectionManager.GetCloudConnection(deviceId);
             Assert.True(cloudProxy.HasValue);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -266,8 +266,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsManager, GetIdentityProvider(), deviceConnectivityManager);
             Try<ICloudProxy> cloudProxyTry = await connectionManager.CreateCloudConnectionAsync(deviceCredentials);
             Assert.True(cloudProxyTry.Success);
-            TimeSpan defaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
-            var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub.Object, connectionManager, defaultMessageResponseTimeout);
+            TimeSpan defaultMessageAckTimeout = TimeSpan.FromSeconds(30);
+            var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub.Object, connectionManager, defaultMessageAckTimeout);
 
             Option<ICloudProxy> cloudProxy = await connectionManager.GetCloudConnection(deviceId);
             Assert.True(cloudProxy.HasValue);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
     public class ConnectionProviderTest
     {
-        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+        static readonly TimeSpan DefaultMessageAckTimeout = TimeSpan.FromSeconds(30);
 
         [Fact]
         [Unit]
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connectionManager = Mock.Of<IConnectionManager>();
             var edgeHub = Mock.Of<IEdgeHub>();
 
-            Assert.NotNull(new ConnectionProvider(connectionManager, edgeHub, DefaultMessageResponseTimeout));
+            Assert.NotNull(new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout));
         }
 
         [Fact]
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             var edgeHub = Mock.Of<IEdgeHub>();
 
-            Assert.Throws<ArgumentNullException>(() => new ConnectionProvider(null, edgeHub, DefaultMessageResponseTimeout));
+            Assert.Throws<ArgumentNullException>(() => new ConnectionProvider(null, edgeHub, DefaultMessageAckTimeout));
         }
 
         [Fact]
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             var connectionManager = Mock.Of<IConnectionManager>();
 
-            Assert.Throws<ArgumentNullException>(() => new ConnectionProvider(connectionManager, null, DefaultMessageResponseTimeout));
+            Assert.Throws<ArgumentNullException>(() => new ConnectionProvider(connectionManager, null, DefaultMessageAckTimeout));
         }
 
         [Fact]
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var edgeHub = Mock.Of<IEdgeHub>();
             var moduleCredentials = new TokenCredentials(new ModuleIdentity("hub", "device", "module"), "token", "productInfo", false);
 
-            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageResponseTimeout);
+            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout);
             Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity));
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var clientCertChain = new List<X509Certificate2>();
             var moduleCredentials = new X509CertCredentials(new ModuleIdentity("hub", "device", "module"), string.Empty, clientCertificate, clientCertChain);
 
-            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageResponseTimeout);
+            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout);
             Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity));
         }
 
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connectionManager = Mock.Of<IConnectionManager>();
             var edgeHub = Mock.Of<IEdgeHub>();
 
-            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageResponseTimeout);
+            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout);
             await Assert.ThrowsAsync<ArgumentNullException>(() => connectionProvider.GetDeviceListenerAsync(null));
         }
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
     public class ConnectionProviderTest
     {
+        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+
         [Fact]
         [Unit]
         public void ConnectionProviderConstructorTest()
@@ -19,7 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connectionManager = Mock.Of<IConnectionManager>();
             var edgeHub = Mock.Of<IEdgeHub>();
 
-            Assert.NotNull(new ConnectionProvider(connectionManager, edgeHub));
+            Assert.NotNull(new ConnectionProvider(connectionManager, edgeHub, DefaultMessageResponseTimeout));
         }
 
         [Fact]
@@ -28,7 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             var edgeHub = Mock.Of<IEdgeHub>();
 
-            Assert.Throws<ArgumentNullException>(() => new ConnectionProvider(null, edgeHub));
+            Assert.Throws<ArgumentNullException>(() => new ConnectionProvider(null, edgeHub, DefaultMessageResponseTimeout));
         }
 
         [Fact]
@@ -37,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             var connectionManager = Mock.Of<IConnectionManager>();
 
-            Assert.Throws<ArgumentNullException>(() => new ConnectionProvider(connectionManager, null));
+            Assert.Throws<ArgumentNullException>(() => new ConnectionProvider(connectionManager, null, DefaultMessageResponseTimeout));
         }
 
         [Fact]
@@ -48,7 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var edgeHub = Mock.Of<IEdgeHub>();
             var moduleCredentials = new TokenCredentials(new ModuleIdentity("hub", "device", "module"), "token", "productInfo", false);
 
-            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub);
+            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageResponseTimeout);
             Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity));
         }
 
@@ -62,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var clientCertChain = new List<X509Certificate2>();
             var moduleCredentials = new X509CertCredentials(new ModuleIdentity("hub", "device", "module"), string.Empty, clientCertificate, clientCertChain);
 
-            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub);
+            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageResponseTimeout);
             Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity));
         }
 
@@ -73,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connectionManager = Mock.Of<IConnectionManager>();
             var edgeHub = Mock.Of<IEdgeHub>();
 
-            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub);
+            var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageResponseTimeout);
             await Assert.ThrowsAsync<ArgumentNullException>(() => connectionProvider.GetDeviceListenerAsync(null));
         }
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     [Unit]
     public class DeviceMessageHandlerTest
     {
-        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+        static readonly TimeSpan DefaultMessageAckTimeout = TimeSpan.FromSeconds(30);
 
         [Fact]
         public async Task ForwardsGetTwinOperationToEdgeHub()
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             IMessage expectedMessage = new EdgeMessage.Builder(new byte[0]).Build();
             edgeHub.Setup(e => e.GetTwinAsync(It.IsAny<string>())).Returns(Task.FromResult(expectedMessage));
             Mock.Get(connMgr).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageResponseTimeout);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout);
             listener.BindDeviceProxy(deviceProxy.Object);
             await listener.SendGetTwinRequest("cid");
 
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             messages.Add(Mock.Of<IMessage>());
             messages.Add(Mock.Of<IMessage>());
             Mock.Get(connectionManager).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var deviceListener = new DeviceMessageHandler(identity, edgeHub, connectionManager, DefaultMessageResponseTimeout);
+            var deviceListener = new DeviceMessageHandler(identity, edgeHub, connectionManager, DefaultMessageAckTimeout);
             await deviceListener.ProcessDeviceMessageBatchAsync(messages);
 
             Mock.Get(edgeHub).Verify(eh => eh.ProcessDeviceMessageBatch(identity, It.IsAny<IEnumerable<IMessage>>()), Times.Once());
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IIdentity, IMessage>((id, m) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             Mock.Get(connMgr).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageResponseTimeout);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout);
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
             bool updateSent = false;
             underlyingDeviceProxy.Setup(d => d.SendTwinUpdate(It.IsAny<IMessage>()))
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             underlyingDeviceProxy.Setup(d => d.SendMessageAsync(It.IsAny<IMessage>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             underlyingDeviceProxy.Setup(d => d.SendMessageAsync(It.IsAny<IMessage>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -263,7 +263,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -303,7 +303,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                     })
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(cloudProxy));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage>(m => sentMessage = m)
                 .Returns(Task.CompletedTask);
 
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageResponseTimeout);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout);
             listener.BindDeviceProxy(deviceProxy.Object);
             string correlationId = Guid.NewGuid().ToString();
 
@@ -357,7 +357,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage>(m => sentMessage = m)
                 .Returns(Task.CompletedTask);
 
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageResponseTimeout);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout);
             listener.BindDeviceProxy(deviceProxy.Object);
             string correlationId = Guid.NewGuid().ToString();
 
@@ -386,7 +386,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -425,7 +425,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -513,7 +513,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
             return deviceMessageHandler;
         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     [Unit]
     public class DeviceMessageHandlerTest
     {
+        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+
         [Fact]
         public async Task ForwardsGetTwinOperationToEdgeHub()
         {
@@ -32,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             IMessage expectedMessage = new EdgeMessage.Builder(new byte[0]).Build();
             edgeHub.Setup(e => e.GetTwinAsync(It.IsAny<string>())).Returns(Task.FromResult(expectedMessage));
             Mock.Get(connMgr).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageResponseTimeout);
             listener.BindDeviceProxy(deviceProxy.Object);
             await listener.SendGetTwinRequest("cid");
 
@@ -51,7 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             messages.Add(Mock.Of<IMessage>());
             messages.Add(Mock.Of<IMessage>());
             Mock.Get(connectionManager).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var deviceListener = new DeviceMessageHandler(identity, edgeHub, connectionManager);
+            var deviceListener = new DeviceMessageHandler(identity, edgeHub, connectionManager, DefaultMessageResponseTimeout);
             await deviceListener.ProcessDeviceMessageBatchAsync(messages);
 
             Mock.Get(edgeHub).Verify(eh => eh.ProcessDeviceMessageBatch(identity, It.IsAny<IEnumerable<IMessage>>()), Times.Once());
@@ -70,7 +72,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IIdentity, IMessage>((id, m) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             Mock.Get(connMgr).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageResponseTimeout);
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
             bool updateSent = false;
             underlyingDeviceProxy.Setup(d => d.SendTwinUpdate(It.IsAny<IMessage>()))
@@ -155,7 +157,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -183,7 +185,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -211,7 +213,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             underlyingDeviceProxy.Setup(d => d.SendMessageAsync(It.IsAny<IMessage>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -233,7 +235,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             underlyingDeviceProxy.Setup(d => d.SendMessageAsync(It.IsAny<IMessage>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -261,7 +263,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -301,7 +303,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                     })
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(cloudProxy));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -326,7 +328,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage>(m => sentMessage = m)
                 .Returns(Task.CompletedTask);
 
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageResponseTimeout);
             listener.BindDeviceProxy(deviceProxy.Object);
             string correlationId = Guid.NewGuid().ToString();
 
@@ -355,7 +357,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage>(m => sentMessage = m)
                 .Returns(Task.CompletedTask);
 
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageResponseTimeout);
             listener.BindDeviceProxy(deviceProxy.Object);
             string correlationId = Guid.NewGuid().ToString();
 
@@ -384,7 +386,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -423,7 +425,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -463,7 +465,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -511,7 +513,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageResponseTimeout);
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
             return deviceMessageHandler;
         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
     [Unit]
     public class RoutingEdgeHubTest
     {
+        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+
         [Fact]
         public async Task ProcessDeviceMessageBatch_ConvertsMessages()
         {
@@ -281,7 +283,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 subscriptionProcessor);
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageResponseTimeout);
             var methodRequest = new DirectMethodRequest("device1/module1", "shutdown", null, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10));
 
             // Act
@@ -363,7 +365,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 Mock.Of<ISubscriptionProcessor>());
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageResponseTimeout);
 
             // Act
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
@@ -440,7 +442,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 subscriptionProcessor);
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageResponseTimeout);
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
 
             // Arrange

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
     [Unit]
     public class RoutingEdgeHubTest
     {
-        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+        static readonly TimeSpan DefaultMessageAckTimeout = TimeSpan.FromSeconds(30);
 
         [Fact]
         public async Task ProcessDeviceMessageBatch_ConvertsMessages()
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 subscriptionProcessor);
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout);
             var methodRequest = new DirectMethodRequest("device1/module1", "shutdown", null, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10));
 
             // Act
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 Mock.Of<ISubscriptionProcessor>());
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout);
 
             // Act
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
@@ -442,7 +442,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 subscriptionProcessor);
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageResponseTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout);
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
 
             // Arrange

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
     [Integration]
     public class RoutingTest
     {
+        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
         static readonly Random Rand = new Random();
 
         [Fact]
@@ -522,7 +523,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 Try<ICloudProxy> cloudProxy = await connectionManager.CreateCloudConnectionAsync(deviceCredentials);
                 Assert.True(cloudProxy.Success);
                 var deviceProxy = Mock.Of<IDeviceProxy>();
-                var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub, connectionManager);
+                var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub, connectionManager, DefaultMessageResponseTimeout);
+
                 deviceListener.BindDeviceProxy(deviceProxy);
                 return new TestDevice(deviceCredentials.Identity as IDeviceIdentity, deviceListener);
             }
@@ -562,7 +564,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 IClientCredentials moduleCredentials = SetupModuleCredentials(moduleId, deviceId);
                 Try<ICloudProxy> cloudProxy = await connectionManager.CreateCloudConnectionAsync(moduleCredentials);
                 Assert.True(cloudProxy.Success);
-                var deviceListener = new DeviceMessageHandler(moduleCredentials.Identity, edgeHub, connectionManager);
+                var deviceListener = new DeviceMessageHandler(moduleCredentials.Identity, edgeHub, connectionManager, DefaultMessageResponseTimeout);
+
                 var receivedMessages = new List<IMessage>();
                 var deviceProxy = new Mock<IDeviceProxy>();
                 deviceProxy.Setup(d => d.SendMessageAsync(It.IsAny<IMessage>(), It.Is<string>(e => inputEndpointIds.Contains(e))))

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
     [Integration]
     public class RoutingTest
     {
-        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+        static readonly TimeSpan DefaultMessageAckTimeout = TimeSpan.FromSeconds(30);
         static readonly Random Rand = new Random();
 
         [Fact]
@@ -523,7 +523,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 Try<ICloudProxy> cloudProxy = await connectionManager.CreateCloudConnectionAsync(deviceCredentials);
                 Assert.True(cloudProxy.Success);
                 var deviceProxy = Mock.Of<IDeviceProxy>();
-                var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub, connectionManager, DefaultMessageResponseTimeout);
+                var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub, connectionManager, DefaultMessageAckTimeout);
 
                 deviceListener.BindDeviceProxy(deviceProxy);
                 return new TestDevice(deviceCredentials.Identity as IDeviceIdentity, deviceListener);
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 IClientCredentials moduleCredentials = SetupModuleCredentials(moduleId, deviceId);
                 Try<ICloudProxy> cloudProxy = await connectionManager.CreateCloudConnectionAsync(moduleCredentials);
                 Assert.True(cloudProxy.Success);
-                var deviceListener = new DeviceMessageHandler(moduleCredentials.Identity, edgeHub, connectionManager, DefaultMessageResponseTimeout);
+                var deviceListener = new DeviceMessageHandler(moduleCredentials.Identity, edgeHub, connectionManager, DefaultMessageAckTimeout);
 
                 var receivedMessages = new List<IMessage>();
                 var deviceProxy = new Mock<IDeviceProxy>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     Option.Some(UpstreamProtocol.Amqp),
                     TimeSpan.FromSeconds(5),
                     101,
+                    TimeSpan.FromSeconds(30),
                     TimeSpan.FromSeconds(3600),
                     true,
                     TimeSpan.FromSeconds(20),

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
     public class MessagingServiceClientTest
     {
         static readonly IByteBufferConverter ByteBufferConverter = new ByteBufferConverter(PooledByteBufferAllocator.Default);
-        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
+        static readonly TimeSpan DefaultMessageAckTimeout = TimeSpan.FromSeconds(30);
         static readonly IIdentity MockIdentity = Mock.Of<IIdentity>(i => i.Id == "device1");
         static readonly Mock<IMessagingChannel<IProtocolGatewayMessage>> Channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
         static readonly Mock<IEdgeHub> EdgeHub = new Mock<IEdgeHub>();
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
                 Mock.Of<IConnectionManager>(),
-                DefaultMessageResponseTimeout);
+                DefaultMessageAckTimeout);
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             channel.Setup(x => x.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
                 Mock.Of<IConnectionManager>(),
-                DefaultMessageResponseTimeout);
+                DefaultMessageAckTimeout);
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             channel.Setup(x => x.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
                 Mock.Of<IConnectionManager>(),
-                DefaultMessageResponseTimeout);
+                DefaultMessageAckTimeout);
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             ProtocolGatewayMessage message = new ProtocolGatewayMessage.Builder(ByteBufferConverter.ToByteBuffer(new byte[0]), "$iothub/twin/PATCH/properties/reported/")
                 .Build();
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
 
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageResponseTimeout);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout);
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
@@ -371,7 +371,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageResponseTimeout);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout);
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
@@ -402,7 +402,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageResponseTimeout);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout);
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
@@ -433,7 +433,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageResponseTimeout);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout);
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
     public class MessagingServiceClientTest
     {
         static readonly IByteBufferConverter ByteBufferConverter = new ByteBufferConverter(PooledByteBufferAllocator.Default);
+        static readonly TimeSpan DefaultMessageResponseTimeout = TimeSpan.FromSeconds(30);
         static readonly IIdentity MockIdentity = Mock.Of<IIdentity>(i => i.Id == "device1");
         static readonly Mock<IMessagingChannel<IProtocolGatewayMessage>> Channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
         static readonly Mock<IEdgeHub> EdgeHub = new Mock<IEdgeHub>();
@@ -111,7 +112,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             IDeviceListener listener = new DeviceMessageHandler(
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
-                Mock.Of<IConnectionManager>());
+                Mock.Of<IConnectionManager>(),
+                DefaultMessageResponseTimeout);
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             channel.Setup(x => x.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -155,7 +157,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             IDeviceListener listener = new DeviceMessageHandler(
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
-                Mock.Of<IConnectionManager>());
+                Mock.Of<IConnectionManager>(),
+                DefaultMessageResponseTimeout);
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             channel.Setup(x => x.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -181,7 +184,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             IDeviceListener listener = new DeviceMessageHandler(
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
-                Mock.Of<IConnectionManager>());
+                Mock.Of<IConnectionManager>(),
+                DefaultMessageResponseTimeout);
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             ProtocolGatewayMessage message = new ProtocolGatewayMessage.Builder(ByteBufferConverter.ToByteBuffer(new byte[0]), "$iothub/twin/PATCH/properties/reported/")
                 .Build();
@@ -336,7 +340,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
 
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageResponseTimeout);
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
@@ -367,7 +371,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageResponseTimeout);
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
@@ -398,7 +402,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageResponseTimeout);
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
@@ -429,7 +433,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageResponseTimeout);
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))


### PR DESCRIPTION
This timeout can now be configured with a new environment variable in the edge hub deployment:
```MessageAckTimeoutSecs```

Normally, we wait for commits to reach master and cherry-pick them over, but seeing how this is a time sensitive fix both this PR and #2652 are open in parallel.