### PR TITLE
[k8s]Increase chart version and use beta6 as new image url

### DIFF
--- a/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for installing CRD for Azure IoT Edge on Kubernetes
 name: edge-kubernetes-crd
-version: 0.2.3
+version: 0.2.4

--- a/kubernetes/charts/edge-kubernetes/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for running Azure IoT Edge on Kubernetes
 name: edge-kubernetes
-version: 0.2.3
+version: 0.2.4

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -2,7 +2,7 @@
 iotedged:
   image:
     repository: azureiotedge/azureiotedge-iotedged
-    tag: 0.1.0-beta5
+    tag: 0.1.0-beta6
     pullPolicy: Always
   service:
     name: iotedged
@@ -92,7 +92,7 @@ iotedged:
 iotedgedProxy:
   image:
     repository: azureiotedge/azureiotedge-proxy
-    tag: 0.1.0-beta5
+    tag: 0.1.0-beta6
     pullPolicy: Always
 
 # Edge Agent image configuration
@@ -106,7 +106,7 @@ edgeAgent:
   containerName: edgeagent
   image:
     repository: azureiotedge/azureiotedge-agent
-    tag: 0.1.0-beta5
+    tag: 0.1.0-beta6
     pullPolicy: Always
   hostname: "localhost"
   env:


### PR DESCRIPTION
New since beta5:
- **BREAKING** Remove "persistentVolumeName" setting for Agent at startup and replace with "useMountSourceForVolumeName".  Setting this new variable will tell Agent to assume Docker volume name in module spec is the Persistent Volume name.

- Translate  "Cmd", "Entrypoint", and "WorkingDir" of DockerOptions into K8s equivalents.

- Pull in critical vulnerability fixes from 1.0.9 branch.