### PR TITLE
Support bundle fixes into 1.0.9

### DIFF
--- a/edgelet/iotedge/src/support_bundle.rs
+++ b/edgelet/iotedge/src/support_bundle.rs
@@ -232,8 +232,7 @@ where
          let inspect = ShellCommand::new("powershell.exe")
             .arg("-NoProfile")
             .arg("-Command")
-            .arg(&format!(r"$start=[Xml.XmlConvert]::ToDateTime('{}');
-                            Get-WinEvent -ea SilentlyContinue -FilterHashtable @{{ProviderName='iotedged';LogName='application';StartTime=$start}} |
+            .arg(&format!(r"Get-WinEvent -ea SilentlyContinue -FilterHashtable @{{ProviderName='iotedged';LogName='application';StartTime='{}'}} |
                             Select TimeCreated, Message |
                             Sort-Object @{{Expression='TimeCreated';Descending=$false}} |
                             Format-List", since_time.to_rfc3339()))
@@ -271,13 +270,12 @@ where
             NaiveDateTime::from_timestamp(state.log_options.since().into(), 0),
             Utc,
         );
-        let since = since_time.format("%F %T").to_string();
 
         #[cfg(unix)]
         let inspect = ShellCommand::new("journalctl")
             .arg("-a")
             .args(&["-u", "docker"])
-            .args(&["-S", &since])
+            .args(&["-S", &since_time.format("%F %T").to_string()])
             .arg("--no-pager")
             .output();
 
@@ -290,7 +288,7 @@ where
                 r#"Get-EventLog -LogName Application -Source Docker -After "{}" |
                     Sort-Object Time |
                     Format-List"#,
-                since
+                since_time.to_rfc3339()
             ))
             .output();
 

--- a/edgelet/iotedge/src/support_bundle.rs
+++ b/edgelet/iotedge/src/support_bundle.rs
@@ -258,7 +258,7 @@ where
 
         state
             .zip_writer
-            .write(&output)
+            .write_all(&output)
             .map_err(|err| Error::from(err.context(ErrorKind::SupportBundle)))?;
 
         state.print_verbose("Got logs for iotedged");
@@ -313,7 +313,7 @@ where
 
         state
             .zip_writer
-            .write(&output)
+            .write_all(&output)
             .map_err(|err| Error::from(err.context(ErrorKind::SupportBundle)))?;
 
         state.print_verbose("Got logs for docker");
@@ -341,7 +341,7 @@ where
 
         state
             .zip_writer
-            .write(&check.stdout)
+            .write_all(&check.stdout)
             .map_err(|err| Error::from(err.context(ErrorKind::SupportBundle)))?;
 
         state.print_verbose("Wrote check output to file");
@@ -392,7 +392,7 @@ where
 
         state
             .zip_writer
-            .write(&output)
+            .write_all(&output)
             .map_err(|err| Error::from(err.context(ErrorKind::SupportBundle)))?;
 
         state.print_verbose(&format!("Got docker inspect for {}", module_name));
@@ -474,7 +474,7 @@ where
 
         state
             .zip_writer
-            .write(&output)
+            .write_all(&output)
             .map_err(|err| Error::from(err.context(ErrorKind::SupportBundle)))?;
 
         state.print_verbose(&format!("Got docker network inspect for {}", network_name));

--- a/edgelet/iotedge/src/support_bundle.rs
+++ b/edgelet/iotedge/src/support_bundle.rs
@@ -219,13 +219,12 @@ where
             NaiveDateTime::from_timestamp(state.log_options.since().into(), 0),
             Utc,
         );
-        let since = since_time.format("%F %T").to_string();
 
         #[cfg(unix)]
         let inspect = ShellCommand::new("journalctl")
             .arg("-a")
             .args(&["-u", "iotedge"])
-            .args(&["-S", &since])
+            .args(&["-S", &since_time.format("%F %T").to_string()])
             .arg("--no-pager")
             .output();
 
@@ -233,10 +232,11 @@ where
          let inspect = ShellCommand::new("powershell.exe")
             .arg("-NoProfile")
             .arg("-Command")
-            .arg(&format!(r"Get-WinEvent -ea SilentlyContinue -FilterHashtable @{{ProviderName='iotedged';LogName='application';StartTime='{}'}} |
+            .arg(&format!(r"$start=[Xml.XmlConvert]::ToDateTime('{}');
+                            Get-WinEvent -ea SilentlyContinue -FilterHashtable @{{ProviderName='iotedged';LogName='application';StartTime=$start}} |
                             Select TimeCreated, Message |
                             Sort-Object @{{Expression='TimeCreated';Descending=$false}} |
-                            Format-List", since))
+                            Format-List", since_time.to_rfc3339()))
             .output();
 
         let (file_name, output) = if let Ok(result) = inspect {


### PR DESCRIPTION
This fixes 2 bugs. First, large enough logs weren't being written to the bundle b/c write was used instead of writre_all. Second, windows didn't respect time zones properly. This fixes that. 