### PR TITLE
Give Pi more time to download images

### DIFF
--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -120,9 +120,9 @@ steps:
     if ('$(arch)' -eq 'arm32v7')
     {
       $context['optimizeForPerformance'] = 'false'
-      $context['setupTimeoutMinutes'] = 8
+      $context['setupTimeoutMinutes'] = 10
       $context['teardownTimeoutMinutes'] = 5
-      $context['testTimeoutMinutes'] = 8
+      $context['testTimeoutMinutes'] = 10
     }
 
     $context | ConvertTo-Json | Out-File -Encoding Utf8 '$(binDir)/context.json'


### PR DESCRIPTION
With the introduction of #2736, our self-hosted Pi agent has to download docker images from scratch. The current timeout (8 min) isn't enough for the first test to download all images and run the test. This change increases the timeouts (setup and test) to 10 minutes, which should be enough.