### PR TITLE
Handle ServiceClient timeout on DirectMethodSender

### DIFF
--- a/test/modules/DirectMethodSender/DirectMethodSenderBase.cs
+++ b/test/modules/DirectMethodSender/DirectMethodSenderBase.cs
@@ -57,6 +57,12 @@ namespace DirectMethodSender
                 logger.LogInformation(e, $"Transient exception caught with count {this.directMethodCount}");
                 return new Tuple<HttpStatusCode, ulong>(HttpStatusCode.NotFound, this.directMethodCount);
             }
+            catch (IotHubCommunicationException e) when (e.Message.Contains("operation timed out"))
+            {
+                logger.LogInformation(e, $"Transient IotHubCommunicationException caught with count {this.directMethodCount}. Retry.");
+                this.directMethodCount--;
+                return new Tuple<HttpStatusCode, ulong>(HttpStatusCode.RequestTimeout, this.directMethodCount + 1);
+            }
             catch (Exception e)
             {
                 logger.LogError(e, $"Exception caught with count {this.directMethodCount}");

--- a/test/modules/DirectMethodSender/DirectMethodSenderBase.cs
+++ b/test/modules/DirectMethodSender/DirectMethodSenderBase.cs
@@ -79,12 +79,14 @@ namespace DirectMethodSender
             {
                 try
                 {
+                    logger.LogDebug($"InvokeDirectMethodWithRetryAsync with count {directMethodCount}; Retry {transientRetryCount}");
                     transientRetryCount++;
                     resultStatus = await this.InvokeDeviceMethodAsync(deviceId, targetModuleId, methodName, directMethodCount, CancellationToken.None);
+                    return resultStatus;
                 }
                 catch (IotHubCommunicationException e) when (e.IsTransient)
                 {
-                    logger.LogInformation(e, $"Transient IotHubCommunicationException caught with count {this.directMethodCount}. Retry: {transientRetryCount}");
+                    logger.LogInformation(e, $"Transient IotHubCommunicationException caught with count {directMethodCount}. Retry: {transientRetryCount}");
                     resultStatus = (int)HttpStatusCode.RequestTimeout;
                 }
             }

--- a/test/modules/DirectMethodSender/DirectMethodSenderBase.cs
+++ b/test/modules/DirectMethodSender/DirectMethodSenderBase.cs
@@ -75,7 +75,7 @@ namespace DirectMethodSender
             int resultStatus = (int)HttpStatusCode.InternalServerError;
             int transientRetryCount = 0;
 
-            while (transientRetryCount <= maxRetry)
+            while (transientRetryCount < maxRetry)
             {
                 try
                 {
@@ -84,15 +84,8 @@ namespace DirectMethodSender
                 }
                 catch (IotHubCommunicationException e) when (e.IsTransient)
                 {
-                    if (transientRetryCount < maxRetry)
-                    {
-                        logger.LogInformation(e, $"Transient IotHubCommunicationException caught with count {this.directMethodCount}.");
-                    }
-                    else
-                    {
-                        logger.LogInformation(e, $"Transient IotHubCommunicationException caught with count {this.directMethodCount}. Retry Exceeded.");
-                        resultStatus = (int)HttpStatusCode.RequestTimeout;
-                    }
+                    logger.LogInformation(e, $"Transient IotHubCommunicationException caught with count {this.directMethodCount}. Retry: {transientRetryCount}");
+                    resultStatus = (int)HttpStatusCode.RequestTimeout;
                 }
             }
 

--- a/test/modules/DirectMethodSender/DirectMethodSenderBase.cs
+++ b/test/modules/DirectMethodSender/DirectMethodSenderBase.cs
@@ -72,7 +72,7 @@ namespace DirectMethodSender
             ulong directMethodCount)
         {
             const int maxRetry = 3;
-            int resultStatus = (int)HttpStatusCode.InternalServerError;
+            int resultStatus = 0;
             int transientRetryCount = 0;
 
             while (transientRetryCount < maxRetry)
@@ -82,7 +82,7 @@ namespace DirectMethodSender
                     logger.LogDebug($"InvokeDirectMethodWithRetryAsync with count {directMethodCount}; Retry {transientRetryCount}");
                     transientRetryCount++;
                     resultStatus = await this.InvokeDeviceMethodAsync(deviceId, targetModuleId, methodName, directMethodCount, CancellationToken.None);
-                    return resultStatus;
+                    break;
                 }
                 catch (IotHubCommunicationException e) when (e.IsTransient)
                 {

--- a/test/modules/DirectMethodSender/Program.cs
+++ b/test/modules/DirectMethodSender/Program.cs
@@ -140,7 +140,8 @@ namespace DirectMethodSender
 
         static bool ShouldReportResults(DirectMethodResultType resultType, HttpStatusCode statusCode)
         {
-            return !(resultType == DirectMethodResultType.LegacyDirectMethodTestResult && statusCode == HttpStatusCode.NotFound);
+            return !(resultType == DirectMethodResultType.LegacyDirectMethodTestResult && statusCode == HttpStatusCode.NotFound) &&
+                   !(resultType == DirectMethodResultType.DirectMethodTestResult && statusCode == HttpStatusCode.RequestTimeout);
         }
     }
 }

--- a/test/modules/DirectMethodSender/Program.cs
+++ b/test/modules/DirectMethodSender/Program.cs
@@ -140,8 +140,7 @@ namespace DirectMethodSender
 
         static bool ShouldReportResults(DirectMethodResultType resultType, HttpStatusCode statusCode)
         {
-            return !(resultType == DirectMethodResultType.LegacyDirectMethodTestResult && statusCode == HttpStatusCode.NotFound) &&
-                   !(resultType == DirectMethodResultType.DirectMethodTestResult && statusCode == HttpStatusCode.RequestTimeout);
+            return !(resultType == DirectMethodResultType.LegacyDirectMethodTestResult && statusCode == HttpStatusCode.NotFound);
         }
     }
 }


### PR DESCRIPTION
In some rare occasion, the IoTHub would take too long to response causing ServiceClient to operation time out which translates to InternalServerError500 by Direct Method Sender. Frankly, we don't care how long IoTHub takes to response. Direct Method Sender should simply retry to send the direct method again by triggering the ServiceClient with the same directMethodSequence number.