### PR TITLE
[mqtt] Add versioned file format

### DIFF
--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -34,7 +34,7 @@ pub use crate::configuration::BrokerConfig;
 pub use crate::connection::ConnectionHandle;
 pub use crate::error::{Error, InitializeBrokerError};
 pub use crate::persist::{
-    VersionedFileFormat, FileFormat, FilePersistor, NullPersistor, Persist, PersistError,
+    FileFormat, FilePersistor, NullPersistor, Persist, PersistError, VersionedFileFormat,
 };
 pub use crate::server::Server;
 pub use crate::session::SessionState;

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -34,7 +34,7 @@ pub use crate::configuration::BrokerConfig;
 pub use crate::connection::ConnectionHandle;
 pub use crate::error::{Error, InitializeBrokerError};
 pub use crate::persist::{
-    ConsolidatedStateFormat, FileFormat, FilePersistor, NullPersistor, Persist, PersistError,
+    VersionedFileFormat, FileFormat, FilePersistor, NullPersistor, Persist, PersistError,
 };
 pub use crate::server::Server;
 pub use crate::session::SessionState;

--- a/mqtt/mqtt-broker/tests/persist_failpoints.rs
+++ b/mqtt/mqtt-broker/tests/persist_failpoints.rs
@@ -1,6 +1,6 @@
 use fail::FailScenario;
 
-use mqtt_broker::{BrokerState, VersionedFileFormat, FilePersistor, Persist, PersistError};
+use mqtt_broker::{BrokerState, FilePersistor, Persist, PersistError, VersionedFileFormat};
 use proptest::collection::vec;
 use proptest::prelude::*;
 use tempfile::TempDir;

--- a/mqtt/mqtt-broker/tests/persist_failpoints.rs
+++ b/mqtt/mqtt-broker/tests/persist_failpoints.rs
@@ -1,6 +1,6 @@
 use fail::FailScenario;
 
-use mqtt_broker::{BrokerState, ConsolidatedStateFormat, FilePersistor, Persist, PersistError};
+use mqtt_broker::{BrokerState, VersionedFileFormat, FilePersistor, Persist, PersistError};
 use proptest::collection::vec;
 use proptest::prelude::*;
 use tempfile::TempDir;
@@ -49,7 +49,7 @@ async fn test_persistor(count: usize, ops: Vec<Op>) {
     let tmp_dir = TempDir::new().unwrap();
     let path = tmp_dir.path().to_owned();
     let mut persistor =
-        FilePersistor::new(path, ConsolidatedStateFormat::default()).with_previous_count(count);
+        FilePersistor::new(path, VersionedFileFormat::default()).with_previous_count(count);
 
     // Make sure we've stored at least one state
     tear_down_failpoints();
@@ -88,7 +88,7 @@ fn test_failpoints_smoketest() {
 
             let tmp_dir = TempDir::new().unwrap();
             let path = tmp_dir.path().to_owned();
-            let mut persistor = FilePersistor::new(path, ConsolidatedStateFormat::default());
+            let mut persistor = FilePersistor::new(path, VersionedFileFormat::default());
 
             let result = persistor.load().await;
             matches::assert_matches!(result, Err(PersistError::TaskJoin(_)));

--- a/mqtt/mqttd/src/main.rs
+++ b/mqtt/mqttd/src/main.rs
@@ -37,7 +37,7 @@ async fn run() -> Result<(), Error> {
     // Setup the snapshotter
     let mut persistor = FilePersistor::new(
         env::current_dir().expect("can't get cwd").join("state"),
-        ConsolidatedStateFormat::default(),
+        VersionedFileFormat::default(),
     );
     info!("Loading state...");
     let state = persistor.load().await?.unwrap_or_else(BrokerState::default);


### PR DESCRIPTION
This wraps the consolidated file format in a version enum. We decided that compression and encoding would be handled by file extension, so this only encapsulates the brokerstate object. 