### PR TITLE
Correct Image Tagging & Manifest Publication on "Azure-IoT-Edge-Core Images Release YAML" Pipeline

### DIFF
--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -299,16 +299,19 @@ jobs:
           imageName: azureiotedge-agent
           name: "Edge Agent"
           project: Microsoft.Azure.Devices.Edge.Agent.Service
+          version: $(version)
       - template: templates/image-linux.yaml
         parameters: 
           imageName: azureiotedge-hub
           name: "Edge Hub"
           project: Microsoft.Azure.Devices.Edge.Hub.Service
+          version: $(version)
       - template: templates/image-linux.yaml
         parameters: 
           imageName: azureiotedge-simulated-temperature-sensor
           name: "Temperature Sensor"
           project: SimulatedTemperatureSensor
+          version: $(version)
       - bash: |
             scripts/linux/buildEdgelet.sh -i azureiotedge-diagnostics -n microsoft -P iotedge-diagnostics -c $(configuration) &&
             scripts/linux/buildImage.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -i azureiotedge-diagnostics -n $(namespace) -P azureiotedge-diagnostics
@@ -605,3 +608,21 @@ jobs:
         inputs: 
           ArtifactName: publish-win
           PathtoPublish: $(Build.BinariesDirectory)\publish
+################################################################################
+  - job: manifest
+################################################################################
+    displayName: Publish Manifest Images
+    pool:
+      vmImage: 'ubuntu-16.04'
+    dependsOn:
+      - linux_dotnet_projects
+      - windows
+    steps:
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -u '$(registry.user)' -p '$(registry.password)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edgelet/iotedge-diagnostics/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish azureiotedge-diagnostics Manifest'
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -u '$(registry.user)' -p '$(registry.password)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish Edge Agent Manifest'
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -u '$(registry.user)' -p '$(registry.password)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish Edge Hub Manifest'
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -u '$(registry.user)' -p '$(registry.password)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish Temperature Sensor Manifest'

--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -3,21 +3,22 @@ parameters:
   imageName: ''
   namespace: 'microsoft'
   project: ''
+  version: ''
 
 steps:
   - task: Bash@3
     displayName: Build Image - ${{ parameters.name }} - amd64
     inputs:
       filePath: scripts/linux/buildImage.sh
-      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }}
+      arguments: -r "$(registry.address)" -u "$(registry.user)" -p "$(registry.password)" -i "${{ parameters.imageName }}" -n "${{ parameters.namespace }}" -P "${{ parameters.project }}" -v "${{ parameters.version }}"
   - task: Bash@3
     displayName: Build Image - ${{ parameters.name }} - arm32
     inputs:
       filePath: scripts/linux/buildImage.sh
-      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }} --target-arch armv7l
+      arguments: -r "$(registry.address)" -u "$(registry.user)" -p "$(registry.password)" -i "${{ parameters.imageName }}" -n "${{ parameters.namespace }}" -P "${{ parameters.project }}" -v "${{ parameters.version }}" --target-arch armv7l
   - task: Bash@3
     displayName: Build Image - ${{ parameters.name }} - arm64 
     condition: and(ne('${{ parameters.name }}', 'Functions Sample'), succeeded())
     inputs:
       filePath: scripts/linux/buildImage.sh
-      arguments: -r $(registry.address) -u $(registry.user) -p $(registry.password) -i ${{ parameters.imageName }} -n ${{ parameters.namespace }} -P ${{ parameters.project }} --target-arch aarch64
+      arguments: -r "$(registry.address)" -u "$(registry.user)" -p "$(registry.password)" -i "${{ parameters.imageName }}" -n "${{ parameters.namespace }}" -P "${{ parameters.project }}" -v "${{ parameters.version }}" --target-arch aarch64


### PR DESCRIPTION
Correct Image Tagging & Manifest Publication on "Azure-IoT-Edge-Core Images Release YAML" Pipeline.

Currently the "Azure-IoT-Edge-Core Images Release YAML" Pipeline incorrectly tags a releasing image with a BuildNumber causing the manifest publication step to fail when it tries to pull the published image to generate a manifest.

Cherry-picked: https://github.com/Azure/iotedge/commit/c92d5870aeeb67a51d9efe81393a49458ef56db3