### PR TITLE
[mqtt] Cache allowed iothub topics

### DIFF
--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -32,7 +32,7 @@ where
 
 impl<Z> Server<Z>
 where
-    Z: Authorizer + Send + Sync + 'static,
+    Z: Authorizer + Send + 'static,
 {
     pub fn from_broker(broker: Broker<Z>) -> Self {
         Self {

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -1,7 +1,7 @@
 use std::{
+    cell::RefCell,
     collections::{HashMap, HashSet},
     convert::Infallible,
-    sync::Mutex,
 };
 
 use mqtt_broker_core::{
@@ -11,7 +11,7 @@ use mqtt_broker_core::{
 
 #[derive(Debug, Default)]
 pub struct EdgeHubAuthorizer {
-    iothub_allowed_topics: Mutex<HashMap<ClientId, HashSet<String>>>,
+    iothub_allowed_topics: RefCell<HashMap<ClientId, HashSet<String>>>,
 }
 
 impl EdgeHubAuthorizer {
@@ -111,12 +111,8 @@ impl EdgeHubAuthorizer {
     }
 
     fn is_iothub_topic_allowed(&self, client_id: &ClientId, topic: &str) -> bool {
-        let mut cache = self
-            .iothub_allowed_topics
-            .lock()
-            .expect("iothub_allowed_topics");
-
-        let allowed_topics = cache
+        let mut iothub_allowed_topics = self.iothub_allowed_topics.borrow_mut();
+        let allowed_topics = iothub_allowed_topics
             .entry(client_id.clone())
             .or_insert_with(|| allowed_iothub_topic(client_id));
 

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -1,8 +1,4 @@
-use std::{
-    cell::RefCell,
-    collections::{HashMap, HashSet},
-    convert::Infallible,
-};
+use std::{cell::RefCell, collections::HashMap, convert::Infallible};
 
 use mqtt_broker_core::{
     auth::{Activity, AuthId, Authorization, Authorizer, Connect, Operation, Publish, Subscribe},
@@ -11,7 +7,7 @@ use mqtt_broker_core::{
 
 #[derive(Debug, Default)]
 pub struct EdgeHubAuthorizer {
-    iothub_allowed_topics: RefCell<HashMap<ClientId, HashSet<String>>>,
+    iothub_allowed_topics: RefCell<HashMap<ClientId, Vec<String>>>,
 }
 
 impl EdgeHubAuthorizer {
@@ -138,37 +134,37 @@ fn is_iothub_topic(topic: &str) -> bool {
     topic.starts_with("$edgehub/") || topic.starts_with("$iothub/")
 }
 
-fn allowed_iothub_topic(client_id: &ClientId) -> HashSet<String> {
-    let mut topic = HashSet::new();
-    topic.insert(format!("$edgehub/clients/{}/messages/events", client_id));
-    topic.insert(format!("$iothub/clients/{}/messages/events", client_id));
-    topic.insert(format!("$edgehub/clients/{}/messages/c2d/post", client_id));
-    topic.insert(format!("$iothub/clients/{}/messages/c2d/post", client_id));
-    topic.insert(format!(
-        "$iothub/clients/{}/twin/patch/properties/desired",
-        client_id
-    ));
-    topic.insert(format!(
-        "$edgehub/clients/{}/twin/patch/properties/desired",
-        client_id
-    ));
-    topic.insert(format!(
-        "$iothub/clients/{}/twin/patch/properties/reported",
-        client_id
-    ));
-    topic.insert(format!(
-        "$edgehub/clients/{}/twin/patch/properties/reported",
-        client_id
-    ));
-    topic.insert(format!("$edgehub/clients/{}/twin/get", client_id));
-    topic.insert(format!("$iothub/clients/{}/twin/get", client_id));
-    topic.insert(format!("$edgehub/clients/{}/twin/res", client_id));
-    topic.insert(format!("$iothub/clients/{}/twin/res", client_id));
-    topic.insert(format!("$edgehub/clients/{}/methods/post", client_id));
-    topic.insert(format!("$iothub/clients/{}/methods/post", client_id));
-    topic.insert(format!("$edgehub/clients/{}/methods/res", client_id));
-    topic.insert(format!("$iothub/clients/{}/methods/res", client_id));
-    topic
+fn allowed_iothub_topic(client_id: &ClientId) -> Vec<String> {
+    vec![
+        format!("$edgehub/clients/{}/messages/events", client_id),
+        format!("$iothub/clients/{}/messages/events", client_id),
+        format!("$edgehub/clients/{}/messages/c2d/post", client_id),
+        format!("$iothub/clients/{}/messages/c2d/post", client_id),
+        format!(
+            "$iothub/clients/{}/twin/patch/properties/desired",
+            client_id
+        ),
+        format!(
+            "$edgehub/clients/{}/twin/patch/properties/desired",
+            client_id
+        ),
+        format!(
+            "$iothub/clients/{}/twin/patch/properties/reported",
+            client_id
+        ),
+        format!(
+            "$edgehub/clients/{}/twin/patch/properties/reported",
+            client_id
+        ),
+        format!("$edgehub/clients/{}/twin/get", client_id),
+        format!("$iothub/clients/{}/twin/get", client_id),
+        format!("$edgehub/clients/{}/twin/res", client_id),
+        format!("$iothub/clients/{}/twin/res", client_id),
+        format!("$edgehub/clients/{}/methods/post", client_id),
+        format!("$iothub/clients/{}/methods/post", client_id),
+        format!("$edgehub/clients/{}/methods/res", client_id),
+        format!("$iothub/clients/{}/methods/res", client_id),
+    ]
 }
 
 impl Authorizer for EdgeHubAuthorizer {

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -123,15 +123,19 @@ const FORBIDDEN_TOPIC_FILTER_PREFIXES: [&str; 2] = ["#", "$"];
 fn is_forbidden_topic_filter(topic_filter: &str) -> bool {
     FORBIDDEN_TOPIC_FILTER_PREFIXES
         .iter()
-        .any(|forbidden_topic| topic_filter.starts_with(forbidden_topic))
+        .any(|prefix| topic_filter.starts_with(prefix))
 }
 
 fn is_forbidden_topic(topic_filter: &str) -> bool {
     topic_filter.starts_with('$')
 }
 
+const IOTHUB_TOPICS_PREFIX: [&str; 2] = ["$edgehub/", "$iothub/"];
+
 fn is_iothub_topic(topic: &str) -> bool {
-    topic.starts_with("$edgehub/") || topic.starts_with("$iothub/")
+    IOTHUB_TOPICS_PREFIX
+        .iter()
+        .any(|prefix| topic.starts_with(prefix))
 }
 
 fn allowed_iothub_topic(client_id: &ClientId) -> Vec<String> {

--- a/mqtt/mqttd/src/main.rs
+++ b/mqtt/mqttd/src/main.rs
@@ -86,7 +86,7 @@ async fn run_broker_server<Z>(
     config: BrokerConfig,
 ) -> Result<BrokerSnapshot, Error>
 where
-    Z: Authorizer + Send + Sync + 'static,
+    Z: Authorizer + Send + 'static,
 {
     // Setup the shutdown handle
     let shutdown = shutdown::shutdown();


### PR DESCRIPTION
`authorize` is called for each CONNECT, SUBSCRIBE, and PUBLISH packets. While the first two is happening on rare occasion, PUBLISHes are going to make a huge load on authorizer during packets processing.
To mitigate possible performance hit allowed IoTHub topics are cached per client bases. It is fine to store it until broker restart because of static authorization rules for IoTHub topics.