### PR TITLE
Content trust twin fields in module and module spec

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/ContentTrust.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/ContentTrust.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Agent.Core
+{
+    using Newtonsoft.Json;
+
+    public class ContentTrust
+    {
+        [JsonProperty("rootJsonPath")]
+        public string RootJsonPath { get; }
+
+        [JsonProperty("rootID")]
+        public string RootID { get; }
+
+        [JsonProperty("rootCertificatePath")]
+        public string RootCertificatePath { get; }
+
+        [JsonProperty("disableTOFU")]
+        public bool DisableTOFU { get; }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IModule.cs
@@ -3,8 +3,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using System.Runtime.Serialization;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
 
@@ -122,6 +123,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         IDictionary<string, EnvVal> Env { get; }
 
         bool IsOnlyModuleStatusChanged(IModule other);
+
+        [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+        Option<ContentTrust> ContentTrust { get; }
     }
 
     public interface IModule<TConfig> : IModule, IEquatable<IModule<TConfig>>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IModule.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         bool IsOnlyModuleStatusChanged(IModule other);
 
-        [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+        [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
         Option<ContentTrust> ContentTrust { get; }
     }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/UnknownModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/UnknownModule.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 {
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
 
     public class UnknownModule : IModule
@@ -32,6 +33,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         public bool IsOnlyModuleStatusChanged(IModule other) => other is UnknownModule;
 
         public bool Equals(IModule other) => other != null && ReferenceEquals(this, other);
+
+        public Option<ContentTrust> ContentTrust { get; }
     }
 
     public class UnknownEdgeHubModule : UnknownModule, IEdgeHubModule

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
         [JsonProperty(PropertyName = "env")]
         public IDictionary<string, EnvVal> Env { get; }
 
-        [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+        [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
         public Option<ContentTrust> ContentTrust { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as DockerModule);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
@@ -22,8 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             ImagePullPolicy imagePullPolicy,
             uint priority,
             ConfigurationInfo configurationInfo,
-            IDictionary<string, EnvVal> env,
-            Option<ContentTrust> contentTrust)
+            IDictionary<string, EnvVal> env)
         {
             this.Name = name;
             this.Version = version ?? string.Empty;
@@ -34,7 +33,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             this.Priority = priority;
             this.ConfigurationInfo = configurationInfo ?? new ConfigurationInfo(string.Empty);
             this.Env = env?.ToImmutableDictionary() ?? ImmutableDictionary<string, EnvVal>.Empty;
-            this.ContentTrust = contentTrust;
         }
 
         [JsonIgnore]
@@ -72,7 +70,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
         public IDictionary<string, EnvVal> Env { get; }
 
         [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
-        public virtual Option<ContentTrust> ContentTrust { get; }
+        public Option<ContentTrust> ContentTrust { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as DockerModule);
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
     using System.ComponentModel;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
 
     public class DockerModule : IModule<DockerConfig>
@@ -21,7 +22,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             ImagePullPolicy imagePullPolicy,
             uint priority,
             ConfigurationInfo configurationInfo,
-            IDictionary<string, EnvVal> env)
+            IDictionary<string, EnvVal> env,
+            Option<ContentTrust> contentTrust)
         {
             this.Name = name;
             this.Version = version ?? string.Empty;
@@ -32,6 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             this.Priority = priority;
             this.ConfigurationInfo = configurationInfo ?? new ConfigurationInfo(string.Empty);
             this.Env = env?.ToImmutableDictionary() ?? ImmutableDictionary<string, EnvVal>.Empty;
+            this.ContentTrust = contentTrust;
         }
 
         [JsonIgnore]
@@ -67,6 +70,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
 
         [JsonProperty(PropertyName = "env")]
         public IDictionary<string, EnvVal> Env { get; }
+
+        [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+        public virtual Option<ContentTrust> ContentTrust { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as DockerModule);
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
         [JsonProperty(PropertyName = "env")]
         public IDictionary<string, EnvVal> Env { get; }
 
-        [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
+        [JsonProperty(PropertyName = "contentTrust", Required = Required.Default)]
         public Option<ContentTrust> ContentTrust { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as DockerModule);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerRuntimeModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerRuntimeModule.cs
@@ -25,8 +25,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             ImagePullPolicy imagePullPolicy,
             uint priority,
             ConfigurationInfo configuration,
-            IDictionary<string, EnvVal> env,
-            Option<ContentTrust> contentTrust)
+            IDictionary<string, EnvVal> env)
             : base(name, version, desiredStatus, restartPolicy, config, imagePullPolicy, priority, configuration, env)
         {
             this.ExitCode = exitCode;

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerRuntimeModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerRuntimeModule.cs
@@ -25,7 +25,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             ImagePullPolicy imagePullPolicy,
             uint priority,
             ConfigurationInfo configuration,
-            IDictionary<string, EnvVal> env)
+            IDictionary<string, EnvVal> env,
+            Option<ContentTrust> contentTrust)
             : base(name, version, desiredStatus, restartPolicy, config, imagePullPolicy, priority, configuration, env)
         {
             this.ExitCode = exitCode;

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/models/ModuleSpec.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/models/ModuleSpec.cs
@@ -30,5 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Models
         public IEnumerable<EnvVar> EnvironmentVariables { get; }
 
         public ImagePullPolicy ImagePullPolicy { get; }
+
+        public Option<ContentTrust> ContentTrust { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
         public bool Equals(IModule<KubernetesConfig> other) => this.Equals(other as KubernetesModule);
 
-        [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
+        [JsonProperty(PropertyName = "contentTrust", Required = Required.Default)]
         public Option<ContentTrust> ContentTrust { get; }
 
         public static string PvcName(KubernetesModule module, Mount mount)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         public bool Equals(IModule<KubernetesConfig> other) => this.Equals(other as KubernetesModule);
 
         [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
-        Option<ContentTrust> ContentTrust { get; }
+        public Option<ContentTrust> ContentTrust { get; }
 
         public static string PvcName(KubernetesModule module, Mount mount)
         {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
     using Microsoft.Azure.Devices.Edge.Agent.Core;
     using Microsoft.Azure.Devices.Edge.Agent.Docker.Models;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
 
     public class KubernetesModule : IModule<KubernetesConfig>
@@ -93,6 +94,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         public virtual bool Equals(IModule other) => this.Equals(other as KubernetesModule);
 
         public bool Equals(IModule<KubernetesConfig> other) => this.Equals(other as KubernetesModule);
+
+        [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+        Option<ContentTrust> ContentTrust { get; }
 
         public static string PvcName(KubernetesModule module, Mount mount)
         {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesModule.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
         public bool Equals(IModule<KubernetesConfig> other) => this.Equals(other as KubernetesModule);
 
-        [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+        [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
         public Option<ContentTrust> ContentTrust { get; }
 
         public static string PvcName(KubernetesModule module, Mount mount)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 new SystemModules(null, null),
                 new Dictionary<string, IModule>
                 {
-                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null) }
+                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>()) }
                 });
             var deploymentConfigInfo = new DeploymentConfigInfo(0, deploymentConfig);
             ModuleSet desiredModuleSet = deploymentConfig.GetModuleSet();
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 new SystemModules(null, null),
                 new Dictionary<string, IModule>
                 {
-                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null) }
+                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>()) }
                 });
             var deploymentConfigInfo = new DeploymentConfigInfo(0, deploymentConfig);
             ModuleSet desiredModuleSet = deploymentConfig.GetModuleSet();
@@ -316,9 +316,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 new SystemModules(null, null),
                 new Dictionary<string, IModule>
                 {
-                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null) }
+                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>()) }
                 });
-            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>());
             var recordKeeper = Option.Some(new TestPlanRecorder());
             var deploymentConfigInfo = new DeploymentConfigInfo(0, deploymentConfig);
             ModuleSet desiredModuleSet = deploymentConfig.GetModuleSet();
@@ -357,8 +357,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         [Fact]
         public async void ReconcileAsyncOnSetPlan()
         {
-            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
-            var currentModule = new TestModule("current", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>());
+            var currentModule = new TestModule("current", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>());
             var recordKeeper = Option.Some(new TestPlanRecorder());
             var moduleExecutionList = new List<TestRecordType>
             {
@@ -416,8 +416,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         [Fact]
         public async void ReconcileAsyncWithNoDeploymentChange()
         {
-            var desiredModule = new TestModule("CustomModule", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
-            var currentModule = new TestModule("CustomModule", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var desiredModule = new TestModule("CustomModule", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>());
+            var currentModule = new TestModule("CustomModule", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>());
 
             var testPlan = new Plan(new List<ICommand>());
             var token = default(CancellationToken);
@@ -545,7 +545,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 new SystemModules(null, null),
                 new Dictionary<string, IModule>
                 {
-                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null) }
+                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>()) }
                 });
             var deploymentConfigInfo = new DeploymentConfigInfo(0, deploymentConfig);
             var token = default(CancellationToken);
@@ -568,8 +568,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             // Arrange
             var mockConfigSource = new Mock<IConfigSource>();
 
