### PR TITLE
[k8s] Default Service protocol to "TCP"

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/PortAndProtocolTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/PortAndProtocolTest.cs
@@ -31,9 +31,26 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void UnableToParseInvalidPort()
         {
-            var result = PortAndProtocol.Parse("1a23/HTTP");
+            var result = PortAndProtocol.Parse("1a23/TCP");
 
             Assert.Equal(Option.None<PortAndProtocol>(), result);
+        }
+
+        [Fact]
+        public void UnableToParseTooManyParts()
+        {
+            var result = PortAndProtocol.Parse("10/tcp/udp");
+
+            Assert.Equal(Option.None<PortAndProtocol>(), result);
+        }
+
+        [Fact]
+        public void DefaultProtocolIsTCP()
+        {
+            var result = PortAndProtocol.Parse("3434").OrDefault();
+
+            Assert.Equal(3434, result.Port);
+            Assert.Equal("TCP", result.Protocol);
         }
 
         [Theory]


### PR DESCRIPTION
If you create a module with Docker createOptions like so:
```json
{
  "ExposedPorts":{
    "35000":{}
  },
  "HostConfig":{
    "PortBindings":{
      "35000":[{"HostPort":"35000"}]
    }
  }
}
```

The Docker API will default the port to be "TCP".  Therefore, the Docker->K8s translation should do the same.

