### PR TITLE
[mqtt] Swap notifier subscriptions order

### DIFF
--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -2138,7 +2138,7 @@ pub(crate) mod tests {
             &mut broker_handle,
             &mut a_rx,
             a_id.clone(),
-            &["$edgehub/subscriptions/client_b"],
+            &["$edgehub/client_b/subscriptions"],
         )
         .await;
         check_notify_received(&mut a_rx, &[]).await;
@@ -2175,7 +2175,7 @@ pub(crate) mod tests {
             &mut broker_handle,
             &mut a_rx,
             a_id.clone(),
-            &["$edgehub/subscriptions/client_b"],
+            &["$edgehub/client_b/subscriptions"],
         )
         .await;
         check_notify_received(&mut a_rx, &[]).await;
@@ -2217,7 +2217,7 @@ pub(crate) mod tests {
             &mut broker_handle,
             &mut a_rx,
             a_id.clone(),
-            &["$edgehub/subscriptions/client_b"],
+            &["$edgehub/client_b/subscriptions"],
         )
         .await;
 

--- a/mqtt/mqtt-broker/src/state_change.rs
+++ b/mqtt/mqtt-broker/src/state_change.rs
@@ -66,7 +66,7 @@ impl<'a> TryFrom<StateChange<'a>> for proto::Publication {
                     .unwrap_or_default();
 
                 proto::Publication {
-                    topic_name: format!("$edgehub/subscriptions/{}", client_id),
+                    topic_name: format!("$edgehub/{}/subscriptions", client_id),
                     qos: STATE_CHANGE_QOS,
                     retain: true,
                     payload,
@@ -387,7 +387,7 @@ mod tests {
     ) {
         matches_publication(
             publication,
-            &format!("$edgehub/subscriptions/{}", client_id),
+            &format!("$edgehub/{}/subscriptions", client_id),
             body,
         );
     }

--- a/mqtt/mqtt-broker/tests/translation.rs
+++ b/mqtt/mqtt-broker/tests/translation.rs
@@ -215,9 +215,9 @@ async fn translation_twin_notify() {
         .subscribe("$edgehub/+/twin/get/#", QoS::AtLeastOnce)
         .await;
     edge_hub_core
-        .subscribe("$edgehub/subscriptions/device_1", QoS::AtLeastOnce)
+        .subscribe("$edgehub/device_1/subscriptions", QoS::AtLeastOnce)
         .await;
-    receive_with_topic_and_payload(&mut edge_hub_core, "$edgehub/subscriptions/device_1", "[]")
+    receive_with_topic_and_payload(&mut edge_hub_core, "$edgehub/device_1/subscriptions", "[]")
         .await;
 
     // device requests twin update
@@ -226,7 +226,7 @@ async fn translation_twin_notify() {
         .await;
     receive_with_topic_and_payload(
         &mut edge_hub_core,
-        "$edgehub/subscriptions/device_1",
+        "$edgehub/device_1/subscriptions",
         "[\"$edgehub/device_1/twin/res/#\"]",
     )
     .await;


### PR DESCRIPTION
Changes `$edgehub/subscriptions/{client}` to `$edgehub/{client}/subscriptions`