### PR TITLE
[mqtt] Remove PUBACK0

### DIFF
--- a/mqtt/mqtt-broker-tests-util/src/lib.rs
+++ b/mqtt/mqtt-broker-tests-util/src/lib.rs
@@ -28,7 +28,7 @@ use mqtt3::{
 };
 use mqtt_broker::{
     auth::{AuthenticationContext, Authenticator, Authorizer},
-    AuthId, Broker, BrokerSnapshot, Error, Server,
+    AuthId, BrokerRunner, BrokerSnapshot, Error, Server,
 };
 
 /// A wrapper on the [`mqtt3::Client`] to help simplify client event loop management.
@@ -424,7 +424,7 @@ impl Drop for ServerHandle {
 
 /// Starts a test server with a provided broker and returns
 /// shutdown handle, broker task and server binding.
-pub fn start_server<N, Z>(broker: Broker<Z>, authenticator: N) -> ServerHandle
+pub fn start_server<N, Z>(broker: BrokerRunner<Z>, authenticator: N) -> ServerHandle
 where
     N: Authenticator<Error = Box<dyn StdError>> + Send + Sync + 'static,
     Z: Authorizer + Send + Sync + 'static,

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -235,7 +235,7 @@ where
                 Ok(())
             }
             ClientEvent::PublishFrom(publish, _) => self.process_publish(&client_id, publish),