-            IModule mod1 = new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
-            IModule mod2 = new TestModule("mod2", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            IModule mod1 = new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>());
+            IModule mod2 = new TestModule("mod2", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>());
             var modules = new Dictionary<string, IModule>
             {
                 [mod1.Name] = mod1,

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigInfoTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigInfoTest.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 {
     using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Xunit;
 
@@ -15,7 +16,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             new TestConfig("microsoft/edgeAgent:1.0"),
             ImagePullPolicy.OnCreate,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeAgentModule TestEdgeAgent1_1 = new TestAgentModule(
             "edgeAgent",
@@ -23,7 +25,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             new TestConfig("microsoft/edgeAgent:1.0"),
             ImagePullPolicy.OnCreate,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeHubModule TestEdgeHub1 = new TestHubModule(
             "edgeHub",
@@ -34,7 +37,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeHubModule TestEdgeHub1_1 = new TestHubModule(
             "edgeHub",
@@ -45,7 +49,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1 = new TestModule(
             "mod1",
@@ -57,7 +62,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1_1 = new TestModule(
             "mod1",
@@ -69,7 +75,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule2 = new TestModule(
             "mod2",
@@ -81,7 +88,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.Never,
             Constants.HighestPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule2_1 = new TestModule(
             "mod2",
@@ -93,7 +101,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.Never,
             Constants.HighestPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly DeploymentConfig Config1 = new DeploymentConfig(
             "1.0",

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DeploymentConfigTest.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 {
     using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Xunit;
@@ -16,7 +17,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             new TestConfig("microsoft/edgeAgent:1.0"),
             ImagePullPolicy.OnCreate,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeAgentModule TestEdgeAgent1_1 = new TestAgentModule(
             "edgeAgent",
@@ -24,7 +26,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             new TestConfig("microsoft/edgeAgent:1.0"),
             ImagePullPolicy.OnCreate,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeAgentModule TestEdgeAgent2 = new TestAgentModule(
             "edgeAgent",
@@ -32,7 +35,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             new TestConfig("microsoft/edgeAgent:2.0"),
             ImagePullPolicy.OnCreate,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeAgentModule TestEdgeAgent3 = new TestAgentModule(
             "edgeAgent",
@@ -40,7 +44,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             new TestConfig("microsoft/edgeAgent:1.0"),
             ImagePullPolicy.OnCreate,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeHubModule TestEdgeHub1 = new TestHubModule(
             "edgeHub",
@@ -51,7 +56,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeHubModule TestEdgeHub1_1 = new TestHubModule(
             "edgeHub",
@@ -62,7 +68,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeHubModule TestEdgeHub2 = new TestHubModule(
             "edgeHub",
@@ -73,7 +80,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IEdgeHubModule TestEdgeHub3 = new TestHubModule(
             "edgeHub",
@@ -84,7 +92,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1 = new TestModule(
             "mod1",
@@ -96,7 +105,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1_1 = new TestModule(
             "mod1",
@@ -108,7 +118,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1_2 = new TestModule(
             "mod1",
@@ -120,7 +131,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1_3 = new TestModule(
             "mod1",
@@ -132,7 +144,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1_4 = new TestModule(
             "mod1",
@@ -144,7 +157,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1_5 = new TestModule(
             "mod1",
@@ -156,7 +170,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.Never,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule1_6 = new TestModule(
             "mod1",
@@ -168,7 +183,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.OnCreate,
             Constants.HighestPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule2 = new TestModule(
             "mod2",
@@ -180,7 +196,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.Never,
             Constants.HighestPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly IModule TestModule2_1 = new TestModule(
             "mod2",
@@ -192,7 +209,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy.Never,
             Constants.HighestPriority,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
 
         static readonly DeploymentConfig Config1 = new DeploymentConfig(
             "1.0",
@@ -397,8 +415,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             var edgeHubModule = Mock.Of<IEdgeHubModule>(m => m.Name == "edgeHub");
             var systemModules = new SystemModules(edgeAgentModule, edgeHubModule);
 
-            var mod1 = new TestModule(null, string.Empty, "test", ModuleStatus.Running, new TestConfig("mod1"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo(), null);
-            var mod2 = new TestModule(null, string.Empty, "test", ModuleStatus.Running, new TestConfig("mod2"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo(), null);
+            var mod1 = new TestModule(null, string.Empty, "test", ModuleStatus.Running, new TestConfig("mod1"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo(), null, Option.None<ContentTrust>());
+            var mod2 = new TestModule(null, string.Empty, "test", ModuleStatus.Running, new TestConfig("mod2"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo(), null, Option.None<ContentTrust>());
 
             var modules = new Dictionary<string, IModule>
             {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DiffTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/DiffTest.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 {
     using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Xunit;
@@ -11,12 +12,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         static readonly IDictionary<string, EnvVal> EnvVars = new Dictionary<string, EnvVal>();
         static readonly TestConfig Config1 = new TestConfig("image1");
         static readonly TestConfig Config2 = new TestConfig("image2");
-        static readonly IModule Module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars);
-        static readonly IModule Module1A = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars);
-        static readonly IModule Module2 = new TestModule("mod2", "version2", "type2", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars);
-        static readonly IModule Module2A = new TestModule("mod2", "version2", "type2", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars);
-        static readonly IModule Module2B = new TestModule("mod2", "version2", "type2", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars);
-        static readonly IModule Module3 = new TestModule("mod3", "version3", "type3", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars);
+        static readonly IModule Module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module1A = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module2 = new TestModule("mod2", "version2", "type2", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module2A = new TestModule("mod2", "version2", "type2", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module2B = new TestModule("mod2", "version2", "type2", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module3 = new TestModule("mod3", "version3", "type3", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), EnvVars, Option.None<ContentTrust>());
 
         [Fact]
         [Unit]

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/ModuleSetTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/ModuleSetTest.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
     using System;
     using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Serde;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Newtonsoft.Json;
     using Xunit;
@@ -15,13 +16,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         static readonly TestConfig Config1 = new TestConfig("image1");
         static readonly TestConfig Config2 = new TestConfig("image2");
 
-        static readonly IModule Module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.HighestPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module2 = new TestModule("mod2", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module3 = new TestModule("mod3", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.HighestPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module4 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+        static readonly IModule Module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.HighestPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module2 = new TestModule("mod2", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module3 = new TestModule("mod3", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.HighestPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module4 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
-        static readonly TestModule Module5 = new TestModule("mod5", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module6 = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+        static readonly TestModule Module5 = new TestModule("mod5", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module6 = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
         static readonly ModuleSet ModuleSet1 = ModuleSet.Create(Module1);
         static readonly ModuleSet ModuleSet2 = ModuleSet.Create(Module5, Module3);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/OrderedPlanRunnerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/OrderedPlanRunnerTest.cs
@@ -24,11 +24,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             Option<TestPlanRecorder> recordKeeper = Option.Some(new TestPlanRecorder());
             var moduleExecutionList = new List<TestRecordType>
             {
-                new TestRecordType(TestCommandType.TestCreate, new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestCreate, new TestModule("module2", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image2"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestCreate, new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestCreate, new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestCreate, new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
+                new TestRecordType(TestCommandType.TestCreate, new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestCreate, new TestModule("module2", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image2"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestCreate, new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestCreate, new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestCreate, new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
             };
             var commandList = new List<ICommand>
             {
@@ -69,11 +69,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             var runtimeInfo = Mock.Of<IRuntimeInfo>();
             var moduleExecutionList = new List<TestRecordType>
             {
-                new TestRecordType(TestCommandType.TestCreate, new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestUpdate, new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestRemove, new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestStart, new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestStop, new TestModule("module6", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image6"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
+                new TestRecordType(TestCommandType.TestCreate, new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>() )),
+                new TestRecordType(TestCommandType.TestUpdate, new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestRemove, new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestStart, new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestStop, new TestModule("module6", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image6"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
             };
             var identity = new Mock<IModuleIdentity>();
             var commandList = new List<ICommand>
@@ -108,11 +108,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             var failureFactory = new TestCommandFailureFactory();
             var moduleExecutionList = new List<TestRecordType>
             {
-                new TestRecordType(TestCommandType.TestCreate, new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestUpdate, new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestRemove, new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestStart, new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
-                new TestRecordType(TestCommandType.TestStop, new TestModule("module6", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image6"), RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)),
+                new TestRecordType(TestCommandType.TestCreate, new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestUpdate, new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestRemove, new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestStart, new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
+                new TestRecordType(TestCommandType.TestStop, new TestModule("module6", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image6"), RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())),
             };
             var identity = new Mock<IModuleIdentity>();
             var commandList = new List<ICommand>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
     using System.Collections.Immutable;
     using System.ComponentModel;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
 
     public class TestConfig : IEquatable<TestConfig>
@@ -106,6 +107,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 
         [JsonProperty("env")]
         public IDictionary<string, EnvVal> Env { get; }
+
+        [JsonProperty("ContentTrust", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<IDictionary<string, string>>))]
+        public Option<IDictionary<string, string>> ContentTrust { get; }
 
         public bool IsOnlyModuleStatusChanged(IModule other) =>
             other is TestModuleBase<TConfig> testModuleBase &&

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             this.ImagePullPolicy == other.ImagePullPolicy &&
             this.Priority == other.Priority;
 
-        [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
+        [JsonProperty(PropertyName = "contentTrust", Required = Required.Default)]
         public Option<ContentTrust> ContentTrust { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as TestModuleBase<TConfig>);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             this.ImagePullPolicy == other.ImagePullPolicy &&
             this.Priority == other.Priority;
 
-        [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+        [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
         public Option<ContentTrust> ContentTrust { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as TestModuleBase<TConfig>);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
@@ -107,11 +107,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 
         [JsonProperty("env")]
         public IDictionary<string, EnvVal> Env { get; }
-
-        [JsonProperty("ContentTrust", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        [JsonConverter(typeof(OptionConverter<IDictionary<string, string>>))]
-        public Option<IDictionary<string, string>> ContentTrust { get; }
-
         public bool IsOnlyModuleStatusChanged(IModule other) =>
             other is TestModuleBase<TConfig> testModuleBase &&
             string.Equals(this.Name, other.Name) &&
@@ -122,6 +117,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             this.RestartPolicy == other.RestartPolicy &&
             this.ImagePullPolicy == other.ImagePullPolicy &&
             this.Priority == other.Priority;
+
+        [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+        public Option<ContentTrust> ContentTrust { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as TestModuleBase<TConfig>);
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModule.cs
@@ -60,7 +60,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy imagePullPolicy,
             uint priority,
             ConfigurationInfo configuration,
-            IDictionary<string, EnvVal> env)
+            IDictionary<string, EnvVal> env,
+            Option<ContentTrust> contentTrust)
         {
             this.Name = name;
             this.Version = Preconditions.CheckNotNull(version, nameof(version));
@@ -72,6 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             this.Priority = priority;
             this.ConfigurationInfo = configuration ?? new ConfigurationInfo();
             this.Env = env?.ToImmutableDictionary() ?? ImmutableDictionary<string, EnvVal>.Empty;
+            this.ContentTrust = Option.None<ContentTrust>();
         }
 
         [JsonIgnore]
@@ -118,7 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             this.ImagePullPolicy == other.ImagePullPolicy &&
             this.Priority == other.Priority;
 
-        [JsonProperty(PropertyName = "contentTrust", Required = Required.Default)]
+        [JsonProperty(Required = Required.Default, PropertyName = "contentTrust")]
         public Option<ContentTrust> ContentTrust { get; }
 
         public override bool Equals(object obj) => this.Equals(obj as TestModuleBase<TConfig>);
@@ -179,21 +181,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             ImagePullPolicy imagePullPolicy,
             uint priority,
             ConfigurationInfo configuration,
-            IDictionary<string, EnvVal> env)
-            : base(name, version, type, desiredStatus, config, restartPolicy, imagePullPolicy, priority, configuration, env)
+            IDictionary<string, EnvVal> env,
+            Option<ContentTrust> contentTrust)
+            : base(name, version, type, desiredStatus, config, restartPolicy, imagePullPolicy, priority, configuration, env, contentTrust)
         {
         }
 
         public TestModule CloneWithImage(string image)
         {
-            return new TestModule(this.Name, this.Version, this.Type, this.DesiredStatus, new TestConfig(image), this.RestartPolicy, this.ImagePullPolicy, this.Priority, this.ConfigurationInfo, this.Env);
+            return new TestModule(this.Name, this.Version, this.Type, this.DesiredStatus, new TestConfig(image), this.RestartPolicy, this.ImagePullPolicy, this.Priority, this.ConfigurationInfo, this.Env, this.ContentTrust);
         }
     }
 
     public class TestAgentModule : TestModule, IEdgeAgentModule
     {
-        public TestAgentModule(string name, string type, TestConfig config, ImagePullPolicy imagePullPolicy, ConfigurationInfo configuration, IDictionary<string, EnvVal> env)
-            : base(name ?? Constants.EdgeAgentModuleName, string.Empty, type, ModuleStatus.Running, config, RestartPolicy.Always, imagePullPolicy, Constants.HighestPriority, configuration, env)
+        public TestAgentModule(string name, string type, TestConfig config, ImagePullPolicy imagePullPolicy, ConfigurationInfo configuration, IDictionary<string, EnvVal> env, Option<ContentTrust> contentTrust)
+            : base(name ?? Constants.EdgeAgentModuleName, string.Empty, type, ModuleStatus.Running, config, RestartPolicy.Always, imagePullPolicy, Constants.HighestPriority, configuration, env, contentTrust)
         {
             this.Version = string.Empty;
             this.RestartPolicy = RestartPolicy.Always;
@@ -217,8 +220,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 
     public class TestHubModule : TestModule, IEdgeHubModule
     {
-        public TestHubModule(string name, string type, ModuleStatus desiredStatus, TestConfig config, RestartPolicy restartPolicy, ImagePullPolicy imagePullPolicy, uint priority, ConfigurationInfo configuration, IDictionary<string, EnvVal> env)
-            : base(name ?? Constants.EdgeHubModuleName, string.Empty, type, desiredStatus, config, restartPolicy, imagePullPolicy, priority, configuration, env)
+        public TestHubModule(string name, string type, ModuleStatus desiredStatus, TestConfig config, RestartPolicy restartPolicy, ImagePullPolicy imagePullPolicy, uint priority, ConfigurationInfo configuration, IDictionary<string, EnvVal> env, Option<ContentTrust> contentTrust)
+            : base(name ?? Constants.EdgeHubModuleName, string.Empty, type, desiredStatus, config, restartPolicy, imagePullPolicy, priority, configuration, env, contentTrust)
         {
             this.Version = string.Empty;
         }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModuleTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestModuleTest.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Serde;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
@@ -21,17 +22,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         static readonly TestConfig Config2 = new TestConfig("image2");
         static readonly TestConfig Config3 = new TestConfig("image1");
 
-        static readonly IModule Module1 = new TestModule("mod1", "version1", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module2 = new TestModule("mod1", "version1", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module3 = new TestModule("mod3", "version1", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module4 = new TestModule("mod1", "version2", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module5 = new TestModule("mod1", "version1", "type2", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module6 = new TestModule("mod1", "version1", "type1", ModuleStatus.Unknown, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule Module7 = new TestModule("mod1", "version1", "type1", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly TestModule Module8 = new TestModule("mod1", "version1", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+        static readonly IModule Module1 = new TestModule("mod1", "version1", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module2 = new TestModule("mod1", "version1", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module3 = new TestModule("mod3", "version1", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module4 = new TestModule("mod1", "version2", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module5 = new TestModule("mod1", "version1", "type2", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module6 = new TestModule("mod1", "version1", "type1", ModuleStatus.Unknown, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule Module7 = new TestModule("mod1", "version1", "type1", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly TestModule Module8 = new TestModule("mod1", "version1", "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
-        static readonly IModule ValidJsonModule = new TestModule("<module_name>", "<semantic_version_number>", "docker", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly IModule ValidJsonModuleWithPriority = new TestModule("<module_name>", "<semantic_version_number>", "docker", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.HighestPriority, DefaultConfigurationInfo, EnvVars);
+        static readonly IModule ValidJsonModule = new TestModule("<module_name>", "<semantic_version_number>", "docker", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IModule ValidJsonModuleWithPriority = new TestModule("<module_name>", "<semantic_version_number>", "docker", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.HighestPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
         static readonly string serializedModule = "{\"version\":\"version1\",\"type\":\"type1\",\"status\":\"running\",\"settings\":{\"image\":\"image1\"},\"restartPolicy\":\"on-unhealthy\",\"imagePullPolicy\":\"on-create\",\"configuration\":{\"id\":\"1\"}}";
 
         static readonly JObject TestJsonInputs = JsonConvert.DeserializeObject<JObject>(
@@ -235,9 +236,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         [Unit]
         public void TestConstructor()
         {
-            Assert.Throws<ArgumentNullException>(() => new TestModule("mod1", null, "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars));
-            Assert.Throws<ArgumentNullException>(() => new TestModule("mod1", "version1", null, ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars));
-            Assert.Throws<ArgumentNullException>(() => new TestModule("mod1", "version1", "type1", ModuleStatus.Running, null, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars));
+            Assert.Throws<ArgumentNullException>(() => new TestModule("mod1", null, "type1", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>()));
+            Assert.Throws<ArgumentNullException>(() => new TestModule("mod1", "version1", null, ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>()));
+            Assert.Throws<ArgumentNullException>(() => new TestModule("mod1", "version1", "type1", ModuleStatus.Running, null, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>()));
         }
 
         [Fact]

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestRuntimeModule.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestRuntimeModule.cs
@@ -3,11 +3,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 {
     using System;
     using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
 
     public class TestRuntimeModule : TestModule, IRuntimeModule<TestConfig>
     {
-        public TestRuntimeModule(
+        public TestRuntimeModule(            
             string name,
             string version,
             RestartPolicy restartPolicy,
@@ -21,11 +22,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             int restartCount,
             DateTime lastRestartTimeUtc,
             ModuleStatus runtimeStatus,
+            Option<ContentTrust> contentTrust,
             ImagePullPolicy imagePullPolicy = ImagePullPolicy.OnCreate,
             uint priority = Constants.DefaultPriority,
             ConfigurationInfo deploymentInfo = null,
             IDictionary<string, EnvVal> env = null)
-            : base(name, version, type, desiredStatus, config, restartPolicy, imagePullPolicy, priority, deploymentInfo, env)
+            : base(name, version, type, desiredStatus, config, restartPolicy, imagePullPolicy, priority, deploymentInfo, env, contentTrust)
         {
             this.ExitCode = exitCode;
             this.StatusDescription = statusDescription;
@@ -116,6 +118,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             this.RestartCount,
             this.LastRestartTimeUtc,
             newStatus,
+            Option.None<ContentTrust>(),
             this.ImagePullPolicy,
             this.Priority,
             this.ConfigurationInfo);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestRuntimeModuleTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/TestRuntimeModuleTest.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Xunit;
 
@@ -11,20 +12,20 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
     public class TestRuntimeModuleTest
     {
         static readonly TestConfig Config1 = new TestConfig("image1");
-        public static TestModule TestModule1 = new TestModule("name", "version", "type", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+        public static TestModule TestModule1 = new TestModule("name", "version", "type", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null, Option.None<ContentTrust>());
 
         static readonly DateTime lastStartTime = DateTime.Parse("2017-08-04T17:52:13.0419502Z", null, DateTimeStyles.RoundtripKind);
         static readonly DateTime lastExitTime = lastStartTime.AddDays(1);
-        public static TestRuntimeModule ReportedModule1 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config1, 0, "statusDescription", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running);
+        public static TestRuntimeModule ReportedModule1 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config1, 0, "statusDescription", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
         static readonly TestConfig Config2 = new TestConfig("image2");
-        public static TestRuntimeModule ReportedModule2 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config2, 0, "statusDescription", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running);
+        public static TestRuntimeModule ReportedModule2 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config2, 0, "statusDescription", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
         static readonly TestConfig Config3 = new TestConfig("image1");
-        public static TestRuntimeModule ReportedModule3 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, 0, "statusDescription", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running);
+        public static TestRuntimeModule ReportedModule3 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, 0, "statusDescription", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
 
-        public static TestRuntimeModule ReportedModule4 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, -1, "statusDescription", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running);
-        public static TestRuntimeModule ReportedModule5 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, 0, "status is different", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running);
-        public static TestRuntimeModule ReportedModule6 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, 0, "statusDescription", lastStartTime.AddDays(-1), lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running);
-        public static TestRuntimeModule ReportedModule7 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, 0, "statusDescription", lastStartTime, lastExitTime.AddDays(1), 0, DateTime.MinValue, ModuleStatus.Running);
+        public static TestRuntimeModule ReportedModule4 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, -1, "statusDescription", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
+        public static TestRuntimeModule ReportedModule5 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, 0, "status is different", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
+        public static TestRuntimeModule ReportedModule6 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, 0, "statusDescription", lastStartTime.AddDays(-1), lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
+        public static TestRuntimeModule ReportedModule7 = new TestRuntimeModule("name", "version", RestartPolicy.OnUnhealthy, "type", ModuleStatus.Running, Config3, 0, "statusDescription", lastStartTime, lastExitTime.AddDays(1), 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
 
         [Fact]
         [Unit]
@@ -70,7 +71,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         [Unit]
         public static void TestNullIsOk()
         {
-            var reportedModule = new TestRuntimeModule(TestModule1.Name, TestModule1.Version, TestModule1.RestartPolicy, TestModule1.Type, ModuleStatus.Running, TestModule1.Config, 0, null, DateTime.MinValue, DateTime.MinValue, 0, DateTime.MinValue, ModuleStatus.Running);
+            var reportedModule = new TestRuntimeModule(TestModule1.Name, TestModule1.Version, TestModule1.RestartPolicy, TestModule1.Type, ModuleStatus.Running, TestModule1.Config, 0, null, DateTime.MinValue, DateTime.MinValue, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
 
             Assert.True(TestModule1.Equals(reportedModule));
             Assert.True(reportedModule.Equals(TestModule1));
@@ -81,7 +82,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         [Unit]
         public static void TestWithRuntimeStatus()
         {
-            var reportedModule = new TestRuntimeModule(TestModule1.Name, TestModule1.Version, TestModule1.RestartPolicy, TestModule1.Type, ModuleStatus.Running, TestModule1.Config, 0, null, DateTime.MinValue, DateTime.MinValue, 0, DateTime.MinValue, ModuleStatus.Running);
+            var reportedModule = new TestRuntimeModule(TestModule1.Name, TestModule1.Version, TestModule1.RestartPolicy, TestModule1.Type, ModuleStatus.Running, TestModule1.Config, 0, null, DateTime.MinValue, DateTime.MinValue, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>());
             var updatedModule = (TestRuntimeModule)reportedModule.WithRuntimeStatus(ModuleStatus.Unknown);
 
             Assert.True(reportedModule.RuntimeStatus != updatedModule.RuntimeStatus);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/commands/GroupCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/commands/GroupCommandTest.cs
@@ -114,11 +114,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Commands
             };
             var tm = new List<TestModule>
             {
-                new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars),
-                new TestModule("module2", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image2"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars),
-                new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars),
-                new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars),
-                new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars)
+                new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>()),
+                new TestModule("module2", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image2"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>()),
+                new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>()),
+                new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>()),
+                new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>())
             };
             (Option<TestPlanRecorder> recorder, List<TestRecordType> moduleExecutionList, List<ICommand> commandList)[] testInputRecords =
             {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/commands/LoggingCommandFactoryTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/commands/LoggingCommandFactoryTest.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Commands
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Commands;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Extensions.Logging;
     using Moq;
@@ -35,8 +36,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Commands
     {
         static readonly ConfigurationInfo DefaultConfigurationInfo = new ConfigurationInfo("1");
         static readonly IDictionary<string, EnvVal> EnvVars = new Dictionary<string, EnvVal>();
-        static readonly TestModule TestModule = new TestModule("module", "version", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-        static readonly TestModule UpdateModule = new TestModule("module", "version", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+        static readonly TestModule TestModule = new TestModule("module", "version", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly TestModule UpdateModule = new TestModule("module", "version", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
         static readonly TestCommand WrapTargetCommand = new TestCommand(TestCommandType.TestCreate, TestModule);
 
         [Fact]

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/commands/NullCommandFactoryTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/commands/NullCommandFactoryTest.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Commands
 {
     using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Commands;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Xunit;
@@ -17,8 +18,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Commands
             NullCommandFactory nf = NullCommandFactory.Instance;
             var moduleIdentity = new Mock<IModuleIdentity>();
             var runtimeInfo = Mock.Of<IRuntimeInfo>();
-            var nm = new TestModule("null", "version_null", "null", ModuleStatus.Running, new TestConfig("null"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo(), envVars);
-            var nmn = new TestModule("next", "version_null", "null", ModuleStatus.Running, new TestConfig("null"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo(), envVars);
+            var nm = new TestModule("null", "version_null", "null", ModuleStatus.Running, new TestConfig("null"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo(), envVars, Option.None<ContentTrust>());
+            var nmn = new TestModule("next", "version_null", "null", ModuleStatus.Running, new TestConfig("null"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo(), envVars, Option.None<ContentTrust>());
             ICommand createCommand = await nf.CreateAsync(new ModuleWithIdentity(nm, moduleIdentity.Object), runtimeInfo);
             ICommand updateCommand = await nf.UpdateAsync(nm, new ModuleWithIdentity(nmn, moduleIdentity.Object), runtimeInfo);
             ICommand removeCommand = await nf.RemoveAsync(nm);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/commands/ParallelGroupCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/commands/ParallelGroupCommandTest.cs
@@ -173,11 +173,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Commands
 
             var tm = new List<TestModule>
             {
-                new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars),
-                new TestModule("module2", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image2"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars),
-                new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars),
-                new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars),
-                new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars)
+                new TestModule("module1", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image1"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>()),
+                new TestModule("module2", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image2"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>()),
+                new TestModule("module3", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image3"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>()),
+                new TestModule("module4", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image4"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>()),
+                new TestModule("module5", "version1", "type1", ModuleStatus.Stopped, new TestConfig("image5"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, defaultConfigurationInfo, envVars, Option.None<ContentTrust>())
             };
 
             (Option<TestPlanRecorder> recorder, List<TestRecordType> moduleExecutionList, List<ICommand> commandList)[] testInputRecords =

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/configsources/DeploymentFileBackupTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/configsources/DeploymentFileBackupTest.cs
@@ -18,11 +18,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources
         const string TestType = "test";
         static readonly IDictionary<string, EnvVal> EnvVars = new Dictionary<string, EnvVal>();
         static readonly ConfigurationInfo ConfigurationInfo = new ConfigurationInfo();
-        static readonly IEdgeAgentModule EdgeAgentModule = new TestAgentModule("edgeAgent", "test", new TestConfig("edge-agent"), ImagePullPolicy.OnCreate, ConfigurationInfo, EnvVars);
+        static readonly IEdgeAgentModule EdgeAgentModule = new TestAgentModule("edgeAgent", "test", new TestConfig("edge-agent"), ImagePullPolicy.OnCreate, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
         static readonly TestRuntimeInfo TestRuntimeInfo = new TestRuntimeInfo("test");
         static readonly TestConfig Config1 = new TestConfig("image1");
-        static readonly IModule ValidModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars);
-        static readonly IEdgeHubModule EdgeHubModule = new TestHubModule("edgeHub", "test", ModuleStatus.Running, new TestConfig("edge-hub:latest"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars);
+        static readonly IModule ValidModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IEdgeHubModule EdgeHubModule = new TestHubModule("edgeHub", "test", ModuleStatus.Running, new TestConfig("edge-hub:latest"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
         static readonly IDictionary<string, IModule> Modules1 = new Dictionary<string, IModule> { ["mod1"] = ValidModule1 };
         static readonly IDictionary<string, IModule> Modules2 = new Dictionary<string, IModule> { ["mod2"] = ValidModule1 };
         static readonly DeploymentConfig ValidConfig1 = new DeploymentConfig("1.0", TestRuntimeInfo, new SystemModules(EdgeAgentModule, EdgeHubModule), Modules1);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/configsources/FileConfigSourceTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/configsources/FileConfigSourceTest.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core.ConfigSources;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Serde;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Extensions.Configuration;
     using Xunit;
@@ -146,19 +147,19 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.ConfigSources
 
         static readonly TestConfig Config1 = new TestConfig("image1");
 
-        static readonly IModule ValidModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.HighestPriority, ConfigurationInfo, EnvVars);
+        static readonly IModule ValidModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.HighestPriority, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
-        static readonly IEdgeHubModule EdgeHubModule = new TestHubModule("edgeHub", "test", ModuleStatus.Running, new TestConfig("edge-hub:latest"), RestartPolicy.Always, ImagePullPolicy.OnCreate, 10, ConfigurationInfo, EnvVars);
+        static readonly IEdgeHubModule EdgeHubModule = new TestHubModule("edgeHub", "test", ModuleStatus.Running, new TestConfig("edge-hub:latest"), RestartPolicy.Always, ImagePullPolicy.OnCreate, 10, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
-        static readonly IEdgeAgentModule EdgeAgentModule = new TestAgentModule("edgeAgent", "test", new TestConfig("edge-agent"), ImagePullPolicy.OnCreate, ConfigurationInfo, null);
+        static readonly IEdgeAgentModule EdgeAgentModule = new TestAgentModule("edgeAgent", "test", new TestConfig("edge-agent"), ImagePullPolicy.OnCreate, ConfigurationInfo, null, Option.None<ContentTrust>());
 
         static readonly IDictionary<string, IModule> Modules1 = new Dictionary<string, IModule> { ["mod1"] = ValidModule1 };
 
         static readonly ModuleSet ValidSet1 = new ModuleSet(new Dictionary<string, IModule>(Modules1) { [EdgeHubModule.Name] = EdgeHubModule, [EdgeAgentModule.Name] = EdgeAgentModule });
 
-        static readonly IModule UpdatedModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.HighestPriority, ConfigurationInfo, EnvVars);
+        static readonly IModule UpdatedModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.Never, Constants.HighestPriority, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
-        static readonly IModule ValidModule2 = new TestModule("mod2", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars);
+        static readonly IModule ValidModule2 = new TestModule("mod2", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
         static readonly IDictionary<string, IModule> Modules2 = new Dictionary<string, IModule> { ["mod1"] = UpdatedModule1, ["mod2"] = ValidModule2 };
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/metrics/AvaliabilityMetricsTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/metrics/AvaliabilityMetricsTest.cs
@@ -142,6 +142,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Metrics
                         0,
                         DateTime.MinValue,
                         ModuleStatus.Running,
+                        Option.None<ContentTrust>(),
                         ImagePullPolicy.OnCreate,
                         Constants.DefaultPriority,
                         null,
@@ -156,7 +157,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Metrics
                         ImagePullPolicy.OnCreate,
                         Constants.DefaultPriority,
                         DefaultConfigurationInfo,
-                        envVars)
+                        envVars,
+                        Option.None<ContentTrust>())
              );
         }
     }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/planners/HealthRestartPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/planners/HealthRestartPlannerTest.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
     using Microsoft.Azure.Devices.Edge.Agent.Core.Planners;
     using Microsoft.Azure.Devices.Edge.Agent.Core.PlanRunners;
     using Microsoft.Azure.Devices.Edge.Storage;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Xunit;
@@ -61,7 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         {
             (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
-            IModule addModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            IModule addModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { addModule });
             ModuleSet addRunning = ModuleSet.Create(addModule);
             var addExecutionList = new List<TestRecordType>
@@ -82,7 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         {
             (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
-            IModule addModule = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            IModule addModule = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { addModule });
             ModuleSet addRunning = ModuleSet.Create(addModule);
             var addExecutionList = new List<TestRecordType>
@@ -115,8 +116,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Running);
-            IModule desiredModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+                ModuleStatus.Running,
+                Option.None<ContentTrust>()
+                );
+            IModule desiredModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { desiredModule });
             ModuleSet currentSet = ModuleSet.Create(currentModule);
             ModuleSet desiredSet = ModuleSet.Create(desiredModule);
@@ -152,7 +155,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Running);
+                ModuleStatus.Running,
+                Option.None<ContentTrust>());
             ModuleSet removeRunning = ModuleSet.Create(removeModule);
             var removeExecutionList = new List<TestRecordType>
             {
@@ -510,7 +514,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - IntensiveCareTime - TimeSpan.FromMinutes(1),  // module exited > IntensiveCareTime min ago
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Running)
+                    ModuleStatus.Running,
+                    Option.None<ContentTrust>())
             };
 
             (TestCommandFactory factory, Mock<IEntityStore<string, ModuleState>> store, _, HealthRestartPlanner planner) = CreatePlanner();
@@ -537,8 +542,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
             // Arrange
             (TestCommandFactory factory, _, _, HealthRestartPlanner planner) = CreatePlanner();
 
-            IModule module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-            IModule edgeAgentModule = new TestModule(Constants.EdgeAgentModuleName, "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            IModule module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+            IModule edgeAgentModule = new TestModule(Constants.EdgeAgentModuleName, "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
             var modules = new List<IModule>
             {
                 module1,
@@ -586,7 +591,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Running),
+                ModuleStatus.Running,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule2",
                 "version1",
@@ -600,7 +606,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Backoff),
+                ModuleStatus.Backoff,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule3",
                 "version1",
@@ -614,7 +621,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Unhealthy),
+                ModuleStatus.Unhealthy,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule4",
                 "version1",
@@ -628,7 +636,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Stopped),
+                ModuleStatus.Stopped,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule5",
                 "version1",
@@ -642,7 +651,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Failed),
+                ModuleStatus.Failed,
+                Option.None<ContentTrust>()),
 
             // OnUnhealthy
             new TestRuntimeModule(
@@ -658,7 +668,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Running),
+                ModuleStatus.Running,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule7",
                 "version1",
@@ -672,7 +683,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Backoff),
+                ModuleStatus.Backoff,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule8",
                 "version1",
@@ -686,7 +698,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Unhealthy),
+                ModuleStatus.Unhealthy,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule9",
                 "version1",
@@ -700,7 +713,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Stopped),
+                ModuleStatus.Stopped,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule10",
                 "version1",
@@ -714,7 +728,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Failed),
+                ModuleStatus.Failed,
+                Option.None<ContentTrust>()),
 
             // OnFailure
             new TestRuntimeModule(
@@ -730,7 +745,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Running),
+                ModuleStatus.Running,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule12",
                 "version1",
@@ -744,7 +760,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Backoff),
+                ModuleStatus.Backoff,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule13",
                 "version1",
@@ -758,7 +775,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Unhealthy),
+                ModuleStatus.Unhealthy,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule14",
                 "version1",
@@ -772,7 +790,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Stopped),
+                ModuleStatus.Stopped,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule15",
                 "version1",
@@ -786,7 +805,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Failed),
+                ModuleStatus.Failed,
+                Option.None<ContentTrust>()),
 
             // Never
             new TestRuntimeModule(
@@ -802,7 +822,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Running),
+                ModuleStatus.Running,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule17",
                 "version1",
@@ -816,7 +837,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Backoff),
+                ModuleStatus.Backoff,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule18",
                 "version1",
@@ -830,7 +852,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Unhealthy),
+                ModuleStatus.Unhealthy,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule19",
                 "version1",
@@ -844,7 +867,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Stopped),
+                ModuleStatus.Stopped,
+                Option.None<ContentTrust>()),
             new TestRuntimeModule(
                 "removeModule20",
                 "version1",
@@ -858,7 +882,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                 DateTime.MinValue,
                 0,
                 DateTime.MinValue,
-                ModuleStatus.Failed)
+                ModuleStatus.Failed,
+                Option.None<ContentTrust>())
         };
 
         static (IRuntimeModule RunningModule, IModule UpdatedModule)[] GetUpdateDeployTestData() => new (IRuntimeModule RunningModule, IModule UpdatedModule)[]
@@ -879,11 +904,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
-                    EnvVars),
-                new TestModule("updateDeployModule1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                    EnvVars
+                    ),
+                new TestModule("updateDeployModule1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -900,11 +927,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule2", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule2", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -921,11 +949,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule3", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule3", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -942,11 +971,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule4", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule4", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -963,11 +993,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Failed,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule5", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule5", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
 
             // OnUnhealthy
@@ -986,11 +1017,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule6", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule6", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1007,11 +1039,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule7", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule7", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1028,11 +1061,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule8", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule8", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1049,11 +1083,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule9", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule9", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1070,11 +1105,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Failed,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule10", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule10", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
 
             // OnFailure
@@ -1093,11 +1129,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule11", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule11", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1114,11 +1151,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule12", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule12", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1135,11 +1173,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule13", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule13", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1156,11 +1195,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule14", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule14", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1177,11 +1217,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Failed,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule15", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule15", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnFailure, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
 
             // Never
@@ -1200,11 +1241,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule16", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule16", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1221,11 +1263,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule17", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule17", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1242,11 +1285,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule18", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule18", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1263,11 +1307,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule19", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule19", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1284,11 +1329,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Failed,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule20", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule20", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Never, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
 
             // Always with module priority
@@ -1307,11 +1353,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule21", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule21", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1328,11 +1375,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 1,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule22", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority + 1, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule22", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority + 1, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1349,11 +1397,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 2,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule23", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority + 2, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule23", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority + 2, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1370,11 +1419,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 3,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule24", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority + 3, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule24", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority + 3, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1391,11 +1441,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Failed,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 4,
                     null,
                     EnvVars),
-                new TestModule("updateDeployModule25", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority + 4, DefaultConfigurationInfo, EnvVars)
+                new TestModule("updateDeployModule25", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.HighestPriority + 4, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             ),
         };
 
@@ -1417,6 +1468,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1431,7 +1483,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // OnUnhealthy
@@ -1450,6 +1503,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1464,7 +1518,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // OnFailure
@@ -1483,6 +1538,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1497,7 +1553,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // Never - Never started
@@ -1516,6 +1573,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1530,7 +1588,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // Never - started before
@@ -1549,6 +1608,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1563,7 +1623,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // Always with Higher Priority
@@ -1582,6 +1643,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority,
                     null,
@@ -1596,7 +1658,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1613,6 +1676,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 1,
                     null,
@@ -1627,7 +1691,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 1,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
         };
 
@@ -1649,6 +1714,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1663,7 +1729,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1680,6 +1747,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1694,7 +1762,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1711,6 +1780,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1725,7 +1795,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1742,6 +1813,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1756,7 +1828,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1773,6 +1846,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Failed,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1787,7 +1861,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // OnUnhealthy
@@ -1806,6 +1881,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1820,7 +1896,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1837,6 +1914,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1851,7 +1929,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1868,6 +1947,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1882,7 +1962,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1899,6 +1980,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1913,7 +1995,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1930,6 +2013,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Failed,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1944,7 +2028,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // OnFailure
@@ -1963,6 +2048,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -1977,7 +2063,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -1994,6 +2081,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2008,7 +2096,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2025,6 +2114,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2039,7 +2129,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2056,6 +2147,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2070,7 +2162,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2087,6 +2180,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2101,7 +2195,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // Never
@@ -2120,6 +2215,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2134,7 +2230,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2151,6 +2248,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2165,7 +2263,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2182,6 +2281,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2196,7 +2296,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2213,6 +2314,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2227,7 +2329,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2244,6 +2347,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Failed,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     null,
@@ -2258,7 +2362,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.DefaultPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
 
             // Always with module priority
@@ -2277,6 +2382,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Running,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority,
                     null,
@@ -2291,7 +2397,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2308,6 +2415,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 1,
                     null,
@@ -2322,7 +2430,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 1,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2339,6 +2448,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 2,
                     null,
@@ -2353,7 +2463,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 2,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2370,6 +2481,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Stopped,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 3,
                     null,
@@ -2384,7 +2496,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 3,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
             (
                 new TestRuntimeModule(
@@ -2400,7 +2513,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed,
+                    ModuleStatus.Failed,Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 4,
                     null,
@@ -2415,7 +2528,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 4,
                     DefaultConfigurationInfo,
-                    EnvVars)
+                    EnvVars,
+                    Option.None<ContentTrust>())
             ),
         };
 
@@ -2440,7 +2554,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - IntensiveCareTime - TimeSpan.FromMinutes(5),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Running),
+                    ModuleStatus.Running,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2459,7 +2574,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 true
             ),
             (
@@ -2476,7 +2592,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 true
             ),
             (
@@ -2493,7 +2610,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2512,7 +2630,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2529,7 +2648,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2546,7 +2666,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2565,7 +2686,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2582,7 +2704,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2599,7 +2722,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2618,7 +2742,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2635,7 +2760,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2652,7 +2778,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2675,7 +2802,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - IntensiveCareTime - TimeSpan.FromMinutes(5),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Running),
+                    ModuleStatus.Running,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2694,7 +2822,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 true
             ),
             (
@@ -2711,7 +2840,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 true
             ),
             (
@@ -2728,7 +2858,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2747,7 +2878,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2764,7 +2896,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2781,7 +2914,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2800,7 +2934,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2817,7 +2952,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2834,7 +2970,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2853,7 +2990,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2870,7 +3008,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2887,7 +3026,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2910,7 +3050,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - IntensiveCareTime - TimeSpan.FromMinutes(5),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Running),
+                    ModuleStatus.Running,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2929,7 +3070,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 true
             ),
             (
@@ -2946,7 +3088,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 true
             ),
             (
@@ -2963,7 +3106,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -2982,7 +3126,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -2999,7 +3144,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3016,7 +3162,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -3035,7 +3182,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3052,7 +3200,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3069,7 +3218,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -3088,7 +3238,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3105,7 +3256,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3122,7 +3274,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -3145,7 +3298,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - IntensiveCareTime - TimeSpan.FromMinutes(5),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Running),
+                    ModuleStatus.Running,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -3164,7 +3318,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3181,7 +3336,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3198,7 +3354,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Backoff),
+                    ModuleStatus.Backoff,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -3217,7 +3374,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3234,7 +3392,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3251,7 +3410,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Unhealthy),
+                    ModuleStatus.Unhealthy,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -3270,7 +3430,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3287,7 +3448,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3304,7 +3466,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Stopped),
+                    ModuleStatus.Stopped,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -3323,7 +3486,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.MinValue,
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3340,7 +3504,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromHours(1),
                     0,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
             (
@@ -3357,7 +3522,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     DateTime.UtcNow - TimeSpan.FromSeconds(40),
                     3,
                     DateTime.MinValue,
-                    ModuleStatus.Failed),
+                    ModuleStatus.Failed,
+                    Option.None<ContentTrust>()),
                 false
             ),
 
@@ -3381,6 +3547,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority),
                 true
@@ -3400,6 +3567,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
                     0,
                     DateTime.MinValue,
                     ModuleStatus.Backoff,
+                    Option.None<ContentTrust>(),
                     ImagePullPolicy.OnCreate,
                     Constants.HighestPriority + 1),
                 true

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/planners/RestartPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/planners/RestartPlannerTest.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
     using System.Threading;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Planners;
     using Microsoft.Azure.Devices.Edge.Agent.Core.PlanRunners;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Xunit;
@@ -42,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         {
             var factory = new TestCommandFactory();
 
-            IModule addModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            IModule addModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { addModule });
 
@@ -68,7 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         {
             var factory = new TestCommandFactory();
 
-            IModule stoppedModule = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            IModule stoppedModule = new TestModule("mod1", "version1", "test", ModuleStatus.Stopped, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
             ModuleSet addStopped = ModuleSet.Create(stoppedModule);
 
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { stoppedModule });
@@ -92,8 +93,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         {
             var factory = new TestCommandFactory();
 
-            IModule currentModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-            IModule desiredModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            IModule currentModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+            IModule desiredModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { desiredModule });
             var planner = new RestartPlanner(factory);
@@ -122,7 +123,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
             var planner = new RestartPlanner(factory);
             var token = default(CancellationToken);
 
-            IModule removeModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            IModule removeModule = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
             ModuleSet removeRunning = ModuleSet.Create(removeModule);
             var removeExecutionList = new List<TestRecordType>
             {
@@ -147,17 +148,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
 
             var currentModules = new List<IModule>
             {
-                new TestRuntimeModule("UpdateMod1", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1, 0, "Running", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running),
-                new TestRuntimeModule("UpdateMod2", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1, 0, "Running", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Stopped),
-                new TestRuntimeModule("RemoveMod1", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1, 0, "Running", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running),
-                new TestRuntimeModule("RemoveMod2", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1, 0, "Running", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Stopped)
+                new TestRuntimeModule("UpdateMod1", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1, 0, "Running", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>()),
+                new TestRuntimeModule("UpdateMod2", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1, 0, "Running", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Stopped, Option.None<ContentTrust>()),
+                new TestRuntimeModule("RemoveMod1", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1, 0, "Running", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Running, Option.None<ContentTrust>()),
+                new TestRuntimeModule("RemoveMod2", "version1", RestartPolicy.OnUnhealthy, "test", ModuleStatus.Running, Config1, 0, "Running", lastStartTime, lastExitTime, 0, DateTime.MinValue, ModuleStatus.Stopped, Option.None<ContentTrust>())
             };
             var desiredModules = new List<IModule>
             {
-                new TestModule("NewMod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars),
-                new TestModule("NewMod2", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars),
-                new TestModule("UpdateMod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars),
-                new TestModule("UpdateMod2", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars)
+                new TestModule("NewMod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>()),
+                new TestModule("NewMod2", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>()),
+                new TestModule("UpdateMod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>()),
+                new TestModule("UpdateMod2", "version1", "test", ModuleStatus.Stopped, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>())
             };
 
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(desiredModules);
@@ -210,10 +211,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Planners
         {
             var factory = new TestCommandFactory();
 
-            IModule module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 3, DefaultConfigurationInfo, EnvVars);
-            IModule updatedModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 3, DefaultConfigurationInfo, EnvVars);
-            IModule addModule2 = new TestModule("mod2", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 2, DefaultConfigurationInfo, EnvVars);
-            IModule addModule3 = new TestModule("mod3", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 1, DefaultConfigurationInfo, EnvVars);
+            IModule module1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 3, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+            IModule updatedModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config2, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 3, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+            IModule addModule2 = new TestModule("mod2", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 2, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+            IModule addModule3 = new TestModule("mod3", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 1, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> moduleIdentities = GetModuleIdentities(new List<IModule>() { module1, addModule2, addModule3 });
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/EdgeAgentDockerRuntimeModuleTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/EdgeAgentDockerRuntimeModuleTest.cs
@@ -51,7 +51,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
                         imageHash = "someSha",
                         createOptions = "{}"
                     },
-                    env = new { }
+                    env = new { },
+                    contentTrust = new
+                    {
+                        HasValue = false
+                    }
                 });
 
             Assert.True(JToken.DeepEquals(expected, json));

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/EdgeHubDockerRuntimeModuleTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/EdgeHubDockerRuntimeModuleTest.cs
@@ -54,7 +54,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
     ""image"": ""edg0eHubImage:latest"",
     ""createOptions"": ""{}""
   },
-  ""env"": {}
+  ""env"": {},
+  ""contentTrust"" : {
+    ""HasValue"": false
+  }
 }
             ");
 
@@ -218,7 +221,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
     ""image"": ""edg0eHubImage:latest"",
     ""createOptions"": ""{}""
   },
-  ""env"": {}
+  ""env"": {},
+  ""contentTrust"" : {
+    ""HasValue"": false
+  }
 }
             ");
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/commands/CreateCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/commands/CreateCommandTest.cs
@@ -745,7 +745,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test.Commands
             new TestConfig("EdgeAgentImage"),
             ImagePullPolicy.OnCreate,
             new ConfigurationInfo(),
-            EnvVars);
+            EnvVars,
+            Option.None<ContentTrust>());
 
         IEdgeHubModule CreateMockEdgeHubModule() => new TestHubModule(
             Constants.EdgeHubModuleName,
@@ -756,6 +757,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test.Commands
             ImagePullPolicy.OnCreate,
             Constants.DefaultPriority,
             new ConfigurationInfo(),
-            EnvVars);
+            EnvVars,
+            Option.None<ContentTrust>());
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleIdentityLifecycleManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleIdentityLifecycleManagerTest.cs
@@ -48,10 +48,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
             var moduleIdentityLifecycleManager = new ModuleIdentityLifecycleManager(identityManager, ModuleIdentityProviderServiceBuilder, EdgeletUri);
             var envVar = new Dictionary<string, EnvVal>();
 
-            var module1 = new TestModule("mod1", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module2 = new TestModule("mod2", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module3 = new TestModule("mod3", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module4 = new TestModule("$edgeHub", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
+            var module1 = new TestModule("mod1", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module2 = new TestModule("mod2", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module3 = new TestModule("mod3", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module4 = new TestModule("$edgeHub", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
             ModuleSet desired = ModuleSet.Create(module1, module4);
             ModuleSet current = ModuleSet.Create(module2, module3, module4);
 
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
                     m.CreateIdentityAsync(Name, Constants.ModuleIdentityEdgeManagedByValue) == Task.FromResult(identity));
 
             var moduleIdentityLifecycleManager = new ModuleIdentityLifecycleManager(identityManager, ModuleIdentityProviderServiceBuilder, EdgeletUri);
-            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, new Dictionary<string, EnvVal>());
+            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, new Dictionary<string, EnvVal>(), Option.None<ContentTrust>());
 
             // Act
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await moduleIdentityLifecycleManager.GetModuleIdentitiesAsync(
@@ -128,11 +128,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
 
             var moduleIdentityLifecycleManager = new ModuleIdentityLifecycleManager(identityManager, ModuleIdentityProviderServiceBuilder, EdgeletUri);
             var envVar = new Dictionary<string, EnvVal>();
-            var module1 = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module2 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module3 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module4 = new TestModule(Module4, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module5 = new TestModule(Module5, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
+            var module1 = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module2 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module3 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module4 = new TestModule(Module4, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module5 = new TestModule(Module5, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
             ModuleSet desired = ModuleSet.Create(module1, module2.CloneWithImage("image2"), module3.CloneWithImage("image2"), module4.CloneWithImage("image2"), module5.CloneWithImage("image2"));
             ModuleSet current = ModuleSet.Create(module2, module3, module4, module5);
 
@@ -175,9 +175,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
 
             var moduleIdentityLifecycleManager = new ModuleIdentityLifecycleManager(identityManager, ModuleIdentityProviderServiceBuilder, EdgeletUri);
             var envVar = new Dictionary<string, EnvVal>();
-            var desiredModule = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var currentModule1 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var currentModule2 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
+            var desiredModule = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var currentModule1 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var currentModule2 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
             ModuleSet desired = ModuleSet.Create(new IModule[] { desiredModule });
             ModuleSet current = ModuleSet.Create(new IModule[] { currentModule1, currentModule2 });
 
@@ -217,9 +217,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
 
             var moduleIdentityLifecycleManager = new ModuleIdentityLifecycleManager(identityManager, ModuleIdentityProviderServiceBuilder, EdgeletUri);
             var envVar = new Dictionary<string, EnvVal>();
-            var desiredModule = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var currentModule1 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var currentModule2 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
+            var desiredModule = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var currentModule1 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var currentModule2 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
             ModuleSet desired = ModuleSet.Create(new IModule[] { currentModule1, desiredModule });
             ModuleSet current = ModuleSet.Create(new IModule[] { currentModule1, currentModule2 });
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/ModuleIdentityLifecycleManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/ModuleIdentityLifecycleManagerTest.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Test;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Newtonsoft.Json;
@@ -58,7 +59,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             // ReSharper disable PossibleMultipleEnumeration
             serviceClient.Setup(sc => sc.CreateModules(It.Is<IEnumerable<string>>(m => m.Count() == 1 && m.First() == Name))).Returns(Task.FromResult(updatedServiceIdentities));
             // ReSharper restore PossibleMultipleEnumeration
-            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await new ModuleIdentityLifecycleManager(serviceClient.Object, hostname, deviceId, gatewayHostName)
                 .GetModuleIdentitiesAsync(ModuleSet.Create(new IModule[] { module }), ModuleSet.Empty);
@@ -98,7 +99,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                     }
                 }).Returns(Task.FromResult(serviceIdentities));
 
-            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await new ModuleIdentityLifecycleManager(serviceClient.Object, hostname, deviceId, gatewayHostName)
                 .GetModuleIdentitiesAsync(ModuleSet.Create(new IModule[] { module }), ModuleSet.Empty);
@@ -134,7 +135,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                     }
                 }).Returns(Task.FromResult(serviceIdentities));
 
-            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await new ModuleIdentityLifecycleManager(serviceClient.Object, hostname, deviceId, gatewayHostName)
                 .GetModuleIdentitiesAsync(ModuleSet.Create(new IModule[] { module }), ModuleSet.Empty);
@@ -181,7 +182,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                     }
                 }).Returns(Task.FromResult(serviceIdentities));
 
-            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await new ModuleIdentityLifecycleManager(serviceClient.Object, hostname, deviceId, gatewayHostName)
                 .GetModuleIdentitiesAsync(ModuleSet.Create(new IModule[] { module }), ModuleSet.Empty);
@@ -223,7 +224,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                     }
                 }).Returns(Task.FromResult(serviceIdentities));
 
-            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await new ModuleIdentityLifecycleManager(serviceClient.Object, hostname, deviceId, gatewayHostName)
                 .GetModuleIdentitiesAsync(ModuleSet.Create(new IModule[] { module }), ModuleSet.Empty);
@@ -260,7 +261,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             serviceClient.Setup(sc => sc.CreateModules(It.Is<IEnumerable<string>>(m => !m.Any()))).Returns(Task.FromResult(new Module[0]));
             serviceClient.Setup(sc => sc.UpdateModules(It.Is<IEnumerable<Module>>(m => !m.Any()))).Returns(Task.FromResult(new Module[0]));
 
-            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await new ModuleIdentityLifecycleManager(serviceClient.Object, hostname, deviceId, gatewayHostName)
                 .GetModuleIdentitiesAsync(ModuleSet.Create(module), ModuleSet.Empty);
@@ -278,7 +279,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             // Use Json to create module because managedBy property can't has private set on Module object
             const string ModuleJson = "{\"moduleId\":\"test-filters\",\"deviceId\":\"device1\",\"authentication\":{\"symmetricKey\":{\"primaryKey\":\"cHJpbWFyeVN5bW1ldHJpY0tleQ == \",\"secondaryKey\":\"c2Vjb25kYXJ5U3ltbWV0cmljS2V5\"},\"x509Thumbprint\":{\"primaryThumbprint\":null,\"secondaryThumbprint\":null},\"type\":\"sas\"},\"managedBy\":\"iotEdge\"}";
             var serviceModuleIdentity = JsonConvert.DeserializeObject<Module>(ModuleJson);
-            var currentModule = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var currentModule = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             var serviceClient = new Mock<IServiceClient>();
             string hostname = "hostname";
@@ -309,7 +310,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             // Use Json to create module because managedBy property can't has private set on Module object
             const string ModuleJson = "{\"moduleId\":\"test-filters\",\"deviceId\":\"device1\",\"authentication\":{\"symmetricKey\":{\"primaryKey\":\"cHJpbWFyeVN5bW1ldHJpY0tleQ == \",\"secondaryKey\":\"c2Vjb25kYXJ5U3ltbWV0cmljS2V5\"},\"x509Thumbprint\":{\"primaryThumbprint\":null,\"secondaryThumbprint\":null},\"type\":\"sas\"},\"managedBy\":null}";
             var serviceModuleIdentity = JsonConvert.DeserializeObject<Module>(ModuleJson);
-            var currentModule = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var currentModule = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             var serviceClient = new Mock<IServiceClient>();
             string hostname = "hostname";
@@ -363,8 +364,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             serviceClient.Setup(sc => sc.CreateModules(It.Is<IEnumerable<string>>(m => !m.Any()))).Returns(Task.FromResult(new Module[0]));
             serviceClient.Setup(sc => sc.UpdateModules(It.Is<IEnumerable<Module>>(m => !m.Any()))).Returns(Task.FromResult(new Module[0]));
 
-            var testMod = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
-            var edgeHubMod = new TestModule(Constants.EdgeHubModuleName, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var testMod = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+            var edgeHubMod = new TestModule(Constants.EdgeHubModuleName, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await new ModuleIdentityLifecycleManager(serviceClient.Object, hostname, deviceId, gatewayHostName)
                 .GetModuleIdentitiesAsync(ModuleSet.Create(testMod, edgeHubMod), ModuleSet.Empty);
@@ -403,7 +404,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             // ReSharper disable PossibleMultipleEnumeration
             serviceClient.Setup(sc => sc.CreateModules(It.Is<IEnumerable<string>>(m => m.Count() == 1 && m.First() == Name))).ThrowsAsync(new InvalidOperationException());
             // ReSharper restore PossibleMultipleEnumeration
-            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
+            var module = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars, Option.None<ContentTrust>());
 
             IImmutableDictionary<string, IModuleIdentity> modulesIdentities = await new ModuleIdentityLifecycleManager(serviceClient.Object, hostname, deviceId, gatewayHostName)
                 .GetModuleIdentitiesAsync(ModuleSet.Create(module), ModuleSet.Empty);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/reporters/IoTHubReporterTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/reporters/IoTHubReporterTest.cs
@@ -98,7 +98,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Running),
+                            ModuleStatus.Running,
+                            Option.None<ContentTrust>()),
                         new TestRuntimeModule(
                             "extra_mod",
                             "1.0",
@@ -112,7 +113,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Backoff)).Modules.ToImmutableDictionary(),
+                            ModuleStatus.Backoff,
+                            Option.None<ContentTrust>())).Modules.ToImmutableDictionary(),
                     string.Empty,
                     versionInfo);
                 edgeAgentConnection
@@ -160,7 +162,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Backoff),
+                        ModuleStatus.Backoff,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -174,7 +177,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running));
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()));
 
                 // Act
                 var reporter = new IoTHubReporter(edgeAgentConnection.Object, agentStateSerde.Object, versionInfo);
@@ -280,7 +284,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Running),
+                            ModuleStatus.Running,
+                            Option.None<ContentTrust>()),
                         new TestRuntimeModule(
                             "extra_mod",
                             "1.0",
@@ -294,7 +299,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Backoff)).Modules.ToImmutableDictionary(),
+                            ModuleStatus.Backoff,
+                            Option.None<ContentTrust>())).Modules.ToImmutableDictionary(),
                     string.Empty,
                     versionInfo);
                 edgeAgentConnection
@@ -338,7 +344,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Backoff),
+                        ModuleStatus.Backoff,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -352,7 +359,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running));
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()));
 
                 var agentStateSerde = new Mock<ISerde<AgentState>>();
                 agentStateSerde.Setup(s => s.Deserialize(It.IsAny<string>()))
@@ -459,7 +467,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Running),
+                            ModuleStatus.Running,
+                            Option.None<ContentTrust>()),
                         new TestRuntimeModule(
                             "extra_mod",
                             "1.0",
@@ -473,7 +482,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Backoff)).Modules.ToImmutableDictionary(),
+                            ModuleStatus.Backoff,
+                            Option.None<ContentTrust>())).Modules.ToImmutableDictionary(),
                     string.Empty,
                     versionInfo);
                 edgeAgentConnection
@@ -517,7 +527,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Backoff),
+                        ModuleStatus.Backoff,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -531,7 +542,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running));
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()));
 
                 var agentStateSerde = new Mock<ISerde<AgentState>>();
                 agentStateSerde.Setup(s => s.Deserialize(It.IsAny<string>()))
@@ -647,7 +659,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Running),
+                            ModuleStatus.Running,
+                            Option.None<ContentTrust>()),
                         new TestRuntimeModule(
                             "extra_mod",
                             "1.0",
@@ -661,7 +674,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Backoff)).Modules.ToImmutableDictionary(),
+                            ModuleStatus.Backoff,
+                            Option.None<ContentTrust>())).Modules.ToImmutableDictionary(),
                     string.Empty,
                     versionInfo);
 
@@ -711,7 +725,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Backoff),
+                        ModuleStatus.Backoff,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -725,7 +740,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running));
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()));
 
                 var agentStateSerde = new Mock<ISerde<AgentState>>();
                 agentStateSerde.Setup(s => s.Deserialize(It.IsAny<string>()))
