### PR TITLE
[mqtt] Fix bug when broker attempts to send message to offline session

### DIFF
--- a/mqtt/mqtt-broker/src/auth/mod.rs
+++ b/mqtt/mqtt-broker/src/auth/mod.rs
@@ -1,3 +1,5 @@
+use serde::{Deserialize, Serialize};
+
 mod authentication;
 mod authorization;
 
@@ -7,7 +9,7 @@ pub use authentication::{
 pub use authorization::{Activity, AuthorizeError, Authorizer, DefaultAuthorizer, Operation};
 
 /// Authenticated MQTT client identity.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum AuthId {
     /// Identity for anonymous client.
     Anonymous,

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -200,8 +200,12 @@ pub(crate) mod tests {
 
     use crate::subscription::tests::arb_qos;
 
-    pub fn arb_clientid() -> impl Strategy<Value = ClientId> {
+    pub fn arb_client_id() -> impl Strategy<Value = ClientId> {
         "[a-zA-Z0-9]{1,23}".prop_map(|s| ClientId(Arc::new(s)))
+    }
+
+    pub fn arb_auth_id() -> impl Strategy<Value = AuthId> {
+        "\\PC*".prop_map(|s| s.into())
     }
 
     pub fn arb_packet_identifier() -> impl Strategy<Value = proto::PacketIdentifier> {


### PR DESCRIPTION
Compliance test caught a bug when the broker errors when tries to publish a message to offline session. This error originated because of the wrong assumption that accessing offline session is somewhat illegal operation. It turns out that it's not: accessing a persistent session for a disconnected client is just as regular operation as any other.

There are 2 ways to solve this error. When accessing `auth_id` for offline session
1. return special marker that allows the broker to publish messages to the offline session
2. store `auth_id` along with session in the broker state and return `auth_id` for a previously connected client. 

This PR solves the issue with approach 2.