### PR TITLE
Message priority metrics and debug logging

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeMessage.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeMessage.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     using System.Collections.Generic;
     using System.Linq;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Routing.Core;
 
     public class EdgeMessage : IMessage
     {
@@ -13,6 +14,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             this.Body = Preconditions.CheckNotNull(body, nameof(body));
             this.Properties = Preconditions.CheckNotNull(properties, nameof(properties));
             this.SystemProperties = Preconditions.CheckNotNull(systemProperties, nameof(systemProperties));
+            this.ProcessedPriority = RouteFactory.DefaultPriority;
+        }
+
+        public EdgeMessage(byte[] body, IDictionary<string, string> properties, IDictionary<string, string> systemProperties, uint processedPriority)
+        {
+            this.Body = Preconditions.CheckNotNull(body, nameof(body));
+            this.Properties = Preconditions.CheckNotNull(properties, nameof(properties));
+            this.SystemProperties = Preconditions.CheckNotNull(systemProperties, nameof(systemProperties));
+            this.ProcessedPriority = processedPriority;
         }
 
         public byte[] Body { get; }
@@ -20,6 +30,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public IDictionary<string, string> Properties { get; }
 
         public IDictionary<string, string> SystemProperties { get; }
+
+        public uint ProcessedPriority { get; }
 
         public bool Equals(EdgeMessage other)
         {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IMessage.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IMessage.cs
@@ -11,5 +11,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         IDictionary<string, string> Properties { get; }
 
         IDictionary<string, string> SystemProperties { get; }
+
+        uint ProcessedPriority { get; }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IMessage.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IMessage.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         IDictionary<string, string> SystemProperties { get; }
 
+        // Used to report the priority at which the message
+        // is being processed. This value is not valid at
+        // at routing and enqueue time, and is strictly
+        // meant to be used for metrics.
         uint ProcessedPriority { get; }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
             static readonly IMetricsTimer MessagesTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "message_send_duration_seconds",
                 "Time taken to send a message",
-                new List<string> { "from", "to", "priority" });
+                new List<string> { "from", "to" });
 
             static readonly IMetricsTimer GetTwinTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "gettwin_duration_seconds",
@@ -504,8 +504,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
             {
                 string from = message.GetSenderId();
                 string to = identity.Id;
-                string priority = message.ProcessedPriority.ToString();
-                return MessagesTimer.GetTimer(new[] { from, to, priority });
+                return MessagesTimer.GetTimer(new[] { from, to });
             }
 
             public static IDisposable TimeGetTwin(string id) => GetTwinTimer.GetTimer(new[] { "edge_hub", id });

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingMessageConverter.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingMessageConverter.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
                 }
             }
 
-            var edgeMessage = new EdgeMessage(routingMessage.Body, properties, systemProperties);
+            var edgeMessage = new EdgeMessage(routingMessage.Body, properties, systemProperties, routingMessage.ProcessedPriority);
             return edgeMessage;
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
@@ -536,6 +536,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
 
             public long Offset { get; }
 
+            public uint ProcessedPriority { get; set; }
+
             public DateTime EnqueuedTime => this.inner.EnqueuedTime;
 
             public DateTime DequeuedTime => this.inner.DequeuedTime;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceProxy.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceProxy.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             static readonly IMetricsCounter SentMessagesCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "messages_sent",
                 "Messages sent from edge hub",
-                new List<string> { "from", "to", "from_route_output", "to_route_input" });
+                new List<string> { "from", "to", "from_route_output", "to_route_input", "priority" });
 
             public static void AddSentMessage(IIdentity identity, IMessage message)
             {
@@ -173,7 +173,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
                 string fromRouteOutput = message.GetOutput();
                 string toRouteInput = message.GetInput();
-                SentMessagesCounter.Increment(1, new[] { from, to, fromRouteOutput, toRouteInput });
+                string priority = message.ProcessedPriority.ToString();
+                SentMessagesCounter.Increment(1, new[] { from, to, fromRouteOutput, toRouteInput, priority });
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttFeedbackMessage.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttFeedbackMessage.cs
@@ -3,12 +3,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 {
     using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Routing.Core;
+    using HubMessage = Microsoft.Azure.Devices.Edge.Hub.Core.IMessage;
 
     class MqttFeedbackMessage : IFeedbackMessage
     {
-        readonly IMessage message;
+        readonly HubMessage message;
 
-        public MqttFeedbackMessage(IMessage message, FeedbackStatus status)
+        public MqttFeedbackMessage(HubMessage message, FeedbackStatus status)
         {
             this.message = message;
             this.FeedbackStatus = status;
@@ -21,6 +23,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
         public IDictionary<string, string> Properties => this.message.Properties;
 
         public IDictionary<string, string> SystemProperties => this.message.SystemProperties;
+
+        public uint ProcessedPriority => RouteFactory.DefaultPriority;
 
         public void Dispose() => this.message.Dispose();
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/IMessage.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/IMessage.cs
@@ -18,6 +18,8 @@ namespace Microsoft.Azure.Devices.Routing.Core
 
         long Offset { get; }
 
+        uint ProcessedPriority { get; set; }
+
         DateTime EnqueuedTime { get; }
 
         DateTime DequeuedTime { get; }

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Message.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Message.cs
@@ -84,6 +84,8 @@ namespace Microsoft.Azure.Devices.Routing.Core
 
         public long Offset { get; }
 
+        public uint ProcessedPriority { get; set; }
+
         public DateTime EnqueuedTime { get; }
 
         public DateTime DequeuedTime { get; }


### PR DESCRIPTION
This change adds priority to RoutingMessage and EdgeMessage, so that the values can be plumb down to the lower layers where we record message metrics.

The following metrics were modified with message priority information:
- Total messages sent
- Message time to process
- Message time to send

I've also added more detailed debug logging in the executor regarding priority changes, message enqueue, and message processing.