### PR TITLE
Add cleanup threshold for reported properties validation

### DIFF
--- a/test/modules/TwinTester/ReportedPropertiesValidator.cs
+++ b/test/modules/TwinTester/ReportedPropertiesValidator.cs
@@ -112,14 +112,14 @@ namespace TwinTester
                     propertiesToRemove[reportedPropertyUpdate.Key] = null; // will later be serialized as a twin update
                 }
                 else if (!this.reportedPropertyKeysFailedToReceiveWithinThreshold.Contains(reportedPropertyUpdate.Key) &&
-                        this.ExceedFailureThreshold(this.twinState, reportedPropertyUpdate.Key, reportedPropertyUpdate.Value))
+                        this.DoesExceedFailureThreshold(this.twinState, reportedPropertyUpdate.Key, reportedPropertyUpdate.Value))
                 {
                     this.reportedPropertyKeysFailedToReceiveWithinThreshold.Add(reportedPropertyUpdate.Key);
                     status = $"{(int)StatusCode.ReportedPropertyUpdateNotInCloudTwin}: Failure receiving reported property update";
                     await this.HandleReportStatusAsync(status);
                     Logger.LogInformation($"{status} for reported property update {reportedPropertyUpdate.Key}");
                 }
-                else if (this.ExceedCleanupThreshold(this.twinState, reportedPropertyUpdate.Key, reportedPropertyUpdate.Value))
+                else if (this.DoesExceedCleanupThreshold(this.twinState, reportedPropertyUpdate.Key, reportedPropertyUpdate.Value))
                 {
                     status = $"{(int)StatusCode.ReportedPropertyUpdateNotInCloudTwinAfterCleanUpThreshold}: Failure receiving reported property update after cleanup threshold";
                     await this.HandleReportStatusAsync(status);
@@ -131,7 +131,7 @@ namespace TwinTester
             return propertiesToRemove;
         }
 
-        bool ExceedFailureThreshold(TwinState twinState, string reportedPropertyKey, DateTime reportedPropertyUpdatedAt)
+        bool DoesExceedFailureThreshold(TwinState twinState, string reportedPropertyKey, DateTime reportedPropertyUpdatedAt)
         {
             DateTime comparisonPoint = reportedPropertyUpdatedAt > twinState.LastTimeOffline ? reportedPropertyUpdatedAt : twinState.LastTimeOffline;
             bool exceedFailureThreshold = DateTime.UtcNow - comparisonPoint > Settings.Current.TwinUpdateFailureThreshold;
@@ -146,7 +146,7 @@ namespace TwinTester
             return exceedFailureThreshold;
         }
 
-        bool ExceedCleanupThreshold(TwinState twinState, string reportedPropertyKey, DateTime reportedPropertyUpdatedAt)
+        bool DoesExceedCleanupThreshold(TwinState twinState, string reportedPropertyKey, DateTime reportedPropertyUpdatedAt)
         {
             TimeSpan cleanUpThreshold = TimeSpan.FromMinutes(5);
             DateTime comparisonPoint = reportedPropertyUpdatedAt > twinState.LastTimeOffline ? reportedPropertyUpdatedAt : twinState.LastTimeOffline;

--- a/test/modules/TwinTester/ReportedPropertiesValidator.cs
+++ b/test/modules/TwinTester/ReportedPropertiesValidator.cs
@@ -19,6 +19,7 @@ namespace TwinTester
         readonly ModuleClient moduleClient;
         readonly TwinEventStorage storage;
         readonly ITwinTestResultHandler reporter;
+        HashSet<string> reportedPropertyKeysFailedToReceiveWithinThreshold = new HashSet<string>();
 
         public ReportedPropertiesValidator(RegistryManager registryManager, ModuleClient moduleClient, TwinEventStorage storage, ITwinTestResultHandler reporter, TwinState twinState)
         {
@@ -52,14 +53,14 @@ namespace TwinTester
                 return;
             }
 
-            TwinCollection propertiesToRemoveFromTwin = await this.ValidatePropertiesFromTwinAsync(receivedTwin);
-            await this.RemovePropertiesFromStorage(propertiesToRemoveFromTwin);
-            await this.RemovePropertiesFromTwin(propertiesToRemoveFromTwin);
+            TwinCollection propertiesToRemove = await this.ValidatePropertiesFromTwinAsync(receivedTwin);
+            await this.RemovePropertiesFromStorage(propertiesToRemove);
+            await this.RemovePropertiesFromTwin(propertiesToRemove);
         }
 
-        async Task RemovePropertiesFromStorage(TwinCollection propertiesToRemoveFromTwin)
+        async Task RemovePropertiesFromStorage(TwinCollection propertiesToRemove)
         {
-            foreach (dynamic pair in propertiesToRemoveFromTwin)
+            foreach (dynamic pair in propertiesToRemove)
             {
                 KeyValuePair<string, object> property = (KeyValuePair<string, object>)pair;
                 try
@@ -73,11 +74,11 @@ namespace TwinTester
             }
         }
 
