### PR TITLE
Fix about edge agent get twin fix (#3075)

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -1590,9 +1590,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 .Returns(Task.CompletedTask);
 
             IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
+            var deviceManager = new Mock<IDeviceManager>();
 
             // Act
-            IEdgeAgentConnection connection = new EdgeAgentConnection(moduleClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), true, TimeSpan.FromHours(1), retryStrategy.Object);
+            IEdgeAgentConnection connection = new EdgeAgentConnection(moduleClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), deviceManager.Object, true, TimeSpan.FromHours(1), retryStrategy.Object);
 
             // Assert
             // The connection hasn't been created yet. So wait for it.

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -1401,7 +1401,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 receivedDeploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
 
                 // Assert
-                moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(5));
+                moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(7));
                 Assert.True(receivedDeploymentConfigInfo.HasValue);
                 Assert.False(receivedDeploymentConfigInfo.OrDefault().Exception.HasValue);
                 Assert.Equal(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
@@ -1523,6 +1523,90 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 Assert.Equal(deploymentConfig2, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
                 Assert.NotEqual(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
             }
+        }
+
+        [Fact]
+        [Unit]
+        public async Task GetDeploymentConfigInfoAsync_CreateNewModuleClientWhenGetTwinThrowsMoreThanRetryCount()
+        {
+            // Arrange
+            var moduleClient = new Mock<IModuleClient>();
+            var serde = new Mock<ISerde<DeploymentConfig>>();
+            var runtime = new Mock<IRuntimeInfo>();
+            var edgeAgent = new Mock<IEdgeAgentModule>();
+            var edgeHub = new Mock<IEdgeHubModule>();
+            var retryStrategy = new Mock<RetryStrategy>(new object[] { false });
+
+            var deploymentConfig = new DeploymentConfig(
+                "1.0",
+                runtime.Object,
+                new SystemModules(edgeAgent.Object, edgeHub.Object),
+                ImmutableDictionary<string, IModule>.Empty);
+
+            var moduleClientProvider = new Mock<IModuleClientProvider>();
+            moduleClientProvider.Setup(p => p.Create(It.IsAny<ConnectionStatusChangesHandler>()))
+                .ReturnsAsync(moduleClient.Object);
+
+            serde.Setup(s => s.Deserialize(It.IsAny<string>())).Returns(deploymentConfig);
+            // var retryStrategy = new FixedInterval(1, TimeSpan.FromMilliseconds(1));
+            retryStrategy.Setup(rs => rs.GetShouldRetry())
+                .Returns(
+                    (int retryCount, Exception lastException, out TimeSpan delay) =>
+                    {
+                        if (retryCount >= 1)
+                        {
+                            delay = TimeSpan.Zero;
+                            return false;
+                        }
+
+                        delay = TimeSpan.Zero;
+                        return true;
+                    });
+
+            var twin = new Twin
+            {
+                Properties = new TwinProperties
+                {
+                    Desired = new TwinCollection(
+                        JObject.FromObject(
+                            new Dictionary<string, object>
+                            {
+                                { "$version", 10 },
+
+                                // This is here to prevent the "empty" twin error from being thrown.
+                                { "MoreStuff", "MoreStuffHereToo" }
+                            }).ToString()),
+                    Reported = new TwinCollection()
+                }
+            };
+
+            moduleClient.SetupSequence(d => d.GetTwinAsync())
+                .ThrowsAsync(new InvalidOperationException())
+                .ThrowsAsync(new InvalidOperationException())
+                .ReturnsAsync(twin);
+            moduleClient.Setup(d => d.SetDesiredPropertyUpdateCallbackAsync(It.IsAny<DesiredPropertyUpdateCallback>()))
+                .Returns(Task.CompletedTask);
+            moduleClient.Setup(d => d.SetMethodHandlerAsync(It.IsAny<string>(), It.IsAny<MethodCallback>()))
+                .Returns(Task.CompletedTask);
+
+            IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
+
+            // Act
+            IEdgeAgentConnection connection = new EdgeAgentConnection(moduleClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), true, TimeSpan.FromHours(1), retryStrategy.Object);
+
+            // Assert
+            // The connection hasn't been created yet. So wait for it.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Act
+            Option<DeploymentConfigInfo> deploymentConfigInfo = await connection.GetDeploymentConfigInfoAsync();
+
+            // Assert
+            Assert.True(deploymentConfigInfo.HasValue);
+            moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(3));
+            moduleClient.Verify(m => m.CloseAsync(), Times.Once);
+            Assert.Equal(10, deploymentConfigInfo.OrDefault().Version);
+            Assert.Equal(deploymentConfigInfo.OrDefault().DeploymentConfig, deploymentConfig);
         }
 
         [Theory]


### PR DESCRIPTION
When Edge agent calling GetTwinAsync method throws exception after retry policy, if the exception is not timeout exception it will trigger to close module client and retry again.

Merge fix from 1.0.9 https://github.com/Azure/iotedge/pull/3075 to master