### PR TITLE
[mqtt] Model-based tests to verify broker subscriptions management

### DIFF
--- a/mqtt/build/linux/clippy.sh
+++ b/mqtt/build/linux/clippy.sh
@@ -59,5 +59,5 @@ $RUSTUP component add clippy
 
 echo "Running clippy..."
 $CARGO clippy --all
-$CARGO clippy --all --tests
+$CARGO clippy --all --tests --all-features
 $CARGO clippy --all --examples

--- a/mqtt/build/linux/test.sh
+++ b/mqtt/build/linux/test.sh
@@ -55,7 +55,7 @@ process_args()
 process_args "$@"
 
 if [[ -z ${RELEASE} ]]; then
-    cd "$PROJECT_ROOT" && IOTEDGE_HOMEDIR=/tmp $CARGO test --all
+    cd "$PROJECT_ROOT" && IOTEDGE_HOMEDIR=/tmp $CARGO test --all --all-features
 else
-    cd "$PROJECT_ROOT" && IOTEDGE_HOMEDIR=/tmp $CARGO test --all --release
+    cd "$PROJECT_ROOT" && IOTEDGE_HOMEDIR=/tmp $CARGO test --all --all-features --release
 fi

--- a/mqtt/build/windows/clippy.ps1
+++ b/mqtt/build/windows/clippy.ps1
@@ -37,8 +37,8 @@ if ($LastExitCode -ne 0) {
     Throw "cargo clippy --all failed with exit code $LastExitCode"
 }
 
-Write-Host "$cargo clippy --all --tests"
-Invoke-Expression "$cargo clippy --all --tests"
+Write-Host "$cargo clippy --all --tests --all-features"
+Invoke-Expression "$cargo clippy --all --tests --all-features"
 
 if ($LastExitCode -ne 0) {
     Throw "cargo clippy --all --tests failed with exit code $LastExitCode"

--- a/mqtt/build/windows/test.ps1
+++ b/mqtt/build/windows/test.ps1
@@ -18,8 +18,8 @@ cd (Get-MqttFolder)
 
 $env:IOTEDGE_HOMEDIR = $env:Temp
 
-Write-Host "$cargo test --all $(if ($Release) { '--release' })"
-Invoke-Expression "$cargo test --all $(if ($Release) { '--release' })"
+Write-Host "$cargo test --all --all-features $(if ($Release) { '--release' })"
+Invoke-Expression "$cargo test --all --all-features $(if ($Release) { '--release' })"
 if ($LastExitCode) {
     Throw "cargo test failed with exit code $LastExitCode"
 }

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -19,6 +19,7 @@ humantime = "2.0"
 humantime-serde = "1.0"
 lazy_static = "1.4"
 native-tls = "0.2"
+proptest = { version = "0.9", optional = true }
 rand = { version = "0.7", optional = true }
 regex = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -103,6 +103,7 @@ where
         BrokerState { retained, sessions }
     }
 
