### PR TITLE
IoTEdgeDevOps: Add bug counts to database

### DIFF
--- a/tools/IoTEdgeDevOps/DevOpsLib/BugManagement.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BugManagement.cs
@@ -2,13 +2,10 @@
 namespace DevOpsLib
 {
     using System;
-    using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
-    using DevOpsLib.VstsModels;
     using Flurl;
     using Flurl.Http;
-    using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
 
     public class BugManagement
@@ -26,18 +23,17 @@ namespace DevOpsLib
         /// This method is used to execute a Dev Ops work item query and get a list of bugs. 
         /// If result is not found for a query Id, it will return an entity with no result.
         /// Note: there is no validation of work item query ids.
-        /// Reference: https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-5.1
+        /// Reference: https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/wiql/get?view=azure-devops-rest-5.1
         /// </summary>
-        /// <param name="buildDefinitionIds">build definition Ids</param>
-        /// <param name="branchName">github repository branch name</param>
-        /// <returns>List of vsts build entities</returns>
-        public async Task<IList<VstsBuild>> GetLatestBuildsAsync(WorkItemQueryId workItemQueryId)
+        /// <param name="bugQueryId">bug query id from azure dev ops shared queries</param>
+        /// <returns>Number of bugs output by query</returns>
+        public async Task<int> GetBugsQuery(string bugQueryId)
         {
-            ValidationUtil.ThrowIfNullOrEmptySet(workItemQueryId, nameof(workItemQueryId));
+            ValidationUtil.ThrowIfNullOrEmptySet(bugQueryId, nameof(bugQueryId));
 
             // TODO: need to think about how to handle unexpected exception during REST API call
-            string requestPath = string.Format(WorkItemPathSegmentFormat, this.accessSetting.Organization, this.accessSetting.Project, this.accessSetting.Team, workItemQueryId);
-            IFlurlRequest latestBuildRequest = GetBugsRequestUri(workItemQueryId, requestPath)
+            string requestPath = string.Format(WorkItemPathSegmentFormat, this.accessSetting.Organization, this.accessSetting.Project, this.accessSetting.Team, bugQueryId);
+            IFlurlRequest latestBuildRequest = GetBugsRequestUri(requestPath)
                 .WithBasicAuth(string.Empty, this.accessSetting.PersonalAccessToken);
 
             string resultJson = await latestBuildRequest.GetStringAsync().ConfigureAwait(false);
@@ -45,38 +41,18 @@ namespace DevOpsLib
 
             if (!result.ContainsKey("queryType"))
             {
-                return buildDefinitionIds.Select(i => VstsBuild.CreateBuildWithNoResult(i, branchName)).ToList();
+                return 0; 
             }
-
-            Dictionary<BuildDefinitionId, VstsBuild> latestBuilds = JsonConvert.DeserializeObject<VstsBuild[]>(result["value"].ToString()).ToDictionary(b => b.DefinitionId, b => b);
-            return buildDefinitionIds.Select(i => latestBuilds.ContainsKey(i) ? latestBuilds[i] : VstsBuild.CreateBuildWithNoResult(i, branchName)).ToList();
-        }
-
-        public async Task<IList<VstsBuild>> GetBuildsAsync(HashSet<BuildDefinitionId> buildDefinitionIds, string branchName, DateTime? minTime = null, int? maxBuildsPerDefinition = null)
-        {
-            ValidationUtil.ThrowIfNullOrEmptySet(buildDefinitionIds, nameof(buildDefinitionIds));
-            ValidationUtil.ThrowIfNullOrWhiteSpace(branchName, nameof(branchName));
-
-            // TODO: need to think about how to handle unexpected exception during REST API call
-            string requestPath = string.Format(LatestBuildPathSegmentFormat, this.accessSetting.Organization, this.accessSetting.Project);
-            IFlurlRequest latestBuildRequest = GetBuildsRequestUri(buildDefinitionIds, branchName, requestPath, minTime, maxBuildsPerDefinition)
-                .WithBasicAuth(string.Empty, this.accessSetting.PersonalAccessToken);
-
-            string resultJson = await latestBuildRequest.GetStringAsync().ConfigureAwait(false);
-            JObject result = JObject.Parse(resultJson);
-
-            if (!result.ContainsKey("count") || (int)result["count"] <= 0)
+            else
             {
-                return buildDefinitionIds.Select(i => VstsBuild.CreateBuildWithNoResult(i, branchName)).ToList();
+                Console.WriteLine($"Bugs: {result["workItems"].Count()}");
+                return result["workItems"].Count();
             }
-
-            return JsonConvert.DeserializeObject<VstsBuild[]>(result["value"].ToString()).ToList();
         }
 
-        private static Url GetBugsRequestUri(HashSet<BuildDefinitionId> buildDefinitionIds, string requestPath)
+        private static Url GetBugsRequestUri(string requestPath)
         {
             Url requestUri = DevOpsAccessSetting.BaseUrl.AppendPathSegment(requestPath);
-
             return requestUri;
         }
     }

