### PR TITLE
[mqtt] Append a simple version to mqtt persistance

### DIFF
--- a/mqtt/mqtt-broker/src/persist.rs
+++ b/mqtt/mqtt-broker/src/persist.rs
@@ -329,10 +329,7 @@ where
                     .map_err(|_| Error::from(ErrorKind::Persist(ErrorReason::ReadVersion)))?;
                 let size: usize = u32::from_be_bytes(size).try_into().unwrap();
 
-                let mut version = Vec::with_capacity(size);
-                unsafe {
-                    version.set_len(size);
-                }
+                let mut version = vec![0; size];
                 file.read_exact(&mut version)
                     .map_err(|_| Error::from(ErrorKind::Persist(ErrorReason::ReadVersion)))?;
                 let version: &str = bincode::deserialize(&version)


### PR DESCRIPTION
~~This simply reserves 100 bytes for version information~~

This now has a string for version. It appends a header to the file that is 4 bytes representing the length of the version string, then the version string.

Later more sophisticated processing can happen after the string is read to enable legacy formats