### PR TITLE
[Draft] Adding InvalidOperationException to list of unretryable exceptions

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         static readonly Type[] NonRecoverableExceptions =
         {
             typeof(NullReferenceException),
-            typeof(ObjectDisposedException)
+            typeof(ObjectDisposedException),
+            typeof(InvalidOperationException)
         };
 
         readonly IClient client;

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -224,6 +224,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         [Theory]
         [InlineData(typeof(NullReferenceException))]
         [InlineData(typeof(ObjectDisposedException))]
+        [InlineData(typeof(InvalidOperationException))]
         public async Task TestHandleNonRecoverableExceptions(Type exceptionType)
         {
             // Arrange


### PR DESCRIPTION
We received a GH issue that showed many EdgeHub InvalidOperationException (429 from IoTHub) errors. It looked like EdgeHub was using the same sdk moduleClient to connect, when the moduleClient connection had been broken. 

If we add InvalidOperationException to our list of NonRetryableExceptions, we will make a new moduleClient every time we receive that exception.