### PR TITLE
Set transport type correctly on test sender module

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                         .WithEnvironment(
                             new[]
                             {
-                                ("ClientTransportType", clientTransport),
+                                ("TransportType", clientTransport),
                                 ("TargetModuleId", methodReceiver)
                             });
                     builder.AddModule(methodReceiver, receiverImage)


### PR DESCRIPTION
DirectMethodSender module expects an environment variable named "TransportType" to tell it which transport to use (e.g. AMQP over WebSocket). But the ModuleToModuleDirectMethod test is setting the "ClientTransportType" environment variable. As a result, the test is always directing the sender module to use the default transport, AMQP.

This change fixes the environment variable so that the right transport setting is given.