### PR TITLE
Use Registry class for E2E tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         readonly string configYamlFile;
         readonly YamlDocument config;
 
-        public DaemonConfiguration(string configYamlFile, Option<string> agentImage, Option<(string address, string username, string password)> agentRegistry)
+        public DaemonConfiguration(string configYamlFile, Option<string> agentImage, Option<Registry> agentRegistry)
         {
             this.configYamlFile = configYamlFile;
             string contents = File.ReadAllText(this.configYamlFile);
@@ -23,15 +23,15 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 agentRegistry);
         }
 
-        public void UpdateAgentImage(string agentImage, Option<(string address, string username, string password)> agentRegistry)
+        public void UpdateAgentImage(string agentImage, Option<Registry> agentRegistry)
         {
             this.config.ReplaceOrAdd("agent.config.image", agentImage);
             agentRegistry.ForEach(
                 r =>
                 {
-                    this.config.ReplaceOrAdd("agent.config.auth.serveraddress", r.address);
-                    this.config.ReplaceOrAdd("agent.config.auth.username", r.username);
-                    this.config.ReplaceOrAdd("agent.config.auth.password", r.password);
+                    this.config.ReplaceOrAdd("agent.config.auth.serveraddress", r.Address);
+                    this.config.ReplaceOrAdd("agent.config.auth.username", r.Username);
+                    this.config.ReplaceOrAdd("agent.config.auth.password", r.Password);
                 });
         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Registries = System.Collections.Generic.IEnumerable<(string address, string username, string password)>;
+    using Registries = System.Collections.Generic.IEnumerable<Registry>;
 
     public class EdgeRuntime
     {
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             bool stageSystemModules = true)
         {
             var builder = new EdgeConfigBuilder(this.DeviceId);
-            builder.AddRegistryCredentials(this.registries);
+            builder.AddRegistries(this.registries);
             builder.AddEdgeAgent(this.agentImage.OrDefault())
                 .WithEnvironment(new[] { ("RuntimeLogLevel", "debug") })
                 .WithProxy(this.proxy);

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Registries = System.Collections.Generic.IEnumerable<Registry>;
 
     public class EdgeRuntime
     {
@@ -17,11 +16,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         readonly IotHub iotHub;
         readonly bool optimizeForPerformance;
         readonly Option<Uri> proxy;
-        readonly Registries registries;
+        readonly IEnumerable<Registry> registries;
 
         public string DeviceId { get; }
 
-        public EdgeRuntime(string deviceId, Option<string> agentImage, Option<string> hubImage, Option<Uri> proxy, Registries registries, bool optimizeForPerformance, IotHub iotHub)
+        public EdgeRuntime(string deviceId, Option<string> agentImage, Option<string> hubImage, Option<Uri> proxy, IEnumerable<Registry> registries, bool optimizeForPerformance, IotHub iotHub)
         {
             this.agentImage = agentImage;
             this.hubImage = hubImage;

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IOsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IOsPlatform.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     {
         Task<string> CollectDaemonLogsAsync(DateTime testStartTime, string filePrefix, CancellationToken token);
 
-        IEdgeDaemon CreateEdgeDaemon(Option<string> installerPath, Option<string> bootstrapAgentImage, Option<(string address, string username, string password)> bootstrapRegistry);
+        IEdgeDaemon CreateEdgeDaemon(Option<string> installerPath, Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry);
 
         // After calling this function, the following files will be available under {scriptPath}:
         //  certs/iot-device-{deviceId}-full-chain.cert.pem

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Registry.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Registry.cs
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Test.Common
+{
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public class Registry
+    {
+        public string Address { get; }
+
+        public string Username { get; }
+
+        public string Password { get; }
+
+        public Registry(
+            string address,
+            string username,
+            string password)
+        {
+            this.Address = Preconditions.CheckNotNull(address, nameof(address));
+            this.Username = Preconditions.CheckNotNull(username, nameof(username));
+            this.Password = Preconditions.CheckNotNull(password, nameof(password));
+        }
+    }
+}

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/EdgeConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/EdgeConfigBuilder.cs
@@ -9,23 +9,23 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
     {
         readonly string deviceId;
         readonly Dictionary<string, IModuleConfigBuilder> moduleBuilders;
-        readonly List<(string address, string username, string password)> registries;
+        readonly List<Registry> registries;
 
         public EdgeConfigBuilder(string deviceId)
         {
             this.deviceId = deviceId;
             this.moduleBuilders = new Dictionary<string, IModuleConfigBuilder>();
-            this.registries = new List<(string, string, string)>();
+            this.registries = new List<Registry>();
         }
 
-        public void AddRegistryCredentials(string address, string username, string password) =>
-            this.registries.Add((address, username, password));
+        public void AddRegistry(Registry registry) =>
+            this.registries.Add(registry);
 
-        public void AddRegistryCredentials(IEnumerable<(string address, string username, string password)> credentials)
+        public void AddRegistries(IEnumerable<Registry> credentials)
         {
-            foreach ((string address, string username, string password) in credentials)
+            foreach (Registry registry in credentials)
             {
-                this.AddRegistryCredentials(address, username, password);
+                this.AddRegistry(registry);
             }
         }
 
@@ -113,14 +113,14 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
                 var credentials = new Dictionary<string, object>();
                 for (int i = 0; i < this.registries.Count; ++i)
                 {
-                    (string address, string username, string password) = this.registries[i];
+                    Registry registry = this.registries[i];
                     credentials.Add(
                         $"reg{i}",
                         new
                         {
-                            username,
-                            password,
-                            address
+                            registry.Username,
+                            registry.Password,
+                            registry.Address
                         });
                 }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
     public class EdgeDaemon : IEdgeDaemon
     {
         Option<string> bootstrapAgentImage;
-        Option<(string address, string username, string password)> bootstrapRegistry;
+        Option<Registry> bootstrapRegistry;
 
-        public EdgeDaemon(Option<string> bootstrapAgentImage, Option<(string serverAddress, string username, string password)> bootstrapRegistry)
+        public EdgeDaemon(Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry)
         {
             this.bootstrapAgentImage = bootstrapAgentImage;
             this.bootstrapRegistry = bootstrapRegistry;

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/OsPlatform.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
             return daemonLog;
         }
 
-        public IEdgeDaemon CreateEdgeDaemon(Option<string> _, Option<string> bootstrapAgentImage, Option<(string address, string username, string password)> bootstrapRegistry) => new EdgeDaemon(bootstrapAgentImage, bootstrapRegistry);
+        public IEdgeDaemon CreateEdgeDaemon(Option<string> _, Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry) => new EdgeDaemon(bootstrapAgentImage, bootstrapRegistry);
 
         public async Task<IdCertificates> GenerateIdentityCertificatesAsync(string deviceId, string scriptPath, CancellationToken token)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
@@ -14,10 +14,10 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
     public class EdgeDaemon : IEdgeDaemon
     {
         Option<string> bootstrapAgentImage;
-        Option<(string address, string username, string password)> bootstrapRegistry;
+        Option<Registry> bootstrapRegistry;
         Option<string> scriptDir;
 
-        public EdgeDaemon(Option<string> scriptDir, Option<string> bootstrapAgentImage, Option<(string serverAddress, string username, string password)> bootstrapRegistry)
+        public EdgeDaemon(Option<string> scriptDir, Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry)
         {
             this.scriptDir = scriptDir;
             this.bootstrapAgentImage = bootstrapAgentImage;

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/OsPlatform.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
             return daemonLog;
         }
 
-        public IEdgeDaemon CreateEdgeDaemon(Option<string> installerPath, Option<string> bootstrapAgentImage, Option<(string address, string username, string password)> bootstrapRegistry) => new EdgeDaemon(installerPath, bootstrapAgentImage, bootstrapRegistry);
+        public IEdgeDaemon CreateEdgeDaemon(Option<string> installerPath, Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry) => new EdgeDaemon(installerPath, bootstrapAgentImage, bootstrapRegistry);
 
         public async Task<IdCertificates> GenerateIdentityCertificatesAsync(string deviceId, string scriptPath, CancellationToken token)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         public SetupFixture()
         {
-            Option<(string address, string username, string password)> bootstrapRegistry =
-                Option.Maybe<(string address, string username, string password)>(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry =
+                Option.Maybe(Context.Current.Registries.First());
             this.daemon = OsPlatform.Current.CreateEdgeDaemon(Context.Current.InstallerPath, Context.Current.EdgeAgentBootstrapImage, bootstrapRegistry);
             this.iotHub = new IotHub(
                 Context.Current.ConnectionString,

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
@@ -22,9 +22,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
             string Get(string name) => context.GetValue<string>(name);
 
-            IEnumerable<(string, string, string)> GetAndValidateRegistries()
+            IEnumerable<Registry> GetAndValidateRegistries()
             {
-                var result = new List<(string, string, string)>();
+                var result = new List<Registry>();
 
                 var registries = context.GetSection("registries").GetChildren().ToArray();
                 foreach (var reg in registries)
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                     Preconditions.CheckNonWhiteSpace(username, nameof(username));
                     Preconditions.CheckNonWhiteSpace(password, nameof(password));
 
-                    result.Add((address, username, password));
+                    result.Add(new Registry(address, username, password));
                 }
 
                 return result;
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
         public Option<Uri> Proxy { get; }
 
-        public IEnumerable<(string address, string username, string password)> Registries { get; }
+        public IEnumerable<Registry> Registries { get; }
 
         public Option<(string certificate, string key, string password)> RootCaKeys { get; }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
@@ -11,8 +11,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
         public DeviceProvisioningFixture()
         {
-            Option<(string address, string username, string password)> bootstrapRegistry =
-                Option.Maybe<(string address, string username, string password)>(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry =
+                Option.Maybe(Context.Current.Registries.First());
             this.daemon = OsPlatform.Current.CreateEdgeDaemon(Context.Current.InstallerPath, Context.Current.EdgeAgentBootstrapImage, bootstrapRegistry);
         }
     }

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
         public ManualProvisioningFixture()
         {
-            Option<(string address, string username, string password)> bootstrapRegistry =
-                Option.Maybe<(string address, string username, string password)>(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry =
+                Option.Maybe(Context.Current.Registries.First());
             this.daemon = OsPlatform.Current.CreateEdgeDaemon(Context.Current.InstallerPath, Context.Current.EdgeAgentBootstrapImage, bootstrapRegistry);
             this.iotHub = new IotHub(
                 Context.Current.ConnectionString,


### PR DESCRIPTION
We've been using (string username, string address, string password) for registries. 

Now that we're using it more, and we're using it with Option.Maybe that requires a class or a struct, let's change it to be a class instead.