### PR TITLE
[mqtt] Suspend sender task not block a thread

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -40,6 +40,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da71fef07bc806586090247e971229289f64c210a278ee5ae419314eb386b31d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,16 +269,6 @@ checksum = "a01e15e0ea58e8234f96146b1f91fa9d0e4dd7a38da93ff7a75d42c0b9d3a545"
 dependencies = [
  "cast",
  "itertools 0.8.2",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cced8691919c02aac3cb0a1bc2e9b73d89e832bf9a06fc579d4e71b68a2da061"
-dependencies = [
- "crossbeam-utils",
- "maybe-uninit",
 ]
 
 [[package]]
@@ -747,13 +748,13 @@ dependencies = [
 name = "mqtt-broker"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "atty",
  "bincode",
  "bytes",
  "chrono",
  "config",
  "criterion",
- "crossbeam-channel",
  "fail",
  "flate2",
  "futures",

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -10,7 +10,6 @@ bytes = "0.5"
 chrono = "0.4"
 config = { version = "0.10", default-features = false, features = ["json"] }
 criterion = { version = "0.3", optional = true }
-crossbeam-channel = "0.4"
 fail = "0.3"
 flate2 = "1.0"
 futures = "0.3"
@@ -32,6 +31,7 @@ tracing-futures = "0.2"
 uuid = { version = "0.8", features = ["v4"] }
 
 mqtt3 = { path = "../mqtt3", features = ["serde1"] }
+async-trait = "0.1"
 
 [dev-dependencies]
 atty = "0.2"

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]
+async-trait = "0.1"
 bincode = "1.2"
 bytes = "0.5"
 chrono = "0.4"
@@ -31,7 +32,6 @@ tracing-futures = "0.2"
 uuid = { version = "0.8", features = ["v4"] }
 
 mqtt3 = { path = "../mqtt3", features = ["serde1"] }
-async-trait = "0.1"
 
 [dev-dependencies]
 atty = "0.2"

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -13,7 +13,6 @@ use crate::session::{ConnectedSession, Session, SessionState};
 use crate::{
     subscription::Subscription, AuthId, ClientEvent, ClientId, ConnReq, Error, Message, SystemEvent,
 };
-use futures::StreamExt;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
 static EXPECTED_PROTOCOL_NAME: &str = mqtt3::PROTOCOL_NAME;
@@ -49,7 +48,7 @@ where
     }
 
     pub async fn run(mut self) -> Result<BrokerState, Error> {
-        while let Some(message) = self.messages.next().await {
+        while let Some(message) = self.messages.recv().await {
             match message {
                 Message::Client(client_id, event) => {
                     let span = span!(Level::INFO, "broker", client_id = %client_id, event="client");

--- a/mqtt/mqtt-broker/src/connection.rs
+++ b/mqtt/mqtt-broker/src/connection.rs
@@ -122,7 +122,7 @@ where
                 let req = ConnReq::new(client_id.clone(), connect, certificate, connection_handle);
                 let event = ClientEvent::ConnReq(req);
                 let message = Message::Client(client_id.clone(), event);
-                broker_handle.send(message)?;
+                broker_handle.send(message).await?;
 
                 // Start up the processing tasks
                 let (outgoing, incoming) = codec.split();
@@ -151,7 +151,7 @@ where
                         // task to drain
                         debug!(message = "incoming_task finished with an error. sending drop connection request to broker", error=%e);
                         let msg = Message::Client(client_id.clone(), ClientEvent::DropConnection);
-                        broker_handle.send(msg)?;
+                        broker_handle.send(msg).await?;
 
                         debug!("waiting for outgoing_task to complete...");
                         if let Err((mut recv, e)) = out.await {
@@ -177,7 +177,7 @@ where
 
                         debug!(message = "outgoing_task finished with an error. notifying the broker to remove the connection", %e);
                         let msg = Message::Client(client_id.clone(), ClientEvent::CloseSession);
-                        broker_handle.send(msg)?;
+                        broker_handle.send(msg).await?;
 
                         debug!("draining message receiver for connection...");
                         while let Some(message) = recv.recv().await {
@@ -223,7 +223,7 @@ where
                     Packet::Disconnect(disconnect) => {
                         let event = ClientEvent::Disconnect(disconnect);
                         let message = Message::Client(client_id.clone(), event);
-                        broker.send(message)?;
+                        broker.send(message).await?;
                         debug!("disconnect received. shutting down receive side of connection");
                         return Ok(());
                     }
@@ -241,7 +241,7 @@ where
                 };
 
                 let message = Message::Client(client_id.clone(), event);
-                broker.send(message)?;
+                broker.send(message).await?;
             }
             Err(e) => {
                 warn!(message="error occurred while reading from connection", error=%e);
@@ -252,7 +252,7 @@ where
 
     debug!("no more packets. sending DropConnection to broker.");
     let message = Message::Client(client_id.clone(), ClientEvent::DropConnection);
-    broker.send(message)?;
+    broker.send(message).await?;
     debug!("incoming_task completing...");
     Ok(())
 }
@@ -298,7 +298,7 @@ where
                         return Err((messages, e.into()));
                     } else {
                         let message = Message::Client(client_id.clone(), ClientEvent::PubAck0(id));
-                        if let Err(e) = broker.send(message) {
+                        if let Err(e) = broker.send(message).await {
                             warn!(message = "error occurred while sending QoS ack to broker", error=%e);
                             return Err((messages, e));
                         }

--- a/mqtt/mqtt-broker/src/error.rs
+++ b/mqtt/mqtt-broker/src/error.rs
@@ -8,7 +8,7 @@ use crate::Message;
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("An error occurred sending a message to the broker.")]
-    SendBrokerMessage(#[source] crossbeam_channel::TrySendError<Message>),
+    SendBrokerMessage(#[source] tokio::sync::mpsc::error::SendError<Message>),
 
     #[error("An error occurred sending a message to a connection.")]
     SendConnectionMessage(#[source] tokio::sync::mpsc::error::SendError<Message>),

--- a/mqtt/mqtt-broker/src/persist.rs
+++ b/mqtt/mqtt-broker/src/persist.rs
@@ -9,6 +9,7 @@ use std::os::unix::fs::symlink;
 use std::os::windows::fs::symlink_file;
 use std::path::PathBuf;
 
+use async_trait::async_trait;
 use bytes::Bytes;
 use fail::fail_point;
 use flate2::read::GzDecoder;
@@ -29,26 +30,28 @@ const STATE_DEFAULT_PREVIOUS_COUNT: usize = 2;
 static STATE_DEFAULT_STEM: &str = "state";
 static STATE_EXTENSION: &str = "dat";
 
+#[async_trait]
 pub trait Persist {
     type Error: std::error::Error;
 
-    fn load(&mut self) -> Result<Option<BrokerState>, Self::Error>;
+    async fn load(&mut self) -> Result<Option<BrokerState>, Self::Error>;
 
-    fn store(&mut self, state: BrokerState) -> Result<(), Self::Error>;
+    async fn store(&mut self, state: BrokerState) -> Result<(), Self::Error>;
 }
 
 /// A persistor that does nothing.
 #[derive(Debug)]
 pub struct NullPersistor;
 
+#[async_trait]
 impl Persist for NullPersistor {
     type Error = PersistError;
 
-    fn load(&mut self) -> Result<Option<BrokerState>, Self::Error> {
+    async fn load(&mut self) -> Result<Option<BrokerState>, Self::Error> {
         Ok(None)
     }
 
-    fn store(&mut self, _: BrokerState) -> Result<(), Self::Error> {
+    async fn store(&mut self, _: BrokerState) -> Result<(), Self::Error> {
         Ok(())
     }
 }
@@ -284,182 +287,199 @@ where
     Ok(payloads)
 }
 
+#[async_trait]
 impl<F> Persist for FilePersistor<F>
 where
     F: FileFormat<Error = PersistError> + Clone + Send + 'static,
 {
     type Error = PersistError;
 
-    fn load(&mut self) -> Result<Option<BrokerState>, Self::Error> {
-        let path = self
-            .dir
-            .join(format!("{}.{}", STATE_DEFAULT_STEM, STATE_EXTENSION));
-        let state = if path.exists() {
-            info!("loading state from file {}.", path.display());
+    async fn load(&mut self) -> Result<Option<BrokerState>, Self::Error> {
+        let dir = self.dir.clone();
+        let format = self.format.clone();
 
-            fail_point!("filepersistor.load.fileopen", |_| {
-                Err(PersistError::FileOpen(path.clone(), None))
-            });
-            let file = OpenOptions::new()
-                .read(true)
-                .open(&path)
-                .map_err(|e| PersistError::FileOpen(path.clone(), Some(e)))?;
+        let res = tokio::task::spawn_blocking(move || {
+            let path = dir.join(format!("{}.{}", STATE_DEFAULT_STEM, STATE_EXTENSION));
+            if path.exists() {
+                info!("loading state from file {}.", path.display());
 
-            fail_point!("filepersistor.load.format", |_| {
-                Err(PersistError::Deserialize(None))
-            });
-            let state = self.format.load(file)?;
-            Some(state)
-        } else {
-            info!("no state file found at {}.", path.display());
-            None
-        };
-        Ok(state)
+                fail_point!("filepersistor.load.fileopen", |_| {
+                    Err(PersistError::FileOpen(path.clone(), None))
+                });
+                let file = OpenOptions::new()
+                    .read(true)
+                    .open(&path)
+                    .map_err(|e| PersistError::FileOpen(path.clone(), Some(e)))?;
+
+                fail_point!("filepersistor.load.format", |_| {
+                    Err(PersistError::Deserialize(None))
+                });
+                let state = format.load(file)?;
+                Ok(Some(state))
+            } else {
+                info!("no state file found at {}.", path.display());
+                Ok(None)
+            }
+        })
+        .await;
+
+        fail_point!("filepersistor.load.spawn_blocking", |_| {
+            Err(PersistError::TaskJoin(None))
+        });
+        res.map_err(|e| PersistError::TaskJoin(Some(e)))?
     }
 
     #[allow(clippy::too_many_lines)]
-    fn store(&mut self, state: BrokerState) -> Result<(), Self::Error> {
+    async fn store(&mut self, state: BrokerState) -> Result<(), Self::Error> {
+        let dir = self.dir.clone();
+        let format = self.format.clone();
         let previous_count = self.previous_count;
 
         self.seq = self.seq.wrapping_add(1);
         let seq = self.seq;
 
-        let span = span!(Level::INFO, "persistor", dir = %self.dir.display());
-        let _guard = span.enter();
+        let res = tokio::task::spawn_blocking(move || {
+            let span = span!(Level::INFO, "persistor", dir = %dir.display());
+            let _guard = span.enter();
 
-        if !self.dir.exists() {
-            fail_point!("filepersistor.store.createdir", |_| {
-                Err(PersistError::CreateDir(self.dir.clone(), None))
+            if !dir.exists() {
+                fail_point!("filepersistor.store.createdir", |_| {
+                    Err(PersistError::CreateDir(dir.clone(), None))
+                });
+                fs::create_dir_all(&dir)
+                    .map_err(|e| PersistError::CreateDir(dir.clone(), Some(e)))?;
+            }
+
+            let link_path = dir.join(format!("{}.{}", STATE_DEFAULT_STEM, STATE_EXTENSION));
+            let temp_link_path =
+                dir.join(format!("{}.{}.tmp", STATE_DEFAULT_STEM, STATE_EXTENSION));
+
+            let path = dir.join(format!(
+                "{}.{}-{:05}.{}",
+                STATE_DEFAULT_STEM,
+                chrono::Utc::now().format("%Y%m%d%H%M%S%3f"),
+                seq,
+                STATE_EXTENSION
+            ));
+
+            info!(message="persisting state...", file=%path.display());
+            debug!("opening {} for writing state...", path.display());
+            fail_point!("filepersistor.store.fileopen", |_| {
+                Err(PersistError::FileOpen(path.clone(), None))
             });
-            fs::create_dir_all(&self.dir)
-                .map_err(|e| PersistError::CreateDir(self.dir.clone(), Some(e)))?;
-        }
+            let file = OpenOptions::new()
+                .create(true)
+                .write(true)
+                .open(&path)
+                .map_err(|e| PersistError::FileOpen(path.clone(), Some(e)))?;
+            debug!("{} opened.", path.display());
 
-        let link_path = self
-            .dir
-            .join(format!("{}.{}", STATE_DEFAULT_STEM, STATE_EXTENSION));
-        let temp_link_path = self
-            .dir
-            .join(format!("{}.{}.tmp", STATE_DEFAULT_STEM, STATE_EXTENSION));
+            debug!("persisting state to {}...", path.display());
+            match format.store(file, state) {
+                Ok(_) => {
+                    debug!("state persisted to {}.", path.display());
 
-        let path = self.dir.join(format!(
-            "{}.{}-{:05}.{}",
-            STATE_DEFAULT_STEM,
-            chrono::Utc::now().format("%Y%m%d%H%M%S%3f"),
-            seq,
-            STATE_EXTENSION
-        ));
+                    // Swap the symlink
+                    //   - remove the old link if it exists
+                    //   - link the new file
+                    if temp_link_path.exists() {
+                        fail_point!("filepersistor.store.symlink_unlink", |_| {
+                            Err(PersistError::SymlinkUnlink(temp_link_path.clone(), None))
+                        });
+                        fs::remove_file(&temp_link_path).map_err(|e| {
+                            PersistError::SymlinkUnlink(temp_link_path.clone(), Some(e))
+                        })?;
+                    }
 
-        info!(message="persisting state...", file=%path.display());
-        debug!("opening {} for writing state...", path.display());
-        fail_point!("filepersistor.store.fileopen", |_| {
-            Err(PersistError::FileOpen(path.clone(), None))
-        });
-        let file = OpenOptions::new()
-            .create(true)
-            .write(true)
-            .open(&path)
-            .map_err(|e| PersistError::FileOpen(path.clone(), Some(e)))?;
-        debug!("{} opened.", path.display());
+                    debug!("linking {} to {}", temp_link_path.display(), path.display());
 
-        debug!("persisting state to {}...", path.display());
-        match self.format.store(file, state) {
-            Ok(_) => {
-                debug!("state persisted to {}.", path.display());
-
-                // Swap the symlink
-                //   - remove the old link if it exists
-                //   - link the new file
-                if temp_link_path.exists() {
-                    fail_point!("filepersistor.store.symlink_unlink", |_| {
-                        Err(PersistError::SymlinkUnlink(temp_link_path.clone(), None))
+                    fail_point!("filepersistor.store.symlink", |_| {
+                        Err(PersistError::Symlink(
+                            temp_link_path.clone(),
+                            path.clone(),
+                            None,
+                        ))
                     });
-                    fs::remove_file(&temp_link_path).map_err(|e| {
-                        PersistError::SymlinkUnlink(temp_link_path.clone(), Some(e))
+
+                    #[cfg(unix)]
+                    symlink(&path, &temp_link_path).map_err(|e| {
+                        PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
                     })?;
-                }
 
-                debug!("linking {} to {}", temp_link_path.display(), path.display());
+                    #[cfg(windows)]
+                    symlink_file(&path, &temp_link_path).map_err(|e| {
+                        PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
+                    })?;
 
-                fail_point!("filepersistor.store.symlink", |_| {
-                    Err(PersistError::Symlink(
-                        temp_link_path.clone(),
-                        path.clone(),
-                        None,
-                    ))
-                });
-
-                #[cfg(unix)]
-                symlink(&path, &temp_link_path).map_err(|e| {
-                    PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
-                })?;
-
-                #[cfg(windows)]
-                symlink_file(&path, &temp_link_path).map_err(|e| {
-                    PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
-                })?;
-
-                // Commit the updated link by renaming the temp link.
-                // This is the so-called "capistrano" trick for atomically updating links
-                // https://github.com/capistrano/capistrano/blob/d04c1e3ea33e84b183d056b71c7cacf7744ce7ad/lib/capistrano/tasks/deploy.rake
-                fail_point!("filepersistor.store.filerename", |_| {
-                    Err(PersistError::FileRename(
-                        temp_link_path.clone(),
-                        path.clone(),
-                        None,
-                    ))
-                });
-                fs::rename(&temp_link_path, &link_path).map_err(|e| {
-                    PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
-                })?;
-
-                // Prune old states
-                fail_point!("filepersistor.store.readdir", |_| {
-                    Err(PersistError::ReadDir(self.dir.clone(), None))
-                });
-
-                let mut entries = fs::read_dir(&self.dir)
-                    .map_err(|e| (PersistError::ReadDir(self.dir.clone(), Some(e))))?
-                    .filter_map(Result::ok)
-                    .filter(|entry| entry.file_type().ok().map_or(false, |f| f.is_file()))
-                    .filter(|entry| {
-                        entry
-                            .file_name()
-                            .to_string_lossy()
-                            .starts_with(STATE_DEFAULT_STEM)
-                    })
-                    .collect::<Vec<fs::DirEntry>>();
-
-                entries.sort_unstable_by(|a, b| {
-                    b.file_name()
-                        .partial_cmp(&a.file_name())
-                        .unwrap_or(cmp::Ordering::Equal)
-                });
-
-                for entry in entries.iter().skip(previous_count) {
-                    debug!(
-                        "pruning old state file {}...",
-                        entry.file_name().to_string_lossy()
-                    );
-
-                    fail_point!("filepersistor.store.entry_unlink", |_| {
-                        Err(PersistError::FileUnlink(entry.path(), None))
+                    // Commit the updated link by renaming the temp link.
+                    // This is the so-called "capistrano" trick for atomically updating links
+                    // https://github.com/capistrano/capistrano/blob/d04c1e3ea33e84b183d056b71c7cacf7744ce7ad/lib/capistrano/tasks/deploy.rake
+                    fail_point!("filepersistor.store.filerename", |_| {
+                        Err(PersistError::FileRename(
+                            temp_link_path.clone(),
+                            path.clone(),
+                            None,
+                        ))
                     });
-                    fs::remove_file(&entry.path())
-                        .map_err(|e| PersistError::FileUnlink(entry.path(), Some(e)))?;
-                    debug!("{} pruned.", entry.file_name().to_string_lossy());
+                    fs::rename(&temp_link_path, &link_path).map_err(|e| {
+                        PersistError::Symlink(temp_link_path.clone(), path.clone(), Some(e))
+                    })?;
+
+                    // Prune old states
+                    fail_point!("filepersistor.store.readdir", |_| {
+                        Err(PersistError::ReadDir(dir.clone(), None))
+                    });
+
+                    let mut entries = fs::read_dir(&dir)
+                        .map_err(|e| (PersistError::ReadDir(dir.clone(), Some(e))))?
+                        .filter_map(Result::ok)
+                        .filter(|entry| entry.file_type().ok().map_or(false, |f| f.is_file()))
+                        .filter(|entry| {
+                            entry
+                                .file_name()
+                                .to_string_lossy()
+                                .starts_with(STATE_DEFAULT_STEM)
+                        })
+                        .collect::<Vec<fs::DirEntry>>();
+
+                    entries.sort_unstable_by(|a, b| {
+                        b.file_name()
+                            .partial_cmp(&a.file_name())
+                            .unwrap_or(cmp::Ordering::Equal)
+                    });
+
+                    for entry in entries.iter().skip(previous_count) {
+                        debug!(
+                            "pruning old state file {}...",
+                            entry.file_name().to_string_lossy()
+                        );
+
+                        fail_point!("filepersistor.store.entry_unlink", |_| {
+                            Err(PersistError::FileUnlink(entry.path(), None))
+                        });
+                        fs::remove_file(&entry.path())
+                            .map_err(|e| PersistError::FileUnlink(entry.path(), Some(e)))?;
+                        debug!("{} pruned.", entry.file_name().to_string_lossy());
+                    }
+                }
+                Err(e) => {
+                    fail_point!("filepersistor.store.new_file_unlink", |_| {
+                        Err(PersistError::FileUnlink(path.clone(), None))
+                    });
+                    fs::remove_file(&path)
+                        .map_err(|e| (PersistError::FileUnlink(path, Some(e))))?;
+                    return Err(e);
                 }
             }
-            Err(e) => {
-                fail_point!("filepersistor.store.new_file_unlink", |_| {
-                    Err(PersistError::FileUnlink(path.clone(), None))
-                });
-                fs::remove_file(&path).map_err(|e| (PersistError::FileUnlink(path, Some(e))))?;
-                return Err(e);
-            }
-        }
-        info!(message="persisted state.", file=%path.display());
-        Ok(())
+            info!(message="persisted state.", file=%path.display());
+            Ok(())
+        })
+        .await;
+
+        fail_point!("filepersistor.load.spawn_blocking", |_| {
+            Err(PersistError::TaskJoin(None))
+        });
+        res.map_err(|e| PersistError::TaskJoin(Some(e)))?
     }
 }
 
@@ -553,8 +573,8 @@ pub(crate) mod tests {
         let path = tmp_dir.path().to_owned();
         let mut persistor = FilePersistor::new(path, ConsolidatedStateFormat::default());
 
-        persistor.store(BrokerState::default()).unwrap();
-        let state = persistor.load().unwrap().unwrap();
+        persistor.store(BrokerState::default()).await.unwrap();
+        let state = persistor.load().await.unwrap().unwrap();
         assert_eq!(BrokerState::default(), state);
     }
 }

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -82,7 +82,7 @@ where
                         }
 
                         debug!("sending Shutdown message to broker");
-                        handle.send(Message::System(SystemEvent::Shutdown))?;
+                        handle.send(Message::System(SystemEvent::Shutdown)).await?;
                         broker_task.await?
                     }
                     Either::Left((broker_state, incoming_tasks)) => {
@@ -118,7 +118,7 @@ where
                     let mut results = vec![result];
                     results.extend(future::join_all(unfinished_incoming_tasks).await);
 
-                    handle.send(Message::System(SystemEvent::Shutdown))?;
+                    handle.send(Message::System(SystemEvent::Shutdown)).await?;
 
                     let broker_state = broker_task.await;
 

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -42,7 +42,7 @@ pub struct Snapshotter<P> {
 
 impl<P> Snapshotter<P> {
     pub fn new(persistor: P) -> Self {
-        let (sender, events) = mpsc::channel(1024);
+        let (sender, events) = mpsc::channel(5);
         Snapshotter {
             persistor,
             sender,

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -1,12 +1,10 @@
-use std::{panic, thread};
-
-use crossbeam_channel::{Receiver, Sender};
-use tracing::{error, info, warn};
+use tokio::sync::mpsc::{self, Receiver, Sender};
+use tracing::{info, warn};
 
 use crate::persist::Persist;
 use crate::{BrokerState, Error};
 
-pub(crate) enum Event {
+enum Event {
     State(BrokerState),
     Shutdown,
 }
@@ -17,8 +15,8 @@ pub struct StateSnapshotHandle(Sender<Event>);
 impl StateSnapshotHandle {
     pub fn try_send(&mut self, state: BrokerState) -> Result<(), Error> {
         self.0
-            .send(Event::State(state))
-            .map_err(|_e| Error::SendSnapshotMessage)?;
+            .try_send(Event::State(state))
+            .map_err(|_| Error::SendSnapshotMessage)?;
         Ok(())
     }
 }
@@ -27,10 +25,11 @@ impl StateSnapshotHandle {
 pub struct ShutdownHandle(Sender<Event>);
 
 impl ShutdownHandle {
-    pub fn try_shutdown(&mut self) -> Result<(), Error> {
+    pub async fn shutdown(&mut self) -> Result<(), Error> {
         self.0
             .send(Event::Shutdown)
-            .map_err(|_e| Error::SendSnapshotMessage)?;
+            .await
+            .map_err(|_| Error::SendSnapshotMessage)?;
         Ok(())
     }
 }
@@ -43,7 +42,7 @@ pub struct Snapshotter<P> {
 
 impl<P> Snapshotter<P> {
     pub fn new(persistor: P) -> Self {
-        let (sender, events) = crossbeam_channel::bounded(5);
+        let (sender, events) = mpsc::channel(1024);
         Snapshotter {
             persistor,
             sender,
@@ -62,46 +61,13 @@ impl<P> Snapshotter<P> {
 
 impl<P> Snapshotter<P>
 where
-    P: Persist + Send + 'static,
+    P: Persist,
 {
-    pub async fn run(self) -> Result<P, Error> {
-        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
-
-        let handle = thread::Builder::new()
-            .name("mqtt::snapshotter".to_string())
-            .spawn(|| {
-                let persist = self.snapshotter_loop();
-                if let Err(_e) = tx.send(()) {
-                    error!(
-                        "failed to signal the event loop that the snapshotter thread is exiting"
-                    );
-                }
-                persist
-            })
-            .expect("failed to spawn snapshotter thread");
-
-        // Wait for the thread to exit
-        // This rx will complete for two reasons:
-        //   1. The thread gracefully shutdown
-        //   2. The thread panicked and the tx was dropped.
-        //
-        // We don't really care about the error here ---
-        //   we just want to join the thread handle to get the result
-        //   or deal with the panic
-        let _ = rx.await;
-
-        // propagate any panics onto the event loop thread
-        match handle.join() {
-            Ok(persist) => Ok(persist),
-            Err(e) => panic::resume_unwind(e),
-        }
-    }
-
-    fn snapshotter_loop(mut self) -> P {
-        while let Ok(event) = self.events.recv() {
+    pub async fn run(mut self) -> P {
+        while let Some(event) = self.events.recv().await {
             match event {
                 Event::State(state) => {
-                    if let Err(e) = self.persistor.store(state) {
+                    if let Err(e) = self.persistor.store(state).await {
                         warn!(message = "an error occurred persisting state snapshot.", error=%e);
                     }
                 }

--- a/mqtt/mqttd/src/main.rs
+++ b/mqtt/mqttd/src/main.rs
@@ -40,7 +40,7 @@ async fn run() -> Result<(), Error> {
         ConsolidatedStateFormat::default(),
     );
     info!("Loading state...");
-    let state = persistor.load()?.unwrap_or_else(BrokerState::default);
+    let state = persistor.load().await?.unwrap_or_else(BrokerState::default);
     let broker = BrokerBuilder::default()
         .authenticator(|_| Ok(Some(AuthId::Anonymous)))
         .authorizer(|_| Ok(true))
@@ -78,12 +78,12 @@ async fn run() -> Result<(), Error> {
         .await?;
 
     // Stop snapshotting
-    shutdown_handle.try_shutdown()?;
-    let mut persistor = join_handle.await??;
+    shutdown_handle.shutdown().await?;
+    let mut persistor = join_handle.await?;
     info!("state snapshotter shutdown.");
 
     info!("persisting state before exiting...");
-    persistor.store(state)?;
+    persistor.store(state).await?;
     info!("state persisted.");
     info!("exiting... goodbye");
 

--- a/mqtt/mqttd/src/main.rs
+++ b/mqtt/mqttd/src/main.rs
@@ -100,9 +100,12 @@ async fn tick_snapshot(
     let mut interval = tokio::time::interval_at(start, period);
     loop {
         interval.tick().await;
-        if let Err(e) = broker_handle.try_send(Message::System(SystemEvent::StateSnapshot(
-            snapshot_handle.clone(),
-        ))) {
+        if let Err(e) = broker_handle
+            .send(Message::System(SystemEvent::StateSnapshot(
+                snapshot_handle.clone(),
+            )))
+            .await
+        {
             warn!(message = "failed to tick the snapshotter", error=%e);
         }
     }

--- a/mqtt/mqttd/src/snapshot.rs
+++ b/mqtt/mqttd/src/snapshot.rs
@@ -28,9 +28,12 @@ mod imp {
         loop {
             stream.recv().await;
             info!("Received signal USR1");
-            if let Err(e) = broker_handle.send(Message::System(SystemEvent::StateSnapshot(
-                snapshot_handle.clone(),
-            ))) {
+            if let Err(e) = broker_handle
+                .send(Message::System(SystemEvent::StateSnapshot(
+                    snapshot_handle.clone(),
+                )))
+                .await
+            {
                 warn!(message = "failed to signal the snapshotter", error=%e);
             }
         }


### PR DESCRIPTION
Performance tests showed that we have performance degradation introduced with #2842 PR. This changed introduced `crossbeam_channel` dependency that implements sync blocking operations for both sender and receiver parts.
Synchronous blocking operations allows broker to run in separate native thread with receiver. Under a high-load when broker channel got filled with events and **all threads** in the tokio thread-pool got blocked on `channel.send()` operation. 

This PR reverts some changes introduced #2842 for work with broker channel. It uses `tokio::sync::mpsc` channel instead that blocks **tasks** that run on tokio thread pool instead of whole thread. Broker main loop is spawned as a separate task but all operations within broker iteration and sync now.

Performance tests show improvements with new changes.