### PR TITLE
Don't delete provisioning backup when configuration changes

### DIFF
--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -2703,10 +2703,7 @@ mod tests {
             .unwrap();
 
         let file1 = tmp_dir.path().join("file1.txt");
-        File::create(&file1)
-            .unwrap()
-            .write_all(b"hello")
-            .unwrap();
+        File::create(&file1).unwrap().write_all(b"hello").unwrap();
 
         // change settings; will force update of settings_state
         let settings1 = Settings::new(Path::new(GOOD_SETTINGS1)).unwrap();

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -1368,10 +1368,6 @@ where
 
     let path = subdir.join(filename);
 
-    // Ignore errors from this operation because we could be recovering from a previous bad
-    // configuration and shouldn't stall the current configuration because of that
-    let _ = fs::remove_file(path);
-
     // regenerate the workload CA certificate
     destroy_workload_ca(crypto)?;
     prepare_workload_ca(crypto)?;

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -1357,7 +1357,6 @@ where
     M::Settings: Serialize,
     C: CreateCertificate + GetIssuerAlias + MasterEncryptionKey,
 {
-    // Remove all edge containers and delete settings state
     info!("Removing all modules...");
     tokio_runtime
         .block_on(runtime.remove_all())

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -2699,13 +2699,13 @@ mod tests {
         let provisioning_backup_json = tmp_dir.path().join("provisioning_backup.json");
         File::create(&provisioning_backup_json)
             .unwrap()
-            .write_all("{}".as_bytes())
+            .write_all(b"{}")
             .unwrap();
 
         let file1 = tmp_dir.path().join("file1.txt");
         File::create(&file1)
             .unwrap()
-            .write_all("hello".as_bytes())
+            .write_all(b"hello")
             .unwrap();
 
         // change settings; will force update of settings_state


### PR DESCRIPTION
At startup, if iotedged detects that `config.yaml` has changed it will remove the `{homedir}/cache/` folder, rebuild the `settings_state` file in that folder (the hash used to detect `config.yaml` changes), and remove any running containers so edge agent can recreate them. When this logic was originally introduced into iotedged, the _other_ file in that folder, `provisioning_backup.json`, would have also been recreated a little later in the startup cycle after provisioning took place.

The problem is that, in 1.0.9, the startup sequence was adjusted and provisioning now takes place _before_ we detect changes in `config.yaml`. As a result, `provisioning_backup.json` is created but then subsequently deleted if `config.yaml` changes are detected.

The impact is that users who specify some form of DPS provisioning in their `config.yaml`, and who upgrade their devices to 1.0.9 will not be able to reprovision their offline devices without doing an additional reboot.

This change removes the code that deleted the entire `cache/` folder. The existing code to recreate `settings_state` already creates the file if it didn't exist, or overwrites it otherwise. The provisioning backup file will already have been refreshed earlier in the startup sequence and doesn't need to be recreated.