### PR TITLE
Conditionally deploy vanilla agent in Metrics test

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -14,8 +14,10 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
     public enum EdgeModuleStatus
     {
+        Failed,
         Running,
-        Stopped
+        Stopped,
+        Unknown
     }
 
     public class EdgeModule

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -108,7 +108,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                     string[] columns = line.Split(null as char[], StringSplitOptions.RemoveEmptyEntries);
                     // each line is "name status description config"
                     if (columns[0] == id &&
-                        desired == Enum.Parse<EdgeModuleStatus>(columns[1], ignoreCase: true))
+                        desired == Enum.Parse<EdgeModuleStatus>(columns[1], ignoreCase: true) &&
+                        image == columns[3])
                     {
                         return true;
                     }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -102,14 +102,14 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 string[] output = await Process.RunAsync("iotedge", "list", token);
 
                 Log.Verbose(string.Join("\n", output));
-
-                foreach (string line in output)
+				
+                foreach (string line in output.Skip(1))
                 {
                     string[] columns = line.Split(null as char[], StringSplitOptions.RemoveEmptyEntries);
                     // each line is "name status description config"
                     if (columns[0] == id &&
                         desired == Enum.Parse<EdgeModuleStatus>(columns[1], ignoreCase: true) &&
-                        image == columns[3])
+                        image == columns.Last())
                     {
                         return true;
                     }

--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -43,13 +43,17 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         async Task Deploy(CancellationToken token)
         {
-            // First deploy different agent image. This will force agent to update environment variables
-            await this.runtime.DeployConfigurationAsync(
-                builder =>
-                {
-                    builder.GetModule(ConfigModuleName.EdgeAgent).WithSettings(("image", EdgeAgentBaseImage));
-                    builder.RemoveModule(ConfigModuleName.EdgeHub);
-                }, token);
+            // First deploy different agent image (if needed). This will force agent to update environment variables
+            var agent = new EdgeModule(ConfigModuleName.EdgeAgent, Context.Current.DeviceId, this.iotHub);
+            if (!await agent.Matches(EdgeModuleStatus.Running, EdgeAgentBaseImage, token))
+            {
+                await this.runtime.DeployConfigurationAsync(
+                    builder =>
+                    {
+                        builder.GetModule(ConfigModuleName.EdgeAgent).WithSettings(("image", EdgeAgentBaseImage));
+                        builder.RemoveModule(ConfigModuleName.EdgeHub);
+                    }, token);
+            }
 
             // Next deploy everything needed for this test, including a temporary image that will be removed later to bump the "stopped" metric
             string metricsValidatorImage = Context.Current.MetricsValidatorImage.Expect(() => new InvalidOperationException("Missing Metrics Validator image"));


### PR DESCRIPTION
In the Metrics end-to-end test, we currently deploy a vanilla agent module at the start of the test so that a later update to agent with some extra settings will actually be deployed. We do this to work around a bug that impacts when edge agent is (or is not) updated.

Given a recent change in the end-to-end test helper libraries (#2635), if you run the Metrics test all by itself it hangs while confirming the first deployment because vanilla agent was already deployed so it never updates (same bug as previously mentioned).

To fix this problem, this change only deploys the vanilla agent if it's not already deployed.

To make this easier, the PR introduces a new method, `EdgeModule.Matches`, which shares its guts with `EdgeModule.WaitForStatusAsync`.