--- a/tools/IoTEdgeDevOps/DevOpsLib/BugManagement.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BugManagement.cs
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace DevOpsLib
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using DevOpsLib.VstsModels;
+    using Flurl;
+    using Flurl.Http;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    public class BugManagement
+    {
+        const string WorkItemPathSegmentFormat = "{0}/{1}/{2}/_apis/wit/wiql/{3}";
+
+        readonly DevOpsAccessSetting accessSetting;
+
+        public BugManagement(DevOpsAccessSetting accessSetting)
+        {
+            this.accessSetting = accessSetting;
+        }
+
+        /// <summary>
+        /// This method is used to execute a Dev Ops work item query and get a list of bugs. 
+        /// If result is not found for a query Id, it will return an entity with no result.
+        /// Note: there is no validation of work item query ids.
+        /// Reference: https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-5.1
+        /// </summary>
+        /// <param name="buildDefinitionIds">build definition Ids</param>
+        /// <param name="branchName">github repository branch name</param>
+        /// <returns>List of vsts build entities</returns>
+        public async Task<IList<VstsBuild>> GetLatestBuildsAsync(WorkItemQueryId workItemQueryId)
+        {
+            ValidationUtil.ThrowIfNullOrEmptySet(workItemQueryId, nameof(workItemQueryId));
+
+            // TODO: need to think about how to handle unexpected exception during REST API call
+            string requestPath = string.Format(WorkItemPathSegmentFormat, this.accessSetting.Organization, this.accessSetting.Project, this.accessSetting.Team, workItemQueryId);
+            IFlurlRequest latestBuildRequest = GetBugsRequestUri(workItemQueryId, requestPath)
+                .WithBasicAuth(string.Empty, this.accessSetting.PersonalAccessToken);
+
+            string resultJson = await latestBuildRequest.GetStringAsync().ConfigureAwait(false);
+            JObject result = JObject.Parse(resultJson);
+
+            if (!result.ContainsKey("queryType"))
+            {
+                return buildDefinitionIds.Select(i => VstsBuild.CreateBuildWithNoResult(i, branchName)).ToList();
+            }
+
+            Dictionary<BuildDefinitionId, VstsBuild> latestBuilds = JsonConvert.DeserializeObject<VstsBuild[]>(result["value"].ToString()).ToDictionary(b => b.DefinitionId, b => b);
+            return buildDefinitionIds.Select(i => latestBuilds.ContainsKey(i) ? latestBuilds[i] : VstsBuild.CreateBuildWithNoResult(i, branchName)).ToList();
+        }
+
+        public async Task<IList<VstsBuild>> GetBuildsAsync(HashSet<BuildDefinitionId> buildDefinitionIds, string branchName, DateTime? minTime = null, int? maxBuildsPerDefinition = null)
+        {
+            ValidationUtil.ThrowIfNullOrEmptySet(buildDefinitionIds, nameof(buildDefinitionIds));
+            ValidationUtil.ThrowIfNullOrWhiteSpace(branchName, nameof(branchName));
+
+            // TODO: need to think about how to handle unexpected exception during REST API call
+            string requestPath = string.Format(LatestBuildPathSegmentFormat, this.accessSetting.Organization, this.accessSetting.Project);
+            IFlurlRequest latestBuildRequest = GetBuildsRequestUri(buildDefinitionIds, branchName, requestPath, minTime, maxBuildsPerDefinition)
+                .WithBasicAuth(string.Empty, this.accessSetting.PersonalAccessToken);
+
+            string resultJson = await latestBuildRequest.GetStringAsync().ConfigureAwait(false);
+            JObject result = JObject.Parse(resultJson);
+
+            if (!result.ContainsKey("count") || (int)result["count"] <= 0)
+            {
+                return buildDefinitionIds.Select(i => VstsBuild.CreateBuildWithNoResult(i, branchName)).ToList();
+            }
+
+            return JsonConvert.DeserializeObject<VstsBuild[]>(result["value"].ToString()).ToList();
+        }
+
+        private static Url GetBugsRequestUri(HashSet<BuildDefinitionId> buildDefinitionIds, string requestPath)
+        {
+            Url requestUri = DevOpsAccessSetting.BaseUrl.AppendPathSegment(requestPath);
+
+            return requestUri;
+        }
+    }
+}

