### PR TITLE
Manually run end-to-end pipeline without arguments

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -4,13 +4,13 @@ pr: none
 resources:
   pipelines:
   - pipeline: images
-    source: ${{ variables.az.pipeline.images }}
+    source: $[variables.az.pipeline.images]
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
-    source: ${{ variables.az.pipeline.packages }}
+    source: $[variables.az.pipeline.packages]
     trigger:
       branches:
       - master

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -18,33 +18,33 @@ resources:
 
 jobs:
 
-# ################################################################################	
-#   - job: linux_arm32v7
-# ################################################################################	
-#     displayName: Linux arm32v7
+################################################################################	
+  - job: linux_arm32v7
+################################################################################	
+    displayName: Linux arm32v7
 
-#     pool:
-#       name: $(pool.name)
-#       demands: rpi3-e2e-tests
+    pool:
+      name: $(pool.name)
+      demands: rpi3-e2e-tests
 
-#     variables:
-#       os: linux
-#       arch: arm32v7
-#       artifactName: iotedged-debian9-arm32v7
+    variables:
+      os: linux
+      arch: arm32v7
+      artifactName: iotedged-debian9-arm32v7
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - bash: |
-#         # We use a self-hosted agent for this job, so we need to handle
-#         # clean up root-owned files and docker images ourselves (anything
-#         # created during `dotnet vstest ...`)
-#         sudo git clean -ffdx || true
-#         sudo docker rm -f $(docker ps -a -q) || true
-#         sudo docker system prune -a -f --volumes || true
-#       displayName: Clean up files and images
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - bash: |
+        # We use a self-hosted agent for this job, so we need to handle
+        # clean up root-owned files and docker images ourselves (anything
+        # created during `dotnet vstest ...`)
+        sudo git clean -ffdx || true
+        sudo docker rm -f $(docker ps -a -q) || true
+        sudo docker system prune -a -f --volumes || true
+      displayName: Clean up files and images
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
 ################################################################################	
   - job: linux_amd64
@@ -61,41 +61,41 @@ jobs:
 
     steps:
     - template: templates/e2e-setup.yaml
-    # - template: templates/e2e-run.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################	
-#   - job: windows_amd64
-# ################################################################################	
-#     displayName: Windows amd64
+################################################################################	
+  - job: windows_amd64
+################################################################################	
+    displayName: Windows amd64
 
-#     pool:
-#       vmImage: windows-2019
+    pool:
+      vmImage: windows-2019
 
-#     variables:
-#       os: windows
-#       arch: amd64
-#       artifactName: iotedged-windows
+    variables:
+      os: windows
+      arch: amd64
+      artifactName: iotedged-windows
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
 
-#     - pwsh: |
-#         $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
-#         $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
-#         $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
-#           -ArgumentList 'Root', 'LocalMachine'
-#         $store.Open('ReadWrite')
-#         $store.Add($cert)
-#       displayName: Install CAB signing root cert
-#       env:
-#         PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
+    - pwsh: |
+        $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
+        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
+        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
+          -ArgumentList 'Root', 'LocalMachine'
+        $store.Open('ReadWrite')
+        $store.Add($cert)
+      displayName: Install CAB signing root cert
+      env:
+        PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
 
-#     - pwsh: |
-#         Write-Output '>>> BEFORE:'
-#         netsh interface ipv6 show prefixpolicies
-#         netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
-#         Write-Output '>>> AFTER:'
-#         netsh interface ipv6 show prefixpolicies
-#       displayName: Prefer IPv4
+    - pwsh: |
+        Write-Output '>>> BEFORE:'
+        netsh interface ipv6 show prefixpolicies
+        netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
+        Write-Output '>>> AFTER:'
+        netsh interface ipv6 show prefixpolicies
+      displayName: Prefer IPv4
 
-#     - template: templates/e2e-run.yaml
+    - template: templates/e2e-run.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -18,33 +18,33 @@ resources:
 
 jobs:
 
-################################################################################	
-  - job: linux_arm32v7
-################################################################################	
-    displayName: Linux arm32v7
+# ################################################################################	
+#   - job: linux_arm32v7
+# ################################################################################	
+#     displayName: Linux arm32v7
 
