### PR TITLE
Longhaul / Stress: Prune networks on deployment to avoid module start failure

### DIFF
--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -22,6 +22,7 @@ function clean_up() {
     if [ "$CLEAN_ALL" = '1' ]; then
         echo 'Prune docker system'
         docker system prune -af --volumes || true
+        docker network prune -f || true
     else
         echo 'Remove docker containers'
         docker rm -f $(docker ps -aq) || true


### PR DESCRIPTION
There is a moby issue (31643) where containers references fail to get removed from a network, leading to new modules with the same name as the last deployment failing to start.

This fixes it by pruning the networks on every deployment.