### PR TITLE
Fix build failure due to SA1135

### DIFF
--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -6,6 +6,7 @@
     <Rule Id="SA1108" Action="None" />
     <Rule Id="SA1118" Action="None" />
     <Rule Id="SA1124" Action="None" />
+    <Rule Id="SA1135" Action="None" />
     <Rule Id="SA1201" Action="None" />
     <Rule Id="SA1202" Action="None" />
     <Rule Id="SA1204" Action="None" />


### PR DESCRIPTION
SA1135 throws exception when using .net core 3.1 or using Visual studio 16.5.  Our build is failing now. 
 Therefore need to suppress SA1135 for short term solution.