-    pool:
-      name: $(pool.name)
-      demands: rpi3-e2e-tests
+#     pool:
+#       name: $(pool.name)
+#       demands: rpi3-e2e-tests
 
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactDir: iotedged-debian9-arm32v7
+#     variables:
+#       os: linux
+#       arch: arm32v7
+#       artifactDir: iotedged-debian9-arm32v7
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - bash: |
-        # We use a self-hosted agent for this job, so we need to handle
-        # clean up root-owned files and docker images ourselves (anything
-        # created during `dotnet vstest ...`)
-        sudo git clean -ffdx || true
-        sudo docker rm -f $(docker ps -a -q) || true
-        sudo docker system prune -a -f --volumes || true
-      displayName: Clean up files and images
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - bash: |
+#         # We use a self-hosted agent for this job, so we need to handle
+#         # clean up root-owned files and docker images ourselves (anything
+#         # created during `dotnet vstest ...`)
+#         sudo git clean -ffdx || true
+#         sudo docker rm -f $(docker ps -a -q) || true
+#         sudo docker system prune -a -f --volumes || true
+#       displayName: Clean up files and images
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
 ################################################################################	
   - job: linux_amd64
@@ -63,39 +63,39 @@ jobs:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
 
-################################################################################	
-  - job: windows_amd64
-################################################################################	
-    displayName: Windows amd64
+# ################################################################################	
+#   - job: windows_amd64
+# ################################################################################	
+#     displayName: Windows amd64
 
-    pool:
-      vmImage: windows-2019
+#     pool:
+#       vmImage: windows-2019
 
-    variables:
-      os: windows
-      arch: amd64
-      artifactDir: iotedged-windows
+#     variables:
+#       os: windows
+#       arch: amd64
+#       artifactDir: iotedged-windows
 
-    steps:
-    - template: templates/e2e-setup.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
 
-    - pwsh: |
-        $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
-        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
-        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
-          -ArgumentList 'Root', 'LocalMachine'
-        $store.Open('ReadWrite')
-        $store.Add($cert)
-      displayName: Install CAB signing root cert
-      env:
-        PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
+#     - pwsh: |
+#         $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
+#         $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
+#         $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
+#           -ArgumentList 'Root', 'LocalMachine'
+#         $store.Open('ReadWrite')
+#         $store.Add($cert)
+#       displayName: Install CAB signing root cert
+#       env:
+#         PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
 
-    - pwsh: |
-        Write-Output '>>> BEFORE:'
-        netsh interface ipv6 show prefixpolicies
-        netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
-        Write-Output '>>> AFTER:'
-        netsh interface ipv6 show prefixpolicies
-      displayName: Prefer IPv4
+#     - pwsh: |
+#         Write-Output '>>> BEFORE:'
+#         netsh interface ipv6 show prefixpolicies
+#         netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
+#         Write-Output '>>> AFTER:'
+#         netsh interface ipv6 show prefixpolicies
+#       displayName: Prefer IPv4
 
-    - template: templates/e2e-run.yaml
+#     - template: templates/e2e-run.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -4,13 +4,13 @@ pr: none
 resources:
   pipelines:
   - pipeline: images
-    source: '$[variables.az.pipeline.images]'
+    source: 'Azure-IoT-Edge-Core Build Images'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
-    source: '$[variables.az.pipeline.packages]'
+    source: 'Azure-IoT-Edge-Core Edgelet Packages'
     trigger:
       branches:
       - master

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -4,13 +4,13 @@ pr: none
 resources:
   pipelines:
   - pipeline: images
-    source: $[variables.az.pipeline.images]
+    source: '$[variables.az.pipeline.images]'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
-    source: $[variables.az.pipeline.packages]
+    source: '$[variables.az.pipeline.packages]'
     trigger:
       branches:
       - master

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -1,8 +1,20 @@
-# End-to-end tests should run after new docker images and edgelet packages are
-# built, but 'build completion triggers' are not yet supported in YAML. Set to
-# 'none' here and override in the online editor.
 trigger: none
 pr: none
