### PR TITLE
Nested Edge deployment and config part 1

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IModuleIdentity.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IModuleIdentity.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         string GatewayHostname { get; }
 
+        string EdgeDeviceHostname { get; }
+
         string DeviceId { get; }
 
         string ModuleId { get; }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/ModuleIdentity.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/ModuleIdentity.cs
@@ -5,16 +5,25 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
     public class ModuleIdentity : IModuleIdentity
     {
-        public ModuleIdentity(string iotHubHostname, string gatewayHostname, string deviceId, string moduleId, ICredentials credentials)
+        public ModuleIdentity(
+            string iotHubHostname,
+            string edgeDeviceHostname,
+            string gatewayHostname,
+            string deviceId,
+            string moduleId,
+            ICredentials credentials)
         {
-            this.IotHubHostname = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(this.IotHubHostname));
+            this.IotHubHostname = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
             this.GatewayHostname = gatewayHostname;
-            this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(this.DeviceId));
-            this.ModuleId = Preconditions.CheckNonWhiteSpace(moduleId, nameof(this.ModuleId));
+            this.EdgeDeviceHostname = Preconditions.CheckNonWhiteSpace(edgeDeviceHostname, nameof(edgeDeviceHostname));
+            this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
+            this.ModuleId = Preconditions.CheckNonWhiteSpace(moduleId, nameof(moduleId));
             this.Credentials = Preconditions.CheckNotNull(credentials, nameof(this.Credentials));
         }
 
         public string IotHubHostname { get; }
+
+        public string EdgeDeviceHostname { get; }
 
         public string GatewayHostname { get; }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/ModuleIdentityProviderServiceBuilder.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/ModuleIdentityProviderServiceBuilder.cs
@@ -1,19 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.Core
 {
+    using System;
     using Microsoft.Azure.Devices.Edge.Util;
 
     public class ModuleIdentityProviderServiceBuilder
     {
-        readonly string iotHubHostName;
+        readonly string iotHubHostname;
         readonly string deviceId;
-        readonly string gatewayHostname;
+        readonly string edgeDeviceHostname;
+        readonly string parentEdgeHostname;
 
-        public ModuleIdentityProviderServiceBuilder(string iotHubHostName, string deviceId, string gatewayHostname)
+        public ModuleIdentityProviderServiceBuilder(string iotHubHostname, string deviceId, string edgeDeviceHostname, string parentEdgeHostname)
         {
-            this.iotHubHostName = Preconditions.CheckNonWhiteSpace(iotHubHostName, nameof(iotHubHostName));
+            this.iotHubHostname = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
             this.deviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
-            this.gatewayHostname = gatewayHostname;
+            this.edgeDeviceHostname = Preconditions.CheckNonWhiteSpace(edgeDeviceHostname, nameof(edgeDeviceHostname));
+            this.parentEdgeHostname = parentEdgeHostname;
         }
 
         public IModuleIdentity Create(string moduleId, string generationId, string providerUri)
@@ -23,7 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
             Preconditions.CheckNonWhiteSpace(providerUri, nameof(providerUri));
 
             ICredentials credentials = new IdentityProviderServiceCredentials(providerUri, generationId);
-            return new ModuleIdentity(this.iotHubHostName, this.gatewayHostname, this.deviceId, moduleId, credentials);
+            return new ModuleIdentity(this.iotHubHostname, this.edgeDeviceHostname, this.GetGatewayHostname(moduleId), this.deviceId, moduleId, credentials);
         }
 
         public IModuleIdentity Create(string moduleId, string generationId, string providerUri, string authScheme)
@@ -34,7 +37,18 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
             Preconditions.CheckNonWhiteSpace(authScheme, nameof(authScheme));
 
             ICredentials credentials = new IdentityProviderServiceCredentials(providerUri, generationId, authScheme);
-            return new ModuleIdentity(this.iotHubHostName, this.gatewayHostname, this.deviceId, moduleId, credentials);
+            return new ModuleIdentity(this.iotHubHostname, this.edgeDeviceHostname, this.GetGatewayHostname(moduleId), this.deviceId, moduleId, credentials);
+        }
+
+        string GetGatewayHostname(string moduleId)
+        {
+            if (moduleId.Equals(Constants.EdgeAgentModuleIdentityName, StringComparison.OrdinalIgnoreCase) ||
+                moduleId.Equals(Constants.EdgeHubModuleIdentityName, StringComparison.OrdinalIgnoreCase))
+            {
+                return this.parentEdgeHostname;
+            }
+
+            return this.edgeDeviceHostname;
         }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
 
         public string Id => this.id.Value;
 
+        public ModuleSpec ModuleSpec => this.moduleSpec;
+
         public static CreateOrUpdateCommand BuildCreate(
             IModuleManager moduleManager,
             IModule module,
@@ -118,16 +120,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
                 envVars.Add(new EnvVar(Constants.IotHubHostnameVariableName, identity.IotHubHostname));
             }
 
+            if (identity.ModuleId.Equals(Constants.EdgeAgentModuleIdentityName) || identity.ModuleId.Equals(Constants.EdgeHubModuleIdentityName))
+            {
+                envVars.Add(new EnvVar(Constants.EdgeDeviceHostNameKey, identity.EdgeDeviceHostname));
+            }
+
             if (!string.IsNullOrWhiteSpace(identity.GatewayHostname))
             {
-                if (identity.ModuleId.Equals(Constants.EdgeAgentModuleIdentityName) || identity.ModuleId.Equals(Constants.EdgeHubModuleIdentityName))
-                {
-                    envVars.Add(new EnvVar(Constants.EdgeDeviceHostNameKey, identity.GatewayHostname));
-                }
-                else if (!identity.ModuleId.Equals(Constants.EdgeHubModuleIdentityName))
-                {
-                    envVars.Add(new EnvVar(Constants.GatewayHostnameVariableName, identity.GatewayHostname));
-                }
+                envVars.Add(new EnvVar(Constants.GatewayHostnameVariableName, identity.GatewayHostname));
             }
 
             if (!string.IsNullOrWhiteSpace(identity.DeviceId))

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             bool enableNonPersistentStorageBackup;
             Option<string> storageBackupPath = Option.None<string>();
             string edgeDeviceHostName;
