### PR TITLE
update docker file for vulnerability issue

### DIFF
--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm32v7
+ARG base_tag=3.1.5-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm64v8
+ARG base_tag=3.1.5-bionic-arm64v8
 ARG num_procs=4
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/edge-agent/docker/windows/arm32v7/Dockerfile
+++ b/edge-agent/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-agent-base:${base_tag}
 

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm32v7
+ARG base_tag=3.1.5-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm64v8
+ARG base_tag=3.1.5-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/windows/arm32v7/Dockerfile
+++ b/edge-hub/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-hub-base:${base_tag}
 

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm32v7
+ARG base_tag=3.1.5-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm64v8
+ARG base_tag=3.1.5-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
-ARG base_tag=1.0.5-linux-arm64v8
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+ARG base_tag=1.0.6-linux-arm64v8
+FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/test/connectivity/modules/NetworkController/docker/windows/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/EdgeHubRestartTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.2-windows-arm32v7
+ARG base_tag=1.0.5-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm32v7
+ARG base_tag=3.1.5-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm64v8
+ARG base_tag=3.1.5-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/test/modules/TestAnalyzer/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
-ARG base_tag=1.0.5-linux-arm32v7
-FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rocksdb:${base_tag}
+ARG base_tag=1.0.6-linux-arm32v7
+FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
-ARG base_tag=1.0.5-linux-arm64v8
-FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rocksdb:${base_tag}
+ARG base_tag=1.0.6-linux-arm64v8
+FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/test/modules/TwinTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.1.0-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm64v8
+ARG base_tag=1.1.0-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.6-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.1.0-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 


### PR DESCRIPTION
update Linux arm32 and arm64 docker base image for vulnerability issue. And fix docker base image/tag in EdgeHubRestartTester windows arm32 and TwinTester.