### PR TITLE
Fix route config change

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/AsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/AsyncEndpointExecutor.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             this.checkpointer = Preconditions.CheckNotNull(checkpointer);
             this.cts = new CancellationTokenSource();
             this.options = Preconditions.CheckNotNull(options);
-            this.machine = new EndpointExecutorFsm(endpoint, checkpointer, config);
+            this.machine = new EndpointExecutorFsm(endpoint, checkpointer, config, this.cts.Token);
             this.closed = new AtomicBoolean();
 
             // The three size variables below adjust the following parameters:

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/StoringAsyncEndpointExecutor.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
 
                     // Create a checkpointer and a FSM for every message queue
                     ICheckpointer checkpointer = await this.checkpointerFactory.CreateAsync(id);
-                    EndpointExecutorFsm fsm = new EndpointExecutorFsm(this.Endpoint, checkpointer, this.config);
+                    EndpointExecutorFsm fsm = new EndpointExecutorFsm(this.Endpoint, checkpointer, this.config, this.cts.Token);
 
                     // Add it to our dictionary
                     snapshot.Add(priority, fsm);

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/SyncEndpointExecutor.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/SyncEndpointExecutor.cs
@@ -36,8 +36,8 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints
             Preconditions.CheckNotNull(config);
 
             this.checkpointer = Preconditions.CheckNotNull(checkpointer);
-            this.machine = new EndpointExecutorFsm(endpoint, checkpointer, config);
             this.cts = new CancellationTokenSource();
+            this.machine = new EndpointExecutorFsm(endpoint, checkpointer, config, this.cts.Token);
             this.closed = new AtomicBoolean();
             this.sync = new AsyncLock();
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/endpoints/statemachine/EndpointExecutorFsm.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
         readonly Timer retryTimer;
         readonly AsyncLock sync = new AsyncLock();
         readonly ISystemTime systemTime;
+        readonly CancellationToken endpointExecutorToken;
 
         volatile State state;
         volatile int retryAttempts;
@@ -91,12 +92,12 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
         volatile IProcessor processor;
         TimeSpan retryPeriod;
 
-        public EndpointExecutorFsm(Endpoint endpoint, ICheckpointer checkpointer, EndpointExecutorConfig config)
-            : this(endpoint, checkpointer, config, SystemTime.Instance)
+        public EndpointExecutorFsm(Endpoint endpoint, ICheckpointer checkpointer, EndpointExecutorConfig config, CancellationToken endpointExecutorToken)
+            : this(endpoint, checkpointer, config, SystemTime.Instance, endpointExecutorToken)
         {
         }
 
