### PR TITLE
[PnP] Parse modelID from username in Mqtt connect packet and stamp every message 

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ClientConnectionHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ClientConnectionHandler.cs
@@ -47,7 +47,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                                 .GetOrElse(
                                     async () =>
                                     {
-                                        IDeviceListener dl = await this.connectionProvider.GetDeviceListenerAsync(this.identity);
+                                        // TODO: Implement plug and play for AMQP
+                                        IDeviceListener dl = await this.connectionProvider.GetDeviceListenerAsync(this.identity, Option.None<string>());
                                         var deviceProxy = new DeviceProxy(this, this.identity);
                                         dl.BindDeviceProxy(deviceProxy);
                                         this.deviceListener = Option.Some(dl);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionProvider.cs
@@ -20,9 +20,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             this.messageAckTimeout = messageAckTimeout;
         }
 
-        public Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity)
+        public Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity, Option<string> modelId)
         {
-            IDeviceListener deviceListener = new DeviceMessageHandler(Preconditions.CheckNotNull(identity, nameof(identity)), this.edgeHub, this.connectionManager, this.messageAckTimeout);
+            IDeviceListener deviceListener = new DeviceMessageHandler(Preconditions.CheckNotNull(identity, nameof(identity)), this.edgeHub, this.connectionManager, this.messageAckTimeout, modelId);
             return Task.FromResult(deviceListener);
         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IConnectionProvider.cs
@@ -5,9 +5,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util;
 
     public interface IConnectionProvider : IDisposable
     {
-        Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity);
+        Task<IDeviceListener> GetDeviceListenerAsync(IIdentity identity, Option<string> modelId);
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SystemProperties.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SystemProperties.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const string Operation = "operation";
         public const string SequenceNumber = "sequenceNumber";
         public const string InterfaceId = "iothub-interface-id";
+        public const string ModelId = "modelId";
 
         public static readonly Dictionary<string, string> IncomingSystemPropertiesMap = new Dictionary<string, string>
         {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -189,10 +189,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
 
         public Task ProcessDeviceMessageBatchAsync(IEnumerable<IMessage> messages)
         {
-            foreach (IMessage message in messages)
+            this.modelId.ForEach(modelId =>
             {
-                this.modelId.ForEach(modelId => message.SystemProperties[SystemProperties.ModelId] = modelId);
-            }
+                foreach (IMessage message in messages)
+                {
+                    message.SystemProperties[SystemProperties.ModelId] = modelId;
+                }
+            });
 
             return this.edgeHub.ProcessDeviceMessageBatch(this.Identity, messages);
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -26,14 +26,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
         readonly IConnectionManager connectionManager;
         readonly TimeSpan messageAckTimeout;
         readonly AsyncLock serializeMessagesLock = new AsyncLock();
+        readonly Option<string> modelId;
         IDeviceProxy underlyingProxy;
 
-        public DeviceMessageHandler(IIdentity identity, IEdgeHub edgeHub, IConnectionManager connectionManager, TimeSpan messageAckTimeout)
+        public DeviceMessageHandler(IIdentity identity, IEdgeHub edgeHub, IConnectionManager connectionManager, TimeSpan messageAckTimeout, Option<string> modelId)
         {
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.edgeHub = Preconditions.CheckNotNull(edgeHub, nameof(edgeHub));
             this.connectionManager = Preconditions.CheckNotNull(connectionManager, nameof(connectionManager));
             this.messageAckTimeout = messageAckTimeout;
+            this.modelId = modelId;
         }
 
         public IIdentity Identity { get; }
@@ -179,9 +181,21 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
             }
         }
 
-        public Task ProcessDeviceMessageAsync(IMessage message) => this.edgeHub.ProcessDeviceMessage(this.Identity, message);
+        public Task ProcessDeviceMessageAsync(IMessage message)
+        {
+            this.modelId.ForEach(modelId => message.SystemProperties[SystemProperties.ModelId] = modelId);
+            return this.edgeHub.ProcessDeviceMessage(this.Identity, message);
+        }
 
