### PR TITLE
[k8s public preview] Add deployment strategy to k8s-experimental (#2745)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CombinedKubernetesConfigProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CombinedKubernetesConfigProvider.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
                 experimentalOptions.ForEach(parameters => createOptions.NodeSelector = parameters.NodeSelector);
                 experimentalOptions.ForEach(parameters => createOptions.Resources = parameters.Resources);
                 experimentalOptions.ForEach(parameters => createOptions.SecurityContext = parameters.SecurityContext);
+                experimentalOptions.ForEach(parameters => createOptions.DeploymentStrategy = parameters.DeploymentStrategy);
             }
 
             Option<ImagePullSecret> imagePullSecret = dockerConfig.AuthConfig

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CreatePodParameters.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CreatePodParameters.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             IEnumerable<string> cmd,
             IEnumerable<string> entrypoint,
             string workingDir)
-            : this(env?.ToList(), exposedPorts, hostConfig, image, labels, cmd?.ToList(), entrypoint?.ToList(), workingDir, null, null, null, null)
+            : this(env?.ToList(), exposedPorts, hostConfig, image, labels, cmd?.ToList(), entrypoint?.ToList(), workingDir, null, null, null, null, null)
         {
         }
 
@@ -38,7 +38,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             IDictionary<string, string> nodeSelector,
             V1ResourceRequirements resources,
             IReadOnlyList<KubernetesModuleVolumeSpec> volumes,
-            V1PodSecurityContext securityContext)
+            V1PodSecurityContext securityContext,
+            V1DeploymentStrategy strategy)
         {
             this.Env = Option.Maybe(env);
             this.ExposedPorts = Option.Maybe(exposedPorts);
@@ -52,6 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             this.Resources = Option.Maybe(resources);
             this.Volumes = Option.Maybe(volumes);
             this.SecurityContext = Option.Maybe(securityContext);
+            this.DeploymentStrategy = Option.Maybe(strategy);
         }
 
         internal static CreatePodParameters Create(
@@ -66,8 +68,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             IDictionary<string, string> nodeSelector = null,
             V1ResourceRequirements resources = null,
             IReadOnlyList<KubernetesModuleVolumeSpec> volumes = null,
-            V1PodSecurityContext securityContext = null)
-            => new CreatePodParameters(env, exposedPorts, hostConfig, image, labels, cmd, entrypoint, workingDir, nodeSelector, resources, volumes, securityContext);
+            V1PodSecurityContext securityContext = null,
+            V1DeploymentStrategy deploymentStrategy = null)
+            => new CreatePodParameters(env, exposedPorts, hostConfig, image, labels, cmd, entrypoint, workingDir, nodeSelector, resources, volumes, securityContext, deploymentStrategy);
 
         [JsonProperty("env", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<IReadOnlyList<string>>))]
@@ -104,6 +107,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         [JsonProperty("securityContext", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<V1PodSecurityContext>))]
         public Option<V1PodSecurityContext> SecurityContext { get; set; }
+
+        [JsonProperty("strategy", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<V1DeploymentStrategy>))]
+        public Option<V1DeploymentStrategy> DeploymentStrategy { get; set; }
 
         [JsonProperty("cmd", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<IReadOnlyList<string>>))]

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesExperimentalCreatePodParameters.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesExperimentalCreatePodParameters.cs
@@ -19,16 +19,20 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
         public Option<V1PodSecurityContext> SecurityContext { get; }
 
+        public Option<V1DeploymentStrategy> DeploymentStrategy { get; }
+
         KubernetesExperimentalCreatePodParameters(
             Option<IDictionary<string, string>> nodeSelector,
             Option<V1ResourceRequirements> resources,
             Option<IReadOnlyList<KubernetesModuleVolumeSpec>> volumes,
-            Option<V1PodSecurityContext> securityContext)
+            Option<V1PodSecurityContext> securityContext,
+            Option<V1DeploymentStrategy> deploymentStrategy)
         {
             this.NodeSelector = nodeSelector;
             this.Resources = resources;
             this.Volumes = volumes;
             this.SecurityContext = securityContext;
+            this.DeploymentStrategy = deploymentStrategy;
         }
 
         static class ExperimentalParameterNames
@@ -38,6 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             public const string Resources = "Resources";
             public const string Volumes = "Volumes";
             public const string SecurityContext = "SecurityContext";
+            public const string DeploymentStrategy = "Strategy";
         }
 
         public static Option<KubernetesExperimentalCreatePodParameters> Parse(IDictionary<string, JToken> other)
@@ -69,7 +74,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             var securityContext = options.Get(ExperimentalParameterNames.SecurityContext)
                 .FlatMap(option => Option.Maybe(option.ToObject<V1PodSecurityContext>()));
 
