### PR TITLE
[mqtt] Group broker init errors under one ErrorKind value

### DIFF
--- a/mqtt/mqtt-broker/src/error.rs
+++ b/mqtt/mqtt-broker/src/error.rs
@@ -9,9 +9,6 @@ pub struct Error {
 
 #[derive(Debug, Fail, PartialEq)]
 pub enum ErrorKind {
-    #[fail(display = "An error occurred trying to connect.")]
-    Connect,
-
     #[fail(display = "An error occurred sending a message to the broker.")]
     SendBrokerMessage,
 
@@ -20,18 +17,6 @@ pub enum ErrorKind {
 
     #[fail(display = "An error occurred sending a message to a snapshotter.")]
     SendSnapshotMessage,
-
-    #[fail(display = "An error occurred binding the server's listening socket.")]
-    BindServer,
-
-    #[fail(display = "An error occurred getting a connection's peer address.")]
-    ConnectionPeerAddress,
-
-    #[fail(display = "An error occurred getting local address.")]
-    ConnectionLocalAddress,
-
-    #[fail(display = "An error occurred configuring a connection.")]
-    ConnectionConfiguration,
 
     #[fail(display = "An error occurred decoding a packet.")]
     DecodePacket,
@@ -66,26 +51,11 @@ pub enum ErrorKind {
     #[fail(display = "An error occurred persisting state: {}", _0)]
     Persist(crate::persist::ErrorReason),
 
-    #[fail(display = "An error occurred loading configuration.")]
-    LoadConfiguration,
-
-    #[fail(display = "An error occurred joining the broker task.")]
-    BrokerJoin,
-
-    #[fail(display = "An error occurred obtaining service identity.")]
-    IdentityConfiguration,
-
-    #[fail(display = "Error loading identity from file.")]
-    LoadIdentity,
-
-    #[fail(display = "Error decoding identity content.")]
-    DecodeIdentity,
-
-    #[fail(display = "Error starting listener.")]
-    StartListener,
-
     #[fail(display = "Unable to obtain peer leaf certificate.")]
     PeerCertificate,
+
+    #[fail(display = "Unable to start broker: {}", _0)]
+    InitializeBroker(InitializeBrokerReason),
 
     #[fail(display = "An error occurred checking client permissions: {}.", _0)]
     Auth(crate::auth::ErrorReason),
@@ -123,4 +93,38 @@ impl From<Context<ErrorKind>> for Error {
     fn from(inner: Context<ErrorKind>) -> Self {
         Error { inner }
     }
+}
+
+/// Represents reason for errors occurred while bootstrapping broker.
+#[derive(Debug, Display, PartialEq)]
+pub enum InitializeBrokerReason {
+    #[display(fmt = "An error occurred binding the server's listening socket.")]
+    BindServer,
+
+    #[display(fmt = "An error occurred getting a connection's peer address.")]
+    ConnectionPeerAddress,
+
+    #[display(fmt = "An error occurred getting local address.")]
+    ConnectionLocalAddress,
+
+    #[display(fmt = "An error occurred configuring a connection.")]
+    ConnectionConfiguration,
+
+    #[display(fmt = "An error occurred loading configuration.")]
+    LoadConfiguration,
+
+    #[display(fmt = "An error occurred  obtaining service identity.")]
+    IdentityConfiguration,
+
+    #[display(fmt = "An error occurred  loading identity from file.")]
+    LoadIdentity,
+
+    #[display(fmt = "An error occurred  decoding identity content.")]
+    DecodeIdentity,
+
+    #[display(fmt = "An error occurred  starting listener.")]
+    StartListener,
+
+    #[display(fmt = "An error occurred  bootstrapping TLS")]
+    Tls,
 }

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -33,7 +33,7 @@ pub use crate::auth::{AuthId, Certificate};
 pub use crate::broker::{Broker, BrokerBuilder, BrokerHandle, BrokerState};
 pub use crate::configuration::BrokerConfig;
 pub use crate::connection::ConnectionHandle;
-pub use crate::error::{Error, ErrorKind};
+pub use crate::error::{Error, ErrorKind, InitializeBrokerReason};
 pub use crate::persist::{
     ConsolidatedStateFormat, FileFormat, FilePersistor, NullPersistor, Persist,
 };

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -11,7 +11,7 @@ use tracing_futures::Instrument;
 use crate::auth::{Authenticator, Authorizer};
 use crate::broker::{Broker, BrokerHandle, BrokerState};
 use crate::transport::TransportBuilder;
-use crate::{connection, Error, ErrorKind, Message, SystemEvent};
+use crate::{connection, Error, ErrorKind, InitializeBrokerReason, Message, SystemEvent};
 
 pub struct Server<N, Z>
 where
@@ -186,9 +186,9 @@ where
     loop {
         match future::select(&mut shutdown_signal, incoming.next()).await {
             Either::Right((Some(Ok(stream)), _)) => {
-                let peer = stream
-                    .peer_addr()
-                    .context(ErrorKind::ConnectionPeerAddress)?;
+                let peer = stream.peer_addr().context(ErrorKind::InitializeBroker(
+                    InitializeBrokerReason::ConnectionPeerAddress,
+                ))?;
 
                 let broker_handle = handle.clone();
                 let span = span.clone();


### PR DESCRIPTION
* code clean up
* group all errors occurred during broker initialization phase under the same `ErrorKind` value