-        public Task ProcessDeviceMessageBatchAsync(IEnumerable<IMessage> messages) => this.edgeHub.ProcessDeviceMessageBatch(this.Identity, messages);
+        public Task ProcessDeviceMessageBatchAsync(IEnumerable<IMessage> messages)
+        {
+            foreach (IMessage message in messages)
+            {
+                this.modelId.ForEach(modelId => message.SystemProperties[SystemProperties.ModelId] = modelId);
+            }
+
+            return this.edgeHub.ProcessDeviceMessageBatch(this.Identity, messages);
+        }
 
         public async Task UpdateReportedPropertiesAsync(IMessage reportedPropertiesMessage, string correlationId)
         {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
     {
         const string ApiVersionKey = "api-version";
         const string DeviceClientTypeKey = "DeviceClientType";
+        const string ModelIdKey = "digital-twin-model-id";
         readonly IAuthenticator authenticator;
         readonly IClientCredentialsFactory clientCredentialsFactory;
         readonly bool clientCertAuthAllowed;
@@ -46,7 +47,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 Preconditions.CheckNonWhiteSpace(username, nameof(username));
                 Preconditions.CheckNonWhiteSpace(clientId, nameof(clientId));
 
-                (string deviceId, string moduleId, string deviceClientType) = ParseUserName(username);
+                (string deviceId, string moduleId, string deviceClientType, Option<string> modelId) = ParseUserName(username);
                 IClientCredentials deviceCredentials = null;
 
                 if (!string.IsNullOrEmpty(password))
@@ -88,7 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
                 await this.productInfoStore.SetProductInfo(deviceCredentials.Identity.Id, deviceClientType);
                 Events.Success(clientId, username);
-                return new ProtocolGatewayIdentity(deviceCredentials);
+                return new ProtocolGatewayIdentity(deviceCredentials, modelId);
             }
             catch (Exception ex)
             {
@@ -103,7 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             this.remoteCertificateChain = Preconditions.CheckNotNull(chain, nameof(chain));
         }
 
-        internal static (string deviceId, string moduleId, string deviceClientType) ParseUserName(string username)
+        internal static (string deviceId, string moduleId, string deviceClientType, Option<string> modelId) ParseUserName(string username)
         {
             // Username is of one of the 2 forms:
             //   username   = edgeHubHostName "/" deviceId [ "/" moduleId ] "/?" properties
@@ -112,9 +113,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             //   username   = edgeHubHostName "/" deviceId [ "/" moduleId ] "/" properties
             //   properties = property *("&" property)
             //   property   = name "=" value
-            // We recognize two property names:
+            // We recognize three property names:
             //   "api-version" [mandatory]
             //   "DeviceClientType" [optional]
+            //   "digital-twin-model-id" [optional]
             // We ignore any properties we don't recognize.
             // Note - this logic does not check the query parameters for special characters, and '?' is treated as a valid value
             // and not used as a separator, unless it is the first character of the last segment
@@ -198,7 +200,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 deviceClientType = string.Empty;
             }
 
-            return (deviceId, moduleId, deviceClientType);
+            Option<string> modelIdOption = Option.None<string>();
+            if (queryParameters.TryGetValue(ModelIdKey, out string modelId))
+            {
+                if (!string.IsNullOrWhiteSpace(modelId))
+                {
+                    modelIdOption = Option.Some(modelId);
+                }
+            }
+
+            return (deviceId, moduleId, deviceClientType, modelIdOption);
         }
 
         static IDictionary<string, string> ParseDeviceClientType(string queryParameterString)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
@@ -201,12 +201,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             }
 
             Option<string> modelIdOption = Option.None<string>();
-            if (queryParameters.TryGetValue(ModelIdKey, out string modelId))
+            if (queryParameters.TryGetValue(ModelIdKey, out string modelId) && !string.IsNullOrWhiteSpace(modelId))
             {
-                if (!string.IsNullOrWhiteSpace(modelId))
-                {
-                    modelIdOption = Option.Some(modelId);
-                }
+                modelIdOption = Option.Some(modelId);
             }
 
             return (deviceId, moduleId, deviceClientType, modelIdOption);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttConnectionProvider.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 throw new AuthenticationException("Invalid identity object received");
             }
 