@@ -831,7 +847,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Running),
+                            ModuleStatus.Running,
+                            Option.None<ContentTrust>()),
                         new TestRuntimeModule(
                             "extra_mod",
                             "1.0",
@@ -845,7 +862,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Backoff)).Modules.ToImmutableDictionary(),
+                            ModuleStatus.Backoff,
+                            Option.None<ContentTrust>())).Modules.ToImmutableDictionary(),
                     string.Empty,
                     versionInfo);
                 edgeAgentConnection.SetupGet(c => c.ReportedProperties).Returns(Option.Some(new TwinCollection(JsonConvert.SerializeObject(reportedState))));
@@ -887,7 +905,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Backoff),
+                        ModuleStatus.Backoff,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -901,7 +920,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running));
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()
+                        ));
 
                 var agentStateSerde = new Mock<ISerde<AgentState>>();
                 agentStateSerde.Setup(s => s.Deserialize(It.IsAny<string>()))
@@ -929,7 +950,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Failed),
+                        ModuleStatus.Failed,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -943,7 +965,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running));
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()));
 
                 await reporter.ReportAsync(cts.Token, currentModuleSet, runtimeInfo, DesiredVersion, DeploymentStatus.Success);
 
@@ -1006,7 +1029,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Running),
+                            ModuleStatus.Running,
+                            Option.None<ContentTrust>()),
                         new TestRuntimeModule(
                             "mod2",
                             "1.0",
@@ -1020,7 +1044,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Backoff)).Modules.ToImmutableDictionary(),
+                            ModuleStatus.Backoff,
+                            Option.None<ContentTrust>())).Modules.ToImmutableDictionary(),
                     string.Empty,
                     versionInfo);
                 edgeAgentConnection.SetupGet(c => c.ReportedProperties).Returns(Option.Some(new TwinCollection(JsonConvert.SerializeObject(reportedState))));