--- a/tools/IoTEdgeDevOps/DevOpsLib/BugManagement.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BugManagement.cs
@@ -45,7 +45,6 @@ namespace DevOpsLib
             }
             else
             {
-                Console.WriteLine($"Bugs: {result["workItems"].Count()}");
                 return result["workItems"].Count();
             }
         }

--- a/tools/IoTEdgeDevOps/DevOpsLib/BugQueryId.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BugQueryId.cs
@@ -5,11 +5,9 @@ namespace DevOpsLib
 {
     public static class BugQueryId
     {
-        public const string SampleQuery = "d7f4e036-0ccb-46a6-a33d-87a932296543";
-
         public readonly static Dictionary<string, string> QueryNamestoIds = new Dictionary<string, string>() 
         { 
-            {nameof(SampleQuery), SampleQuery  } 
+            {"SampleQuery", "d7f4e036-0ccb-46a6-a33d-87a932296543"} 
         };
     }
 }

--- a/tools/IoTEdgeDevOps/DevOpsLib/BugQueryId.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BugQueryId.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft. All rights reserved.
+using System.Collections.Generic;
+
+namespace DevOpsLib
+{
+    public static class BugQueryId
+    {
+        public const string SampleQuery = "d7f4e036-0ccb-46a6-a33d-87a932296543";
+
+        public readonly static Dictionary<string, string> QueryNamestoIds = new Dictionary<string, string>() 
+        { 
+            {nameof(SampleQuery), SampleQuery  } 
+        };
+    }
+}