-            IDeviceListener deviceListener = await this.connectionProvider.GetDeviceListenerAsync(protocolGatewayIdentity.ClientCredentials.Identity);
+            IDeviceListener deviceListener = await this.connectionProvider.GetDeviceListenerAsync(protocolGatewayIdentity.ClientCredentials.Identity, protocolGatewayIdentity.ModelId);
             IMessagingServiceClient messagingServiceClient = new MessagingServiceClient(deviceListener, this.pgMessageConverter, this.byteBufferConverter);
             IMessagingBridge messagingBridge = new SingleClientMessagingBridge(deviceidentity, messagingServiceClient);
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayIdentity.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayIdentity.cs
@@ -7,9 +7,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
     class ProtocolGatewayIdentity : IDeviceIdentity
     {
-        public ProtocolGatewayIdentity(IClientCredentials clientCredentials)
+        public ProtocolGatewayIdentity(IClientCredentials clientCredentials, Option<string> modelId)
         {
             this.ClientCredentials = Preconditions.CheckNotNull(clientCredentials, nameof(clientCredentials));
+            this.ModelId = modelId;
         }
 
         public bool IsAuthenticated => true;
@@ -17,6 +18,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
         public string Id => this.ClientCredentials.Identity.Id;
 
         public IClientCredentials ClientCredentials { get; }
+
+        public Option<string> ModelId { get; }
 
         public override string ToString() => this.Id;
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/ConnectionHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/ConnectionHandlerTest.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Xunit;
@@ -40,7 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity, Option.None<string>()) == Task.FromResult(deviceListener));
             var connectionHandler = new ClientConnectionHandler(identity, connectionProvider);
 
             // Act
@@ -61,7 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             }
 
             Assert.NotNull(deviceProxy);
-            Mock.Get(connectionProvider).Verify(c => c.GetDeviceListenerAsync(It.IsAny<IIdentity>()), Times.Once);
+            Mock.Get(connectionProvider).Verify(c => c.GetDeviceListenerAsync(It.IsAny<IIdentity>(), It.IsAny<Option<string>>()), Times.Once);
             Mock.Get(deviceListener).Verify(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()), Times.Once);
         }
 
@@ -75,7 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity, Option.None<string>()) == Task.FromResult(deviceListener));
 
             var connectionHandler = new ClientConnectionHandler(identity, connectionProvider);
 
@@ -111,7 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity, Option.None<string>()) == Task.FromResult(deviceListener));
 
             var connectionHandler = new ClientConnectionHandler(identity, connectionProvider);
 
@@ -147,7 +148,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity, Option.None<string>()) == Task.FromResult(deviceListener));
 
             var connectionHandler = new ClientConnectionHandler(identity, connectionProvider);
 
@@ -183,7 +184,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Mock.Get(deviceListener).Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()))
                 .Callback<IDeviceProxy>(d => deviceProxy = d);
 
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity) == Task.FromResult(deviceListener));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity, Option.None<string>()) == Task.FromResult(deviceListener));
 
             var connectionHandler = new ClientConnectionHandler(identity, connectionProvider);
 
@@ -214,7 +215,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var deviceListener = new Mock<IDeviceListener>();
             deviceListener.Setup(d => d.CloseAsync()).Returns(Task.CompletedTask);
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1/m1");
-            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity) == Task.FromResult(deviceListener.Object));
+            var connectionProvider = Mock.Of<IConnectionProvider>(c => c.GetDeviceListenerAsync(identity, Option.None<string>()) == Task.FromResult(deviceListener.Object));
             deviceListener.Setup(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()));
 
             var connectionHandler = new ClientConnectionHandler(identity, connectionProvider);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Try<ICloudProxy> cloudProxyTry = await connectionManager.CreateCloudConnectionAsync(deviceCredentials);
             Assert.True(cloudProxyTry.Success);
             TimeSpan defaultMessageAckTimeout = TimeSpan.FromSeconds(30);
