### PR TITLE
Increase dotnet version to 3.1

### DIFF
--- a/dotnetVersion.props
+++ b/dotnetVersion.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Microsoft.Azure.Devices.Edge.Agent.Core.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Microsoft.Azure.Devices.Edge.Agent.Core.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Microsoft.Azure.Devices.Edge.Agent.Docker.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/Microsoft.Azure.Devices.Edge.Agent.Docker.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <HighEntropyVA>true</HighEntropyVA>
     <Configurations>Debug;Release;CheckInBuild</Configurations>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/Microsoft.Azure.Devices.Edge.Agent.Edgelet.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/Microsoft.Azure.Devices.Edge.Agent.Edgelet.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Microsoft.Azure.Devices.Edge.Agent.Service.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Microsoft.Azure.Devices.Edge.Agent.Service.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/Microsoft.Azure.Devices.Edge.Agent.Core.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/Microsoft.Azure.Devices.Edge.Agent.Core.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.E2E.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
@@ -24,12 +18,8 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(DotNet_Runtime)' == 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.2" />
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.csproj
@@ -1,11 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest.csproj
@@ -1,14 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-        <TargetFramework>netcoreapp2.1</TargetFramework>
-    </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
-    <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-        <TargetFramework>netcoreapp3.0</TargetFramework>
-    </PropertyGroup>
-
-    <PropertyGroup>
+  <PropertyGroup>
         <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
         <Configurations>Debug;Release;CheckInBuild</Configurations>
         <HighEntropyVA>true</HighEntropyVA>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
@@ -22,11 +16,8 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(DotNet_Runtime)' == 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.2" />
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Microsoft.Azure.Devices.Edge.Hub.Amqp.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Microsoft.Azure.Devices.Edge.Hub.Amqp.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/Microsoft.Azure.Devices.Edge.Hub.Http.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/Microsoft.Azure.Devices.Edge.Hub.Http.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+  <Import Project="..\..\..\dotnetVersion.props" />
+
+  <PropertyGroup>
     <!--
     MVC requires compilation context to be available. Compilation context tells it if 
     a library references MVC which is used as a filter to skip assemblies that are deemed 

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Microsoft.Azure.Devices.Routing.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Microsoft.Azure.Devices.Routing.Core.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <NoWarn>3021</NoWarn>
     <Configurations>Debug;Release;CheckInBuild</Configurations>

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/Microsoft.Azure.Devices.Edge.Hub.Core.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/Microsoft.Azure.Devices.Edge.Hub.Core.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/Microsoft.Azure.Devices.Edge.Hub.Http.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/Microsoft.Azure.Devices.Edge.Hub.Http.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Service.Test/Microsoft.Azure.Devices.Edge.Hub.Service.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Service.Test/Microsoft.Azure.Devices.Edge.Hub.Service.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/Microsoft.Azure.Devices.Routing.Core.Test.csproj
+++ b/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/Microsoft.Azure.Devices.Routing.Core.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/edge-modules/MetricsCollector/MetricsCollector.csproj
+++ b/edge-modules/MetricsCollector/MetricsCollector.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
+++ b/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
@@ -2,8 +2,10 @@
   <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
     <CompileBlocked>true</CompileBlocked>
   </PropertyGroup>
+
+  <Import Project="..\..\..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <AssemblyName>Microsoft.Azure.WebJobs.Extensions.EdgeHub</AssemblyName>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>

--- a/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
+++ b/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
     <AzureFunctionsVersion></AzureFunctionsVersion>
     <OutputType>Library</OutputType>

--- a/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
+++ b/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <AzureFunctionsVersion></AzureFunctionsVersion>
     <OutputType>Library</OutputType>
     <ApplicationIcon />
@@ -17,7 +17,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/Microsoft.Azure.Devices.Edge.Storage.RocksDb.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/Microsoft.Azure.Devices.Edge.Storage.RocksDb.csproj
@@ -1,8 +1,9 @@
 ﻿<!--EXTERNAL_PROPERTIES: RocksDbAsPackage-->
 <Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/Microsoft.Azure.Devices.Edge.Storage.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/Microsoft.Azure.Devices.Edge.Storage.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Microsoft.Azure.Devices.Edge.Util.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Microsoft.Azure.Devices.Edge.Util.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SslProtocolsHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SslProtocolsHelper.cs
