### PR TITLE
Clean up docker images on pi agent

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -25,10 +25,12 @@ jobs:
     steps:
     - bash: |
         # We use a self-hosted agent for this job, so we need to handle
-        # cleanup of root-owned files ourselves (anything created during
-        # `sudo dotnet vstest ...`)
-        sudo git clean -ffdx . || true
-      displayName: sudo git clean
+        # clean up root-owned files and docker images ourselves (anything
+        # created during `dotnet vstest ...`)
+        sudo git clean -ffdx || true
+        sudo docker rm -f $(docker ps -a -q) || true
+        sudo docker system prune -a -f --volumes || true
+      displayName: Clean up files and images
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
 


### PR DESCRIPTION
Our new end-to-end tests don't clean up docker images/containers on the Raspberry Pi agent before running the tests, so over time the agent device storage fills up. This change cleans up images and containers before each test run (we were already cleaning up log files).

Note I also removed the path specifier (`.`) from the end of the `git clean` command, because per the docs the `-d` flag is redundant if you use a path specifier. One or the other had to go; I picked the path specifier because the `-d` flag is more explicit.