-        public EndpointExecutorFsm(Endpoint endpoint, ICheckpointer checkpointer, EndpointExecutorConfig config, ISystemTime systemTime)
+        public EndpointExecutorFsm(Endpoint endpoint, ICheckpointer checkpointer, EndpointExecutorConfig config, ISystemTime systemTime, CancellationToken endpointExecutorToken)
         {
             this.processor = Preconditions.CheckNotNull(endpoint).CreateProcessor();
             this.Checkpointer = Preconditions.CheckNotNull(checkpointer);
@@ -106,6 +107,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
             this.retryPeriod = Timeout.InfiniteTimeSpan;
             this.lastFailedRevivalTime = checkpointer.LastFailedRevivalTime;
             this.unhealthySince = checkpointer.UnhealthySince;
+            this.endpointExecutorToken = endpointExecutorToken;
 
             if (checkpointer.LastFailedRevivalTime.HasValue)
             {
@@ -124,6 +126,8 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
 
         public EndpointExecutorStatus Status =>
             new EndpointExecutorStatus(this.Endpoint.Id, this.state, this.retryAttempts, this.retryPeriod, this.lastFailedRevivalTime, this.unhealthySince, new CheckpointerStatus(this.Checkpointer.Id, this.Checkpointer.Offset, this.Checkpointer.Proposed));
+
+        public CancellationToken EndpointExecutorToken => this.endpointExecutorToken;
 
         public async Task RunAsync(ICommand command)
         {
@@ -286,6 +290,15 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
             ICollection<IMessage> messages = EmptyMessages;
             Stopwatch stopwatch = Stopwatch.StartNew();
             TimeSpan endpointTimeout = TimeSpan.FromMilliseconds(thisPtr.config.Timeout.TotalMilliseconds * thisPtr.Endpoint.FanOutFactor);
+
+            if (thisPtr.EndpointExecutorToken.IsCancellationRequested)
+            {
+                Events.SendCanceled(thisPtr);
+                next = Commands.Checkpoint(SinkResult<IMessage>.Empty);
+                await RunInternalAsync(thisPtr, next);
+                return;
+            }
+
             try
             {
                 Preconditions.CheckNotNull(thisPtr.currentSendCommand);
@@ -674,6 +687,11 @@ namespace Microsoft.Azure.Devices.Routing.Core.Endpoints.StateMachine
                     GetContextString(fsm));
 
                 LogUnhealthyEndpointOpMonError(fsm, failureDetails.FailureKind);
+            }
+
+            public static void SendCanceled(EndpointExecutorFsm fsm)
+            {
+                Log.LogDebug((int)EventIds.SendNone, "[SendCancelled] Endpoint executor token is canceled. {0}", GetContextString(fsm));
             }
 
             public static void SendNone(EndpointExecutorFsm fsm)

--- a/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/statemachine/EndpointExecutorFsmTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/statemachine/EndpointExecutorFsmTest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             checkpointer.Setup(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), Option.None<DateTime>(), Option.None<DateTime>(), It.IsAny<CancellationToken>())).Returns(TaskEx.Done);
             checkpointer.Setup(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), Option.None<DateTime>(), Option.None<DateTime>(), It.IsAny<CancellationToken>())).Returns(TaskEx.Done);
 
-            var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer.Object, MaxConfig);
+            var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer.Object, MaxConfig, CancellationToken.None);
             await machine1.RunAsync(Commands.SendMessage(Message1, Message2));
             checkpointer.Verify(c => c.CommitAsync(new[] { Message1, Message2 }, new IMessage[0], Option.None<DateTime>(), Option.None<DateTime>(), It.IsAny<CancellationToken>()), Times.Exactly(1));
             await machine1.CloseAsync();
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             checkpointer2.Setup(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), Option.None<DateTime>(), Option.None<DateTime>(), It.IsAny<CancellationToken>())).Returns(TaskEx.Done);
             checkpointer2.Setup(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), Option.None<DateTime>(), Option.None<DateTime>(), It.IsAny<CancellationToken>())).Returns(TaskEx.Done);
 
-            var machine2 = new EndpointExecutorFsm(endpoint2, checkpointer2.Object, MaxConfig);
+            var machine2 = new EndpointExecutorFsm(endpoint2, checkpointer2.Object, MaxConfig, CancellationToken.None);
             await machine2.RunAsync(Commands.SendMessage(Message1));
             checkpointer2.Verify(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), Option.None<DateTime>(), Option.None<DateTime>(), It.IsAny<CancellationToken>()), Times.Never);
             await machine2.CloseAsync();
@@ -70,7 +70,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             dao.Setup(d => d.GetCheckpointDataAsync("id1", It.IsAny<CancellationToken>())).Returns(Task.FromResult(new CheckpointData(10L)));
 
             using (ICheckpointer checkpointer = await Checkpointer.CreateAsync("id1", dao.Object))
-            using (var machine = new EndpointExecutorFsm(endpoint, checkpointer, MaxConfig))
+            using (var machine = new EndpointExecutorFsm(endpoint, checkpointer, MaxConfig, CancellationToken.None))
             {
                 await machine.RunAsync(Commands.SendMessage(MessageWithOffset(1), MessageWithOffset(2), MessageWithOffset(3)));
                 dao.Verify(d => d.SetCheckpointDataAsync(It.IsAny<string>(), new CheckpointData(It.IsAny<long>()), It.IsAny<CancellationToken>()), Times.Never);
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.MaxValue);
 
             using (ICheckpointer checkpointer = await Checkpointer.CreateAsync("id1", dao.Object))