+            string parentEdgeHostname;
             string dockerLoggingDriver;
             Dictionary<string, string> dockerLoggingOptions;
             IEnumerable<global::Docker.DotNet.Models.AuthConfig> dockerAuthConfig;
@@ -96,7 +97,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
 
             try
             {
-                mode = configuration.GetValue(Constants.ModeKey, "docker");
+                mode = configuration.GetValue(Constants.ModeKey, "iotedged");
                 configSourceConfig = configuration.GetValue<string>("ConfigSource");
                 backupConfigFilePath = configuration.GetValue<string>("BackupConfigFilePath");
                 maxRestartCount = configuration.GetValue<int>("MaxRestartCount");
@@ -115,6 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 }
 
                 edgeDeviceHostName = configuration.GetValue<string>(Constants.EdgeDeviceHostNameKey);
+                parentEdgeHostname = configuration.GetValue<string>(Constants.GatewayHostnameVariableName);
                 dockerLoggingDriver = configuration.GetValue<string>("DockerLoggingDriver");
                 dockerLoggingOptions = configuration.GetSection("DockerLoggingOptions").Get<Dictionary<string, string>>() ?? new Dictionary<string, string>();
                 dockerAuthConfig = configuration.GetSection("DockerRegistryAuth").Get<List<global::Docker.DotNet.Models.AuthConfig>>() ?? new List<global::Docker.DotNet.Models.AuthConfig>();
@@ -166,7 +168,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         apiVersion = configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
                         TimeSpan performanceMetricsUpdateFrequency = configuration.GetTimeSpan("PerformanceMetricsUpdateFrequency", TimeSpan.FromMinutes(5));
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize, storageLogLevel));
-                        builder.RegisterModule(new EdgeletModule(iothubHostname, edgeDeviceHostName, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, performanceMetricsUpdateFrequency, useServerHeartbeat, backupConfigFilePath));
+                        builder.RegisterModule(new EdgeletModule(iothubHostname, edgeDeviceHostName, parentEdgeHostname, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, performanceMetricsUpdateFrequency, useServerHeartbeat, backupConfigFilePath));
 
                         IEnumerable<X509Certificate2> trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(new Uri(workloadUri), apiVersion, Constants.WorkloadApiVersion, moduleId, moduleGenerationId);
                         CertificateHelper.InstallCertificates(trustBundle, logger);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DockerModule.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly string deviceId;
         readonly string iotHubHostName;
         readonly string edgeDeviceConnectionString;
