### PR TITLE
remove dependency on DockerNAT for Linux containers on Windows

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -370,7 +370,7 @@ function Initialize-IoTEdge {
     Set-AgentImage
     Set-Hostname
     if ($ContainerOs -eq 'Linux') {
-        Set-GatewayAddress
+        Set-ListenConnectUriForLinuxContainers
     }
     else {
         Set-CorrectProgramData
@@ -1949,15 +1949,17 @@ function Set-ListenConnectUri([string] $ManagementUri, [string] $WorkloadUri) {
     $env:IOTEDGE_HOST = $ManagementUri
 }
 
-function Set-GatewayAddress {
-    $gatewayAddress = (Get-NetIpAddress |
-            Where-Object {$_.InterfaceAlias -like '*vEthernet (DockerNAT)*' -and $_.AddressFamily -eq 'IPv4'}).IPAddress
+function Set-ListenConnectUriForLinuxContainers {
+  # "host.docker.internal" is a well-known address that maps to the Host from inside a container on Docker Desktop.
 
-    Set-ListenConnectUri `
-        -ManagementUri "http://${gatewayAddress}:15580" `
-        -WorkloadUri "http://${gatewayAddress}:15581"
+  $connectAddress = 'http://host.docker.internal'
+  $listenAddress = 'http://127.0.0.1'
 
-    Write-HostGreen "Configured device with gateway address '$gatewayAddress'."
+  Set-ConfigUri -Section 'connect' -ManagementUri "${connectAddress}:15580" -WorkloadUri "${connectAddress}:15581"
+  Set-ConfigUri -Section 'listen' -ManagementUri "${listenAddress}:15580" -WorkloadUri "${listenAddress}:15581" 
+
+  Set-MachineEnvironmentVariable 'IOTEDGE_HOST' "${listenAddress}:15580" 
+  $env:IOTEDGE_HOST = "${listenAddress}:15580"
 }
 
 function Set-CorrectProgramData {

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -1950,16 +1950,16 @@ function Set-ListenConnectUri([string] $ManagementUri, [string] $WorkloadUri) {
 }
 
 function Set-ListenConnectUriForLinuxContainers {
-  # "host.docker.internal" is a well-known address that maps to the Host from inside a container on Docker Desktop.
+    # "host.docker.internal" is a well-known address that maps to the Host from inside a container on Docker Desktop.
 
-  $connectAddress = 'http://host.docker.internal'
-  $listenAddress = 'http://127.0.0.1'
+    $connectAddress = 'http://host.docker.internal'
+    $listenAddress = 'http://127.0.0.1'
 
-  Set-ConfigUri -Section 'connect' -ManagementUri "${connectAddress}:15580" -WorkloadUri "${connectAddress}:15581"
-  Set-ConfigUri -Section 'listen' -ManagementUri "${listenAddress}:15580" -WorkloadUri "${listenAddress}:15581" 
+    Set-ConfigUri -Section 'connect' -ManagementUri "${connectAddress}:15580" -WorkloadUri "${connectAddress}:15581"
+    Set-ConfigUri -Section 'listen' -ManagementUri "${listenAddress}:15580" -WorkloadUri "${listenAddress}:15581" 
 
-  Set-MachineEnvironmentVariable 'IOTEDGE_HOST' "${listenAddress}:15580" 
-  $env:IOTEDGE_HOST = "${listenAddress}:15580"
+    Set-MachineEnvironmentVariable 'IOTEDGE_HOST' "${listenAddress}:15580" 
+    $env:IOTEDGE_HOST = "${listenAddress}:15580"
 }
 
 function Set-CorrectProgramData {


### PR DESCRIPTION
Docker Desktop has removed 'DockerNAT' interface in its newer versions. 

This change removes the Windows install script dependency on the interface allowing use of Linux containers on Windows with newer Docker Desktop versions. Though not tested, this change should work with older versions of Docker Desktop as well.