-            ClientEvent::PublishTo(_publish) => {
+            ClientEvent::PublishTo(_publish, _) => {
                 info!("broker received a PublishTo, ignoring");
                 Ok(())
             }

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -40,7 +40,7 @@ use tokio::sync::OwnedSemaphorePermit;
 use mqtt3::proto;
 
 pub use crate::auth::{AuthId, Identity};
-pub use crate::broker::{Broker, BrokerBuilder, BrokerHandle};
+pub use crate::broker::{BrokerBuilder, BrokerHandle, BrokerRunner};
 pub use crate::connection::{
     ConnectionHandle, IncomingPacketProcessor, MakeIncomingPacketProcessor,
     MakeMqttPacketProcessor, MakeOutgoingPacketProcessor, OutgoingPacketProcessor, PacketAction,
@@ -170,7 +170,7 @@ pub enum Auth {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Publish {
-    QoS0(proto::PacketIdentifier, proto::Publish),
+    QoS0(proto::Publish),
     QoS12(proto::PacketIdentifier, proto::Publish),
 }
 
@@ -216,9 +216,6 @@ pub enum ClientEvent {
 
     /// PublishTo - publish packet to a client
     PublishTo(Publish),
-
-    /// Publish acknowledgement (QoS 0)
-    PubAck0(proto::PacketIdentifier),
 
     /// Publish acknowledgement (QoS 1)
     PubAck(proto::PubAck),

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -259,7 +259,8 @@ impl PublishPermits {
     }
 
     pub fn add_permits(&self, permits: u16) {
-        self.permits.fetch_add(permits, Ordering::SeqCst);
+        let _p = self.permits.fetch_add(permits, Ordering::SeqCst);
+        // tracing::warn!("released: {}", p + permits);
     }
 
     pub fn acquire(self: Arc<Self>) -> Option<PublishPermit> {
@@ -272,6 +273,7 @@ impl PublishPermits {
                     .compare_and_swap(current, current - 1, Ordering::SeqCst);
 
                 if prev == current {
+                    // tracing::warn!("acquired: {}", current - 1);
                     return Some(PublishPermit { permits: self });
                 }
             } else {

--- a/mqtt/mqtt-broker/src/proptest.rs
+++ b/mqtt/mqtt-broker/src/proptest.rs
@@ -208,8 +208,7 @@ prop_compose! {
 
 pub fn arb_publish() -> impl Strategy<Value = Publish> {
     prop_oneof![
-        (arb_packet_identifier(), arb_proto_publish())
-            .prop_map(|(id, publish)| Publish::QoS0(id, publish)),
+        arb_proto_publish().prop_map(Publish::QoS0),
         (arb_packet_identifier(), arb_proto_publish())
             .prop_map(|(id, publish)| Publish::QoS12(id, publish)),
     ]

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -11,7 +11,7 @@ use tracing_futures::Instrument;
 
 use crate::{
     auth::{Authenticator, Authorizer},
-    broker::{Broker, BrokerHandle},
+    broker::{BrokerHandle, BrokerRunner},
     connection::{
         self, MakeIncomingPacketProcessor, MakeMqttPacketProcessor, MakeOutgoingPacketProcessor,
     },
@@ -24,7 +24,7 @@ pub struct Server<Z, P>
 where
     Z: Authorizer,
 {
-    broker: Broker<Z>,
+    broker: BrokerRunner<Z>,
     #[allow(clippy::type_complexity)]
     transports: Vec<(
         BoxFuture<'static, Result<Transport, InitializeBrokerError>>,
@@ -37,7 +37,7 @@ impl<Z> Server<Z, MakeMqttPacketProcessor>
 where
     Z: Authorizer + Send + 'static,
 {
-    pub fn from_broker(broker: Broker<Z>) -> Self {
+    pub fn from_broker(broker: BrokerRunner<Z>) -> Self {
         Self {
             broker,
             transports: Vec::new(),

--- a/mqtt/mqtt-broker/src/session/connected.rs
+++ b/mqtt/mqtt-broker/src/session/connected.rs
@@ -110,6 +110,10 @@ impl ConnectedSession {
         self.state.publish_to(publication)
     }
 
+    pub fn try_publish(&mut self) -> Result<Option<ClientEvent>, Error> {
+        self.state.try_publish()
+    }
+
     pub fn subscribe_to(
         &mut self,
         subscribe_to: proto::SubscribeTo,

--- a/mqtt/mqtt-broker/src/session/connected.rs
+++ b/mqtt/mqtt-broker/src/session/connected.rs
@@ -78,13 +78,6 @@ impl ConnectedSession {
         self.state.handle_puback(puback)
     }
 
-    pub fn handle_puback0(
-        &mut self,
-        id: proto::PacketIdentifier,
-    ) -> Result<Option<ClientEvent>, Error> {
-        self.state.handle_puback0(id)
-    }
-
     pub fn handle_pubrec(&mut self, pubrec: &proto::PubRec) -> Result<Option<ClientEvent>, Error> {
         self.state.handle_pubrec(pubrec)
     }
@@ -112,6 +105,10 @@ impl ConnectedSession {
 
     pub fn try_publish(&mut self) -> Result<Option<ClientEvent>, Error> {
         self.state.try_publish()
+    }
+
+    pub fn queued_messages(&self) -> usize {
+        self.state.queued_messages()
     }
 
     pub fn subscribe_to(

--- a/mqtt/mqtt-broker/src/session/mod.rs
+++ b/mqtt/mqtt-broker/src/session/mod.rs
@@ -113,18 +113,6 @@ impl Session {
         }
     }
 
-    pub fn handle_puback0(
-        &mut self,
-        id: proto::PacketIdentifier,
-    ) -> Result<Option<ClientEvent>, Error> {
-        match self {
-            Self::Transient(connected) => connected.handle_puback0(id),
-            Self::Persistent(connected) => connected.handle_puback0(id),
-            Self::Offline(_offline) => Err(Error::SessionOffline),
-            Self::Disconnecting(_) => Err(Error::SessionOffline),
-        }
-    }
-
     pub fn handle_pubrec(&mut self, pubrec: &proto::PubRec) -> Result<Option<ClientEvent>, Error> {
         match self {
             Self::Transient(connected) => connected.handle_pubrec(pubrec),

--- a/mqtt/mqtt-broker/src/session/offline.rs
+++ b/mqtt/mqtt-broker/src/session/offline.rs
@@ -43,12 +43,6 @@ impl OfflineSession {
         let mut events = Vec::new();
         let OfflineSession { mut state } = self;
 
-        // Drop all outstanding QoS 0 packets
-        if !state.waiting_to_be_acked_qos0_mut().is_empty() {
-            debug!("dropping all QoS0 packet");
-            state.waiting_to_be_acked_qos0_mut().clear();
-        }
-
         // Handle the outstanding QoS 1 and QoS 2 packets
         for (id, publish) in state.waiting_to_be_acked() {
             let to_publish = match publish {

--- a/mqtt/mqtt-broker/src/session/state/mod.rs
+++ b/mqtt/mqtt-broker/src/session/state/mod.rs
@@ -243,7 +243,7 @@ impl SessionState {
         self.try_publish()
     }
 
-    fn try_publish(&mut self) -> Result<Option<ClientEvent>, Error> {
+    pub(super) fn try_publish(&mut self) -> Result<Option<ClientEvent>, Error> {
         if self.allowed_to_send() {
             if let Some(publication) = self.waiting_to_be_sent.dequeue() {
                 let event = self.prepare_to_send(&publication)?;

--- a/mqtt/mqtt-broker/src/session/state/mod.rs
+++ b/mqtt/mqtt-broker/src/session/state/mod.rs
@@ -6,7 +6,7 @@ use map::SmallIndexMap;
 use queue::BoundedQueue;
 use set::SmallIndexSet;
 
-use std::{cmp, collections::HashMap, sync::Arc};
+use std::{cmp, collections::HashMap};
 
 use tracing::{debug, info};
 
@@ -34,7 +34,7 @@ pub struct SessionState {
     waiting_to_be_acked: SmallIndexMap<proto::PacketIdentifier, Publish>,
     waiting_to_be_completed: SmallIndexSet<proto::PacketIdentifier>,
     config: SessionConfig,
-    publish_permits: Arc<PublishPermits>,
+    publish_permits: PublishPermits,
 }
 
 impl SessionState {
@@ -54,7 +54,7 @@ impl SessionState {
             waiting_to_be_released: SmallIndexMap::new(),
             waiting_to_be_completed: SmallIndexSet::new(),
             config,
-            publish_permits: Arc::new(PublishPermits::new(32)), // todo make it always greater than max_inflight_messages
+            publish_permits: PublishPermits::new(32), // todo make it always greater than max_inflight_messages
         }
     }
 
@@ -78,7 +78,7 @@ impl SessionState {
             waiting_to_be_completed: SmallIndexSet::new(),
             packet_identifiers_qos0: PacketIdentifiers::default(),
             config,
-            publish_permits: Arc::new(PublishPermits::new(32)),
+            publish_permits: PublishPermits::new(32),
         }
     }
 
@@ -259,7 +259,7 @@ impl SessionState {
     }
 
     pub(super) fn acquire_publish_permit(&self) -> Option<PublishPermit> {
-        self.publish_permits.clone().acquire()
+        self.publish_permits.acquire()
     }
 
     fn filter(&self, mut publication: proto::Publication) -> Option<proto::Publication> {

--- a/mqtt/mqtt-broker/src/session/state/queue.rs
+++ b/mqtt/mqtt-broker/src/session/state/queue.rs
@@ -76,7 +76,6 @@ impl BoundedQueue {
         None
     }
 
-    #[cfg(test)]
     pub fn len(&self) -> usize {
         self.inner.len()
     }

--- a/mqtt/mqtt-broker/tests/broker_model.rs
+++ b/mqtt/mqtt-broker/tests/broker_model.rs
@@ -37,7 +37,10 @@ proptest! {
 }
 
 async fn test_broker_manages_sessions(events: impl IntoIterator<Item = BrokerEvent>) {
-    let mut broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
+    let mut broker = BrokerBuilder::default()
+        .with_authorizer(AllowAll)
+        .build()
+        .into_broker();
 
     let mut model = BrokerModel::default();
 
@@ -46,7 +49,7 @@ async fn test_broker_manages_sessions(events: impl IntoIterator<Item = BrokerEve
         let (client_id, broker_event, model_event) = into_events(event, &mut clients);
 
         broker
-            .process_message(client_id.clone(), broker_event)
+            .process_client_event(client_id.clone(), broker_event)
             .expect("process message");
 
         model.process_message(client_id, model_event);

--- a/mqtt/mqtt-edgehub/src/connection.rs
+++ b/mqtt/mqtt-edgehub/src/connection.rs
@@ -58,13 +58,10 @@ impl<P> OutgoingPacketProcessor for EdgeHubPacketProcessor<P>
 where
     P: OutgoingPacketProcessor + Send,
 {
-    async fn process(
-        &mut self,
-        mut message: Message,
-    ) -> PacketAction<Option<(Packet, Option<Message>)>, ()> {
+    async fn process(&mut self, mut message: Message) -> PacketAction<Option<Packet>, ()> {
         match &mut message {
-            Message::Client(_, ClientEvent::PublishTo(Publish::QoS12(_id, publish)))
-            | Message::Client(_, ClientEvent::PublishTo(Publish::QoS0(_id, publish))) => {
+            Message::Client(_, ClientEvent::PublishTo(Publish::QoS12(_, publish)))
+            | Message::Client(_, ClientEvent::PublishTo(Publish::QoS0(publish))) => {
                 translate_outgoing_publish(publish);
             }
             _ => (),

--- a/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
@@ -15,7 +15,7 @@ use tokio::time;
 use tracing::{info, warn};
 
 use mqtt_broker::{
-    auth::Authorizer, Broker, BrokerBuilder, BrokerConfig, BrokerSnapshot, Server,
+    auth::Authorizer, BrokerBuilder, BrokerConfig, BrokerRunner, BrokerSnapshot, Server,
     ServerCertificate,
 };
 use mqtt_edgehub::{
@@ -42,7 +42,7 @@ where
 pub async fn broker(
     config: &BrokerConfig,
     state: Option<BrokerSnapshot>,
-) -> Result<Broker<LocalAuthorizer<EdgeHubAuthorizer>>> {
+) -> Result<BrokerRunner<LocalAuthorizer<EdgeHubAuthorizer>>> {
     let broker = BrokerBuilder::default()
         .with_authorizer(LocalAuthorizer::new(EdgeHubAuthorizer::default()))
         .with_state(state.unwrap_or_default())
@@ -54,7 +54,7 @@ pub async fn broker(
 
 pub async fn start_server<Z, F>(
     config: Settings,
-    broker: Broker<Z>,
+    broker: BrokerRunner<Z>,
     shutdown_signal: F,
 ) -> Result<BrokerSnapshot>
 where

--- a/mqtt/mqttd/src/broker/bootstrap/generic.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/generic.rs
@@ -9,7 +9,7 @@ use tracing::info;
 use mqtt_broker::{
     auth::{authenticate_fn_ok, AllowAll, Authorizer},
     settings::BrokerConfig,
-    AuthId, Broker, BrokerBuilder, BrokerSnapshot, Error, Server, ServerCertificate,
+    AuthId, BrokerRunner, BrokerBuilder, BrokerSnapshot, Error, Server, ServerCertificate,
 };
 use mqtt_generic::settings::{CertificateConfig, Settings};
 
@@ -31,7 +31,7 @@ where
 pub async fn broker(
     config: &BrokerConfig,
     state: Option<BrokerSnapshot>,
-) -> Result<Broker<impl Authorizer>, Error> {
+) -> Result<BrokerRunner<impl Authorizer>, Error> {
     let broker = BrokerBuilder::default()
         .with_authorizer(AllowAll)
         .with_state(state.unwrap_or_default())
@@ -43,7 +43,7 @@ pub async fn broker(
 
 pub async fn start_server<Z, F>(
     config: Settings,
-    broker: Broker<Z>,
+    broker: BrokerRunner<Z>,
     shutdown_signal: F,
 ) -> Result<BrokerSnapshot>
 where


### PR DESCRIPTION
TODO: limit numbers of all messages in-transit from broker to connection.