+
+resources:
+  pipelines:
+  - pipeline: images
+    source: $(az.pipeline.images)
+    trigger:
+      branches:
+      - master
+      - release/*
+  - pipeline: packages
+    source: $(az.pipeline.packages)
+    trigger:
+      branches:
+      - master
+      - release/*
 
 jobs:
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -30,7 +30,7 @@ jobs:
 #     variables:
 #       os: linux
 #       arch: arm32v7
-#       artifactDir: iotedged-debian9-arm32v7
+#       artifactName: iotedged-debian9-arm32v7
 
 #     timeoutInMinutes: 120
 
@@ -57,7 +57,7 @@ jobs:
     variables:
       os: linux
       arch: amd64
-      artifactDir: iotedged-ubuntu16.04-amd64
+      artifactName: iotedged-ubuntu16.04-amd64
 
     steps:
     - template: templates/e2e-setup.yaml
@@ -74,7 +74,7 @@ jobs:
 #     variables:
 #       os: windows
 #       arch: amd64
-#       artifactDir: iotedged-windows
+#       artifactName: iotedged-windows
 
 #     steps:
 #     - template: templates/e2e-setup.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -4,13 +4,13 @@ pr: none
 resources:
   pipelines:
   - pipeline: images
-    source: '$(az.pipeline.images)'
+    source: 'Azure-IoT-Edge-Core Build Images'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
-    source: '$(az.pipeline.packages)'
+    source: 'Azure-IoT-Edge-Core Edgelet Packages'
     trigger:
       branches:
       - master

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -60,8 +60,37 @@ jobs:
       artifactDir: iotedged-ubuntu16.04-amd64
 
     steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+    - script: |
+        echo "Build Images pipeline:"
+        echo "projectName: [$(resources.pipeline.images.projectName)]"
+        echo "projectID: [$(resources.pipeline.images.projectID)]"
+        echo "pipelineName: [$(resources.pipeline.images.pipelineName)]"
+        echo "pipelineID: [$(resources.pipeline.images.pipelineID)]"
+        echo "runName: [$(resources.pipeline.images.runName)]"
+        echo "runID: [$(resources.pipeline.images.runID)]"
+        echo "runURI: [$(resources.pipeline.images.runURI)]"
+        echo "sourceBranch: [$(resources.pipeline.images.sourceBranch)]"
+        echo "sourceCommit: [$(resources.pipeline.images.sourceCommit)]"
+        echo "sourceProvider: [$(resources.pipeline.images.sourceProvider)]"
+        echo "requestedFor: [$(resources.pipeline.images.requestedFor)]"
+        echo "requestedForID: [$(resources.pipeline.images.requestedForID)]"
+
+        echo "Edgelet Packages pipeline:"
+        echo "projectName: [$(resources.pipeline.packages.projectName)]"
+        echo "projectID: [$(resources.pipeline.packages.projectID)]"
+        echo "pipelineName: [$(resources.pipeline.packages.pipelineName)]"
+        echo "pipelineID: [$(resources.pipeline.packages.pipelineID)]"
+        echo "runName: [$(resources.pipeline.packages.runName)]"
+        echo "runID: [$(resources.pipeline.packages.runID)]"
+        echo "runURI: [$(resources.pipeline.packages.runURI)]"
+        echo "sourceBranch: [$(resources.pipeline.packages.sourceBranch)]"
+        echo "sourceCommit: [$(resources.pipeline.packages.sourceCommit)]"
+        echo "sourceProvider: [$(resources.pipeline.packages.sourceProvider)]"
+        echo "requestedFor: [$(resources.pipeline.packages.requestedFor)]"
+        echo "requestedForID: [$(resources.pipeline.packages.requestedForID)]"
+      displayName: Print pipeline resource vars
+    # - template: templates/e2e-setup.yaml
+    # - template: templates/e2e-run.yaml
 
 # ################################################################################	
 #   - job: windows_amd64

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -60,36 +60,7 @@ jobs:
       artifactDir: iotedged-ubuntu16.04-amd64
 
     steps:
-    - script: |
-        echo "Build Images pipeline:"
-        echo "projectName: [$(resources.pipeline.images.projectName)]"
-        echo "projectID: [$(resources.pipeline.images.projectID)]"
-        echo "pipelineName: [$(resources.pipeline.images.pipelineName)]"
-        echo "pipelineID: [$(resources.pipeline.images.pipelineID)]"
-        echo "runName: [$(resources.pipeline.images.runName)]"
-        echo "runID: [$(resources.pipeline.images.runID)]"
-        echo "runURI: [$(resources.pipeline.images.runURI)]"
-        echo "sourceBranch: [$(resources.pipeline.images.sourceBranch)]"
-        echo "sourceCommit: [$(resources.pipeline.images.sourceCommit)]"
-        echo "sourceProvider: [$(resources.pipeline.images.sourceProvider)]"
-        echo "requestedFor: [$(resources.pipeline.images.requestedFor)]"
-        echo "requestedForID: [$(resources.pipeline.images.requestedForID)]"
-
-        echo "Edgelet Packages pipeline:"
-        echo "projectName: [$(resources.pipeline.packages.projectName)]"
-        echo "projectID: [$(resources.pipeline.packages.projectID)]"
-        echo "pipelineName: [$(resources.pipeline.packages.pipelineName)]"
-        echo "pipelineID: [$(resources.pipeline.packages.pipelineID)]"
-        echo "runName: [$(resources.pipeline.packages.runName)]"
-        echo "runID: [$(resources.pipeline.packages.runID)]"
-        echo "runURI: [$(resources.pipeline.packages.runURI)]"
-        echo "sourceBranch: [$(resources.pipeline.packages.sourceBranch)]"
-        echo "sourceCommit: [$(resources.pipeline.packages.sourceCommit)]"
-        echo "sourceProvider: [$(resources.pipeline.packages.sourceProvider)]"
-        echo "requestedFor: [$(resources.pipeline.packages.requestedFor)]"
-        echo "requestedForID: [$(resources.pipeline.packages.requestedForID)]"
-      displayName: Print pipeline resource vars
-    # - template: templates/e2e-setup.yaml
+    - template: templates/e2e-setup.yaml
     # - template: templates/e2e-run.yaml
 
 # ################################################################################	

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -4,13 +4,13 @@ pr: none
 resources:
   pipelines:
   - pipeline: images
-    source: '${{ variables.az.pipeline.images }}'
+    source: ${{ variables.az.pipeline.images }}
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
-    source: '${{ variables.az.pipeline.packages }}'
+    source: ${{ variables.az.pipeline.packages }}
     trigger:
       branches:
       - master

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -4,13 +4,13 @@ pr: none
 resources:
   pipelines:
   - pipeline: images
-    source: 'Azure-IoT-Edge-Core Build Images'
+    source: '${{ variables.az.pipeline.images }}'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
-    source: 'Azure-IoT-Edge-Core Edgelet Packages'
+    source: '${{ variables.az.pipeline.packages }}'
     trigger:
       branches:
       - master

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -4,13 +4,13 @@ pr: none
 resources:
   pipelines:
   - pipeline: images
-    source: $(az.pipeline.images)
+    source: '$(az.pipeline.images)'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
-    source: $(az.pipeline.packages)
+    source: '$(az.pipeline.packages)'
     trigger:
       branches:
       - master

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -18,13 +18,13 @@ steps:
       TestRootCaKey,
       TestRootCaPassword
 
-# - download: images
-#   artifact: '$(az.pipeline.images.artifacts)'
-#   patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
+- download: images
+  # artifact: '$(az.pipeline.images.artifacts)'
+  # patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
 
-# - download: packages
-#   artifact: '$(artifactDir)'
-#   patterns: '$(artifactDir)/*'
+- download: packages
+  # artifact: '$(artifactDir)'
+  # patterns: '$(artifactDir)/*'
 
 # - task: DownloadBuildArtifacts@0
 #   displayName: Download edgelet packages

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -18,69 +18,37 @@ steps:
       TestRootCaKey,
       TestRootCaPassword
 
-- pwsh: |
-    # We care about three cases:
-    # 1) 'Edgelet Packages' build triggered this build (use latest 'Build Images' build on master)
-    if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.packages)')
-    {
-      Write-Output "Triggered by build '$(az.pipeline.packages)' \#$(Build.TriggeredBy.BuildId)"
-      Write-Output '##vso[task.setvariable variable=whichPackageBuild]specific'
-      Write-Output '##vso[task.setvariable variable=whichImageBuild]latestFromBranch'
-      Write-Output '##vso[task.setvariable variable=packageBuildId]$(Build.TriggeredBy.BuildId)'
-    }
-    # 2) 'Build Images' build triggered this build (use latest 'Edgelet Packages' build on master)
-    elseif ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME -eq '$(az.pipeline.images)')
-    {
-      Write-Output "Triggered by build '$(az.pipeline.images)' \#$(Build.TriggeredBy.BuildId)"
-      Write-Output '##vso[task.setvariable variable=whichPackageBuild]latestFromBranch'
-      Write-Output '##vso[task.setvariable variable=whichImageBuild]specific'
-      Write-Output '##vso[task.setvariable variable=imageBuildId]$(Build.TriggeredBy.BuildId)'
-    }
-    # 3) Manual build (use given args for 'Build Images' build ID and 'Edgelet Packages' build ID)
-    elseif ('$(az.pipeline.packages.buildId)' -and '$(az.pipeline.images.buildId)')
-    {
-      Write-Output '##vso[task.setvariable variable=whichPackageBuild]specific'
-      Write-Output '##vso[task.setvariable variable=whichImageBuild]specific'
-      Write-Output '##vso[task.setvariable variable=packageBuildId]$(az.pipeline.packages.buildId)'
-      Write-Output '##vso[task.setvariable variable=imageBuildId]$(az.pipeline.images.buildId)'
-    }
-    else # Error
-    {
-      if ($env:BUILD_TRIGGEREDBY_DEFINITIONNAME)
-      {
-        Write-Output "Build triggered by unrecognized build '$env:BUILD_TRIGGEREDBY_DEFINITIONNAME'"
-      }
-      else
-      {
-        Write-Output "Missing build parameter 'az.pipeline.packages.buildId' or 'az.pipeline.images.buildId'"
-      }
-      exit 1
-    }
-  displayName: Locate edgelet packages, runtime images
+- download: images
+  artifact: $(az.pipeline.images.artifacts)
+  patterns: $(az.pipeline.images.artifacts)/artifactInfo.txt
 
-- task: DownloadBuildArtifacts@0
-  displayName: Download edgelet packages
-  inputs:
-    buildType: specific
-    project: one
-    pipeline: $(az.pipeline.packages)
-    buildVersionToDownload: $(whichPackageBuild)
-    branchName: refs/heads/master
-    buildId: $(packageBuildId)
-    downloadType: specific
-    itemPattern: $(artifactDir)/*
+- download: packages
+  artifact: $(artifactDir)
+  patterns: $(artifactDir)/*
 
-- task: DownloadBuildArtifacts@0
-  displayName: Get Docker image info
-  inputs:
-    buildType: specific
-    project: one
-    pipeline: $(az.pipeline.images)
-    buildVersionToDownload: $(whichImageBuild)
-    branchName: refs/heads/master
-    buildId: $(imageBuildId)
-    downloadType: specific
-    itemPattern: $(az.pipeline.images.artifacts)/artifactInfo.txt
+# - task: DownloadBuildArtifacts@0
+#   displayName: Download edgelet packages
+#   inputs:
+#     buildType: specific
+#     project: one
+#     pipeline: $(az.pipeline.packages)
+#     buildVersionToDownload: $(whichPackageBuild)
+#     branchName: refs/heads/master
+#     buildId: $(packageBuildId)
+#     downloadType: specific
+#     itemPattern: $(artifactDir)/*
+
+# - task: DownloadBuildArtifacts@0
+#   displayName: Get Docker image info
+#   inputs:
+#     buildType: specific
+#     project: one
+#     pipeline: $(az.pipeline.images)
+#     buildVersionToDownload: $(whichImageBuild)
+#     branchName: refs/heads/master
+#     buildId: $(imageBuildId)
+#     downloadType: specific
+#     itemPattern: $(az.pipeline.images.artifacts)/artifactInfo.txt
 
 - pwsh: |
     $certsDir = '$(System.ArtifactsDirectory)/certs'

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -18,13 +18,25 @@ steps:
       TestRootCaKey,
       TestRootCaPassword
 
-- download: images
-  artifact: '$(az.pipeline.images.artifacts)'
-  # patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
+# - download: images
+#   artifact: '$(az.pipeline.images.artifacts)'
+#   patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
 
-- download: packages
-  artifact: '$(artifactDir)'
-  # patterns: '$(artifactDir)/*'
+- task: DownloadBuildArtifacts@0
+  displayName: Get Docker image info
+  inputs:
+    buildType: specific
+    project: $(resources.pipeline.images.projectID)
+    pipeline: $(resources.pipeline.images.pipelineName)
+    buildVersionToDownload: specific
+    buildId: $(resources.pipeline.images.runID)
+    downloadType: single
+    artifactName: $(az.pipeline.images.artifacts)
+    itemPattern: $(az.pipeline.images.artifacts)/artifactInfo.txt
+
+# - download: packages
+#   artifact: '$(artifactDir)'
+#   patterns: '$(artifactDir)/*'
 
 # - task: DownloadBuildArtifacts@0
 #   displayName: Download edgelet packages

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -18,6 +18,26 @@ steps:
       TestRootCaKey,
       TestRootCaPassword
 
+- pwsh: |
+    $imageBuildId = $(resources.pipeline.images.runID)
+    $packageBuildId = $(resources.pipeline.packages.runID)
+
+    if ('$(az.pipeline.images.buildId)')
+    {
+      Write-Output ">> User supplied az.pipeline.images.buildId=$(az.pipeline.images.buildId)"
+      $imageBuildId = $(az.pipeline.images.buildId)
+    }
+
+    if ('$(az.pipeline.packages.buildId)')
+    {
+      Write-Output ">> User supplied az.pipeline.packages.buildId=$(az.pipeline.packages.buildId)"
+      $packageBuildId = $(az.pipeline.packages.buildId)
+    }
+
+    Write-Output "##vso[task.setvariable variable=imageBuildId]$imageBuildId"
+    Write-Output "##vso[task.setvariable variable=packageBuildId]$packageBuildId"
+  displayName: Override artifacts with user-supplied args
+
 - task: DownloadBuildArtifacts@0
   displayName: Get Docker image info
   inputs:
@@ -25,7 +45,7 @@ steps:
     project: $(resources.pipeline.images.projectID)
     pipeline: $(resources.pipeline.images.pipelineName)
     buildVersionToDownload: specific
-    buildId: $(resources.pipeline.images.runID)
+    buildId: $(imageBuildId)
     downloadType: single
     artifactName: $(az.pipeline.images.artifacts)
     itemPattern: $(az.pipeline.images.artifacts)/artifactInfo.txt

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -24,14 +24,14 @@ steps:
 
     if ('$(az.pipeline.images.buildId)')
     {
-      Write-Output ">> User supplied az.pipeline.images.buildId=$(az.pipeline.images.buildId)"
-      $imageBuildId = $(az.pipeline.images.buildId)
+      Write-Output '>> User supplied az.pipeline.images.buildId=$(az.pipeline.images.buildId)'
+      $imageBuildId = '$(az.pipeline.images.buildId)'
     }
 
     if ('$(az.pipeline.packages.buildId)')
     {
-      Write-Output ">> User supplied az.pipeline.packages.buildId=$(az.pipeline.packages.buildId)"
-      $packageBuildId = $(az.pipeline.packages.buildId)
+      Write-Output '>> User supplied az.pipeline.packages.buildId=$(az.pipeline.packages.buildId)'
+      $packageBuildId = '$(az.pipeline.packages.buildId)'
     }
 
     Write-Output "##vso[task.setvariable variable=imageBuildId]$imageBuildId"

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -39,7 +39,7 @@ steps:
     buildVersionToDownload: specific
     buildId: $(resources.pipeline.packages.runID)
     downloadType: single
-    artifactName: $(az.pipeline.images.artifacts)
+    artifactName: $(artifactName)
 
 - pwsh: |
     $certsDir = '$(System.ArtifactsDirectory)/certs'
@@ -82,7 +82,7 @@ steps:
           username = '$(cr.username)';
         }
       );
-      packagePath = Convert-Path '$(System.ArtifactsDirectory)/$(artifactDir)';
+      packagePath = Convert-Path '$(System.ArtifactsDirectory)/$(artifactName)';
       caCertScriptPath = Convert-Path '$(Build.SourcesDirectory)/tools/CACertificates';
       rootCaCertificatePath = Convert-Path '$(certsDir)/rsa_root_ca.cert.pem';
       rootCaPrivateKeyPath = Convert-Path '$(certsDir)/rsa_root_ca.key.pem';

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -18,13 +18,13 @@ steps:
       TestRootCaKey,
       TestRootCaPassword
 
-- download: images
-  artifact: '$(az.pipeline.images.artifacts)'
-  patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
+# - download: images
+#   artifact: '$(az.pipeline.images.artifacts)'
+#   patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
 
-- download: packages
-  artifact: '$(artifactDir)'
-  patterns: '$(artifactDir)/*'
+# - download: packages
+#   artifact: '$(artifactDir)'
+#   patterns: '$(artifactDir)/*'
 
 # - task: DownloadBuildArtifacts@0
 #   displayName: Download edgelet packages

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -19,12 +19,12 @@ steps:
       TestRootCaPassword
 
 - download: images
-  artifact: $(az.pipeline.images.artifacts)
-  patterns: $(az.pipeline.images.artifacts)/artifactInfo.txt
+  artifact: '$(az.pipeline.images.artifacts)'
+  patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
 
 - download: packages
-  artifact: $(artifactDir)
-  patterns: $(artifactDir)/*
+  artifact: '$(artifactDir)'
+  patterns: '$(artifactDir)/*'
 
 # - task: DownloadBuildArtifacts@0
 #   displayName: Download edgelet packages

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -19,11 +19,11 @@ steps:
       TestRootCaPassword
 
 - download: images
-  # artifact: '$(az.pipeline.images.artifacts)'
+  artifact: '$(az.pipeline.images.artifacts)'
   # patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
 
 - download: packages
-  # artifact: '$(artifactDir)'
+  artifact: '$(artifactDir)'
   # patterns: '$(artifactDir)/*'
 
 # - task: DownloadBuildArtifacts@0

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -18,10 +18,6 @@ steps:
       TestRootCaKey,
       TestRootCaPassword
 
-# - download: images
-#   artifact: '$(az.pipeline.images.artifacts)'
-#   patterns: '$(az.pipeline.images.artifacts)/artifactInfo.txt'
-
 - task: DownloadBuildArtifacts@0
   displayName: Get Docker image info
   inputs:
@@ -34,33 +30,16 @@ steps:
     artifactName: $(az.pipeline.images.artifacts)
     itemPattern: $(az.pipeline.images.artifacts)/artifactInfo.txt
 
-# - download: packages
-#   artifact: '$(artifactDir)'
-#   patterns: '$(artifactDir)/*'
-
-# - task: DownloadBuildArtifacts@0
-#   displayName: Download edgelet packages
-#   inputs:
-#     buildType: specific
-#     project: one
-#     pipeline: $(az.pipeline.packages)
-#     buildVersionToDownload: $(whichPackageBuild)
-#     branchName: refs/heads/master
-#     buildId: $(packageBuildId)
-#     downloadType: specific
-#     itemPattern: $(artifactDir)/*
-
-# - task: DownloadBuildArtifacts@0
-#   displayName: Get Docker image info
-#   inputs:
-#     buildType: specific
-#     project: one
-#     pipeline: $(az.pipeline.images)
-#     buildVersionToDownload: $(whichImageBuild)
-#     branchName: refs/heads/master
-#     buildId: $(imageBuildId)
-#     downloadType: specific
-#     itemPattern: $(az.pipeline.images.artifacts)/artifactInfo.txt
+- task: DownloadBuildArtifacts@0
+  displayName: Download edgelet packages
+  inputs:
+    buildType: specific
+    project: $(resources.pipeline.packages.projectID)
+    pipeline: $(resources.pipeline.packages.pipelineName)
+    buildVersionToDownload: specific
+    buildId: $(resources.pipeline.packages.runID)
+    downloadType: single
+    artifactName: $(az.pipeline.images.artifacts)
 
 - pwsh: |
     $certsDir = '$(System.ArtifactsDirectory)/certs'

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -57,7 +57,7 @@ steps:
     project: $(resources.pipeline.packages.projectID)
     pipeline: $(resources.pipeline.packages.pipelineName)
     buildVersionToDownload: specific
-    buildId: $(resources.pipeline.packages.runID)
+    buildId: $(packageBuildId)
     downloadType: single
     artifactName: $(artifactName)
 


### PR DESCRIPTION
This change updates the new end-to-end test pipeline to use pipeline triggers instead of (deprecated) build completion triggers. There are a few benefits:
- We're using the officially recommended/supported trigger
- It requires less code in the YAML definition than what's there now
- It still allows you to run the build manually and specify which "Build Images" and "Edgelet Packages" builds to grab artifacts from (e.g. if you've made changes to iotedged or edge agent, and you want to run end-to-end tests against your changes before you merge your PR), but you're no longer _required_ to supply build IDs. So for instance, if you want to try out the new end-to-end test you're writing, just run the build against your PR without any arguments and it will use the latest artifacts from master builds.