### PR TITLE
Temporarily disable windows metrics

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -88,13 +88,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
             // Temporarly make metrics default to off for windows. This is only until the dotnet 3.1 work is completed
             // This temp fix is needed to fix all e2e tests since edgehub currently crashes
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                var conf = configuration.GetSection("metrics:listener");
-                configuration.Bind("conf", configuration.GetValue("conf", false));
-            }
-
-            MetricsConfig metricsConfig = new MetricsConfig(this.configuration.GetSection("metrics:listener"));
+            MetricsConfig metricsConfig = new MetricsConfig(this.configuration.GetSection("metrics:listener"), !RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
 
             this.RegisterCommonModule(builder, optimizeForPerformance, storeAndForward, metricsConfig);
             this.RegisterRoutingModule(builder, storeAndForward, experimentalFeatures);
@@ -258,7 +252,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             string storagePath = GetOrCreateDirectoryPath(this.configuration.GetValue<string>("StorageFolder"), Constants.EdgeHubStorageFolder);
             bool storeAndForwardEnabled = this.configuration.GetValue<bool>("storeAndForwardEnabled");
             Option<ulong> storageMaxTotalWalSize = this.GetConfigIfExists<ulong>(Constants.ConfigKey.StorageMaxTotalWalSize, this.configuration);
-            Option<StorageLogLevel> storageLogLevel = this.GetConfigIfExists<StorageLogLevel>(Constants.ConfigKey.StorageLogLevel,  this.configuration);
+            Option<StorageLogLevel> storageLogLevel = this.GetConfigIfExists<StorageLogLevel>(Constants.ConfigKey.StorageLogLevel, this.configuration);
 
             if (storeAndForwardEnabled)
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
     using System.Collections.Generic;
     using System.Diagnostics.Tracing;
     using System.IO;
+    using System.Runtime.InteropServices;
     using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
     using Autofac;
@@ -84,6 +85,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
             IConfiguration configuration = this.configuration.GetSection("experimentalFeatures");
             ExperimentalFeatures experimentalFeatures = ExperimentalFeatures.Create(configuration, Logger.Factory.CreateLogger("EdgeHub"));
+
+            // Temporarly make metrics default to off for windows. This is only until the dotnet 3.1 work is completed
+            // This temp fix is needed to fix all e2e tests since edgehub currently crashes
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                var conf = configuration.GetSection("metrics:listener");
+                configuration.Bind("conf", configuration.GetValue("conf", false));
+            }
 
             MetricsConfig metricsConfig = new MetricsConfig(this.configuration.GetSection("metrics:listener"));
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -3,7 +3,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 {
     using System;
     using System.Collections.Generic;
-    using System.Runtime.InteropServices;
     using System.Security.Authentication;
     using System.Threading;
     using System.Threading.Tasks;
@@ -35,13 +34,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 .AddJsonFile(Constants.ConfigFileName)
                 .AddEnvironmentVariables()
                 .Build();
-
-            // Temporarly make metrics default to off for windows. This is only until the dotnet 3.1 work is completed
-            // This temp fix is needed to fix all e2e tests since edgehub currently crashes
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                configuration.Bind("MetricsEnabled", configuration.GetValue("MetricsEnabled", false));
-            }
 
             return MainAsync(configuration).Result;
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.InteropServices;
     using System.Security.Authentication;
     using System.Threading;
     using System.Threading.Tasks;
@@ -34,6 +35,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 .AddJsonFile(Constants.ConfigFileName)
                 .AddEnvironmentVariables()
                 .Build();
+
+            // Temporarly make metrics default to off for windows. This is only until the dotnet 3.1 work is completed
+            // This temp fix is needed to fix all e2e tests since edgehub currently crashes
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                configuration.Bind("MetricsEnabled", configuration.GetValue("MetricsEnabled", false));
+            }
 
             return MainAsync(configuration).Result;
         }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/MetricsConfig.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/MetricsConfig.cs
@@ -5,9 +5,9 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics
 
     public class MetricsConfig
     {
-        public MetricsConfig(IConfiguration config)
+        public MetricsConfig(IConfiguration config, bool enabledDefault = true)
         {
-            this.Enabled = config.GetValue("MetricsEnabled", true);
+            this.Enabled = config.GetValue("MetricsEnabled", enabledDefault);
             this.ListenerConfig = MetricsListenerConfig.Create(config);
         }
 


### PR DESCRIPTION
Until dotnet 3.1 is in, the metrics break e2e tests. This temporarily disables metrics until then.