### PR TITLE
[mqtt] Require proptest feature for model-based tests

### DIFF
--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -52,6 +52,11 @@ tracing-subscriber = "0.1"
 name = "persist_failpoints"
 required-features = ["fail/failpoints"]
 
+[[test]]
+name = "broker_model"
+path = "tests/broker_model.rs"
+required-features = ["proptest"]
+
 [[bench]]
 name = "persist_broker_state"
 harness = false


### PR DESCRIPTION
Fix to annoying `cargo test` failed command. Change is to require `proptest` feature for model based tests. 