### PR TITLE
Fix build for new Rust stable 1.42.0

### DIFF
--- a/edgelet/edgelet-http-external-provisioning/src/client/external_provisioning.rs
+++ b/edgelet/edgelet-http-external-provisioning/src/client/external_provisioning.rs
@@ -310,7 +310,7 @@ mod tests {
 
                     Ok::<_, Error>(())
                 }
-                Err(_err) => panic!("Did not expect a failure."),
+                Err(err) => panic!("Did not expect a failure: {}", err),
             }
             .is_ok()
         };

--- a/edgelet/edgelet-kube/src/settings.rs
+++ b/edgelet/edgelet-kube/src/settings.rs
@@ -68,7 +68,7 @@ impl Settings {
     }
 
     pub fn iot_hub_hostname(&self) -> Option<&str> {
-        self.iot_hub_hostname.as_ref().map(String::as_str)
+        self.iot_hub_hostname.as_deref()
     }
 
     pub fn proxy(&self) -> &ProxySettings {
@@ -76,7 +76,7 @@ impl Settings {
     }
 
     pub fn device_id(&self) -> Option<&str> {
-        self.device_id.as_ref().map(String::as_str)
+        self.device_id.as_deref()
     }
 
     pub fn device_hub_selector(&self) -> &str {

--- a/edgelet/iotedge/src/support_bundle.rs
+++ b/edgelet/iotedge/src/support_bundle.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 use std::env;
-use std::error::Error as StdError;
 use std::ffi::OsString;
 use std::fs::File;
 use std::io::{stdout, Cursor, Seek};
@@ -296,7 +295,7 @@ where
                 ("iotedged_err.txt", result.stderr)
             }
         } else {
-            let err_message = inspect.err().unwrap().description().to_owned();
+            let err_message = inspect.err().unwrap().to_string();
             println!("Could not find system logs for iotedge. Including error in bundle.\nError message: {}", err_message);
             ("iotedged_err.txt", err_message.as_bytes().to_vec())
         };
@@ -354,7 +353,7 @@ where
                 ("docker_err.txt", result.stderr)
             }
         } else {
-            let err_message = inspect.err().unwrap().description().to_owned();
+            let err_message = inspect.err().unwrap().to_string();
             println!("Could not find system logs for docker. Including error in bundle.\nError message: {}", err_message);
             ("docker_err.txt", err_message.as_bytes().to_vec())
         };
