### PR TITLE
[mqtt] Preserve initial ordering when re-delivering packets 

### DIFF
--- a/mqtt/mqtt-broker/src/session/offline.rs
+++ b/mqtt/mqtt-broker/src/session/offline.rs
@@ -43,6 +43,12 @@ impl OfflineSession {
         let mut events = Vec::new();
         let OfflineSession { mut state } = self;
 
+        // Drop all outstanding QoS 0 packets
+        if !state.waiting_to_be_acked_qos0_mut().is_empty() {
+            debug!("dropping all QoS0 packet");
+            state.waiting_to_be_acked_qos0_mut().clear();
+        }
+
         // Handle the outstanding QoS 1 and QoS 2 packets
         for (id, publish) in state.waiting_to_be_acked() {
             let to_publish = match publish {
@@ -68,12 +74,6 @@ impl OfflineSession {
 
             debug!("resending QoS12 packet {}", id);
             events.push(ClientEvent::PublishTo(to_publish));
-        }
-
-        // Handle the outstanding QoS 0 packets
-        for (id, publish) in state.waiting_to_be_acked_qos0() {
-            debug!("resending QoS0 packet {}", id);
-            events.push(ClientEvent::PublishTo(publish.clone()));
         }
 
         // Handle the outstanding QoS 2 packets in the second stage of transmission

--- a/mqtt/mqtt-broker/src/session/state/map.rs
+++ b/mqtt/mqtt-broker/src/session/state/map.rs
@@ -1,0 +1,156 @@
+use std::{
+    borrow::Borrow,
+    collections::btree_map::IntoIter,
+    collections::{BTreeMap, HashMap},
+    hash::Hash,
+};
+
+/// `SmallIndexMap` is a `HashMap`-like collection that preserves order
+/// in which items were inserted in the collection.
+///
+/// It is suppose to work good enough on a very small number of items (~100).
+/// DO NOT use for large amount of items!
+///
+/// Internally it maintains a `HashMap` for fast access to the value by a key.
+/// The value of the `HashMap` is a pair (order, value). `order` is used when
+/// contructing iterator to restore order in which items were added.
+/// `order` has a type `u64` which should be enough to handle 8472380 years
+/// uptime with a rate of `70_000` messages/sec incoming rate.
+#[derive(Debug, Clone)]
+pub struct SmallIndexMap<K, V> {
+    last_inserted: u64,
+    items: HashMap<K, (u64, V)>,
+}
+
+impl<K, V> SmallIndexMap<K, V> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&mut self) {
+        self.last_inserted = 0;
+        self.items.clear();
+    }
+
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        let mut ordered = BTreeMap::new();
+        for (key, (order, value)) in &self.items {
+            ordered.insert(order, (key, value));
+        }
+
+        Iter(ordered.into_iter())
+    }
+}
+
+impl<K, V> SmallIndexMap<K, V>
+where
+    K: Eq + Hash,
+{
+    pub fn get<Q: ?Sized>(&self, k: &Q) -> Option<&V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.items.get(k).map(|(_, v)| v)
+    }
+
+    pub fn insert(&mut self, key: K, value: V) -> Option<V> {
+        self.last_inserted += 1;
+        let value = (self.last_inserted, value);
+        self.items.insert(key, value).map(|pair| pair.1)
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, key: &Q) -> Option<V>
+    where
+        K: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.items.remove(key).map(|pair| pair.1)
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<K, V> PartialEq for SmallIndexMap<K, V>
+where
+    K: Eq + Hash,
+    V: PartialEq,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.items == other.items
+    }
+}
+
+impl<K, V> Default for SmallIndexMap<K, V> {
+    fn default() -> Self {
+        Self {
+            last_inserted: 0,
+            items: HashMap::default(),
+        }
+    }
+}
+
+impl<'a, K, V> IntoIterator for &'a SmallIndexMap<K, V> {
+    type Item = (&'a K, &'a V);
+    type IntoIter = Iter<'a, K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub struct Iter<'a, K, V>(IntoIter<&'a u64, (&'a K, &'a V)>);
+
+impl<'a, K, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(_, v)| v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SmallIndexMap;
+
+    #[test]
+    fn it_iterates_in_insertion_order() {
+        let mut map = SmallIndexMap::new();
+        assert_eq!(map.iter().next(), None);
+
+        assert_eq!(map.insert(1, 1), None);
+        assert_eq!(map.iter().next(), Some((&1, &1)));
+
+        assert_eq!(map.insert(1, 2), Some(1));
+        assert_eq!(map.iter().next(), Some((&1, &2)));
+
+        assert_eq!(map.insert(0, 1), None);
+        assert_eq!(map.insert(2, 3), None);
+
+        assert_eq!(map.insert(3, 3), None);
+
+        let mut iter = map.iter();
+        assert_eq!(iter.next(), Some((&1, &2)));
+        assert_eq!(iter.next(), Some((&0, &1)));
+        assert_eq!(iter.next(), Some((&2, &3)));
+        assert_eq!(iter.next(), Some((&3, &3)));
+        drop(iter);
+
+        assert_eq!(map.remove(&0), Some(1));
+        map.insert(4, 4);
+        map.insert(0, 0);
+
+        let mut iter = map.iter();
+        assert_eq!(iter.next(), Some((&1, &2)));
+        assert_eq!(iter.next(), Some((&2, &3)));
+        assert_eq!(iter.next(), Some((&3, &3)));
+        assert_eq!(iter.next(), Some((&4, &4)));
+        assert_eq!(iter.next(), Some((&0, &0)));
+    }
+}

--- a/mqtt/mqtt-broker/src/session/state/mod.rs
+++ b/mqtt/mqtt-broker/src/session/state/mod.rs
@@ -1,8 +1,12 @@
-use std::{
-    cmp,
-    collections::{HashMap, HashSet, VecDeque},
-    num::NonZeroUsize,
-};
+mod map;
+mod queue;
+mod set;
+
+use map::SmallIndexMap;
+use queue::BoundedQueue;
+use set::SmallIndexSet;
+
+use std::{cmp, collections::HashMap};
 
 use tracing::debug;
 
@@ -10,8 +14,8 @@ use mqtt3::proto;
 
 use super::identifiers::PacketIdentifiers;
 use crate::{
-    configuration::QueueFullAction, snapshot::SessionSnapshot, subscription::Subscription,
-    ClientEvent, ClientId, Error, Publish, SessionConfig,
+    snapshot::SessionSnapshot, subscription::Subscription, ClientEvent, ClientId, Error, Publish,
+    SessionConfig,
 };
 
 /// Common data and functions for broker sessions.
@@ -25,12 +29,12 @@ pub struct SessionState {
     waiting_to_be_sent: BoundedQueue,
 
     // for incoming messages - QoS2
-    waiting_to_be_released: HashMap<proto::PacketIdentifier, proto::Publish>,
+    waiting_to_be_released: SmallIndexMap<proto::PacketIdentifier, proto::Publish>,
 
     // for outgoing messages - all QoS
-    waiting_to_be_acked: HashMap<proto::PacketIdentifier, Publish>,
-    waiting_to_be_acked_qos0: HashMap<proto::PacketIdentifier, Publish>,
-    waiting_to_be_completed: HashSet<proto::PacketIdentifier>,
+    waiting_to_be_acked: SmallIndexMap<proto::PacketIdentifier, Publish>,
+    waiting_to_be_acked_qos0: SmallIndexMap<proto::PacketIdentifier, Publish>,
+    waiting_to_be_completed: SmallIndexSet<proto::PacketIdentifier>,
     config: SessionConfig,
 }
 
@@ -47,10 +51,10 @@ impl SessionState {
                 config.max_queued_size(),
                 config.when_full(),
             ),
-            waiting_to_be_acked: HashMap::new(),
-            waiting_to_be_acked_qos0: HashMap::new(),
-            waiting_to_be_released: HashMap::new(),
-            waiting_to_be_completed: HashSet::new(),
+            waiting_to_be_acked: SmallIndexMap::new(),
+            waiting_to_be_acked_qos0: SmallIndexMap::new(),
+            waiting_to_be_released: SmallIndexMap::new(),
+            waiting_to_be_completed: SmallIndexSet::new(),
             config,
         }
     }
