### PR TITLE
[mqtt] Added support for building and publishing MQTT broker images

### DIFF
--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -1,0 +1,41 @@
+trigger:
+  batch: true
+  branches:
+    include:
+      - master
+pr: none
+
+jobs:
+################################################################################
+  - job: linux_amd64
+################################################################################
+    displayName: Linux AMD64
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - bash: 'docker login $(registry.address) --username $(registry.user) --password $(registry.password)'
+        displayName: 'Docker Login'
+
+      - script: scripts/mqtt/build/linux/buildImage.sh amd64 $(registry.address) $(registry.user) $(registry.password)
+        name: build
+        displayName: Build ($(Build.Configuration))
+
+      - bash: 'docker push $(registry.address)/azureiotedge/mqttd-linux-amd64'
+        displayName: 'Docker Push'
+
+################################################################################
+  - job: linux_arm32
+################################################################################
+    displayName: Linux ARM32
+    pool:
+      vmImage: 'ubuntu-16.04'
+    steps:
+      - bash: 'docker login $(registry.address) --username $(registry.user) --password $(registry.password)'
+        displayName: 'Docker Login'
+
+      - script: scripts/mqtt/build/linux/buildImage.sh armv7 $(registry.address) $(registry.user) $(registry.password)
+        name: build
+        displayName: Build ($(Build.Configuration))
+
+      - bash: 'docker push $(registry.address)/azureiotedge/mqttd-linux-arm32v7'
+        displayName: 'Docker Push'

--- a/mqtt/build/linux/buildImage.sh
+++ b/mqtt/build/linux/buildImage.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# This script copies the iodedged executable files that go into the azureiotedge-iotedged image,
+# for each supported arch (x86_64, arm32v7, arm64v8).
+# It then publishes executable files along with their corresponding dockerfiles to the publish directory,
+# so that buildImage.sh can build the container image.
+
+set -e
+###############################################################################
+# Define Environment Variables
+###############################################################################
+
+ARCH=$1
+DOCKER_REGISTRY=$2
+DOCKER_USERNAME=$3
+DOCKER_PASSWORD=$4
+DOCKER_IMAGEVERSION=${BUILD_BUILDNUMBER:=$5}
+
+if [[ "$ARCH" == "amd64" ]]; then
+    ARCH="amd64"
+    DOCKER_IMAGENAME="azureiotedge/mqttd-linux-amd64"
+    TARGET="x86_64-unknown-linux-musl"
+    DOCKERFILE="../../docker/linux/amd64/Dockerfile"
+elif [[ "$ARCH" == "armv7" ]]; then
+    ARCH="arm32v7"
+    DOCKER_IMAGENAME="azureiotedge/mqttd-linux-arm32v7"
+    TARGET="armv7-unknown-linux-musleabihf"
+    DOCKERFILE="../../docker/linux/arm32v7/Dockerfile"
+else
+    echo "Unsupported architecture"
+    exit 1
+fi
+
+echo "Arch:                 $ARCH"
+echo "DOCKER_IMAGENAME:     $DOCKER_IMAGENAME"
+echo "TARGET:               $TARGET"
+echo "DOCKERFILE:           $DOCKERFILE"
+
+echo "Building and pushing Docker image $imagename for $arch"
+docker_build_cmd="docker build --no-cache"
+docker_build_cmd+=" -t $DOCKER_REGISTRY/$DOCKER_IMAGENAME"
+docker_build_cmd+=" --file $DOCKERFILE"
+docker_build_cmd+=" ../.."
+
+echo "Running... $docker_build_cmd"
+
+${docker_build_cmd}
+
+if [[ $? -ne 0 ]]; then
+    echo "Docker build failed with exit code $?"
+    exit 1
+fi
+
+echo "Done building Docker image $DOCKER_IMAGENAME for $PROJECT"

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -1,0 +1,30 @@
+# -*- mode: dockerfile -*-
+#
+# An example Dockerfile showing how to build a Rust executable using this
+# image, and deploy it with a tiny Alpine Linux container.
+
+# You can override this `--build-arg BASE_IMAGE=...` to use different
+# version of Rust or OpenSSL.
+ARG BASE_IMAGE=ekidd/rust-musl-builder:stable
+
+# Our first FROM statement declares the build environment.
+FROM ${BASE_IMAGE} AS builder
+
+# Add our source code.
+ADD . ./
+
+# Fix permissions on source code.
+# RUN sudo chown -R rust:rust /home/rust
+
+# Build our application.
+RUN cargo build -p mqttd --release && strip /home/rust/src/target/x86_64-unknown-linux-musl/release/mqttd
+
+FROM scratch
+ENV RUST_LOG=info
+EXPOSE 1883/tcp
+EXPOSE 8883/tcp
+
+COPY --from=builder \
+    /home/rust/src/target/x86_64-unknown-linux-musl/release/mqttd \
+    /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/mqttd"]

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -1,0 +1,30 @@
+# -*- mode: dockerfile -*-
+#
+# An example Dockerfile showing how to build a Rust executable using this
+# image, and deploy it with a tiny Alpine Linux container.
+
+# You can override this `--build-arg BASE_IMAGE=...` to use different
+# version of Rust or OpenSSL.
+ARG BASE_IMAGE=messense/rust-musl-cross:armv7-musleabihf
+
+# Our first FROM statement declares the build environment.
+FROM ${BASE_IMAGE} AS builder
+
+# Add our source code.
+ADD . ./
+
+# Fix permissions on source code.
+# RUN sudo chown -R rust:rust /home/rust
+
+# Build our application.
+RUN cargo build -p mqttd --release && musl-strip /home/rust/src/target/armv7-unknown-linux-musleabihf/release/mqttd
+
+FROM scratch
+ENV RUST_LOG=info
+EXPOSE 1883/tcp
+EXPOSE 8883/tcp
+
+COPY --from=builder \
+    /home/rust/src/target/armv7-unknown-linux-musleabihf/release/mqttd \
+    /usr/local/bin/
+ENTRYPOINT ["/usr/local/bin/mqttd"]


### PR DESCRIPTION
This is a stop-gap solution to enable us to build and publish MQTT broker images for performance tests. It will be reworked when MQTT will be integrated with EdgeHub.