### PR TITLE
Test Dashboard: Add network controller description to test info

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -16,51 +16,51 @@ jobs:
       matrix:
         Online:
           testrun.config: 1
-          testrun.network.runProfile: "Online"
           testrun.network.description: "Online"
           testrun.network.frequencies: "00:00:00 00:00:00 0"
+          testrun.network.runProfile: "Online"
           testrun.duration: "01:00:00"
         Offline(5/5/5):
           testrun.config: 2
+          testrun.network.description: "Offline(5/5/5)"
           testrun.network.frequencies: "00:05:00 00:05:00 5"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(5/5/5)"
           testrun.duration: "00:50:00"
         Offline(10/10/3):
           testrun.config: 3
+          testrun.network.description: "Offline(10/10/3)"
           testrun.network.frequencies: "00:10:00 00:10:00 3"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(10/10/3)"
           testrun.duration: "01:00:00"
         Offline(15/15/3):
           testrun.config: 4
+          testrun.network.description: "Offline(15/15/3)"
           testrun.network.frequencies: "00:15:00 00:15:00 3"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(15/15/3)"
           testrun.duration: "01:30:00"
         Offline(30/30/2):
           testrun.config: 5
+          testrun.network.description: "Offline(30/30/2)"
           testrun.network.frequencies: "00:30:00 00:30:00 2"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(30/30/2)"
           testrun.duration: "02:00:00"
         Offline(5/20/3):
           testrun.config: 6
+          testrun.network.description: "Offline(5/20/3)"
           testrun.network.frequencies: "00:05:00 00:20:00 3"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(5/20/3)"
           testrun.duration: "01:15:00"
         SatelliteGood(60/0/1):
           testrun.config: 7
+          testrun.network.description: "SatelliteGood(60/0/1)"
           testrun.network.frequencies: "01:00:00 00:00:00 1"
           testrun.network.runProfile: "SatelliteGood"
-          testrun.network.description: "SatelliteGood(60/0/1)"
           testrun.duration: "01:00:00"
         Cellular3G(60/0/1):
           testrun.config: 8
+          testrun.network.description: "Cellular3G(60/0/1)"
           testrun.network.frequencies: "01:00:00 00:00:00 1"
           testrun.network.runProfile: "Cellular3G"
-          testrun.network.description: "Cellular3G(60/0/1)"
           testrun.duration: "01:00:00"
     pool:
       name: $(pool.name)
@@ -171,51 +171,51 @@ jobs:
       matrix:
         Online:
           testrun.config: 1
-          testrun.network.runProfile: "Online"
           testrun.network.description: "Online"
           testrun.network.frequencies: "00:00:00 00:00:00 0"
+          testrun.network.runProfile: "Online"
           testrun.duration: "01:00:00"
         Offline(5/5/5):
           testrun.config: 2
+          testrun.network.description: "Offline(5/5/5)"
           testrun.network.frequencies: "00:05:00 00:05:00 5"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(5/5/5)"
           testrun.duration: "00:50:00"
         Offline(10/10/3):
           testrun.config: 3
+          testrun.network.description: "Offline(10/10/3)"
           testrun.network.frequencies: "00:10:00 00:10:00 3"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(10/10/3)"
           testrun.duration: "01:00:00"
         Offline(15/15/3):
           testrun.config: 4
+          testrun.network.description: "Offline(15/15/3)"
           testrun.network.frequencies: "00:15:00 00:15:00 3"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(15/15/3)"
           testrun.duration: "01:30:00"
         Offline(30/30/2):
           testrun.config: 5
+          testrun.network.description: "Offline(30/30/2)"
           testrun.network.frequencies: "00:30:00 00:30:00 2"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(30/30/2)"
           testrun.duration: "02:00:00"
         Offline(5/20/3):
           testrun.config: 6
+          testrun.network.description: "Offline(5/20/3)"
           testrun.network.frequencies: "00:05:00 00:20:00 3"
           testrun.network.runProfile: "Offline"
-          testrun.network.description: "Offline(5/20/3)"
           testrun.duration: "01:15:00"
         SatelliteGood(60/0/1):
           testrun.config: 7
+          testrun.network.description: "SatelliteGood(60/0/1)"
           testrun.network.frequencies: "01:00:00 00:00:00 1"
           testrun.network.runProfile: "SatelliteGood"
