### PR TITLE
Fix for MQTT Image CI pipeline.

### DIFF
--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -33,9 +33,9 @@ jobs:
           containerRegistry: iotedge-edgebuilds-acr
           Dockerfile: mqtt/docker/$(os)/$(arch)/Dockerfile
           buildContext: mqtt/.
-          tags: $(Build.BuildId)-$(os)-$(arch)
+          tags: $(Build.BuildNumber)-$(os)-$(arch)
       
-      - script: echo $(registry.address)/$(imageName):$(Build.BuildId)-$(os)-$(arch) > artifactInfo.txt
+      - script: echo $(registry.address)/$(imageName):$(Build.BuildNumber)-$(os)-$(arch) > artifactInfo.txt
         displayName: Create image name
       
       - publish: artifactInfo.txt
@@ -69,9 +69,9 @@ jobs:
           containerRegistry: iotedge-edgebuilds-acr
           Dockerfile: mqtt/docker/$(os)/$(arch)/Dockerfile
           buildContext: mqtt/.
-          tags: $(Build.BuildId)-$(os)-$(arch)
+          tags: $(Build.BuildNumber)-$(os)-$(arch)
 
-      - script: echo $(registry.address)/$(imageName):$(Build.BuildId)-$(os)-$(arch) > artifactInfo.txt
+      - script: echo $(registry.address)/$(imageName):$(Build.BuildNumber)-$(os)-$(arch) > artifactInfo.txt
         displayName: Create image name
       
       - publish: artifactInfo.txt

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -10,6 +10,11 @@ FROM ${BASE_IMAGE} AS builder
 # Add our source code.
 ADD . ./
 
+# Force add tartget platform in case 
+# rust-toolchain file contains version other than 'stable'.
+# Otherwise it's noop.
+RUN rustup target add x86_64-unknown-linux-musl
+
 # Build our application.
 RUN cargo build --release --manifest-path mqttd/Cargo.toml --no-default-features \
     && strip /home/rust/src/target/x86_64-unknown-linux-musl/release/mqttd

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -10,6 +10,11 @@ FROM ${BASE_IMAGE} AS builder
 # Add our source code.
 ADD . ./
 
+# Force add tartget platform in case 
+# rust-toolchain file contains version other than 'stable'.
+# Otherwise it's noop.
+RUN rustup target add armv7-unknown-linux-musleabihf
+
 # Build our application.
 RUN cargo build --release --manifest-path mqttd/Cargo.toml --no-default-features \ 
     && musl-strip /home/rust/src/target/armv7-unknown-linux-musleabihf/release/mqttd


### PR DESCRIPTION
**Context:**
If we try to override `rust-toolchain` version, our build images fail, b/c they don't have specific version installed.

**Fix:**
Added a statement in Dockerfiles to force add specific rustup target, in case it has been overriden in `rust-toolchain` file