@@ -1057,7 +1082,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Backoff),
+                        ModuleStatus.Backoff,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -1071,7 +1097,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running));
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()));
 
                 var agentStateSerde = new Mock<ISerde<AgentState>>();
                 agentStateSerde.Setup(s => s.Deserialize(It.IsAny<string>()))
@@ -1142,7 +1169,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Running),
+                            ModuleStatus.Running,
+                            Option.None<ContentTrust>()),
                         new TestRuntimeModule(
                             "mod2",
                             "1.0",
@@ -1156,7 +1184,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Backoff)).Modules.ToImmutableDictionary(),
+                            ModuleStatus.Backoff,
+                            Option.None<ContentTrust>())).Modules.ToImmutableDictionary(),
                     "1.0",
                     versionInfo);
                 edgeAgentConnection.SetupGet(c => c.ReportedProperties).Returns(Option.Some(new TwinCollection(JsonConvert.SerializeObject(reportedState))));
@@ -1180,7 +1209,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running),
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -1194,7 +1224,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Backoff));
+                        ModuleStatus.Backoff,
+                        Option.None<ContentTrust>()));
 
                 var agentStateSerde = new Mock<ISerde<AgentState>>();
                 agentStateSerde.Setup(s => s.Deserialize(It.IsAny<string>()))