--- a/tools/IoTEdgeDevOps/DevOpsLib/DevOpsAccessSetting.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/DevOpsAccessSetting.cs
@@ -20,6 +20,11 @@ namespace DevOpsLib
             string personalAccessToken,
             string team)
         {
+            ValidationUtil.ThrowIfNullOrWhiteSpace(organization, nameof(organization));
+            ValidationUtil.ThrowIfNullOrWhiteSpace(project, nameof(project));
+            ValidationUtil.ThrowIfNullOrWhiteSpace(personalAccessToken, nameof(personalAccessToken));
+            ValidationUtil.ThrowIfNullOrWhiteSpace(team, nameof(team));
+
             this.Organization = organization;
             this.Project = project;
             this.PersonalAccessToken = personalAccessToken;

--- a/tools/IoTEdgeDevOps/DevOpsLib/DevOpsAccessSetting.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/DevOpsAccessSetting.cs
@@ -7,20 +7,23 @@ namespace DevOpsLib
         public const string ReleaseManagementBaseUrl = "https://vsrm.dev.azure.com";
         public const string AzureOrganization = "msazure";
         public const string AzureProject = "one";
+        public const string IoTTeam = "IoT-Platform-Edge";
 
         public DevOpsAccessSetting(string personalAccessToken)
-            : this(AzureOrganization, AzureProject, personalAccessToken)
+            : this(AzureOrganization, AzureProject, personalAccessToken, IoTTeam)
         {
         }
 
         public DevOpsAccessSetting(
             string organization,
             string project,
-            string personalAccessToken)
+            string personalAccessToken,
+            string team)
         {
             this.Organization = organization;
             this.Project = project;
             this.PersonalAccessToken = personalAccessToken;
+            this.Team = team;
         }
 
         public string Organization { get; }
@@ -28,5 +31,7 @@ namespace DevOpsLib
         public string Project { get; }
 
         public string PersonalAccessToken { get; }
+
+        public string Team { get; }
     }
 }

