### PR TITLE
[k8s] throw exception on watch error.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEnvironmentOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEnvironmentOperator.cs
@@ -69,7 +69,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
                         // kick off a new watch
                         this.StartListPods();
                     },
-                    onError: Events.PodWatchFailed));
+                    onError: (ex) =>
+                    {
+                        Events.PodWatchFailed(ex);
+                        throw ex;
+                    }));
         }
 
         void HandlePodChangedAsync(WatchEventType type, V1Pod pod)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentOperator.cs
@@ -73,7 +73,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
                         // kick off a new watch
                         this.StartListEdgeDeployments();
                     },
-                    onError: Events.EdgeDeploymentWatchFailed));
+                    onError: (ex) =>
+                    {
+                        Events.EdgeDeploymentWatchFailed(ex);
+                        throw ex;
+                    }));
         }
 
         internal async Task EdgeDeploymentOnEventHandlerAsync(WatchEventType type, EdgeDeploymentDefinition item)


### PR DESCRIPTION
When we actually got an error from the watch, the watch stops and does not restart.

Throw an error and let Agent recover from crash.