### PR TITLE
Fix windows e2e PQ tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -32,6 +32,11 @@ namespace Microsoft.Azure.Devices.Edge.Test
         [Test]
         public async Task PriorityQueueModuleToModuleMessages()
         {
+            if (!OsPlatform.Is64Bit())
+            {
+                Assert.Ignore("Priority Queue module to module messages test has been disabled for Arm32 until we can fix it.");
+            }
+
             CancellationToken token = this.TestToken;
             string trcImage = Context.Current.TestResultCoordinatorImage.Expect(() => new ArgumentException("testResultCoordinatorImage parameter is required for Priority Queues test"));
             string loadGenImage = Context.Current.LoadGenImage.Expect(() => new ArgumentException("loadGenImage parameter is required for Priority Queues test"));
@@ -52,9 +57,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
         public async Task PriorityQueueTimeToLive()
         {
             // TODO: Fix PriorityQueue TTL E2E tests for Windows and ARM32
-            if (OsPlatform.IsWindows() || !OsPlatform.Is64Bit())
+            if (!OsPlatform.Is64Bit())
             {
-                Assert.Ignore("Priority Queue time to live test has been disabled for Windows and Arm32 until we can fix it.");
+                Assert.Ignore("Priority Queue time to live test has been disabled for Arm32 until we can fix it.");
             }
 
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -32,12 +32,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
         [Test]
         public async Task PriorityQueueModuleToModuleMessages()
         {
-            // TODO: Fix PriorityQueue E2E tests for Windows and ARM32
-            if (OsPlatform.IsWindows() || !OsPlatform.Is64Bit() )
-            {
-                Assert.Ignore("Priority Queue module to module messages test has been disabled for Windows and Arm32 until we can fix it.");
-            }
-
             CancellationToken token = this.TestToken;
             string trcImage = Context.Current.TestResultCoordinatorImage.Expect(() => new ArgumentException("testResultCoordinatorImage parameter is required for Priority Queues test"));
             string loadGenImage = Context.Current.LoadGenImage.Expect(() => new ArgumentException("loadGenImage parameter is required for Priority Queues test"));

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     [EndToEnd]
     public class PriorityQueues : SasManualProvisioningFixture
     {
-        const string TrcModuleName = "testResultCoordinator";
+        const string TrcModuleName = "testresultroordinator";
         const string LoadGenModuleName = "loadGenModule";
         const string RelayerModuleName = "relayerModule";
         const string TrcUrl = "http://" + TrcModuleName + ":5001";

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     [EndToEnd]
     public class PriorityQueues : SasManualProvisioningFixture
     {
-        const string TrcModuleName = "testresultroordinator";
+        const string TrcModuleName = "testresultcoordinator";
         const string LoadGenModuleName = "loadGenModule";
         const string RelayerModuleName = "relayerModule";
         const string TrcUrl = "http://" + TrcModuleName + ":5001";

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             this.TestResultCoordinatorImage = Option.Maybe(Get("testResultCoordinatorImage"));
             this.LoadGenImage = Option.Maybe(Get("loadGenImage"));
             this.RelayerImage = Option.Maybe(Get("relayerImage"));
-            this.TestTimeout = TimeSpan.FromMinutes(context.GetValue("testTimeoutMinutes", 8));
+            this.TestTimeout = TimeSpan.FromMinutes(context.GetValue("testTimeoutMinutes", 5));
             this.Verbose = context.GetValue<bool>("verbose");
         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             this.TestResultCoordinatorImage = Option.Maybe(Get("testResultCoordinatorImage"));
             this.LoadGenImage = Option.Maybe(Get("loadGenImage"));
             this.RelayerImage = Option.Maybe(Get("relayerImage"));
-            this.TestTimeout = TimeSpan.FromMinutes(context.GetValue("testTimeoutMinutes", 5));
+            this.TestTimeout = TimeSpan.FromMinutes(context.GetValue("testTimeoutMinutes", 8));
             this.Verbose = context.GetValue<bool>("verbose");
         }
 

--- a/test/modules/Relayer/Program.cs
+++ b/test/modules/Relayer/Program.cs
@@ -7,7 +7,6 @@ namespace Relayer
     using System.Linq;
     using System.Net;
     using System.Net.NetworkInformation;
-    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -174,7 +173,7 @@ namespace Relayer
             string uri = Settings.Current.TestResultCoordinatorUrl;
             string pingMe = uri.Substring(uri.LastIndexOf('/') + 1).Split(':')[0];
             Logger.LogInformation($"Sending ping to this: {pingMe}");
-            ExecuteWithRetry(() => ping.Send(pingMe), RetryingPing);
+            ExecuteWithRetry(() => ping.Send(pingMe), RetryingPing); 
         }
 
         static void ExecuteWithRetry(Action act, Action<RetryingEventArgs> onRetry)

--- a/test/modules/Relayer/Relayer.csproj
+++ b/test/modules/Relayer/Relayer.csproj
@@ -32,6 +32,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\edge-util\src\Microsoft.Azure.Devices.Edge.Util\Microsoft.Azure.Devices.Edge.Util.csproj" />
+    <ProjectReference Include="..\..\Microsoft.Azure.Devices.Edge.Test.Common\Microsoft.Azure.Devices.Edge.Test.Common.csproj" />
     <ProjectReference Include="..\ModuleLib\Microsoft.Azure.Devices.Edge.ModuleUtil.csproj" />
   </ItemGroup>
 

--- a/test/modules/Relayer/Settings.cs
+++ b/test/modules/Relayer/Settings.cs
@@ -17,7 +17,7 @@ namespace Relayer
             TransportType transportType,
             string inputName,
             string outputName,
-            Uri testResultCoordinatorUrl,
+            string testResultCoordinatorUrl,
             string moduleId,
             bool receiveOnly,
             Option<int> uniqueResultsExpected)
@@ -46,7 +46,7 @@ namespace Relayer
                 configuration.GetValue("transportType", TransportType.Amqp_Tcp_Only),
                 configuration.GetValue("inputName", "input1"),
                 configuration.GetValue("outputName", "output1"),
-                configuration.GetValue<Uri>("testResultCoordinatorUrl", new Uri("http://testresultcoordinator:5001")),
+                configuration.GetValue("testResultCoordinatorUrl", "http://testresultcoordinator:5001"),
                 configuration.GetValue<string>("IOTEDGE_MODULEID"),
                 configuration.GetValue<bool>("receiveOnly", false),
                 uniqueResultsExpected);
@@ -58,7 +58,7 @@ namespace Relayer
 
         public string OutputName { get; }
 
-        public Uri TestResultCoordinatorUrl { get; }
+        public string TestResultCoordinatorUrl { get; }
 
         public string ModuleId { get; }
 
@@ -75,7 +75,7 @@ namespace Relayer
                 { nameof(this.OutputName), this.OutputName },
                 { nameof(this.ModuleId), this.ModuleId },
                 { nameof(this.TransportType), Enum.GetName(typeof(TransportType), this.TransportType) },
-                { nameof(this.TestResultCoordinatorUrl), this.TestResultCoordinatorUrl.ToString() },
+                { nameof(this.TestResultCoordinatorUrl), this.TestResultCoordinatorUrl },
                 { nameof(this.ReceiveOnly), this.ReceiveOnly.ToString() }
             };
 

