### PR TITLE
Add manifest step for release image build

### DIFF
--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -608,7 +608,7 @@ jobs:
 ################################################################################
   - job: manifest
 ################################################################################
-    displayName: Manifest
+    displayName: Publish Manifest Images
     pool:
       vmImage: 'ubuntu-16.04'
     dependsOn:

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -605,3 +605,21 @@ jobs:
         inputs: 
           ArtifactName: publish-win
           PathtoPublish: $(Build.BinariesDirectory)\publish
+################################################################################
+  - job: manifest
+################################################################################
+    displayName: Manifest
+    pool:
+      vmImage: 'ubuntu-16.04'
+    dependsOn:
+      - linux_dotnet_projects
+      - windows
+    steps:
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -u '$(registry.user)' -p '$(registry.password)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edgelet/iotedge-diagnostics/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish azureiotedge-diagnostics Manifest'
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n $(namespace) --tags "$(tags)"
+      displayName: 'Publish Edge Agent Manifest'
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n $(namespace) --tags "$(tags)"
+      displayName: 'Publish Edge Hub Manifest'
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n $(namespace) --tags "$(tags)"
+      displayName: 'Publish Temperature Sensor Manifest'


### PR DESCRIPTION
When converting the pipeline to yaml I missed the manifest step, as I mistakenly thought it happened in the subsequent release job. Adding it here.