--- a/tools/IoTEdgeDevOps/DevOpsLib/IoTEdgeReleaseDeployment.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/IoTEdgeReleaseDeployment.cs
@@ -16,7 +16,7 @@ namespace DevOpsLib
 
         public IoTEdgeReleaseDeployment(int id, int attempt, VstsDeploymentStatus status, DateTime lastModifiedOn, HashSet<IoTEdgePipelineTask> tasks)
         {
-            ValidationUtil.ThrowIfNonPositive(id, nameof(id));
+            ValidationUtil.ThrowIfNegative(id, nameof(id));
             ValidationUtil.ThrowIfNonPositive(attempt, nameof(attempt));
             ValidationUtil.ThrowIfNull(tasks, nameof(tasks));
 

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/Program.cs
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/Program.cs
@@ -28,7 +28,7 @@ namespace VstsPipelineSync
                 Console.WriteLine(" branches: comma deliminated name of branches");
                 Console.WriteLine(" wait-period: time between db updates (e.g. 00:01:00)");
                 Console.WriteLine(" vsts-pat: personal access token to vsts");
-                Console.WriteLine(" db-connection-string: connection string found in the azure portal");
+                Console.WriteLine(" db-connection-string: sql server connection string found in the azure portal");
                 Environment.Exit(1);
             }
 

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
@@ -36,45 +36,18 @@ namespace VstsPipelineSync
 
             while (!ct.IsCancellationRequested)
             {
-                try
-                {
-                    Console.WriteLine($"Import bugs data started at {DateTime.UtcNow}");
+                await ImportVstsBugDataAsync(bugManagement);
 
-                    await ImportVstsBugDataAsync(bugManagement);
-                }
-                catch (Exception ex)
+                foreach (string branch in this.branches)
                 {
-                    Console.WriteLine($"Unexcepted Exception: {ex}");
+                    buildLastUpdatePerBranchPerDefinition.Upsert(
+                        branch,
+                        await ImportVstsBuildsDataAsync(buildManagement, branch, BuildExtension.BuildDefinitions));
                 }
 
-                try
+                foreach (string branch in this.branches)
                 {
-                    Console.WriteLine($"Import Vsts Builds data started at {DateTime.UtcNow}");
-
-                    foreach (string branch in this.branches)
-                    {
-                        buildLastUpdatePerBranchPerDefinition.Upsert(
-                            branch,
-                            await ImportVstsBuildsDataAsync(buildManagement, branch, BuildExtension.BuildDefinitions));
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Unexcepted Exception: {ex}");
-                }
-
-                try
-                {
-                    Console.WriteLine($"Import Vsts Releases data started at {DateTime.UtcNow}");
-
-                    foreach (string branch in this.branches)
-                    {
-                        await ImportVstsReleasesDataAsync(releaseManagement, branch, ReleaseDefinitionId.E2ETest);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    Console.WriteLine($"Unexcepted Exception: {ex}");
+                    await ImportVstsReleasesDataAsync(releaseManagement, branch, ReleaseDefinitionId.E2ETest);
                 }
 
                 Console.WriteLine($"Import Vsts data finished at {DateTime.UtcNow}; wait {waitPeriodAfterEachUpdate} for next update.");

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
@@ -71,6 +71,7 @@ namespace VstsPipelineSync
                     string queryId = queryNameToId.Value;
                     int bugCount = await bugManagement.GetBugsQuery(queryId);
 
+                    Console.WriteLine($"Query VSTS bugs for work item query id {queryId}: last update={DateTime.UtcNow} => result count={bugCount}");
                     UpsertVstsBugToDb(sqlConnection, queryName, bugCount);
                 }
             }
@@ -117,7 +118,7 @@ namespace VstsPipelineSync
                 sqlConnection.Open();
 
                 IList<VstsBuild> buildResults = await buildManagement.GetBuildsAsync(new HashSet<BuildDefinitionId> { buildDefinitionId }, branch, lastUpdate);
-                Console.WriteLine($"Query VSTS for branch [{branch}] and build definition [{buildDefinitionId.ToString()}]: last update={lastUpdate} => result count={buildResults.Count}");
+                Console.WriteLine($"Query VSTS builds for branch [{branch}] and build definition [{buildDefinitionId.ToString()}]: last update={lastUpdate} => result count={buildResults.Count}");
                 DateTime maxLastChange = lastUpdate;
 
                 foreach (VstsBuild build in buildResults.Where(r => r.HasResult()))
@@ -183,6 +184,8 @@ namespace VstsPipelineSync
 
         async Task ImportVstsReleasesDataAsync(ReleaseManagement releaseManagement, string branch, ReleaseDefinitionId releaseDefinitionId)
         {
+            Console.WriteLine($"Import VSTS releases from branch [{branch}] started at {DateTime.UtcNow}.");
+
             SqlConnection sqlConnection = null;
 
             try
@@ -191,7 +194,7 @@ namespace VstsPipelineSync
                 sqlConnection.Open();
 
                 List<IoTEdgeRelease> releaseResults = await releaseManagement.GetReleasesAsync(releaseDefinitionId, branch, 200);
-                Console.WriteLine($"Query VSTS for branch [{branch}] and release definition [{releaseDefinitionId.ToString()}]: result count={releaseResults.Count} at {DateTime.UtcNow}.");
+                Console.WriteLine($"Query VSTS releases for branch [{branch}] and release definition [{releaseDefinitionId.ToString()}]: result count={releaseResults.Count} at {DateTime.UtcNow}.");
 
                 int releaseCount = 0;
 
@@ -225,7 +228,7 @@ namespace VstsPipelineSync
 
                     if (releaseCount % 10 ==0)
                     {
-                        Console.WriteLine($"Query VSTS for branch [{branch}] and release definition [{releaseDefinitionId.ToString()}]: release count={releaseCount} at {DateTime.UtcNow}.");
+                        Console.WriteLine($"Query VSTS releases for branch [{branch}] and release definition [{releaseDefinitionId.ToString()}]: release count={releaseCount} at {DateTime.UtcNow}.");
                     }
                 }
             }

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBug.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBug.sql
@@ -1,0 +1,19 @@
+CREATE PROCEDURE [dbo].[UpsertVstsBug]
+	@QueryName varchar(20),
+	@BugCount int
+AS
+	DECLARE @now datetime2;
+	SET @now = SYSDATETIME();
+
+	IF EXISTS (SELECT 1 FROM dbo.VstsBug WHERE QueryName = @QueryName)
+	BEGIN
+		UPDATE dbo.VstsBug
+		SET QueryName = @QueryName,
+		    BugCount = @BugCount
+		WHERE QueryName = @QueryName
+	END
+	ELSE
+	BEGIN
+		INSERT INTO dbo.VstsBug(QueryName, BugCount)
+		VALUES (@QueryName, @BugCount)
+	END

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBug.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBug.sql
@@ -2,18 +2,20 @@ CREATE PROCEDURE [dbo].[UpsertVstsBug]
 	@QueryName varchar(20),
 	@BugCount int
 AS