@@ -47,15 +47,6 @@ namespace Microsoft.Azure.Devices.Edge.Util
         public static string Print(this SslProtocols sslProtocols)
         {
             var sslProtocolsList = new List<string>();
-            if ((sslProtocols & SslProtocols.Ssl2) > 0)
-            {
-                sslProtocolsList.Add($"{SslProtocols.Ssl2}");
-            }
-
-            if ((sslProtocols & SslProtocols.Ssl3) > 0)
-            {
-                sslProtocolsList.Add($"{SslProtocols.Ssl3}");
-            }
 
             if ((sslProtocols & SslProtocols.Tls) > 0)
             {

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/Microsoft.Azure.Devices.Edge.Storage.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/Microsoft.Azure.Devices.Edge.Storage.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+    <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <Configurations>Debug;Release;CheckInBuild</Configurations>
     <HighEntropyVA>true</HighEntropyVA>

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/Microsoft.Azure.Devices.Edge.Util.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/Microsoft.Azure.Devices.Edge.Util.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
@@ -25,12 +19,8 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(DotNet_Runtime)' == 'netcoreapp3.0'">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.2.2" />
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
+++ b/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(Platform)' != 'ARM64'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(Platform)' == 'Unix|ARM64'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/samples/dotnet/EdgeX509AuthDownstreamDevice/EdgeX509AuthDownstreamDevice.csproj
+++ b/samples/dotnet/EdgeX509AuthDownstreamDevice/EdgeX509AuthDownstreamDevice.csproj
@@ -1,8 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="..\..\..\dotnetVersion.props" />
+
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
     <RootNamespace>EdgeDownstreamDevice</RootNamespace>
   </PropertyGroup>
 

--- a/smoke/IotEdgeQuickstart/IotEdgeQuickstart.csproj
+++ b/smoke/IotEdgeQuickstart/IotEdgeQuickstart.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/smoke/LeafDevice/LeafDevice.csproj
+++ b/smoke/LeafDevice/LeafDevice.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
@@ -1,15 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Configurations>Debug;Release;CheckInBuild</Configurations>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\dotnetVersion.props" />
 
   <PropertyGroup>
+    <Configurations>Debug;Release;CheckInBuild</Configurations>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/Microsoft.Azure.Devices.Edge.Test.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Microsoft.Azure.Devices.Edge.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/test/connectivity/modules/NetworkController/NetworkController.csproj
+++ b/test/connectivity/modules/NetworkController/NetworkController.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageTester.csproj
+++ b/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageTester.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/DeploymentTester/DeploymentTester.csproj
+++ b/test/modules/DeploymentTester/DeploymentTester.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/DirectMethodReceiver/DirectMethodReceiver.csproj
+++ b/test/modules/DirectMethodReceiver/DirectMethodReceiver.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/DirectMethodSender/DirectMethodSender.csproj
+++ b/test/modules/DirectMethodSender/DirectMethodSender.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/EdgeHubRestartTester/EdgeHubRestartTester.csproj
+++ b/test/modules/EdgeHubRestartTester/EdgeHubRestartTester.csproj
@@ -1,12 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/MetricsValidator/MetricsValidator.csproj
+++ b/test/modules/MetricsValidator/MetricsValidator.csproj
@@ -1,11 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
+++ b/test/modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
@@ -1,13 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Configurations>Debug;Release;CheckInBuild</Configurations>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />

--- a/test/modules/ModuleRestarter/ModuleRestarter.csproj
+++ b/test/modules/ModuleRestarter/ModuleRestarter.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/Modules.Test/Modules.Test.csproj
+++ b/test/modules/Modules.Test/Modules.Test.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>

--- a/test/modules/Relayer/Relayer.csproj
+++ b/test/modules/Relayer/Relayer.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/TemperatureFilter/TemperatureFilter.csproj
+++ b/test/modules/TemperatureFilter/TemperatureFilter.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/TestAnalyzer/TestAnalyzer.csproj
+++ b/test/modules/TestAnalyzer/TestAnalyzer.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/TestResultCoordinator/TestResultCoordinator.csproj
+++ b/test/modules/TestResultCoordinator/TestResultCoordinator.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/TwinTester/TwinTester.csproj
+++ b/test/modules/TwinTester/TwinTester.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>

--- a/test/modules/load-gen/load-gen.csproj
+++ b/test/modules/load-gen/load-gen.csproj
@@ -1,12 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(OS)|$(DotNet_Runtime)' == 'Unix|netcoreapp3.0'">
-    <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\dotnetVersion.props" />
   
   <PropertyGroup>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
What this PR accomplishes:
- Increases build to 3.1
- Alters build / test pipelines to be compatible with dotnet 3.1 increase