### PR TITLE
Fixing metrics for priority routes

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/ModuleMessageLinkHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/ModuleMessageLinkHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
             static readonly IMetricsCounter MessagesMeter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "messages_sent",
                 "Messages sent to module",
-                new List<string> { "from", "to", "from_route_output", "to_route_input" });
+                new List<string> { "from", "to", "from_route_output", "to_route_input", "priority" });
 
             public static void AddMessage(IIdentity identity, IMessage message)
             {
@@ -55,7 +55,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
 
                 string fromRouteOutput = message.GetOutput();
                 string toRouteInput = message.GetInput();
-                MessagesMeter.Increment(1, new[] { from, to, fromRouteOutput, toRouteInput });
+                uint priority = message.ProcessedPriority;
+                MessagesMeter.Increment(1, new[] { from, to, fromRouteOutput, toRouteInput, priority.ToString() });
             }
         }
     }


### PR DESCRIPTION
Adding priority to ModuleMessageLinkHandler metrics to fix metrics throwing exceptions.


