### PR TITLE
Allow Edge attached Hardware accelerators

### DIFF
--- a/edgelet/docker-rs/src/models/host_config.rs
+++ b/edgelet/docker-rs/src/models/host_config.rs
@@ -93,9 +93,9 @@ pub struct HostConfig {
     // /// A list of devices to add to the container.
     // #[serde(rename = "Devices", skip_serializing_if = "Option::is_none")]
     // devices: Option<Vec<crate::models::DeviceMapping>>,
-    // /// a list of cgroup rules to apply to the container
-    // #[serde(rename = "DeviceCgroupRules", skip_serializing_if = "Option::is_none")]
-    // device_cgroup_rules: Option<Vec<String>>,
+    /// a list of cgroup rules to apply to the container
+    #[serde(rename = "DeviceCgroupRules", skip_serializing_if = "Option::is_none")]
+    device_cgroup_rules: Option<Vec<String>>,
     // /// Disk limit (in bytes).
     // #[serde(rename = "DiskQuota", skip_serializing_if = "Option::is_none")]
     // disk_quota: Option<i64>,
@@ -263,7 +263,7 @@ impl HostConfig {
             // cpuset_cpus: None,
             // cpuset_mems: None,
             // devices: None,
-            // device_cgroup_rules: None,
+            device_cgroup_rules: None,
             // disk_quota: None,
             // kernel_memory: None,
             // memory_reservation: None,
@@ -618,22 +618,22 @@ impl HostConfig {
     //     self.devices = None;
     // }
 
-    // pub fn set_device_cgroup_rules(&mut self, device_cgroup_rules: Vec<String>) {
-    //     self.device_cgroup_rules = Some(device_cgroup_rules);
-    // }
+    pub fn set_device_cgroup_rules(&mut self, device_cgroup_rules: Vec<String>) {
+        self.device_cgroup_rules = Some(device_cgroup_rules);
+    }
 
-    // pub fn with_device_cgroup_rules(mut self, device_cgroup_rules: Vec<String>) -> Self {
-    //     self.device_cgroup_rules = Some(device_cgroup_rules);
-    //     self
-    // }
+    pub fn with_device_cgroup_rules(mut self, device_cgroup_rules: Vec<String>) -> Self {
+        self.device_cgroup_rules = Some(device_cgroup_rules);
+        self
+    }
 
-    // pub fn device_cgroup_rules(&self) -> Option<&[String]> {
-    //     self.device_cgroup_rules.as_ref().map(AsRef::as_ref)
-    // }
+    pub fn device_cgroup_rules(&self) -> Option<&[String]> {
+        self.device_cgroup_rules.as_ref().map(AsRef::as_ref)
+    }
 
-    // pub fn reset_device_cgroup_rules(&mut self) {
-    //     self.device_cgroup_rules = None;
-    // }
+    pub fn reset_device_cgroup_rules(&mut self) {
+        self.device_cgroup_rules = None;
+    }
 
     // pub fn set_disk_quota(&mut self, disk_quota: i64) {
     //     self.disk_quota = Some(disk_quota);


### PR DESCRIPTION
"device_cgroup_rules" attribute is not allowed to be changed. But this is mandatory setting to be able to access USB based hardware accelerators (like INTEL VPUs). Without this attribute set, only way is to run IoTEdge module with previlidged rights... But using this setting it is not required to give admin previliges and also it allows USB attached dynamic devices.

Here is an example of intel OpenVino docker image (to use intel VPU, FPGA etc. attached to edge devie) https://docs.openvinotoolkit.org/latest/_docs_install_guides_installing_openvino_docker_linux.html
as in the above example to run the iotedge module without admin privilages, you will use following container create parameters:

docker run --device-cgroup-rule='c 189:* rmw' -v /dev/bus/usb:/dev/bus/usb <image_name>

Here there is no way to pass "--device-cgroup-rule". parameter in IoTEdge Hub... Today it allows such manifest:

{
   "HostConfig": {
      "PortBindings": {
         ...
         ]
      },
      "DeviceCgroupRules": [
         "c 189:* rmw"
      ],
....
}

But above manifest always reflected as "DeviceCgroupRules": null on the edge device... 

so above changes hope to solve this issue...