### PR TITLE
Update long haul log size for debug

### DIFF
--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -22,7 +22,7 @@
             "type": "docker",
             "settings": {
               "image": "<Container_Registry>/microsoft/azureiotedge-agent:<Build.BuildNumber>-linux-<Architecture>",
-              "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}}}"
+              "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"<MaxLogSize>\",\"max-file\":\"7\"}}}}"
             },
             "env": {
             }
@@ -31,7 +31,7 @@
             "type": "docker",
             "settings": {
               "image": "<Container_Registry>/microsoft/azureiotedge-hub:<Build.BuildNumber>-linux-<Architecture>",
-              "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}},\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
+              "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"<MaxLogSize>\",\"max-file\":\"7\"}},\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
               "CollectMetrics": {

--- a/e2e_deployment_files/long_haul_deployment.template.windows.json
+++ b/e2e_deployment_files/long_haul_deployment.template.windows.json
@@ -22,7 +22,7 @@
             "type": "docker",
             "settings": {
               "image": "<Container_Registry>/microsoft/azureiotedge-agent:<Build.BuildNumber>-windows-<Architecture>",
-              "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}}}"
+              "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"<MaxLogSize>\",\"max-file\":\"7\"}}}}"
             },
             "env": {
             }
@@ -31,7 +31,7 @@
             "type": "docker",
             "settings": {
               "image": "<Container_Registry>/microsoft/azureiotedge-hub:<Build.BuildNumber>-windows-<Architecture>",
-              "createOptions": "{\"User\": \"ContainerAdministrator\",\"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}},\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
+              "createOptions": "{\"User\": \"ContainerAdministrator\",\"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"<MaxLogSize>\",\"max-file\":\"7\"}},\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
               "CollectMetrics": {

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -159,6 +159,7 @@ function prepare_test_from_artifacts() {
                     cp "$long_haul_deployment_artifact_file" "$deployment_working_file"
                     sed -i -e "s@<DesiredModulesToRestartCSV>@$DESIRED_MODULES_TO_RESTART_CSV@g" "$deployment_working_file"
                     sed -i -e "s@<RestartIntervalInMins>@$RESTART_INTERVAL_IN_MINS@g" "$deployment_working_file"
+                    sed -i -e "s@<MaxLogSize>@$max_log_size@g" "$deployment_working_file"
                 else
                     echo "Copy deployment file from $stress_deployment_artifact_file"
                     cp "$stress_deployment_artifact_file" "$deployment_working_file"
@@ -1118,6 +1119,12 @@ if [[ "${TEST_NAME,,}" == "longhaul" ]]; then
     TWIN_UPDATE_SIZE="${TWIN_UPDATE_SIZE:-1}"
     TWIN_UPDATE_FREQUENCY="${TWIN_UPDATE_FREQUENCY:-00:00:15}"
     TEST_START_DELAY="${TEST_START_DELAY:-00:00:00}"
+
+    # if Run log level is debug, we need ~96M for 24hr of edgeHub/edgeAgent log
+    if [[ "${RUNTIME_LOG_LEVEL,,}" == "debug" ]]; then
+        max_log_size="96m"
+    fi
+    max_log_size="${max_log_size:-4m}"
 fi
 if [[ "${TEST_NAME,,}" == "stress" ]]; then
     LOADGEN_MESSAGE_FREQUENCY="${LOADGEN_MESSAGE_FREQUENCY:-00:00:00.03}"

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -499,6 +499,7 @@ Function PrepareTestFromArtifacts
                     Copy-Item $LongHaulDeploymentArtifactFilePath -Destination $DeploymentWorkingFilePath -Force
                     (Get-Content $DeploymentWorkingFilePath).replace('<DesiredModulesToRestartCSV>',$DesiredModulesToRestartCSV) | Set-Content $DeploymentWorkingFilePath
                     (Get-Content $DeploymentWorkingFilePath).replace('<RestartIntervalInMins>',$RestartIntervalInMins) | Set-Content $DeploymentWorkingFilePath
+                    (Get-Content $DeploymentWorkingFilePath).replace('<MaxLogSize>',$MaxLogSize) | Set-Content $DeploymentWorkingFilePath
                 }
                 Else
                 {
@@ -1608,6 +1609,7 @@ If ($TestName -eq "LongHaul")
     If ([string]::IsNullOrEmpty($TwinUpdateFrequency)) {$TwinUpdateSize = "00:00:15"}
     If ([string]::IsNullOrEmpty($TwinUpdateSize)) {$TwinUpdateSize = "1"}
     If ([string]::IsNullOrWhiteSpace($TestStartDelay)) {$TestStartDelay="00:00:00";}
+    If ($RuntimeLogLevel -like "debug") {$MaxLogSize="96m";} else {$MaxLogSize="4m";}
 }
 
 If ($TestName -eq "Stress")


### PR DESCRIPTION
Update long haul log size for debug
If the RunTimeLogLevel is set to `debug` the log rotation is set to 96MB for edgeHub and edgeAgent. Otherwise the log rotaiton is set to 4MB. The reason behind this is to facilitate that the debugging log can be fully captured for 7 days without being rotated out for a newer log on the two modules. 

Our most memory constrains test agent is ARM32 with 8GB of storage. With ARM32 with 8GB storage ( ~5GB actually available for logging ), we have 96M x 7 days x 2 modules (edgeHub & edgeAgent) = ~1.4GB.  And the rest of the modules takes up = 4M x 7 days x 16 modules = 448MB. Total = ~2GB. We should ideally have about 3GB left on ARM32 device storage.