### PR TITLE
Single quotes around file path variables in cmds

### DIFF
--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -624,11 +624,11 @@ function Install-RootCACertificate(
 
     $rootKeyFile = Get-KeyPathForPrefix($_rootCAPrefix)
     Write-Host ("Copying the Root CA private key to $rootKeyFile")
-    Copy-Item $rootCAKeyFile $rootKeyFile
+    Copy-Item "$rootCAKeyFile" "$rootKeyFile"
 
     $rootCertFile = Get-CertPathForPrefix($_rootCAPrefix)
     Write-Host ("Copying the Root CA certificate to $rootCertFile")
-    Copy-Item $rootCAFile $rootCertFile
+    Copy-Item "$rootCAFile" "$rootCertFile"
 
     New-IntermediateCACertificate $_intermediatePrefix $_rootCAPrefix $_intermediateCommonName $_privateKeyPassword $rootPrivateKeyPassword
     Write-Host "Success"
@@ -637,7 +637,7 @@ function Install-RootCACertificate(
 # Get-CACertsCertUseEdge retrieves the algorithm (RSA vs ECC) that was specified during New-CACertsCertChain
 function Get-CACertsCertUseRsa()
 {
-    Write-Output ((Get-Content $algorithmUsedFile -ErrorAction SilentlyContinue) -eq "rsa")
+    Write-Output ((Get-Content "$algorithmUsedFile" -ErrorAction SilentlyContinue) -eq "rsa")
 }
 
 <#
@@ -682,9 +682,9 @@ function New-CACertsVerificationCert([Parameter(Mandatory=$TRUE)][string]$reques
     $verifCertPath = Get-CertPathForPrefix($verificationPrefix)
     $verifCertFullChainPath = Get-CertPathForPrefix("$verificationPrefix-full-chain")
     $verifKeyPath = Get-KeyPathForPrefix($verificationPrefix)
-    Remove-Item -Path $verifCertPath -ErrorAction SilentlyContinue
-    Remove-Item -Path $verifCertFullChainPath -ErrorAction SilentlyContinue
-    Remove-Item -Path $verifKeyPath -ErrorAction SilentlyContinue
+    Remove-Item -Path "$verifCertPath" -ErrorAction SilentlyContinue
+    Remove-Item -Path "$verifCertFullChainPath" -ErrorAction SilentlyContinue
+    Remove-Item -Path "$verifKeyPath" -ErrorAction SilentlyContinue
     New-ClientCertificate $verificationPrefix $_rootCAPrefix $requestedCommonName
     if (-not (Test-Path $verifCertPath))
     {

--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -474,7 +474,7 @@ function New-CertFullChain([string]$certFile, [string]$prefix, [string]$issuerPr
     {
         $issuerFullChainCertFileName  = Get-CertPathForPrefix("$issuerPrefix-full-chain")
     }
-    Get-Content $certFile, $issuerFullChainCertFileName | Set-Content $fullCertChain
+    Get-Content "$certFile", "$issuerFullChainCertFileName" | Set-Content "$fullCertChain"
     Write-Host ("Certificate with subject {0} has been output to {1} and with full chain to {2}" -f $subject, $certFile, $fullCertChain)
 }
 

--- a/tools/CACertificates/ca-certs.ps1
+++ b/tools/CACertificates/ca-certs.ps1
@@ -555,15 +555,15 @@ function New-RootCACertificate()
 
     Write-Host ("Creating the Root CA certificate")
     $passwordUseCmd = "-passin pass:$_privateKeyPassword"
-    $cmd =  "openssl req -new -x509 -config $_opensslRootConfigFile $passwordUseCmd "
-    $cmd += "-key $keyFile -subj $_rootCertSubject -days $_days_until_expiration "
-    $cmd += "-sha256 -extensions v3_ca -out $certFile 2>&1"
+    $cmd =  "openssl req -new -x509 -config '$_opensslRootConfigFile' $passwordUseCmd "
+    $cmd += "-key '$keyFile' -subj $_rootCertSubject -days $_days_until_expiration "
+    $cmd += "-sha256 -extensions v3_ca -out '$certFile' 2>&1"
     Invoke-External -verbose $cmd
 
     Write-Host ("CA Root Certificate Generated At:")
     Write-Host ("---------------------------------")
     Write-Host ("    $certFile`r`n")
-    $cmd = "openssl x509 -noout -text -in $certFile 2>&1"
+    $cmd = "openssl x509 -noout -text -in '$certFile' 2>&1"
     Invoke-External $cmd
 
     # Now use splatting to process this


### PR DESCRIPTION
New-RootCACertificate breaks if the file path has a space in it because it doesn't have single quotes around file variables in its cmd strings, unlike the other functions.

https://github.com/MicrosoftDocs/azure-docs/issues/53576