### PR TITLE
Changing case of transportType for C2D connectivity tests to match deployment files

### DIFF
--- a/test/modules/CloudToDeviceMessageTester/Settings.cs
+++ b/test/modules/CloudToDeviceMessageTester/Settings.cs
@@ -88,7 +88,7 @@ namespace CloudToDeviceMessageTester
                 configuration.GetValue<string>("IOTEDGE_IOTHUBHOSTNAME"),
                 configuration.GetValue("C2DMESSAGE_TESTER_MODE", CloudToDeviceMessageTesterMode.Receiver),
                 configuration.GetValue<string>("trackingId"),
-                configuration.GetValue("TransportType", TransportType.Amqp),
+                configuration.GetValue("transportType", TransportType.Amqp),
                 configuration.GetValue("MessageDelay", TimeSpan.FromSeconds(5)),
                 configuration.GetValue<Uri>("ReportingEndpointUrl"),
                 configuration.GetValue("testDuration", TimeSpan.Zero),


### PR DESCRIPTION
Typo in C2D connectivity test files: wrong casing.

In the deployment files, we specify that the case is "transportType," but in the Settings file of the C2DTester module, we match to "TransportType." Therefore, the actual transportType setting won't get picked up by the C2DTesterModule, and it will always pick the default. 

This change fixes the casing. Now, the correct transportType will get picked up.