--- a/test/modules/load-gen/PriorityMessageSender.cs
+++ b/test/modules/load-gen/PriorityMessageSender.cs
@@ -112,13 +112,6 @@ namespace LoadGen
             // Need to add 1 for the first sequence number, since it is a special case that we omitted in the expectedSequenceNumberList.
             this.resultsSent = expectedSequenceNumberList.Count + 1;
 
-            // For Windows, module to module direct communication doesn't work unless we ping from inside the docker container first
-            // TODO: Investigate why this is happening and remove this workaround. It could be a DNS caching issue
-            if (OsPlatform.IsWindows())
-            {
-                this.SendPing();
-            }
-
             // See explanation above why we need to send sequence number 1 as the first expected value.
             await this.ReportResult(1);
 
@@ -130,30 +123,6 @@ namespace LoadGen
             }
 
             this.isFinished = true;
-        }
-
-        void SendPing()
-        {
-            Ping ping = new Ping();
-            Settings.Current.TestResultCoordinatorUrl.ForEach(
-                url =>
-                {
-                    string pingMe = url.Substring(url.LastIndexOf('/') + 1).Split(':')[0];
-                    this.Logger.LogInformation($"Sending ping to this: {pingMe}");
-                    ExecuteWithRetry(() => ping.Send(pingMe), RetryingPing, this.Logger);
-                });
-        }
-
-        static void ExecuteWithRetry(Action act, Action<RetryingEventArgs, ILogger> onRetry, ILogger logger)
-        {
-            var transientRetryPolicy = RetryPolicy.DefaultExponential;
-            transientRetryPolicy.Retrying += (_, args) => onRetry(args, logger);
-            transientRetryPolicy.ExecuteAction(act);
-        }
-
-        static void RetryingPing(RetryingEventArgs retryingEventArgs, ILogger logger)
-        {
-            logger.LogDebug($"Retrying Ping {retryingEventArgs.CurrentRetryCount} times because of error - {retryingEventArgs.LastException}");
         }
 
         private async Task SetIsFinishedDirectMethodAsync()

--- a/test/modules/load-gen/Program.cs
+++ b/test/modules/load-gen/Program.cs
@@ -33,7 +33,8 @@ namespace LoadGen
                     Settings.Current.TransportType,
                     ModuleUtil.DefaultTimeoutErrorDetectionStrategy,
                     ModuleUtil.DefaultTransientRetryStrategy,
-                    Logger);
+                    Logger,
+                    10);
 
                 Logger.LogInformation($"Load gen delay start for {Settings.Current.TestStartDelay}.");
                 await Task.Delay(Settings.Current.TestStartDelay);

--- a/test/modules/load-gen/load-gen.csproj
+++ b/test/modules/load-gen/load-gen.csproj
@@ -35,6 +35,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\edge-util\src\Microsoft.Azure.Devices.Edge.Util\Microsoft.Azure.Devices.Edge.Util.csproj" />
+    <ProjectReference Include="..\..\Microsoft.Azure.Devices.Edge.Test.Common\Microsoft.Azure.Devices.Edge.Test.Common.csproj" />
     <ProjectReference Include="..\ModuleLib\Microsoft.Azure.Devices.Edge.ModuleUtil.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
The PQ e2e tests fail for windows currently. 
This is because whenever the modules try to talk to each other, they are unable because they can't find the URI. 
When I was investigating, I tried Pinging from inside the docker container to see what the issue was. Simply by pinging the testresultcoordinator from inside the docker container kickstarted the container to be able to talk to the testresultcoordinator with its name. It probably resolved the hostname, and updated a cache. We've seen DNS caching issues on Windows before for hostnames of docker containers.

So I added a Ping workaround in the e2e tests that will ping TRC on windows before reporting any results. This makes the tests pass. Less than ideal, so we should eventually figure out the root cause of why DNS resolution isn't working correctly on Windows containers.