-            using (var machine = new EndpointExecutorFsm(endpoint, checkpointer, config))
+            using (var machine = new EndpointExecutorFsm(endpoint, checkpointer, config, CancellationToken.None))
             {
                 await machine.RunAsync(Commands.SendMessage(MessageWithOffset(11)));
                 Assert.Equal(State.DeadIdle, machine.Status.State);
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(1, TimeSpan.FromSeconds(1));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer1.Object, config);
+            var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer1.Object, config, CancellationToken.None);
             SendMessage command1 = Commands.SendMessage(Message1);
             await machine1.RunAsync(command1);
             await command1.Completion;
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             checkpointer2.Setup(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), It.IsAny<Option<DateTime>>(), It.IsAny<Option<DateTime>>(), It.IsAny<CancellationToken>())).Throws(new Exception());
 
             var config2 = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5), true);
-            var machine2 = new EndpointExecutorFsm(endpoint2, checkpointer2.Object, config2);
+            var machine2 = new EndpointExecutorFsm(endpoint2, checkpointer2.Object, config2, CancellationToken.None);
             SendMessage command2 = Commands.SendMessage(Message1);
             await machine2.RunAsync(command2);
             await Assert.ThrowsAsync<Exception>(() => command2.Completion);
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             checkpointer3.Setup(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), It.IsAny<Option<DateTime>>(), It.IsAny<Option<DateTime>>(), It.IsAny<CancellationToken>())).Throws(new Exception());
             checkpointer3.Setup(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), It.IsAny<Option<DateTime>>(), It.IsAny<Option<DateTime>>(), It.IsAny<CancellationToken>())).Throws(new Exception());
 
-            var machine3 = new EndpointExecutorFsm(endpoint3, checkpointer3.Object, config);
+            var machine3 = new EndpointExecutorFsm(endpoint3, checkpointer3.Object, config, CancellationToken.None);
             SendMessage command3 = Commands.SendMessage(Message1, Message2);
             await machine3.RunAsync(command3);
             Assert.Equal(State.Failing, machine3.Status.State);
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(1, TimeSpan.FromMilliseconds(5));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer1, config))
+            using (var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer1, config, CancellationToken.None))
             {
                 SendMessage command1 = Commands.SendMessage(Message1, Message3, Message2, Message4);
                 await machine1.RunAsync(command1);
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(4, TimeSpan.FromMilliseconds(100));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer1, config))
+            using (var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer1, config, CancellationToken.None))
             {
                 SendMessage command1 = Commands.SendMessage(Message1, Message3, Message2, Message4);
                 await machine1.RunAsync(command1);
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var endpoint2 = new TestEndpoint("id1");
             var endpoint3 = new TestEndpoint("id3");
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), MaxConfig))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), MaxConfig, CancellationToken.None))
             {
                 await Assert.ThrowsAsync<ArgumentNullException>(() => machine.RunAsync(Commands.UpdateEndpoint(null)));
 
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new Incremental(int.MaxValue, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var endpoint2 = new FailedEndpoint("id1", new Exception("endpoint failed"));
             var endpoint3 = new TestEndpoint("id1");
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), MaxConfig))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), MaxConfig, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var endpoint1 = new FailedEndpoint("id1", new Exception("endpoint failed"));
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromSeconds(1)))
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), MaxConfig))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), MaxConfig, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -391,7 +391,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMinutes(1));
             var config = new EndpointExecutorConfig(TimeSpan.FromMilliseconds(1), retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine = new EndpointExecutorFsm(endpoint, new NullCheckpointer(), config))
