### PR TITLE
[k8s] [public preview] Fix Azure Stack issues.

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -9,6 +9,10 @@ ARG EXE_DIR=.
 RUN apk update && \
     apk add --no-cache snappy
 
+# create a user to allow agent to optionally run as non-root
+ARG EDGEAGENTUSER_ID=1000	
+RUN adduser -Ds /bin/sh -u ${EDGEAGENTUSER_ID} edgeagentuser 
+
 # Install RocksDB
 COPY --from=builder publish/* /usr/local/lib/
 

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -7,4 +7,8 @@ RUN apt-get update && \
     ln -s /lib/arm-linux-gnueabihf/libc.so.6 /usr/lib/arm-linux-gnueabihf/libc.so && \
     rm -rf /var/lib/apt/lists/*
 
+# create a user to allow agent to optionally run as non-root
+ARG EDGEAGENTUSER_ID=1000	
+RUN useradd -ms /bin/bash -u ${EDGEAGENTUSER_ID} edgeagentuser 
+
 COPY librocksdb.so /usr/lib/

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -14,4 +14,8 @@ RUN apt-get update && \
     ln -s /lib/aarch64-linux-gnu/libdl.so.2 /usr/lib/aarch64-linux-gnu/libdl.so && \
     ln -s /lib/aarch64-linux-gnu/libc.so.6 /usr/lib/aarch64-linux-gnu/libc.so.6
 
+# create a user to allow agent to optionally run as non-root
+ARG EDGEAGENTUSER_ID=1000	
+RUN useradd -ms /bin/bash -u ${EDGEAGENTUSER_ID} edgeagentuser 
+
 COPY  librocksdb.so /usr/lib

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Constants.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
         public const string K8sEdgeDeviceLabel = "net.azure-devices.edge.deviceid";
 
-        public const string K8sEdgeHubNameLabel = "net.azure-devices.edge.hub";
-
         public const string K8sNameDivider = "-";
 
         public const string K8sPullSecretType = "kubernetes.io/dockerconfigjson";

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentCommand.cs
@@ -74,7 +74,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
             var deviceOnlyLabels = new Dictionary<string, string>
             {
                 [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue(this.resourceName.DeviceId),
-                [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue(this.resourceName.Hostname)
             };
 
             // Modules may share an image pull secret, so only pick unique ones to add to the dictionary.

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentController.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentController.cs
@@ -74,12 +74,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
                         {
                             [KubernetesConstants.K8sEdgeModuleLabel] = moduleIdentities[module.Key].DeploymentName(),
                             [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue(this.resourceName.DeviceId),
-                            [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue(this.resourceName.Hostname)
                         });
                 var deviceOnlyLabels = new Dictionary<string, string>
                 {
                     [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue(this.resourceName.DeviceId),
-                    [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue(this.resourceName.Hostname)
                 };
 
                 var desiredServiceAccounts = desiredModules.Modules
@@ -290,13 +288,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
                 return false;
             }
 
-            if (!labels.ContainsKey(KubernetesConstants.K8sEdgeDeviceLabel) || !labels.ContainsKey(KubernetesConstants.K8sEdgeHubNameLabel))
+            if (!labels.ContainsKey(KubernetesConstants.K8sEdgeDeviceLabel))
             {
                 return false;
             }
 
-            return labels[KubernetesConstants.K8sEdgeDeviceLabel] == KubeUtils.SanitizeLabelValue(this.resourceName.DeviceId) &&
-                    labels[KubernetesConstants.K8sEdgeHubNameLabel] == KubeUtils.SanitizeLabelValue(this.resourceName.Hostname);
+            return labels[KubernetesConstants.K8sEdgeDeviceLabel] == KubeUtils.SanitizeLabelValue(this.resourceName.DeviceId);
         }
 
         static IEqualityComparer<V1PersistentVolumeClaim> KubernetesPvcByValueEqualityComparer { get; } = new KubernetesPvcByValueEqualityComparer();

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -237,6 +237,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                                 runAsNonRoot,
                                 useServerHeartbeat));
 
+                        IEnumerable<X509Certificate2> k8sTrustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(new Uri(workloadUri), apiVersion, Constants.WorkloadApiVersion, moduleId, moduleGenerationId);
+                        CertificateHelper.InstallCertificates(k8sTrustBundle, logger);
                         break;
 
                     default:

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.proxyTrustBundleVolumeName = Preconditions.CheckNonWhiteSpace(proxyTrustBundleVolumeName, nameof(proxyTrustBundleVolumeName));
             this.proxyTrustBundleConfigMapName = Preconditions.CheckNonWhiteSpace(proxyTrustBundleConfigMapName, nameof(proxyTrustBundleConfigMapName));
             this.apiVersion = Preconditions.CheckNonWhiteSpace(apiVersion, nameof(apiVersion));
-            this.deviceSelector = $"{Constants.K8sEdgeDeviceLabel}={KubeUtils.SanitizeLabelValue(this.resourceName.DeviceId)},{Constants.K8sEdgeHubNameLabel}={KubeUtils.SanitizeLabelValue(this.resourceName.Hostname)}";
+            this.deviceSelector = $"{Constants.K8sEdgeDeviceLabel}={KubeUtils.SanitizeLabelValue(this.resourceName.DeviceId)}";
             this.deviceNamespace = Preconditions.CheckNonWhiteSpace(deviceNamespace, nameof(deviceNamespace));
             this.managementUri = Preconditions.CheckNotNull(managementUri, nameof(managementUri));
             this.workloadUri = Preconditions.CheckNotNull(workloadUri, nameof(workloadUri));

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/KubernetesImagePullSecretBySecretDataEqualityComparerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/KubernetesImagePullSecretBySecretDataEqualityComparerTest.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                     Labels = new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     },
                     Name = "object1"
                 },
@@ -57,7 +56,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                     Labels = new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     },
                     Name = "object1"
                 },
@@ -95,7 +93,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                     Labels = new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     },
                     Name = "object1",
                     OwnerReferences = new List<V1OwnerReference>
@@ -115,7 +112,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                     Labels = new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     },
                     Name = "object1"
                 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcByValueComparerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcByValueComparerTest.cs
@@ -35,7 +35,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                     labels: new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue("device1"),
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue("hostname")
                     }),
                 Spec = new V1PersistentVolumeClaimSpec
                 {
@@ -50,7 +49,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                     labels: new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue("device1"),
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue("hostname")
                     }),
                 Spec = new V1PersistentVolumeClaimSpec
                 {
@@ -71,7 +69,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                     labels: new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     }),
                 Spec = new V1PersistentVolumeClaimSpec
                 {
@@ -88,7 +85,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                     labels: new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     }),
                 Spec = new V1PersistentVolumeClaimSpec
                 {
@@ -164,7 +160,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                     labels: new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue("device1"),
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue("hostname")
                     },
                     ownerReferences: new List<V1OwnerReference>
                     {
@@ -183,7 +178,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                     labels: new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue("device1"),
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue("hostname")
                     }),
                 Spec = new V1PersistentVolumeClaimSpec
                 {
@@ -203,7 +197,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                     labels: new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     }),
                 Spec = new V1PersistentVolumeClaimSpec
                 {
@@ -219,7 +212,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
                     labels: new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     }),
                 Spec = new V1PersistentVolumeClaimSpec
                 {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/pvc/KubernetesPvcMapperTest.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Pvc
         static readonly Dictionary<string, string> DefaultLabels = new Dictionary<string, string>
         {
             [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue("device1"),
-            [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue("hostname")
         };
 
         static readonly ResourceName ResourceName = new ResourceName("hostname", "deviceId");

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
@@ -24,10 +24,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
         static readonly DockerConfig Config1 = new DockerConfig("test-image:1");
 
         static readonly Dictionary<string, DockerEmptyStruct> ExposedPorts = new Dictionary<string, DockerEmptyStruct>
-            {
-                ["80/tcp"] = default(DockerEmptyStruct),
-                ["5000/udp"] = default(DockerEmptyStruct)
-            };
+        {
+            ["80/tcp"] = default(DockerEmptyStruct),
+            ["5000/udp"] = default(DockerEmptyStruct)
+        };
 
         static readonly HostConfig HostPorts = new HostConfig
         {
@@ -47,7 +47,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
         static readonly Dictionary<string, string> DefaultLabels = new Dictionary<string, string>
         {
             [KubernetesConstants.K8sEdgeDeviceLabel] = KubeUtils.SanitizeLabelValue("device1"),
-            [KubernetesConstants.K8sEdgeHubNameLabel] = KubeUtils.SanitizeLabelValue("hostname")
         };
 
         static readonly ModuleIdentity CreateIdentity = new ModuleIdentity("hostname", "gateway", "device1", "Module1", new ConnectionStringCredentials("connection string"));

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/serviceaccount/KubernetesServiceAccountByValueComparerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/serviceaccount/KubernetesServiceAccountByValueComparerTest.cs
@@ -39,7 +39,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
                     Labels = new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     },
                     Name = "object1"
                 }
@@ -55,7 +54,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
                     Labels = new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     },
                     Name = "object1"
                 }
@@ -101,7 +99,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
                     Labels = new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     },
                     Name = "object1",
                     OwnerReferences = new List<V1OwnerReference>
@@ -121,7 +118,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
                     Labels = new Dictionary<string, string>
                     {
                         [KubernetesConstants.K8sEdgeDeviceLabel] = "device1",
-                        [KubernetesConstants.K8sEdgeHubNameLabel] = "hostname"
                     },
                     Name = "object1"
                 }

--- a/edgelet/edgelet-kube/src/constants.rs
+++ b/edgelet/edgelet-kube/src/constants.rs
@@ -8,8 +8,6 @@ pub const EDGE_ORIGINAL_MODULEID: &str = "net.azure-devices.edge.original-module
 
 pub const EDGE_DEVICE_LABEL: &str = "net.azure-devices.edge.deviceid";
 
-pub const EDGE_HUBNAME_LABEL: &str = "net.azure-devices.edge.hub";
-
 pub const PROXY_CONTAINER_NAME: &str = "proxy";
 
 pub const PROXY_CONFIG_VOLUME_NAME: &str = "config-volume";

--- a/edgelet/edgelet-kube/src/convert/to_k8s.rs
+++ b/edgelet/edgelet-kube/src/convert/to_k8s.rs
@@ -13,8 +13,18 @@ use k8s_openapi::api::rbac::v1 as api_rbac;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1 as api_meta;
 use log::warn;
 
-use crate::constants::env::*;
-use crate::constants::*;
+use crate::constants::env::{
+    EDGE_NETWORK_ID_KEY, EDGE_OBJECT_OWNER_API_VERSION_KEY, EDGE_OBJECT_OWNER_KIND_KEY,
+    EDGE_OBJECT_OWNER_NAME_KEY, EDGE_OBJECT_OWNER_UID_KEY, NAMESPACE_KEY,
+    PROXY_CONFIG_MAP_NAME_KEY, PROXY_CONFIG_PATH_KEY, PROXY_CONFIG_VOLUME_KEY, PROXY_IMAGE_KEY,
+    PROXY_IMAGE_PULL_SECRET_NAME_KEY, PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME_KEY,
+    PROXY_TRUST_BUNDLE_PATH_KEY, PROXY_TRUST_BUNDLE_VOLUME_KEY,
+};
+use crate::constants::{
+    EDGE_DEVICE_LABEL, EDGE_EDGE_AGENT_NAME, EDGE_MODULE_LABEL, EDGE_ORIGINAL_MODULEID,
+    PROXY_CONFIG_VOLUME_NAME, PROXY_CONTAINER_NAME, PROXY_TRUST_BUNDLE_FILENAME,
+    PROXY_TRUST_BUNDLE_VOLUME_NAME,
+};
 use crate::convert::{sanitize_dns_value, sanitize_label_value};
 use crate::error::{ErrorKind, Result};
 use crate::registry::ImagePullSecret;
@@ -329,11 +339,6 @@ pub fn spec_to_deployment(
     let module_label_value = sanitize_dns_value(spec.name())?;
     let device_label_value =
         sanitize_label_value(settings.device_id().ok_or(ErrorKind::MissingDeviceId)?);
-    let hubname_label = sanitize_label_value(
-        settings
-            .iot_hub_hostname()
-            .ok_or(ErrorKind::MissingHubName)?,
-    );
     let deployment_name = module_label_value.clone();
     let module_image = spec.config().image().to_string();
 
@@ -341,7 +346,6 @@ pub fn spec_to_deployment(
     let mut pod_labels = BTreeMap::new();
     pod_labels.insert(EDGE_MODULE_LABEL.to_string(), module_label_value.clone());
     pod_labels.insert(EDGE_DEVICE_LABEL.to_string(), device_label_value);
-    pod_labels.insert(EDGE_HUBNAME_LABEL.to_string(), hubname_label);
 
     let deployment_labels = pod_labels.clone();
     let selector_labels = pod_labels.clone();
@@ -401,11 +405,6 @@ pub fn spec_to_service_account(
     let module_label_value = sanitize_dns_value(spec.name())?;
     let device_label_value =
         sanitize_label_value(settings.device_id().ok_or(ErrorKind::MissingDeviceId)?);
-    let hubname_label = sanitize_label_value(
-        settings
-            .iot_hub_hostname()
-            .ok_or(ErrorKind::MissingHubName)?,
-    );
 
     let service_account_name = module_label_value.clone();
 
@@ -413,7 +412,6 @@ pub fn spec_to_service_account(
     let mut labels = BTreeMap::new();
     labels.insert(EDGE_MODULE_LABEL.to_string(), module_label_value.clone());
     labels.insert(EDGE_DEVICE_LABEL.to_string(), device_label_value);
-    labels.insert(EDGE_HUBNAME_LABEL.to_string(), hubname_label);
 
     // annotations
     let mut annotations = BTreeMap::new();
@@ -443,11 +441,6 @@ pub fn spec_to_role_binding(
     let module_label_value = sanitize_dns_value(spec.name())?;
     let device_label_value =
         sanitize_label_value(settings.device_id().ok_or(ErrorKind::MissingDeviceId)?);
-    let hubname_label = sanitize_label_value(
-        settings
-            .iot_hub_hostname()
-            .ok_or(ErrorKind::MissingHubName)?,
-    );
 
     let role_binding_name = module_label_value.clone();
 
@@ -455,7 +448,6 @@ pub fn spec_to_role_binding(
     let mut labels = BTreeMap::new();
     labels.insert(EDGE_MODULE_LABEL.to_string(), module_label_value.clone());
     labels.insert(EDGE_DEVICE_LABEL.to_string(), device_label_value);
-    labels.insert(EDGE_HUBNAME_LABEL.to_string(), hubname_label);
 
     // annotations
     let mut annotations = BTreeMap::new();
@@ -493,16 +485,10 @@ pub fn trust_bundle_to_config_map(
 ) -> Result<(String, api_core::ConfigMap)> {
     let device_label_value =
         sanitize_label_value(settings.device_id().ok_or(ErrorKind::MissingDeviceId)?);
-    let hubname_label = sanitize_label_value(
-        settings
-            .iot_hub_hostname()
-            .ok_or(ErrorKind::MissingHubName)?,
-    );
 
     // labels
     let mut labels = BTreeMap::new();
     labels.insert(EDGE_DEVICE_LABEL.to_string(), device_label_value);
-    labels.insert(EDGE_HUBNAME_LABEL.to_string(), hubname_label);
 
     let cert = cert.pem().context(ErrorKind::IdentityCertificate)?;
     let cert = str::from_utf8(cert.as_ref()).context(ErrorKind::IdentityCertificate)?;
@@ -540,8 +526,16 @@ mod tests {
     use edgelet_docker::DockerConfig;
     use edgelet_test_utils::cert::TestCert;
 
-    use crate::constants::env::*;
-    use crate::constants::*;
+    use crate::constants::env::{
+        EDGE_OBJECT_OWNER_API_VERSION_KEY, EDGE_OBJECT_OWNER_KIND_KEY, EDGE_OBJECT_OWNER_NAME_KEY,
+        EDGE_OBJECT_OWNER_UID_KEY, NAMESPACE_KEY, PROXY_CONFIG_MAP_NAME_KEY, PROXY_CONFIG_PATH_KEY,
+        PROXY_CONFIG_VOLUME_KEY, PROXY_IMAGE_KEY, PROXY_TRUST_BUNDLE_CONFIG_MAP_NAME_KEY,
+        PROXY_TRUST_BUNDLE_PATH_KEY, PROXY_TRUST_BUNDLE_VOLUME_KEY,
+    };
+    use crate::constants::{
+        EDGE_DEVICE_LABEL, EDGE_MODULE_LABEL, EDGE_ORIGINAL_MODULEID, PROXY_CONFIG_VOLUME_NAME,
+        PROXY_CONTAINER_NAME, PROXY_TRUST_BUNDLE_FILENAME, PROXY_TRUST_BUNDLE_VOLUME_NAME,
+    };
     use crate::convert::{
         spec_to_deployment, spec_to_role_binding, spec_to_service_account,
         trust_bundle_to_config_map,
@@ -607,7 +601,6 @@ mod tests {
     fn validate_deployment_metadata(
         module: &str,
         device: &str,
-        iothub: &str,
         meta: Option<&api_meta::ObjectMeta>,
     ) {
         assert!(meta.is_some());
@@ -617,7 +610,6 @@ mod tests {
             if let Some(labels) = meta.labels.as_ref() {
                 assert_eq!(labels.get(EDGE_MODULE_LABEL).unwrap(), "edgeagent");
                 assert_eq!(labels.get(EDGE_DEVICE_LABEL).unwrap(), device);
-                assert_eq!(labels.get(EDGE_HUBNAME_LABEL).unwrap(), iothub);
             }
         }
     }
@@ -631,12 +623,7 @@ mod tests {
         let (name, deployment) =
             spec_to_deployment(&make_settings(None), &module_config, &module_owner).unwrap();
         assert_eq!(name, "edgeagent");
-        validate_deployment_metadata(
-            "edgeagent",
-            "device1",
-            "iothub",
-            deployment.metadata.as_ref(),
-        );
+        validate_deployment_metadata("edgeagent", "device1", deployment.metadata.as_ref());
 
         assert!(deployment.spec.is_some());
         if let Some(spec) = deployment.spec.as_ref() {
@@ -645,7 +632,6 @@ mod tests {
             if let Some(match_labels) = spec.selector.match_labels.as_ref() {
                 assert_eq!(match_labels.get(EDGE_MODULE_LABEL).unwrap(), "edgeagent");
                 assert_eq!(match_labels.get(EDGE_DEVICE_LABEL).unwrap(), "device1");
-                assert_eq!(match_labels.get(EDGE_HUBNAME_LABEL).unwrap(), "iothub");
             }
             assert!(spec.template.spec.is_some());
             if let Some(podspec) = spec.template.spec.as_ref() {
@@ -741,9 +727,8 @@ mod tests {
 
             assert!(metadata.labels.is_some());
             if let Some(labels) = metadata.labels {
-                assert_eq!(labels.len(), 3);
+                assert_eq!(labels.len(), 2);
                 assert_eq!(labels[EDGE_DEVICE_LABEL], "device1");
-                assert_eq!(labels[EDGE_HUBNAME_LABEL], "iothub");
                 assert_eq!(labels[EDGE_MODULE_LABEL], "edgeagent");
             }
         }
@@ -771,9 +756,8 @@ mod tests {
 
             assert!(metadata.labels.is_some());
             if let Some(labels) = metadata.labels {
-                assert_eq!(labels.len(), 3);
+                assert_eq!(labels.len(), 2);
                 assert_eq!(labels[EDGE_DEVICE_LABEL], "device1");
-                assert_eq!(labels[EDGE_HUBNAME_LABEL], "iothub");
                 assert_eq!(labels[EDGE_MODULE_LABEL], "edgeagent");
             }
         }
@@ -839,9 +823,8 @@ mod tests {
 
             assert!(metadata.labels.is_some());
             if let Some(labels) = metadata.labels {
-                assert_eq!(labels.len(), 2);
+                assert_eq!(labels.len(), 1);
                 assert_eq!(labels[EDGE_DEVICE_LABEL], "device1");
-                assert_eq!(labels[EDGE_HUBNAME_LABEL], "iothub");
             }
         }
 

--- a/edgelet/iotedge/src/support_bundle.rs
+++ b/edgelet/iotedge/src/support_bundle.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 use std::env;
-use std::error::Error as StdError;
 use std::ffi::OsString;
 use std::fs::File;
 use std::path::{Path, PathBuf};
@@ -246,7 +245,7 @@ where
                 ("iotedged_err.txt", result.stderr)
             }
         } else {
-            let err_message = inspect.err().unwrap().description().to_owned();
+            let err_message = inspect.err().unwrap().to_string();
             println!("Could not find system logs for iotedge. Including error in bundle.\nError message: {}", err_message);
             ("iotedged_err.txt", err_message.as_bytes().to_vec())
         };
@@ -301,7 +300,7 @@ where
                 ("docker_err.txt", result.stderr)
             }
         } else {
-            let err_message = inspect.err().unwrap().description().to_owned();
+            let err_message = inspect.err().unwrap().to_string();
             println!("Could not find system logs for docker. Including error in bundle.\nError message: {}", err_message);
             ("docker_err.txt", err_message.as_bytes().to_vec())
         };
@@ -374,7 +373,7 @@ where
                 (format!("inspect/{}_err.json", module_name), result.stderr)
             }
         } else {
-            let err_message = inspect.err().unwrap().description().to_owned();
+            let err_message = inspect.err().unwrap().to_string();
             println!(
                 "Could not reach docker. Including error in bundle.\nError message: {}",
                 err_message
@@ -456,7 +455,7 @@ where
                 (format!("network/{}_err.json", network_name), result.stderr)
             }
         } else {
-            let err_message = inspect.err().unwrap().description().to_owned();
+            let err_message = inspect.err().unwrap().to_string();
             println!(
                 "Could not reach docker. Including error in bundle.\nError message: {}",
                 err_message

--- a/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for installing CRD for Azure IoT Edge on Kubernetes
 name: edge-kubernetes-crd
-version: 0.2.6
+version: 0.2.7

--- a/kubernetes/charts/edge-kubernetes/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for running Azure IoT Edge on Kubernetes
 name: edge-kubernetes
-version: 0.2.6
+version: 0.2.7

--- a/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
@@ -46,6 +46,10 @@ spec:
             readOnly: true
           {{- end}}
           {{- end}}
+          {{- if .Values.iotedged.data.useHostTrust }}
+          - name: ca-edge-host-trust
+            mountPath: "/etc/ssl/certs"
+          {{- end }}
           {{- with .Values.provisioning.authentication }}
           {{- if .identitySecret }}
           - name: edge-authentication
@@ -127,6 +131,12 @@ spec:
             path: identity_pk
       {{- end}}
       {{- end}}
+      {{- if .Values.iotedged.data.useHostTrust }}
+      - name: ca-edge-host-trust
+        hostPath:
+          path: /etc/ssl/certs
+          type: Directory
+      {{- end}}
       {{- with .Values.iotedged.certificates }}
       {{- if .secret }}
       {{- /*
@@ -142,6 +152,7 @@ spec:
             path: device_ca_pk
           - key: {{ .trusted_ca_certs | default "trusted_ca_certs" }}
             path: trusted_ca_certs
+
       {{- end}}
       {{- else}}
       {{- /*

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -2,7 +2,7 @@
 iotedged:
   image:
     repository: azureiotedge/azureiotedge-iotedged
-    tag: 0.1.0-beta8
+    tag: 0.1.0-beta9
     pullPolicy: Always
   nodeSelector: {}
   # Volumes which support ownership management are modified to be owned and 
@@ -101,7 +101,7 @@ iotedged:
 iotedgedProxy:
   image:
     repository: azureiotedge/azureiotedge-proxy
-    tag: 0.1.0-beta8
+    tag: 0.1.0-beta9
     pullPolicy: Always
 
 # Edge Agent image configuration
@@ -115,7 +115,7 @@ edgeAgent:
   containerName: edgeagent
   image:
     repository: azureiotedge/azureiotedge-agent
-    tag: 0.1.0-beta8
+    tag: 0.1.0-beta9
     pullPolicy: Always
   hostname: "localhost"
   env:

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -19,6 +19,11 @@ iotedged:
   data:
     enableGetNodesRBAC: true
     targetPath: /var/lib/iotedge
+    # Normally the iotedged is running as a host process, and has access to 
+    # the host's trusted CA certificates.  Use this options to allow the 
+    # iotedged deployment to use the host OS's /etc/ssl/certs 
+    # useHostTrust: false
+    #
     # In order to benefit from HA, at a minimum the data location for iotedged
     # should be backed by a persistent volume. 
     # User may create a PersistentVolumeClaim and provide the name only here. Alternatively.

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <RuleSet Name="Azure IoT Edge StyleCop Ruleset" Description="These StyleCop rules are customized for Azure IoT Edge projects." ToolsVersion="15.0">
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="AD0001" Action="None" />
     <Rule Id="SA0001" Action="None" />
     <Rule Id="SA1009" Action="None" />
     <Rule Id="SA1108" Action="None" />


### PR DESCRIPTION
Two major bug fixes in this PR:
1. Long IoTHub names, like those in Azure Stack were causing edgeAgent to crash.

**FIX**: remove the "hubname" label on objects created by Edge on K8s.  We can still select on device name label. Affects iotedged and edgeagent containers.

2. Unable to make TLS connection to IoT Hub.  The iotedged and edgeAgent containers were not getting the trusted CA certificates installed in such a way that they could create a TLS  connection.

**FIX**: **iotedged**: Helm chart changes to iotedged deployment, allowing the user to mount the Host OS ceretificate store.  (`.Values.iotedged.data.useHostTrust`) **edgeAgent**: use the trust bundle provided by iotedged and install it in a user trusted certificate store. create a user in edgeAgent container to have a place to put the store.