-        async Task RemovePropertiesFromTwin(TwinCollection propertiesToRemoveFromTwin)
+        async Task RemovePropertiesFromTwin(TwinCollection propertiesToRemove)
         {
             try
             {
-                await this.moduleClient.UpdateReportedPropertiesAsync(propertiesToRemoveFromTwin);
+                await this.moduleClient.UpdateReportedPropertiesAsync(propertiesToRemove);
             }
             catch (Exception e)
             {
@@ -89,46 +90,76 @@ namespace TwinTester
         {
             TwinCollection propertyUpdatesFromTwin = receivedTwin.Properties.Reported;
             Dictionary<string, DateTime> reportedPropertiesUpdated = await this.storage.GetAllReportedPropertiesUpdatedAsync();
-            TwinCollection propertiesToRemoveFromTwin = new TwinCollection();
+            TwinCollection propertiesToRemove = new TwinCollection();
+
             foreach (KeyValuePair<string, DateTime> reportedPropertyUpdate in reportedPropertiesUpdated)
             {
                 string status;
                 if (propertyUpdatesFromTwin.Contains(reportedPropertyUpdate.Key))
                 {
-                    try
+                    if (this.reportedPropertyKeysFailedToReceiveWithinThreshold.Contains(reportedPropertyUpdate.Key))
                     {
-                        await this.storage.RemoveReportedPropertyUpdateAsync(reportedPropertyUpdate.Key);
+                        this.reportedPropertyKeysFailedToReceiveWithinThreshold.Remove(reportedPropertyUpdate.Key);
+                        status = $"{(int)StatusCode.ReportedPropertyReceivedAfterThreshold}: Successfully validated reported property update (exceeded failure threshold)";
                     }
-                    catch (Exception e)
+                    else
                     {
-                        Logger.LogError(e, $"Failed to remove validated reported property id {reportedPropertyUpdate.Key} from storage.");
-                        continue;
+                        status = $"{(int)StatusCode.ValidationSuccess}: Successfully validated reported property update";
                     }
 
-                    status = $"{(int)StatusCode.ValidationSuccess}: Successfully validated reported property update";
-                    Logger.LogInformation(status + $" {reportedPropertyUpdate.Key}");
+                    await this.HandleReportStatusAsync(status);
+                    Logger.LogInformation($"{status} for reported property update {reportedPropertyUpdate.Key}");
+                    propertiesToRemove[reportedPropertyUpdate.Key] = null; // will later be serialized as a twin update
                 }
-                else if (this.ExceedFailureThreshold(this.twinState, reportedPropertyUpdate.Value))
+                else if (!this.reportedPropertyKeysFailedToReceiveWithinThreshold.Contains(reportedPropertyUpdate.Key) &&
+                        this.ExceedFailureThreshold(this.twinState, reportedPropertyUpdate.Key, reportedPropertyUpdate.Value))
                 {
+                    this.reportedPropertyKeysFailedToReceiveWithinThreshold.Add(reportedPropertyUpdate.Key);
                     status = $"{(int)StatusCode.ReportedPropertyUpdateNotInCloudTwin}: Failure receiving reported property update";
+                    await this.HandleReportStatusAsync(status);
                     Logger.LogInformation($"{status} for reported property update {reportedPropertyUpdate.Key}");
                 }
-                else
+                else if (this.ExceedCleanupThreshold(this.twinState, reportedPropertyUpdate.Key, reportedPropertyUpdate.Value))
                 {
-                    continue;
+                    status = $"{(int)StatusCode.ReportedPropertyUpdateNotInCloudTwinAfterCleanUpThreshold}: Failure receiving reported property update after cleanup threshold";
+                    await this.HandleReportStatusAsync(status);
+                    Logger.LogInformation($"{status} for reported property update {reportedPropertyUpdate.Key}");
+                    propertiesToRemove[reportedPropertyUpdate.Key] = null; // will later be serialized as a twin update
                 }
-
-                propertiesToRemoveFromTwin[reportedPropertyUpdate.Key] = null; // will later be serialized as a twin update
-                await this.HandleReportStatusAsync(status);
             }
 
-            return propertiesToRemoveFromTwin;
+            return propertiesToRemove;
         }
 
-        bool ExceedFailureThreshold(TwinState twinState, DateTime twinUpdateTime)
+        bool ExceedFailureThreshold(TwinState twinState, string reportedPropertyKey, DateTime reportedPropertyUpdatedAt)
         {
-            DateTime comparisonPoint = twinUpdateTime > twinState.LastTimeOffline ? twinUpdateTime : twinState.LastTimeOffline;
-            return DateTime.UtcNow - comparisonPoint > Settings.Current.TwinUpdateFailureThreshold;
+            DateTime comparisonPoint = reportedPropertyUpdatedAt > twinState.LastTimeOffline ? reportedPropertyUpdatedAt : twinState.LastTimeOffline;
+            bool exceedFailureThreshold = DateTime.UtcNow - comparisonPoint > Settings.Current.TwinUpdateFailureThreshold;
+
+            if (exceedFailureThreshold)
+            {
+                Logger.LogInformation(
+                    $"Reported Property [{reportedPropertyKey}] exceed failure threshold: updated at={reportedPropertyUpdatedAt}, " +
+                    $"last offline={twinState.LastTimeOffline}, threshold={Settings.Current.TwinUpdateFailureThreshold}");
+            }
+
+            return exceedFailureThreshold;
+        }
+
+        bool ExceedCleanupThreshold(TwinState twinState, string reportedPropertyKey, DateTime reportedPropertyUpdatedAt)
+        {
+            TimeSpan cleanUpThreshold = TimeSpan.FromMinutes(5);
+            DateTime comparisonPoint = reportedPropertyUpdatedAt > twinState.LastTimeOffline ? reportedPropertyUpdatedAt : twinState.LastTimeOffline;
+            bool exceedCleanupThreshold = DateTime.UtcNow - comparisonPoint > (Settings.Current.TwinUpdateFailureThreshold + cleanUpThreshold);
+
+            if (exceedCleanupThreshold)
+            {
+                Logger.LogInformation(
+                    $"Reported Property [{reportedPropertyKey}] exceed cleanup threshold: updated at={reportedPropertyUpdatedAt}, " +
+                    $"last offline={twinState.LastTimeOffline}, threshold={Settings.Current.TwinUpdateFailureThreshold + cleanUpThreshold}");
+            }
+
+            return exceedCleanupThreshold;
         }
 
         async Task HandleReportStatusAsync(string status)

--- a/test/modules/TwinTester/StatusCode.cs
+++ b/test/modules/TwinTester/StatusCode.cs
@@ -8,12 +8,12 @@ namespace TwinTester
         DesiredPropertyReceived = 202,
         ReportedPropertyReceived = 203,
         ReportedPropertyUpdated = 204,
-        ReportedPropertyReceivedAfterThreshold = 205,
         DesiredPropertyUpdateNoCallbackReceived = 501,
         DesiredPropertyUpdateNotInEdgeTwin = 502,
         DesiredPropertyUpdateTotalFailure = 503,
         ReportedPropertyUpdateCallFailure = 504,
         ReportedPropertyUpdateNotInCloudTwin = 505,
         ReportedPropertyUpdateNotInCloudTwinAfterCleanUpThreshold = 506,
+        ReportedPropertyReceivedAfterThreshold = 507,
     }
 }

