### PR TITLE
Darobs/draft test protocol on error

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEnvironmentOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEnvironmentOperator.cs
@@ -69,7 +69,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
                         // kick off a new watch
                         this.StartListPods();
                     },
-                    onError: Events.PodWatchFailed));
+                    onError: (ex) =>
+                    {
+                        Events.PodWatchFailed(ex);
+                        throw ex;
+                    }));
         }
 
         void HandlePodChangedAsync(WatchEventType type, V1Pod pod)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentOperator.cs
@@ -73,7 +73,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
                         // kick off a new watch
                         this.StartListEdgeDeployments();
                     },
-                    onError: Events.EdgeDeploymentWatchFailed));
+                    onError: (ex) =>
+                    {
+                        Events.EdgeDeploymentWatchFailed(ex);
+                        throw ex;
+                    }));
         }
 
         internal async Task EdgeDeploymentOnEventHandlerAsync(WatchEventType type, EdgeDeploymentDefinition item)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/PortAndProtocolTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/PortAndProtocolTest.cs
@@ -31,9 +31,26 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void UnableToParseInvalidPort()
         {
-            var result = PortAndProtocol.Parse("1a23/HTTP");
+            var result = PortAndProtocol.Parse("1a23/TCP");
 
             Assert.Equal(Option.None<PortAndProtocol>(), result);
+        }
+
+        [Fact]
+        public void UnableToParseTooManyParts()
+        {
+            var result = PortAndProtocol.Parse("10/tcp/udp");
+
+            Assert.Equal(Option.None<PortAndProtocol>(), result);
+        }
+
+        [Fact]
+        public void DefaultProtocolIsTCP()
+        {
+            var result = PortAndProtocol.Parse("3434").OrDefault();
+
+            Assert.Equal(3434, result.Port);
+            Assert.Equal("TCP", result.Protocol);
         }
 
         [Theory]


### PR DESCRIPTION
Tests:
fail on error
default protocol is TCP if not given in createOptions.