### PR TITLE
[1.0.9] Remove CreateOrUpdate from ConnectionManager

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             Preconditions.CheckNotNull(credentials, nameof(credentials));
 
-            ConnectedDevice device = this.CreateOrUpdateConnectedDevice(credentials.Identity);
+            ConnectedDevice device = this.GetOrCreateConnectedDevice(credentials.Identity);
             Try<ICloudConnection> newCloudConnection = await device.CreateOrUpdateCloudConnection(c => this.CreateOrUpdateCloudConnection(c, credentials));
             Events.NewCloudConnection(credentials.Identity, newCloudConnection);
             Try<ICloudProxy> cloudProxyTry = GetCloudProxyFromCloudConnection(newCloudConnection, credentials.Identity);
@@ -304,16 +304,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             return this.devices.GetOrAdd(
                 Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId)),
                 id => this.CreateNewConnectedDevice(identity));
-        }
-
-        ConnectedDevice CreateOrUpdateConnectedDevice(IIdentity identity)
-        {
-            string deviceId = Preconditions.CheckNotNull(identity, nameof(identity)).Id;
-            Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
-            return this.devices.AddOrUpdate(
-                deviceId,
-                id => this.CreateNewConnectedDevice(identity),
-                (id, cd) => new ConnectedDevice(identity, cd.CloudConnection, cd.DeviceConnection));
         }
 
         ConnectedDevice CreateNewConnectedDevice(IIdentity identity)


### PR DESCRIPTION
CreateOrUpdate is causing issues in ConnectionManager. We will make a new instance of a ConnectedDevice every time we make a new CloudConnection

We were seeing that when there is a leaf device that does not have its parent set to edgeHub (a valid, but rare, case), edgeHub needs to create a new cloud connection in order to reauthenticate the device with edgeHub.

This new cloud connection will be made, even if there is already another cloud connection that is busy doing something else. In our case we were seeing that a CloudConnection was blocked forever on an OpenAsync call (which we are remedying). Then we saw a new cloud connection being made. This shouldn't happen, as there is a lock on the CloudConnection. But this lock isn't being respected, as we just create a new instance of CloudConnection with this CreateOrUpdate call. 

This PR removes CreateOrUpdate and uses GetOrCreate, which should work the same, but won't create a new connection unnecessarily 