@@ -70,10 +74,10 @@ impl SessionState {
             subscriptions,
             packet_identifiers: PacketIdentifiers::default(),
             waiting_to_be_sent,
-            waiting_to_be_acked: HashMap::new(),
-            waiting_to_be_released: HashMap::new(),
-            waiting_to_be_completed: HashSet::new(),
-            waiting_to_be_acked_qos0: HashMap::new(),
+            waiting_to_be_acked: SmallIndexMap::new(),
+            waiting_to_be_released: SmallIndexMap::new(),
+            waiting_to_be_completed: SmallIndexSet::new(),
+            waiting_to_be_acked_qos0: SmallIndexMap::new(),
             packet_identifiers_qos0: PacketIdentifiers::default(),
             config,
         }
@@ -87,15 +91,17 @@ impl SessionState {
         &self.subscriptions
     }
 
-    pub(super) fn waiting_to_be_acked(&self) -> &HashMap<proto::PacketIdentifier, Publish> {
+    pub(super) fn waiting_to_be_acked(&self) -> &SmallIndexMap<proto::PacketIdentifier, Publish> {
         &self.waiting_to_be_acked
     }
 
-    pub(super) fn waiting_to_be_acked_qos0(&self) -> &HashMap<proto::PacketIdentifier, Publish> {
-        &self.waiting_to_be_acked_qos0
+    pub(super) fn waiting_to_be_acked_qos0_mut(
+        &mut self,
+    ) -> &mut SmallIndexMap<proto::PacketIdentifier, Publish> {
+        &mut self.waiting_to_be_acked_qos0
     }
 
-    pub(super) fn waiting_to_be_completed(&self) -> &HashSet<proto::PacketIdentifier> {
+    pub(super) fn waiting_to_be_completed(&self) -> &SmallIndexSet<proto::PacketIdentifier> {
         &self.waiting_to_be_completed
     }
 
@@ -330,99 +336,6 @@ impl From<SessionState> for SessionSnapshot {
             state.subscriptions,
             state.waiting_to_be_sent.into_inner(),
         )
-    }
-}
-
-/// `BoundedQueue` is a queue of publications with bounds by count and total payload size in bytes.
-///
-/// Packets will be queued until either `max_len` (max number of publications)
-/// or `max_size` (max total payload size of publications)
-/// is reached, and then `when_full` strategy is applied.
-///
-/// None for `max_len` or `max_size` means "unbounded".
-#[derive(Clone, Debug, PartialEq)]
-pub(super) struct BoundedQueue {
-    inner: VecDeque<proto::Publication>,
-    max_len: Option<NonZeroUsize>,
-    max_size: Option<NonZeroUsize>,
-    when_full: QueueFullAction,
-    current_size: usize,
-}
-
-impl BoundedQueue {
-    pub fn new(
-        max_len: Option<NonZeroUsize>,
-        max_size: Option<NonZeroUsize>,
-        when_full: QueueFullAction,
-    ) -> Self {
-        Self {
-            inner: VecDeque::new(),
-            max_len,
-            max_size,
-            when_full,
-            current_size: 0,
-        }
-    }
-
-    pub fn into_inner(self) -> VecDeque<proto::Publication> {
-        self.inner
-    }
-
-    pub fn dequeue(&mut self) -> Option<proto::Publication> {
-        match self.inner.pop_front() {
-            Some(publication) => {
-                self.current_size -= publication.payload.len();
-                Some(publication)
-            }
-            None => None,
-        }
-    }
-
-    pub fn enqueue(&mut self, publication: proto::Publication) {
-        if let Some(max_len) = self.max_len {
-            if self.inner.len() >= max_len.get() {
-                return self.handle_queue_limit(publication);
-            }
-        }
-
-        if let Some(max_size) = self.max_size {
-            let pub_len = publication.payload.len();
-            if self.current_size + pub_len > max_size.get() {
-                return self.handle_queue_limit(publication);
-            }
-        }
-
-        self.current_size += publication.payload.len();
-        self.inner.push_back(publication);
-    }
-
-    #[cfg(test)]
-    pub fn len(&self) -> usize {
-        self.inner.len()
-    }
-
-    #[cfg(test)]
-    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, proto::Publication> {
-        self.inner.iter()
-    }
-
-    fn handle_queue_limit(&mut self, publication: proto::Publication) {
-        match self.when_full {
-            QueueFullAction::DropNew => {
-                // do nothing
-            }
-            QueueFullAction::DropOld => {
-                let _ = self.dequeue();
-                self.current_size += publication.payload.len();
-                self.inner.push_back(publication);
-            }
-        };
-    }
-}
-
-impl Extend<proto::Publication> for BoundedQueue {
-    fn extend<T: IntoIterator<Item = proto::Publication>>(&mut self, iter: T) {
-        iter.into_iter().for_each(|item| self.enqueue(item));
     }
 }
 

--- a/mqtt/mqtt-broker/src/session/state/queue.rs
+++ b/mqtt/mqtt-broker/src/session/state/queue.rs
@@ -1,0 +1,98 @@
+use std::{collections::VecDeque, num::NonZeroUsize};
+
+use mqtt3::proto;
+
+use crate::configuration::QueueFullAction;
+
+/// `BoundedQueue` is a queue of publications with bounds by count and total payload size in bytes.
+///
+/// Packets will be queued until either `max_len` (max number of publications)
+/// or `max_size` (max total payload size of publications)
+/// is reached, and then `when_full` strategy is applied.
+///
+/// None for `max_len` or `max_size` means "unbounded".
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct BoundedQueue {
+    inner: VecDeque<proto::Publication>,
+    max_len: Option<NonZeroUsize>,
+    max_size: Option<NonZeroUsize>,
+    when_full: QueueFullAction,
+    current_size: usize,
+}
+
+impl BoundedQueue {
+    pub fn new(
+        max_len: Option<NonZeroUsize>,
+        max_size: Option<NonZeroUsize>,
+        when_full: QueueFullAction,
+    ) -> Self {
+        Self {
+            inner: VecDeque::new(),
+            max_len,
+            max_size,
+            when_full,
+            current_size: 0,
+        }
+    }
+
+    pub fn into_inner(self) -> VecDeque<proto::Publication> {
+        self.inner
+    }
+
+    pub fn dequeue(&mut self) -> Option<proto::Publication> {
+        match self.inner.pop_front() {
+            Some(publication) => {
+                self.current_size -= publication.payload.len();
+                Some(publication)
+            }
+            None => None,
+        }
+    }
+
+    pub fn enqueue(&mut self, publication: proto::Publication) {
+        if let Some(max_len) = self.max_len {
+            if self.inner.len() >= max_len.get() {
+                return self.handle_queue_limit(publication);
+            }
+        }
+
+        if let Some(max_size) = self.max_size {
+            let pub_len = publication.payload.len();
+            if self.current_size + pub_len > max_size.get() {
+                return self.handle_queue_limit(publication);
+            }
+        }
+
+        self.current_size += publication.payload.len();
+        self.inner.push_back(publication);
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    #[cfg(test)]
+    pub fn iter(&self) -> std::collections::vec_deque::Iter<'_, proto::Publication> {
+        self.inner.iter()
+    }
+
+    fn handle_queue_limit(&mut self, publication: proto::Publication) {
+        match self.when_full {
+            QueueFullAction::DropNew => {
+                // do nothing
+            }
+            QueueFullAction::DropOld => {
+                let _ = self.dequeue();
+                self.current_size += publication.payload.len();
+                self.inner.push_back(publication);
+            }
+        };
+    }
+}
+
+impl Extend<proto::Publication> for BoundedQueue {
+    fn extend<T: IntoIterator<Item = proto::Publication>>(&mut self, iter: T) {
+        iter.into_iter().for_each(|item| self.enqueue(item));
+    }
+}

--- a/mqtt/mqtt-broker/src/session/state/set.rs
+++ b/mqtt/mqtt-broker/src/session/state/set.rs
@@ -1,0 +1,155 @@
+use std::{
+    borrow::Borrow,
+    collections::{btree_map::IntoIter, BTreeMap, HashMap},
+    hash::Hash,
+};
+
+/// `SmallIndexSet` is a `HashSet`-like collection that preserves order
+/// in which items were inserted in the collection.
+///
+/// It is suppose to work good enough on a very small number of items (~100).
+/// DO NOT use for large amount of items!
+///
+/// Internally it maintains a `HashMap` for fast access to the value.
+/// The value of the `HashMap` is a ordering number. `order` is used when
+/// contructing iterator to restore order in which items were added.
+/// `order` has a type `u64` which should be enough to handle 8472380 years
+/// uptime with a rate of `70_000` messages/sec incoming rate.
+#[derive(Debug, Clone)]
+pub struct SmallIndexSet<V> {
+    last_inserted: u64,
+    items: HashMap<V, u64>,
+}
+
+impl<V> PartialEq for SmallIndexSet<V>
+where
+    V: Eq + Hash,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.items == other.items
+    }
+}
+
+impl<V> Default for SmallIndexSet<V> {
+    fn default() -> Self {
+        Self {
+            last_inserted: 0,
+            items: HashMap::default(),
+        }
+    }
+}
+
+impl<V> SmallIndexSet<V> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn iter(&self) -> Iter<'_, V> {
+        let mut ordered = BTreeMap::new();
+        for (value, order) in &self.items {
+            ordered.insert(order, value);
+        }
+
+        Iter(ordered.into_iter())
+    }
+}
+
+impl<V> SmallIndexSet<V>
+where
+    V: Eq + Hash,
+{
+    pub fn get<Q: ?Sized>(&self, value: &Q) -> Option<&V>
+    where
+        V: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.items.get_key_value(value).map(|(k, _)| k)
+    }
+
+    pub fn insert(&mut self, value: V) -> bool {
+        self.last_inserted += 1;
+        self.items.insert(value, self.last_inserted).is_some()
+    }
+
+    pub fn remove<Q: ?Sized>(&mut self, value: &Q) -> bool
+    where
+        V: Borrow<Q>,
+        Q: Hash + Eq,
+    {
+        self.items.remove(value).is_some()
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<'a, V> IntoIterator for &'a SmallIndexSet<V> {
+    type Item = &'a V;
+    type IntoIter = Iter<'a, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+pub struct Iter<'a, V>(IntoIter<&'a u64, &'a V>);
+
+impl<'a, V> Iterator for Iter<'a, V> {
+    type Item = &'a V;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(_, v)| v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SmallIndexSet;
+
+    #[test]
+    fn it_iterates_in_insertion_order() {
+        let mut set = SmallIndexSet::new();
+        assert_eq!(set.iter().next(), None);
+
+        assert_eq!(set.insert(1), false);
+        assert_eq!(set.iter().next(), Some(&1));
+
+        assert_eq!(set.insert(2), false);
+        {
+            let mut iter = set.iter();
+            assert_eq!(iter.next(), Some(&1));
+            assert_eq!(iter.next(), Some(&2));
+            assert_eq!(iter.next(), None);
+        }
+
+        assert_eq!(set.insert(1), true);
+        {
+            let mut iter = set.iter();
+            assert_eq!(iter.next(), Some(&2));
+            assert_eq!(iter.next(), Some(&1));
+            assert_eq!(iter.next(), None);
+        }
+
+        assert_eq!(set.insert(0), false);
+        {
+            let mut iter = set.iter();
+            assert_eq!(iter.next(), Some(&2));
+            assert_eq!(iter.next(), Some(&1));
+            assert_eq!(iter.next(), Some(&0));
+            assert_eq!(iter.next(), None);
+        }
+
+        assert_eq!(set.remove(&1), true);
+        {
+            let mut iter = set.iter();
+            assert_eq!(iter.next(), Some(&2));
+            assert_eq!(iter.next(), Some(&0));
+            assert_eq!(iter.next(), None);
+        }
+    }
+}

--- a/mqtt/mqtt-broker/src/session/state/set.rs
+++ b/mqtt/mqtt-broker/src/session/state/set.rs
@@ -21,24 +21,6 @@ pub struct SmallIndexSet<V> {
     items: HashMap<V, u64>,
 }
 
-impl<V> PartialEq for SmallIndexSet<V>
-where
-    V: Eq + Hash,
-{
-    fn eq(&self, other: &Self) -> bool {
-        self.items == other.items
-    }
-}
-
-impl<V> Default for SmallIndexSet<V> {
-    fn default() -> Self {
-        Self {
-            last_inserted: 0,
-            items: HashMap::default(),
-        }
-    }
-}
-
 impl<V> SmallIndexSet<V> {
     pub fn new() -> Self {
         Self::default()
@@ -85,6 +67,24 @@ where
 
     pub fn is_empty(&self) -> bool {
         self.len() == 0
+    }
+}
+
+impl<V> PartialEq for SmallIndexSet<V>
+where
+    V: Eq + Hash,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.items == other.items
+    }
+}
+
+impl<V> Default for SmallIndexSet<V> {
+    fn default() -> Self {
+        Self {
+            last_inserted: 0,
+            items: HashMap::default(),
+        }
     }
 }
 

--- a/mqtt/mqtt-broker/tests/smoke.rs
+++ b/mqtt/mqtt-broker/tests/smoke.rs
@@ -9,6 +9,7 @@ use mqtt3::{
     proto::{
         ClientId, ConnAck, Connect, ConnectReturnCode, ConnectionRefusedReason, Packet,
         PacketIdentifier, PacketIdentifierDupQoS, PingReq, PubAck, Publication, Publish, QoS,
+        SubAck, SubAckQos, Subscribe, SubscribeTo,
     },
     Event, ReceivedPublication, PROTOCOL_LEVEL, PROTOCOL_NAME,
 };
@@ -504,6 +505,144 @@ async fn offline_messages_persisted_on_broker_restart() {
     assert_eq!(events[2], Bytes::from("o qos 2"));
 
     client_a.shutdown().await;
+}
+
+/// Scenario:
+/// - Client A connects with clean session
+/// - Client B connects with existing session
+/// - Client B sunbscribes to a topic
+/// - Client A sends QoS0 and several QoS1 packets
+/// - Client B receives packets and don't send PUBACKs
+/// - Client B reconnects
+/// - Client B expects to receive only QoS1 packets with dup=true in correct order
+#[tokio::test]
+async fn inflight_qos1_messages_redelivered_on_reconnect() {
+    let topic_a = "topic/A";
+
+    let broker = BrokerBuilder::default()
+        .with_authorizer(DummyAuthorizer::allow())
+        .build();
+
+    let server_handle = common::start_server(broker, DummyAuthenticator::anonymous());
+
+    let mut client_a = PacketStream::connect(
+        ClientId::IdWithCleanSession("test-client-a".into()),
+        server_handle.address(),
+        None,
+        None,
+    )
+    .await;
+
+    client_a.next().await; // skip connack
+
+    let mut client_b = PacketStream::connect(
+        ClientId::IdWithExistingSession("test-client-b".into()),
+        server_handle.address(),
+        None,
+        None,
+    )
+    .await;
+
+    client_b.next().await; // skip connack
+
+    client_b
+        .send_packet(Packet::Subscribe(Subscribe {
+            packet_identifier: PacketIdentifier::new(1).unwrap(),
+            subscribe_to: vec![SubscribeTo {
+                topic_filter: topic_a.into(),
+                qos: QoS::AtLeastOnce,
+            }],
+        }))
+        .await;
+
+    assert_eq!(
+        client_b.next().await,
+        Some(Packet::SubAck(SubAck {
+            packet_identifier: PacketIdentifier::new(1).unwrap(),
+            qos: vec![SubAckQos::Success(QoS::AtLeastOnce)]
+        }))
+    );
+
+    client_a
+        .send_publish(Publish {
+            packet_identifier_dup_qos: PacketIdentifierDupQoS::AtMostOnce,
+            retain: false,
+            topic_name: topic_a.into(),
+            payload: Bytes::from("qos 0"),
+        })
+        .await;
+
+    const QOS1_MESSAGES: u16 = 3;
+
+    for i in 1..=QOS1_MESSAGES {
+        client_a
+            .send_publish(Publish {
+                packet_identifier_dup_qos: PacketIdentifierDupQoS::AtLeastOnce(
+                    PacketIdentifier::new(i).unwrap(),
+                    false,
+                ),
+                retain: false,
+                topic_name: topic_a.into(),
+                payload: Bytes::from(format!("qos 1-{}", i)),
+            })
+            .await;
+    }
+
+    // receive all messages but don't send puback for QoS1/2.
+    assert_matches!(
+        client_b.next().await,
+        Some(Packet::Publish(Publish {
+            payload,
+            ..
+        })) if payload == Bytes::from("qos 0")
+    );
+
+    for i in 1..=QOS1_MESSAGES {
+        let publish = match client_b.next().await {
+            Some(Packet::Publish(publish)) => publish,
+            x => panic!("Expected publish but {:?} found", x),
+        };
+
+        assert_eq!(
+            publish.packet_identifier_dup_qos,
+            PacketIdentifierDupQoS::AtLeastOnce(PacketIdentifier::new(i).unwrap(), false),
+        );
+        assert_eq!(publish.payload, Bytes::from(format!("qos 1-{0}", i)));
+    }
+
+    // disconnect client_b;
+    drop(client_b);
+
+    // reconnect client_b
+    let mut client_b = PacketStream::connect(
+        ClientId::IdWithExistingSession("test-client-b".into()),
+        server_handle.address(),
+        None,
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        client_b.next().await,
+        Some(Packet::ConnAck(ConnAck {
+            session_present: true,
+            return_code: ConnectReturnCode::Accepted
+        }))
+    );
+
+    // expect messages to be redelivered (QoS 1/2).
+    for i in 1..=QOS1_MESSAGES {
+        let publish = match client_b.next().await {
+            Some(Packet::Publish(publish)) => publish,
+            x => panic!("Expected publish but {:?} found", x),
+        };
+
+        assert_eq!(
+            publish.packet_identifier_dup_qos,
+            PacketIdentifierDupQoS::AtLeastOnce(PacketIdentifier::new(i).unwrap(), true),
+        );
+        assert_eq!(publish.payload, Bytes::from(format!("qos 1-{0}", i)));
+    }
 }
 
 /// Scenario:

--- a/mqtt/mqtt-broker/tests/smoke.rs
+++ b/mqtt/mqtt-broker/tests/smoke.rs
@@ -603,9 +603,9 @@ async fn inflight_qos1_messages_redelivered_on_reconnect() {
             x => panic!("Expected publish but {:?} found", x),
         };
 
-        assert_eq!(
+        assert_matches!(
             publish.packet_identifier_dup_qos,
-            PacketIdentifierDupQoS::AtLeastOnce(PacketIdentifier::new(i).unwrap(), false),
+            PacketIdentifierDupQoS::AtLeastOnce(_, false)
         );
         assert_eq!(publish.payload, Bytes::from(format!("qos 1-{0}", i)));
     }
@@ -637,9 +637,9 @@ async fn inflight_qos1_messages_redelivered_on_reconnect() {
             x => panic!("Expected publish but {:?} found", x),
         };
 
-        assert_eq!(
+        assert_matches!(
             publish.packet_identifier_dup_qos,
-            PacketIdentifierDupQoS::AtLeastOnce(PacketIdentifier::new(i).unwrap(), true),
+            PacketIdentifierDupQoS::AtLeastOnce(_, true)
         );
         assert_eq!(publish.payload, Bytes::from(format!("qos 1-{0}", i)));
     }


### PR DESCRIPTION
When a persistent session goes online broker should:
* **not** resend those QoS 0 messages that have been send already
* re-deliver QoS 1 packets that are awaiting a PUBACK from client
* re-deliver QoS 2 packets in the second stage of transmission

For all packets broker **must** preserve the order messages were processed initially.