### PR TITLE
Edgehub E2E tests fix

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeCertificateAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeCertificateAuthenticator.cs
@@ -19,8 +19,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache,
             IAuthenticator underlyingAuthenticator,
             IList<X509Certificate2> trustBundle,
-            bool syncServiceIdentityOnFailure)
-            : base(deviceScopeIdentitiesCache, underlyingAuthenticator, false, syncServiceIdentityOnFailure)
+            bool syncServiceIdentityOnFailure,
+            bool nestedEdgeEnabled = false)
+            : base(deviceScopeIdentitiesCache, underlyingAuthenticator, false, syncServiceIdentityOnFailure, nestedEdgeEnabled)
         {
             this.trustBundle = Preconditions.CheckNotNull(trustBundle, nameof(trustBundle));
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -23,8 +23,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             string edgeHubHostName,
             IAuthenticator underlyingAuthenticator,
             bool allowDeviceAuthForModule,
-            bool syncServiceIdentityOnFailure)
-            : base(deviceScopeIdentitiesCache, underlyingAuthenticator, allowDeviceAuthForModule, syncServiceIdentityOnFailure)
+            bool syncServiceIdentityOnFailure,
+            bool nestedEdgeEnabled = false)
+            : base(deviceScopeIdentitiesCache, underlyingAuthenticator, allowDeviceAuthForModule, syncServiceIdentityOnFailure, nestedEdgeEnabled)
         {
             this.iothubHostName = Preconditions.CheckNonWhiteSpace(iothubHostName, nameof(iothubHostName));
             this.edgeHubHostName = Preconditions.CheckNotNull(edgeHubHostName, nameof(edgeHubHostName));

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
@@ -16,17 +16,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         readonly IAuthenticator underlyingAuthenticator;
         readonly bool allowDeviceAuthForModule;
         readonly bool syncServiceIdentityOnFailure;
+        readonly bool nestedEdgeEnabled;
 
         protected DeviceScopeAuthenticator(
             IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache,
             IAuthenticator underlyingAuthenticator,
             bool allowDeviceAuthForModule,
-            bool syncServiceIdentityOnFailure)
+            bool syncServiceIdentityOnFailure,
+            bool nestedEdgeEnabled)
         {
             this.underlyingAuthenticator = Preconditions.CheckNotNull(underlyingAuthenticator, nameof(underlyingAuthenticator));
             this.deviceScopeIdentitiesCache = Preconditions.CheckNotNull(deviceScopeIdentitiesCache, nameof(deviceScopeIdentitiesCache));
             this.allowDeviceAuthForModule = allowDeviceAuthForModule;
             this.syncServiceIdentityOnFailure = syncServiceIdentityOnFailure;
+            this.nestedEdgeEnabled = nestedEdgeEnabled;
         }
 
         public async Task<bool> AuthenticateAsync(IClientCredentials clientCredentials)
@@ -103,7 +106,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             Option<string> authChain = await this.deviceScopeIdentitiesCache.GetAuthChain(serviceIdentityId);
 
-            if (!authChain.HasValue)
+            if (this.nestedEdgeEnabled && !authChain.HasValue)
             {
                 // The identity is not within our nested hierarchy
                 return (false, false);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -159,6 +159,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool checkEntireQueueOnCleanup = this.configuration.GetValue("CheckEntireQueueOnCleanup", false);
             Option<string> gatewayHostname = Option.Maybe(this.configuration.GetValue<string>(Constants.ConfigKey.GatewayHostname));
             bool closeCloudConnectionOnDeviceDisconnect = this.configuration.GetValue("CloseCloudConnectionOnDeviceDisconnect", true);
+            bool nestedEdgeEnabled = this.configuration.GetValue<bool>(Constants.ConfigKey.NestedEdgeEnabled);
 
             builder.RegisterModule(
                 new RoutingModule(
@@ -190,7 +191,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     configUpdateFrequency,
                     checkEntireQueueOnCleanup,
                     experimentalFeatures,
-                    closeCloudConnectionOnDeviceDisconnect));
+                    closeCloudConnectionOnDeviceDisconnect,
+                    nestedEdgeEnabled));
         }
 
         void RegisterCommonModule(

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -337,7 +337,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         var credentialsCacheTask = c.Resolve<Task<ICredentialsCache>>();
                         // by default regardless of how the authenticationMode, X.509 certificate validation will always be scoped
                         deviceScopeIdentitiesCache = await c.Resolve<Task<IDeviceScopeIdentitiesCache>>();
-                        certificateAuthenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, new NullAuthenticator(), this.trustBundle, true);
+                        certificateAuthenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache, new NullAuthenticator(), this.trustBundle, true, this.nestedEdgeEnabled);
                         switch (this.authenticationMode)
                         {
                             case AuthenticationMode.Cloud:
@@ -345,12 +345,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                                 break;
 
                             case AuthenticationMode.Scope:
-                                tokenAuthenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, this.edgeDeviceHostName, new NullAuthenticator(), true, true);
+                                tokenAuthenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, this.edgeDeviceHostName, new NullAuthenticator(), true, true, this.nestedEdgeEnabled);
                                 break;
 
                             default:
                                 IAuthenticator cloudTokenAuthenticator = await this.GetCloudTokenAuthenticator(c);
