### PR TITLE
Back port twin array 

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/TwinManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/TwinManagerTest.cs
@@ -1623,8 +1623,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 array = new[] { 0, 1, 2 }
             };
 
-            InvalidOperationException ex = Assert.Throws<InvalidOperationException>(() => TwinManager.ValidateTwinProperties(JToken.FromObject(reported)));
-            Assert.Equal("Property array has a value of unsupported type. Valid types are integer, float, string, bool, null and nested object", ex.Message);
+            string reportedJson = "{ \"ok\": [\"good\"], \"level1\": { \"field1\": [ {\"something\": \"ok\"} ] } }";
+
+            TwinManager.ValidateTwinProperties(JToken.FromObject(reported));
+            TwinManager.ValidateTwinProperties(JToken.Parse(reportedJson));
         }
 
         [Fact]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                 {
                     array = new[] { 0, 1, 2 }
                 })),
-                typeof(InvalidOperationException),
-                "Property array has a value of unsupported type. Valid types are integer, float, string, bool, null and nested object"
+                null,
+                string.Empty
             };
 
             yield return new object[]
@@ -192,6 +192,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                 } )),
                 typeof(InvalidOperationException),
                 "Twin properties size 36189 exceeds maximum 32768"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection("{ \"ok\": [\"good\"], \"ok2\": [], \"level1\": [{ \"field1\": null }] }"),
+                null,
+                string.Empty
             };
         }
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/JsonEx.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.Devices.Edge.Util
             JTokenType.Null,
             JTokenType.Object,
             JTokenType.String,
-            JTokenType.Date
+            JTokenType.Date,
+            JTokenType.Array
         };
 
         static readonly string[] MetadataPropertyNames = { "$metadata", "$version" };
@@ -131,7 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
                         // if this property exists in 'to' but has a different value
                         // then add the prop from 'to' to 'patch'
-                        else if (fromProp.Value.Type != toProp.Value.Type || fromProp.Value.Equals(toProp.Value) == false)
+                        else if (fromProp.Value.Type != toProp.Value.Type || !JToken.DeepEquals(fromProp.Value, toProp.Value))
                         {
                             patch.Add(fromProp.Name, toProp.Value);
                         }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/JsonExTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/JsonExTest.cs
@@ -97,7 +97,9 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 {
                     level1 = "value1"
                 },
-                create = "yes"
+                create = "yes",
+                array = new object[] { new object[] { 100L, false } },
+                arrayString = new string[] { "a" }
             };
 
             var patch = new
@@ -118,13 +120,17 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 {
                     level1 = "value1",
                 },
+                array = new object[] { new object[] { 100L, true }, new { a = 0, b = "doom" } },
+                arrayString = "a"
             };
 
             var removeAll = new
             {
                 name = (Dictionary<string, string>)null,
                 overwrite = (Dictionary<string, string>)null,
-                create = (Dictionary<string, string>)null
+                create = (Dictionary<string, string>)null,
+                array = (int[])null,
+                arrayString = (string[])null
             };
 
             var removeAllInefficient = new
@@ -144,6 +150,8 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                     level1 = (Dictionary<string, string>)null,
                 },
                 create = (Dictionary<string, string>)null,
+                array = (int[])null,
+                arrayString = (string[])null
             };
 
             var mergedExcludeNull = new
@@ -162,7 +170,9 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 create = new
                 {
                     level1 = "value1",
-                }
+                },
+                array = new object[] { new object[] { 100L, true }, new { a = 0, b = "doom" } },
+                arrayString = "a"
             };
 
             var mergedIncludeNull = new
@@ -183,7 +193,9 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 create = new
                 {
                     level1 = "value1",
-                }
+                },
+                array = new object[] { new object[] { 100L, true }, new { a = 0, b = "doom" } },
+                arrayString = "a"
             };
 
             var emptyBaseline = new { };
@@ -198,7 +210,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 },
                 overwrite = new
                 {
-                },
+                }
             };
 
             var emptyPatch = new { };
@@ -207,7 +219,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             JToken resultCollection = JsonEx.Merge(JToken.FromObject(baseline), JToken.FromObject(patch), true);
 
             // Assert
-            Assert.True(JToken.DeepEquals(JToken.FromObject(resultCollection), JToken.FromObject(mergedExcludeNull)));
+            Assert.True(JToken.DeepEquals(JToken.FromObject(resultCollection), JToken.FromObject(mergedExcludeNull)), resultCollection.ToString());
 
             // Act
             resultCollection = JsonEx.Merge(JToken.FromObject(baseline), JToken.FromObject(patch), false);
@@ -266,7 +278,11 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 {
                     level1 = "value1"
                 },
-                create = "yes"
+                create = "yes",
+                arrayWithObjects = new object[] { new object[] { 100L, false } },
+                arrayWithValue = new string[] { "a" },
+                arrayChangeType = new string[] { "a" },
+                arrayNoChange = new string[] { "a" }
             };
 
             var patch = new
@@ -286,6 +302,10 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 {
                     level1 = "value1",
                 },
+                arrayWithObjects = new object[] { new object[] { 100L, true }, new { a = 0, b = "doom" } },
+                arrayWithValue = new string[] { "b" },
+                arrayChangeType = "a",
+                // arrayNoChange = new string[] { "a" } // unchanged
             };
 
             var mergedExcludeNull = new
@@ -304,14 +324,22 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 create = new
                 {
                     level1 = "value1",
-                }
+                },
+                arrayWithObjects = new object[] { new object[] { 100L, true }, new { a = 0, b = "doom" } },
+                arrayWithValue = new string[] { "b" },
+                arrayChangeType = "a",
+                arrayNoChange = new string[] { "a" }
             };
 
             var removeAll = new
             {
                 name = (Dictionary<string, string>)null,
                 overwrite = (Dictionary<string, string>)null,
-                create = (Dictionary<string, string>)null
+                create = (Dictionary<string, string>)null,
+                arrayWithObjects = (int[])null,
+                arrayWithValue = (string[])null,
+                arrayChangeType = (string[])null,
+                arrayNoChange = (string[])null,
             };
 
             var emptyBaseline = new { };
@@ -322,13 +350,13 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             JToken resultCollection = JsonEx.Diff(JToken.FromObject(baseline), JToken.FromObject(mergedExcludeNull));
 
             // Assert
-            Assert.True(JToken.DeepEquals(resultCollection, JToken.FromObject(patch)));
+            Assert.True(JToken.DeepEquals(resultCollection, JToken.FromObject(patch)), JToken.FromObject(patch).ToString());
 
             // Act
             resultCollection = JsonEx.Diff(JToken.FromObject(baseline), JToken.FromObject(baseline));
 
             // Assert
-            Assert.True(JToken.DeepEquals(resultCollection, JToken.FromObject(emptyPatch)));
+            Assert.True(JToken.DeepEquals(resultCollection, JToken.FromObject(emptyPatch)), resultCollection.ToString());
 
             // Act
             resultCollection = JsonEx.Diff(JToken.FromObject(emptyBaseline), JToken.FromObject(emptyBaseline));


### PR DESCRIPTION
This change depends on the sdk update to support arrays in twin (currently included in 1.26.0 version)

Updated reported properties validator to include array as a supported data type.
Updated tests with arrays in twin.

(Cherry-picked from https://github.com/Azure/iotedge/commit/d1e7bf4fe9fde86d02ecbcf38c8c51c29739f95f)