### PR TITLE
Adding timeout for device and moduleClients

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceClientWrapper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceClientWrapper.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         {
             try
             {
-                await this.underlyingDeviceClient.OpenAsync();
+                await this.underlyingDeviceClient.OpenAsync().TimeoutAfter(TimeSpan.FromMilliseconds(this.underlyingDeviceClient.OperationTimeoutInMilliseconds));
             }
             catch (Exception)
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceClientWrapper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceClientWrapper.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         {
             try
             {
-                await this.underlyingDeviceClient.OpenAsync().TimeoutAfter(TimeSpan.FromMilliseconds(this.underlyingDeviceClient.OperationTimeoutInMilliseconds));
+                await this.underlyingDeviceClient.OpenAsync().TimeoutAfter(TimeSpan.FromMinutes(2));
             }
             catch (Exception)
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleClientWrapper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleClientWrapper.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         {
             try
             {
-                await this.underlyingModuleClient.OpenAsync().TimeoutAfter(TimeSpan.FromMilliseconds(this.underlyingModuleClient.OperationTimeoutInMilliseconds));
+                await this.underlyingModuleClient.OpenAsync().TimeoutAfter(TimeSpan.FromMinutes(2));
             }
             catch (Exception)
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleClientWrapper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ModuleClientWrapper.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Concurrency;
     using Microsoft.Azure.Devices.Shared;
 
@@ -51,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         {
             try
             {
-                await this.underlyingModuleClient.OpenAsync();
+                await this.underlyingModuleClient.OpenAsync().TimeoutAfter(TimeSpan.FromMilliseconds(this.underlyingModuleClient.OperationTimeoutInMilliseconds));
             }
             catch (Exception)
             {

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -286,7 +286,7 @@ function Initialize-IoTEdge {
     Set-AgentImage
     Set-Hostname
     if ($ContainerOs -eq 'Linux') {
-        Set-GatewayAddress
+        Set-ListenConnectUriForLinuxContainers
     }
     else {
         Set-CorrectProgramData
@@ -1746,15 +1746,17 @@ function Set-ListenConnectUri([string] $ManagementUri, [string] $WorkloadUri) {
     $env:IOTEDGE_HOST = $ManagementUri
 }
 
-function Set-GatewayAddress {
-    $gatewayAddress = (Get-NetIpAddress |
-            Where-Object {$_.InterfaceAlias -like '*vEthernet (DockerNAT)*' -and $_.AddressFamily -eq 'IPv4'}).IPAddress
+function Set-ListenConnectUriForLinuxContainers {
+    # "host.docker.internal" is a well-known address that maps to the Host from inside a container on Docker Desktop.
 
-    Set-ListenConnectUri `
-        -ManagementUri "http://${gatewayAddress}:15580" `
-        -WorkloadUri "http://${gatewayAddress}:15581"
+    $connectAddress = 'http://host.docker.internal'
+    $listenAddress = 'http://127.0.0.1'
 
-    Write-HostGreen "Configured device with gateway address '$gatewayAddress'."
+    Set-ConfigUri -Section 'connect' -ManagementUri "${connectAddress}:15580" -WorkloadUri "${connectAddress}:15581"
+    Set-ConfigUri -Section 'listen' -ManagementUri "${listenAddress}:15580" -WorkloadUri "${listenAddress}:15581" 
+
+    Set-MachineEnvironmentVariable 'IOTEDGE_HOST' "${listenAddress}:15580" 
+    $env:IOTEDGE_HOST = "${listenAddress}:15580"
 }
 
 function Set-CorrectProgramData {


### PR DESCRIPTION
Adding timeout on OpenAsync for device and module wrapper clients. 

We are seeing sometimes that OpenAsync hangs forever. This is an SDK issue, but by adding a timeout here, we don't need to rely on the SDK making sure to come back. This way we force a timeout from our side. Even if the SDK hangs forever, we will timeout on this call.