-          testrun.network.description: "SatelliteGood(60/0/1)"
           testrun.duration: "01:00:00"
         Cellular3G(60/0/1):
           testrun.config: 8
+          testrun.network.description: "Cellular3G(60/0/1)"
           testrun.network.frequencies: "01:00:00 00:00:00 1"
           testrun.network.runProfile: "Cellular3G"
-          testrun.network.description: "Cellular3G(60/0/1)"
           testrun.duration: "01:00:00"
     pool:
       name: $(pool.name)

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -17,42 +17,50 @@ jobs:
         Online:
           testrun.config: 1
           testrun.network.runProfile: "Online"
+          testrun.network.description: "Online"
           testrun.network.frequencies: "00:00:00 00:00:00 0"
           testrun.duration: "01:00:00"
         Offline(5/5/5):
           testrun.config: 2
           testrun.network.frequencies: "00:05:00 00:05:00 5"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(5/5/5)"
           testrun.duration: "00:50:00"
         Offline(10/10/3):
           testrun.config: 3
           testrun.network.frequencies: "00:10:00 00:10:00 3"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(10/10/3)"
           testrun.duration: "01:00:00"
         Offline(15/15/3):
           testrun.config: 4
           testrun.network.frequencies: "00:15:00 00:15:00 3"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(15/15/3)"
           testrun.duration: "01:30:00"
         Offline(30/30/2):
           testrun.config: 5
           testrun.network.frequencies: "00:30:00 00:30:00 2"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(30/30/2)"
           testrun.duration: "02:00:00"
         Offline(5/20/3):
           testrun.config: 6
           testrun.network.frequencies: "00:05:00 00:20:00 3"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(5/20/3)"
           testrun.duration: "01:15:00"
         SatelliteGood(60/0/1):
           testrun.config: 7
           testrun.network.frequencies: "01:00:00 00:00:00 1"
           testrun.network.runProfile: "SatelliteGood"
+          testrun.network.description: "SatelliteGood(60/0/1)"
           testrun.duration: "01:00:00"
         Cellular3G(60/0/1):
           testrun.config: 8
           testrun.network.frequencies: "01:00:00 00:00:00 1"
           testrun.network.runProfile: "Cellular3G"
+          testrun.network.description: "Cellular3G(60/0/1)"
           testrun.duration: "01:00:00"
     pool:
       name: $(pool.name)
@@ -139,6 +147,7 @@ jobs:
           testStartDelay: '$(testStartDelay)'
           networkController.frequencies: '$(testrun.network.frequencies)'
           networkController.runProfile: '$(testrun.network.runProfile)'
+          networkController.description: '$(testrun.network.description)'
           logAnalyticsWorkspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalyticsSharedKey: '$(kvLogAnalyticSharedKey)'
           testResultCoordinator.logAnalyticsLogType: '$(testResultCoordinator.logAnalyticsLogType)'
@@ -163,42 +172,50 @@ jobs:
         Online:
           testrun.config: 1
           testrun.network.runProfile: "Online"
+          testrun.network.description: "Online"
           testrun.network.frequencies: "00:00:00 00:00:00 0"
           testrun.duration: "01:00:00"
         Offline(5/5/5):
           testrun.config: 2
           testrun.network.frequencies: "00:05:00 00:05:00 5"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(5/5/5)"
           testrun.duration: "00:50:00"
         Offline(10/10/3):
           testrun.config: 3
           testrun.network.frequencies: "00:10:00 00:10:00 3"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(10/10/3)"
           testrun.duration: "01:00:00"
         Offline(15/15/3):
           testrun.config: 4
           testrun.network.frequencies: "00:15:00 00:15:00 3"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(15/15/3)"
           testrun.duration: "01:30:00"
         Offline(30/30/2):
           testrun.config: 5
           testrun.network.frequencies: "00:30:00 00:30:00 2"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(30/30/2)"
           testrun.duration: "02:00:00"
         Offline(5/20/3):
           testrun.config: 6
           testrun.network.frequencies: "00:05:00 00:20:00 3"
           testrun.network.runProfile: "Offline"
+          testrun.network.description: "Offline(5/20/3)"
           testrun.duration: "01:15:00"
         SatelliteGood(60/0/1):
           testrun.config: 7
           testrun.network.frequencies: "01:00:00 00:00:00 1"
           testrun.network.runProfile: "SatelliteGood"
