### PR TITLE
Upgrade Sdk NuGet

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="3.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/edge-modules/DirectMethodCloudSender/DirectMethodCloudSender.csproj
+++ b/edge-modules/DirectMethodCloudSender/DirectMethodCloudSender.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/DirectMethodReceiver/DirectMethodReceiver.csproj
+++ b/edge-modules/DirectMethodReceiver/DirectMethodReceiver.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/DirectMethodSender/DirectMethodSender.csproj
+++ b/edge-modules/DirectMethodSender/DirectMethodSender.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
+++ b/edge-modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-modules/ModuleRestarter/ModuleRestarter.csproj
+++ b/edge-modules/ModuleRestarter/ModuleRestarter.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
+++ b/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/TemperatureFilter/TemperatureFilter.csproj
+++ b/edge-modules/TemperatureFilter/TemperatureFilter.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />

--- a/edge-modules/TwinTester/TwinTester.csproj
+++ b/edge-modules/TwinTester/TwinTester.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
   </ItemGroup>
 

--- a/edge-modules/load-gen/load-gen.csproj
+++ b/edge-modules/load-gen/load-gen.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
+++ b/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
@@ -15,6 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.20.3-asc-edge" />
+	<PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
   </ItemGroup>
 </Project>

--- a/smoke/LeafDevice/LeafDevice.csproj
+++ b/smoke/LeafDevice/LeafDevice.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="15.9.0" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />


### PR DESCRIPTION
Upgrade Microsoft.Azure.Devices.Client NuGet package from 1.23.1 to 1.23.2, which contains AMQP Safely close fix.