### PR TITLE
Fix windows supportbundle

### DIFF
--- a/edgelet/iotedge/src/support_bundle.rs
+++ b/edgelet/iotedge/src/support_bundle.rs
@@ -281,8 +281,8 @@ where
          let inspect = ShellCommand::new("powershell.exe")
             .arg("-NoProfile")
             .arg("-Command")
-            .arg(&format!(r"Get-WinEvent -ea SilentlyContinue -FilterHashtable |
-                                @{{ProviderName='iotedged';LogName='application';StartTime=$([Xml.XmlConvert]::ToDateTime({}))}} |
+            .arg(&format!(r"$start=[Xml.XmlConvert]::ToDateTime('{}');
+                            Get-WinEvent -ea SilentlyContinue -FilterHashtable @{{ProviderName='iotedged';LogName='application';StartTime=$start}} |
                             Select TimeCreated, Message |
                             Sort-Object @{{Expression='TimeCreated';Descending=$false}} |
                             Format-List", since_time.to_rfc3339()))

--- a/edgelet/iotedge/src/support_bundle.rs
+++ b/edgelet/iotedge/src/support_bundle.rs
@@ -268,13 +268,12 @@ where
             NaiveDateTime::from_timestamp(state.log_options.since().into(), 0),
             Utc,
         );
-        let since = since_time.format("%F %T").to_string();
 
         #[cfg(unix)]
         let inspect = ShellCommand::new("journalctl")
             .arg("-a")
             .args(&["-u", "iotedge"])
-            .args(&["-S", &since])
+            .args(&["-S", &since_time.format("%F %T").to_string()])
             .arg("--no-pager")
             .output();
 
@@ -282,10 +281,11 @@ where
          let inspect = ShellCommand::new("powershell.exe")
             .arg("-NoProfile")
             .arg("-Command")
-            .arg(&format!(r"Get-WinEvent -ea SilentlyContinue -FilterHashtable @{{ProviderName='iotedged';LogName='application';StartTime='{}'}} |
+            .arg(&format!(r"Get-WinEvent -ea SilentlyContinue -FilterHashtable |
+                                @{{ProviderName='iotedged';LogName='application';StartTime=$([Xml.XmlConvert]::ToDateTime({}))}} |
                             Select TimeCreated, Message |
                             Sort-Object @{{Expression='TimeCreated';Descending=$false}} |
-                            Format-List", since))
+                            Format-List", since_time.to_rfc3339()))
             .output();
 
         let (file_name, output) = if let Ok(result) = inspect {


### PR DESCRIPTION
The timestamp for start time wasn't properly respecting timezonse. It is now passed in using rfc3339

Note Windows uses https://docs.microsoft.com/en-us/dotnet/api/system.xml.xmlconvert.todatetime?view=netframework-4.8 to parse and linux uses http://man7.org/linux/man-pages/man1/journalctl.1.html