@@ -1307,6 +1338,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         0,
                         DateTime.MinValue,
                         ModuleStatus.Backoff,
+                        Option.None<ContentTrust>(),
                         ImagePullPolicy.OnCreate),
                     new TestRuntimeModule(
                         "mod2",
@@ -1322,6 +1354,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         0,
                         DateTime.MinValue,
                         ModuleStatus.Running,
+                        Option.None<ContentTrust>(),
                         ImagePullPolicy.Never,
                         Constants.HighestPriority),
                     edgeHubRuntimeModule);
@@ -1541,7 +1574,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Backoff),
+                        ModuleStatus.Backoff,
+                        Option.None<ContentTrust>()),
                     new TestRuntimeModule(
                         "mod2",
                         "1.0",
@@ -1555,7 +1589,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         DateTime.MinValue,
                         0,
                         DateTime.MinValue,
-                        ModuleStatus.Running));
+                        ModuleStatus.Running,
+                        Option.None<ContentTrust>()));
 
                 var agentStateSerde = new Mock<ISerde<AgentState>>();
                 agentStateSerde.Setup(s => s.Deserialize(It.IsAny<string>()))
@@ -1743,7 +1778,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Running),
+                            ModuleStatus.Running,
+                            Option.None<ContentTrust>()),
                         new TestRuntimeModule(
                             "extra_mod",
                             "1.0",
@@ -1757,7 +1793,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                             DateTime.MinValue,
                             0,
                             DateTime.MinValue,
-                            ModuleStatus.Backoff)).Modules.ToImmutableDictionary(),
+                            ModuleStatus.Backoff,
+                            Option.None<ContentTrust>())).Modules.ToImmutableDictionary(),
                     string.Empty,
                     versionInfo);
                 edgeAgentConnection