-	DECLARE @now datetime2;
-	SET @now = SYSDATETIME();
+    DECLARE @now datetime2;
+    SET @now = SYSDATETIME();
 
 	IF EXISTS (SELECT 1 FROM dbo.VstsBug WHERE QueryName = @QueryName)
-	BEGIN
-		UPDATE dbo.VstsBug
+    BEGIN
+        UPDATE dbo.VstsBug
 		SET QueryName = @QueryName,
-		    BugCount = @BugCount
+		    BugCount = @BugCount,
+			UpdatedAt = @now
 		WHERE QueryName = @QueryName
-	END
-	ELSE
-	BEGIN
-		INSERT INTO dbo.VstsBug(QueryName, BugCount)
-		VALUES (@QueryName, @BugCount)
-	END
+    END
+    ELSE
+    BEGIN
+        INSERT INTO dbo.VstsBug(QueryName, BugCount, InsertedAt, UpdatedAt)
+        VALUES (@QueryName, @BugCount, @now, @now)
+    END
+GO

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBug.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBug.sql
@@ -1,17 +1,17 @@
 CREATE PROCEDURE [dbo].[UpsertVstsBug]
-	@QueryName varchar(20),
-	@BugCount int
+    @QueryName varchar(20),
+    @BugCount int
 AS
     DECLARE @now datetime2;
     SET @now = SYSDATETIME();
 
-	IF EXISTS (SELECT 1 FROM dbo.VstsBug WHERE QueryName = @QueryName)
+    IF EXISTS (SELECT 1 FROM dbo.VstsBug WHERE QueryName = @QueryName)
     BEGIN
         UPDATE dbo.VstsBug
-		SET QueryName = @QueryName,
-		    BugCount = @BugCount,
-			UpdatedAt = @now
-		WHERE QueryName = @QueryName
+        SET QueryName = @QueryName,
+            BugCount = @BugCount,
+            UpdatedAt = @now
+        WHERE QueryName = @QueryName
     END
     ELSE
     BEGIN

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.VstsBug.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.VstsBug.sql
@@ -8,6 +8,8 @@ GO
 CREATE TABLE [dbo].[VstsBug](
 	[QueryName] [varchar](20) NOT NULL,
 	[BugCount] [int] NOT NULL,
+	[InsertedAt] [datetime2](7) NOT NULL,
+	[UpdatedAt] [datetime2](7) NOT NULL,
  CONSTRAINT [PK_QueryName] PRIMARY KEY CLUSTERED 
 (
 	[QueryName] ASC

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.VstsBug.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.VstsBug.sql
@@ -1,0 +1,17 @@
+/****** Object:  Table [dbo].[VstsBuildRun]    Script Date: 2/12/2020 4:56:48 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+CREATE TABLE [dbo].[VstsBug](
+	[QueryName] [varchar](20) NOT NULL,
+	[BugCount] [int] NOT NULL,
+ CONSTRAINT [PK_QueryName] PRIMARY KEY CLUSTERED 
+(
+	[QueryName] ASC
+)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+) ON [PRIMARY]
+GO
+


### PR DESCRIPTION
We need to start storing bug counts of certain shared queries in Azure Dev Ops. This will allow us to get an up to date picture of the stability of iotedge.

This is implemented by calling the Dev Ops [Wiql API](https://docs.microsoft.com/en-us/rest/api/azure/devops/wit/wiql/get?view=azure-devops-rest-5.1) to execute a shared query, getting the number of bugs returned, then storing this information in our test dashboard database.