-            var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub.Object, connectionManager, defaultMessageAckTimeout);
+            var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub.Object, connectionManager, defaultMessageAckTimeout, Option.None<string>());
 
             Option<ICloudProxy> cloudProxy = await connectionManager.GetCloudConnection(deviceId);
             Assert.True(cloudProxy.HasValue);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
+    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Xunit;
@@ -51,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var moduleCredentials = new TokenCredentials(new ModuleIdentity("hub", "device", "module"), "token", "productInfo", false);
 
             var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout);
-            Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity));
+            Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity, Option.None<string>()));
         }
 
         [Fact]
@@ -65,7 +66,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var moduleCredentials = new X509CertCredentials(new ModuleIdentity("hub", "device", "module"), string.Empty, clientCertificate, clientCertChain);
 
             var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout);
-            Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity));
+            Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity, Option.None<string>()));
         }
 
         [Fact]
@@ -76,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var edgeHub = Mock.Of<IEdgeHub>();
 
             var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout);
-            await Assert.ThrowsAsync<ArgumentNullException>(() => connectionProvider.GetDeviceListenerAsync(null));
+            await Assert.ThrowsAsync<ArgumentNullException>(() => connectionProvider.GetDeviceListenerAsync(null, Option.None<string>()));
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
@@ -66,6 +66,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         }
 
         [Fact]
+        public async Task ProcessMessageAsync_WithModelIdAsyncTest()
+        {
+            var cloudProxy = Mock.Of<ICloudProxy>();
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var edgeHub = Mock.Of<IEdgeHub>();
+            var identity = Mock.Of<IDeviceIdentity>();
+            var message = new EdgeMessage(new byte[] { }, new Dictionary<string, string>(), new Dictionary<string, string>());
+            Mock.Get(connectionManager).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
+            var deviceListener = new DeviceMessageHandler(identity, edgeHub, connectionManager, DefaultMessageAckTimeout, Option.Some("testModelId"));
+            await deviceListener.ProcessDeviceMessageAsync(message);
+
+            Mock.Get(edgeHub).Verify(eh => eh.ProcessDeviceMessage(identity, It.IsAny<IMessage>()), Times.Once());
+            Assert.Equal("testModelId", message.SystemProperties[SystemProperties.ModelId]);
+        }
+
+        [Fact]
         public async Task ProcessMessageBatchAsync_RouteAsyncTest()
         {
             var cloudProxy = Mock.Of<ICloudProxy>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
@@ -34,12 +34,35 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             IMessage expectedMessage = new EdgeMessage.Builder(new byte[0]).Build();
             edgeHub.Setup(e => e.GetTwinAsync(It.IsAny<string>())).Returns(Task.FromResult(expectedMessage));
             Mock.Get(connMgr).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout, Option.None<string>());
             listener.BindDeviceProxy(deviceProxy.Object);
             await listener.SendGetTwinRequest("cid");
 
             edgeHub.Verify(x => x.GetTwinAsync(identity.Id), Times.Once);
             Assert.Same(expectedMessage, actualMessage);
+        }
+
+        [Fact]
+        public async Task ProcessMessageBatchAsync_WithModelIdAsyncTest()
+        {
+            var cloudProxy = Mock.Of<ICloudProxy>();
+            var connectionManager = Mock.Of<IConnectionManager>();
+            var edgeHub = Mock.Of<IEdgeHub>();
+            var identity = Mock.Of<IDeviceIdentity>();
+            var messages = new List<IMessage>();
+            var message1 = new EdgeMessage(new byte[] { }, new Dictionary<string, string>(), new Dictionary<string, string>());
+            var message2 = new EdgeMessage(new byte[] { }, new Dictionary<string, string>(), new Dictionary<string, string>());
+            messages.Add(message1);
+            messages.Add(message2);
+            Mock.Get(connectionManager).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
+            var deviceListener = new DeviceMessageHandler(identity, edgeHub, connectionManager, DefaultMessageAckTimeout, Option.Some("testModelId"));
+            await deviceListener.ProcessDeviceMessageBatchAsync(messages);
+
+            Mock.Get(edgeHub).Verify(eh => eh.ProcessDeviceMessageBatch(identity, It.IsAny<IEnumerable<IMessage>>()), Times.Once());
+            foreach (IMessage message in messages)
+            {
+                Assert.Equal("testModelId", message.SystemProperties[SystemProperties.ModelId]);
+            }
         }
 
         [Fact]
