### PR TITLE
[mqtt] Moving authentication to connection from the broker

### DIFF
--- a/mqtt/mqtt-broker/src/auth/mod.rs
+++ b/mqtt/mqtt-broker/src/auth/mod.rs
@@ -1,9 +1,7 @@
 mod authentication;
 mod authorization;
 
-pub use authentication::{
-    AuthenticateError, Authenticator, Certificate, Credentials, DefaultAuthenticator,
-};
+pub use authentication::{Authenticator, Certificate, Credentials, DefaultAuthenticator};
 pub use authorization::{Activity, AuthorizeError, Authorizer, DefaultAuthorizer, Operation};
 
 /// Authenticated MQTT client identity.

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -1055,7 +1055,8 @@ pub(crate) mod tests {
         broker::{BrokerBuilder, BrokerHandle},
         error::Error,
         session::Session,
-        AuthId, AuthenticationError, AuthResult, ClientEvent, ClientId, ConnReq, ConnectionHandle, Message, Publish,
+        AuthId, AuthResult, AuthenticationError, ClientEvent, ClientId, ConnReq, ConnectionHandle,
+        Message, Publish,
     };
 
     pub fn connection_handle() -> ConnectionHandle {
@@ -2065,9 +2066,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_notify_state_change_single_connection() {
-        let broker = BrokerBuilder::default()
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -2106,9 +2105,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_notify_state_change_multiple_connection() {
-        let broker = BrokerBuilder::default()
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -2137,9 +2134,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_notify_state_change_add_remove_connection() {
-        let broker = BrokerBuilder::default()
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -2175,9 +2170,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_notify_state_change_add_remove_subscription() {
-        let broker = BrokerBuilder::default()
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -2211,9 +2204,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_notify_state_change_add_remove_multiple_subscriptions() {
-        let broker = BrokerBuilder::default()
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -2250,9 +2241,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_notify_state_change_existing_subscriptions() {
-        let broker = BrokerBuilder::default()
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -6,14 +6,12 @@ use mqtt3::proto;
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info, span, warn, Level};
 
-use crate::auth::{
-    Activity, Authenticator, Authorizer, Credentials, DefaultAuthenticator, DefaultAuthorizer,
-    Operation,
-};
+use crate::auth::{Activity, Authorizer, DefaultAuthorizer, Operation};
 use crate::session::{ConnectedSession, Session, SessionState};
 use crate::state_change::StateChange;
 use crate::{
-    subscription::Subscription, AuthId, ClientEvent, ClientId, ConnReq, Error, Message, SystemEvent,
+    subscription::Subscription, AuthId, AuthResult, ClientEvent, ClientId, ConnReq, Error, Message,
+    SystemEvent,
 };
 use tokio::sync::mpsc::{self, Receiver, Sender};
 
@@ -28,21 +26,19 @@ macro_rules! try_send {
     }};
 }
 
-pub struct Broker<N, Z> {
+pub struct Broker<Z> {
     sender: Sender<Message>,
     messages: Receiver<Message>,
     sessions: HashMap<ClientId, Session>,
     retained: HashMap<String, proto::Publication>,
-    authenticator: N,
     authorizer: Z,
 
     #[cfg(feature = "__internal_broker_callbacks")]
     pub on_publish: Option<tokio::sync::mpsc::UnboundedSender<std::time::Duration>>,
 }
 
-impl<N, Z> Broker<N, Z>
+impl<Z> Broker<Z>
 where
-    N: Authenticator + Send + 'static,
     Z: Authorizer + Send + 'static,
 {
     pub fn handle(&self) -> BrokerHandle {
@@ -249,27 +245,20 @@ where
         // and authorization checks. If any of these checks fail, it SHOULD send an
         // appropriate CONNACK response with a non-zero return code as described in
         // section 3.2 and it MUST close the Network Connection.
-        let credentials = connreq.certificate().map_or(
-            Credentials::Basic(
-                connreq.connect().username.clone(),
-                connreq.connect().password.clone(),
-            ),
-            |certificate| Credentials::ClientCertificate(certificate.clone()),
-        );
-        let auth_id = match self.authenticator.authenticate(credentials) {
-            Ok(Some(auth_id)) => {
+        let auth_id = match connreq.auth() {
+            AuthResult::Successful(Some(auth_id)) => {
                 debug!(
                     "client {} successfully authenticated: {}",
                     client_id, auth_id
                 );
-                auth_id
+                auth_id.clone()
             }
-            Ok(None) => {
+            AuthResult::Successful(None) => {
                 warn!("unable to authenticate client: {}", client_id);
                 refuse_connection!(proto::ConnectionRefusedReason::BadUserNameOrPassword);
                 return Ok(());
             }
-            Err(e) => {
+            AuthResult::Failed(e) => {
                 warn!(message = "error authenticating client: {}", error = %e);
                 refuse_connection!(proto::ConnectionRefusedReason::ServerUnavailable);
                 return Ok(());
@@ -967,45 +956,30 @@ impl BrokerState {
     }
 }
 
-pub struct BrokerBuilder<N, Z> {
+pub struct BrokerBuilder<Z> {
     state: Option<BrokerState>,
-    authenticator: N,
     authorizer: Z,
 }
 
-impl Default for BrokerBuilder<DefaultAuthenticator, DefaultAuthorizer> {
+impl Default for BrokerBuilder<DefaultAuthorizer> {
     fn default() -> Self {
         Self {
             state: None,
-            authenticator: DefaultAuthenticator,
             authorizer: DefaultAuthorizer,
         }
     }
 }
 
-impl<N, Z> BrokerBuilder<N, Z>
+impl<Z> BrokerBuilder<Z>
 where
-    N: Authenticator,
     Z: Authorizer,
 {
-    pub fn authenticator<N1>(self, authenticator: N1) -> BrokerBuilder<N1, Z>
-    where
-        N1: Authenticator,
-    {
-        BrokerBuilder {
-            state: self.state,
-            authenticator,
-            authorizer: self.authorizer,
-        }
-    }
-
-    pub fn authorizer<Z1>(self, authorizer: Z1) -> BrokerBuilder<N, Z1>
+    pub fn authorizer<Z1>(self, authorizer: Z1) -> BrokerBuilder<Z1>
     where
         Z1: Authorizer,
     {
         BrokerBuilder {
             state: self.state,
-            authenticator: self.authenticator,
             authorizer,
         }
     }
@@ -1015,7 +989,7 @@ where
         self
     }
 
-    pub fn build(self) -> Broker<N, Z> {
+    pub fn build(self) -> Broker<Z> {
         let (retained, sessions) = match self.state {
             Some(state) => {
                 let sessions = state
@@ -1035,7 +1009,6 @@ where
             messages,
             sessions,
             retained,
-            authenticator: self.authenticator,
             authorizer: self.authorizer,
 
             #[cfg(feature = "__internal_broker_callbacks")]
@@ -1078,11 +1051,11 @@ pub(crate) mod tests {
 
     use super::OpenSession;
     use crate::{
-        auth::{Activity, AuthenticateError, AuthorizeError, Operation},
+        auth::{Activity, AuthorizeError, Operation},
         broker::{BrokerBuilder, BrokerHandle},
         error::Error,
         session::Session,
-        AuthId, ClientEvent, ClientId, ConnReq, ConnectionHandle, Message, Publish,
+        AuthId, AuthenticationError, AuthResult, ClientEvent, ClientId, ConnReq, ConnectionHandle, Message, Publish,
     };
 
     pub fn connection_handle() -> ConnectionHandle {
@@ -1118,10 +1091,7 @@ pub(crate) mod tests {
     #[tokio::test]
     #[should_panic]
     async fn test_double_connect_protocol_violation() {
-        let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -1150,8 +1120,18 @@ pub(crate) mod tests {
         let conn2 = ConnectionHandle::new(id, tx1);
         let client_id = ClientId::from("blah".to_string());
 
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
-        let req2 = ConnReq::new(client_id.clone(), connect2, None, conn2);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn1,
+        );
+        let req2 = ConnReq::new(
+            client_id.clone(),
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn2,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1181,10 +1161,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_double_connect_drop_first_transient() {
-        let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -1213,8 +1190,18 @@ pub(crate) mod tests {
         let conn2 = ConnectionHandle::from_sender(tx2);
         let client_id = ClientId::from("blah".to_string());
 
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
-        let req2 = ConnReq::new(client_id.clone(), connect2, None, conn2);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn1,
+        );
+        let req2 = ConnReq::new(
+            client_id.clone(),
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn2,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1249,10 +1236,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_invalid_protocol_name() {
-        let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -1269,7 +1253,12 @@ pub(crate) mod tests {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn1,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1288,10 +1277,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_invalid_protocol_level() {
-        let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -1308,7 +1294,12 @@ pub(crate) mod tests {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn1,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1337,10 +1328,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_connect_auth_succeeded() {
-        let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -1358,7 +1346,12 @@ pub(crate) mod tests {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn1,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1380,10 +1373,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_connect_unknown_client() {
-        let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(None))
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -1401,7 +1391,12 @@ pub(crate) mod tests {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(None),
+            conn1,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1430,10 +1425,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_connect_authentication_failed() {
-        let broker = BrokerBuilder::default()
-            .authenticator(|_| Err(AuthenticateError))
-            .authorizer(|_| Ok(true))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -1451,7 +1443,12 @@ pub(crate) mod tests {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Failed(AuthenticationError::GeneralError),
+            conn1,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1480,10 +1477,7 @@ pub(crate) mod tests {
 
     #[tokio::test]
     async fn test_connect_client_has_no_permissions() {
-        let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some("client-a".into())))
-            .authorizer(|_| Ok(false))
-            .build();
+        let broker = BrokerBuilder::default().authorizer(|_| Ok(false)).build();
 
         let mut broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
@@ -1501,7 +1495,12 @@ pub(crate) mod tests {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn1,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1531,7 +1530,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_connect_authorization_failed() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
             .authorizer(|_| Err(AuthorizeError))
             .build();
 
@@ -1551,7 +1549,12 @@ pub(crate) mod tests {
         let (tx1, mut rx1) = mpsc::unbounded_channel();
         let conn1 = ConnectionHandle::from_sender(tx1);
         let client_id = ClientId::from("blah".to_string());
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, conn1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn1,
+        );
 
         broker_handle
             .send(Message::Client(
@@ -1580,16 +1583,18 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_session_empty_transient() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
         let connect = transient_connect(id);
         let handle = connection_handle();
-        let req = ConnReq::new(client_id.clone(), connect, None, handle);
+        let req = ConnReq::new(
+            client_id.clone(),
+            connect,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id, req).unwrap();
@@ -1606,16 +1611,18 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_session_empty_persistent() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
         let connect = persistent_connect(id);
         let handle = connection_handle();
-        let req = ConnReq::new(client_id.clone(), connect, None, handle);
+        let req = ConnReq::new(
+            client_id.clone(),
+            connect,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id, req).unwrap();
@@ -1633,10 +1640,7 @@ pub(crate) mod tests {
     #[test]
     #[should_panic]
     fn test_add_session_same_connection_transient() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
@@ -1647,8 +1651,18 @@ pub(crate) mod tests {
         let handle1 = ConnectionHandle::new(id, tx1.clone());
         let handle2 = ConnectionHandle::new(id, tx1);
 
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, handle1);
-        let req2 = ConnReq::new(client_id, connect2, None, handle2);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle1,
+        );
+        let req2 = ConnReq::new(
+            client_id,
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle2,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id.clone(), req1).unwrap();
@@ -1662,10 +1676,7 @@ pub(crate) mod tests {
     #[test]
     #[should_panic]
     fn test_add_session_same_connection_persistent() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
@@ -1676,8 +1687,18 @@ pub(crate) mod tests {
         let handle1 = ConnectionHandle::new(id, tx1.clone());
         let handle2 = ConnectionHandle::new(id, tx1);
 
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, handle1);
-        let req2 = ConnReq::new(client_id, connect2, None, handle2);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle1,
+        );
+        let req2 = ConnReq::new(
+            client_id,
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle2,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id.clone(), req1).unwrap();
@@ -1690,10 +1711,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_session_different_connection_transient_then_transient() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
@@ -1701,13 +1719,23 @@ pub(crate) mod tests {
         let connect2 = transient_connect(id);
         let handle1 = connection_handle();
         let handle2 = connection_handle();
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, handle1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle1,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id.clone(), req1).unwrap();
         assert_eq!(1, broker.sessions.len());
 
-        let req2 = ConnReq::new(client_id.clone(), connect2, None, handle2);
+        let req2 = ConnReq::new(
+            client_id.clone(),
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle2,
+        );
         let result = broker.open_session(auth_id, req2);
         assert_matches!(result, Ok(OpenSession::DuplicateSession(_, _)));
         assert_matches!(broker.sessions[&client_id], Session::Transient(_));
@@ -1716,10 +1744,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_session_different_connection_transient_then_persistent() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
@@ -1727,13 +1752,23 @@ pub(crate) mod tests {
         let connect2 = persistent_connect(id);
         let handle1 = connection_handle();
         let handle2 = connection_handle();
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, handle1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle1,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id.clone(), req1).unwrap();
         assert_eq!(1, broker.sessions.len());
 
-        let req2 = ConnReq::new(client_id.clone(), connect2, None, handle2);
+        let req2 = ConnReq::new(
+            client_id.clone(),
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle2,
+        );
         let result = broker.open_session(auth_id, req2);
         assert_matches!(result, Ok(OpenSession::DuplicateSession(_, _)));
         assert_matches!(broker.sessions[&client_id], Session::Persistent(_));
@@ -1742,10 +1777,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_session_different_connection_persistent_then_transient() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
@@ -1753,13 +1785,23 @@ pub(crate) mod tests {
         let connect2 = transient_connect(id);
         let handle1 = connection_handle();
         let handle2 = connection_handle();
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, handle1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle1,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id.clone(), req1).unwrap();
         assert_eq!(1, broker.sessions.len());
 
-        let req2 = ConnReq::new(client_id.clone(), connect2, None, handle2);
+        let req2 = ConnReq::new(
+            client_id.clone(),
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle2,
+        );
         let result = broker.open_session(auth_id, req2);
         assert_matches!(result, Ok(OpenSession::DuplicateSession(_, _)));
         assert_matches!(broker.sessions[&client_id], Session::Transient(_));
@@ -1768,10 +1810,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_session_different_connection_persistent_then_persistent() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
@@ -1779,8 +1818,18 @@ pub(crate) mod tests {
         let connect2 = persistent_connect(id);
         let handle1 = connection_handle();
         let handle2 = connection_handle();
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, handle1);
-        let req2 = ConnReq::new(client_id.clone(), connect2, None, handle2);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle1,
+        );
+        let req2 = ConnReq::new(
+            client_id.clone(),
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle2,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id.clone(), req1).unwrap();
@@ -1794,10 +1843,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_session_offline_persistent() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
@@ -1805,8 +1851,18 @@ pub(crate) mod tests {
         let connect2 = persistent_connect(id);
         let handle1 = connection_handle();
         let handle2 = connection_handle();
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, handle1);
-        let req2 = ConnReq::new(client_id.clone(), connect2, None, handle2);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle1,
+        );
+        let req2 = ConnReq::new(
+            client_id.clone(),
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle2,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id.clone(), req1).unwrap();
@@ -1829,17 +1885,19 @@ pub(crate) mod tests {
 
     #[test]
     fn test_add_session_offline_transient() {
-        let mut broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-            .authorizer(|_| Ok(true))
-            .build();
+        let mut broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
         let id = "id1".to_string();
         let client_id = ClientId::from(id.clone());
         let connect1 = persistent_connect(id.clone());
         let handle1 = connection_handle();
         let handle2 = connection_handle();
-        let req1 = ConnReq::new(client_id.clone(), connect1, None, handle1);
+        let req1 = ConnReq::new(
+            client_id.clone(),
+            connect1,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle1,
+        );
         let auth_id = AuthId::Anonymous;
 
         broker.open_session(auth_id.clone(), req1).unwrap();
@@ -1855,7 +1913,12 @@ pub(crate) mod tests {
 
         // Reopen session
         let connect2 = transient_connect(id);
-        let req2 = ConnReq::new(client_id.clone(), connect2, None, handle2);
+        let req2 = ConnReq::new(
+            client_id.clone(),
+            connect2,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            handle2,
+        );
         broker.open_session(auth_id, req2).unwrap();
 
         assert_eq!(1, broker.sessions.len());
@@ -1865,7 +1928,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_publish_client_has_no_permissions() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some("client-a".into())))
             .authorizer(|activity: Activity| match activity.operation() {
                 Operation::Connect(_) => Ok(true),
                 _ => Ok(false),
@@ -1900,7 +1962,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_subscribe_client_has_no_permissions() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some("client-a".into())))
             .authorizer(|activity: Activity| match activity.operation() {
                 Operation::Connect(_) => Ok(true),
                 Operation::Subscribe(subscribe) => match subscribe.topic_filter() {
@@ -1951,7 +2012,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_receive_client_has_no_permissions() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some("client-a".into())))
             .authorizer(|activity: Activity| match activity.operation() {
                 Operation::Connect(_) => Ok(true),
                 Operation::Publish(_) => Ok(true),
@@ -2006,7 +2066,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_notify_state_change_single_connection() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
             .authorizer(|_| Ok(true))
             .build();
 
@@ -2048,7 +2107,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_notify_state_change_multiple_connection() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
             .authorizer(|_| Ok(true))
             .build();
 
@@ -2080,7 +2138,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_notify_state_change_add_remove_connection() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
             .authorizer(|_| Ok(true))
             .build();
 
@@ -2119,7 +2176,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_notify_state_change_add_remove_subscription() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
             .authorizer(|_| Ok(true))
             .build();
 
@@ -2156,7 +2212,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_notify_state_change_add_remove_multiple_subscriptions() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
             .authorizer(|_| Ok(true))
             .build();
 
@@ -2196,7 +2251,6 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn test_notify_state_change_existing_subscriptions() {
         let broker = BrokerBuilder::default()
-            .authenticator(|_| Ok(Some(AuthId::Anonymous)))
             .authorizer(|_| Ok(true))
             .build();
 
@@ -2233,7 +2287,12 @@ pub(crate) mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let conn = ConnectionHandle::from_sender(tx);
         let client_id = ClientId::from(client_id);
-        let req = ConnReq::new(client_id.clone(), connect, None, conn);
+        let req = ConnReq::new(
+            client_id.clone(),
+            connect,
+            AuthResult::Successful(Some(AuthId::Anonymous)),
+            conn,
+        );
         broker_handle
             .send(Message::Client(
                 client_id.clone(),

--- a/mqtt/mqtt-broker/src/error.rs
+++ b/mqtt/mqtt-broker/src/error.rs
@@ -55,6 +55,9 @@ pub enum Error {
     #[error("Unable to start broker.")]
     InitializeBroker(#[from] InitializeBrokerError),
 
+    #[error("Authentication error.")]
+    Authenticate(#[from] AuthenticationError),
+
     #[error("An error occurred when constructing state change: {0}")]
     StateChange(#[from] serde_json::Error),
 }
@@ -82,4 +85,11 @@ pub enum InitializeBrokerError {
 
     #[error("An error occurred  bootstrapping TLS")]
     Tls(#[source] native_tls::Error),
+}
+
+/// Authentication errors.
+#[derive(Debug, Error)]
+pub enum AuthenticationError {
+    #[error("GeneralError")]
+    GeneralError,
 }

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -1,4 +1,5 @@
 use std::future::Future;
+use std::sync::Arc;
 
 use futures_util::future::{self, Either, FutureExt};
 use futures_util::pin_mut;
@@ -10,38 +11,41 @@ use tracing_futures::Instrument;
 use crate::auth::{Authenticator, Authorizer};
 use crate::broker::{Broker, BrokerHandle, BrokerState};
 use crate::transport::TransportBuilder;
-use crate::{connection, Error, InitializeBrokerError, Message, SystemEvent};
+use crate::{connection, AuthenticationError, Error, InitializeBrokerError, Message, SystemEvent};
 
-pub struct Server<N, Z>
+pub struct Server<Z>
 where
-    N: Authenticator,
     Z: Authorizer,
 {
-    broker: Broker<N, Z>,
+    broker: Broker<Z>,
 }
 
-impl<N, Z> Server<N, Z>
+impl<Z> Server<Z>
 where
-    N: Authenticator + Send + Sync + 'static,
     Z: Authorizer + Send + Sync + 'static,
 {
-    pub fn from_broker(broker: Broker<N, Z>) -> Self {
+    pub fn from_broker(broker: Broker<Z>) -> Self {
         Self { broker }
     }
 
-    pub async fn serve<A, F, I>(
+    pub async fn serve<A, F, I, N>(
         self,
         transports: I,
         shutdown_signal: F,
+        authenticator: N,
     ) -> Result<BrokerState, Error>
     where
         A: ToSocketAddrs,
         F: Future<Output = ()> + Unpin,
         I: IntoIterator<Item = TransportBuilder<A>>,
+        N: Authenticator + Send + Sync + 'static,
+        N::Error: Into<AuthenticationError>,
     {
         let Server { broker } = self;
         let mut handle = broker.handle();
         let broker_task = tokio::spawn(broker.run());
+
+        let authenticator = Arc::new(authenticator);
 
         let mut incoming_tasks = Vec::new();
         let mut shutdown_handles = Vec::new();
@@ -49,7 +53,12 @@ where
             let (itx, irx) = oneshot::channel::<()>();
             shutdown_handles.push(itx);
 
-            let incoming_task = incoming_task(transport, handle.clone(), irx.map(drop));
+            let incoming_task = incoming_task(
+                transport,
+                handle.clone(),
+                irx.map(drop),
+                authenticator.clone(),
+            );
 
             let incoming_task = Box::pin(incoming_task);
             incoming_tasks.push(incoming_task);
@@ -163,14 +172,17 @@ where
     }
 }
 
-async fn incoming_task<A, F>(
+async fn incoming_task<A, F, N>(
     transport: TransportBuilder<A>,
     handle: BrokerHandle,
     mut shutdown_signal: F,
+    authenticator: Arc<N>,
 ) -> Result<(), Error>
 where
     A: ToSocketAddrs,
     F: Future<Output = ()> + Unpin,
+    N: Authenticator + Send + Sync + 'static,
+    N::Error: Into<AuthenticationError>,
 {
     let io = transport.build().await?;
     let addr = io.local_addr()?;
@@ -190,8 +202,9 @@ where
 
                 let broker_handle = handle.clone();
                 let span = span.clone();
+                let authenticator = authenticator.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = connection::process(stream, peer, broker_handle)
+                    if let Err(e) = connection::process(stream, peer, broker_handle, authenticator)
                         .instrument(span)
                         .await
                     {

--- a/mqtt/mqtt-broker/src/session.rs
+++ b/mqtt/mqtt-broker/src/session.rs
@@ -920,7 +920,7 @@ pub(crate) mod tests {
     use crate::{
         auth::AuthId,
         session::{PacketIdentifiers, Session, SessionState},
-        ClientId, ConnReq, ConnectionHandle, Error,
+        AuthResult, ClientId, ConnReq, ConnectionHandle, Error,
     };
 
     fn connection_handle() -> ConnectionHandle {
@@ -947,7 +947,7 @@ pub(crate) mod tests {
         let client_id = ClientId::from(id.clone());
         let connect1 = transient_connect(id);
         let handle1 = connection_handle();
-        let req1 = ConnReq::new(client_id, connect1, None, handle1);
+        let req1 = ConnReq::new(client_id, connect1, AuthResult::Successful(None), handle1);
         let auth_id = "auth-id1".into();
         let mut session = Session::new_transient(auth_id, req1);
         let subscribe_to = proto::SubscribeTo {
@@ -997,7 +997,7 @@ pub(crate) mod tests {
         let client_id = ClientId::from(id.clone());
         let connect1 = transient_connect(id);
         let handle1 = connection_handle();
-        let req1 = ConnReq::new(client_id, connect1, None, handle1);
+        let req1 = ConnReq::new(client_id, connect1, AuthResult::Successful(None), handle1);
         let auth_id = "auth-id1".into();
         let mut session = Session::new_transient(auth_id, req1);
         let subscribe_to = proto::SubscribeTo {
@@ -1017,7 +1017,7 @@ pub(crate) mod tests {
         let client_id = ClientId::from(id.clone());
         let connect1 = transient_connect(id);
         let handle1 = connection_handle();
-        let req1 = ConnReq::new(client_id, connect1, None, handle1);
+        let req1 = ConnReq::new(client_id, connect1, AuthResult::Successful(None), handle1);
         let auth_id = AuthId::Anonymous;
         let mut session = Session::new_transient(auth_id, req1);
 

--- a/mqtt/mqtt-broker/src/state_change.rs
+++ b/mqtt/mqtt-broker/src/state_change.rs
@@ -100,7 +100,7 @@ mod tests {
     use crate::session::{Session, SessionState};
     use crate::state_change::{StateChange, STATE_CHANGE_QOS};
     use crate::subscription::{Subscription, TopicFilter};
-    use crate::{AuthId, ClientId, ConnReq};
+    use crate::{AuthId, AuthResult, ClientId, ConnReq};
 
     #[test]
     fn test_subscriptions() {
@@ -370,7 +370,7 @@ mod tests {
                 ConnReq::new(
                     id.into(),
                     persistent_connect(id.to_owned()),
-                    None,
+                    AuthResult::Successful(Some(AuthId::Anonymous)),
                     connection_handle(),
                 ),
                 state,

--- a/mqtt/mqtt-broker/tests/broker_model.rs
+++ b/mqtt/mqtt-broker/tests/broker_model.rs
@@ -37,7 +37,6 @@ proptest! {
 
 async fn test_broker_manages_sessions(events: impl IntoIterator<Item = BrokerEvent>) {
     let mut broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
         .authorizer(|_| Ok(true))
         .build();
 

--- a/mqtt/mqtt-broker/tests/smoke.rs
+++ b/mqtt/mqtt-broker/tests/smoke.rs
@@ -18,12 +18,9 @@ mod common;
 
 #[tokio::test]
 async fn basic_connect_clean_session() {
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithCleanSession("mqtt-smoke-tests".into()))
@@ -47,12 +44,9 @@ async fn basic_connect_clean_session() {
 ///	- Expects to see `reset_session` flag = false (existing session on the server).
 #[tokio::test]
 async fn basic_connect_existing_session() {
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithExistingSession("mqtt-smoke-tests".into()))
@@ -92,12 +86,9 @@ async fn basic_connect_existing_session() {
 async fn basic_pub_sub() {
     let topic = "topic/A";
 
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithCleanSession("mqtt-smoke-tests".into()))
@@ -143,12 +134,9 @@ async fn retained_messages() {
     let topic_b = "topic/B";
     let topic_c = "topic/C";
 
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let mut server_handle = common::start_server(broker);
+    let mut server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithCleanSession("mqtt-smoke-tests".into()))
@@ -214,12 +202,9 @@ async fn retained_messages_zero_payload() {
     let topic_b = "topic/B";
     let topic_c = "topic/C";
 
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let mut server_handle = common::start_server(broker);
+    let mut server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithCleanSession("mqtt-smoke-tests".into()))
@@ -268,12 +253,9 @@ async fn retained_messages_persisted_on_broker_restart() {
     let topic_b = "topic/B";
     let topic_c = "topic/C";
 
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let mut server_handle = common::start_server(broker);
+    let mut server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithCleanSession("mqtt-smoke-tests".into()))
@@ -292,11 +274,10 @@ async fn retained_messages_persisted_on_broker_restart() {
     // restart broker with saved state
     let broker = BrokerBuilder::default()
         .state(state)
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
         .authorizer(|_| Ok(true))
         .build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithCleanSession("mqtt-smoke-tests".into()))
@@ -332,12 +313,9 @@ async fn retained_messages_persisted_on_broker_restart() {
 async fn will_message() {
     let topic = "topic/A";
 
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client_b = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithCleanSession("mqtt-smoke-tests-b".into()))
@@ -387,12 +365,9 @@ async fn offline_messages() {
     let topic_b = "topic/B";
     let topic_c = "topic/C";
 
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client_a = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithExistingSession("mqtt-smoke-tests-a".into()))
@@ -448,12 +423,9 @@ async fn offline_messages_persisted_on_broker_restart() {
     let topic_b = "topic/B";
     let topic_c = "topic/C";
 
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let mut server_handle = common::start_server(broker);
+    let mut server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client_a = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithExistingSession("mqtt-smoke-tests-a".into()))
@@ -480,11 +452,10 @@ async fn offline_messages_persisted_on_broker_restart() {
     // restart broker with saved state
     let broker = BrokerBuilder::default()
         .state(state)
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
         .authorizer(|_| Ok(true))
         .build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client_a = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithExistingSession("mqtt-smoke-tests-a".into()))
@@ -531,12 +502,9 @@ async fn overlapping_subscriptions() {
     let topic_filter_pound = "topic/#";
     let topic_filter_plus = "topic/+";
 
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client_a = TestClientBuilder::new(server_handle.address())
         .client_id(ClientId::IdWithCleanSession("mqtt-smoke-tests-a".into()))
@@ -583,12 +551,9 @@ async fn overlapping_subscriptions() {
 
 #[tokio::test]
 async fn wrong_first_packet_connection_dropped() {
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = PacketStream::open(server_handle.address()).await;
     client.send_packet(Packet::PingReq(PingReq)).await;
@@ -598,12 +563,9 @@ async fn wrong_first_packet_connection_dropped() {
 
 #[tokio::test]
 async fn duplicate_connect_packet_connection_dropped() {
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = PacketStream::open(server_handle.address()).await;
     client
@@ -643,12 +605,9 @@ async fn duplicate_connect_packet_connection_dropped() {
 
 #[tokio::test]
 async fn wrong_protocol_name_connection_dropped() {
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = PacketStream::open(server_handle.address()).await;
     client
@@ -668,12 +627,9 @@ async fn wrong_protocol_name_connection_dropped() {
 
 #[tokio::test]
 async fn wrong_protocol_version_rejected() {
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = PacketStream::open(server_handle.address()).await;
     client
@@ -701,12 +657,9 @@ async fn wrong_protocol_version_rejected() {
 
 #[tokio::test]
 async fn qos1_puback_should_be_in_order() {
-    let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
-        .authorizer(|_| Ok(true))
-        .build();
+    let broker = BrokerBuilder::default().authorizer(|_| Ok(true)).build();
 
-    let server_handle = common::start_server(broker);
+    let server_handle = common::start_server(broker, |_, _| Ok(Some(AuthId::Anonymous)));
 
     let mut client = PacketStream::connect(
         ClientId::IdWithCleanSession("test-client".into()),

--- a/mqtt/mqttd/src/main.rs
+++ b/mqtt/mqttd/src/main.rs
@@ -42,7 +42,6 @@ async fn run() -> Result<(), Error> {
     info!("Loading state...");
     let state = persistor.load().await?.unwrap_or_else(BrokerState::default);
     let broker = BrokerBuilder::default()
-        .authenticator(|_| Ok(Some(AuthId::Anonymous)))
         .authorizer(|_| Ok(true))
         .state(state)
         .build();
@@ -74,7 +73,7 @@ async fn run() -> Result<(), Error> {
 
     info!("Starting server...");
     let state = Server::from_broker(broker)
-        .serve(transports, shutdown)
+        .serve(transports, shutdown, |_, _| Ok(Some(AuthId::Anonymous)))
         .await?;
 
     // Stop snapshotting


### PR DESCRIPTION
Moving the authentication step to connection - this calls the authentication module and stores the authentication result in the ConnReq event. The broker has the same logic as before, except it uses the already acquired result, instead of calling the authentication module directly