### PR TITLE
[mqtt]: Retained and Will messages integration tests

### DIFF
--- a/mqtt/mqtt-broker/tests/common.rs
+++ b/mqtt/mqtt-broker/tests/common.rs
@@ -5,6 +5,7 @@ use std::{
     time::Duration,
 };
 
+use futures::{future::select, pin_mut};
 use futures_util::{FutureExt, StreamExt};
 use lazy_static::lazy_static;
 use tokio::{
@@ -28,9 +29,14 @@ use mqtt_broker::{Authenticator, Authorizer, Broker, BrokerState, Error, Server}
 pub struct TestClient {
     publish_handle: PublishHandle,
     subscription_handle: UpdateSubscriptionHandle,
+
+    /// Used for proper shutdown w/ Disconnect packet.
     shutdown_handle: ShutdownHandle,
+
+    /// Used to simulate unexpected shutdown.
+    termination_handle: Sender<()>,
     events_receiver: UnboundedReceiver<Event>,
-    task: JoinHandle<()>,
+    event_loop_handle: JoinHandle<()>,
 }
 
 impl TestClient {
@@ -45,6 +51,7 @@ impl TestClient {
         self.subscription_handle.subscribe(subscribe_to).await
     }
 
+    /// Initiates sending Disconnect packet and proper client shutdown.
     pub async fn shutdown(&mut self) -> Result<(), ShutdownError> {
         self.shutdown_handle.shutdown().await
     }
@@ -53,8 +60,17 @@ impl TestClient {
         self.shutdown_handle.clone()
     }
 
+    /// Terminates client w/o sending Disconnect packet.
+    pub async fn terminate(self) -> Result<(), JoinError> {
+        self.termination_handle
+            .send(())
+            .expect("unable to send termination signal");
+        self.event_loop_handle.await
+    }
+
+    /// Watis until client's event loop is finished.
     pub async fn join(self) -> Result<(), JoinError> {
-        self.task.await
+        self.event_loop_handle.await
     }
 }
 
@@ -78,6 +94,7 @@ where
     username: Option<String>,
     password: Option<String>,
     will: Option<Publication>,
+    keep_alive: Duration,
 }
 
 #[allow(dead_code)]
@@ -92,6 +109,7 @@ where
             username: None,
             password: None,
             will: None,
+            keep_alive: Duration::from_secs(60),
         }
     }
 
@@ -115,6 +133,11 @@ where
         self
     }
 
+    pub fn keep_alive(mut self, keep_alive: Duration) -> Self {
+        self.keep_alive = keep_alive;
+        self
+    }
+
     pub fn build(self) -> TestClient {
         let address = self.address;
         let password = self.password;
@@ -132,7 +155,7 @@ where
                 })
             },
             Duration::from_secs(1),
-            Duration::from_secs(60),
+            self.keep_alive,
         );
 
         let publish_handle = client
@@ -149,21 +172,28 @@ where
 
         let (events_sender, events_receiver) = mpsc::unbounded_channel();
 
-        let task = tokio::spawn(async move {
-            while let Some(event) = client.next().await {
-                let event = event.expect("event expected");
-                events_sender
-                    .send(event)
-                    .expect("can't send an event to a channel");
-            }
+        let (termination_handle, tx) = oneshot::channel::<()>();
+
+        let event_loop_handle = tokio::spawn(async move {
+            let event_loop = async {
+                while let Some(event) = client.next().await {
+                    let event = event.expect("event expected");
+                    events_sender
+                        .send(event)
+                        .expect("can't send an event to a channel");
+                }
+            };
+            pin_mut!(event_loop);
+            select(event_loop, tx).await;
         });
 
         TestClient {
             publish_handle,
             subscription_handle,
             shutdown_handle,
+            termination_handle,
             events_receiver,
-            task,
+            event_loop_handle,
         }
     }
 }

--- a/mqtt/mqtt-broker/tests/smoke.rs
+++ b/mqtt/mqtt-broker/tests/smoke.rs
@@ -1,10 +1,13 @@
 use matches::assert_matches;
 
-use common::TestClientBuilder;
-use mqtt3::proto::QoS::{AtLeastOnce, AtMostOnce, ExactlyOnce};
-use mqtt3::proto::SubscribeTo;
-use mqtt3::{Event, ReceivedPublication};
+use futures_util::StreamExt;
+use mqtt3::{
+    proto::{QoS, SubscribeTo},
+    Event, ReceivedPublication,
+};
 use mqtt_broker::{AuthId, BrokerBuilder};
+
+use common::TestClientBuilder;
 
 mod common;
 