@@ -53,7 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             messages.Add(Mock.Of<IMessage>());
             messages.Add(Mock.Of<IMessage>());
             Mock.Get(connectionManager).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var deviceListener = new DeviceMessageHandler(identity, edgeHub, connectionManager, DefaultMessageAckTimeout);
+            var deviceListener = new DeviceMessageHandler(identity, edgeHub, connectionManager, DefaultMessageAckTimeout, Option.None<string>());
             await deviceListener.ProcessDeviceMessageBatchAsync(messages);
 
             Mock.Get(edgeHub).Verify(eh => eh.ProcessDeviceMessageBatch(identity, It.IsAny<IEnumerable<IMessage>>()), Times.Once());
@@ -72,7 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IIdentity, IMessage>((id, m) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             Mock.Get(connMgr).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout, Option.None<string>());
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
             bool updateSent = false;
             underlyingDeviceProxy.Setup(d => d.SendTwinUpdate(It.IsAny<IMessage>()))
@@ -157,7 +180,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -185,7 +208,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -216,7 +239,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
             TimeSpan messageAckTimeout = TimeSpan.FromSeconds(5);
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, messageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, messageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -247,7 +270,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
             TimeSpan messageAckTimeout = TimeSpan.FromSeconds(15);
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, messageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, messageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -275,7 +298,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             underlyingDeviceProxy.Setup(d => d.SendMessageAsync(It.IsAny<IMessage>(), It.IsAny<string>()))
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -303,7 +326,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage, string>((m, s) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -343,7 +366,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                     })
                 .Returns(Task.CompletedTask);
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(cloudProxy));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             IMessage message = new EdgeMessage.Builder(new byte[0]).Build();
@@ -368,7 +391,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage>(m => sentMessage = m)
                 .Returns(Task.CompletedTask);
 
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout, Option.None<string>());
             listener.BindDeviceProxy(deviceProxy.Object);
             string correlationId = Guid.NewGuid().ToString();
 
@@ -397,7 +420,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback<IMessage>(m => sentMessage = m)
                 .Returns(Task.CompletedTask);
 
-            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout);
+            var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout, Option.None<string>());
             listener.BindDeviceProxy(deviceProxy.Object);
             string correlationId = Guid.NewGuid().ToString();
 
@@ -426,7 +449,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -465,7 +488,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -505,7 +528,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
 
             string lockToken = Guid.NewGuid().ToString();
@@ -553,7 +576,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var connMgr = new Mock<IConnectionManager>();
             connMgr.Setup(c => c.AddDeviceConnection(It.IsAny<IIdentity>(), It.IsAny<IDeviceProxy>()));
             connMgr.Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, edgeHub, connMgr.Object, DefaultMessageAckTimeout, Option.None<string>());
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
             return deviceMessageHandler;
         }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 subscriptionProcessor);
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout, Option.None<string>());
             var methodRequest = new DirectMethodRequest("device1/module1", "shutdown", null, TimeSpan.FromSeconds(2), TimeSpan.FromMilliseconds(10));
 
             // Act
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 Mock.Of<ISubscriptionProcessor>());
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout, Option.None<string>());
 
             // Act
             deviceMessageHandler.BindDeviceProxy(underlyingDeviceProxy.Object);
@@ -435,7 +435,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 invokeMethodHandler,
                 subscriptionProcessor);
 
-            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout);
+            var deviceMessageHandler = new DeviceMessageHandler(identity, routingEdgeHub, connectionManager, DefaultMessageAckTimeout, Option.None<string>());
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
 
             // Arrange

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -523,7 +523,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 Try<ICloudProxy> cloudProxy = await connectionManager.CreateCloudConnectionAsync(deviceCredentials);
                 Assert.True(cloudProxy.Success);
                 var deviceProxy = Mock.Of<IDeviceProxy>();
