### PR TITLE
[mqtt] Publish image names as build artifacts

### DIFF
--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -31,7 +31,7 @@ jobs:
           buildContext: mqtt/.
           tags: $(Build.BuildId)-$(os)-$(arch)
       
-      - script: echo $(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+      - script: echo $(registry.address)/$(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
         displayName: Create image name
       
       - publish: image$(arch)
@@ -67,7 +67,7 @@ jobs:
           buildContext: mqtt/.
           tags: $(Build.BuildId)-$(os)-$(arch)
 
-      - script: echo $(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+      - script: echo $(registry.address)/$(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
         displayName: Create image name
       
       - publish: image$(arch)

--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -31,11 +31,11 @@ jobs:
           buildContext: mqtt/.
           tags: $(Build.BuildId)-$(os)-$(arch)
       
-      - script: echo $(registry.address)/$(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+      - script: echo $(registry.address)/$(imageName):$(Build.BuildId)-$(os)-$(arch) > artifactInfo.txt
         displayName: Create image name
       
-      - publish: image$(arch)
-        artifact: image$(arch)
+      - publish: artifactInfo.txt
+        artifact: image-$(arch)
         displayName: Publish image name
 
 ################################################################################
@@ -67,9 +67,9 @@ jobs:
           buildContext: mqtt/.
           tags: $(Build.BuildId)-$(os)-$(arch)
 
-      - script: echo $(registry.address)/$(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+      - script: echo $(registry.address)/$(imageName):$(Build.BuildId)-$(os)-$(arch) > artifactInfo.txt
         displayName: Create image name
       
-      - publish: image$(arch)
-        artifact: image$(arch)
+      - publish: artifactInfo.txt
+        artifact: image-$(arch)
         displayName: Publish image name

--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -21,21 +21,22 @@ jobs:
           command: login
           containerRegistry: iotedge-edgebuilds-acr
 
-      # - task: Docker@2
-      #   displayName: Build amd64 image
-      #   inputs:
-      #     repository: $(imageName)
-      #     command: buildAndPush
-      #     containerRegistry: iotedge-edgebuilds-acr
-      #     Dockerfile: mqtt/docker/linux/amd64/Dockerfile
-      #     buildContext: mqtt/.
-      #     tags: $(Build.BuildId)-$(os)-$(arch)
+      - task: Docker@2
+        displayName: Build amd64 image
+        inputs:
+          repository: $(imageName)
+          command: buildAndPush
+          containerRegistry: iotedge-edgebuilds-acr
+          Dockerfile: mqtt/docker/linux/amd64/Dockerfile
+          buildContext: mqtt/.
+          tags: $(Build.BuildId)-$(os)-$(arch)
       
-      - script: |
-          echo $(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+      - script: echo $(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+        displayName: Create image name
       
       - publish: image$(arch)
         artifact: image$(arch)
+        displayName: Publish image name
 
 ################################################################################
   - job: linux_arm32
@@ -56,18 +57,19 @@ jobs:
           command: login
           containerRegistry: iotedge-edgebuilds-acr
 
-      # - task: Docker@2
-      #   displayName: Build amd64 image
-      #   inputs:
-      #     repository: $(imageName)
-      #     command: buildAndPush
-      #     containerRegistry: iotedge-edgebuilds-acr
-      #     Dockerfile: mqtt/docker/linux/amd64/Dockerfile
-      #     buildContext: mqtt/.
-      #     tags: $(Build.BuildId)-$(os)-$(arch)
+      - task: Docker@2
+        displayName: Build amd64 image
+        inputs:
+          repository: $(imageName)
+          command: buildAndPush
+          containerRegistry: iotedge-edgebuilds-acr
+          Dockerfile: mqtt/docker/linux/amd64/Dockerfile
+          buildContext: mqtt/.
+          tags: $(Build.BuildId)-$(os)-$(arch)
 
-      - script: |
-          echo $(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+      - script: echo $(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+        displayName: Create image name
       
       - publish: image$(arch)
         artifact: image$(arch)
+        displayName: Publish image name

--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -21,15 +21,21 @@ jobs:
           command: login
           containerRegistry: iotedge-edgebuilds-acr
 
-      - task: Docker@2
-        displayName: Build amd64 image
-        inputs:
-          repository: $(imageName)
-          command: buildAndPush
-          containerRegistry: iotedge-edgebuilds-acr
-          Dockerfile: mqtt/docker/linux/amd64/Dockerfile
-          buildContext: mqtt/.
-          tags: $(Build.BuildId)-$(os)-$(arch)
+      # - task: Docker@2
+      #   displayName: Build amd64 image
+      #   inputs:
+      #     repository: $(imageName)
+      #     command: buildAndPush
+      #     containerRegistry: iotedge-edgebuilds-acr
+      #     Dockerfile: mqtt/docker/linux/amd64/Dockerfile
+      #     buildContext: mqtt/.
+      #     tags: $(Build.BuildId)-$(os)-$(arch)
+      
+      - script: |
+          echo $(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+      
+      - publish: image$(arch)
+        artifact: image$(arch)
 
 ################################################################################
   - job: linux_arm32
@@ -50,12 +56,18 @@ jobs:
           command: login
           containerRegistry: iotedge-edgebuilds-acr
 
-      - task: Docker@2
-        displayName: Build amd64 image
-        inputs:
-          repository: $(imageName)
-          command: buildAndPush
-          containerRegistry: iotedge-edgebuilds-acr
-          Dockerfile: mqtt/docker/linux/amd64/Dockerfile
-          buildContext: mqtt/.
-          tags: $(Build.BuildId)-$(os)-$(arch)
+      # - task: Docker@2
+      #   displayName: Build amd64 image
+      #   inputs:
+      #     repository: $(imageName)
+      #     command: buildAndPush
+      #     containerRegistry: iotedge-edgebuilds-acr
+      #     Dockerfile: mqtt/docker/linux/amd64/Dockerfile
+      #     buildContext: mqtt/.
+      #     tags: $(Build.BuildId)-$(os)-$(arch)
+
+      - script: |
+          echo $(imageName):$(Build.BuildId)-$(os)-$(arch) > image$(arch)
+      
+      - publish: image$(arch)
+        artifact: image$(arch)


### PR DESCRIPTION
In order to use latest mqtt broker image, we need to pass fully-qualified image name in artifact file for other pipelines to consume.