### PR TITLE
Allow and validate EdgeHub deployment schema version 1.1.0

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
@@ -24,6 +24,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public const string SecurityMessageIoTHubInterfaceId = "urn:azureiot:Security:SecurityAgent:1";
 
-        public static readonly Version ConfigSchemaVersion = new Version("1.0");
+        public static readonly Version ConfigSchemaVersion = new Version("1.1.0");
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubConfigParser.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubConfigParser.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
         {
             Preconditions.CheckNotNull(desiredProperties, nameof(desiredProperties));
 
-            ValidateSchemaVersion(desiredProperties.SchemaVersion);
-
             var routes = new Dictionary<string, RouteConfig>();
             if (desiredProperties.Routes != null)
             {
@@ -36,16 +34,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
             }
 
             return new EdgeHubConfig(desiredProperties.SchemaVersion, new ReadOnlyDictionary<string, RouteConfig>(routes), desiredProperties.StoreAndForwardConfiguration);
-        }
-
-        internal static void ValidateSchemaVersion(string schemaVersion)
-        {
-            if (Core.Constants.ConfigSchemaVersion.CompareMajorVersion(schemaVersion, "desired properties schema") != 0)
-            {
-                Log.LogWarning(
-                    HubCoreEventIds.EdgeHubConfigParser,
-                    $"Desired properties schema version {schemaVersion} does not match expected schema version {Core.Constants.ConfigSchemaVersion}. Some settings may not be supported.");
-            }
         }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubDesiredProperties.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubDesiredProperties.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
@@ -13,6 +14,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
             this.SchemaVersion = Preconditions.CheckNonWhiteSpace(schemaVersion, nameof(schemaVersion));
             this.Routes = Preconditions.CheckNotNull(routes, nameof(routes));
             this.StoreAndForwardConfiguration = Preconditions.CheckNotNull(storeAndForwardConfiguration, nameof(storeAndForwardConfiguration));
+
+            this.ValidateSchemaVersion();
         }
 
         public string SchemaVersion { get; }
@@ -21,5 +24,48 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
         public IDictionary<string, RouteConfiguration> Routes;
 
         public StoreAndForwardConfiguration StoreAndForwardConfiguration { get; }
+
+        internal void ValidateSchemaVersion()
+        {
+            if (string.IsNullOrWhiteSpace(this.SchemaVersion) || !Version.TryParse(this.SchemaVersion, out Version version))
+            {
+                throw new InvalidSchemaVersionException($"Invalid deployment schema version {this.SchemaVersion}");
+            }
+
+            // Check major version and upper bound
+            if (version.Major != Core.Constants.ConfigSchemaVersion.Major ||
+                version > Core.Constants.ConfigSchemaVersion)
+            {
+                throw new InvalidSchemaVersionException($"The deployment schema version {this.SchemaVersion} is not compatible with the expected version {Core.Constants.ConfigSchemaVersion}");
+            }
+
+            // Validate minor versions
+            if (version.Minor == 0)
+            {
+                // 1.0
+                //
+                // Routes cannot have priority or TTL
+                foreach (KeyValuePair<string, RouteConfiguration> kvp in this.Routes)
+                {
+                    RouteConfiguration route = kvp.Value;
+
+                    if (route.Priority != Routing.EdgeRouteFactory.DefaultPriority ||
+                        route.TimeToLiveSecs != 0)
+                    {
+                        throw new InvalidSchemaVersionException($"Route priority/TTL is not supported in schema {this.SchemaVersion}.");
+                    }
+                }
+            }
+            else if (version.Minor == 1)
+            {
+                // 1.1.0
+                //
+                // Everything from 1.0 is supported
+            }
+            else
+            {
+                throw new InvalidSchemaVersionException($"The deployment schema version {this.SchemaVersion} is not compatible with the expected version {Core.Constants.ConfigSchemaVersion}");
+            }
+        }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/EdgeHubConnectionTest.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     using System.Net;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.CloudProxy;
-    using Microsoft.Azure.Devices.Edge.Hub.Core.Config;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Routing;
@@ -23,29 +22,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     [Unit]
     public class EdgeHubConnectionTest
     {
-        [Theory]
-        [InlineData("1.0", null)]
-        [InlineData("1.1", null)]
-        [InlineData("1.2", null)]
-        [InlineData("1.3", null)]
-        [InlineData("1", typeof(InvalidSchemaVersionException))]
-        [InlineData("", typeof(InvalidSchemaVersionException))]
-        [InlineData(null, typeof(InvalidSchemaVersionException))]
-        [InlineData("0.1", typeof(InvalidSchemaVersionException))]
-        [InlineData("2.0", typeof(InvalidSchemaVersionException))]
-        [InlineData("2.1", typeof(InvalidSchemaVersionException))]
-        public void SchemaVersionCheckTest(string schemaVersion, Type expectedException)
-        {
-            if (expectedException != null)
-            {
-                Assert.Throws(expectedException, () => EdgeHubConfigParser.ValidateSchemaVersion(schemaVersion));
-            }
-            else
-            {
-                EdgeHubConfigParser.ValidateSchemaVersion(schemaVersion);
-            }
-        }
-
         [Fact]
         public async Task HandleMethodInvocationTest()
         {


### PR DESCRIPTION
This change updates the edgeHub deployment schema version to 1.1.0, which is the new version containing the route priority and TTL changes.