@@ -22,7 +25,7 @@ async fn basic_connect_clean_session() {
         .build();
 
     assert_matches!(
-        client.events_receiver.recv().await,
+        client.next().await,
         Some(Event::NewConnection { reset_session }) if reset_session
     );
 
@@ -51,7 +54,7 @@ async fn basic_pub_sub() {
     client
         .subscribe(SubscribeTo {
             topic_filter: topic.into(),
-            qos: AtMostOnce,
+            qos: QoS::AtMostOnce,
         })
         .await
         .expect("couldn't subscribe to a topic");
@@ -59,7 +62,7 @@ async fn basic_pub_sub() {
     client
         .publish(mqtt3::proto::Publication {
             topic_name: topic.into(),
-            qos: AtMostOnce,
+            qos: QoS::AtMostOnce,
             retain: false,
             payload: "qos 0".into(),
         })
@@ -69,7 +72,7 @@ async fn basic_pub_sub() {
     client
         .publish(mqtt3::proto::Publication {
             topic_name: topic.into(),
-            qos: AtLeastOnce,
+            qos: QoS::AtLeastOnce,
             retain: false,
             payload: "qos 1".into(),
         })
@@ -79,35 +82,124 @@ async fn basic_pub_sub() {
     client
         .publish(mqtt3::proto::Publication {
             topic_name: topic.into(),
-            qos: ExactlyOnce,
+            qos: QoS::ExactlyOnce,
             retain: false,
             payload: "qos 2".into(),
         })
         .await
         .expect("couldn't publish");
 
-    client.events_receiver.recv().await; //skip connect event
+    client.next().await; //skip connect event
 
+    assert_matches!(client.next().await, Some(Event::SubscriptionUpdates(_)));
     assert_matches!(
-        client.events_receiver.recv().await,
-        Some(Event::SubscriptionUpdates(_))
-    );
-    assert_matches!(
-        client.events_receiver.recv().await,
+        client.next().await,
         Some(Event::Publication(ReceivedPublication{payload, ..})) if payload == bytes::Bytes::from("qos 0")
     );
     assert_matches!(
-        client.events_receiver.recv().await,
+        client.next().await,
         Some(Event::Publication(ReceivedPublication{payload, ..})) if payload == bytes::Bytes::from("qos 1")
     );
     assert_matches!(
-        client.events_receiver.recv().await,
+        client.next().await,
         Some(Event::Publication(ReceivedPublication{payload, ..})) if payload == bytes::Bytes::from("qos 2")
     );
 
     client.shutdown().await.expect("couldn't shutdown");
     broker_shutdown.send(()).expect("couldn't shutdown broker");
     client.join().await.expect("can't wait for the client");
+    broker_task
+        .await
+        .unwrap()
+        .expect("can't wait for the broker");
+}
+
+#[tokio::test]
+async fn retained_messages() {
+    let topic_a = "topic/A";
+    let topic_b = "topic/B";
+    let topic_c = "topic/C";
+
+    let broker = BrokerBuilder::default()
+        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
+        .authorizer(|_| Ok(true))
+        .build();
+
+    let (broker_shutdown, broker_task, address) = common::start_server(broker);
+
+    let mut client = TestClientBuilder::new(address)
+        .client_id("mqtt-smoke-tests")
+        .build();
+
+    client
+        .publish(mqtt3::proto::Publication {
+            topic_name: topic_a.into(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: "r qos 0".into(),
+        })
+        .await
+        .expect("couldn't publish");
+
+    client
+        .publish(mqtt3::proto::Publication {
+            topic_name: topic_b.into(),
+            qos: QoS::AtLeastOnce,
+            retain: true,
+            payload: "r qos 1".into(),
+        })
+        .await
+        .expect("couldn't publish");
+
+    client
+        .publish(mqtt3::proto::Publication {
+            topic_name: topic_c.into(),
+            qos: QoS::ExactlyOnce,
+            retain: true,
+            payload: "r qos 2".into(),
+        })
+        .await
+        .expect("couldn't publish");
+
+    client
+        .subscribe(SubscribeTo {
+            topic_filter: "topic/+".into(),
+            qos: QoS::ExactlyOnce,
+        })
+        .await
+        .expect("couldn't subscribe to a topic");
+
+    client.next().await; //skip connect event
+
+    assert_matches!(
+        client.next().await,
+        Some(Event::SubscriptionUpdates(_))
+    );
+
+    let mut shutdown_handle = client.shutdown_handle();
+
+    // read and map 3 expected events from the stream
+    let mut events = client
+        .take(3)
+        .filter_map(|e| async {
+            match e {
+                Event::Publication(publication) => Some((publication.payload, publication.retain)),
+                _ => None,
+            }
+        })
+        .collect::<Vec<_>>()
+        .await;
+
+    // sort by payload for ease of comparison.
+    events.sort_by_key(|e| e.0.clone());
+
+    assert_eq!(3, events.len());
+    assert_eq!(events[0], (bytes::Bytes::from("r qos 0"), true));
+    assert_eq!(events[1], (bytes::Bytes::from("r qos 1"), true));
+    assert_eq!(events[2], (bytes::Bytes::from("r qos 2"), true));
+
+    shutdown_handle.shutdown().await.expect("couldn't shutdown");
+    broker_shutdown.send(()).expect("couldn't shutdown broker");
     broker_task
         .await
         .unwrap()


### PR DESCRIPTION
This PR adds:
- Retained messages test
- Will message test
- TestClient implements Stream