### PR TITLE
[mqtt] Convert broker task to a thread

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -272,6 +272,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
+dependencies = [
+ "crossbeam-utils",
+ "maybe-uninit",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -746,6 +756,7 @@ dependencies = [
  "chrono",
  "config",
  "criterion",
+ "crossbeam-channel",
  "fail",
  "flate2",
  "futures",

--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -40,17 +40,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750b1c38a1dfadd108da0f01c08f4cdc7ff1bb39b325f9c82cc972361780a6e1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -749,7 +738,6 @@ dependencies = [
 name = "mqtt-broker"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "atty",
  "bincode",
  "bytes",

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1"
 bincode = "1.2"
 bytes = "0.5"
 chrono = "0.4"

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -11,7 +11,8 @@ async-trait = "0.1"
 bincode = "1.2"
 bytes = "0.5"
 chrono = "0.4"
-config = { version = "0.10", default-features = false, features = ["json"] } 
+config = { version = "0.10", default-features = false, features = ["json"] }
+crossbeam-channel = "0.4"
 fail = "0.3"
 flate2 = "1.0"
 futures = "0.3"

--- a/mqtt/mqtt-broker/src/auth/authentication.rs
+++ b/mqtt/mqtt-broker/src/auth/authentication.rs
@@ -1,5 +1,3 @@
-use async_trait::async_trait;
-
 use crate::auth::AuthId;
 
 /// Describes a MQTT client credentials.
@@ -22,7 +20,6 @@ impl From<Vec<u8>> for Certificate {
 }
 
 /// A trait to authenticate a MQTT client with given credentials.
-#[async_trait]
 pub trait Authenticator {
     /// Authentication error.
     type Error: std::error::Error + Send;
@@ -33,17 +30,16 @@ pub trait Authenticator {
     /// * `Ok(Some(auth_id))` - authenticator is able to identify a client with given credentials.
     /// * `Ok(None)` - authenticator is not able to identify a client with given credentials.
     /// * `Err(e)` - an error occurred when authenticating a client.
-    async fn authenticate(&self, credentials: Credentials) -> Result<Option<AuthId>, Self::Error>;
+    fn authenticate(&self, credentials: Credentials) -> Result<Option<AuthId>, Self::Error>;
 }
 
-#[async_trait]
 impl<F> Authenticator for F
 where
     F: Fn(Credentials) -> Result<Option<AuthId>, AuthenticateError> + Sync,
 {
     type Error = AuthenticateError;
 
-    async fn authenticate(&self, credentials: Credentials) -> Result<Option<AuthId>, Self::Error> {
+    fn authenticate(&self, credentials: Credentials) -> Result<Option<AuthId>, Self::Error> {
         self(credentials)
     }
 }
@@ -57,11 +53,10 @@ pub struct AuthenticateError;
 /// This implementation will be used if custom authentication mechanism was not provided.
 pub struct DefaultAuthenticator;
 
-#[async_trait]
 impl Authenticator for DefaultAuthenticator {
     type Error = AuthenticateError;
 
-    async fn authenticate(&self, _: Credentials) -> Result<Option<AuthId>, Self::Error> {
+    fn authenticate(&self, _: Credentials) -> Result<Option<AuthId>, Self::Error> {
         Ok(None)
     }
 }
@@ -77,17 +72,16 @@ mod tests {
         let authenticator = DefaultAuthenticator;
         let credentials = Credentials::Basic(Some("username".into()), Some("password".into()));
 
-        let auth_id = authenticator.authenticate(credentials).await;
+        let auth_id = authenticator.authenticate(credentials);
 
         assert_matches!(auth_id, Ok(None));
     }
 
-    #[tokio::test]
-    async fn authenticator_wrapper_around_function() {
+    fn authenticator_wrapper_around_function() {
         let authenticator = |_| Ok(Some(AuthId::Anonymous));
         let credentials = Credentials::Basic(Some("username".into()), Some("password".into()));
 
-        let auth_id = authenticator.authenticate(credentials).await;
+        let auth_id = authenticator.authenticate(credentials);
 
         assert_matches!(auth_id, Ok(Some(AuthId::Anonymous)));
     }

--- a/mqtt/mqtt-broker/src/auth/authentication.rs
+++ b/mqtt/mqtt-broker/src/auth/authentication.rs
@@ -67,8 +67,8 @@ mod tests {
 
     use crate::auth::{AuthId, Authenticator, Credentials, DefaultAuthenticator};
 
-    #[tokio::test]
-    async fn default_auth_always_return_unknown_client_identity() {
+    #[test]
+    fn default_auth_always_return_unknown_client_identity() {
         let authenticator = DefaultAuthenticator;
         let credentials = Credentials::Basic(Some("username".into()), Some("password".into()));
 
@@ -77,6 +77,7 @@ mod tests {
         assert_matches!(auth_id, Ok(None));
     }
 
+    #[test]
     fn authenticator_wrapper_around_function() {
         let authenticator = |_| Ok(Some(AuthId::Anonymous));
         let credentials = Credentials::Basic(Some("username".into()), Some("password".into()));

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -1007,7 +1007,7 @@ pub(crate) mod tests {
     use proptest::collection::{hash_map, vec};
     use proptest::prelude::*;
     use tokio::sync::mpsc::error::TryRecvError;
-    use tokio::sync::mpsc::{self, Receiver};
+    use tokio::sync::mpsc::{self, UnboundedReceiver};
     use uuid::Uuid;
 
     use mqtt3::{proto, PROTOCOL_LEVEL, PROTOCOL_NAME};
@@ -1035,7 +1035,7 @@ pub(crate) mod tests {
 
     fn connection_handle() -> ConnectionHandle {
         let id = Uuid::new_v4();
-        let (tx1, _rx1) = mpsc::channel(128);
+        let (tx1, _rx1) = mpsc::unbounded_channel();
         ConnectionHandle::new(id, tx1)
     }
 
@@ -1093,7 +1093,7 @@ pub(crate) mod tests {
             protocol_level: PROTOCOL_LEVEL,
         };
         let id = Uuid::new_v4();
-        let (tx1, mut rx1) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::new(id, tx1.clone());
         let conn2 = ConnectionHandle::new(id, tx1);
         let client_id = ClientId::from("blah".to_string());
@@ -1106,14 +1106,12 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
         broker_handle
             .send(Message::Client(
                 client_id.clone(),
                 ClientEvent::ConnReq(req2),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1155,8 +1153,8 @@ pub(crate) mod tests {
             protocol_name: PROTOCOL_NAME.to_string(),
             protocol_level: PROTOCOL_LEVEL,
         };
-        let (tx1, mut rx1) = mpsc::channel(128);
-        let (tx2, mut rx2) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
+        let (tx2, mut rx2) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let conn2 = ConnectionHandle::from_sender(tx2);
         let client_id = ClientId::from("blah".to_string());
@@ -1169,14 +1167,12 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
         broker_handle
             .send(Message::Client(
                 client_id.clone(),
                 ClientEvent::ConnReq(req2),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1214,7 +1210,7 @@ pub(crate) mod tests {
             protocol_name: "AMQP".to_string(),
             protocol_level: PROTOCOL_LEVEL,
         };
-        let (tx1, mut rx1) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
         let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
@@ -1224,7 +1220,6 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1253,7 +1248,7 @@ pub(crate) mod tests {
             protocol_name: PROTOCOL_NAME.to_string(),
             protocol_level: 0x3,
         };
-        let (tx1, mut rx1) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
         let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
@@ -1263,7 +1258,6 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1303,7 +1297,7 @@ pub(crate) mod tests {
             protocol_level: PROTOCOL_LEVEL,
         };
 
-        let (tx1, mut rx1) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
         let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
@@ -1313,7 +1307,6 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1346,7 +1339,7 @@ pub(crate) mod tests {
             protocol_level: PROTOCOL_LEVEL,
         };
 
-        let (tx1, mut rx1) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
         let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
@@ -1356,7 +1349,6 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1396,7 +1388,7 @@ pub(crate) mod tests {
             protocol_level: PROTOCOL_LEVEL,
         };
 
-        let (tx1, mut rx1) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
         let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
@@ -1406,7 +1398,6 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1446,7 +1437,7 @@ pub(crate) mod tests {
             protocol_level: PROTOCOL_LEVEL,
         };
 
-        let (tx1, mut rx1) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
         let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
@@ -1456,7 +1447,6 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1496,7 +1486,7 @@ pub(crate) mod tests {
             protocol_level: PROTOCOL_LEVEL,
         };
 
-        let (tx1, mut rx1) = mpsc::channel(128);
+        let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
         let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
@@ -1506,7 +1496,6 @@ pub(crate) mod tests {
                 client_id.clone(),
                 ClientEvent::ConnReq(req1),
             ))
-            .await
             .unwrap();
 
         assert_matches!(
@@ -1591,7 +1580,7 @@ pub(crate) mod tests {
         let connect1 = transient_connect(id.clone());
         let connect2 = transient_connect(id);
         let id = Uuid::new_v4();
-        let (tx1, _rx1) = mpsc::channel(128);
+        let (tx1, _rx1) = mpsc::unbounded_channel();
         let handle1 = ConnectionHandle::new(id, tx1.clone());
         let handle2 = ConnectionHandle::new(id, tx1);
 
@@ -1620,7 +1609,7 @@ pub(crate) mod tests {
         let connect1 = persistent_connect(id.clone());
         let connect2 = persistent_connect(id);
         let id = Uuid::new_v4();
-        let (tx1, _rx1) = mpsc::channel(128);
+        let (tx1, _rx1) = mpsc::unbounded_channel();
         let handle1 = ConnectionHandle::new(id, tx1.clone());
         let handle2 = ConnectionHandle::new(id, tx1);
 
@@ -1836,7 +1825,7 @@ pub(crate) mod tests {
         };
 
         let message = Message::Client(client_id.clone(), ClientEvent::PublishFrom(publish));
-        broker_handle.send(message).await.unwrap();
+        broker_handle.send(message).unwrap();
 
         assert_matches!(
             rx.recv().await,
@@ -1883,7 +1872,7 @@ pub(crate) mod tests {
         };
 
         let message = Message::Client(client_id.clone(), ClientEvent::Subscribe(subscribe));
-        broker_handle.send(message).await.unwrap();
+        broker_handle.send(message).unwrap();
 
         let expected_qos = vec![
             proto::SubAckQos::Success(proto::QoS::AtLeastOnce),
@@ -1922,7 +1911,7 @@ pub(crate) mod tests {
         };
 
         let message = Message::Client(sub_id.clone(), ClientEvent::Subscribe(subscribe));
-        broker_handle.send(message).await.unwrap();
+        broker_handle.send(message).unwrap();
 
         let (pub_id, mut pub_rx) = connect_client("pub", &mut broker_handle).await.unwrap();
 
@@ -1937,7 +1926,7 @@ pub(crate) mod tests {
         };
 
         let message = Message::Client(pub_id.clone(), ClientEvent::PublishFrom(publish));
-        broker_handle.send(message).await.unwrap();
+        broker_handle.send(message).unwrap();
 
         assert_matches!(
             pub_rx.recv().await,
@@ -1954,19 +1943,17 @@ pub(crate) mod tests {
     async fn connect_client(
         client_id: &str,
         broker_handle: &mut BrokerHandle,
-    ) -> Result<(ClientId, Receiver<Message>), Error> {
+    ) -> Result<(ClientId, UnboundedReceiver<Message>), Error> {
         let connect = persistent_connect(client_id.into());
 
-        let (tx, mut rx) = mpsc::channel(128);
+        let (tx, mut rx) = mpsc::unbounded_channel();
         let conn = ConnectionHandle::from_sender(tx);
         let client_id = ClientId::from(client_id);
         let req = ConnReq::new(client_id.clone(), connect, None, conn);
-        broker_handle
-            .send(Message::Client(
-                client_id.clone(),
-                ClientEvent::ConnReq(req),
-            ))
-            .await?;
+        broker_handle.send(Message::Client(
+            client_id.clone(),
+            ClientEvent::ConnReq(req),
+        ))?;
 
         assert_matches!(
             rx.recv().await,

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -901,7 +901,7 @@ where
     let client_id = session.client_id().clone();
     // TODO refactor auth_id logic for offline sessions
     let auth_id = session.auth_id().unwrap_or(&AuthId::Anonymous);
-    let activity = Activity::new(auth_id.clone(), client_id.clone(), operation);
+    let activity = Activity::new(auth_id.clone(), client_id, operation);
 
     match authorizer.authorize(activity) {
         Ok(true) => {

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -65,7 +65,7 @@ where
         // We don't really care about the error here ---
         //   we just want to join the thread handle to get the result
         //   or deal with the panic
-        rx.await.map(drop).unwrap_or_else(|_e| ());
+        rx.await.map_or_else(drop, drop);
 
         // propagate any panics onto the event loop thread
         match handle.join() {

--- a/mqtt/mqtt-broker/src/error.rs
+++ b/mqtt/mqtt-broker/src/error.rs
@@ -43,6 +43,9 @@ pub enum Error {
     #[error("An error occurred joining a task.")]
     TaskJoin(#[from] tokio::task::JoinError),
 
+    #[error("An error occurred signaling the event loop of a thread shutdown.")]
+    ThreadShutdown(#[from] tokio::sync::oneshot::error::RecvError),
+
     #[error("An error occurred persisting state")]
     Persist(#[from] crate::persist::PersistError),
 

--- a/mqtt/mqtt-broker/src/error.rs
+++ b/mqtt/mqtt-broker/src/error.rs
@@ -8,7 +8,7 @@ use crate::Message;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("An error occurred sending a message to the broker.")]
-    SendBrokerMessage(#[source] tokio::sync::mpsc::error::SendError<Message>),
+    SendBrokerMessage(#[source] crossbeam_channel::TrySendError<Message>),
 
     #[error("An error occurred sending a message to a connection.")]
     SendConnectionMessage(#[source] tokio::sync::mpsc::error::SendError<Message>),

--- a/mqtt/mqtt-broker/src/persist.rs
+++ b/mqtt/mqtt-broker/src/persist.rs
@@ -9,7 +9,6 @@ use std::os::unix::fs::symlink;
 use std::os::windows::fs::symlink_file;
 use std::path::PathBuf;
 
-use async_trait::async_trait;
 use bytes::Bytes;
 use fail::fail_point;
 use flate2::read::GzDecoder;
@@ -30,28 +29,26 @@ const STATE_DEFAULT_PREVIOUS_COUNT: usize = 2;
 static STATE_DEFAULT_STEM: &str = "state";
 static STATE_EXTENSION: &str = "dat";
 
-#[async_trait]
 pub trait Persist {
     type Error: std::error::Error;
 
-    async fn load(&mut self) -> Result<Option<BrokerState>, Self::Error>;
+    fn load(&mut self) -> Result<Option<BrokerState>, Self::Error>;
 
-    async fn store(&mut self, state: BrokerState) -> Result<(), Self::Error>;
+    fn store(&mut self, state: BrokerState) -> Result<(), Self::Error>;
 }
 
 /// A persistor that does nothing.
 #[derive(Debug)]
 pub struct NullPersistor;
 
-#[async_trait]
 impl Persist for NullPersistor {
     type Error = PersistError;
 
-    async fn load(&mut self) -> Result<Option<BrokerState>, Self::Error> {
+    fn load(&mut self) -> Result<Option<BrokerState>, Self::Error> {
         Ok(None)
     }
 
-    async fn store(&mut self, _: BrokerState) -> Result<(), Self::Error> {
+    fn store(&mut self, _: BrokerState) -> Result<(), Self::Error> {
         Ok(())
     }
 }
@@ -287,199 +284,182 @@ where
     Ok(payloads)
 }
 
-#[async_trait]
 impl<F> Persist for FilePersistor<F>
 where
     F: FileFormat<Error = PersistError> + Clone + Send + 'static,
 {
     type Error = PersistError;
 
-    async fn load(&mut self) -> Result<Option<BrokerState>, Self::Error> {
-        let dir = self.dir.clone();
-        let format = self.format.clone();
+    fn load(&mut self) -> Result<Option<BrokerState>, Self::Error> {
+        let path = self
+            .dir
+            .join(format!("{}.{}", STATE_DEFAULT_STEM, STATE_EXTENSION));
+        let state = if path.exists() {
+            info!("loading state from file {}.", path.display());
 
-        let res = tokio::task::spawn_blocking(move || {
-            let path = dir.join(format!("{}.{}", STATE_DEFAULT_STEM, STATE_EXTENSION));
-            if path.exists() {
-                info!("loading state from file {}.", path.display());
+            fail_point!("filepersistor.load.fileopen", |_| {
+                Err(PersistError::FileOpen(path.clone(), None))
+            });
+            let file = OpenOptions::new()
+                .read(true)
+                .open(&path)
+                .map_err(|e| PersistError::FileOpen(path.clone(), Some(e)))?;
 
-                fail_point!("filepersistor.load.fileopen", |_| {
-                    Err(PersistError::FileOpen(path.clone(), None))
-                });
-                let file = OpenOptions::new()
-                    .read(true)
-                    .open(&path)
-                    .map_err(|e| PersistError::FileOpen(path.clone(), Some(e)))?;
-
-                fail_point!("filepersistor.load.format", |_| {
-                    Err(PersistError::Deserialize(None))
-                });
-                let state = format.load(file)?;
-                Ok(Some(state))
-            } else {
-                info!("no state file found at {}.", path.display());
-                Ok(None)
-            }
-        })
-        .await;
-
-        fail_point!("filepersistor.load.spawn_blocking", |_| {
-            Err(PersistError::TaskJoin(None))
-        });
-        res.map_err(|e| PersistError::TaskJoin(Some(e)))?
+            fail_point!("filepersistor.load.format", |_| {
+                Err(PersistError::Deserialize(None))
+            });
+            let state = self.format.load(file)?;
+            Some(state)
+        } else {
+            info!("no state file found at {}.", path.display());
+            None
+        };
+        Ok(state)
     }
 
     #[allow(clippy::too_many_lines)]
-    async fn store(&mut self, state: BrokerState) -> Result<(), Self::Error> {
-        let dir = self.dir.clone();
-        let format = self.format.clone();
+    fn store(&mut self, state: BrokerState) -> Result<(), Self::Error> {
         let previous_count = self.previous_count;
 
         self.seq = self.seq.wrapping_add(1);
         let seq = self.seq;
 
-        let res = tokio::task::spawn_blocking(move || {
-            let span = span!(Level::INFO, "persistor", dir = %dir.display());
-            let _guard = span.enter();
+        let span = span!(Level::INFO, "persistor", dir = %self.dir.display());
+        let _guard = span.enter();
 
-            if !dir.exists() {
-                fail_point!("filepersistor.store.createdir", |_| {
-                    Err(PersistError::CreateDir(dir.clone(), None))
-                });
-                fs::create_dir_all(&dir)
-                    .map_err(|e| PersistError::CreateDir(dir.clone(), Some(e)))?;
-            }
-
-            let link_path = dir.join(format!("{}.{}", STATE_DEFAULT_STEM, STATE_EXTENSION));
-            let temp_link_path =
-                dir.join(format!("{}.{}.tmp", STATE_DEFAULT_STEM, STATE_EXTENSION));
-
-            let path = dir.join(format!(
-                "{}.{}-{:05}.{}",
-                STATE_DEFAULT_STEM,
-                chrono::Utc::now().format("%Y%m%d%H%M%S%3f"),
-                seq,
-                STATE_EXTENSION
-            ));
-
-            info!(message="persisting state...", file=%path.display());
-            debug!("opening {} for writing state...", path.display());
-            fail_point!("filepersistor.store.fileopen", |_| {
-                Err(PersistError::FileOpen(path.clone(), None))
+        if !self.dir.exists() {
+            fail_point!("filepersistor.store.createdir", |_| {
+                Err(PersistError::CreateDir(self.dir.clone(), None))
             });
-            let file = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .open(&path)
-                .map_err(|e| PersistError::FileOpen(path.clone(), Some(e)))?;
-            debug!("{} opened.", path.display());
+            fs::create_dir_all(&self.dir)
+                .map_err(|e| PersistError::CreateDir(self.dir.clone(), Some(e)))?;
+        }
 
-            debug!("persisting state to {}...", path.display());
-            match format.store(file, state) {
-                Ok(_) => {
-                    debug!("state persisted to {}.", path.display());
+        let link_path = self
+            .dir
+            .join(format!("{}.{}", STATE_DEFAULT_STEM, STATE_EXTENSION));
+        let temp_link_path = self
+            .dir
+            .join(format!("{}.{}.tmp", STATE_DEFAULT_STEM, STATE_EXTENSION));
 
-                    // Swap the symlink
-                    //   - remove the old link if it exists
-                    //   - link the new file
-                    if temp_link_path.exists() {
-                        fail_point!("filepersistor.store.symlink_unlink", |_| {
-                            Err(PersistError::SymlinkUnlink(temp_link_path.clone(), None))
-                        });
-                        fs::remove_file(&temp_link_path).map_err(|e| {
-                            PersistError::SymlinkUnlink(temp_link_path.clone(), Some(e))
-                        })?;
-                    }
+        let path = self.dir.join(format!(
+            "{}.{}-{:05}.{}",
+            STATE_DEFAULT_STEM,
+            chrono::Utc::now().format("%Y%m%d%H%M%S%3f"),
+            seq,
+            STATE_EXTENSION
+        ));
 
-                    debug!("linking {} to {}", temp_link_path.display(), path.display());
+        info!(message="persisting state...", file=%path.display());
+        debug!("opening {} for writing state...", path.display());
+        fail_point!("filepersistor.store.fileopen", |_| {
+            Err(PersistError::FileOpen(path.clone(), None))
+        });
+        let file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .open(&path)
+            .map_err(|e| PersistError::FileOpen(path.clone(), Some(e)))?;
+        debug!("{} opened.", path.display());
 
-                    fail_point!("filepersistor.store.symlink", |_| {
-                        Err(PersistError::Symlink(
-                            temp_link_path.clone(),
-                            path.clone(),
-                            None,
-                        ))
+        debug!("persisting state to {}...", path.display());
+        match self.format.store(file, state) {
+            Ok(_) => {
+                debug!("state persisted to {}.", path.display());
+
+                // Swap the symlink
+                //   - remove the old link if it exists
+                //   - link the new file
+                if temp_link_path.exists() {
+                    fail_point!("filepersistor.store.symlink_unlink", |_| {
+                        Err(PersistError::SymlinkUnlink(temp_link_path.clone(), None))
                     });
-
-                    #[cfg(unix)]
-                    symlink(&path, &temp_link_path).map_err(|e| {
-                        PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
+                    fs::remove_file(&temp_link_path).map_err(|e| {
+                        PersistError::SymlinkUnlink(temp_link_path.clone(), Some(e))
                     })?;
-
-                    #[cfg(windows)]
-                    symlink_file(&path, &temp_link_path).map_err(|e| {
-                        PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
-                    })?;
-
-                    // Commit the updated link by renaming the temp link.
-                    // This is the so-called "capistrano" trick for atomically updating links
-                    // https://github.com/capistrano/capistrano/blob/d04c1e3ea33e84b183d056b71c7cacf7744ce7ad/lib/capistrano/tasks/deploy.rake
-                    fail_point!("filepersistor.store.filerename", |_| {
-                        Err(PersistError::FileRename(
-                            temp_link_path.clone(),
-                            path.clone(),
-                            None,
-                        ))
-                    });
-                    fs::rename(&temp_link_path, &link_path).map_err(|e| {
-                        PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
-                    })?;
-
-                    // Prune old states
-                    fail_point!("filepersistor.store.readdir", |_| {
-                        Err(PersistError::ReadDir(dir.clone(), None))
-                    });
-
-                    let mut entries = fs::read_dir(&dir)
-                        .map_err(|e| (PersistError::ReadDir(dir.clone(), Some(e))))?
-                        .filter_map(Result::ok)
-                        .filter(|entry| entry.file_type().ok().map_or(false, |f| f.is_file()))
-                        .filter(|entry| {
-                            entry
-                                .file_name()
-                                .to_string_lossy()
-                                .starts_with(STATE_DEFAULT_STEM)
-                        })
-                        .collect::<Vec<fs::DirEntry>>();
-
-                    entries.sort_unstable_by(|a, b| {
-                        b.file_name()
-                            .partial_cmp(&a.file_name())
-                            .unwrap_or(cmp::Ordering::Equal)
-                    });
-
-                    for entry in entries.iter().skip(previous_count) {
-                        debug!(
-                            "pruning old state file {}...",
-                            entry.file_name().to_string_lossy()
-                        );
-
-                        fail_point!("filepersistor.store.entry_unlink", |_| {
-                            Err(PersistError::FileUnlink(entry.path(), None))
-                        });
-                        fs::remove_file(&entry.path())
-                            .map_err(|e| PersistError::FileUnlink(entry.path(), Some(e)))?;
-                        debug!("{} pruned.", entry.file_name().to_string_lossy());
-                    }
                 }
-                Err(e) => {
-                    fail_point!("filepersistor.store.new_file_unlink", |_| {
-                        Err(PersistError::FileUnlink(path.clone(), None))
+
+                debug!("linking {} to {}", temp_link_path.display(), path.display());
+
+                fail_point!("filepersistor.store.symlink", |_| {
+                    Err(PersistError::Symlink(
+                        temp_link_path.clone(),
+                        path.clone(),
+                        None,
+                    ))
+                });
+
+                #[cfg(unix)]
+                symlink(&path, &temp_link_path).map_err(|e| {
+                    PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
+                })?;
+
+                #[cfg(windows)]
+                symlink_file(&path, &temp_link_path).map_err(|e| {
+                    PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
+                })?;
+
+                // Commit the updated link by renaming the temp link.
+                // This is the so-called "capistrano" trick for atomically updating links
+                // https://github.com/capistrano/capistrano/blob/d04c1e3ea33e84b183d056b71c7cacf7744ce7ad/lib/capistrano/tasks/deploy.rake
+                fail_point!("filepersistor.store.filerename", |_| {
+                    Err(PersistError::FileRename(
+                        temp_link_path.clone(),
+                        path.clone(),
+                        None,
+                    ))
+                });
+                fs::rename(&temp_link_path, &link_path).map_err(|e| {
+                    PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
+                })?;
+
+                // Prune old states
+                fail_point!("filepersistor.store.readdir", |_| {
+                    Err(PersistError::ReadDir(self.dir.clone(), None))
+                });
+
+                let mut entries = fs::read_dir(&self.dir)
+                    .map_err(|e| (PersistError::ReadDir(self.dir.clone(), Some(e))))?
+                    .filter_map(Result::ok)
+                    .filter(|entry| entry.file_type().ok().map_or(false, |f| f.is_file()))
+                    .filter(|entry| {
+                        entry
+                            .file_name()
+                            .to_string_lossy()
+                            .starts_with(STATE_DEFAULT_STEM)
+                    })
+                    .collect::<Vec<fs::DirEntry>>();
+
+                entries.sort_unstable_by(|a, b| {
+                    b.file_name()
+                        .partial_cmp(&a.file_name())
+                        .unwrap_or(cmp::Ordering::Equal)
+                });
+
+                for entry in entries.iter().skip(previous_count) {
+                    debug!(
+                        "pruning old state file {}...",
+                        entry.file_name().to_string_lossy()
+                    );
+
+                    fail_point!("filepersistor.store.entry_unlink", |_| {
+                        Err(PersistError::FileUnlink(entry.path(), None))
                     });
-                    fs::remove_file(&path)
-                        .map_err(|e| (PersistError::FileUnlink(path, Some(e))))?;
-                    return Err(e);
+                    fs::remove_file(&entry.path())
+                        .map_err(|e| PersistError::FileUnlink(entry.path(), Some(e)))?;
+                    debug!("{} pruned.", entry.file_name().to_string_lossy());
                 }
             }
-            info!(message="persisted state.", file=%path.display());
-            Ok(())
-        })
-        .await;
-
-        fail_point!("filepersistor.load.spawn_blocking", |_| {
-            Err(PersistError::TaskJoin(None))
-        });
-        res.map_err(|e| PersistError::TaskJoin(Some(e)))?
+            Err(e) => {
+                fail_point!("filepersistor.store.new_file_unlink", |_| {
+                    Err(PersistError::FileUnlink(path.clone(), None))
+                });
+                fs::remove_file(&path).map_err(|e| (PersistError::FileUnlink(path, Some(e))))?;
+                return Err(e);
+            }
+        }
+        info!(message="persisted state.", file=%path.display());
+        Ok(())
     }
 }
 

--- a/mqtt/mqtt-broker/src/persist.rs
+++ b/mqtt/mqtt-broker/src/persist.rs
@@ -553,8 +553,8 @@ pub(crate) mod tests {
         let path = tmp_dir.path().to_owned();
         let mut persistor = FilePersistor::new(path, ConsolidatedStateFormat::default());
 
-        persistor.store(BrokerState::default()).await.unwrap();
-        let state = persistor.load().await.unwrap().unwrap();
+        persistor.store(BrokerState::default()).unwrap();
+        let state = persistor.load().unwrap().unwrap();
         assert_eq!(BrokerState::default(), state);
     }
 }

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -61,7 +61,7 @@ where
         let main_task = future::select(broker_task, incoming_tasks);
 
         // Handle shutdown
-        let state = match future::select(shutdown_signal, main_task).await {
+        match future::select(shutdown_signal, main_task).await {
             Either::Left((_, tasks)) => {
                 info!("server received shutdown signal");
 
@@ -148,8 +148,7 @@ where
                     broker_state?
                 }
             },
-        };
-        Ok(state)
+        }
     }
 }
 

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -82,7 +82,7 @@ where
                         }
 
                         debug!("sending Shutdown message to broker");
-                        handle.send(Message::System(SystemEvent::Shutdown)).await?;
+                        handle.send(Message::System(SystemEvent::Shutdown))?;
                         broker_task.await?
                     }
                     Either::Left((broker_state, incoming_tasks)) => {
@@ -118,7 +118,7 @@ where
                     let mut results = vec![result];
                     results.extend(future::join_all(unfinished_incoming_tasks).await);
 
-                    handle.send(Message::System(SystemEvent::Shutdown)).await?;
+                    handle.send(Message::System(SystemEvent::Shutdown))?;
 
                     let broker_state = broker_task.await;
 

--- a/mqtt/mqtt-broker/src/session.rs
+++ b/mqtt/mqtt-broker/src/session.rs
@@ -143,9 +143,9 @@ impl ConnectedSession {
         Ok(unsuback)
     }
 
-    async fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
+    fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
         let message = Message::Client(self.state.client_id.clone(), event);
-        self.handle.send(message).await
+        self.handle.send(message)
     }
 }
 
@@ -270,9 +270,9 @@ impl DisconnectingSession {
         self.will
     }
 
-    async fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
+    fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
         let message = Message::Client(self.client_id.clone(), event);
-        self.handle.send(message).await
+        self.handle.send(message)
     }
 }
 
@@ -721,11 +721,11 @@ impl Session {
         }
     }
 
-    pub async fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
+    pub fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
         match self {
-            Self::Transient(ref mut connected) => connected.send(event).await,
-            Self::Persistent(ref mut connected) => connected.send(event).await,
-            Self::Disconnecting(ref mut disconnecting) => disconnecting.send(event).await,
+            Self::Transient(ref mut connected) => connected.send(event),
+            Self::Persistent(ref mut connected) => connected.send(event),
+            Self::Disconnecting(ref mut disconnecting) => disconnecting.send(event),
             _ => Err(Error::SessionOffline),
         }
     }

--- a/mqtt/mqtt-broker/src/session.rs
+++ b/mqtt/mqtt-broker/src/session.rs
@@ -932,7 +932,7 @@ pub(crate) mod tests {
 
     fn connection_handle() -> ConnectionHandle {
         let id = Uuid::new_v4();
-        let (tx1, _rx1) = mpsc::channel(128);
+        let (tx1, _rx1) = mpsc::unbounded_channel();
         ConnectionHandle::new(id, tx1)
     }
 

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -72,7 +72,9 @@ where
             .spawn(|| {
                 let persist = self.snapshotter_loop();
                 if let Err(_e) = tx.send(()) {
-                    error!("failed to send persist to event loop on shutdown");
+                    error!(
+                        "failed to signal the event loop that the snapshotter thread is exiting"
+                    );
                 }
                 persist
             })

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -86,7 +86,7 @@ where
         // We don't really care about the error here ---
         //   we just want to join the thread handle to get the result
         //   or deal with the panic
-        rx.await.map(drop).unwrap_or_else(|_e| ());
+        rx.await.map_or_else(drop, drop);
 
         // propagate any panics onto the event loop thread
         match handle.join() {

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -1,10 +1,12 @@
-use tokio::sync::mpsc::{self, Receiver, Sender};
-use tracing::{info, warn};
+use std::thread;
+
+use crossbeam_channel::{Receiver, Sender};
+use tracing::{error, info, warn};
 
 use crate::persist::Persist;
 use crate::{BrokerState, Error};
 
-enum Event {
+pub(crate) enum Event {
     State(BrokerState),
     Shutdown,
 }
@@ -13,11 +15,10 @@ enum Event {
 pub struct StateSnapshotHandle(Sender<Event>);
 
 impl StateSnapshotHandle {
-    pub async fn send(&mut self, state: BrokerState) -> Result<(), Error> {
+    pub fn try_send(&mut self, state: BrokerState) -> Result<(), Error> {
         self.0
             .send(Event::State(state))
-            .await
-            .map_err(|_| Error::SendSnapshotMessage)?;
+            .map_err(|_e| Error::SendSnapshotMessage)?;
         Ok(())
     }
 }
@@ -26,11 +27,10 @@ impl StateSnapshotHandle {
 pub struct ShutdownHandle(Sender<Event>);
 
 impl ShutdownHandle {
-    pub async fn shutdown(&mut self) -> Result<(), Error> {
+    pub fn try_shutdown(&mut self) -> Result<(), Error> {
         self.0
             .send(Event::Shutdown)
-            .await
-            .map_err(|_| Error::SendSnapshotMessage)?;
+            .map_err(|_e| Error::SendSnapshotMessage)?;
         Ok(())
     }
 }
@@ -43,7 +43,7 @@ pub struct Snapshotter<P> {
 
 impl<P> Snapshotter<P> {
     pub fn new(persistor: P) -> Self {
-        let (sender, events) = mpsc::channel(1024);
+        let (sender, events) = crossbeam_channel::bounded(5);
         Snapshotter {
             persistor,
             sender,
@@ -62,13 +62,27 @@ impl<P> Snapshotter<P> {
 
 impl<P> Snapshotter<P>
 where
-    P: Persist,
+    P: Persist + Send + 'static,
 {
-    pub async fn run(mut self) -> P {
-        while let Some(event) = self.events.recv().await {
+    pub async fn run(self) -> P {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        thread::spawn(|| {
+            let persist = self.snapshotter_loop();
+            if let Err(_e) = tx.send(persist) {
+                error!("failed to send persist to event loop on shutdown");
+            }
+        });
+
+        // TODO: return errors from the snapshotter run
+        let result = rx.await;
+        result.unwrap()
+    }
+
+    fn snapshotter_loop(mut self) -> P {
+        while let Ok(event) = self.events.recv() {
             match event {
                 Event::State(state) => {
-                    if let Err(e) = self.persistor.store(state).await {
+                    if let Err(e) = self.persistor.store(state) {
                         warn!(message = "an error occurred persisting state snapshot.", error=%e);
                     }
                 }

--- a/mqtt/mqtt-broker/tests/persist_failpoints.rs
+++ b/mqtt/mqtt-broker/tests/persist_failpoints.rs
@@ -73,6 +73,13 @@ fn test_persistor(count: usize, ops: Vec<Op>) {
     assert!(state.is_some());
 }
 
+// This test is meant to verify that the failpoints are actually enabled.
+// This is to prevent the case where someone disables the `fail/failpoints` feature
+// in the `Config.yaml` and unknowingly turns off the failpoints. This would render
+// the proptest tests useless because they would not exercise the failpoints.
+//
+// This smoke test ensures that the failpoints are actually enabled and should
+// catch this mistake.
 #[test]
 fn test_failpoints_smoketest() {
     let scenario = FailScenario::setup();

--- a/mqtt/mqtt-broker/tests/persist_failpoints.rs
+++ b/mqtt/mqtt-broker/tests/persist_failpoints.rs
@@ -10,7 +10,6 @@ const FAILPOINTS: &[&str] = &[
     "consolidatestate.store.serialize_into",
     "filepersistor.load.fileopen",
     "filepersistor.load.format",
-    "filepersistor.load.spawn_blocking",
     "filepersistor.store.fileopen",
     "filepersistor.store.filerename",
     "filepersistor.store.symlink_unlink",
@@ -19,7 +18,6 @@ const FAILPOINTS: &[&str] = &[
     "filepersistor.store.readdir",
     "filepersistor.store.entry_unlink",
     "filepersistor.store.new_file_unlink",
-    "filepersistor.store.spawn_blocking",
 ];
 
 #[derive(Clone, Debug)]

--- a/mqtt/mqttd/src/main.rs
+++ b/mqtt/mqttd/src/main.rs
@@ -79,7 +79,7 @@ async fn run() -> Result<(), Error> {
 
     // Stop snapshotting
     shutdown_handle.try_shutdown()?;
-    let mut persistor = join_handle.await?;
+    let mut persistor = join_handle.await??;
     info!("state snapshotter shutdown.");
 
     info!("persisting state before exiting...");

--- a/mqtt/mqttd/src/main.rs
+++ b/mqtt/mqttd/src/main.rs
@@ -40,7 +40,7 @@ async fn run() -> Result<(), Error> {
         ConsolidatedStateFormat::default(),
     );
     info!("Loading state...");
-    let state = persistor.load().await?.unwrap_or_else(BrokerState::default);
+    let state = persistor.load()?.unwrap_or_else(BrokerState::default);
     let broker = BrokerBuilder::default()
         .authenticator(|_| Ok(Some(AuthId::Anonymous)))
         .authorizer(|_| Ok(true))
@@ -78,12 +78,12 @@ async fn run() -> Result<(), Error> {
         .await?;
 
     // Stop snapshotting
-    shutdown_handle.shutdown().await?;
+    shutdown_handle.try_shutdown()?;
     let mut persistor = join_handle.await?;
     info!("state snapshotter shutdown.");
 
     info!("persisting state before exiting...");
-    persistor.store(state).await?;
+    persistor.store(state)?;
     info!("state persisted.");
     info!("exiting... goodbye");
 
@@ -100,12 +100,9 @@ async fn tick_snapshot(
     let mut interval = tokio::time::interval_at(start, period);
     loop {
         interval.tick().await;
-        if let Err(e) = broker_handle
-            .send(Message::System(SystemEvent::StateSnapshot(
-                snapshot_handle.clone(),
-            )))
-            .await
-        {
+        if let Err(e) = broker_handle.try_send(Message::System(SystemEvent::StateSnapshot(
+            snapshot_handle.clone(),
+        ))) {
             warn!(message = "failed to tick the snapshotter", error=%e);
         }
     }

--- a/mqtt/mqttd/src/snapshot.rs
+++ b/mqtt/mqttd/src/snapshot.rs
@@ -28,12 +28,9 @@ mod imp {
         loop {
             stream.recv().await;
             info!("Received signal USR1");
-            if let Err(e) = broker_handle
-                .send(Message::System(SystemEvent::StateSnapshot(
-                    snapshot_handle.clone(),
-                )))
-                .await
-            {
+            if let Err(e) = broker_handle.send(Message::System(SystemEvent::StateSnapshot(
+                snapshot_handle.clone(),
+            ))) {
                 warn!(message = "failed to signal the snapshotter", error=%e);
             }
         }


### PR DESCRIPTION
* Converts the broker processing from an async "task" to a proper thread.
* Converts the snapshotter processing from an async "task" to a proper thread.

This change leaves all of the async code in the networking code, where it is most beneficial.

In very early perf testing this has a perf benefit of ~25-30% over master.
Quick tests were run with the following load a single subscriber.

```sh
mqtt-benchmark  --broker tcp://127.0.0.1:1883 --count 10000 --size 1000 --clients 24 --qos 1 --format text -quiet true
```

**Current Task Model**
```
========= TOTAL (24) =========
Total Ratio:                 1.000 (240000/240000)
Total Runtime (sec):         4.626
Average Runtime (sec):       4.609
Msg time min (ms):           0.055
Msg time max (ms):           14.706
Msg time mean mean (ms):     0.459
Msg time mean std (ms):      0.001
Average Bandwidth (msg/sec): 2169.886
Total Bandwidth (msg/sec):   52077.253
```

**Thread Model (this PR)**
```
========= TOTAL (24) =========
Total Ratio:                 1.000 (240000/240000)
Total Runtime (sec):         3.564
Average Runtime (sec):       3.549
Msg time min (ms):           0.044
Msg time max (ms):           16.473
Msg time mean mean (ms):     0.353
Msg time mean std (ms):      0.001
Average Bandwidth (msg/sec): 2817.756
Total Bandwidth (msg/sec):   67626.151
```

**Mosquitto**
```
========= TOTAL (24) =========
Total Ratio:                 1.000 (240000/240000)
Total Runtime (sec):         3.469
Average Runtime (sec):       3.459
Msg time min (ms):           0.033
Msg time max (ms):           13.980
Msg time mean mean (ms):     0.345
Msg time mean std (ms):      0.001
Average Bandwidth (msg/sec): 2890.697
Total Bandwidth (msg/sec):   69376.717
```

Further testing is required. These are just quick comparisons on my laptop.