-        readonly string gatewayHostName;
+        readonly string edgeDeviceHostname;
         readonly Uri dockerHostname;
         readonly IEnumerable<AuthConfig> dockerAuthConfig;
         readonly Option<UpstreamProtocol> upstreamProtocol;
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
 
         public DockerModule(
             string edgeDeviceConnectionString,
-            string gatewayHostName,
+            string edgeDeviceHostname,
             Uri dockerHostname,
             IEnumerable<AuthConfig> dockerAuthConfig,
             Option<UpstreamProtocol> upstreamProtocol,
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             string backupConfigFilePath)
         {
             this.edgeDeviceConnectionString = Preconditions.CheckNonWhiteSpace(edgeDeviceConnectionString, nameof(edgeDeviceConnectionString));
-            this.gatewayHostName = Preconditions.CheckNonWhiteSpace(gatewayHostName, nameof(gatewayHostName));
+            this.edgeDeviceHostname = Preconditions.CheckNonWhiteSpace(edgeDeviceHostname, nameof(edgeDeviceHostname));
             IotHubConnectionStringBuilder connectionStringParser = IotHubConnectionStringBuilder.Create(this.edgeDeviceConnectionString);
             this.deviceId = connectionStringParser.DeviceId;
             this.iotHubHostName = connectionStringParser.HostName;
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .SingleInstance();
 
             // IModuleIdentityLifecycleManager
-            builder.Register(c => new ModuleIdentityLifecycleManager(c.Resolve<IServiceClient>(), this.iotHubHostName, this.deviceId, this.gatewayHostName))
+            builder.Register(c => new ModuleIdentityLifecycleManager(c.Resolve<IServiceClient>(), this.iotHubHostName, this.deviceId, this.edgeDeviceHostname))
                 .As<IModuleIdentityLifecycleManager>()
                 .SingleInstance();
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
     {
         readonly string deviceId;
         readonly string iotHubHostName;
-        readonly string gatewayHostName;
+        readonly string edgeDeviceHostname;
+        readonly string parentEdgeHostname;
         readonly Uri managementUri;
         readonly Uri workloadUri;
         readonly string apiVersion;
@@ -48,7 +49,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
 
         public EdgeletModule(
             string iotHubHostname,
-            string gatewayHostName,
+            string edgeDeviceHostname,
+            string parentEdgeHostname,
             string deviceId,
             Uri managementUri,
             Uri workloadUri,
@@ -64,7 +66,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             string backupConfigFilePath)
         {
             this.iotHubHostName = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
-            this.gatewayHostName = Preconditions.CheckNonWhiteSpace(gatewayHostName, nameof(gatewayHostName));
+            this.edgeDeviceHostname = Preconditions.CheckNonWhiteSpace(edgeDeviceHostname, nameof(edgeDeviceHostname));
+            this.parentEdgeHostname = parentEdgeHostname;
             this.deviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
             this.managementUri = Preconditions.CheckNotNull(managementUri, nameof(managementUri));
             this.workloadUri = Preconditions.CheckNotNull(workloadUri, nameof(workloadUri));
@@ -103,7 +106,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .SingleInstance();
 
             // IModuleIdentityLifecycleManager
-            var identityBuilder = new ModuleIdentityProviderServiceBuilder(this.iotHubHostName, this.deviceId, this.gatewayHostName);
+            var identityBuilder = new ModuleIdentityProviderServiceBuilder(this.iotHubHostName, this.deviceId, this.edgeDeviceHostname, this.parentEdgeHostname);
             builder.Register(c => new ModuleIdentityLifecycleManager(c.Resolve<IIdentityManager>(), identityBuilder, this.workloadUri))
                 .As<IModuleIdentityLifecycleManager>()
                 .SingleInstance();

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .SingleInstance();
 
             // IModuleIdentityLifecycleManager
-            var identityBuilder = new ModuleIdentityProviderServiceBuilder(this.resourceName.Hostname, this.resourceName.DeviceId, this.edgeDeviceHostName);
+            var identityBuilder = new ModuleIdentityProviderServiceBuilder(this.resourceName.Hostname, this.resourceName.DeviceId, this.edgeDeviceHostName, string.Empty);
             builder.Register(c => new KubernetesModuleIdentityLifecycleManager(c.Resolve<IIdentityManager>(), identityBuilder, this.workloadUri))
                 .As<IModuleIdentityLifecycleManager>()
                 .SingleInstance();

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/ModuleIdentityProviderServiceBuilderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/ModuleIdentityProviderServiceBuilderTest.cs
@@ -10,20 +10,31 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
     public class ModuleIdentityProviderServiceBuilderTest
     {
         [Theory]
-        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost")]
-        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost", "gateway")]
-        public void TestCreateIdentity_WithEdgelet_DefaultAuthScheme_ShouldCreateIdentity(string iotHubHostName, string deviceId, string moduleId, string generationId, string edgeletUri, string gatewayHostName = null)
+        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost", "edgedevicehostname")]
+        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost", "edgedevicehostname", "edgedevicehostname")]
+        [InlineData("foo.azure.com", "d1", "$edgeAgent", "1", "localhost", "edgedevicehostname")]
+        [InlineData("foo.azure.com", "d1", "$edgeAgent", "1", "localhost", "edgedevicehostname", "parentedgehostname")]
+        public void TestCreateIdentity_WithEdgelet_DefaultAuthScheme_ShouldCreateIdentity(
+            string iotHubHostName, string deviceId, string moduleId, string generationId, string edgeletUri, string edgeDeviceHostname, string parentEdgeHostname = null)
         {
             // Arrange
             string defaultAuthScheme = "sasToken";
-            var builder = new ModuleIdentityProviderServiceBuilder(iotHubHostName, deviceId, gatewayHostName);
+            var builder = new ModuleIdentityProviderServiceBuilder(iotHubHostName, deviceId, edgeDeviceHostname, parentEdgeHostname);
 
             // Act
             IModuleIdentity identity = builder.Create(moduleId, generationId, edgeletUri);
 
             // Assert
             Assert.Equal(iotHubHostName, identity.IotHubHostname);
-            Assert.Equal(gatewayHostName, identity.GatewayHostname);
+            if (moduleId.Equals(Constants.EdgeAgentModuleIdentityName, StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.Equal(parentEdgeHostname, identity.GatewayHostname);
+            }
+            else
+            {
+                Assert.Equal(edgeDeviceHostname, identity.GatewayHostname);
+            }
+
             Assert.Equal(deviceId, identity.DeviceId);
             Assert.Equal(moduleId, identity.ModuleId);
             var creds = identity.Credentials as IdentityProviderServiceCredentials;
@@ -35,20 +46,39 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         }
 
         [Theory]
-        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost")]
-        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost", "x509")]
-        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost", "x509", "gateway")]
-        public void TestCreateIdentity_WithEdgelet_SetAuthScheme_ShouldCreateIdentity(string iotHubHostName, string deviceId, string moduleId, string generationId, string edgeletUri, string authScheme = "sasToken", string gatewayHostName = null)
+        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost", "edgedevicehostname")]
+        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost", "edgedevicehostname", "x509")]
+        [InlineData("foo.azure.com", "d1", "m1", "1", "localhost", "edgedevicehostname", "x509", "gateway")]
+        [InlineData("foo.azure.com", "d1", "$edgeAgent", "1", "localhost", "edgedevicehostname")]
+        [InlineData("foo.azure.com", "d1", "$edgeAgent", "1", "localhost", "edgedevicehostname", "x509")]
+        [InlineData("foo.azure.com", "d1", "$edgeAgent", "1", "localhost", "edgedevicehostname", "x509", "gateway")]
+        public void TestCreateIdentity_WithEdgelet_SetAuthScheme_ShouldCreateIdentity(
+            string iotHubHostName,
+            string deviceId,
+            string moduleId,
+            string generationId,
+            string edgeletUri,
+            string edgeDeviceHostname,
+            string authScheme = "sasToken",
+            string parentEdgeHostname = null)
         {
             // Arrange
-            var builder = new ModuleIdentityProviderServiceBuilder(iotHubHostName, deviceId, gatewayHostName);
+            var builder = new ModuleIdentityProviderServiceBuilder(iotHubHostName, deviceId, edgeDeviceHostname, parentEdgeHostname);
 
             // Act
             IModuleIdentity identity = builder.Create(moduleId, generationId, edgeletUri, authScheme);
 
             // Assert
             Assert.Equal(iotHubHostName, identity.IotHubHostname);
-            Assert.Equal(gatewayHostName, identity.GatewayHostname);
+            if (moduleId.Equals(Constants.EdgeAgentModuleIdentityName, StringComparison.OrdinalIgnoreCase))
+            {
+                Assert.Equal(parentEdgeHostname, identity.GatewayHostname);
+            }
+            else
+            {
+                Assert.Equal(edgeDeviceHostname, identity.GatewayHostname);
+            }
+
             Assert.Equal(deviceId, identity.DeviceId);
             Assert.Equal(moduleId, identity.ModuleId);
             var creds = identity.Credentials as IdentityProviderServiceCredentials;
@@ -62,12 +92,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         [Fact]
         public void InvalidInputsTest()
         {
-            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder(null, "1", "gateway"));
-            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder(string.Empty, "1", "gateway"));
-            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder("iothub", null, "gateway"));
-            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder("iothub", string.Empty, "gateway"));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder(null, "1", "edgedevicehostname", "parentedgehostname"));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder(string.Empty, "1", "edgedevicehostname", "parentedgehostname"));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder("iothub", null, "edgedevicehostname", "parentedgehostname"));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder("iothub", string.Empty, "edgedevicehostname", "parentedgehostname"));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder("iothub", "1", null, "parentedgehostname"));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentityProviderServiceBuilder("iothub", "1", string.Empty, "parentedgehostname"));
 