@@ -377,7 +376,7 @@ where
     where
         W: Write + Seek + Send,
     {
-        let iotedge = env::args().nth(0).unwrap();
+        let iotedge = env::args().next().unwrap();
         state.print_verbose("Calling iotedge check");
 
         let mut check = ShellCommand::new(iotedge);
@@ -433,7 +432,7 @@ where
                 (format!("inspect/{}_err.json", module_name), result.stderr)
             }
         } else {
-            let err_message = inspect.err().unwrap().description().to_owned();
+            let err_message = inspect.err().unwrap().to_string();
             println!(
                 "Could not reach docker. Including error in bundle.\nError message: {}",
                 err_message
@@ -523,7 +522,7 @@ where
                 (format!("network/{}_err.json", network_name), result.stderr)
             }
         } else {
-            let err_message = inspect.err().unwrap().description().to_owned();
+            let err_message = inspect.err().unwrap().to_string();
             println!(
                 "Could not reach docker. Including error in bundle.\nError message: {}",
                 err_message

--- a/edgelet/kube-client/src/kube.rs
+++ b/edgelet/kube-client/src/kube.rs
@@ -44,7 +44,7 @@ pub struct Config {
 
 impl Config {
     pub fn kind(&self) -> Option<&str> {
-        self.kind.as_ref().map(String::as_str)
+        self.kind.as_deref()
     }
 
     pub fn with_kind(mut self, kind: Option<String>) -> Self {
@@ -53,7 +53,7 @@ impl Config {
     }
 
     pub fn api_version(&self) -> Option<&str> {
-        self.api_version.as_ref().map(String::as_str)
+        self.api_version.as_deref()
     }
 
     pub fn with_api_version(mut self, api_version: String) -> Self {
@@ -162,7 +162,7 @@ impl Cluster {
     }
 
     pub fn certificate_authority(&self) -> Option<&str> {
-        self.certificate_authority.as_ref().map(String::as_str)
+        self.certificate_authority.as_deref()
     }
 
     pub fn with_certificate_authority(mut self, certificate_authority: String) -> Self {
@@ -171,7 +171,7 @@ impl Cluster {
     }
 
     pub fn certificate_authority_data(&self) -> Option<&str> {
-        self.certificate_authority_data.as_ref().map(String::as_str)
+        self.certificate_authority_data.as_deref()
     }
 
     pub fn with_certificate_authority_data(mut self, certificate_authority_data: String) -> Self {
@@ -234,7 +234,7 @@ pub struct AuthInfo {
 
 impl AuthInfo {
     pub fn client_certificate(&self) -> Option<&str> {
-        self.client_certificate.as_ref().map(String::as_str)
+        self.client_certificate.as_deref()
     }
 
     pub fn with_client_certificate(mut self, client_certificate: String) -> Self {
@@ -243,7 +243,7 @@ impl AuthInfo {
     }
 
     pub fn client_key(&self) -> Option<&str> {
-        self.client_key.as_ref().map(String::as_str)
+        self.client_key.as_deref()
     }
 
     pub fn with_client_key(mut self, client_key: String) -> Self {
@@ -252,7 +252,7 @@ impl AuthInfo {
     }
 
     pub fn token(&self) -> Option<&str> {
-        self.token.as_ref().map(String::as_str)
+        self.token.as_deref()
     }
 
     pub fn with_token(mut self, token: String) -> Self {
@@ -261,7 +261,7 @@ impl AuthInfo {
     }
 
     pub fn token_file(&self) -> Option<&str> {
-        self.token_file.as_ref().map(String::as_str)
+        self.token_file.as_deref()
     }
 
     pub fn with_token_file(mut self, token_file: String) -> Self {
@@ -270,7 +270,7 @@ impl AuthInfo {
     }
 
     pub fn impersonate(&self) -> Option<&str> {
-        self.impersonate.as_ref().map(String::as_str)
+        self.impersonate.as_deref()
     }
 
     pub fn with_impersonate(mut self, impersonate: String) -> Self {
@@ -279,7 +279,7 @@ impl AuthInfo {
     }
 
     pub fn username(&self) -> Option<&str> {
-        self.username.as_ref().map(String::as_str)
+        self.username.as_deref()
     }
 
     pub fn with_username(mut self, username: String) -> Self {
@@ -288,7 +288,7 @@ impl AuthInfo {
     }
 
     pub fn password(&self) -> Option<&str> {
-        self.password.as_ref().map(String::as_str)
+        self.password.as_deref()
     }
 
     pub fn with_password(mut self, password: String) -> Self {
@@ -297,7 +297,7 @@ impl AuthInfo {
     }
 
     pub fn client_certificate_data(&self) -> Option<&str> {
-        self.client_certificate_data.as_ref().map(String::as_str)
+        self.client_certificate_data.as_deref()
     }
 
     pub fn with_client_certificate_data(mut self, client_certificate_data: String) -> Self {
@@ -306,7 +306,7 @@ impl AuthInfo {
     }
 
     pub fn client_key_data(&self) -> Option<&str> {
-        self.client_key_data.as_ref().map(String::as_str)
+        self.client_key_data.as_deref()
     }
 
     pub fn with_client_key_data(mut self, client_key_data: String) -> Self {
@@ -398,7 +398,7 @@ impl ExecConfig {
     }
 
     pub fn api_version(&self) -> Option<&str> {
-        self.api_version.as_ref().map(String::as_str)
+        self.api_version.as_deref()
     }
 
     pub fn with_api_version(mut self, api_version: String) -> Self {
@@ -497,7 +497,7 @@ impl Context {
     }
 
     pub fn namespace(&self) -> Option<&str> {
-        self.namespace.as_ref().map(String::as_str)
+        self.namespace.as_deref()
     }
 
     pub fn with_namespace(mut self, namespace: String) -> Self {


### PR DESCRIPTION
- `&Option<String>` -> `Option<&str>` conversion using new `Option::as_deref`
  instead of `.as_ref().map(String::as_str)`

- Replace deprecated `std::error::Error::description` with `Display::to_string`

- Replace `Iterator::nth(0)` with `Iterator::next()`

- One of the tests fired a clippy lint about throwing away the error in
  an `Err(_err)` match arm. Make the test use the error.