-                                tokenAuthenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, this.edgeDeviceHostName, cloudTokenAuthenticator, true, true);
+                                tokenAuthenticator = new DeviceScopeTokenAuthenticator(deviceScopeIdentitiesCache, this.iothubHostName, this.edgeDeviceHostName, cloudTokenAuthenticator, true, true, this.nestedEdgeEnabled);
                                 break;
                         }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly bool checkEntireQueueOnCleanup;
         readonly ExperimentalFeatures experimentalFeatures;
         readonly bool closeCloudConnectionOnDeviceDisconnect;
+        readonly bool nestedEdgeEnabled;
 
         public RoutingModule(
             string iotHubName,
@@ -87,7 +88,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             TimeSpan configUpdateFrequency,
             bool checkEntireQueueOnCleanup,
             ExperimentalFeatures experimentalFeatures,
-            bool closeCloudConnectionOnDeviceDisconnect)
+            bool closeCloudConnectionOnDeviceDisconnect,
+            bool nestedEdgeEnabled)
         {
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
             this.gatewayHostname = gatewayHostname;
@@ -118,6 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.checkEntireQueueOnCleanup = checkEntireQueueOnCleanup;
             this.experimentalFeatures = experimentalFeatures;
             this.closeCloudConnectionOnDeviceDisconnect = closeCloudConnectionOnDeviceDisconnect;
+            this.nestedEdgeEnabled = nestedEdgeEnabled;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -239,7 +242,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                             this.operationTimeout,
                             this.useServerHeartbeat,
                             proxy,
-                            productInfoStore);
+                            productInfoStore,
+                            this.nestedEdgeEnabled);
                         return cloudConnectionProvider;
                     })
                 .As<Task<ICloudConnectionProvider>>()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
@@ -439,7 +439,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore);
+                productInfoStore,
+                true);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, Mock.Of<ICredentialsCache>(), new IdentityProvider(hostname), deviceConnectivityManager);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
@@ -146,7 +146,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore);
+                productInfoStore,
+                true);
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             var deviceIdentity = Mock.Of<IDeviceIdentity>(m => m.Id == "d1");
@@ -195,7 +196,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore);
+                productInfoStore,
+                true);
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             var deviceIdentity = Mock.Of<IDeviceIdentity>(m => m.Id == "d1");
@@ -241,7 +243,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore);
+                productInfoStore,
+                true);
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             // Act
@@ -286,7 +289,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore);
+                productInfoStore,
+                true);
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             // Act
@@ -331,7 +335,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore);
+                productInfoStore,
+                true);
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             // Act

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeCertificateAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeCertificateAuthenticatorTest.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 new string[0],
                 new ServiceAuthentication(new X509ThumbprintAuthentication(primaryCertificate.Thumbprint, secondaryCertificate.Thumbprint)),
                 ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId))).ReturnsAsync(Option.Some(serviceIdentity));
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId))).ReturnsAsync(Option.Some(deviceId));
 
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 new string[0],
                 new ServiceAuthentication(new X509ThumbprintAuthentication(primaryCertificate.Thumbprint, secondaryCertificate.Thumbprint)),
                 ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId))).ReturnsAsync(Option.Some(serviceIdentity));
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId))).ReturnsAsync(Option.Some(deviceId));
 
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 new string[0],
                 new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority),
                 ServiceIdentityStatus.Enabled);
-            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true);
+            var authenticator = new DeviceScopeCertificateAuthenticator(deviceScopeIdentitiesCache.Object, UnderlyingAuthenticator, trustBundle, true, true);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId))).ReturnsAsync(Option.Some(serviceIdentity));
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId))).ReturnsAsync(Option.Some(deviceId));
 

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
@@ -84,7 +84,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 TimeSpan.FromMinutes(10),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore.Object);
+                productInfoStore.Object,
+                true);
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
@@ -186,7 +187,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 TimeSpan.FromMinutes(10),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore.Object);
+                productInfoStore.Object,
+                true);
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
@@ -272,7 +274,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 TimeSpan.FromMinutes(10),
                 false,
                 Option.None<IWebProxy>(),
-                productInfoStore.Object);
+                productInfoStore.Object,
+                true);
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -201,7 +201,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     TimeSpan.FromHours(1),
                     checkEntireQueueOnCleanup,
                     experimentalFeatures,
-                    true));
+                    true,
+                    false));
 
             builder.RegisterModule(new HttpModule());
             builder.RegisterModule(new MqttModule(mqttSettingsConfiguration.Object, topics, this.serverCertificate, false, false, false, this.sslProtocols));


### PR DESCRIPTION
This disables authchain check for ConnectionProvider by default, which should fix the bulk of the E2E automation failures.