### PR TITLE
Move metrics out of experimental 

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
@@ -7,14 +7,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
 
     public class ExperimentalFeatures
     {
-        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool enableUploadLogs, bool enableGetLogs, bool enableMetrics, bool enableMetricsUpload)
+        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool enableUploadLogs, bool enableGetLogs)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
             this.EnableUploadLogs = enableUploadLogs;
             this.EnableGetLogs = enableGetLogs;
-            this.EnableMetrics = enableMetrics;
-            this.EnableMetricsUpload = enableMetricsUpload;
         }
 
         public static ExperimentalFeatures Create(IConfiguration experimentalFeaturesConfig, ILogger logger)
@@ -23,9 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
             bool enableUploadLogs = enabled && experimentalFeaturesConfig.GetValue("enableUploadLogs", false);
             bool enableGetLogs = enabled && experimentalFeaturesConfig.GetValue("enableGetLogs", false);
-            bool enableMetrics = enabled && experimentalFeaturesConfig.GetValue("enableMetrics", false);
-            bool enableMetricsUpload = enabled && experimentalFeaturesConfig.GetValue("enableMetricsUpload", false);
-            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, enableUploadLogs, enableGetLogs, enableMetrics, enableMetricsUpload);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, enableUploadLogs, enableGetLogs);
             logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
             return experimentalFeatures;
         }
@@ -37,9 +33,5 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
         public bool EnableUploadLogs { get; }
 
         public bool EnableGetLogs { get; }
-
-        public bool EnableMetrics { get; }
-
-        public bool EnableMetricsUpload { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -269,10 +269,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         throw new InvalidOperationException($"ConfigSource '{configSourceConfig}' not supported.");
                 }
 
-                metricsConfig = new MetricsConfig(experimentalFeatures.EnableMetrics, MetricsListenerConfig.Create(configuration));
+                metricsConfig = new MetricsConfig(configuration);
                 builder.RegisterModule(new MetricsModule(metricsConfig, iothubHostname, deviceId));
 
-                diagnosticConfig = new DiagnosticConfig(experimentalFeatures.EnableMetricsUpload, storagePath, configuration);
+                bool diagnosticsEnabled = configuration.GetValue("SendProductQualityTelemetry", false);
+                diagnosticConfig = new DiagnosticConfig(diagnosticsEnabled, storagePath, configuration);
                 builder.RegisterModule(new DiagnosticsModule(diagnosticConfig));
 
                 container = builder.Build();

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -85,10 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             IConfiguration configuration = this.configuration.GetSection("experimentalFeatures");
             ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Create(configuration, Logger.Factory.CreateLogger("EdgeHub"));
 
-            MetricsListenerConfig listenerConfig = experimentalFeatures.EnableMetrics
-                ? MetricsListenerConfig.Create(this.configuration.GetSection("metrics:listener"))
-                : new MetricsListenerConfig();
-            MetricsConfig metricsConfig = new MetricsConfig(experimentalFeatures.EnableMetrics, listenerConfig);
+            MetricsConfig metricsConfig = new MetricsConfig(this.configuration.GetSection("metrics:listener"));
 
             this.RegisterCommonModule(builder, optimizeForPerformance, storeAndForward, metricsConfig);
             this.RegisterRoutingModule(builder, storeAndForward, experimentalFeatures);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
@@ -7,12 +7,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class ExperimentalFeatures
     {
-        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck, bool enableMetrics)
+        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
             this.DisableConnectivityCheck = disableConnectivityCheck;
-            this.EnableMetrics = enableMetrics;
         }
 
         public static ExperimentalFeatures Create(IConfiguration experimentalFeaturesConfig, ILogger logger)
@@ -20,8 +19,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
             bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("disableConnectivityCheck", false);
-            bool enableMetrics = enabled && experimentalFeaturesConfig.GetValue("enableMetrics", false);
-            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableMetrics);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck);
             logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
             return experimentalFeatures;
         }
@@ -31,7 +29,5 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         public bool DisableCloudSubscriptions { get; }
 
         public bool DisableConnectivityCheck { get; }
-
-        public bool EnableMetrics { get; }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             var mqttSettingsConfiguration = new Mock<IConfiguration>();
             mqttSettingsConfiguration.Setup(c => c.GetSection(It.IsAny<string>())).Returns(Mock.Of<IConfigurationSection>(s => s.Value == null));
 
-            var experimentalFeatures = new ExperimentalFeatures(true, false, false, true);
+            var experimentalFeatures = new ExperimentalFeatures(true, false, false);
 
             builder.RegisterBuildCallback(
                 c =>
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 });
 
             var versionInfo = new VersionInfo("v1", "b1", "c1");
-            var metricsConfig = new MetricsConfig(true, new MetricsListenerConfig());
+            var metricsConfig = new MetricsConfig(mqttSettingsConfiguration.Object);
             var backupFolder = Option.None<string>();
 
             string storageFolder = string.Empty;

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/MetricsConfig.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/MetricsConfig.cs
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Util.Metrics
 {
+    using Microsoft.Extensions.Configuration;
+
     public class MetricsConfig
     {
-        public MetricsConfig(bool enabled, MetricsListenerConfig listenerConfig)
+        public MetricsConfig(IConfiguration config)
         {
-            this.Enabled = enabled;
-            this.ListenerConfig = listenerConfig;
+            this.Enabled = config.GetValue("MetricsEnabled", true);
+            this.ListenerConfig = MetricsListenerConfig.Create(config);
         }
 
         public bool Enabled { get; }


### PR DESCRIPTION
This makes metrics on by default, and the experimental flag is no longer needed.