### PR TITLE
Fix createOptions desired vs reported comparison in tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 {
                     Log.Verbose(
                         "Expected configuration values don't match agent's reported properties:\n  {DifferentValues}",
-                        string.Join("\n  ", missing));
+                        string.Join("\n  ", different));
                 }
             }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                         {
                             if (v.Path.EndsWith("settings.createOptions"))
                             {
-                                // normalize JSON inside "createOptions"
+                                // normalize stringized JSON inside "createOptions"
                                 v.Value = JObject.Parse((string)v.Value).ToString(Formatting.None);
                             }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Shared;
+    using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using Serilog;
 
@@ -159,6 +160,17 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                     .Cast<JContainer>()
                     .DescendantsAndSelf()
                     .OfType<JValue>()
+                    .Select(
+                        v =>
+                        {
+                            if (v.Path.EndsWith("settings.createOptions"))
+                            {
+                                // normalize JSON inside "createOptions"
+                                v.Value = JObject.Parse((string)v.Value).ToString(Formatting.None);
+                            }
+
+                            return v;
+                        })
                     .ToDictionary(v => v.Path.Substring(rootPath.Length).TrimStart('.'));
             }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -173,14 +173,27 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
             if (!match)
             {
-                IEnumerable<string> missing = referenceValues
-                    .Where(kvp =>
-                        !comparandValues.ContainsKey(kvp.Key) ||
-                        !kvp.Value.Equals(comparandValues[kvp.Key]))
-                    .Select(kvp => kvp.Key);
-                Log.Verbose(
-                    "Expected configuration values missing in agent's reported properties:\n  {MissingValues}",
-                    string.Join("\n  ", missing));
+                string[] missing = referenceValues
+                    .Where(kvp => !comparandValues.ContainsKey(kvp.Key))
+                    .Select(kvp => kvp.Key)
+                    .ToArray();
+                if (missing.Length != 0)
+                {
+                    Log.Verbose(
+                        "Expected configuration values missing in agent's reported properties:\n  {MissingValues}",
+                        string.Join("\n  ", missing));
+                }
+
+                string[] different = referenceValues
+                    .Where(kvp => comparandValues.ContainsKey(kvp.Key) && !kvp.Value.Equals(comparandValues[kvp.Key]))
+                    .Select(kvp => $"{kvp.Key}: '{kvp.Value}' != '{comparandValues[kvp.Key]}'")
+                    .ToArray();
+                if (different.Length != 0)
+                {
+                    Log.Verbose(
+                        "Expected configuration values don't match agent's reported properties:\n  {DifferentValues}",
+                        string.Join("\n  ", missing));
+                }
             }
 
             return match;

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using Newtonsoft.Json.Linq;
     using NUnit.Framework;
+    using Serilog;
 
     [EndToEnd]
     public class PriorityQueues : SasManualProvisioningFixture
@@ -111,6 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             HttpClient client = new HttpClient();
             HttpResponseMessage response = await client.GetAsync("http://localhost:5001/api/report");
             var jsonstring = await response.Content.ReadAsStringAsync();
+            Log.Verbose($"Test Result Coordinator response: {Response}", jsonstring);
             bool isPassed = (bool)JArray.Parse(jsonstring)[0]["IsPassed"];
             Assert.IsTrue(isPassed);
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -112,8 +112,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
             HttpClient client = new HttpClient();
             HttpResponseMessage response = await client.GetAsync("http://localhost:5001/api/report");
             var jsonstring = await response.Content.ReadAsStringAsync();
-            Log.Verbose("Test Result Coordinator response: {Response}", jsonstring);
             bool isPassed = (bool)JArray.Parse(jsonstring)[0]["IsPassed"];
+            if (!isPassed)
+            {
+                Log.Verbose("Test Result Coordinator response: {Response}", jsonstring);
+            }
+
             Assert.IsTrue(isPassed);
         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             HttpClient client = new HttpClient();
             HttpResponseMessage response = await client.GetAsync("http://localhost:5001/api/report");
             var jsonstring = await response.Content.ReadAsStringAsync();
-            Log.Verbose($"Test Result Coordinator response: {Response}", jsonstring);
+            Log.Verbose("Test Result Coordinator response: {Response}", jsonstring);
             bool isPassed = (bool)JArray.Parse(jsonstring)[0]["IsPassed"];
             Assert.IsTrue(isPassed);
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                         .WithEnvironment(new[] { ("receiveOnly", "true") });
                 });
 
-            deployment = await this.runtime.DeployConfigurationAsync(addInitialConfig + addRelayerConfig, token);
+            deployment = await this.runtime.DeployConfigurationAsync(addInitialConfig + addRelayerConfig, token, stageSystemModules: false);
 
             // Wait for relayer to spin up, receive messages, and pass along results to TRC
             await Task.Delay(TimeSpan.FromSeconds(30));

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             string routeTemplate = $"FROM /messages/modules/{loadGenModuleName}/outputs/pri{0} INTO BrokeredEndpoint('/modules/{relayerModuleName}/inputs/input1')";
 
             string trackingId = Guid.NewGuid().ToString();
+            string priorityString = this.BuildPriorityString(5);
 
             Action<EdgeConfigBuilder> addInitialConfig = new Action<EdgeConfigBuilder>(
                 builder =>
@@ -76,7 +77,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
                            }
                        });
 
-                    string priorityString = this.BuildPriorityString(5);
                     builder.AddModule(loadGenModuleName, loadGenImage)
                         .WithEnvironment(new[]
                         {


### PR DESCRIPTION
With #2635, deployments in the new end-to-end tests are verified by comparing Edge Agent's reported properties against the deployed config. A recent test (#2735) exposed a bug in this comparison: `settings.createOption` is stringized JSON, and serialization/deserialization at different parts of the pipeline can cause whitespace to be altered between desired and reported versions of this property. Comparison can fail even though the values are semantically the same.

This change normalizes the JSON before comparing it. It also adds more verbose logging so that issues like this are easier to spot.