### PR TITLE
Iotedged Checkin: Large file download timeout increase / Disk space fix

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -184,16 +184,19 @@ jobs:
       - script: |
           zip -1 target/ccov.zip `find ./target \( -name "*.gc*" \) -print`
           ./grcov target/ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" --ignore-dir "*docker-rs*" > target/lcov.info
-          python lcov_cobertura.py target/lcov.info --output target/coverage.xml --demangle --base-dir $(Build.SourcesDirectory)/edgelet -e "${COVERAGE_EXCLUDES}"
+          python lcov_cobertura.py target/lcov.info --output ./coverage.xml --demangle --base-dir $(Build.SourcesDirectory)/edgelet -e "${COVERAGE_EXCLUDES}"
         displayName: Assemble code coverage results
         workingDirectory: edgelet
         env:
           COVERAGE_EXCLUDES: $(coverage.excludes)
+      - script: rm -rf ./target/*
+        displayName: Cleanup build and test artifacts
+        workingDirectory: edgelet
       - task: PublishCodeCoverageResults@1
         displayName: Publish code coverage results
         inputs:
           codeCoverageTool: cobertura
-          summaryFileLocation: "edgelet/target/coverage.xml"
+          summaryFileLocation: "edgelet/coverage.xml"
       - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@5
         displayName: "Check build quality"
         inputs:

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -181,6 +181,9 @@ jobs:
       - script: $CARGO test --verbose
         displayName: Test
         workingDirectory: edgelet
+      - script: find ./target -type f ! -name '*.gc' -delete
+        displayName: Cleanup build and test artifacts
+        workingDirectory: edgelet
       - script: |
           zip -1 target/ccov.zip `find ./target \( -name "*.gc*" \) -print`
           ./grcov target/ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" --ignore-dir "*docker-rs*" > target/lcov.info
@@ -189,9 +192,6 @@ jobs:
         workingDirectory: edgelet
         env:
           COVERAGE_EXCLUDES: $(coverage.excludes)
-      - script: rm -rf ./target/*
-        displayName: Cleanup build and test artifacts
-        workingDirectory: edgelet
       - task: PublishCodeCoverageResults@1
         displayName: Publish code coverage results
         inputs:

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -182,7 +182,7 @@ jobs:
         displayName: Test
         workingDirectory: edgelet
       - script: |
-          zip -0 target/ccov.zip `find ./target \( -name "*.gc*" \) -print`
+          zip -1 target/ccov.zip `find ./target \( -name "*.gc*" \) -print`
           ./grcov target/ccov.zip -s . -t lcov --llvm --branch --ignore-not-existing --ignore-dir "/*" --ignore-dir "*docker-rs*" > target/lcov.info
           python lcov_cobertura.py target/lcov.info --output target/coverage.xml --demangle --base-dir $(Build.SourcesDirectory)/edgelet -e "${COVERAGE_EXCLUDES}"
         displayName: Assemble code coverage results

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -181,7 +181,7 @@ jobs:
       - script: $CARGO test --verbose
         displayName: Test
         workingDirectory: edgelet
-      - script: find ./target -type f ! -name '*.gc' -delete
+      - script: find ./target -type f ! -name '*.gc*' -delete
         displayName: Cleanup build and test artifacts
         workingDirectory: edgelet
       - script: |

--- a/edgelet/build/windows/util.ps1
+++ b/edgelet/build/windows/util.ps1
@@ -101,7 +101,7 @@ function InstallWinArmPrivateRustCompiler {
         $link = "https://edgebuild.blob.core.windows.net/iotedge-win-arm32v7-tools/rust-windows-arm-$toolchain.zip"
 
         Write-Host "Downloading $link to $downloadPath"
-        Invoke-WebRequest $link -OutFile $downloadPath -UseBasicParsing
+        Invoke-WebRequest $link -OutFile $downloadPath -UseBasicParsing -TimeoutSec 300
     }
 
     $targetPath = Join-Path -Path (Get-IotEdgeFolder) -ChildPath "rust-windows-arm-$toolchain"


### PR DESCRIPTION
We saw two errors from the iotedged checkin. 

Firstly, it would timeout when downloading this ~250MB file. This can be solved by adding a timeout of 5 minutes.

Secondly, the agent would crash and run out of disk space caused by a rust update. We can fix this by using compression in our zip command, as well as cleaning up the folder we use for cargo build/test. 