### PR TITLE
Fix build manifest and correct logging

### DIFF
--- a/scripts/linux/buildManifest.sh
+++ b/scripts/linux/buildManifest.sh
@@ -156,14 +156,13 @@ sed "s/__REGISTRY__/${DOCKER_REGISTRY}/g; s/__VERSION__/${DOCKER_IMAGEVERSION}/g
 echo "Build image with following manifest:"
 cat $manifest
 
-echo "Done Building And Pushing Docker Images"
-
-
 if [ $WIN_ARM32_ENABLED -eq 1 ]; then
-    curl -Lo /tmp/manifest-tool 'https://edgebuild.blob.core.windows.net/iotedge-win-arm32v7-tools/manifest-tool-linux-amd64' &&
-        chmod +x /tmp/manifest-tool &&
-        /tmp/manifest-tool --debug push from-spec $IGNORE_MISSING $manifest
+    curl -Lo /tmp/manifest-tool 'https://edgebuild.blob.core.windows.net/iotedge-win-arm32v7-tools/manifest-tool-linux-amd64' && chmod +x /tmp/manifest-tool
 fi
+
+/tmp/manifest-tool --debug push from-spec $IGNORE_MISSING $manifest
+
+echo "Done Building And Pushing Docker Images"
 
 [ $? -eq 0 ] || exit $?
 

--- a/scripts/linux/buildManifest.sh
+++ b/scripts/linux/buildManifest.sh
@@ -42,7 +42,6 @@ usage()
     echo " -i, --image-name               Docker image name (Optional if specified in template yaml)"
     echo " -v, --image-version            Docker Image Version."
     echo " -t, --template                 Yaml file template for manifest definition."
-    echo " -w, --win-arm32-enabled        Enable the windows arm32 build manifest"
     echo "     --tags                     Additional tags to add to the docker image. Specify as a list of strings. e.g. --tags \"['1.0']\""
     echo "     --ignore-missing           Ignore missing images in manifest"
     exit 1;
@@ -97,7 +96,6 @@ process_args()
                        "--tags" ) save_next_arg=6;;
                 "-n" | "--namespace" ) save_next_arg=7;;
                 "-i" | "--image-name" ) save_next_arg=8;;
-                "-w" | "--win-arm32-enabled" ) WIN_ARM32_ENABLED=1;;
                        "--ignore-missing" ) IGNORE_MISSING="--ignore-missing";;
                 * ) usage;;
             esac
@@ -156,15 +154,12 @@ sed "s/__REGISTRY__/${DOCKER_REGISTRY}/g; s/__VERSION__/${DOCKER_IMAGEVERSION}/g
 echo "Build image with following manifest:"
 cat $manifest
 
-if [ $WIN_ARM32_ENABLED -eq 1 ]; then
-    curl -Lo /tmp/manifest-tool 'https://edgebuild.blob.core.windows.net/iotedge-win-arm32v7-tools/manifest-tool-linux-amd64' && chmod +x /tmp/manifest-tool
-fi
-
-/tmp/manifest-tool --debug push from-spec $IGNORE_MISSING $manifest
+curl -Lo /tmp/manifest-tool 'https://edgebuild.blob.core.windows.net/iotedge-win-arm32v7-tools/manifest-tool-linux-amd64' &&
+    chmod +x /tmp/manifest-tool &&
+    /tmp/manifest-tool --debug push from-spec $IGNORE_MISSING $manifest
+[ $? -eq 0 ] || exit $?
 
 echo "Done Building And Pushing Docker Images"
-
-[ $? -eq 0 ] || exit $?
 
 # Remove the temp file
 rm $manifest


### PR DESCRIPTION
We needed to give a feature flag for windows arm32 because it is being removed from the build. The feature flag now blocks the manifest from being completed, which is obviously not desired and a big problem.

This [commit](https://github.com/Azure/iotedge/blame/cdcc9af33c16be270e20d6197357234d3eecaf15/scripts/linux/buildManifest.sh) from the buildManifest.sh file before win arm32 was added shows the expected the behavior in the case where we don't want to have the logic for winarm32