-            return new KubernetesExperimentalCreatePodParameters(nodeSelector, resources, volumes, securityContext);
+            var deploymentStrategy = options.Get(ExperimentalParameterNames.DeploymentStrategy)
+                .FlatMap(option => Option.Maybe(option.ToObject<V1DeploymentStrategy>()));
+
+            return new KubernetesExperimentalCreatePodParameters(nodeSelector, resources, volumes, securityContext, deploymentStrategy);
         }
 
         static Dictionary<string, JToken> PrepareSupportedOptionsStore(JObject experimental)
@@ -94,7 +102,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             ExperimentalParameterNames.NodeSelector,
             ExperimentalParameterNames.Resources,
             ExperimentalParameterNames.Volumes,
-            ExperimentalParameterNames.SecurityContext
+            ExperimentalParameterNames.SecurityContext,
+            ExperimentalParameterNames.DeploymentStrategy
         };
 
         static class Events

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -105,9 +105,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
             var podSpec = this.GetPod(name, identity, module, labels);
 
             var selector = new V1LabelSelector(matchLabels: labels);
+
+            V1DeploymentStrategy deploymentStrategy = module.Config.CreateOptions.DeploymentStrategy.OrDefault();
+
             // Desired status in Deployment should only be Running or Stopped. Assume Running if not Stopped
             int replicas = (module.DesiredStatus != ModuleStatus.Stopped) ? 1 : 0;
-            var deploymentSpec = new V1DeploymentSpec(replicas: replicas, selector: selector, template: podSpec);
+            var deploymentSpec = new V1DeploymentSpec(replicas: replicas, selector: selector, strategy: deploymentStrategy, template: podSpec);
 
             var deploymentMeta = new V1ObjectMeta(
                 name: name,

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -562,6 +562,35 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         }
 
         [Fact]
+        public void LeavesStrategyEmptyWhenNotProvided()
+        {
+            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.Some(new AuthConfig("user-registry1")));
+            var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
+            var labels = new Dictionary<string, string>();
+            var mapper = CreateMapper();
+
+            var deployment = mapper.CreateDeployment(identity, module, labels);
+
+            Assert.Null(deployment.Spec.Strategy);
+        }
+
+        [Fact]
+        public void ApplyDeploymentStrategyWhenProvided()
+        {
+            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var deploymentStrategy = new V1DeploymentStrategy { Type = "Recreate" };
+            var config = new KubernetesConfig("image", CreatePodParameters.Create(deploymentStrategy: deploymentStrategy), Option.Some(new AuthConfig("user-registry1")));
+            var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
+            var labels = new Dictionary<string, string>();
+            var mapper = CreateMapper();
+
+            var deployment = mapper.CreateDeployment(identity, module, labels);
+
+            Assert.Equal("Recreate", deployment.Spec.Strategy.Type);
+        }
+
+        [Fact]
         public void NoCmdOptionsNoContainerArgs()
         {
             var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());

--- a/kubernetes/doc/create-options.md
+++ b/kubernetes/doc/create-options.md
@@ -20,8 +20,9 @@ We added CreateOptions for experimental features on Kubernetes. These options "o
   "k8s-experimental": {
     "volumes": [{...}],
     "resources": [{...}],
-    "nodeSelector": {...}
+    "nodeSelector": {...},
     "securityContext": {...},
+    "strategy": {...}
   }
 }
 ```
@@ -137,6 +138,22 @@ A `securityContext` section of config used to apply a pod security context to a 
       "runAsGroup": "1001",
       "runAsUser": "1000",
       ...
+    }
+  }
+}
+```
+
+## Apply Deployment strategy
+
+EdgeAgent uses the default deployment strategy for handling pod replicas. This doesn't always have the expected effects, especially when dealing with persistent volumes. The user may assign this section to get more desireable behavior. This section has the same structure as the Kubernetes [Deployment Strategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#deploymentstrategy-v1-apps) object.
+
+`EdgeAgent` doesn't do any translations or interpretations of values but simply assigns value from module deployment to `strategy` parameter of a deployment spec.
+
+```json
+{
+  "k8s-experimental": {
+    "strategy": {
+      "type": "Recreate"
     }
   }
 }


### PR DESCRIPTION
## Apply Deployment strategy

EdgeAgent uses the default deployment strategy for handling pod replicas. This doesn't always have the expected effects, especially when dealing with persistent volumes. The user may assign this section to get more desireable behavior. This section has the same structure as the Kubernetes [Deployment Strategy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#deploymentstrategy-v1-apps) object.

`EdgeAgent` doesn't do any translations or interpretations of values but simply assigns value from module deployment to `strategy` parameter of a deployment spec.

```json
{
  "k8s-experimental": {
    "strategy": {
      "type": "Recreate"
    }
  }
}
```