### PR TITLE
Fix service deployment pipeline

### DIFF
--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -7,7 +7,7 @@ schedules:
   displayName: Nightly build
   branches:
     include:
-    - master
+    - release/1.0.9 # TODO: Return to 'master' once 1.0.10 is released
   always: true
 
 pool:

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -28,9 +28,15 @@ steps:
 
 - pwsh: |
     $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
-    dotnet build $testDir
+    $out = dotnet build $testDir
 
-    $binDir = Convert-Path "$testDir/bin/Debug/netcoreapp3.1"
+    $binDir = $out
+      | Where-Object { $_ -match 'Microsoft.Azure.Devices.Edge.Test.dll' }
+      | Select-Object -Last 1
+      | ForEach-Object { -split $_ }
+      | Select-Object -Last 1
+      | Get-Item
+      | ForEach-Object { $_.DirectoryName }
     Write-Output "##vso[task.setvariable variable=binDir]$binDir"
   displayName: Build tests
 


### PR DESCRIPTION
The service deployment pipeline is used by the IoT Hub team to try out IoT Edge against new versions of the service before they release. It uses the released versions of our bits (so, 1.0.9 currently), but it uses the end-to-end test code from `master`.

The problem is that we recently made some changes to the end-to-end tests that rely on new behavior slated for the next release. This caused the service deployment pipeline to fail against our release bits.

The fix is to use test code that matches product bits.

I also updated the pipeline YAML so that is doesn't hardcode `netcoreapp3.1`--it programmatically determines the binary path instead.