### PR TITLE
Use BTreeMap instead of HashMap for config.yaml's hash

### DIFF
--- a/edgelet/docker-rs/src/models/container_create_body.rs
+++ b/edgelet/docker-rs/src/models/container_create_body.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
 //
-// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// Note: We're using BTreeMap instead of HashMap because iotedged stores a hash of its local config (whose object representation uses this struct)
 // to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
 // we need to use another map type that can provide that guarantee.
 //

--- a/edgelet/docker-rs/src/models/container_create_body.rs
+++ b/edgelet/docker-rs/src/models/container_create_body.rs
@@ -16,12 +16,16 @@ use serde_json::Value;
 // We do not want to restrict the properties that the user can set in their create options, because future versions of Docker can add new properties
 // that we don't define here.
 //
-// So this type has a `#[serde(flatten)] HashMap` field to collect all the extra properties that we don't have a struct field for.
+// So this type has a `#[serde(flatten)] BTreeMap` field to collect all the extra properties that we don't have a struct field for.
 //
 // But if an existing field references another type under `crate::models::`, then that would still be parsed lossily, so we would have to also add
-// a `#[serde(flatten)] HashMap` field there. And if that type has fields that reference types under `crate::models::` ...
+// a `#[serde(flatten)] BTreeMap` field there. And if that type has fields that reference types under `crate::models::` ...
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
+//
+// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
+// we need to use another map type that can provide that guarantee.
 //
 // ---
 //
@@ -29,7 +33,7 @@ use serde_json::Value;
 //
 // - If it's a simple built-in type, then that is all you need to do.
 //
-// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] HashMap` property
+// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] BTreeMap` property
 //   and is commented out as much as possible. Also copy this devnote there for future readers.
 
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
@@ -54,7 +58,7 @@ pub struct ContainerCreateBody {
     // attach_stderr: Option<bool>,
     // /// An object mapping ports to an empty object in the form:  `{\"<port>/<tcp|udp>\": {}}`
     // #[serde(rename = "ExposedPorts", skip_serializing_if = "Option::is_none")]
-    // exposed_ports: Option<::std::collections::HashMap<String, Value>>,
+    // exposed_ports: Option<::std::collections::BTreeMap<String, Value>>,
     // /// Attach standard streams to a TTY, including `stdin` if it is not closed.
     // #[serde(rename = "Tty", skip_serializing_if = "Option::is_none")]
     // tty: Option<bool>,
@@ -79,7 +83,7 @@ pub struct ContainerCreateBody {
     #[serde(rename = "Image", skip_serializing_if = "Option::is_none")]
     image: Option<String>,
     #[serde(rename = "Volumes", skip_serializing_if = "Option::is_none")]
-    volumes: Option<::std::collections::HashMap<String, Value>>,
+    volumes: Option<::std::collections::BTreeMap<String, Value>>,
     // /// The working directory for commands to run in.
     // #[serde(rename = "WorkingDir", skip_serializing_if = "Option::is_none")]
     // working_dir: Option<String>,
@@ -100,7 +104,7 @@ pub struct ContainerCreateBody {
     // on_build: Option<Vec<String>>,
     /// User-defined key/value metadata.
     #[serde(rename = "Labels", skip_serializing_if = "Option::is_none")]
-    labels: Option<::std::collections::HashMap<String, String>>,
+    labels: Option<::std::collections::BTreeMap<String, String>>,
     // /// Signal to stop a container as a string or unsigned integer.
     // #[serde(rename = "StopSignal", skip_serializing_if = "Option::is_none")]
     // stop_signal: Option<String>,
@@ -115,7 +119,7 @@ pub struct ContainerCreateBody {
     #[serde(rename = "NetworkingConfig", skip_serializing_if = "Option::is_none")]
     networking_config: Option<crate::models::ContainerCreateBodyNetworkingConfig>,
     #[serde(flatten)]
-    other_properties: std::collections::HashMap<String, serde_json::Value>,
+    other_properties: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 impl ContainerCreateBody {
@@ -254,19 +258,19 @@ impl ContainerCreateBody {
     //     self.attach_stderr = None;
     // }
 
-    // pub fn set_exposed_ports(&mut self, exposed_ports: ::std::collections::HashMap<String, Value>) {
+    // pub fn set_exposed_ports(&mut self, exposed_ports: ::std::collections::BTreeMap<String, Value>) {
     //     self.exposed_ports = Some(exposed_ports);
     // }
 
     // pub fn with_exposed_ports(
     //     mut self,
-    //     exposed_ports: ::std::collections::HashMap<String, Value>,
+    //     exposed_ports: ::std::collections::BTreeMap<String, Value>,
     // ) -> Self {
     //     self.exposed_ports = Some(exposed_ports);
     //     self
     // }
 
-    // pub fn exposed_ports(&self) -> Option<&::std::collections::HashMap<String, Value>> {
+    // pub fn exposed_ports(&self) -> Option<&::std::collections::BTreeMap<String, Value>> {
     //     self.exposed_ports.as_ref()
     // }
 
@@ -410,16 +414,16 @@ impl ContainerCreateBody {
         self.image = None;
     }
 
-    pub fn set_volumes(&mut self, volumes: ::std::collections::HashMap<String, Value>) {
+    pub fn set_volumes(&mut self, volumes: ::std::collections::BTreeMap<String, Value>) {
         self.volumes = Some(volumes);
     }
 
-    pub fn with_volumes(mut self, volumes: ::std::collections::HashMap<String, Value>) -> Self {
+    pub fn with_volumes(mut self, volumes: ::std::collections::BTreeMap<String, Value>) -> Self {
         self.volumes = Some(volumes);
         self
     }
 
-    pub fn volumes(&self) -> Option<&::std::collections::HashMap<String, Value>> {
+    pub fn volumes(&self) -> Option<&::std::collections::BTreeMap<String, Value>> {
         self.volumes.as_ref()
     }
 
@@ -512,16 +516,16 @@ impl ContainerCreateBody {
     //     self.on_build = None;
     // }
 
-    pub fn set_labels(&mut self, labels: ::std::collections::HashMap<String, String>) {
+    pub fn set_labels(&mut self, labels: ::std::collections::BTreeMap<String, String>) {
         self.labels = Some(labels);
     }
 
-    pub fn with_labels(mut self, labels: ::std::collections::HashMap<String, String>) -> Self {
+    pub fn with_labels(mut self, labels: ::std::collections::BTreeMap<String, String>) -> Self {
         self.labels = Some(labels);
         self
     }
 
-    pub fn labels(&self) -> Option<&::std::collections::HashMap<String, String>> {
+    pub fn labels(&self) -> Option<&::std::collections::BTreeMap<String, String>> {
         self.labels.as_ref()
     }
 

--- a/edgelet/docker-rs/src/models/container_create_body_networking_config.rs
+++ b/edgelet/docker-rs/src/models/container_create_body_networking_config.rs
@@ -25,7 +25,7 @@ use serde_json::Value;
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
 //
-// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// Note: We're using BTreeMap instead of HashMap because iotedged stores a hash of its local config (whose object representation uses this struct)
 // to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
 // we need to use another map type that can provide that guarantee.
 //

--- a/edgelet/docker-rs/src/models/container_create_body_networking_config.rs
+++ b/edgelet/docker-rs/src/models/container_create_body_networking_config.rs
@@ -18,12 +18,16 @@ use serde_json::Value;
 // We do not want to restrict the properties that the user can set in their create options, because future versions of Docker can add new properties
 // that we don't define here.
 //
-// So this type has a `#[serde(flatten)] HashMap` field to collect all the extra properties that we don't have a struct field for.
+// So this type has a `#[serde(flatten)] BTreeMap` field to collect all the extra properties that we don't have a struct field for.
 //
 // But if an existing field references another type under `crate::models::`, then that would still be parsed lossily, so we would have to also add
-// a `#[serde(flatten)] HashMap` field there. And if that type has fields that reference types under `crate::models::` ...
+// a `#[serde(flatten)] BTreeMap` field there. And if that type has fields that reference types under `crate::models::` ...
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
+//
+// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
+// we need to use another map type that can provide that guarantee.
 //
 // ---
 //
@@ -31,16 +35,16 @@ use serde_json::Value;
 //
 // - If it's a simple built-in type, then that is all you need to do.
 //
-// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] HashMap` property
+// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] BTreeMap` property
 //   and is commented out as much as possible. Also copy this devnote there for future readers.
 
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
 pub struct ContainerCreateBodyNetworkingConfig {
     /// A mapping of network name to endpoint configuration for that network.
     #[serde(rename = "EndpointsConfig", skip_serializing_if = "Option::is_none")]
-    endpoints_config: Option<::std::collections::HashMap<String, crate::models::EndpointSettings>>,
+    endpoints_config: Option<::std::collections::BTreeMap<String, crate::models::EndpointSettings>>,
     #[serde(flatten)]
-    other_properties: std::collections::HashMap<String, serde_json::Value>,
+    other_properties: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 impl ContainerCreateBodyNetworkingConfig {
@@ -54,14 +58,14 @@ impl ContainerCreateBodyNetworkingConfig {
 
     pub fn set_endpoints_config(
         &mut self,
-        endpoints_config: ::std::collections::HashMap<String, crate::models::EndpointSettings>,
+        endpoints_config: ::std::collections::BTreeMap<String, crate::models::EndpointSettings>,
     ) {
         self.endpoints_config = Some(endpoints_config);
     }
 
     pub fn with_endpoints_config(
         mut self,
-        endpoints_config: ::std::collections::HashMap<String, crate::models::EndpointSettings>,
+        endpoints_config: ::std::collections::BTreeMap<String, crate::models::EndpointSettings>,
     ) -> Self {
         self.endpoints_config = Some(endpoints_config);
         self
@@ -69,7 +73,7 @@ impl ContainerCreateBodyNetworkingConfig {
 
     pub fn endpoints_config(
         &self,
-    ) -> Option<&::std::collections::HashMap<String, crate::models::EndpointSettings>> {
+    ) -> Option<&::std::collections::BTreeMap<String, crate::models::EndpointSettings>> {
         self.endpoints_config.as_ref()
     }
 

--- a/edgelet/docker-rs/src/models/endpoint_settings.rs
+++ b/edgelet/docker-rs/src/models/endpoint_settings.rs
@@ -25,7 +25,7 @@ use serde_json::Value;
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
 //
-// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// Note: We're using BTreeMap instead of HashMap because iotedged stores a hash of its local config (whose object representation uses this struct)
 // to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
 // we need to use another map type that can provide that guarantee.
 //

--- a/edgelet/docker-rs/src/models/endpoint_settings.rs
+++ b/edgelet/docker-rs/src/models/endpoint_settings.rs
@@ -18,12 +18,16 @@ use serde_json::Value;
 // We do not want to restrict the properties that the user can set in their create options, because future versions of Docker can add new properties
 // that we don't define here.
 //
-// So this type has a `#[serde(flatten)] HashMap` field to collect all the extra properties that we don't have a struct field for.
+// So this type has a `#[serde(flatten)] BTreeMap` field to collect all the extra properties that we don't have a struct field for.
 //
 // But if an existing field references another type under `crate::models::`, then that would still be parsed lossily, so we would have to also add
-// a `#[serde(flatten)] HashMap` field there. And if that type has fields that reference types under `crate::models::` ...
+// a `#[serde(flatten)] BTreeMap` field there. And if that type has fields that reference types under `crate::models::` ...
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
+//
+// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
+// we need to use another map type that can provide that guarantee.
 //
 // ---
 //
@@ -31,7 +35,7 @@ use serde_json::Value;
 //
 // - If it's a simple built-in type, then that is all you need to do.
 //
-// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] HashMap` property
+// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] BTreeMap` property
 //   and is commented out as much as possible. Also copy this devnote there for future readers.
 
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
@@ -74,9 +78,9 @@ pub struct EndpointSettings {
     // mac_address: Option<String>,
     // /// DriverOpts is a mapping of driver options and values. These options are passed directly to the driver and are driver specific.
     // #[serde(rename = "DriverOpts", skip_serializing_if = "Option::is_none")]
-    // driver_opts: Option<::std::collections::HashMap<String, String>>,
+    // driver_opts: Option<::std::collections::BTreeMap<String, String>>,
     #[serde(flatten)]
-    other_properties: std::collections::HashMap<String, serde_json::Value>,
+    other_properties: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 impl EndpointSettings {
@@ -304,19 +308,19 @@ impl EndpointSettings {
     //     self.mac_address = None;
     // }
 
-    // pub fn set_driver_opts(&mut self, driver_opts: ::std::collections::HashMap<String, String>) {
+    // pub fn set_driver_opts(&mut self, driver_opts: ::std::collections::BTreeMap<String, String>) {
     //     self.driver_opts = Some(driver_opts);
     // }
 
     // pub fn with_driver_opts(
     //     mut self,
-    //     driver_opts: ::std::collections::HashMap<String, String>,
+    //     driver_opts: ::std::collections::BTreeMap<String, String>,
     // ) -> Self {
     //     self.driver_opts = Some(driver_opts);
     //     self
     // }
 
-    // pub fn driver_opts(&self) -> Option<&::std::collections::HashMap<String, String>> {
+    // pub fn driver_opts(&self) -> Option<&::std::collections::BTreeMap<String, String>> {
     //     self.driver_opts.as_ref()
     // }
 

--- a/edgelet/docker-rs/src/models/host_config.rs
+++ b/edgelet/docker-rs/src/models/host_config.rs
@@ -25,7 +25,7 @@ use serde_json::Value;
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
 //
-// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// Note: We're using BTreeMap instead of HashMap because iotedged stores a hash of its local config (whose object representation uses this struct)
 // to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
 // we need to use another map type that can provide that guarantee.
 //

--- a/edgelet/docker-rs/src/models/host_config.rs
+++ b/edgelet/docker-rs/src/models/host_config.rs
@@ -18,12 +18,16 @@ use serde_json::Value;
 // We do not want to restrict the properties that the user can set in their create options, because future versions of Docker can add new properties
 // that we don't define here.
 //
-// So this type has a `#[serde(flatten)] HashMap` field to collect all the extra properties that we don't have a struct field for.
+// So this type has a `#[serde(flatten)] BTreeMap` field to collect all the extra properties that we don't have a struct field for.
 //
 // But if an existing field references another type under `crate::models::`, then that would still be parsed lossily, so we would have to also add
-// a `#[serde(flatten)] HashMap` field there. And if that type has fields that reference types under `crate::models::` ...
+// a `#[serde(flatten)] BTreeMap` field there. And if that type has fields that reference types under `crate::models::` ...
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
+//
+// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
+// we need to use another map type that can provide that guarantee.
 //
 // ---
 //
@@ -31,7 +35,7 @@ use serde_json::Value;
 //
 // - If it's a simple built-in type, then that is all you need to do.
 //
-// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] HashMap` property
+// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] BTreeMap` property
 //   and is commented out as much as possible. Also copy this devnote there for future readers.
 
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
@@ -149,7 +153,7 @@ pub struct HostConfig {
     /// A map of exposed container ports and the host port they should map to.
     #[serde(rename = "PortBindings", skip_serializing_if = "Option::is_none")]
     port_bindings:
-        Option<::std::collections::HashMap<String, Vec<crate::models::HostConfigPortBindings>>>,
+        Option<::std::collections::BTreeMap<String, Vec<crate::models::HostConfigPortBindings>>>,
     // #[serde(rename = "RestartPolicy", skip_serializing_if = "Option::is_none")]
     // restart_policy: Option<crate::models::RestartPolicy>,
     // /// Automatically remove the container when the container's process exits. This has no effect if `RestartPolicy` is set.
@@ -214,10 +218,10 @@ pub struct HostConfig {
     // security_opt: Option<Vec<String>>,
     // /// Storage driver options for this container, in the form `{\"size\": \"120G\"}`.
     // #[serde(rename = "StorageOpt", skip_serializing_if = "Option::is_none")]
-    // storage_opt: Option<::std::collections::HashMap<String, String>>,
+    // storage_opt: Option<::std::collections::BTreeMap<String, String>>,
     // /// A map of container directories which should be replaced by tmpfs mounts, and their corresponding mount options. For example: `{ \"/run\": \"rw,noexec,nosuid,size=65536k\" }`.
     // #[serde(rename = "Tmpfs", skip_serializing_if = "Option::is_none")]
-    // tmpfs: Option<::std::collections::HashMap<String, String>>,
+    // tmpfs: Option<::std::collections::BTreeMap<String, String>>,
     // /// UTS namespace to use for the container.
     // #[serde(rename = "UTSMode", skip_serializing_if = "Option::is_none")]
     // uts_mode: Option<String>,
@@ -229,7 +233,7 @@ pub struct HostConfig {
     // shm_size: Option<i64>,
     // /// A list of kernel parameters (sysctls) to set in the container. For example: `{\"net.ipv4.ip_forward\": \"1\"}`
     // #[serde(rename = "Sysctls", skip_serializing_if = "Option::is_none")]
-    // sysctls: Option<::std::collections::HashMap<String, String>>,
+    // sysctls: Option<::std::collections::BTreeMap<String, String>>,
     // /// Runtime to use with this container.
     // #[serde(rename = "Runtime", skip_serializing_if = "Option::is_none")]
     // runtime: Option<String>,
@@ -240,7 +244,7 @@ pub struct HostConfig {
     // #[serde(rename = "Isolation", skip_serializing_if = "Option::is_none")]
     // isolation: Option<String>,
     #[serde(flatten)]
-    other_properties: std::collections::HashMap<String, serde_json::Value>,
+    other_properties: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 impl HostConfig {
@@ -926,7 +930,7 @@ impl HostConfig {
 
     pub fn set_port_bindings(
         &mut self,
-        port_bindings: ::std::collections::HashMap<
+        port_bindings: ::std::collections::BTreeMap<
             String,
             Vec<crate::models::HostConfigPortBindings>,
         >,
@@ -936,7 +940,7 @@ impl HostConfig {
 
     pub fn with_port_bindings(
         mut self,
-        port_bindings: ::std::collections::HashMap<
+        port_bindings: ::std::collections::BTreeMap<
             String,
             Vec<crate::models::HostConfigPortBindings>,
         >,
@@ -947,7 +951,7 @@ impl HostConfig {
 
     pub fn port_bindings(
         &self,
-    ) -> Option<&::std::collections::HashMap<String, Vec<crate::models::HostConfigPortBindings>>>
+    ) -> Option<&::std::collections::BTreeMap<String, Vec<crate::models::HostConfigPortBindings>>>
     {
         self.port_bindings.as_ref()
     }
@@ -1313,19 +1317,19 @@ impl HostConfig {
     //     self.security_opt = None;
     // }
 
-    // pub fn set_storage_opt(&mut self, storage_opt: ::std::collections::HashMap<String, String>) {
+    // pub fn set_storage_opt(&mut self, storage_opt: ::std::collections::BTreeMap<String, String>) {
     //     self.storage_opt = Some(storage_opt);
     // }
 
     // pub fn with_storage_opt(
     //     mut self,
-    //     storage_opt: ::std::collections::HashMap<String, String>,
+    //     storage_opt: ::std::collections::BTreeMap<String, String>,
     // ) -> Self {
     //     self.storage_opt = Some(storage_opt);
     //     self
     // }
 
-    // pub fn storage_opt(&self) -> Option<&::std::collections::HashMap<String, String>> {
+    // pub fn storage_opt(&self) -> Option<&::std::collections::BTreeMap<String, String>> {
     //     self.storage_opt.as_ref()
     // }
 
@@ -1333,16 +1337,16 @@ impl HostConfig {
     //     self.storage_opt = None;
     // }
 
-    // pub fn set_tmpfs(&mut self, tmpfs: ::std::collections::HashMap<String, String>) {
+    // pub fn set_tmpfs(&mut self, tmpfs: ::std::collections::BTreeMap<String, String>) {
     //     self.tmpfs = Some(tmpfs);
     // }
 
-    // pub fn with_tmpfs(mut self, tmpfs: ::std::collections::HashMap<String, String>) -> Self {
+    // pub fn with_tmpfs(mut self, tmpfs: ::std::collections::BTreeMap<String, String>) -> Self {
     //     self.tmpfs = Some(tmpfs);
     //     self
     // }
 
-    // pub fn tmpfs(&self) -> Option<&::std::collections::HashMap<String, String>> {
+    // pub fn tmpfs(&self) -> Option<&::std::collections::BTreeMap<String, String>> {
     //     self.tmpfs.as_ref()
     // }
 
@@ -1401,16 +1405,16 @@ impl HostConfig {
     //     self.shm_size = None;
     // }
 
-    // pub fn set_sysctls(&mut self, sysctls: ::std::collections::HashMap<String, String>) {
+    // pub fn set_sysctls(&mut self, sysctls: ::std::collections::BTreeMap<String, String>) {
     //     self.sysctls = Some(sysctls);
     // }
 
-    // pub fn with_sysctls(mut self, sysctls: ::std::collections::HashMap<String, String>) -> Self {
+    // pub fn with_sysctls(mut self, sysctls: ::std::collections::BTreeMap<String, String>) -> Self {
     //     self.sysctls = Some(sysctls);
     //     self
     // }
 
-    // pub fn sysctls(&self) -> Option<&::std::collections::HashMap<String, String>> {
+    // pub fn sysctls(&self) -> Option<&::std::collections::BTreeMap<String, String>> {
     //     self.sysctls.as_ref()
     // }
 

--- a/edgelet/docker-rs/src/models/host_config_port_bindings.rs
+++ b/edgelet/docker-rs/src/models/host_config_port_bindings.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
 //
-// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// Note: We're using BTreeMap instead of HashMap because iotedged stores a hash of its local config (whose object representation uses this struct)
 // to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
 // we need to use another map type that can provide that guarantee.
 //

--- a/edgelet/docker-rs/src/models/host_config_port_bindings.rs
+++ b/edgelet/docker-rs/src/models/host_config_port_bindings.rs
@@ -16,12 +16,16 @@ use serde_json::Value;
 // We do not want to restrict the properties that the user can set in their create options, because future versions of Docker can add new properties
 // that we don't define here.
 //
-// So this type has a `#[serde(flatten)] HashMap` field to collect all the extra properties that we don't have a struct field for.
+// So this type has a `#[serde(flatten)] BTreeMap` field to collect all the extra properties that we don't have a struct field for.
 //
 // But if an existing field references another type under `crate::models::`, then that would still be parsed lossily, so we would have to also add
-// a `#[serde(flatten)] HashMap` field there. And if that type has fields that reference types under `crate::models::` ...
+// a `#[serde(flatten)] BTreeMap` field there. And if that type has fields that reference types under `crate::models::` ...
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
+//
+// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
+// we need to use another map type that can provide that guarantee.
 //
 // ---
 //
@@ -29,7 +33,7 @@ use serde_json::Value;
 //
 // - If it's a simple built-in type, then that is all you need to do.
 //
-// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] HashMap` property
+// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] BTreeMap` property
 //   and is commented out as much as possible. Also copy this devnote there for future readers.
 
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
@@ -42,7 +46,7 @@ pub struct HostConfigPortBindings {
     host_port: Option<String>,
 
     #[serde(flatten)]
-    other_properties: std::collections::HashMap<String, serde_json::Value>,
+    other_properties: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 impl HostConfigPortBindings {

--- a/edgelet/docker-rs/src/models/mount.rs
+++ b/edgelet/docker-rs/src/models/mount.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
 //
-// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// Note: We're using BTreeMap instead of HashMap because iotedged stores a hash of its local config (whose object representation uses this struct)
 // to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
 // we need to use another map type that can provide that guarantee.
 //

--- a/edgelet/docker-rs/src/models/mount.rs
+++ b/edgelet/docker-rs/src/models/mount.rs
@@ -16,12 +16,16 @@ use serde_json::Value;
 // We do not want to restrict the properties that the user can set in their create options, because future versions of Docker can add new properties
 // that we don't define here.
 //
-// So this type has a `#[serde(flatten)] HashMap` field to collect all the extra properties that we don't have a struct field for.
+// So this type has a `#[serde(flatten)] BTreeMap` field to collect all the extra properties that we don't have a struct field for.
 //
 // But if an existing field references another type under `crate::models::`, then that would still be parsed lossily, so we would have to also add
-// a `#[serde(flatten)] HashMap` field there. And if that type has fields that reference types under `crate::models::` ...
+// a `#[serde(flatten)] BTreeMap` field there. And if that type has fields that reference types under `crate::models::` ...
 //
 // To avoid having to do this for effectively the whole crate, instead we've just commented out the fields we don't use in our code.
+//
+// Note: We're using BTreeMap instead of HashMap because iotedged stores an HMAC of its local config (whose object representation uses this struct)
+// to detect changes. Since different HashMaps with the same keys aren't guaranteed to serialize in the same order (and thus won't compare equal),
+// we need to use another map type that can provide that guarantee.
 //
 // ---
 //
@@ -29,7 +33,7 @@ use serde_json::Value;
 //
 // - If it's a simple built-in type, then that is all you need to do.
 //
-// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] HashMap` property
+// - Otherwise if it references another type under `crate::models::`, then ensure that that type also has a `#[serde(flatten)] BTreeMap` property
 //   and is commented out as much as possible. Also copy this devnote there for future readers.
 
 #[derive(Debug, serde_derive::Serialize, serde_derive::Deserialize, Clone)]
@@ -56,7 +60,7 @@ pub struct Mount {
     // #[serde(rename = "TmpfsOptions", skip_serializing_if = "Option::is_none")]
     // tmpfs_options: Option<crate::models::MountTmpfsOptions>,
     #[serde(flatten)]
-    other_properties: std::collections::HashMap<String, serde_json::Value>,
+    other_properties: std::collections::BTreeMap<String, serde_json::Value>,
 }
 
 impl Mount {

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::default::Default;
 use std::fmt;
 use std::result::Result as StdResult;
@@ -12,7 +12,7 @@ use chrono::prelude::*;
 use failure::{Fail, ResultExt};
 use futures::{Future, Stream};
 
-use edgelet_utils::{ensure_not_empty_with_context, serialize_ordered};
+use edgelet_utils::ensure_not_empty_with_context;
 
 use crate::error::{Error, ErrorKind, Result};
 use crate::settings::RuntimeSettings;
@@ -143,9 +143,8 @@ pub struct ModuleSpec<T> {
     #[serde(rename = "type")]
     type_: String,
     config: T,
-    #[serde(default = "HashMap::new")]
-    #[serde(serialize_with = "serialize_ordered")]
-    env: HashMap<String, String>,
+    #[serde(default = "BTreeMap::new")]
+    env: BTreeMap<String, String>,
     #[serde(default)]
     #[serde(rename = "imagePullPolicy")]
     image_pull_policy: ImagePullPolicy,
@@ -171,7 +170,7 @@ impl<T> ModuleSpec<T> {
         name: String,
         type_: String,
         config: T,
-        env: HashMap<String, String>,
+        env: BTreeMap<String, String>,
         image_pull_policy: ImagePullPolicy,
     ) -> Result<Self> {
         ensure_not_empty_with_context(&name, || ErrorKind::InvalidModuleName(name.clone()))?;
@@ -221,15 +220,15 @@ impl<T> ModuleSpec<T> {
         self.config = config;
     }
 
-    pub fn env(&self) -> &HashMap<String, String> {
+    pub fn env(&self) -> &BTreeMap<String, String> {
         &self.env
     }
 
-    pub fn env_mut(&mut self) -> &mut HashMap<String, String> {
+    pub fn env_mut(&mut self) -> &mut BTreeMap<String, String> {
         &mut self.env
     }
 
-    pub fn with_env(mut self, env: HashMap<String, String>) -> Self {
+    pub fn with_env(mut self, env: BTreeMap<String, String>) -> Self {
         self.env = env;
         self
     }
@@ -622,7 +621,7 @@ impl FromStr for ImagePullPolicy {
 
 #[cfg(test)]
 mod tests {
-    use super::{Default, HashMap, ImagePullPolicy, ModuleSpec, SystemInfo};
+    use super::{Default, BTreeMap, ImagePullPolicy, ModuleSpec, SystemInfo};
 
     use std::str::FromStr;
     use std::string::ToString;
@@ -662,7 +661,7 @@ mod tests {
             name.clone(),
             "docker".to_string(),
             10_i32,
-            HashMap::new(),
+            BTreeMap::new(),
             ImagePullPolicy::default(),
         ) {
             Ok(_) => panic!("Expected error"),
@@ -683,7 +682,7 @@ mod tests {
             name.clone(),
             "docker".to_string(),
             10_i32,
-            HashMap::new(),
+            BTreeMap::new(),
             ImagePullPolicy::default(),
         ) {
             Ok(_) => panic!("Expected error"),
@@ -704,7 +703,7 @@ mod tests {
             "m1".to_string(),
             type_.clone(),
             10_i32,
-            HashMap::new(),
+            BTreeMap::new(),
             ImagePullPolicy::default(),
         ) {
             Ok(_) => panic!("Expected error"),
@@ -725,7 +724,7 @@ mod tests {
             "m1".to_string(),
             type_.clone(),
             10_i32,
-            HashMap::new(),
+            BTreeMap::new(),
             ImagePullPolicy::default(),
         ) {
             Ok(_) => panic!("Expected error"),

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -621,7 +621,7 @@ impl FromStr for ImagePullPolicy {
 
 #[cfg(test)]
 mod tests {
-    use super::{Default, BTreeMap, ImagePullPolicy, ModuleSpec, SystemInfo};
+    use super::{BTreeMap, Default, ImagePullPolicy, ModuleSpec, SystemInfo};
 
     use std::str::FromStr;
     use std::string::ToString;

--- a/edgelet/edgelet-docker/src/config.rs
+++ b/edgelet/edgelet-docker/src/config.rs
@@ -84,7 +84,7 @@ impl DockerConfig {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use docker::models::{ContainerCreateBody, HostConfig, HostConfigPortBindings};
     use serde_json::json;
@@ -104,11 +104,11 @@ mod tests {
 
     #[test]
     fn docker_config_ser() {
-        let mut labels = HashMap::new();
+        let mut labels = BTreeMap::new();
         labels.insert("k1".to_string(), "v1".to_string());
         labels.insert("k2".to_string(), "v2".to_string());
 
-        let mut port_bindings = HashMap::new();
+        let mut port_bindings = BTreeMap::new();
         port_bindings.insert(
             "27017/tcp".to_string(),
             vec![HostConfigPortBindings::new().with_host_port("27017".to_string())],
@@ -149,11 +149,11 @@ mod tests {
 
     #[test]
     fn docker_config_ser_auth() {
-        let mut labels = HashMap::new();
+        let mut labels = BTreeMap::new();
         labels.insert("k1".to_string(), "v1".to_string());
         labels.insert("k2".to_string(), "v2".to_string());
 
-        let mut port_bindings = HashMap::new();
+        let mut port_bindings = BTreeMap::new();
         port_bindings.insert(
             "27017/tcp".to_string(),
             vec![HostConfigPortBindings::new().with_host_port("27017".to_string())],

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::ops::Deref;
 use std::time::Duration;
 
@@ -60,10 +60,10 @@ pub struct DockerModuleRuntime {
 }
 
 impl DockerModuleRuntime {
-    fn merge_env(cur_env: Option<&[String]>, new_env: &HashMap<String, String>) -> Vec<String> {
-        // build a new merged hashmap containing string slices for keys and values
+    fn merge_env(cur_env: Option<&[String]>, new_env: &BTreeMap<String, String>) -> Vec<String> {
+        // build a new merged map containing string slices for keys and values
         // pointing into String instances in new_env
-        let mut merged_env = HashMap::new();
+        let mut merged_env = BTreeMap::new();
         merged_env.extend(new_env.iter().map(|(k, v)| (k.as_str(), v.as_str())));
 
         if let Some(env) = cur_env {
@@ -334,7 +334,7 @@ impl ModuleRuntime for DockerModuleRuntime {
                 let mut labels = create_options
                     .labels()
                     .cloned()
-                    .unwrap_or_else(HashMap::new);
+                    .unwrap_or_else(BTreeMap::new);
                 labels.insert(LABEL_KEY.to_string(), LABEL_VALUE.to_string());
 
                 debug!(
@@ -717,8 +717,13 @@ impl ModuleRuntime for DockerModuleRuntime {
                             .flat_map(|container| {
                                 DockerConfig::new(
                                     container.image().to_string(),
-                                    ContainerCreateBody::new()
-                                        .with_labels(container.labels().clone()),
+                                    ContainerCreateBody::new().with_labels(
+                                        container
+                                            .labels()
+                                            .iter()
+                                            .map(|(k, v)| (k.to_string(), v.to_string()))
+                                            .collect::<BTreeMap<_, _>>(),
+                                    ),
                                     None,
                                 )
                                 .map(|config| {
@@ -1017,7 +1022,7 @@ mod tests {
     use super::{
         authenticate, future, list_with_details, parse_get_response, AuthId, Authenticator, Body,
         CoreSystemInfo, Deserializer, DockerModuleRuntime, DockerModuleTop, Duration, Error,
-        ErrorKind, Future, GetTrustBundle, HashMap, InlineResponse200, LogOptions,
+        ErrorKind, Future, GetTrustBundle, BTreeMap, InlineResponse200, LogOptions,
         MakeModuleRuntime, Module, ModuleId, ModuleRuntime, ModuleRuntimeState, ModuleSpec, Pid,
         ProvisioningResult, Request, Settings, Stream, SystemResources,
     };
@@ -1127,14 +1132,14 @@ mod tests {
     #[test]
     fn merge_env_empty() {
         let cur_env = Some(&[][..]);
-        let new_env = HashMap::new();
+        let new_env = BTreeMap::new();
         assert_eq!(0, DockerModuleRuntime::merge_env(cur_env, &new_env).len());
     }
 
     #[test]
     fn merge_env_new_empty() {
         let cur_env = Some(vec!["k1=v1".to_string(), "k2=v2".to_string()]);
-        let new_env = HashMap::new();
+        let new_env = BTreeMap::new();
         let mut merged_env =
             DockerModuleRuntime::merge_env(cur_env.as_ref().map(AsRef::as_ref), &new_env);
         merged_env.sort();
@@ -1144,7 +1149,7 @@ mod tests {
     #[test]
     fn merge_env_extend_new() {
         let cur_env = Some(vec!["k1=v1".to_string(), "k2=v2".to_string()]);
-        let mut new_env = HashMap::new();
+        let mut new_env = BTreeMap::new();
         new_env.insert("k3".to_string(), "v3".to_string());
         let mut merged_env =
             DockerModuleRuntime::merge_env(cur_env.as_ref().map(AsRef::as_ref), &new_env);
@@ -1155,7 +1160,7 @@ mod tests {
     #[test]
     fn merge_env_extend_replace_new() {
         let cur_env = Some(vec!["k1=v1".to_string(), "k2=v2".to_string()]);
-        let mut new_env = HashMap::new();
+        let mut new_env = BTreeMap::new();
         new_env.insert("k2".to_string(), "v02".to_string());
         new_env.insert("k3".to_string(), "v3".to_string());
         let mut merged_env =

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1020,9 +1020,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::{
-        authenticate, future, list_with_details, parse_get_response, AuthId, Authenticator, Body,
-        CoreSystemInfo, Deserializer, DockerModuleRuntime, DockerModuleTop, Duration, Error,
-        ErrorKind, Future, GetTrustBundle, BTreeMap, InlineResponse200, LogOptions,
+        authenticate, future, list_with_details, parse_get_response, AuthId, Authenticator,
+        BTreeMap, Body, CoreSystemInfo, Deserializer, DockerModuleRuntime, DockerModuleTop,
+        Duration, Error, ErrorKind, Future, GetTrustBundle, InlineResponse200, LogOptions,
         MakeModuleRuntime, Module, ModuleId, ModuleRuntime, ModuleRuntimeState, ModuleSpec, Pid,
         ProvisioningResult, Request, Settings, Stream, SystemResources,
     };

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -722,7 +722,7 @@ impl ModuleRuntime for DockerModuleRuntime {
                                             .labels()
                                             .iter()
                                             .map(|(k, v)| (k.to_string(), v.to_string()))
-                                            .collect::<BTreeMap<_, _>>(),
+                                            .collect(),
                                     ),
                                     None,
                                 )

--- a/edgelet/edgelet-docker/src/settings.rs
+++ b/edgelet/edgelet-docker/src/settings.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use config::{Config, Environment};
@@ -197,7 +197,7 @@ fn agent_networking(settings: &mut Settings) -> Result<(), LoadSettingsError> {
     let mut endpoints_config = network_config
         .endpoints_config()
         .cloned()
-        .unwrap_or_else(HashMap::new);
+        .unwrap_or_else(BTreeMap::new);
 
     if !endpoints_config.contains_key(network_id.as_str()) {
         endpoints_config.insert(network_id, EndpointSettings::new());

--- a/edgelet/edgelet-docker/tests/runtime.rs
+++ b/edgelet/edgelet-docker/tests/runtime.rs
@@ -4,7 +4,7 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(clippy::too_many_lines)]
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::str;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -776,7 +776,7 @@ fn container_create_handler(req: Request<Body>) -> ResponseFuture {
                 );
 
                 let volumes = create_options.volumes().unwrap();
-                let mut expected = ::std::collections::HashMap::new();
+                let mut expected = ::std::collections::BTreeMap::new();
                 expected.insert("test1".to_string(), json!({}));
                 assert_eq!(*volumes, expected);
 
@@ -817,13 +817,13 @@ fn container_create_succeeds() {
 
     let task = DockerModuleRuntime::make_runtime(settings, provisioning_result(), crypto())
         .and_then(|runtime| {
-            let mut env = HashMap::new();
+            let mut env = BTreeMap::new();
             env.insert("k1".to_string(), "v1".to_string());
             env.insert("k2".to_string(), "v2".to_string());
             env.insert("k3".to_string(), "v3".to_string());
 
             // add some create options
-            let mut port_bindings = HashMap::new();
+            let mut port_bindings = BTreeMap::new();
             port_bindings.insert(
                 "22/tcp".to_string(),
                 vec![HostConfigPortBindings::new().with_host_port("11022".to_string())],
@@ -833,7 +833,7 @@ fn container_create_succeeds() {
                 vec![HostConfigPortBindings::new().with_host_port("8080".to_string())],
             );
             let memory: i64 = 3_221_225_472;
-            let mut volumes = ::std::collections::HashMap::new();
+            let mut volumes = ::std::collections::BTreeMap::new();
             volumes.insert("test1".to_string(), json!({}));
             let create_options = ContainerCreateBody::new()
                 .with_host_config(
@@ -1286,7 +1286,7 @@ fn create_fails_for_non_docker_type() {
                 name.to_string(),
                 DockerConfig::new("nginx:latest".to_string(), ContainerCreateBody::new(), None)
                     .unwrap(),
-                HashMap::new(),
+                BTreeMap::new(),
                 ImagePullPolicy::default(),
             )
             .unwrap();

--- a/edgelet/edgelet-http-mgmt/src/server/module/mod.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/mod.rs
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use failure::Fail;
 use serde::de::DeserializeOwned;
@@ -45,7 +45,7 @@ where
 {
     let name = spec.name().to_string();
     let type_ = spec.type_().to_string();
-    let env = spec.config().env().map_or_else(HashMap::new, |vars| {
+    let env = spec.config().env().map_or_else(BTreeMap::new, |vars| {
         vars.iter()
             .map(|var| (var.key().clone(), var.value().clone()))
             .collect()

--- a/edgelet/edgelet-kube/src/convert/to_k8s.rs
+++ b/edgelet/edgelet-kube/src/convert/to_k8s.rs
@@ -536,7 +536,7 @@ pub fn trust_bundle_to_config_map(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
     use std::str;
 
     use k8s_openapi::api::core::v1 as api_core;
@@ -599,7 +599,7 @@ mod tests {
                     ]),
             )
             .with_labels({
-                let mut labels = HashMap::<String, String>::new();
+                let mut labels = BTreeMap::<String, String>::new();
                 labels.insert(String::from("label1"), String::from("value1"));
                 labels.insert(String::from("label2"), String::from("value2"));
                 labels
@@ -613,7 +613,7 @@ mod tests {
             "docker".to_string(),
             DockerConfig::new("my-image:v1.0".to_string(), create_body, Some(auth_config)).unwrap(),
             {
-                let mut env = HashMap::new();
+                let mut env = BTreeMap::new();
                 env.insert(String::from("a"), String::from("b"));
                 env.insert(String::from("C"), String::from("D"));
                 env

--- a/edgelet/edgelet-kube/src/module/create.rs
+++ b/edgelet/edgelet-kube/src/module/create.rs
@@ -293,7 +293,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::BTreeMap;
 
     use hyper::service::service_fn;
     use hyper::{Body, Method, Request, StatusCode};
@@ -692,7 +692,7 @@ mod tests {
                     ]),
             )
             .with_labels({
-                let mut labels = HashMap::<String, String>::new();
+                let mut labels = BTreeMap::<String, String>::new();
                 labels.insert(String::from("label1"), String::from("value1"));
                 labels.insert(String::from("label2"), String::from("value2"));
                 labels
@@ -706,7 +706,7 @@ mod tests {
             "docker".to_string(),
             DockerConfig::new("my-image:v1.0".to_string(), create_body, Some(auth_config)).unwrap(),
             {
-                let mut env = HashMap::new();
+                let mut env = BTreeMap::new();
                 env.insert(String::from("a"), String::from("b"));
                 env.insert(String::from("C"), String::from("D"));
                 env

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -23,7 +23,7 @@ use std::collections::HashMap;
 pub use crate::error::{Error, ErrorKind};
 pub use crate::logging::log_failure;
 pub use crate::macros::ensure_not_empty_with_context;
-pub use crate::ser_de::{serde_clone, serialize_ordered, string_or_struct};
+pub use crate::ser_de::{serde_clone, string_or_struct};
 pub use crate::yaml_file_source::YamlFileSource;
 
 pub fn parse_query(query: &str) -> HashMap<&str, &str> {

--- a/edgelet/edgelet-utils/src/ser_de.rs
+++ b/edgelet/edgelet-utils/src/ser_de.rs
@@ -1,15 +1,13 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use std::collections::{BTreeMap, HashMap};
 use std::fmt;
-use std::hash::BuildHasher;
 use std::marker::PhantomData;
 use std::result::Result as StdResult;
 use std::str::FromStr;
 
 use failure::ResultExt;
 use serde::de::{self, Deserialize, DeserializeOwned, Deserializer, MapAccess, Visitor};
-use serde::ser::{Serialize, Serializer};
+use serde::ser::Serialize;
 
 use crate::error::{ErrorKind, Result};
 
@@ -68,18 +66,6 @@ where
         .context(ErrorKind::SerdeClone)?)
 }
 
-pub fn serialize_ordered<S, T>(
-    x: &HashMap<String, String, T>,
-    serializer: S,
-) -> StdResult<S::Ok, S::Error>
-where
-    S: Serializer,
-    T: BuildHasher,
-{
-    let sorted_map: BTreeMap<_, _> = x.iter().collect();
-    sorted_map.serialize(serializer)
-}
-
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -87,7 +73,7 @@ mod tests {
     use serde_derive::{Deserialize, Serialize};
     use serde_json::json;
 
-    use super::{serde_clone, serialize_ordered, string_or_struct, HashMap, StdResult};
+    use super::{serde_clone, string_or_struct, StdResult};
 
     #[derive(Debug, Deserialize)]
     struct Options {
@@ -107,12 +93,6 @@ mod tests {
     struct Container {
         #[serde(deserialize_with = "string_or_struct")]
         options: Options,
-    }
-
-    #[derive(Debug, Serialize)]
-    struct Setting {
-        #[serde(serialize_with = "serialize_ordered")]
-        map: HashMap<String, String>,
     }
 
     #[test]
@@ -170,27 +150,5 @@ mod tests {
         let c2 = serde_clone(&c1).unwrap();
         assert_eq!(c1.name, c2.name);
         assert_eq!(c1.age, c2.age);
-    }
-
-    #[test]
-    fn serde_serialize_map() {
-        let setting_json = json!({
-            "map": {
-                "a": "val1",
-                "b": "val2",
-                "c": "val3"
-            }
-        })
-        .to_string();
-
-        let mut map = HashMap::new();
-        map.insert("b".to_string(), "val2".to_string());
-        map.insert("a".to_string(), "val1".to_string());
-        map.insert("c".to_string(), "val3".to_string());
-
-        let map_container = Setting { map };
-
-        let s = serde_json::to_string(&map_container).unwrap();
-        assert_eq!(s, setting_json);
     }
 }

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -26,7 +26,7 @@ pub mod unix;
 pub mod windows;
 
 use futures::sync::mpsc;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env;
 use std::fs;
 use std::fs::{DirBuilder, File, OpenOptions};
@@ -1985,15 +1985,15 @@ where
 
 // Add the environment variables needed by the EdgeAgent.
 fn build_env<S>(
-    spec_env: &HashMap<String, String>,
+    spec_env: &BTreeMap<String, String>,
     hostname: &str,
     device_id: &str,
     settings: &S,
-) -> HashMap<String, String>
+) -> BTreeMap<String, String>
 where
     S: RuntimeSettings,
 {
-    let mut env = HashMap::new();
+    let mut env = BTreeMap::new();
     env.insert(HOSTNAME_KEY.to_string(), hostname.to_string());
     env.insert(
         GATEWAY_HOSTNAME_KEY.to_string(),


### PR DESCRIPTION
`iotedged` detects changes to `config.yaml` by creating an hash of it's in-memory representation, saving it to disk, and comparing it against the latest next time it starts up. The problem is that several structs which make up our in-memory representation of `config.yaml` use `HashMap` as a dictionary. `HashMap` cannot guarantee that different maps with the same keys will serialize in the same order, so two semantically equivalent `HashMap`s might not compare equal. The impact is that `iotedged` might think that `config.yaml` changed (and remove/restart all modules as a result) when it didn't.

This change moves the offending types to `BTreeMap`, which has the guarantee we need. It also removes the custom `serialize_ordered` attribute on `HashMap`, which just copies the `HashMap` to a `BTreeMap` anyway so using `BTreeMap` to begin with is simpler.