### PR TITLE
[k8s PP]Update iotedged image to debian:10-slim to fix vulnerability.

### DIFF
--- a/edgelet/iotedged/docker/linux/amd64/Dockerfile
+++ b/edgelet/iotedged/docker/linux/amd64/Dockerfile
@@ -1,9 +1,11 @@
-FROM debian:9-slim
+FROM debian:10-slim
 
 # package installation needs to exec as root
 RUN apt-get update && apt-get install -y \
+  ca-certificates && \
+  echo "deb http://deb.debian.org/debian stretch main" >> /etc/apt/sources.list && \
+  apt-get update && apt-get install -y \
   libssl1.0.2 \
-  ca-certificates \
   && rm -rf /var/lib/apt/lists/*
 
 # run everything else as system user


### PR DESCRIPTION
[For reference: CVE-2019-5188](https://security-tracker.debian.org/tracker/CVE-2019-5188)