### PR TITLE
Add logic for image configuration in image-linux.sh

### DIFF
--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -299,16 +299,19 @@ jobs:
           imageName: azureiotedge-agent
           name: "Edge Agent"
           project: Microsoft.Azure.Devices.Edge.Agent.Service
+          version: ${{ parameters.version }} 
       - template: templates/image-linux.yaml
         parameters: 
           imageName: azureiotedge-hub
           name: "Edge Hub"
           project: Microsoft.Azure.Devices.Edge.Hub.Service
+          version: ${{ parameters.version }} 
       - template: templates/image-linux.yaml
         parameters: 
           imageName: azureiotedge-simulated-temperature-sensor
           name: "Temperature Sensor"
           project: SimulatedTemperatureSensor
+          version: ${{ parameters.version }} 
       - bash: |
             scripts/linux/buildEdgelet.sh -i azureiotedge-diagnostics -n microsoft -P iotedge-diagnostics -c $(configuration) &&
             scripts/linux/buildImage.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -i azureiotedge-diagnostics -n $(namespace) -P azureiotedge-diagnostics

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -608,7 +608,7 @@ jobs:
 ################################################################################
   - job: manifest
 ################################################################################
-    displayName: Manifest
+    displayName: Publish Manifest Images
     pool:
       vmImage: 'ubuntu-16.04'
     dependsOn:

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -605,3 +605,21 @@ jobs:
         inputs: 
           ArtifactName: publish-win
           PathtoPublish: $(Build.BinariesDirectory)\publish
+################################################################################
+  - job: manifest
+################################################################################
+    displayName: Manifest
+    pool:
+      vmImage: 'ubuntu-16.04'
+    dependsOn:
+      - linux_dotnet_projects
+      - windows
+    steps:
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -u '$(registry.user)' -p '$(registry.password)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edgelet/iotedge-diagnostics/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish azureiotedge-diagnostics Manifest'
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n $(namespace) --tags "$(tags)"
+      displayName: 'Publish Edge Agent Manifest'
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n $(namespace) --tags "$(tags)"
+      displayName: 'Publish Edge Hub Manifest'
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n $(namespace) --tags "$(tags)"
+      displayName: 'Publish Temperature Sensor Manifest'

--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -3,21 +3,22 @@ parameters:
   imageName: ''
   namespace: 'microsoft'
   project: ''
+  version: '$(Build.BuildNumber)'
 
 steps:
   - task: Bash@3
     displayName: Build Image - ${{ parameters.name }} - amd64
     inputs:
       filePath: scripts/linux/buildImage.sh
-      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }}
+      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }} -v ${{ parameters.version }}
   - task: Bash@3
     displayName: Build Image - ${{ parameters.name }} - arm32
     inputs:
       filePath: scripts/linux/buildImage.sh
-      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }} --target-arch armv7l
+      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }} --target-arch armv7l -v ${{ parameters.version }}
   - task: Bash@3
     displayName: Build Image - ${{ parameters.name }} - arm64 
     condition: and(ne('${{ parameters.name }}', 'Functions Sample'), succeeded())
     inputs:
       filePath: scripts/linux/buildImage.sh
-      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }} --target-arch aarch64
+      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }} --target-arch aarch64 -v ${{ parameters.version }}


### PR DESCRIPTION
The release build isn't working because we switched to using existing templates when converting to yaml. The existing template for linux does not use the pipeline's version parameter. We can fix this by changing the template to accept this parameter and passing it into the script.