### PR TITLE
Update Windows AMD64 base image to version 2.1.17-nanoserver-1809

### DIFF
--- a/edge-agent/docker/windows/amd64/Dockerfile
+++ b/edge-agent/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 USER ContainerAdministrator

--- a/edge-hub/docker/windows/amd64/Dockerfile
+++ b/edge-hub/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodCloudSender/docker/windows/amd64/Dockerfile
+++ b/edge-modules/DirectMethodCloudSender/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
+++ b/edge-modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodSender/docker/windows/amd64/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/ModuleRestarter/docker/windows/amd64/Dockerfile
+++ b/edge-modules/ModuleRestarter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.10-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TemperatureFilter/docker/windows/amd64/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TestAnalyzer/docker/windows/amd64/Dockerfile
+++ b/edge-modules/TestAnalyzer/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TwinTester/docker/windows/amd64/Dockerfile
+++ b/edge-modules/TwinTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/load-gen/docker/windows/amd64/Dockerfile
+++ b/edge-modules/load-gen/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.15-nanoserver-1809
+ARG base_tag=2.1.17-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.


### PR DESCRIPTION
Update Windows AMD64 base image to version 2.1.17-nanoserver-1809