### PR TITLE
Pre-pull docker images for Pi end-to-end tests

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -56,7 +56,7 @@ jobs:
           | foreach { $_.Value }
 
         # Pull required images
-        docker login -u $(cr.username) -p $ACR_PASSWORD $(cr.address)
+        docker login -u '$(cr.username)' -p "$env:ACR_PASSWORD" '$(cr.address)'
         $images | foreach { sudo --preserve-env docker pull $_ }
         Remove-Item $HOME/.docker/config.json
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -34,6 +34,10 @@ jobs:
 
     timeoutInMinutes: 120
 
+    - pwsh: |
+        sudo git clean -ffdx
+      displayName: Clean up files (as sudo)
+
     steps:
     - template: templates/e2e-setup.yaml
 
@@ -65,7 +69,6 @@ jobs:
         sudo docker rm -f $(docker ps -a -q)
         sudo docker network prune -f
         sudo docker volume prune -f
-        sudo git clean -ffdx
       displayName: Cache docker images
       env:
         ACR_PASSWORD: $(TestContainerRegistryPassword)

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -56,7 +56,7 @@ jobs:
           | foreach { $_.Value }
 
         # Pull required images
-        $ACR_PASSWORD | docker login -u '$(cr.username)' --password-stdin '$(cr.address)'
+        docker login -u '$(cr.username)' -p "$ACR_PASSWORD" '$(cr.address)' | Out-Null
         $images | foreach { sudo --preserve-env docker pull $_ }
         Remove-Item $HOME/.docker/config.json
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -61,10 +61,11 @@ jobs:
           | where { $images -notcontains $_ }
         $remove | foreach { sudo docker rmi $_ }
 
-        # Prune everything else
+        # Delete everything else
         sudo docker rm -f $(docker ps -a -q)
         sudo docker network prune -f
         sudo docker volume prune -f
+        sudo git clean -ffdx
       displayName: Cache docker images
       env:
         ACR_PASSWORD: $(TestContainerRegistryPassword)

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -34,11 +34,11 @@ jobs:
 
     timeoutInMinutes: 120
 
+    steps:
     - pwsh: |
         sudo git clean -ffdx
       displayName: Clean up files (as sudo)
 
-    steps:
     - template: templates/e2e-setup.yaml
 
     - pwsh: |

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -35,15 +35,40 @@ jobs:
     timeoutInMinutes: 120
 
     steps:
-    - bash: |
-        # We use a self-hosted agent for this job, so we need to handle
-        # clean up root-owned files and docker images ourselves (anything
-        # created during `dotnet vstest ...`)
-        sudo git clean -ffdx || true
-        sudo docker rm -f $(docker ps -a -q) || true
-        sudo docker system prune -a -f --volumes || true
-      displayName: Clean up files and images
     - template: templates/e2e-setup.yaml
+
+    - pwsh: |
+        # We use a self-hosted agent for this job, so we need to clean up
+        # old docker images and containers to keep disk usage in check. But
+        # pull any required images for this test run first, to take advantage
+        # of cached layers from the old images (and also so that the pull
+        # operation doesn't count against each test's timeout period).
+
+        # Get images required for this run
+        $images = Get-Content -Encoding UTF8 '$(binDir)/context.json' `
+          | ConvertFrom-Json `
+          | foreach { $_.PSObject.Properties } `
+          | where { $_.Name -match 'Image$' } `
+          | foreach { $_.Value }
+
+        # Pull required images
+        $ACR_PASSWORD | docker login -u '$(cr.username)' --password-stdin '$(cr.address)'
+        $images | foreach { sudo --preserve-env docker pull $_ }
+        Remove-Item $HOME/.docker/config.json
+
+        # Remove old images
+        $remove = sudo docker images --format '{{.Repository}}:{{.Tag}}' `
+          | where { $images -notcontains $_ }
+        $remove | foreach { sudo docker rmi $_ }
+
+        # Prune everything else
+        sudo docker rm -f $(docker ps -a -q)
+        sudo docker network prune -f
+        sudo docker volume prune -f
+      displayName: Cache docker images
+      env:
+        ACR_PASSWORD: $(TestContainerRegistryPassword)
+
     - template: templates/e2e-run.yaml
 
 ################################################################################	

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -56,7 +56,7 @@ jobs:
           | foreach { $_.Value }
 
         # Pull required images
-        docker login -u '$(cr.username)' -p "$ACR_PASSWORD" '$(cr.address)' | Out-Null
+        docker login -u $(cr.username) -p $ACR_PASSWORD $(cr.address)
         $images | foreach { sudo --preserve-env docker pull $_ }
         Remove-Item $HOME/.docker/config.json
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -63,10 +63,10 @@ jobs:
         # Remove old images
         $remove = sudo docker images --format '{{.Repository}}:{{.Tag}}' `
           | where { $images -notcontains $_ }
+        sudo docker rm -f $(docker ps -a -q)
         $remove | foreach { sudo docker rmi $_ }
 
         # Delete everything else
-        sudo docker rm -f $(docker ps -a -q)
         sudo docker network prune -f
         sudo docker volume prune -f
       displayName: Cache docker images

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -120,9 +120,9 @@ steps:
     if ('$(arch)' -eq 'arm32v7')
     {
       $context['optimizeForPerformance'] = 'false'
-      $context['setupTimeoutMinutes'] = 10
+      $context['setupTimeoutMinutes'] = 6
       $context['teardownTimeoutMinutes'] = 5
-      $context['testTimeoutMinutes'] = 10
+      $context['testTimeoutMinutes'] = 6
     }
 
     $context | ConvertTo-Json | Out-File -Encoding Utf8 '$(binDir)/context.json'


### PR DESCRIPTION
Docker images take a _long_ time to download on Raspberry Pi. Since we recently started deleting all images before running the tests (#2736), the first test to run (currently it's `QuickstartCerts`) has to download images from scratch. Also, the `TempFilterFunc` test has to download a rather large image that doesn't share anything in common with our other images. Both these tests tend to timeout before they can download everything, even after the recent timeout increase to 10 min (#2761).

This change expands the Linux arm32v7-specific build setup to:
1. git clean as sudo - we need to clean up the source code tree before running the tests, especially the previous run's test logs and certificates (the latter are owned by root, so the `checkout` task in `e2e-setup.yaml` can't delete them).
2. Parse `context.json` to get the list of required images for this test run.
3. `docker pull` the required images _before any old images are removed_, to take advantage of layer caching which speeds up downloads significantly.
4. Remove old containers, images, docker networks, and volumes.

With these changes in place, tests on the Pi are completing in 30 seconds-2.5 minutes. As a result this change also reduces the test timeout to 6 minutes so that failed tests don't slow the run down as much as the previous 10 minute timeout.

A few tests that were failing before are still failing and need to be investigated separately:
- `TransparentGateway` for MQTT + CA/self-signed certs
- `TempFilterFunc` and `ValidateMetrics` (see #2753)
- `PriorityQueueModuleToModuleMessages` (see #2762)