@@ -1807,6 +1844,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         0,
                         DateTime.MinValue,
                         ModuleStatus.Backoff,
+                        Option.None<ContentTrust>(),
                         ImagePullPolicy.Never,
                         Constants.DefaultPriority,
                         null,
@@ -1825,6 +1863,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
                         0,
                         DateTime.MinValue,
                         ModuleStatus.Running,
+                        Option.None<ContentTrust>(),
                         ImagePullPolicy.OnCreate,
                         Constants.DefaultPriority,
                         null,
@@ -1926,6 +1965,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Reporters
             new TestConfig("EdgeAgentImage"),
             ImagePullPolicy.OnCreate,
             new ConfigurationInfo(),
-            new Dictionary<string, EnvVal>());
+            new Dictionary<string, EnvVal>(),
+            Option.None<ContentTrust>());
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/DeploymentSecretBackupTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/DeploymentSecretBackupTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
     using Microsoft.Azure.Devices.Edge.Agent.Core;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Serde;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Test;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Rest;
     using Moq;
@@ -29,11 +30,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
 
         static readonly IDictionary<string, EnvVal> EnvVars = new Dictionary<string, EnvVal>();
         static readonly ConfigurationInfo ConfigurationInfo = new ConfigurationInfo();
-        static readonly IEdgeAgentModule EdgeAgentModule = new TestAgentModule("edgeAgent", "test", new TestConfig("edge-agent"), ImagePullPolicy.OnCreate, ConfigurationInfo, EnvVars);
+        static readonly IEdgeAgentModule EdgeAgentModule = new TestAgentModule("edgeAgent", "test", new TestConfig("edge-agent"), ImagePullPolicy.OnCreate, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
         static readonly TestRuntimeInfo TestRuntimeInfo = new TestRuntimeInfo("test");
         static readonly TestConfig Config1 = new TestConfig("image1");
-        static readonly IModule ValidModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars);
-        static readonly IEdgeHubModule EdgeHubModule = new TestHubModule("edgeHub", "test", ModuleStatus.Running, new TestConfig("edge-hub:latest"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars);
+        static readonly IModule ValidModule1 = new TestModule("mod1", "version1", "test", ModuleStatus.Running, Config1, RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
+        static readonly IEdgeHubModule EdgeHubModule = new TestHubModule("edgeHub", "test", ModuleStatus.Running, new TestConfig("edge-hub:latest"), RestartPolicy.Always, ImagePullPolicy.OnCreate, Constants.DefaultPriority, ConfigurationInfo, EnvVars, Option.None<ContentTrust>());
         static readonly IDictionary<string, IModule> Modules1 = new Dictionary<string, IModule> { ["mod1"] = ValidModule1 };
         static readonly IDictionary<string, IModule> Modules2 = new Dictionary<string, IModule> { ["mod2"] = ValidModule1 };
         static readonly DeploymentConfig ValidConfig1 = new DeploymentConfig("1.0", TestRuntimeInfo, new SystemModules(EdgeAgentModule, EdgeHubModule), Modules1);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesModuleIdentityLifecycleManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesModuleIdentityLifecycleManagerTest.cs
@@ -34,10 +34,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var moduleIdentityLifecycleManager = new KubernetesModuleIdentityLifecycleManager(identityManager, ModuleIdentityProviderServiceBuilder, EdgeletUri);
             var envVar = new Dictionary<string, EnvVal>();
 
-            var module1 = new TestModule("mod1", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module2 = new TestModule("mod2", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module3 = new TestModule("mod3", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var module4 = new TestModule("$edgeHub", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
+            var module1 = new TestModule("mod1", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module2 = new TestModule("mod2", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module3 = new TestModule("mod3", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var module4 = new TestModule("$edgeHub", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
             ModuleSet desired = ModuleSet.Create(module1, module4);
             ModuleSet current = ModuleSet.Create(module2, module3, module4);
 
@@ -69,9 +69,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
 
             var moduleIdentityLifecycleManager = new KubernetesModuleIdentityLifecycleManager(identityManager, ModuleIdentityProviderServiceBuilder, EdgeletUri);
             var envVar = new Dictionary<string, EnvVal>();
-            var desiredModule1 = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var desiredModule2 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
-            var desiredModule3 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar);
+            var desiredModule1 = new TestModule(Module1, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var desiredModule2 = new TestModule(Module2, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
+            var desiredModule3 = new TestModule(Module3, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, envVar, Option.None<ContentTrust>());
             ModuleSet desired = ModuleSet.Create(desiredModule1, desiredModule2, desiredModule3);
             ModuleSet current = ModuleSet.Create(desiredModule1, desiredModule2, desiredModule3);
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
@@ -330,6 +330,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Planners
             public bool Equals(IModule<string> other) => throw new NotImplementedException();
 
             public string Config { get; }
+
+            public Option<IDictionary<string, string>> ContentTrust { get; }
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
@@ -331,7 +331,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Planners
 
             public string Config { get; }
 
-            public Option<IDictionary<string, string>> ContentTrust { get; }
+            [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+            public Option<ContentTrust> ContentTrust { get; }
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Planners
 
             public string Config { get; }
 
-            [JsonProperty(PropertyName = "ContentTrust", Required = Required.AllowNull)]
+            [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
             public Option<ContentTrust> ContentTrust { get; }
         }
     }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/planners/KubernetesPlannerTest.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.Planners
 
             public string Config { get; }
 
-            [JsonProperty(PropertyName = "ContentTrust", Required = Required.Default)]
+            [JsonProperty(PropertyName = "contentTrust", Required = Required.Default)]
             public Option<ContentTrust> ContentTrust { get; }
         }
     }


### PR DESCRIPTION
The design calls out for four fields of content trust information.
1. path to the root.json file
2. root ID 
3. path to the root CA file
4. flag to disableTOFU - Trust On First Use

The PR makes changes per module and the modulespec which gets used by the iotedged