+            using (var machine = new EndpointExecutorFsm(endpoint, new NullCheckpointer(), config, CancellationToken.None))
             {
                 await machine.RunAsync(Commands.SendMessage(Message1));
 
@@ -411,7 +411,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMilliseconds(5));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, CancellationToken.None))
             {
                 // Set endpoint to always fail
                 endpoint1.Failing = true;
@@ -467,7 +467,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMilliseconds(5));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -505,7 +505,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMinutes(5));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5), true);
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -542,7 +542,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMilliseconds(50));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, CancellationToken.None))
             {
                 SendMessage command = Commands.SendMessage(Message1);
                 await machine.RunAsync(command);
@@ -564,6 +564,35 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
 
         [Fact]
         [Unit]
+        public async Task TestSendMessageStopOnceExecutorTokenIsCanceled()
+        {
+            int maxRetryAttempts = 10000;
+            var endpoint1 = new FailedEndpoint("id1", new Exception("endpoint failed"));
+            var retryStrategy = new FixedInterval(maxRetryAttempts, TimeSpan.FromMilliseconds(5));
+            var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
+            var cts = new CancellationTokenSource();
+
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, cts.Token))
+            {
+                SendMessage command = Commands.SendMessage(Message1);
+                await machine.RunAsync(command);
+                EndpointExecutorStatus status = machine.Status;
+                Assert.Equal(State.Failing, status.State);
+                Assert.True(status.RetryAttempts > 0, "Retry attempts should be greater tahn zero.");
+                cts.Cancel();
+                await command.Completion;
+
+                // TransitionAction happens before transition to next state and hence add a small delay
+                await Task.Delay(TimeSpan.FromMilliseconds(1));
+                status = machine.Status;
+                Assert.Equal(State.Idle, status.State);
+                Assert.Equal(0, status.RetryAttempts);
+                await machine.CloseAsync();
+            }
+        }
+
+        [Fact]
+        [Unit]
         public async Task TestReviveToSuccess()
         {
             var endpoint1 = new RevivableEndpoint("id1", new Exception("endpoint failed"));
@@ -571,7 +600,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(1));
             var systemTime = new MockSystemTime();
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, systemTime))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, systemTime, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -627,7 +656,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMilliseconds(int.MaxValue));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMilliseconds(50));
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -679,7 +708,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMilliseconds(int.MaxValue));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMilliseconds(50));
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config))
+            using (var machine = new EndpointExecutorFsm(endpoint1, new NullCheckpointer(), config, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -707,7 +736,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMinutes(5));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            var machine = new EndpointExecutorFsm(endpoint1, checkpointer.Object, config);
+            var machine = new EndpointExecutorFsm(endpoint1, checkpointer.Object, config, CancellationToken.None);
             EndpointExecutorStatus status = machine.Status;
             Assert.Equal(State.Idle, status.State);
             Assert.Equal(0, status.RetryAttempts);
@@ -753,7 +782,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(1, TimeSpan.FromMilliseconds(int.MaxValue));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer1.Object, config))
+            using (var machine1 = new EndpointExecutorFsm(endpoint1, checkpointer1.Object, config, CancellationToken.None))
             {
                 await machine1.RunAsync(Commands.SendMessage(Message1));
                 await machine1.RunAsync(Commands.Retry);
@@ -768,7 +797,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             checkpointer2.Setup(c => c.Admit(It.IsAny<IMessage>())).Returns(true);
             checkpointer2.Setup(c => c.CommitAsync(It.IsAny<ICollection<IMessage>>(), It.IsAny<ICollection<IMessage>>(), It.IsAny<Option<DateTime>>(), It.IsAny<Option<DateTime>>(), It.IsAny<CancellationToken>())).Throws(new Exception());
 
-            var machine2 = new EndpointExecutorFsm(endpoint2, checkpointer2.Object, config);
+            var machine2 = new EndpointExecutorFsm(endpoint2, checkpointer2.Object, config, CancellationToken.None);
             SendMessage command2 = Commands.SendMessage(Message1);
             await machine2.RunAsync(command2);
             await machine2.RunAsync(Commands.Retry);
@@ -794,7 +823,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var retryStrategy = new FixedInterval(5, TimeSpan.FromMilliseconds(5));
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
 
-            using (var machine = new EndpointExecutorFsm(endpoint1, checkpointer.Object, config))
+            using (var machine = new EndpointExecutorFsm(endpoint1, checkpointer.Object, config, CancellationToken.None))
             {
                 EndpointExecutorStatus status = machine.Status;
                 Assert.Equal(State.Idle, status.State);
@@ -837,7 +866,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
 
             var endpoint = new TestEndpoint("endpoint1");
 
-            using (var machine = new EndpointExecutorFsm(endpoint, checkpointer, config))
+            using (var machine = new EndpointExecutorFsm(endpoint, checkpointer, config, CancellationToken.None))
             {
                 // TODO find a way to test this without a delay
                 // await machine.RunAsync(Commands.SendMessage(Message1));
@@ -882,7 +911,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var config = new EndpointExecutorConfig(Timeout.InfiniteTimeSpan, retryStrategy, TimeSpan.FromMinutes(5));
             var endpoint = new TestEndpoint("endpoint1");
 
-            using (var machine = new EndpointExecutorFsm(endpoint, checkpointer, config))
+            using (var machine = new EndpointExecutorFsm(endpoint, checkpointer, config, CancellationToken.None))
             {
                 await machine.RunAsync(Commands.SendMessage(Message1));
                 Assert.Equal(0, endpoint.N); // endpoint should not get the message as it is dead
@@ -897,7 +926,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             }
 
             // restart executor and still we should be in dead state
-            using (var machine1 = new EndpointExecutorFsm(endpoint, checkpointer, config))
+            using (var machine1 = new EndpointExecutorFsm(endpoint, checkpointer, config, CancellationToken.None))
             {
                 Assert.Equal(machine1.Status.LastFailedRevivalTime.GetOrElse(DateTime.MinValue), dateTimeNow);
                 Assert.Equal(State.DeadIdle, machine1.Status.State);
@@ -919,7 +948,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints.StateMachine
             var endpoint = new InvalidEndpoint("id1", () => processor.Object);
             processor.Setup(p => p.Endpoint).Returns(endpoint);
 
-            var machine = new EndpointExecutorFsm(endpoint, checkpointer, MaxConfig);
+            var machine = new EndpointExecutorFsm(endpoint, checkpointer, MaxConfig, CancellationToken.None);
             Assert.Equal(State.Idle, machine.Status.State);
             await machine.RunAsync(Commands.SendMessage(Message1, Message2, Message3));
 


### PR DESCRIPTION
When route endpoint is removing, endpoint executor's cancellation token source will be canceled.  And endpoint executor is running inside a loop to process messages and wait for endpoint executor FSM to run sending command.  Inside FSM, it will keep retry sending messages until delivered or any exception not able to retry.  If an invalid/non-existing endpoint is defined, it will keep retrying forever and endpoint executor is awaiting the result from the sending command forever.  Therefore we need to have a way to tell FSM that endpoint is removing and should stop retrying.  Since endpoint executor is awaiting forever, it block the removal of endpoint which will block to add/update endpoints (in Dispatcher.ReplaceRoutes method).

In order to let FSM aware of removing endpoints, cancellation token source in endpoint executor will pass its token to FSM when FSM creation.  Therefore FSM sending message logic will consider if this token is canceled when endpoint is removing.

Step to reproduce:
1. Run iotedge with tempsenor and tempfilter; set up to route messages from tempsensor to tempfilterXXX, which is an invalid route.
2. start to run iotedged and check log of tempFilter, there is no message shown.
3. fix route to tempfilter and deploy.
4. expected tempfilter log should start showing up records, but it doesn't since the route can't be removed and new route can't be added.