+          testrun.network.description: "SatelliteGood(60/0/1)"
           testrun.duration: "01:00:00"
         Cellular3G(60/0/1):
           testrun.config: 8
           testrun.network.frequencies: "01:00:00 00:00:00 1"
           testrun.network.runProfile: "Cellular3G"
+          testrun.network.description: "Cellular3G(60/0/1)"
           testrun.duration: "01:00:00"
     pool:
       name: $(pool.name)
@@ -286,6 +303,7 @@ jobs:
           testStartDelay: '$(testStartDelay.arm32)'
           networkController.frequencies: '$(testrun.network.frequencies)'
           networkController.runProfile: '$(testrun.network.runProfile)'
+          networkController.description: '$(testrun.network.description)'
           logAnalyticsWorkspaceId: '$(kvLogAnalyticWorkspaceId)'
           logAnalyticsSharedKey: '$(kvLogAnalyticSharedKey)'
           testResultCoordinator.logAnalyticsLogType: '$(testResultCoordinator.logAnalyticsLogType)'

--- a/builds/e2e/templates/connectivity-deploy.yaml
+++ b/builds/e2e/templates/connectivity-deploy.yaml
@@ -14,6 +14,7 @@ parameters:
   eventHub.connectionString: ''
   upstream.protocol: ''
   loadGen.message.frequency: ''
+  networkController.description: ''
   networkController.frequencies: ''
   networkController.runProfile: ''
   logAnalyticsWorkspaceId: ''
@@ -61,7 +62,7 @@ steps:
         testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
         testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
-        testInfo="$testInfo,RunProfile=${{ parameters['networkController.runProfile'] }}"
+        testInfo="$testInfo,NetworkDescription=${{ parameters['networkController.description'] }}"
         testInfo="$testInfo,CustomEdgeAgentImage=${{ parameters['customEdgeAgent.image'] }}"
         testInfo="$testInfo,CustomEdgeHubImage=${{ parameters['customEdgeHub.image'] }}"
         

--- a/test/connectivity/modules/NetworkController/Program.cs
+++ b/test/connectivity/modules/NetworkController/Program.cs
@@ -4,12 +4,9 @@ namespace NetworkController
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Edge.ModuleUtil;
     using Microsoft.Azure.Devices.Edge.ModuleUtil.NetworkController;
-    using Microsoft.Azure.Devices.Edge.ModuleUtil.TestResults;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
 
@@ -45,7 +42,6 @@ namespace NetworkController
 
                         Log.LogInformation($"Delay {durationBeforeTestStart} before starting network controller.");
                         await Task.Delay(durationBeforeTestStart, cts.Token);
-                        await ReportTestInfoAsync();
 
                         switch (Settings.Current.NetworkRunProfile.ProfileType)
                         {
@@ -79,31 +75,6 @@ namespace NetworkController
             await cts.Token.WhenCanceled();
             completed.Set();
             handler.ForEach(h => GC.KeepAlive(h));
-        }
-
-        static async Task ReportTestInfoAsync()
-        {
-            var testInfoResults = new string[]
-            {
-                $"Network Run Profile Type={Settings.Current.NetworkRunProfile.ProfileType}",
-                $"Network Run Profile Settings={Settings.Current.NetworkRunProfile.ProfileSetting.ToString()}",
-                $"Network Network Id={Settings.Current.NetworkId}",
-                $"Network Frequencies={string.Join(",", Settings.Current.Frequencies.Select(f => $"[Enable Network Control:{f.OfflineFrequency},Disable Network Control:{f.OnlineFrequency},Runs:{f.RunsCount}]"))}"
-            };
-
-            var testResultReportingClient = new TestResultReportingClient() { BaseUrl = Settings.Current.TestResultCoordinatorEndpoint.AbsoluteUri };
-
-            foreach (string testInfo in testInfoResults)
-            {
-                await ModuleUtil.ReportTestResultAsync(
-                    testResultReportingClient,
-                    Log,
-                    new TestInfoResult(
-                        Settings.Current.TrackingId,
-                        Settings.Current.ModuleId,
-                        testInfo,
-                        DateTime.UtcNow));
-            }
         }
 
         static async Task StartAsync(INetworkController controller, CancellationToken cancellationToken)


### PR DESCRIPTION
Test info currently contains run profile, however this is not specific enough. We can add a variable to describe the exact network scenario and add to test info.

If unfamiliar, test info is used to describe the context of a test and gets uploaded with the report for connectivity/longhaul/stress.