### PR TITLE
Update end-to-end test docs

### DIFF
--- a/doc/devguide.md
+++ b/doc/devguide.md
@@ -93,6 +93,10 @@ dotnet test --filter Category=Integration
 
 The syntax of the "filter" argument is described [here](https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-test#filter-option-details). All IoT Edge tests are categorized as one of `Unit`, `Integration`, or `Bvt`.
 
+## Run the end-to-end tests
+
+The end-to-end tests are documented [here](../test/README.md).
+
 ## Build Manifest Image
 There is a script in the repo to build multi-architecture images.
 This script assumes that the platform specific images are already in the docker registry.

--- a/test/README.md
+++ b/test/README.md
@@ -1,12 +1,22 @@
-# How to run the end-to-end tests
+# End-to-end tests
 
-## Software Dependency
-Since an IoT Edge device is responsible for running end-to-end (E2E) tests; hence,
-the software requirements to run a test is the combination of IoT Edge and test build.
-* For Building Tests
-    * .NET Core SDK
+## Test code structure
 
-## Test parameters
+There are three directories under `test/`:
+
+1. `test/Microsoft.Azure.Devices.Edge.Test/`: The actual tests live here, as do "fixtures" (setup and tear-down code that runs before/after/between tests) and the `Context` class (exposes the test arguments to tests).
+2. `test/Microsoft.Azure.Devices.Edge.Test.Common/`: The helper library tests use to do interesting things--like deploy modules or wait for a message to arrive in IoT Hub--lives here.
+3. `test/modules`: All test modules live here. The common pattern for an end-to-end test is to deploy some modules that run through a scenario (i.e., the thing you actually want to test, like sending messages between modules), then wait for them to report some result.
+
+## How to run the tests
+
+### Software Requirements
+
+End-to-end tests are written in .NET Core and run with the `dotnet test` command, so you need to [install .NET Core SDK](https://docs.microsoft.com/en-us/dotnet/core/install/sdk).
+
+The tests install the IoT Edge runtime _on the local host_, so your machine must support IoT Edge. Check out our installation docs ([Linux](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-windows), [Windows](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-linux)) to see what steps the test fixtures take to install IoT Edge, and to ensure your machine meets any prerequisites. **Note that on Linux, the fixtures do not install Moby engine**; you need to install Moby engine (or Docker) before you run the tests.
+
+### Test parameters
 
 The end-to-end tests take several parameters, which they expect to find in a file named `context.json` in the same directory as the test binaries (e.g., `test/Microsoft.Azure.Devices.Edge.Test/bin/Debug/netcoreapp2.1/context.json`). Parameter names are case-insensitive. The parameters are:
 
@@ -35,9 +45,9 @@ The end-to-end tests take several parameters, which they expect to find in a fil
 | `testTimeoutMinutes` || The maximum amount of time, in minutes, a single test should take. If this time is exceeded, the associated test will fail with a timeout error. If not given, the default value is `5`. |
 | `verbose` || Boolean value indicating whether to output more verbose logging information to standard output during a test run. If not given, the default is `false`. |
 
-## Test secrets
+### Test secrets
 
-The tests also expect to find several _secret_ parameters. While these can technically be added to `context.json`, it is recommended that you create environment variables and make them available to the test framework in a way that avoids committing them to your shell's command history or saving them in clear text on your filesystem. When set as environment variables, all secret parameters must be prefixed with `E2E_`. Parameter names are case-insensitive; they're only shown in uppercase here so they follow the common convention for environment variables, and to stand out as secrets.
+The tests also expect to find several _secret_ parameters. While these can technically be added to `context.json`, it is recommended that you create environment variables and make them available to the test framework in a way that avoids committing them to your shell's command history or saving them in clear text on your filesystem. When set as environment variables, all secret parameters must be prefixed with `E2E_`. Parameter names are case-**in**sensitive; they're only shown in uppercase here to follow the common convention for environment variables, and to stand out as secrets.
 
 | Name | Required | Description |
 |------|----------|-------------|
@@ -49,7 +59,7 @@ The tests also expect to find several _secret_ parameters. While these can techn
 
 _Note: the definitive source for information about test parameters is `test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs`._
 
-## Running the tests
+### Running the tests
 
 With the test parameters and secrets in place, you can run all the end-to-end tests from the command line
 
@@ -65,13 +75,14 @@ cd {repo root}
 sudo --preserve-env dotnet test ./test/Microsoft.Azure.Devices.Edge.Test 
 ```
 
-For more details please refer to NUnit document: 
-https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests#nunit
+To learn about other ways to run the tests (e.g., to run only certain tests), see 
+[Running selective unit tests](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests#nunit)
 
-## Troubleshooting
+### Troubleshooting
 
-If you are using a VSCode in Linux, it is recommend that you increase the maximum number of file I/O to prevent a test from erroring out by hitting the limit. To increase the file I/O capacity:
-https://code.visualstudio.com/docs/setup/linux#_visual-studio-code-is-unable-to-watch-for-file-changes-in-this-large-workspace-error-enospc
+#### File handle limit in VS Code
 
-Note: You will need to increase both `fs.inotify.max_user_instances` and `fs.inotify.max_user_watches`
+If you are using VS Code in Linux, it is recommended that you increase the maximum number of file I/O handles to prevent tests from hitting the limit. To learn how to increase the file I/O capacity, see
+https://code.visualstudio.com/docs/setup/linux#_visual-studio-code-is-unable-to-watch-for-file-changes-in-this-large-workspace-error-enospc.
 
+_Note: You will need to increase both `fs.inotify.max_user_instances` and `fs.inotify.max_user_watches`_


### PR DESCRIPTION
This change adds more information about the structure of the end-to-end test code, plus other minor updates. It also adds a link to the end-to-end doc from the dev guide.