### PR TITLE
fix e2e using leaf device

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/EdgeAmqpSession.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/EdgeAmqpSession.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
     /// <summary>
     /// This class wraps an AmqpSession, and provides similar functionality.
-    /// This allows unit testing the components that use it
+    /// This allows unit testing the components that use it.
     /// </summary>
     public class EdgeAmqpSession : IAmqpSession
     {

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -19,12 +19,12 @@ function clean_up() {
     rm -rf /var/run/iotedge/
     rm -rf /etc/iotedge/config.yaml
 
+    echo 'Remove docker containers'
+    docker rm -f $(docker ps -aq) || true
+
     if [ "$CLEAN_ALL" = '1' ]; then
         echo 'Prune docker system'
         docker system prune -af --volumes || true
-    else
-        echo 'Remove docker containers'
-        docker rm -f $(docker ps -aq) || true
     fi
 }
 


### PR DESCRIPTION
Currently DM test logic in leaf device is incorrect and always runs for 5 mins (timeout period), fix incorrect exit condition for DM loop. And make sure remove containers before calling docker system prune.