### PR TITLE
Adding parallel processing to CloudConnectivityEstablished in SubscriptionProcessor

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         async void CloudConnectivityEstablished(object sender, EventArgs eventArgs)
         {
             Events.DeviceConnectedProcessingSubscriptions();
-            async Task ProcessIdentity(IIdentity identity)
+            async Task ProcessSubscriptionByIdentity(IIdentity identity)
             {
                 try
                 {
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             try
             {
-                IEnumerable<Task> tasks = this.ConnectionManager.GetConnectedClients().Select(id => ProcessIdentity(id));
+                IEnumerable<Task> tasks = this.ConnectionManager.GetConnectedClients().Select(id => ProcessSubscriptionByIdentity(id));
                 await Task.WhenAll(tasks);
             }
             catch (Exception e)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
@@ -128,8 +128,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             try
             {
-                IList<IIdentity> connectedClients = this.ConnectionManager.GetConnectedClients().ToList();
-                IEnumerable<Task> tasks = connectedClients.Select(id => ProcessIdentity(id));
+                IEnumerable<Task> tasks = this.ConnectionManager.GetConnectedClients().Select(id => ProcessIdentity(id));
                 await Task.WhenAll(tasks);
             }
             catch (Exception e)
@@ -263,7 +262,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public static void ProcessingSubscriptionsOnDeviceConnected(IIdentity identity)
             {
-                Log.LogInformation((int)EventIds.ProcessingSubscriptions, Invariant($"Processing subscriptions for client {identity.Id}."));
+                Log.LogInformation((int)EventIds.ProcessingSubscriptions, Invariant($"Processing subscriptions for client {identity.Id} on device connected."));
             }
 
             public static void ProcessingSubscription(string id, DeviceSubscription deviceSubscription)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SubscriptionProcessor.cs
@@ -125,6 +125,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     Events.ErrorProcessingSubscriptions(e, identity);
                 }
             }
+
             try
             {
                 IList<IIdentity> connectedClients = this.ConnectionManager.GetConnectedClients().ToList();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
@@ -360,6 +360,66 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         }
 
         [Fact]
+        public void ProcessSubscriptionsOnDeviceConnectedWithExceptionInTask()
+        {
+            // Arrange
+            string d1 = "d1";
+            var deviceIdentity = Mock.Of<IIdentity>(d => d.Id == d1);
+            string m1 = "d2/m1";
+            var moduleIdentity = Mock.Of<IIdentity>(m => m.Id == m1);
+
+            var connectedClients = new List<IIdentity>
+            {
+                deviceIdentity,
+                moduleIdentity
+            };
+
+            IReadOnlyDictionary<DeviceSubscription, bool> device1Subscriptions = new Dictionary<DeviceSubscription, bool>()
+            {
+                [DeviceSubscription.Methods] = true,
+                [DeviceSubscription.DesiredPropertyUpdates] = true
+            };
+
+            IReadOnlyDictionary<DeviceSubscription, bool> module1Subscriptions = new Dictionary<DeviceSubscription, bool>()
+            {
+                [DeviceSubscription.Methods] = true,
+                [DeviceSubscription.ModuleMessages] = true
+            };
+
+            var device1CloudProxy = Mock.Of<ICloudProxy>(
+                dc => dc.SetupDesiredPropertyUpdatesAsync() == Task.CompletedTask
+                      && dc.SetupCallMethodAsync() == Task.CompletedTask);
+            Mock.Get(device1CloudProxy).SetupGet(d => d.IsActive).Returns(true);
+            var module1CloudProxy = Mock.Of<ICloudProxy>(mc => mc.SetupCallMethodAsync() == Task.CompletedTask && mc.IsActive);
+
+            var invokeMethodHandler = Mock.Of<IInvokeMethodHandler>(
+                m => m.ProcessInvokeMethodSubscription(m1) == Task.CompletedTask);
+
+            var connectionManager = Mock.Of<IConnectionManager>(
+                c =>
+                    c.GetConnectedClients() == connectedClients
+                    && c.GetSubscriptions(m1) == Option.Some(module1Subscriptions)
+                    && c.GetCloudConnection(m1) == Task.FromResult(Option.Some(module1CloudProxy)));
+
+            Mock.Get(connectionManager).Setup(c => c.GetCloudConnection(d1)).Throws(new TimeoutException("Test GetCloudConnection Timeout"));
+
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
+
+            var subscriptionProcessor = new SubscriptionProcessor(connectionManager, invokeMethodHandler, deviceConnectivityManager);
+
+            // Act
+            Mock.Get(deviceConnectivityManager).Raise(d => d.DeviceConnected += null, new EventArgs());
+
+            // Assert
+
+            Mock.Get(device1CloudProxy).Verify(d => d.SetupDesiredPropertyUpdatesAsync(), Times.Never);
+            Mock.Get(device1CloudProxy).Verify(d => d.SetupCallMethodAsync(), Times.Never);
+            Mock.Get(module1CloudProxy).Verify(m => m.SetupCallMethodAsync(), Times.Once);
+            Mock.Get(invokeMethodHandler).VerifyAll();
+            Mock.Get(connectionManager).VerifyAll();
+        }
+
+        [Fact]
         public void ProcessSubscriptionsOnClientCloudConnectionEstablished()
         {
             // Arrange

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         }
 
         [Fact]
-        public void ProcessSubscriptionsOnDeviceConnectedWithExceptionInTask()
+        public void ProcessSubscriptionsOnDeviceConnectedWithGetCloudConnectionTimeout()
         {
             // Arrange
             string d1 = "d1";
@@ -414,6 +414,68 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Mock.Get(device1CloudProxy).Verify(d => d.SetupDesiredPropertyUpdatesAsync(), Times.Never);
             Mock.Get(device1CloudProxy).Verify(d => d.SetupCallMethodAsync(), Times.Never);
             Mock.Get(module1CloudProxy).Verify(m => m.SetupCallMethodAsync(), Times.Once);
+            Mock.Get(invokeMethodHandler).VerifyAll();
+            Mock.Get(connectionManager).VerifyAll();
+        }
+
+        [Fact]
+        public void ProcessSubscriptionsOnDeviceConnectedWithProcessInvokeMethodSubscriptionException()
+        {
+            // Arrange
+            string d1 = "d1";
+            var deviceIdentity = Mock.Of<IIdentity>(d => d.Id == d1);
+            string m1 = "d2/m1";
+            var moduleIdentity = Mock.Of<IIdentity>(m => m.Id == m1);
+
+            var connectedClients = new List<IIdentity>
+            {
+                deviceIdentity,
+                moduleIdentity
+            };
+
+            IReadOnlyDictionary<DeviceSubscription, bool> device1Subscriptions = new Dictionary<DeviceSubscription, bool>()
+            {
+                [DeviceSubscription.Methods] = true,
+                [DeviceSubscription.DesiredPropertyUpdates] = true
+            };
+
+            IReadOnlyDictionary<DeviceSubscription, bool> module1Subscriptions = new Dictionary<DeviceSubscription, bool>()
+            {
+                [DeviceSubscription.Methods] = true,
+                [DeviceSubscription.ModuleMessages] = true
+            };
+
+            var device1CloudProxy = Mock.Of<ICloudProxy>(
+                dc => dc.SetupDesiredPropertyUpdatesAsync() == Task.CompletedTask
+                      && dc.SetupCallMethodAsync() == Task.CompletedTask);
+            Mock.Get(device1CloudProxy).SetupGet(d => d.IsActive).Returns(true);
+            var module1CloudProxy = Mock.Of<ICloudProxy>(mc => mc.SetupCallMethodAsync() == Task.CompletedTask && mc.IsActive);
+
+            var invokeMethodHandler = Mock.Of<IInvokeMethodHandler>(
+                m =>
+                    m.ProcessInvokeMethodSubscription(d1) == Task.CompletedTask);
+
+            Mock.Get(invokeMethodHandler).Setup(m => m.ProcessInvokeMethodSubscription(m1)).Throws(new TimeoutException("Test ProcessInvokeMethodSubscription timeout"));
+
+            var connectionManager = Mock.Of<IConnectionManager>(
+                c =>
+                    c.GetConnectedClients() == connectedClients
+                    && c.GetSubscriptions(d1) == Option.Some(device1Subscriptions)
+                    && c.GetSubscriptions(m1) == Option.Some(module1Subscriptions)
+                    && c.GetCloudConnection(d1) == Task.FromResult(Option.Some(device1CloudProxy))
+                    && c.GetCloudConnection(m1) == Task.FromResult(Option.Some(module1CloudProxy)));
+
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
+
+            var subscriptionProcessor = new SubscriptionProcessor(connectionManager, invokeMethodHandler, deviceConnectivityManager);
+
+            // Act
+            Mock.Get(deviceConnectivityManager).Raise(d => d.DeviceConnected += null, new EventArgs());
+
+            // Assert
+            Mock.Get(device1CloudProxy).Verify(d => d.SetupDesiredPropertyUpdatesAsync(), Times.Once);
+            Mock.Get(device1CloudProxy).Verify(d => d.SetupCallMethodAsync(), Times.Once);
+            Mock.Get(module1CloudProxy).Verify(m => m.SetupCallMethodAsync(), Times.Exactly(2));
             Mock.Get(invokeMethodHandler).VerifyAll();
             Mock.Get(connectionManager).VerifyAll();
         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/SubscriptionProcessorTest.cs
@@ -411,7 +411,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Mock.Get(deviceConnectivityManager).Raise(d => d.DeviceConnected += null, new EventArgs());
 
             // Assert
-
             Mock.Get(device1CloudProxy).Verify(d => d.SetupDesiredPropertyUpdatesAsync(), Times.Never);
             Mock.Get(device1CloudProxy).Verify(d => d.SetupCallMethodAsync(), Times.Never);
             Mock.Get(module1CloudProxy).Verify(m => m.SetupCallMethodAsync(), Times.Once);


### PR DESCRIPTION
Currently, CloudConnectivityEstablished processes each subscription synchronously. It should be asynchronous.

This also fixes an issue where one of the subscriptions gets stuck forever and blocks the other subscriptions from being processed. Now, all the subscriptions will get processed even if one gets stuck or times out at some point. 