-            var builder = new ModuleIdentityProviderServiceBuilder("foo.azure.com", "device1", "gateway");
+            var builder = new ModuleIdentityProviderServiceBuilder("foo.azure.com", "device1", "edgedevicehostname", "parentedgehostname");
 
             Assert.Throws<ArgumentException>(() => builder.Create(null, "1", "xyz"));
             Assert.Throws<ArgumentException>(() => builder.Create("localhost", null, "xyz"));

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/ModuleIdentityTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/ModuleIdentityTest.cs
@@ -12,16 +12,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         public void TestCreateInstance_ShouldThrowWhithNullArguments()
         {
             string connectionString = "fake";
-            string moduleName = "module1";
-            string gatewayHostname = "gateway.local";
+            string edgeDeviceHostname = "edgedevicehostname";
+            string parentEdgeHostname = "parentedgehostname";
             string iothubHostname = "iothub.local";
             string deviceId = "device1";
+            string moduleName = "module1";
 
-            Assert.Throws<ArgumentException>(() => new ModuleIdentity(null, gatewayHostname, deviceId, moduleName, new ConnectionStringCredentials(connectionString)));
-            Assert.NotNull(new ModuleIdentity(iothubHostname, null, deviceId, moduleName, new ConnectionStringCredentials(connectionString)));
-            Assert.Throws<ArgumentException>(() => new ModuleIdentity(iothubHostname, gatewayHostname, null, moduleName, new ConnectionStringCredentials(connectionString)));
-            Assert.Throws<ArgumentException>(() => new ModuleIdentity(iothubHostname, gatewayHostname, deviceId, null, new ConnectionStringCredentials(connectionString)));
-            Assert.Throws<ArgumentNullException>(() => new ModuleIdentity(iothubHostname, gatewayHostname, deviceId, moduleName, null));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentity(null, edgeDeviceHostname, parentEdgeHostname, deviceId, moduleName, new ConnectionStringCredentials(connectionString)));
+            Assert.NotNull(new ModuleIdentity(iothubHostname, edgeDeviceHostname, null, deviceId, moduleName, new ConnectionStringCredentials(connectionString)));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentity(iothubHostname, edgeDeviceHostname, parentEdgeHostname, null, moduleName, new ConnectionStringCredentials(connectionString)));
+            Assert.Throws<ArgumentException>(() => new ModuleIdentity(iothubHostname, edgeDeviceHostname, parentEdgeHostname, deviceId, null, new ConnectionStringCredentials(connectionString)));
+            Assert.Throws<ArgumentNullException>(() => new ModuleIdentity(iothubHostname, edgeDeviceHostname, parentEdgeHostname, deviceId, moduleName, null));
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleIdentityLifecycleManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleIdentityLifecycleManagerTest.cs
@@ -19,10 +19,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
     {
         const string IothubHostName = "test.azure-devices.net";
         const string DeviceId = "edgeDevice1";
-        const string GatewayHostName = "edgedevicehost";
+        const string EdgeDeviceHostname = "edgedevicehostname";
+        const string ParentEdgeHostname = "parentedgehostname";
         static readonly Uri EdgeletUri = new Uri("http://localhost");
         static readonly ConfigurationInfo DefaultConfigurationInfo = new ConfigurationInfo("1");
-        static readonly ModuleIdentityProviderServiceBuilder ModuleIdentityProviderServiceBuilder = new ModuleIdentityProviderServiceBuilder(IothubHostName, DeviceId, GatewayHostName);
+        static readonly ModuleIdentityProviderServiceBuilder ModuleIdentityProviderServiceBuilder = new ModuleIdentityProviderServiceBuilder(IothubHostName, DeviceId, EdgeDeviceHostname, ParentEdgeHostname);
 
         [Fact]
         public async Task TestGetModulesIdentity_WithEmptyDiff_ShouldReturnEmptyIdentities()

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/commands/CreateOrUpdateCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/commands/CreateOrUpdateCommandTest.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Microsoft.Azure.Devices.Edge.Agent.Core;
+    using Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Microsoft.Extensions.Configuration;
+    using Moq;
+    using Serilog.Events;
+    using Xunit;
+
+    [Unit]
+    public class CreateOrUpdateCommandTest
+    {
+        [Fact]
+        public void VerfiyEdgeAgentEnvironmentVariables()
+        {
+            var mockModuleManager = new Mock<IModuleManager>();
+            var edgeAgentModule = new Mock<IEdgeAgentModule>();
+            var edgeAgentModuleIdentity = new Mock<IModuleIdentity>();
+            var configSource = new Mock<IConfigSource>();
+            var configuration = new Mock<IConfiguration>();
+            var settings = new object();
+
+            edgeAgentModule.Setup(m => m.Name).Returns("edgeAgent");
+            edgeAgentModule.Setup(m => m.Type).Returns("type1");
+            edgeAgentModule.Setup(m => m.ImagePullPolicy).Returns(ImagePullPolicy.OnCreate);
+            edgeAgentModule.Setup(m => m.Env).Returns(
+                new Dictionary<string, EnvVal>
+                {
+                    { "EnvKey1", new EnvVal("EnvValue1") },
+                    { "EnvKey2", new EnvVal("EnvValue2") },
+                });
+
+            edgeAgentModuleIdentity.Setup(id => id.DeviceId).Returns("MyEdgeDeviceId");
+            edgeAgentModuleIdentity.Setup(id => id.ModuleId).Returns("$edgeAgent");
+            edgeAgentModuleIdentity.Setup(id => id.Credentials).Returns(
+                new IdentityProviderServiceCredentials("identityProviderUri1", "moduleGenerationId1", "authScheme1"));
+            edgeAgentModuleIdentity.Setup(id => id.IotHubHostname).Returns("MyTestIoTHub");
+            edgeAgentModuleIdentity.Setup(id => id.GatewayHostname).Returns("MyParentEdge");
+            edgeAgentModuleIdentity.Setup(id => id.EdgeDeviceHostname).Returns("MyEdgeDevice");
+
+            configSource.Setup(cs => cs.Configuration).Returns(configuration.Object);
+            var upstreamProtocolConfig = new Mock<IConfigurationSection>();
+            configuration.Setup(c => c.GetSection(Constants.UpstreamProtocolKey)).Returns(upstreamProtocolConfig.Object);
+            upstreamProtocolConfig.Setup(c => c.Value).Returns("Amqp");
+            var edgeletManagementUriConfig = new Mock<IConfigurationSection>();
+            configuration.Setup(c => c.GetSection(Constants.EdgeletManagementUriVariableName)).Returns(edgeletManagementUriConfig.Object);
+            edgeletManagementUriConfig.Setup(c => c.Value).Returns("Edgelet_Management_Uri");
+            var networkIdConfig = new Mock<IConfigurationSection>();
+            configuration.Setup(c => c.GetSection(Constants.NetworkIdKey)).Returns(networkIdConfig.Object);
+            networkIdConfig.Setup(c => c.Value).Returns("iotedge-network");
+            var edgeletApiVersionConfig = new Mock<IConfigurationSection>();
+            configuration.Setup(c => c.GetSection(Constants.EdgeletApiVersionVariableName)).Returns(edgeletApiVersionConfig.Object);
+            edgeletApiVersionConfig.Setup(c => c.Value).Returns("2020.01.01");
+
+            CreateOrUpdateCommand command = CreateOrUpdateCommand.BuildCreate(
+                mockModuleManager.Object, edgeAgentModule.Object, edgeAgentModuleIdentity.Object, configSource.Object, settings);
+
+            Assert.Equal("edgeAgent", command.ModuleSpec.Name);
+            Assert.Equal("type1", command.ModuleSpec.Type);
+            Assert.Equal(ImagePullPolicy.OnCreate, command.ModuleSpec.ImagePullPolicy);
+            Assert.Equal(settings, command.ModuleSpec.Settings);
+            List<Models.EnvVar> environmentVariables = command.ModuleSpec.EnvironmentVariables.ToList();
+            Assert.Equal("EnvValue1", environmentVariables.Where(v => v.Key.Equals("EnvKey1")).First().Value);
+            Assert.Equal("EnvValue2", environmentVariables.Where(v => v.Key.Equals("EnvKey2")).First().Value);
+            Assert.Equal("identityProviderUri1", environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletWorkloadUriVariableName)).First().Value);
+            Assert.Equal("authScheme1", environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletAuthSchemeVariableName)).First().Value);
+            Assert.Equal("moduleGenerationId1", environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletModuleGenerationIdVariableName)).First().Value);
+            Assert.Equal("MyTestIoTHub", environmentVariables.Where(v => v.Key.Equals(Constants.IotHubHostnameVariableName)).First().Value);
+            Assert.Equal("MyParentEdge", environmentVariables.Where(v => v.Key.Equals(Constants.GatewayHostnameVariableName)).First().Value);
+            Assert.Equal("MyEdgeDevice", environmentVariables.Where(v => v.Key.Equals(Constants.EdgeDeviceHostNameKey)).First().Value);
+            Assert.Equal("MyEdgeDeviceId", environmentVariables.Where(v => v.Key.Equals(Constants.DeviceIdVariableName)).First().Value);
+            Assert.Equal("$edgeAgent", environmentVariables.Where(v => v.Key.Equals(Constants.ModuleIdVariableName)).First().Value);
+            Assert.Equal(LogEventLevel.Information.ToString(), environmentVariables.Where(v => v.Key.Equals(Logger.RuntimeLogLevelEnvKey)).First().Value);
+            Assert.Equal("Amqp", environmentVariables.Where(v => v.Key.Equals(Constants.UpstreamProtocolKey)).First().Value);
+            Assert.Equal("Edgelet_Management_Uri", environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletManagementUriVariableName)).First().Value);
+            Assert.Equal("iotedge-network", environmentVariables.Where(v => v.Key.Equals(Constants.NetworkIdKey)).First().Value);
+            Assert.Equal("iotedged", environmentVariables.Where(v => v.Key.Equals(Constants.ModeKey)).First().Value);
+            Assert.Equal("2020.01.01", environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletApiVersionVariableName)).First().Value);
+        }
+    }
+}

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/DummyModuleIdentityLifecycleManager.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/DummyModuleIdentityLifecycleManager.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest
 {
+    using System;
     using System.Collections.Immutable;
     using System.Linq;
     using System.Threading.Tasks;
@@ -9,16 +10,16 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest
     public class DummyModuleIdentityLifecycleManager : IModuleIdentityLifecycleManager
     {
         readonly string hostName;
-        readonly string gatewayHostname;
+        readonly string edgeDeviceHostname;
         readonly string deviceId;
         readonly string moduleId;
         readonly ICredentials credentials;
         private IImmutableDictionary<string, IModuleIdentity> identites = ImmutableDictionary<string, IModuleIdentity>.Empty;
 
-        public DummyModuleIdentityLifecycleManager(string hostName, string gatewayHostname, string deviceId, string moduleId, ICredentials credentials)
+        public DummyModuleIdentityLifecycleManager(string hostName, string edgeDeviceHostname, string deviceId, string moduleId, ICredentials credentials)
         {
             this.hostName = hostName;
-            this.gatewayHostname = gatewayHostname;
+            this.edgeDeviceHostname = edgeDeviceHostname;
             this.deviceId = deviceId;
             this.moduleId = moduleId;
             this.credentials = credentials;
@@ -30,6 +31,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest
             .Select(name => new { Name = name, ModuleId = this.CreateModuleIdentity() })
             .ToImmutableDictionary(id => id.Name, id => id.ModuleId);
 
-        IModuleIdentity CreateModuleIdentity() => new ModuleIdentity(this.hostName, this.gatewayHostname, this.deviceId, this.moduleId, this.credentials);
+        IModuleIdentity CreateModuleIdentity() => new ModuleIdentity(this.hostName, this.deviceId, this.edgeDeviceHostname, this.GetGatewayHostname(this.moduleId), this.moduleId, this.credentials);
+
+        string GetGatewayHostname(string moduleId)
+        {
+            if (moduleId.Equals(Constants.EdgeAgentModuleIdentityName, StringComparison.OrdinalIgnoreCase) ||
+                moduleId.Equals(Constants.EdgeHubModuleIdentityName, StringComparison.OrdinalIgnoreCase))
+            {
+                return string.Empty;
+            }
+
+            return this.edgeDeviceHostname;
+        }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/EdgeDeploymentControllerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/EdgeDeploymentControllerTest.cs
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest
 
         private DummyModuleIdentityLifecycleManager CreateModuleLifeCycleManager(string moduleName) => new DummyModuleIdentityLifecycleManager(
                 "hostname",
-                "gatewayhostname",
+                "edgeDeviceHostname",
                 "deviceid",
                 moduleName,
                 new ConnectionStringCredentials("connectionString"));

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void EmptyIsNotAllowedAsPodAnnotation()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var labels = new Dictionary<string, string>
             {
                 // string.Empty is an invalid label name
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void SimpleDeploymentCreationHappyPath()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.None<AuthConfig>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void SimpleDeploymentStoppedHasZeroReplicas()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.None<AuthConfig>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Stopped, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void ValidatePodPropertyTranslation()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var labels = new Dictionary<string, string>
             {
                 // Add a label
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void PvcMappingByDefault()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "ModuleId", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "ModuleId", Mock.Of<ICredentials>());
             var labels = new Dictionary<string, string>();
             var hostConfig = VolumeMountHostConfig;
             var config = new KubernetesConfig("image", CreatePodParameters.Create(labels: labels, hostConfig: hostConfig), Option.None<AuthConfig>());
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void PvcMappingForVolumeNameVolume()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "ModuleId", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "ModuleId", Mock.Of<ICredentials>());
             var labels = new Dictionary<string, string>();
             var hostConfig = VolumeMountHostConfig;
             var config = new KubernetesConfig("image", CreatePodParameters.Create(labels: labels, hostConfig: hostConfig), Option.None<AuthConfig>());
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void PvcMappingForStorageClassVolume()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "ModuleId", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "ModuleId", Mock.Of<ICredentials>());
             var labels = new Dictionary<string, string>();
             var hostConfig = VolumeMountHostConfig;
             var config = new KubernetesConfig("image", CreatePodParameters.Create(labels: labels, hostConfig: hostConfig), Option.None<AuthConfig>());
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void PvcMappingForDefaultStorageClassVolume()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "ModuleId", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "ModuleId", Mock.Of<ICredentials>());
             var labels = new Dictionary<string, string>();
             var hostConfig = VolumeMountHostConfig;
             var config = new KubernetesConfig("image", CreatePodParameters.Create(labels: labels, hostConfig: hostConfig), Option.None<AuthConfig>());
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void PvcMappingForPVVolumeExtended()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "ModuleId", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "ModuleId", Mock.Of<ICredentials>());
             var labels = new Dictionary<string, string>();
             var hostConfig = VolumeMountHostConfig;
 
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void AppliesNodeSelectorFromCreateOptionsToPodSpec()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             IDictionary<string, string> nodeSelector = new Dictionary<string, string>
             {
@@ -330,7 +330,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void LeaveNodeSelectorEmptyWhenNothingProvidedInCreateOptions()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.None<AuthConfig>());
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
@@ -345,7 +345,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void AppliesResourcesFromCreateOptionsToContainerSpec()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             var resources = new V1ResourceRequirements(
                 new Dictionary<string, ResourceQuantity>
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void LeaveResourcesEmptyWhenNothingProvidedInCreateOptions()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.None<AuthConfig>());
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
@@ -391,7 +391,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void AppliesVolumesFromCreateOptionsToContainerSpec()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             var volumes = new[]
             {
@@ -427,7 +427,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void AddsVolumesFromCreateOptionsToContainerSpecEvenIfTheyOverrideExistingOnes()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             var volumes = new[]
             {
@@ -463,7 +463,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void LeaveVolumesIntactWhenNothingProvidedInCreateOptions()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVarsDict);
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.None<AuthConfig>());
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
@@ -483,7 +483,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void PassImagePullSecretsInPodSpecForProxyAndModuleContainers()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();
@@ -499,7 +499,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void PassOnlyOneImagePullSecretInPodSpecIfProxyAndModuleContainersHasTheSameImagePullSecrets()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();
@@ -514,7 +514,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void RunAsNonRootAndRunAsUser1000SecurityPolicyWhenSettingSet()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();
@@ -530,7 +530,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void PodSecurityContextFromCreateOptionsOverridesDefaultRunAsNonRootOptionsWhenProvided()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var securityContext = new V1PodSecurityContext { RunAsNonRoot = true, RunAsUser = 0 };
             var config = new KubernetesConfig("image", CreatePodParameters.Create(securityContext: securityContext), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
@@ -547,7 +547,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void ApplyPodSecurityContextFromCreateOptionsWhenProvided()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var securityContext = new V1PodSecurityContext { RunAsNonRoot = true, RunAsUser = 20001 };
             var config = new KubernetesConfig("image", CreatePodParameters.Create(securityContext: securityContext), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void LeavesStrategyEmptyWhenNotProvided()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();
@@ -578,7 +578,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void ApplyDeploymentStrategyWhenProvided()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var deploymentStrategy = new V1DeploymentStrategy { Type = "Recreate" };
             var config = new KubernetesConfig("image", CreatePodParameters.Create(deploymentStrategy: deploymentStrategy), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
@@ -593,7 +593,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void NoCmdOptionsNoContainerArgs()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();
@@ -611,7 +611,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         public void CmdOptionsContainerArgs()
         {
             var cmd = new List<string> { "argument1", "argument2" };
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(cmd: cmd), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();
@@ -630,7 +630,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         public void EntrypointOptionsContainerCommands()
         {
             var entrypoint = new List<string> { "command", "argument-a" };
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(entrypoint: entrypoint), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();
@@ -648,7 +648,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void WorkingDirOptionsContainerWorkingDir()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "Module1", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(workingDir: "/tmp/working"), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();
@@ -664,7 +664,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void EdgeAgentEnvSettingsHaveLotsOfStuff()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "$edgeAgent", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "$edgeAgent", Mock.Of<ICredentials>());
             var config = new KubernetesConfig("image", CreatePodParameters.Create(), Option.Some(new AuthConfig("user-registry1")));
             var module = new KubernetesModule("edgeAgent", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
             var labels = new Dictionary<string, string>();

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesModuleIdentityLifecycleManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesModuleIdentityLifecycleManagerTest.cs
@@ -20,10 +20,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
     {
         const string IothubHostName = "test.azure-devices.net";
         const string DeviceId = "edgeDevice1";
-        const string GatewayHostName = "edgedevicehost";
         static readonly Uri EdgeletUri = new Uri("http://localhost");
         static readonly ConfigurationInfo DefaultConfigurationInfo = new ConfigurationInfo("1");
-        static readonly ModuleIdentityProviderServiceBuilder ModuleIdentityProviderServiceBuilder = new ModuleIdentityProviderServiceBuilder(IothubHostName, DeviceId, GatewayHostName);
+        static readonly ModuleIdentityProviderServiceBuilder ModuleIdentityProviderServiceBuilder = new ModuleIdentityProviderServiceBuilder(IothubHostName, DeviceId, "edgedevicehostname", "edgedevicehostname");
 
         [Fact]
         public async Task TestGetModulesIdentityIIdentityManagerExceptionShouldReturnEmptyIdentities()

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesServiceAccountMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesServiceAccountMapperTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void RequiredMetadataExistsWhenCreated()
         {
-            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "ModuleId", Mock.Of<ICredentials>());
+            var identity = new ModuleIdentity("hostname", "edgedevicehostname", "edgedevicehostname", "deviceid", "ModuleId", Mock.Of<ICredentials>());
             var mapper = new KubernetesServiceAccountMapper();
             var labels = new Dictionary<string, string> { ["device"] = "k8s-device" };
             var config = new KubernetesConfig("image", CreatePodParameters.Create(labels: labels), Option.None<AuthConfig>());

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesServiceMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesServiceMapperTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var labels = new Dictionary<string, string> { { string.Empty, "test" } };
             var createOptions = CreatePodParameters.Create(labels: labels);
             var config = new KubernetesConfig("image", createOptions, Option.None<AuthConfig>());
-            var moduleId = new ModuleIdentity("hub", "gateway", "deviceId", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hub", "edgedevicehostname", "gateway", "deviceId", "moduleid", Mock.Of<ICredentials>());
             var docker = new DockerModule(moduleId.ModuleId, "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         {
             var createOptions = CreatePodParameters.Create();
             var config = new KubernetesConfig("image", createOptions, Option.None<AuthConfig>());
-            var moduleId = new ModuleIdentity("hub", "gateway", "deviceId", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hub", "edgedevicehostname", "gateway", "deviceId", "moduleid", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var exposedPorts = new Dictionary<string, EmptyStruct> { { "aa/TCP", default(EmptyStruct) } };
             var createOptions = CreatePodParameters.Create(exposedPorts: exposedPorts);
             var config = new KubernetesConfig("image", createOptions, Option.None<AuthConfig>());
-            var moduleId = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "moduleid", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var exposedPorts = new Dictionary<string, EmptyStruct> { { "123/XXX", default(EmptyStruct) } };
             var createOptions = CreatePodParameters.Create(exposedPorts: exposedPorts);
             var config = new KubernetesConfig("image", createOptions, Option.None<AuthConfig>());
-            var moduleId = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "moduleid", Mock.Of<ICredentials>());
             var docker = new DockerModule("module1", "v1", ModuleStatus.Running, RestartPolicy.Always, Config1, ImagePullPolicy.OnCreate, Constants.DefaultPriority, DefaultConfigurationInfo, EnvVars);
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
             var mapper = new KubernetesServiceMapper(PortMapServiceType.ClusterIP);
-            var moduleId = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "moduleid", Mock.Of<ICredentials>());
 
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
             var mapper = new KubernetesServiceMapper(PortMapServiceType.ClusterIP);
-            var moduleId = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "moduleid", Mock.Of<ICredentials>());
 
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string> { { "Label1", "VaLue1" } };
             var mapper = new KubernetesServiceMapper(PortMapServiceType.ClusterIP);
-            var moduleId = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "moduleid", Mock.Of<ICredentials>());
 
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
             var mapper = new KubernetesServiceMapper(PortMapServiceType.ClusterIP);
-            var moduleId = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "moduleid", Mock.Of<ICredentials>());
 
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 
@@ -197,7 +197,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
             var mapper = new KubernetesServiceMapper(PortMapServiceType.ClusterIP);
-            var moduleId = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hostname", "edgedevicehostname", "gateway", "deviceid", "moduleid", Mock.Of<ICredentials>());
 
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 
@@ -223,7 +223,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var module = new KubernetesModule(docker, config, EdgeletModuleOwner);
             var moduleLabels = new Dictionary<string, string>();
             var mapper = new KubernetesServiceMapper(PortMapServiceType.ClusterIP);
-            var moduleId = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "moduleid", Mock.Of<ICredentials>());
+            var moduleId = new ModuleIdentity("hostname", "edgeDeviceHostname", "gatewayhostname", "deviceid", "moduleid", Mock.Of<ICredentials>());
 
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
             [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue("hostname")
         };
 
-        static readonly ModuleIdentity CreateIdentity = new ModuleIdentity("hostname", "gateway", "device1", "Module1", new ConnectionStringCredentials("connection string"));
+        static readonly ModuleIdentity CreateIdentity = new ModuleIdentity("hostname", "edgedevicehostname", "edgedevicehostname", "device1", "Module1", new ConnectionStringCredentials("connection string"));
 
         static KubernetesModule CreateKubernetesModule(CreatePodParameters podParameters)
         {

--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -67,8 +67,8 @@
 #                       should be specified as file:///path/identity_key.pem
 #
 # External Settings
-#     endpoint - Required. Value of the endpoint used to retrieve device specific
-#                information such as its IoT hub connection information.
+#     endpoint        - Required. Value of the endpoint used to retrieve device specific
+#                       information such as its IoT hub connection information.
 #
 # Dynamic Re-provisioning Settings
 #     dynamic_reprovisioning - Optional. A flag to opt-in to the dynamic re-provisioning 
@@ -80,6 +80,14 @@
 #                              For the external provisioning mode specifically, the daemon 
 #                              will notify the external provisioning endpoint about the
 #                              re-provisioning event before shutting down.
+#
+# Nesed Edge Settings
+#     gateway_hostname       - Optional. This entry should only be specified for the 
+#                              host name of the parent edge device for nested edge sceanrio.
+#                              This value is injected into Edge Agent and Edge Hub modules as
+#                              environment value 'IOTEDGE_GATEWAYHOSTNAME'. Regardless of case
+#                              the hostname is specified below, a lower case value is used to
+#                              configure the Edge Hub server hostname.
 ###############################################################################
 
 # Manual provisioning configuration using a connection string

--- a/edgelet/contrib/config/windows/config.yaml
+++ b/edgelet/contrib/config/windows/config.yaml
@@ -80,6 +80,14 @@
 #                              For the external provisioning mode specifically, the daemon 
 #                              will notify the external provisioning endpoint about the
 #                              re-provisioning event before shutting down.
+#
+# Nesed Edge Settings
+#     gateway_hostname       - Optional. This entry should only be specified for the 
+#                              host name of the parent edge device for nested edge sceanrio.
+#                              This value is injected into Edge Agent and Edge Hub modules as
+#                              environment value 'IOTEDGE_GATEWAYHOSTNAME'. Regardless of case
+#                              the hostname is specified below, a lower case value is used to
+#                              configure the Edge Hub server hostname.
 ###############################################################################
 
 # Manual provisioning configuration using a connection string

--- a/edgelet/edgelet-core/src/settings.rs
+++ b/edgelet/edgelet-core/src/settings.rs
@@ -404,6 +404,8 @@ pub struct Provisioning {
 
     #[serde(default)]
     dynamic_reprovisioning: bool,
+
+    gateway_hostname: Option<String>,
 }
 
 impl Provisioning {
@@ -413,6 +415,10 @@ impl Provisioning {
 
     pub fn dynamic_reprovisioning(&self) -> bool {
         self.dynamic_reprovisioning
+    }
+
+    pub fn gateway_hostname(&self) -> Option<&str> {
+        self.gateway_hostname.as_ref().map(AsRef::as_ref)
     }
 }
 

--- a/edgelet/iotedged/test/linux/sample_settings.nested.edge.yaml
+++ b/edgelet/iotedged/test/linux/sample_settings.nested.edge.yaml
@@ -1,0 +1,35 @@
+
+# Configures the provisioning mode
+provisioning:
+  source: "manual"
+  device_connection_string: "HostName=something.something.com;DeviceId=something;SharedAccessKey=QXp1cmUgSW9UIEVkZ2U="
+  gateway_hostname: "parent_iotedge_device"
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env:
+    acd: "value2"
+    abc: "value1"
+  config:
+    image: "microsoft/azureiotedge-agent:1.0"
+    auth: {}
+hostname: "localhost"
+
+watchdog:
+  max_retries: 3
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+homedir: "/tmp"
+moby_runtime:
+  uri: "http://localhost:2375"
+  network: "azure-iot-edge"

--- a/edgelet/iotedged/test/windows/sample_settings.nested.edge.yaml
+++ b/edgelet/iotedged/test/windows/sample_settings.nested.edge.yaml
@@ -1,0 +1,35 @@
+
+# Configures the provisioning mode
+provisioning:
+  source: "manual"
+  device_connection_string: "HostName=something.something.com;DeviceId=something;SharedAccessKey=QXp1cmUgSW9UIEVkZ2U="
+  gateway_hostname: "parent_iotedge_device"
+agent:
+  name: "edgeAgent"
+  type: "docker"
+  env:
+    acd: "value2"
+    abc: "value1"
+  config:
+    image: "microsoft/azureiotedge-agent:1.0"
+    auth: {}
+hostname: "localhost"
+
+watchdog:
+  max_retries: 3
+
+# Sets the connection uris for clients
+connect:
+  workload_uri: "http://localhost:8081"
+  management_uri: "http://localhost:8080"
+
+# Sets the uris to listen on
+# These can be different than the connect uris.
+# For instance, when using the fd:// scheme for systemd
+listen:
+  workload_uri: "http://0.0.0.0:8081"
+  management_uri: "http://0.0.0.0:8080"
+homedir: "C:\\Temp"
+moby_runtime:
+  uri: "npipe://./pipe/iotedge_moby_engine"
+  network: "azure-iot-edge"


### PR DESCRIPTION
1. Add gateway_hostname paraemeter under provisioning section in iotedged config.yaml.
2. Set environment variable "IOTEDGE_GATEWAYHOSTNAME" to gateway_hostname parameter in config.yaml if defined, otherwise don't set.
3. Set environment variable "EdgeDeviceHostName" to host_name parameter in config.yaml for Edge agent/hub modules only.
4. All kubernetes related tests will not set parent edge as currently nested edge is not targeted to support with kubernetes.  Similar what did in DockerModule.
5. Added a new test "CreateOrUpdateCommandTest" for CreateOrUpdateCommand class.