+    #[cfg(any(test, feature = "proptest"))]
     pub fn clone_state(&self) -> BrokerState {
         let retained = self.retained.clone();
         let sessions = self

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -1042,34 +1042,18 @@ pub(crate) mod tests {
     use bytes::Bytes;
     use futures_util::future::FutureExt;
     use matches::assert_matches;
-    use proptest::collection::{hash_map, vec};
-    use proptest::prelude::*;
-    use tokio::sync::mpsc::error::TryRecvError;
-    use tokio::sync::mpsc::{self, UnboundedReceiver};
+    use tokio::sync::mpsc::{self, error::TryRecvError, UnboundedReceiver};
     use uuid::Uuid;
 
     use mqtt3::{proto, PROTOCOL_LEVEL, PROTOCOL_NAME};
 
     use crate::{
         auth::{Activity, AuthenticateError, AuthorizeError, Operation},
-        broker::{BrokerBuilder, BrokerHandle, BrokerState, SessionError},
+        broker::{BrokerBuilder, BrokerHandle, SessionError},
         error::Error,
-        session::{tests::arb_session_state, Session},
-        tests::{arb_publication, arb_topic},
+        session::Session,
         AuthId, ClientEvent, ClientId, ConnReq, ConnectionHandle, Message,
     };
-
-    prop_compose! {
-        pub fn arb_broker_state()(
-            retained in hash_map(arb_topic(), arb_publication(), 0..20),
-            sessions in vec(arb_session_state(), 0..10),
-        ) -> BrokerState {
-            BrokerState {
-                retained,
-                sessions,
-            }
-        }
-    }
 
     fn connection_handle() -> ConnectionHandle {
         let id = Uuid::new_v4();

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -42,6 +42,9 @@ pub use crate::snapshot::{Snapshotter, StateSnapshotHandle};
 pub use crate::subscription::{Segment, Subscription, TopicFilter};
 pub use crate::transport::TransportBuilder;
 
+#[cfg(any(test, feature = "proptest"))]
+pub mod proptest;
+
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ClientId(Arc<String>);
 
@@ -188,91 +191,4 @@ pub enum SystemEvent {
 pub enum Message {
     Client(ClientId, ClientEvent),
     System(SystemEvent),
-}
-
-#[cfg(test)]
-pub(crate) mod tests {
-    use std::sync::Arc;
-
-    use bytes::Bytes;
-    use proptest::collection::vec;
-    use proptest::num;
-    use proptest::prelude::*;
-
-    use mqtt3::proto;
-
-    use crate::{subscription::tests::arb_qos, ClientId, Publish};
-
-    pub fn arb_clientid() -> impl Strategy<Value = ClientId> {
-        "[a-zA-Z0-9]{1,23}".prop_map(|s| ClientId(Arc::new(s)))
-    }
-
-    pub fn arb_packet_identifier() -> impl Strategy<Value = proto::PacketIdentifier> {
-        (1_u16..=u16::max_value())
-            .prop_map(|i| proto::PacketIdentifier::new(i).expect("packet identifier failed"))
-    }
-
-    pub fn arb_topic() -> impl Strategy<Value = String> {
-        "\\PC+(/\\PC+)*"
-    }
-
-    pub fn arb_payload() -> impl Strategy<Value = Bytes> {
-        vec(num::u8::ANY, 0..1024).prop_map(Bytes::from)
-    }
-
-    prop_compose! {
-        pub fn arb_publication()(
-            topic_name in arb_topic(),
-            qos in arb_qos(),
-            retain in proptest::bool::ANY,
-            payload in arb_payload(),
-        ) -> proto::Publication {
-            proto::Publication {
-                topic_name,
-                qos,
-                retain,
-                payload,
-            }
-        }
-    }
-
-    pub fn arb_pidq() -> impl Strategy<Value = proto::PacketIdentifierDupQoS> {
-        prop_oneof![
-            Just(proto::PacketIdentifierDupQoS::AtMostOnce),
-            (arb_packet_identifier(), proptest::bool::ANY)
-                .prop_map(|(id, dup)| proto::PacketIdentifierDupQoS::AtLeastOnce(id, dup)),
-            (arb_packet_identifier(), proptest::bool::ANY)
-                .prop_map(|(id, dup)| proto::PacketIdentifierDupQoS::ExactlyOnce(id, dup)),
-        ]
-    }
-
-    prop_compose! {
-        pub fn arb_proto_publish()(
-            pidq in arb_pidq(),
-            retain in proptest::bool::ANY,
-            topic_name in arb_topic(),
-            payload in arb_payload(),
-        ) -> proto::Publish {
-            proto::Publish {
-                packet_identifier_dup_qos: pidq,
-                retain,
-                topic_name,
-                payload,
-            }
-        }
-    }
-
-    pub fn arb_publish() -> impl Strategy<Value = Publish> {
-        prop_oneof![
-            (arb_packet_identifier(), arb_proto_publish())
-                .prop_map(|(id, publish)| Publish::QoS0(id, publish)),
-            (arb_packet_identifier(), arb_proto_publish())
-                .prop_map(|(id, publish)| Publish::QoS12(id, publish)),
-        ]
-    }
-
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
 }

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -39,6 +39,7 @@ pub use crate::persist::{
 pub use crate::server::Server;
 pub use crate::session::SessionState;
 pub use crate::snapshot::{Snapshotter, StateSnapshotHandle};
+pub use crate::subscription::{Segment, Subscription, TopicFilter};
 pub use crate::transport::TransportBuilder;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]

--- a/mqtt/mqtt-broker/src/persist.rs
+++ b/mqtt/mqtt-broker/src/persist.rs
@@ -523,9 +523,10 @@ pub(crate) mod tests {
     use proptest::prelude::*;
     use tempfile::TempDir;
 
-    use crate::broker::{tests::arb_broker_state, BrokerState};
-    use crate::persist::{
-        ConsolidatedState, ConsolidatedStateFormat, FileFormat, FilePersistor, Persist,
+    use crate::{
+        persist::{ConsolidatedState, ConsolidatedStateFormat, FileFormat, FilePersistor, Persist},
+        proptest::arb_broker_state,
+        BrokerState,
     };
 
     proptest! {

--- a/mqtt/mqtt-broker/src/proptest.rs
+++ b/mqtt/mqtt-broker/src/proptest.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use bytes::Bytes;
 use mqtt3::proto;
 use proptest::{
     bool,
@@ -12,7 +13,6 @@ use crate::{
     session::{IdentifiersInUse, PacketIdentifiers},
     BrokerState, ClientId, Publish, Segment, SessionState, Subscription, TopicFilter,
 };
-use bytes::Bytes;
 
 prop_compose! {
     pub fn arb_broker_state()(
@@ -144,7 +144,7 @@ pub fn arb_client_id() -> impl Strategy<Value = proto::ClientId> {
     ]
 }
 pub fn arb_clientid() -> impl Strategy<Value = ClientId> {
-    "[a-zA-Z0-9]{1,23}".prop_map(|s| ClientId::from(s))
+    "[a-zA-Z0-9]{1,23}".prop_map(Into::into)
 }
 
 pub fn arb_client_id_weighted() -> impl Strategy<Value = proto::ClientId> {

--- a/mqtt/mqtt-broker/src/proptest.rs
+++ b/mqtt/mqtt-broker/src/proptest.rs
@@ -1,0 +1,268 @@
+use std::time::Duration;
+
+use mqtt3::proto;
+use proptest::{
+    bool,
+    collection::{hash_map, hash_set, vec, vec_deque},
+    num,
+    prelude::*,
+};
+
+use crate::{
+    session::{IdentifiersInUse, PacketIdentifiers},
+    BrokerState, ClientId, Publish, Segment, SessionState, Subscription, TopicFilter,
+};
+use bytes::Bytes;
+
+prop_compose! {
+    pub fn arb_broker_state()(
+        retained in hash_map(arb_topic(), arb_publication(), 0..20),
+        sessions in vec(arb_session_state(), 0..10),
+    ) -> BrokerState {
+        BrokerState::new(retained, sessions)
+    }
+}
+
+prop_compose! {
+    pub(crate) fn arb_packet_identifiers()(
+        in_use in arb_identifiers_in_use(),
+        previous in arb_packet_identifier(),
+    ) -> PacketIdentifiers {
+        PacketIdentifiers::new(in_use, previous)
+    }
+}
+
+pub(crate) fn arb_identifiers_in_use() -> impl Strategy<Value = IdentifiersInUse> {
+    vec(num::usize::ANY, PacketIdentifiers::SIZE).prop_map(|v| {
+        let mut array = [0; PacketIdentifiers::SIZE];
+        let nums = &v[..array.len()];
+        array.copy_from_slice(nums);
+        IdentifiersInUse(Box::new(array))
+    })
+}
+
+prop_compose! {
+    pub fn arb_session_state()(
+        client_id in arb_clientid(),
+        subscriptions in hash_map(arb_topic(), arb_subscription(), 0..10),
+        packet_identifiers in arb_packet_identifiers(),
+        packet_identifiers_qos0 in arb_packet_identifiers(),
+        waiting_to_be_sent in vec_deque(arb_publication(), 0..10),
+        waiting_to_be_released in hash_map(arb_packet_identifier(), arb_proto_publish(), 0..10),
+        waiting_to_be_acked in hash_map(arb_packet_identifier(), arb_publish(), 0..10),
+        waiting_to_be_acked_qos0 in hash_map(arb_packet_identifier(), arb_publish(), 0..10),
+        waiting_to_be_completed in hash_set(arb_packet_identifier(), 0..10),
+    ) -> SessionState {
+        SessionState::from_state_parts(
+            client_id,
+            subscriptions,
+            packet_identifiers,
+            packet_identifiers_qos0,
+            waiting_to_be_sent,
+            waiting_to_be_released,
+            waiting_to_be_acked,
+            waiting_to_be_acked_qos0,
+            waiting_to_be_completed,
+        )
+    }
+}
+
+prop_compose! {
+    pub fn arb_connect(client_id: proto::ClientId)(
+        username in arb_username(),
+        password in arb_password(),
+    ) -> proto::Connect{
+        proto::Connect{
+            username,
+            password,
+            will: None,
+            client_id: client_id.clone(),
+            keep_alive: Duration::from_secs(1),
+            protocol_name: mqtt3::PROTOCOL_NAME.into(),
+            protocol_level: mqtt3::PROTOCOL_LEVEL,
+        }
+    }
+}
+
+prop_compose! {
+    pub fn arb_subscribe()(
+        packet_identifier in arb_packet_identifier(),
+        subscribe_to in proptest::collection::vec(arb_subscribe_to(), 1..10)
+    ) -> proto::Subscribe {
+        proto::Subscribe {
+            packet_identifier,
+            subscribe_to
+        }
+    }
+}
+
+prop_compose! {
+    pub fn arb_subscribe_to()(
+        topic_filter in arb_topic_filter_weighted(),
+        qos in arb_qos()
+    ) -> proto::SubscribeTo {
+        proto::SubscribeTo {
+            topic_filter,
+            qos
+        }
+    }
+}
+
+prop_compose! {
+    pub fn arb_unsubscribe()(
+        packet_identifier in arb_packet_identifier(),
+        unsubscribe_from in proptest::collection::vec(arb_topic_filter_weighted(), 1..10)
+    ) -> proto::Unsubscribe {
+        proto::Unsubscribe {
+            packet_identifier,
+            unsubscribe_from
+        }
+    }
+}
+
+pub fn arb_topic_filter_weighted() -> impl Strategy<Value = String> {
+    let max = 10;
+    prop_oneof![
+        arb_topic_filter().prop_map(|topic| topic.to_string()),
+        (0..max).prop_map(|n| format!("topic/{}", n)),
+    ]
+}
+
+pub fn arb_username() -> impl Strategy<Value = Option<String>> {
+    prop_oneof!["\\PC*".prop_map(Some), Just(None)]
+}
+
+pub fn arb_password() -> impl Strategy<Value = Option<String>> {
+    prop_oneof!["\\PC*".prop_map(Some), Just(None)]
+}
+
+pub fn arb_client_id() -> impl Strategy<Value = proto::ClientId> {
+    prop_oneof![
+        Just(proto::ClientId::ServerGenerated),
+        "[a-zA-Z0-9]{1,23}".prop_map(proto::ClientId::IdWithCleanSession),
+        "[a-zA-Z0-9]{1,23}".prop_map(proto::ClientId::IdWithExistingSession)
+    ]
+}
+pub fn arb_clientid() -> impl Strategy<Value = ClientId> {
+    "[a-zA-Z0-9]{1,23}".prop_map(|s| ClientId::from(s))
+}
+
+pub fn arb_client_id_weighted() -> impl Strategy<Value = proto::ClientId> {
+    let max = 10;
+    prop_oneof![
+        Just(proto::ClientId::ServerGenerated),
+        "[a-zA-Z0-9]{1,23}".prop_map(proto::ClientId::IdWithCleanSession),
+        "[a-zA-Z0-9]{1,23}".prop_map(proto::ClientId::IdWithExistingSession),
+        (0..max).prop_map(|s| proto::ClientId::IdWithCleanSession(format!("client_{}", s))),
+        (0..max).prop_map(|s| proto::ClientId::IdWithExistingSession(format!("client_{}", s)))
+    ]
+}
+
+pub fn arb_packet_identifier() -> impl Strategy<Value = proto::PacketIdentifier> {
+    (1_u16..=u16::max_value())
+        .prop_map(|i| proto::PacketIdentifier::new(i).expect("packet identifier failed"))
+}
+
+pub fn arb_topic() -> impl Strategy<Value = String> {
+    "\\PC+(/\\PC+)*"
+}
+
+pub fn arb_payload() -> impl Strategy<Value = Bytes> {
+    vec(num::u8::ANY, 0..1024).prop_map(Bytes::from)
+}
+
+prop_compose! {
+    pub fn arb_publication()(
+        topic_name in arb_topic(),
+        qos in arb_qos(),
+        retain in proptest::bool::ANY,
+        payload in arb_payload(),
+    ) -> proto::Publication {
+        proto::Publication {
+            topic_name,
+            qos,
+            retain,
+            payload,
+        }
+    }
+}
+
+pub fn arb_pidq() -> impl Strategy<Value = proto::PacketIdentifierDupQoS> {
+    prop_oneof![
+        Just(proto::PacketIdentifierDupQoS::AtMostOnce),
+        (arb_packet_identifier(), bool::ANY)
+            .prop_map(|(id, dup)| proto::PacketIdentifierDupQoS::AtLeastOnce(id, dup)),
+        (arb_packet_identifier(), bool::ANY)
+            .prop_map(|(id, dup)| proto::PacketIdentifierDupQoS::ExactlyOnce(id, dup)),
+    ]
+}
+
+prop_compose! {
+    pub fn arb_proto_publish()(
+        pidq in arb_pidq(),
+        retain in bool::ANY,
+        topic_name in arb_topic(),
+        payload in arb_payload(),
+    ) -> proto::Publish {
+        proto::Publish {
+            packet_identifier_dup_qos: pidq,
+            retain,
+            topic_name,
+            payload,
+        }
+    }
+}
+
+pub fn arb_publish() -> impl Strategy<Value = Publish> {
+    prop_oneof![
+        (arb_packet_identifier(), arb_proto_publish())
+            .prop_map(|(id, publish)| Publish::QoS0(id, publish)),
+        (arb_packet_identifier(), arb_proto_publish())
+            .prop_map(|(id, publish)| Publish::QoS12(id, publish)),
+    ]
+}
+
+fn arb_segment() -> impl Strategy<Value = Segment> {
+    prop_oneof![
+        "[^+#\0/]+".prop_map(Segment::Level),
+        Just(Segment::SingleLevelWildcard),
+        Just(Segment::MultiLevelWildcard),
+    ]
+}
+
+prop_compose! {
+    pub fn arb_topic_filter()(
+        segments in vec(arb_segment(), 1..20),
+        multi in bool::ANY,
+    ) -> TopicFilter {
+        let mut filtered = vec![];
+        for segment in segments {
+            if segment != Segment::MultiLevelWildcard {
+                filtered.push(segment);
+            }
+        }
+
+        if multi || filtered.is_empty() {
+            filtered.push(Segment::MultiLevelWildcard);
+        }
+
+        TopicFilter::new(filtered)
+    }
+}
+
+pub fn arb_qos() -> impl Strategy<Value = proto::QoS> {
+    prop_oneof![
+        Just(proto::QoS::AtMostOnce),
+        Just(proto::QoS::AtLeastOnce),
+        Just(proto::QoS::ExactlyOnce),
+    ]
+}
+
+prop_compose! {
+    pub fn arb_subscription()(
+        filter in arb_topic_filter(),
+        max_qos in arb_qos(),
+    ) -> Subscription {
+        Subscription::new(filter, max_qos)
+    }
+}

--- a/mqtt/mqtt-broker/src/session.rs
+++ b/mqtt/mqtt-broker/src/session.rs
@@ -555,6 +555,34 @@ impl SessionState {
     }
 }
 
+#[cfg(any(test, feature = "proptest"))]
+#[allow(clippy::too_many_arguments)]
+impl SessionState {
+    pub(crate) fn from_state_parts(
+        client_id: ClientId,
+        subscriptions: HashMap<String, Subscription>,
+        packet_identifiers: PacketIdentifiers,
+        packet_identifiers_qos0: PacketIdentifiers,
+        waiting_to_be_sent: VecDeque<proto::Publication>,
+        waiting_to_be_released: HashMap<proto::PacketIdentifier, proto::Publish>,
+        waiting_to_be_acked: HashMap<proto::PacketIdentifier, Publish>,
+        waiting_to_be_acked_qos0: HashMap<proto::PacketIdentifier, Publish>,
+        waiting_to_be_completed: HashSet<proto::PacketIdentifier>,
+    ) -> Self {
+        Self {
+            client_id,
+            subscriptions,
+            packet_identifiers,
+            packet_identifiers_qos0,
+            waiting_to_be_sent,
+            waiting_to_be_acked,
+            waiting_to_be_acked_qos0,
+            waiting_to_be_released,
+            waiting_to_be_completed,
+        }
+    }
+}
+
 #[derive(Debug)]
 pub enum Session {
     Transient(ConnectedSession),
@@ -732,7 +760,7 @@ impl Session {
 }
 
 #[derive(Clone)]
-struct IdentifiersInUse(Box<[usize; PacketIdentifiers::SIZE]>);
+pub(crate) struct IdentifiersInUse(pub(crate) Box<[usize; PacketIdentifiers::SIZE]>);
 
 impl fmt::Debug for IdentifiersInUse {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -795,7 +823,7 @@ impl<'de> Deserialize<'de> for IdentifiersInUse {
 }
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
-struct PacketIdentifiers {
+pub(crate) struct PacketIdentifiers {
     in_use: IdentifiersInUse,
     previous: proto::PacketIdentifier,
 }
@@ -809,7 +837,12 @@ impl PacketIdentifiers {
     /// = pow(2, 16) / (`size_of::<usize>()` * 8)
     ///
     /// We use a bitshift instead of `usize::pow` because the latter is not a const fn
-    const SIZE: usize = (1 << 16) / (mem::size_of::<usize>() * 8);
+    pub(crate) const SIZE: usize = (1 << 16) / (mem::size_of::<usize>() * 8);
+
+    #[cfg(any(test, feature = "proptest"))]
+    pub(crate) fn new(in_use: IdentifiersInUse, previous: proto::PacketIdentifier) -> Self {
+        Self { in_use, previous }
+    }
 
     fn reserve(&mut self) -> Result<proto::PacketIdentifier, Error> {
         let start = self.previous;
@@ -864,71 +897,16 @@ pub(crate) mod tests {
     use std::time::Duration;
 
     use matches::assert_matches;
-    use proptest::collection::{hash_map, hash_set, vec, vec_deque};
-    use proptest::num;
-    use proptest::prelude::*;
     use tokio::sync::mpsc;
     use uuid::Uuid;
 
     use mqtt3::{proto, PROTOCOL_LEVEL, PROTOCOL_NAME};
 
-    use crate::subscription::tests::arb_subscription;
-    use crate::tests::{
-        arb_clientid, arb_packet_identifier, arb_proto_publish, arb_publication, arb_publish,
-        arb_topic,
-    };
-    use crate::{auth::AuthId, ConnectionHandle};
     use crate::{
-        session::{IdentifiersInUse, PacketIdentifiers, Session, SessionState},
-        ClientId, ConnReq, Error,
+        auth::AuthId,
+        session::{PacketIdentifiers, Session, SessionState},
+        ClientId, ConnReq, ConnectionHandle, Error,
     };
-
-    fn arb_identifiers_in_use() -> impl Strategy<Value = IdentifiersInUse> {
-        vec(num::usize::ANY, PacketIdentifiers::SIZE).prop_map(|v| {
-            let mut array = [0; PacketIdentifiers::SIZE];
-            let nums = &v[..array.len()];
-            array.copy_from_slice(nums);
-            IdentifiersInUse(Box::new(array))
-        })
-    }
-
-    prop_compose! {
-        fn arb_packet_identifiers()(
-            in_use in arb_identifiers_in_use(),
-            previous in arb_packet_identifier(),
-        ) -> PacketIdentifiers {
-            PacketIdentifiers {
-                in_use,
-                previous,
-            }
-        }
-    }
-
-    prop_compose! {
-        pub fn arb_session_state()(
-            client_id in arb_clientid(),
-            subscriptions in hash_map(arb_topic(), arb_subscription(), 0..10),
-            packet_identifiers in arb_packet_identifiers(),
-            packet_identifiers_qos0 in arb_packet_identifiers(),
-            waiting_to_be_sent in vec_deque(arb_publication(), 0..10),
-            waiting_to_be_released in hash_map(arb_packet_identifier(), arb_proto_publish(), 0..10),
-            waiting_to_be_acked in hash_map(arb_packet_identifier(), arb_publish(), 0..10),
-            waiting_to_be_acked_qos0 in hash_map(arb_packet_identifier(), arb_publish(), 0..10),
-            waiting_to_be_completed in hash_set(arb_packet_identifier(), 0..10),
-        ) -> SessionState {
-            SessionState {
-                client_id,
-                subscriptions,
-                packet_identifiers,
-                packet_identifiers_qos0,
-                waiting_to_be_sent,
-                waiting_to_be_released,
-                waiting_to_be_acked,
-                waiting_to_be_acked_qos0,
-                waiting_to_be_completed,
-            }
-        }
-    }
 
     fn connection_handle() -> ConnectionHandle {
         let id = Uuid::new_v4();

--- a/mqtt/mqtt-broker/src/subscription.rs
+++ b/mqtt/mqtt-broker/src/subscription.rs
@@ -38,7 +38,7 @@ pub struct TopicFilter {
 }
 
 impl TopicFilter {
-    fn new(segments: Vec<Segment>) -> Self {
+    pub fn new(segments: Vec<Segment>) -> Self {
         let len = segments.len();
         let multilevel = len > 0 && segments[len - 1] == Segment::MultiLevelWildcard;
         Self {
@@ -84,7 +84,7 @@ impl TopicFilter {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-enum Segment {
+pub enum Segment {
     Level(String),
     SingleLevelWildcard,
     MultiLevelWildcard,

--- a/mqtt/mqtt-broker/src/subscription.rs
+++ b/mqtt/mqtt-broker/src/subscription.rs
@@ -163,61 +163,9 @@ impl FromStr for TopicFilter {
 pub(crate) mod tests {
     use std::str::FromStr;
 
-    use proptest::bool;
-    use proptest::collection::vec;
     use proptest::prelude::*;
 
-    use mqtt3::proto;
-
-    use crate::subscription::{Segment, Subscription, TopicFilter};
-
-    fn arb_segment() -> impl Strategy<Value = Segment> {
-        prop_oneof![
-            "[^+#\0/]+".prop_map(Segment::Level),
-            Just(Segment::SingleLevelWildcard),
-            Just(Segment::MultiLevelWildcard),
-        ]
-    }
-
-    prop_compose! {
-        pub fn arb_topic_filter()(
-            segments in vec(arb_segment(), 1..20),
-            multi in bool::ANY,
-        ) -> TopicFilter {
-            let mut filtered = vec![];
-            for segment in segments {
-                if segment != Segment::MultiLevelWildcard {
-                    filtered.push(segment);
-                }
-            }
-
-            if multi || filtered.is_empty() {
-                filtered.push(Segment::MultiLevelWildcard);
-            }
-
-            TopicFilter::new(filtered)
-        }
-    }
-
-    pub fn arb_qos() -> impl Strategy<Value = proto::QoS> {
-        prop_oneof![
-            Just(proto::QoS::AtMostOnce),
-            Just(proto::QoS::AtLeastOnce),
-            Just(proto::QoS::ExactlyOnce),
-        ]
-    }
-
-    prop_compose! {
-        pub fn arb_subscription()(
-            filter in arb_topic_filter(),
-            max_qos in arb_qos(),
-        ) -> Subscription {
-            Subscription {
-                filter,
-                max_qos,
-            }
-        }
-    }
+    use crate::subscription::{Segment, TopicFilter};
 
     fn filter(segments: Vec<Segment>) -> TopicFilter {
         TopicFilter::new(segments)
@@ -293,7 +241,7 @@ pub(crate) mod tests {
 
     proptest! {
         #[test]
-        fn display_roundtrip(filter in arb_topic_filter()) {
+        fn display_roundtrip(filter in crate::proptest::arb_topic_filter()) {
             let string = filter.to_string();
             prop_assert_eq!(filter, string.parse::<TopicFilter>().unwrap());
         }

--- a/mqtt/mqtt-broker/tests/broker_model.rs
+++ b/mqtt/mqtt-broker/tests/broker_model.rs
@@ -1,0 +1,300 @@
+use matches::assert_matches;
+use mqtt3::{proto, PROTOCOL_LEVEL, PROTOCOL_NAME};
+use mqtt_broker::{
+    AuthId, Broker, BrokerBuilder, ClientEvent, ClientId, ConnReq, ConnectionHandle, Message,
+};
+use proptest::proptest;
+use std::{collections::HashMap, time::Duration};
+use uuid::Uuid;
+
+proptest! {
+    #[test]
+    fn broker_manages_sessions(
+        connect in tests_util::arb_connect()
+    ) {
+    tokio::runtime::Builder::new()
+        .basic_scheduler()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(test_broker_manages_sessions(connect));
+    }
+}
+
+async fn test_broker_manages_sessions(connect: proto::Connect) {
+    let mut broker = BrokerBuilder::default()
+        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
+        .authorizer(|_| Ok(true))
+        .build();
+
+    let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+    let connection_handle = ConnectionHandle::from_sender(tx);
+
+    let client_id = client_id(&connect.client_id);
+    // let connect = proto::Connect {
+    //     username: None,
+    //     password: None,
+    //     will: None,
+    //     client_id: proto::ClientId::IdWithCleanSession(id.into()),
+    //     keep_alive: Duration::from_secs(1),
+    //     protocol_name: PROTOCOL_NAME.into(),
+    //     protocol_level: PROTOCOL_LEVEL,
+    // };
+    let event = ClientEvent::ConnReq(ConnReq::new(
+        client_id.clone(),
+        connect.clone(),
+        None,
+        connection_handle,
+    ));
+
+    let mut model = BrokerModel::default();
+
+    broker
+        .process_message(client_id.clone(), event)
+        .await
+        .expect("process message");
+
+    let model_response = model.process_message(client_id.clone(), ModelEventIn::ConnReq(connect));
+
+    let (retained, sessions) = broker.clone_state().into_parts();
+
+    match (rx.recv().await, model_response) {
+        (
+            Some(Message::Client(broker_client_id, ClientEvent::ConnAck(broker_connack))),
+            Some(ModelEventOut::ConnAck(model_connack)),
+        ) => {
+            assert_eq!(broker_client_id, client_id);
+            assert_eq!(broker_connack, model_connack);
+        }
+        _ => todo!(),
+    }
+
+    assert_eq!(sessions.len(), model.sessions.len());
+    for (broker, model) in sessions.into_iter().zip(model.sessions) {
+        assert_eq!(broker.client_id(), &model.0);
+    }
+}
+
+fn client_id(client_id: &proto::ClientId) -> ClientId {
+    match client_id {
+        proto::ClientId::ServerGenerated => Uuid::new_v4().to_string().into(),
+        proto::ClientId::IdWithCleanSession(id) => id.into(),
+        proto::ClientId::IdWithExistingSession(id) => id.into(),
+    }
+}
+
+#[derive(Debug, Default)]
+struct BrokerModel {
+    pub sessions: HashMap<ClientId, ModelSession>,
+}
+
+impl BrokerModel {
+    fn process_message(
+        &mut self,
+        client_id: ClientId,
+        event: ModelEventIn,
+    ) -> Option<ModelEventOut> {
+        match event {
+            ModelEventIn::ConnReq(connreq) => Some(self.process_connect(client_id, connreq)),
+        }
+    }
+
+    fn process_connect(&mut self, client_id: ClientId, connect: proto::Connect) -> ModelEventOut {
+        let existing = self.sessions.remove(&client_id);
+        let session_present = existing.is_some();
+
+        let session = match connect.client_id {
+            proto::ClientId::ServerGenerated | proto::ClientId::IdWithCleanSession(_) => {
+                ModelSession::Transient(Vec::default())
+            }
+            _ => existing.unwrap_or_else(|| ModelSession::Persisted(Vec::default())),
+        };
+
+        self.sessions.insert(client_id, session);
+
+        ModelEventOut::ConnAck(proto::ConnAck {
+            session_present,
+            return_code: proto::ConnectReturnCode::Accepted,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub enum ModelSession {
+    Transient(Vec<String>),
+    Persisted(Vec<String>),
+}
+
+enum ModelEventIn {
+    ConnReq(proto::Connect),
+}
+
+enum ModelEventOut {
+    ConnAck(proto::ConnAck),
+}
+
+mod tests_util {
+    use std::{sync::Arc, time::Duration};
+
+    use mqtt3::proto;
+    use proptest::{bool, collection::vec, num, prelude::*};
+
+    use bytes::Bytes;
+    use mqtt_broker::{ClientId, Publish, Segment, Subscription, TopicFilter};
+
+    //     pub fn arb_client_event() -> impl Strategy<Value = ClientEvent> {
+
+    //         prop_oneof![
+    //             arb_connect()
+    //         ]
+    //     }
+    // }
+
+    prop_compose! {
+        pub fn arb_connect()(
+            username in arb_username(),
+            password in arb_password(),
+            client_id in arb_client_id()
+        ) -> proto::Connect{
+            proto::Connect{
+
+                username,
+                password,
+                will: None,
+                client_id,
+                keep_alive: Duration::from_secs(1),
+                protocol_name: mqtt3::PROTOCOL_NAME.into(),
+                protocol_level: mqtt3::PROTOCOL_LEVEL,
+            }
+        }
+    }
+
+    pub fn arb_username() -> impl Strategy<Value = Option<String>> {
+        prop_oneof!["\\PC*".prop_map(|s| Some(s.into())), Just(None)]
+    }
+
+    pub fn arb_password() -> impl Strategy<Value = Option<String>> {
+        prop_oneof!["\\PC*".prop_map(|s| Some(s.to_string())), Just(None)]
+    }
+
+    pub fn arb_client_id() -> impl Strategy<Value = proto::ClientId> {
+        prop_oneof![
+            Just(proto::ClientId::ServerGenerated),
+            "[a-zA-Z0-9]{1,23}".prop_map(|s| proto::ClientId::IdWithCleanSession(s)),
+            "[a-zA-Z0-9]{1,23}".prop_map(|s| proto::ClientId::IdWithExistingSession(s))
+        ]
+    }
+
+    // pub fn arb_client_id() -> impl Strategy<Value = ClientId> {
+    //     "[a-zA-Z0-9]{1,23}".prop_map(|s| ClientId(Arc::new(s)))
+    // }
+
+    pub fn arb_packet_identifier() -> impl Strategy<Value = proto::PacketIdentifier> {
+        (1_u16..=u16::max_value())
+            .prop_map(|i| proto::PacketIdentifier::new(i).expect("packet identifier failed"))
+    }
+
+    pub fn arb_topic() -> impl Strategy<Value = String> {
+        "\\PC+(/\\PC+)*"
+    }
+
+    pub fn arb_payload() -> impl Strategy<Value = Bytes> {
+        vec(num::u8::ANY, 0..1024).prop_map(Bytes::from)
+    }
+
+    prop_compose! {
+        pub fn arb_publication()(
+            topic_name in arb_topic(),
+            qos in arb_qos(),
+            retain in proptest::bool::ANY,
+            payload in arb_payload(),
+        ) -> proto::Publication {
+            proto::Publication {
+                topic_name,
+                qos,
+                retain,
+                payload,
+            }
+        }
+    }
+
+    pub fn arb_pidq() -> impl Strategy<Value = proto::PacketIdentifierDupQoS> {
+        prop_oneof![
+            Just(proto::PacketIdentifierDupQoS::AtMostOnce),
+            (arb_packet_identifier(), bool::ANY)
+                .prop_map(|(id, dup)| proto::PacketIdentifierDupQoS::AtLeastOnce(id, dup)),
+            (arb_packet_identifier(), bool::ANY)
+                .prop_map(|(id, dup)| proto::PacketIdentifierDupQoS::ExactlyOnce(id, dup)),
+        ]
+    }
+
+    prop_compose! {
+        pub fn arb_proto_publish()(
+            pidq in arb_pidq(),
+            retain in bool::ANY,
+            topic_name in arb_topic(),
+            payload in arb_payload(),
+        ) -> proto::Publish {
+            proto::Publish {
+                packet_identifier_dup_qos: pidq,
+                retain,
+                topic_name,
+                payload,
+            }
+        }
+    }
+
+    pub fn arb_publish() -> impl Strategy<Value = Publish> {
+        prop_oneof![
+            (arb_packet_identifier(), arb_proto_publish())
+                .prop_map(|(id, publish)| Publish::QoS0(id, publish)),
+            (arb_packet_identifier(), arb_proto_publish())
+                .prop_map(|(id, publish)| Publish::QoS12(id, publish)),
+        ]
+    }
+
+    fn arb_segment() -> impl Strategy<Value = Segment> {
+        prop_oneof![
+            "[^+#\0/]+".prop_map(Segment::Level),
+            Just(Segment::SingleLevelWildcard),
+            Just(Segment::MultiLevelWildcard),
+        ]
+    }
+
+    prop_compose! {
+        pub fn arb_topic_filter()(
+            segments in vec(arb_segment(), 1..20),
+            multi in bool::ANY,
+        ) -> TopicFilter {
+            let mut filtered = vec![];
+            for segment in segments {
+                if segment != Segment::MultiLevelWildcard {
+                    filtered.push(segment);
+                }
+            }
+
+            if multi || filtered.is_empty() {
+                filtered.push(Segment::MultiLevelWildcard);
+            }
+
+            TopicFilter::new(filtered)
+        }
+    }
+
+    pub fn arb_qos() -> impl Strategy<Value = proto::QoS> {
+        prop_oneof![
+            Just(proto::QoS::AtMostOnce),
+            Just(proto::QoS::AtLeastOnce),
+            Just(proto::QoS::ExactlyOnce),
+        ]
+    }
+
+    prop_compose! {
+        pub fn arb_subscription()(
+            filter in arb_topic_filter(),
+            max_qos in arb_qos(),
+        ) -> Subscription {
+            Subscription::new(filter, max_qos)
+        }
+    }
+}

--- a/mqtt/mqtt-broker/tests/broker_model.rs
+++ b/mqtt/mqtt-broker/tests/broker_model.rs
@@ -11,6 +11,17 @@ use mqtt_broker::{
 };
 
 proptest! {
+    /// Model based test to check whether broker can manage arbitrary packet sequence while
+    /// maintaining sessions and subscriptions for clients properly.
+    ///
+    /// Model-based tests contain a simplified model of MQTT broker that handles some MQTT packets.
+    /// Randomly generated MQTT packets processed by both: broker and broker model. Later tests verify
+    /// that the broker and its model processed packet in a similar way.
+    ///
+    /// Currently, there is only on a test case that handles a randomly generated sequence of
+    /// CONNECT, DISCONNECT, SUBSCRIBE, UNSUBSCRIBE packets with pseudo-random data. In the end,
+    /// the test verifies that both the broker and its model contain the same number of sessions
+    //// and same number of subscriptions.
     #[test]
     fn broker_manages_sessions(
         events in proptest::collection::vec(arb_broker_event(), 1..50)

--- a/mqtt/mqtt-broker/tests/broker_model.rs
+++ b/mqtt/mqtt-broker/tests/broker_model.rs
@@ -1,18 +1,19 @@
 use std::collections::{HashMap, HashSet};
 
-use proptest::proptest;
+use proptest::{prop_oneof, proptest, strategy::Strategy};
 use tokio::sync::mpsc::{self, UnboundedReceiver};
 use uuid::Uuid;
 
 use mqtt3::proto;
 use mqtt_broker::{
+    proptest::{arb_client_id_weighted, arb_connect, arb_subscribe, arb_unsubscribe},
     AuthId, BrokerBuilder, ClientEvent, ClientId, ConnReq, ConnectionHandle, Message,
 };
 
 proptest! {
     #[test]
     fn broker_manages_sessions(
-        events in proptest::collection::vec(tests_util::arb_broker_event(), 1..50)
+        events in proptest::collection::vec(arb_broker_event(), 1..50)
     ) {
     tokio::runtime::Builder::new()
         .basic_scheduler()
@@ -222,230 +223,18 @@ enum ModelEventIn {
     Unsubscribe(proto::Unsubscribe),
 }
 
-mod tests_util {
-    use std::time::Duration;
-
-    use mqtt3::proto;
-    use proptest::{bool, collection::vec, num, prelude::*};
-
-    use bytes::Bytes;
-    use mqtt_broker::{Publish, Segment, Subscription, TopicFilter};
-
-    use crate::{client_id, BrokerEvent};
-
-    pub fn arb_broker_event() -> impl Strategy<Value = BrokerEvent> {
-        prop_oneof![
-            arb_client_id_weighted()
-                .prop_flat_map(|id| arb_connect(id)
-                    .prop_map(|p| BrokerEvent::ConnReq(client_id(&p.client_id), p))),
-            arb_client_id_weighted()
-                .prop_map(|id| BrokerEvent::Disconnect(client_id(&id), proto::Disconnect)),
-            arb_client_id_weighted()
-                .prop_flat_map(|id| arb_subscribe()
-                    .prop_map(move |p| BrokerEvent::Subscribe(client_id(&id), p))),
-            arb_client_id_weighted().prop_flat_map(|id| arb_unsubscribe()
+pub fn arb_broker_event() -> impl Strategy<Value = BrokerEvent> {
+    prop_oneof![
+        arb_client_id_weighted().prop_flat_map(
+            |id| arb_connect(id).prop_map(|p| BrokerEvent::ConnReq(client_id(&p.client_id), p))
+        ),
+        arb_client_id_weighted()
+            .prop_map(|id| BrokerEvent::Disconnect(client_id(&id), proto::Disconnect)),
+        arb_client_id_weighted().prop_flat_map(
+            |id| arb_subscribe().prop_map(move |p| BrokerEvent::Subscribe(client_id(&id), p))
+        ),
+        arb_client_id_weighted()
+            .prop_flat_map(|id| arb_unsubscribe()
                 .prop_map(move |p| BrokerEvent::Unsubscribe(client_id(&id), p))),
-        ]
-    }
-
-    prop_compose! {
-        pub fn arb_connect(client_id: proto::ClientId)(
-            username in arb_username(),
-            password in arb_password(),
-        ) -> proto::Connect{
-            proto::Connect{
-                username,
-                password,
-                will: None,
-                client_id: client_id.clone(),
-                keep_alive: Duration::from_secs(1),
-                protocol_name: mqtt3::PROTOCOL_NAME.into(),
-                protocol_level: mqtt3::PROTOCOL_LEVEL,
-            }
-        }
-    }
-
-    prop_compose! {
-        pub fn arb_subscribe()(
-            packet_identifier in arb_packet_identifier(),
-            subscribe_to in proptest::collection::vec(arb_subscribe_to(), 1..10)
-        ) -> proto::Subscribe {
-            proto::Subscribe {
-                packet_identifier,
-                subscribe_to
-            }
-        }
-    }
-
-    prop_compose! {
-        pub fn arb_subscribe_to()(
-            topic_filter in arb_topic_filter_weighted(),
-            qos in arb_qos()
-        ) -> proto::SubscribeTo {
-            proto::SubscribeTo {
-                topic_filter,
-                qos
-            }
-        }
-    }
-
-    prop_compose! {
-        pub fn arb_unsubscribe()(
-            packet_identifier in arb_packet_identifier(),
-            unsubscribe_from in proptest::collection::vec(arb_topic_filter_weighted(), 1..10)
-        ) -> proto::Unsubscribe {
-            proto::Unsubscribe {
-                packet_identifier,
-                unsubscribe_from
-            }
-        }
-    }
-
-    pub fn arb_topic_filter_weighted() -> impl Strategy<Value = String> {
-        let max = 10;
-        prop_oneof![
-            arb_topic_filter().prop_map(|topic| topic.to_string()),
-            (0..max).prop_map(|n| format!("topic/{}", n)),
-        ]
-    }
-
-    pub fn arb_username() -> impl Strategy<Value = Option<String>> {
-        prop_oneof!["\\PC*".prop_map(|s| Some(s.into())), Just(None)]
-    }
-
-    pub fn arb_password() -> impl Strategy<Value = Option<String>> {
-        prop_oneof!["\\PC*".prop_map(|s| Some(s.to_string())), Just(None)]
-    }
-
-    pub fn arb_client_id() -> impl Strategy<Value = proto::ClientId> {
-        prop_oneof![
-            Just(proto::ClientId::ServerGenerated),
-            "[a-zA-Z0-9]{1,23}".prop_map(|s| proto::ClientId::IdWithCleanSession(s)),
-            "[a-zA-Z0-9]{1,23}".prop_map(|s| proto::ClientId::IdWithExistingSession(s))
-        ]
-    }
-
-    pub fn arb_client_id_weighted() -> impl Strategy<Value = proto::ClientId> {
-        let max = 10;
-        prop_oneof![
-            Just(proto::ClientId::ServerGenerated),
-            "[a-zA-Z0-9]{1,23}".prop_map(|s| proto::ClientId::IdWithCleanSession(s)),
-            "[a-zA-Z0-9]{1,23}".prop_map(|s| proto::ClientId::IdWithExistingSession(s)),
-            (0..max).prop_map(|s| proto::ClientId::IdWithCleanSession(format!("client_{}", s))),
-            (0..max).prop_map(|s| proto::ClientId::IdWithExistingSession(format!("client_{}", s)))
-        ]
-    }
-
-    // pub fn arb_client_id() -> impl Strategy<Value = ClientId> {
-    //     "[a-zA-Z0-9]{1,23}".prop_map(|s| ClientId(Arc::new(s)))
-    // }
-
-    pub fn arb_packet_identifier() -> impl Strategy<Value = proto::PacketIdentifier> {
-        (1_u16..=u16::max_value())
-            .prop_map(|i| proto::PacketIdentifier::new(i).expect("packet identifier failed"))
-    }
-
-    pub fn arb_topic() -> impl Strategy<Value = String> {
-        "\\PC+(/\\PC+)*"
-    }
-
-    pub fn arb_payload() -> impl Strategy<Value = Bytes> {
-        vec(num::u8::ANY, 0..1024).prop_map(Bytes::from)
-    }
-
-    prop_compose! {
-        pub fn arb_publication()(
-            topic_name in arb_topic(),
-            qos in arb_qos(),
-            retain in proptest::bool::ANY,
-            payload in arb_payload(),
-        ) -> proto::Publication {
-            proto::Publication {
-                topic_name,
-                qos,
-                retain,
-                payload,
-            }
-        }
-    }
-
-    pub fn arb_pidq() -> impl Strategy<Value = proto::PacketIdentifierDupQoS> {
-        prop_oneof![
-            Just(proto::PacketIdentifierDupQoS::AtMostOnce),
-            (arb_packet_identifier(), bool::ANY)
-                .prop_map(|(id, dup)| proto::PacketIdentifierDupQoS::AtLeastOnce(id, dup)),
-            (arb_packet_identifier(), bool::ANY)
-                .prop_map(|(id, dup)| proto::PacketIdentifierDupQoS::ExactlyOnce(id, dup)),
-        ]
-    }
-
-    prop_compose! {
-        pub fn arb_proto_publish()(
-            pidq in arb_pidq(),
-            retain in bool::ANY,
-            topic_name in arb_topic(),
-            payload in arb_payload(),
-        ) -> proto::Publish {
-            proto::Publish {
-                packet_identifier_dup_qos: pidq,
-                retain,
-                topic_name,
-                payload,
-            }
-        }
-    }
-
-    pub fn arb_publish() -> impl Strategy<Value = Publish> {
-        prop_oneof![
-            (arb_packet_identifier(), arb_proto_publish())
-                .prop_map(|(id, publish)| Publish::QoS0(id, publish)),
-            (arb_packet_identifier(), arb_proto_publish())
-                .prop_map(|(id, publish)| Publish::QoS12(id, publish)),
-        ]
-    }
-
-    fn arb_segment() -> impl Strategy<Value = Segment> {
-        prop_oneof![
-            "[^+#\0/]+".prop_map(Segment::Level),
-            Just(Segment::SingleLevelWildcard),
-            Just(Segment::MultiLevelWildcard),
-        ]
-    }
-
-    prop_compose! {
-        pub fn arb_topic_filter()(
-            segments in vec(arb_segment(), 1..20),
-            multi in bool::ANY,
-        ) -> TopicFilter {
-            let mut filtered = vec![];
-            for segment in segments {
-                if segment != Segment::MultiLevelWildcard {
-                    filtered.push(segment);
-                }
-            }
-
-            if multi || filtered.is_empty() {
-                filtered.push(Segment::MultiLevelWildcard);
-            }
-
-            TopicFilter::new(filtered)
-        }
-    }
-
-    pub fn arb_qos() -> impl Strategy<Value = proto::QoS> {
-        prop_oneof![
-            Just(proto::QoS::AtMostOnce),
-            Just(proto::QoS::AtLeastOnce),
-            Just(proto::QoS::ExactlyOnce),
-        ]
-    }
-
-    prop_compose! {
-        pub fn arb_subscription()(
-            filter in arb_topic_filter(),
-            max_qos in arb_qos(),
-        ) -> Subscription {
-            Subscription::new(filter, max_qos)
-        }
-    }
+    ]
 }

--- a/mqtt/mqtt-broker/tests/persist_failpoints.rs
+++ b/mqtt/mqtt-broker/tests/persist_failpoints.rs
@@ -97,7 +97,7 @@ fn test_failpoints_smoketest() {
 }
 
 // Generates random sequences of events and failures and ensures
-// that the last commited snapshot isn't corrupted.
+// that the last committed snapshot isn't corrupted.
 proptest! {
     #[test]
     fn test_failpoints(count in 0usize..10, ops in vec(arb_op(), 0..50)) {


### PR DESCRIPTION
Model-based tests contain a simplified model of MQTT broker that handles some MQTT packets. Randomly generated MQTT packets processed by both: broker and broker model. Later tests verify that the broker and its model processed packet in a similar way.

Currently, there is only on a test case that handles a randomly generated sequence of CONNECT, DISCONNECT, SUBSCRIBE, UNSUBSCRIBE packets with pseudo-random data. In the end, the test verifies that both the broker and its model contain the same number of sessions and same number of subscriptions.