-                var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub, connectionManager, DefaultMessageAckTimeout);
+                var deviceListener = new DeviceMessageHandler(deviceCredentials.Identity, edgeHub, connectionManager, DefaultMessageAckTimeout, Option.None<string>());
 
                 deviceListener.BindDeviceProxy(deviceProxy);
                 return new TestDevice(deviceCredentials.Identity as IDeviceIdentity, deviceListener);
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 IClientCredentials moduleCredentials = SetupModuleCredentials(moduleId, deviceId);
                 Try<ICloudProxy> cloudProxy = await connectionManager.CreateCloudConnectionAsync(moduleCredentials);
                 Assert.True(cloudProxy.Success);
-                var deviceListener = new DeviceMessageHandler(moduleCredentials.Identity, edgeHub, connectionManager, DefaultMessageAckTimeout);
+                var deviceListener = new DeviceMessageHandler(moduleCredentials.Identity, edgeHub, connectionManager, DefaultMessageAckTimeout, Option.None<string>());
 
                 var receivedMessages = new List<IMessage>();
                 var deviceProxy = new Mock<IDeviceProxy>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
@@ -374,8 +374,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
-            var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
+            var deviceListener = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
+            var messagingServiceClient = new MessagingServiceClient(deviceListener, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -405,8 +405,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
-            var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
+            var deviceListener = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
+            var messagingServiceClient = new MessagingServiceClient(deviceListener, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -436,8 +436,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
-            var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
+            var deviceListener = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
+            var messagingServiceClient = new MessagingServiceClient(deviceListener, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
@@ -113,7 +113,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
                 Mock.Of<IConnectionManager>(),
-                DefaultMessageAckTimeout);
+                DefaultMessageAckTimeout,
+                Option.None<string>());
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             channel.Setup(x => x.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -158,7 +159,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
                 Mock.Of<IConnectionManager>(),
-                DefaultMessageAckTimeout);
+                DefaultMessageAckTimeout,
+                Option.None<string>());
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             channel.Setup(x => x.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -185,7 +187,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
                 Mock.Of<IIdentity>(i => i.Id == "d1"),
                 edgeHub,
                 Mock.Of<IConnectionManager>(),
-                DefaultMessageAckTimeout);
+                DefaultMessageAckTimeout,
+                Option.None<string>());
             var channel = new Mock<IMessagingChannel<IProtocolGatewayMessage>>();
             ProtocolGatewayMessage message = new ProtocolGatewayMessage.Builder(ByteBufferConverter.ToByteBuffer(new byte[0]), "$iothub/twin/PATCH/properties/reported/")
                 .Build();
@@ -340,8 +343,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
 
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout);
-            var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
+            var deviceListener = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
+            var messagingServiceClient = new MessagingServiceClient(deviceListener, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
                 .Callback<IProtocolGatewayMessage>(
@@ -371,7 +374,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
@@ -402,7 +405,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))
@@ -433,7 +436,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var connectionManager = new Mock<IConnectionManager>();
             connectionManager.Setup(c => c.GetCloudConnection(It.IsAny<string>()))
                 .Returns(Task.FromResult(Option.Some(cloudProxy.Object)));
-            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout);
+            var deviceListner = new DeviceMessageHandler(MockIdentity, EdgeHub.Object, connectionManager.Object, DefaultMessageAckTimeout, Option.None<string>());
             var messagingServiceClient = new MessagingServiceClient(deviceListner, messageConverter, ByteBufferConverter);
 
             Channel.Setup(r => r.Handle(It.IsAny<IProtocolGatewayMessage>()))


### PR DESCRIPTION
The Azure IoT SDK passes the modelID on the MQTT CONNECT packet when a Plug and Play (pnp) device connects to hub. In order to integrate pnp with edge, edge needs to parse this modelID to pass along to the hub when edge's deviceClient connects to hub.

We cache the modelID in DeviceListener for all devices that connected with a modelID and stamp every message that comes from those devices with the associated modelID. Every message from a device with a modelID will have a ModelID in the SystemProperties. This will be used to create/recreate the cloud connection depending on if the modelID has changed.

Currently, this PR only handles MQTT. But we will add the modelID for amqp as well in a separate PR. 