### PR TITLE
Fixing TRC for PQ e2e tests from 3.1 update

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -215,7 +215,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
                        .WithEnvironment(new[]
                        {
                            ("trackingId", trackingId),
-                           ("eventHubConnectionString", "Unnecessary"),
                            ("IOT_HUB_CONNECTION_STRING", Context.Current.ConnectionString),
                            ("logAnalyticsWorkspaceId", "Unnecessary"),
                            ("logAnalyticsSharedKey", "Unnecessary"),

--- a/test/modules/TestResultCoordinator/Services/TestResultEventReceivingService.cs
+++ b/test/modules/TestResultCoordinator/Services/TestResultEventReceivingService.cs
@@ -34,7 +34,7 @@ namespace TestResultCoordinator.Services
             this.logger.LogInformation("Test Result Event Receiving Service running.");
 
             DateTime eventEnqueuedFrom = DateTime.UtcNow;
-            var builder = new EventHubsConnectionStringBuilder(Settings.Current.EventHubConnectionString);
+            var builder = new EventHubsConnectionStringBuilder(Settings.Current.EventHubConnectionString.Expect(() => new ArgumentException("Event Hub connection string must be supplied")));
             this.logger.LogDebug($"Receiving events from device '{Settings.Current.DeviceId}' on Event Hub '{builder.EntityPath}' enqueued on or after {eventEnqueuedFrom}");
 
             EventHubClient eventHubClient = EventHubClient.CreateFromConnectionString(builder.ToString());

--- a/test/modules/TestResultCoordinator/Settings.cs
+++ b/test/modules/TestResultCoordinator/Settings.cs
@@ -51,7 +51,7 @@ namespace TestResultCoordinator
             Preconditions.CheckRange(testDuration.Ticks, 1);
 
             this.TrackingId = Preconditions.CheckNonWhiteSpace(trackingId, nameof(trackingId));
-            this.EventHubConnectionString = Preconditions.CheckNonWhiteSpace(eventHubConnectionString, nameof(eventHubConnectionString));
+            this.EventHubConnectionString = Option.Maybe(eventHubConnectionString);
             this.IoTHubConnectionString = Preconditions.CheckNonWhiteSpace(iotHubConnectionString, nameof(iotHubConnectionString));
             this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
             this.ModuleId = Preconditions.CheckNonWhiteSpace(moduleId, nameof(moduleId));
@@ -118,7 +118,7 @@ namespace TestResultCoordinator
                 configuration.GetValue<string>("TEST_INFO"));
         }
 
-        public string EventHubConnectionString { get; }
+        public Option<string> EventHubConnectionString { get; }
 
         public string IoTHubConnectionString { get; }
 

--- a/test/modules/TestResultCoordinator/Startup.cs
+++ b/test/modules/TestResultCoordinator/Startup.cs
@@ -65,7 +65,7 @@ namespace TestResultCoordinator
                     sources).Result);
 
             services.AddHostedService<TestResultReportingService>();
-            services.AddHostedService<TestResultEventReceivingService>();
+            Settings.Current.EventHubConnectionString.ForEach(s => services.AddHostedService<TestResultEventReceivingService>());
 
             Logger.LogInformation("Calling Startup.ConfigureServices Completed.");
         }


### PR DESCRIPTION
Dotnet 3.1 broke the priority queue e2e tests because of the way AspNet handles errors. 

This change makes the testResultEventReceivingService and the EventHubConnectionString optional for TRC