### PR TITLE
Install the latest linux packages in the end-to-end tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                         default:
                             throw new NotImplementedException($"Don't know how to install daemon on operating system '{os}'");
                     }
+
                     return new[]
                     {
                         $"curl https://packages.microsoft.com/config/{os}/{version}/multiarch/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -50,9 +50,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     {
                         case "Ubuntu":
                             os = "ubuntu";
+                            break;
                         case "Raspbian":
                             os = "debian";
                             version = "stretch";
+                            break;
                         default:
                             throw new NotImplementedException($"Don't know how to install daemon on operating system '{os}'");
                     }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 },
                 async () =>
                 {
+                    // Based on instructions at:
+                    // https://github.com/MicrosoftDocs/azure-docs/blob/058084949656b7df518b64bfc5728402c730536a/articles/iot-edge/how-to-install-iot-edge-linux.md
+
                     // TODO: 8/30/2019 support curl behind a proxy
                     string[] platformInfo = await Process.RunAsync("lsb_release", "-sir", token);
                     string os = platformInfo[0].Trim();
@@ -46,25 +49,20 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     switch (os)
                     {
                         case "Ubuntu":
-                            return new[]
-                            {
-                                $"curl https://packages.microsoft.com/config/ubuntu/{version}/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
-                                "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
-                                "apt-get update",
-                                "apt-get install --yes iotedge"
-                            };
+                            os = "ubuntu";
                         case "Raspbian":
-                            return new[]
-                            {
-                                "curl -L https://aka.ms/libiothsm-std-linux-armhf-latest -o libiothsm-std.deb",
-                                "curl -L https://aka.ms/iotedged-linux-armhf-latest -o iotedge.deb",
-                                "dpkg --force-confnew -i libiothsm-std.deb iotedge.deb",
-                                "apt-get install -f",
-                                "rm libiothsm-std.deb iotedge.deb"
-                            };
+                            os = "debian";
+                            version = "stretch";
                         default:
                             throw new NotImplementedException($"Don't know how to install daemon on operating system '{os}'");
                     }
+                    return new[]
+                    {
+                        $"curl https://packages.microsoft.com/config/{os}/{version}/multiarch/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
+                        "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
+                        "apt-get update",
+                        "apt-get install --yes iotedge"
+                    };
                 });
 
             await Profiler.Run(


### PR DESCRIPTION
On Linux, the end-to-end test framework was following outdated instructions to configure the repository for apt packages. This meant it didn't pick up the new 1.0.9 release, which was only pushed to the multiarch repository. I updated the code to grab the multiarch configuration, so the test framework should be able to install the latest version of edge.