### PR TITLE
Fix broken arm32 build.

### DIFF
--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -82,10 +82,7 @@ where
         // We don't really care about the error here ---
         //   we just want to join the thread handle to get the result
         //   or deal with the panic
-        match rx.await {
-            Ok(_) => (),
-            Err(_) => (),
-        };
+        let _ = rx.await;
 
         // propagate any panics onto the event loop thread
         match handle.join() {

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -82,7 +82,10 @@ where
         // We don't really care about the error here ---
         //   we just want to join the thread handle to get the result
         //   or deal with the panic
-        rx.await.map_or_else(drop, drop);
+        match rx.await {
+            Ok(_) => (),
+            Err(_) => (),
+        };
 
         // propagate any panics onto the event loop thread
         match handle.join() {

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -88,7 +88,10 @@ where
         // We don't really care about the error here ---
         //   we just want to join the thread handle to get the result
         //   or deal with the panic
-        rx.await.map_or_else(drop, drop);
+        match rx.await {
+            Ok(_) => (),
+            Err(_) => (),
+        };
 
         // propagate any panics onto the event loop thread
         match handle.join() {

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -88,10 +88,7 @@ where
         // We don't really care about the error here ---
         //   we just want to join the thread handle to get the result
         //   or deal with the panic
-        match rx.await {
-            Ok(_) => (),
-            Err(_) => (),
-        };
+        let _ = rx.await;
 
         // propagate any panics onto the event loop thread
         match handle.join() {


### PR DESCRIPTION
Our ARM32 mqtt image build fails b/c of the outdated base image toolchain, with error `use of unstable library feature 'result_map_or_else'`.

This is not a proper fix, but rather a temp workaround to make our mqtt images build green. We need to update our build image ASAP.