--- a/test/modules/TwinTester/StatusCode.cs
+++ b/test/modules/TwinTester/StatusCode.cs
@@ -8,10 +8,12 @@ namespace TwinTester
         DesiredPropertyReceived = 202,
         ReportedPropertyReceived = 203,
         ReportedPropertyUpdated = 204,
+        ReportedPropertyReceivedAfterThreshold = 205,
         DesiredPropertyUpdateNoCallbackReceived = 501,
         DesiredPropertyUpdateNotInEdgeTwin = 502,
         DesiredPropertyUpdateTotalFailure = 503,
         ReportedPropertyUpdateCallFailure = 504,
-        ReportedPropertyUpdateNotInCloudTwin = 505
+        ReportedPropertyUpdateNotInCloudTwin = 505,
+        ReportedPropertyUpdateNotInCloudTwinAfterCleanUpThreshold = 506,
     }
 }

--- a/test/modules/TwinTester/TwinAllOperationsResultHandler.cs
+++ b/test/modules/TwinTester/TwinAllOperationsResultHandler.cs
@@ -72,11 +72,11 @@ namespace TwinTester
             return this.CallAnalyzer(failureStatus);
         }
 
-        async Task CallAnalyzer(string failureStatus)
+        async Task CallAnalyzer(string result)
         {
             try
             {
-                await this.testResultReportingClient.ReportResultAsync(new TestOperationResultDto { Source = this.moduleId, Result = failureStatus, CreatedAt = DateTime.UtcNow, Type = TestOperationResultType.LegacyTwin.ToString() });
+                await this.testResultReportingClient.ReportResultAsync(new TestOperationResultDto { Source = this.moduleId, Result = result, CreatedAt = DateTime.UtcNow, Type = TestOperationResultType.LegacyTwin.ToString() });
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Add cleanup threshold for reported properties validation to see if there is any reported property received after failure threshold and before cleanup threshold.