### PR TITLE
add ms_telemetry to edgehub metrics

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/ModuleMessageLinkHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/ModuleMessageLinkHandler.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
             static readonly IMetricsCounter MessagesMeter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "messages_sent",
                 "Messages sent to module",
-                new List<string> { "from", "to", "from_route_output", "to_route_input", "priority" });
+                new List<string> { "from", "to", "from_route_output", "to_route_input", "priority", "ms_telemetry" });
 
             public static void AddMessage(IIdentity identity, IMessage message)
             {
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
                 string fromRouteOutput = message.GetOutput();
                 string toRouteInput = message.GetInput();
                 uint priority = message.ProcessedPriority;
-                MessagesMeter.Increment(1, new[] { from, to, fromRouteOutput, toRouteInput, priority.ToString() });
+                MessagesMeter.Increment(1, new[] { from, to, fromRouteOutput, toRouteInput, priority.ToString(), true.ToString() });
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
@@ -624,57 +624,57 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             static readonly IMetricsTimer MessagesTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "message_send_duration_seconds",
                 "Time taken to send a message",
-                new List<string> { "from", "to", "from_route_output", "to_route_input" });
+                new List<string> { "from", "to", "from_route_output", "to_route_input", "ms_telemetry" });
 
             static readonly IMetricsCounter SentMessagesCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "messages_sent",
                 "Messages sent from edge hub",
-                new List<string> { "from", "to", "from_route_output", "to_route_input", "priority" });
+                new List<string> { "from", "to", "from_route_output", "to_route_input", "priority", "ms_telemetry" });
 
             static readonly IMetricsTimer GetTwinTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "gettwin_duration_seconds",
                 "Time taken to get twin",
-                new List<string> { "source", "id" });
+                new List<string> { "source", "id", "ms_telemetry" });
 
             static readonly IMetricsCounter GetTwinCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "gettwin",
                 "Get twin calls",
-                new List<string> { "source", "id" });
+                new List<string> { "source", "id", "ms_telemetry" });
 
             static readonly IMetricsTimer ReportedPropertiesTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "reported_properties_update_duration_seconds",
                 "Time taken to update reported properties",
-                new List<string> { "target", "id" });
+                new List<string> { "target", "id", "ms_telemetry" });
 
             static readonly IMetricsCounter ReportedPropertiesCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "reported_properties",
                 "Reported properties update calls",
-                new List<string> { "target", "id" });
+                new List<string> { "target", "id", "ms_telemetry" });
 
             static readonly IMetricsTimer DirectMethodsTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "direct_method_duration_seconds",
                 "Time taken to call direct method",
-                new List<string> { "from", "to" });
+                new List<string> { "from", "to", "ms_telemetry" });
 
             static readonly IMetricsDuration MessagesProcessLatency = Util.Metrics.Metrics.Instance.CreateDuration(
                 "message_process_duration",
                 "Time taken to process message in EdgeHub",
-                new List<string> { "from", "to", "priority" });
+                new List<string> { "from", "to", "priority", "ms_telemetry" });
 
-            public static IDisposable TimeMessageSend(string id, string fromRoute) => MessagesTimer.GetTimer(new[] { id, "upstream", fromRoute, string.Empty });
+            public static IDisposable TimeMessageSend(string id, string fromRoute) => MessagesTimer.GetTimer(new[] { id, "upstream", fromRoute, string.Empty, true.ToString() });
 
             public static void AddSentMessages(string id, int count, string fromRoute, uint priority) =>
-                SentMessagesCounter.Increment(count, new[] { id, "upstream", fromRoute, string.Empty, priority.ToString() });
+                SentMessagesCounter.Increment(count, new[] { id, "upstream", fromRoute, string.Empty, priority.ToString(), true.ToString() });
 
-            public static IDisposable TimeGetTwin(string id) => GetTwinTimer.GetTimer(new[] { "upstream", id });
+            public static IDisposable TimeGetTwin(string id) => GetTwinTimer.GetTimer(new[] { "upstream", id, true.ToString() });
 
-            public static void AddGetTwin(string id) => GetTwinCounter.Increment(1, new[] { "upstream", id });
+            public static void AddGetTwin(string id) => GetTwinCounter.Increment(1, new[] { "upstream", id, true.ToString() });
 
-            public static IDisposable TimeReportedPropertiesUpdate(string id) => ReportedPropertiesTimer.GetTimer(new[] { "upstream", id });
+            public static IDisposable TimeReportedPropertiesUpdate(string id) => ReportedPropertiesTimer.GetTimer(new[] { "upstream", id, true.ToString() });
 
-            public static void AddUpdateReportedProperties(string id) => ReportedPropertiesCounter.Increment(1, new[] { "upstream", id });
+            public static void AddUpdateReportedProperties(string id) => ReportedPropertiesCounter.Increment(1, new[] { "upstream", id, true.ToString() });
 
-            public static IDisposable TimeDirectMethod(string id) => DirectMethodsTimer.GetTimer(new[] { "upstream", id });
+            public static IDisposable TimeDirectMethod(string id) => DirectMethodsTimer.GetTimer(new[] { "upstream", id, true.ToString() });
 
             public static void MessageProcessingLatency(string id, IMessage message)
             {
@@ -686,7 +686,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                     string priority = message.ProcessedPriority.ToString();
                     MessagesProcessLatency.Set(
                         duration.TotalSeconds,
-                        new[] { id, "upstream", priority });
+                        new[] { id, "upstream", priority, true.ToString() });
                 }
             }
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -490,47 +490,47 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
             static readonly IMetricsTimer MessagesTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "message_send_duration_seconds",
                 "Time taken to send a message",
-                new List<string> { "from", "to", "from_route_output", "to_route_input" });
+                new List<string> { "from", "to", "from_route_output", "to_route_input", "ms_telemetry" });
 
             static readonly IMetricsTimer GetTwinTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "gettwin_duration_seconds",
                 "Time taken to get twin",
-                new List<string> { "source", "id" });
+                new List<string> { "source", "id", "ms_telemetry" });
 
             static readonly IMetricsCounter GetTwinCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "gettwin",
                 "Get twin calls",
-                new List<string> { "source", "id" });
+                new List<string> { "source", "id", "ms_telemetry" });
 
             static readonly IMetricsTimer ReportedPropertiesTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "reported_properties_update_duration_seconds",
                 "Time taken to update reported properties",
-                new List<string> { "target", "id" });
+                new List<string> { "target", "id", "ms_telemetry" });
 
             static readonly IMetricsCounter ReportedPropertiesCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "reported_properties",
                 "Reported properties update calls",
-                new List<string> { "target", "id" });
+                new List<string> { "target", "id", "ms_telemetry" });
 
             static readonly IMetricsDuration MessagesProcessLatency = Util.Metrics.Metrics.Instance.CreateDuration(
                 "message_process_duration",
                 "Time taken to process message in EdgeHub",
-                new List<string> { "from", "to", "priority" });
+                new List<string> { "from", "to", "priority", "ms_telemetry" });
 
             public static IDisposable TimeMessageSend(IIdentity identity, IMessage message, string fromRoute, string toRoute)
             {
                 string from = message.GetSenderId();
                 string to = identity.Id;
-                return MessagesTimer.GetTimer(new[] { from, to, fromRoute, toRoute });
+                return MessagesTimer.GetTimer(new[] { from, to, fromRoute, toRoute, true.ToString() });
             }
 
-            public static IDisposable TimeGetTwin(string id) => GetTwinTimer.GetTimer(new[] { "edge_hub", id });
+            public static IDisposable TimeGetTwin(string id) => GetTwinTimer.GetTimer(new[] { "edge_hub", id, true.ToString() });
 
-            public static void AddGetTwin(string id) => GetTwinCounter.Increment(1, new[] { "edge_hub", id });
+            public static void AddGetTwin(string id) => GetTwinCounter.Increment(1, new[] { "edge_hub", id, true.ToString() });
 
-            public static IDisposable TimeReportedPropertiesUpdate(string id) => ReportedPropertiesTimer.GetTimer(new[] { "edge_hub", id });
+            public static IDisposable TimeReportedPropertiesUpdate(string id) => ReportedPropertiesTimer.GetTimer(new[] { "edge_hub", id, true.ToString() });
 
-            public static void AddUpdateReportedProperties(string id) => ReportedPropertiesCounter.Increment(1, new[] { "edge_hub", id });
+            public static void AddUpdateReportedProperties(string id) => ReportedPropertiesCounter.Increment(1, new[] { "edge_hub", id, true.ToString() });
 
             public static void MessageProcessingLatency(IIdentity identity, IMessage message)
             {
@@ -544,7 +544,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
                     TimeSpan duration = DateTime.UtcNow - enqueuedTime.ToUniversalTime();
                     MessagesProcessLatency.Set(
                         duration.TotalSeconds,
-                        new[] { from, to, priority });
+                        new[] { from, to, priority, true.ToString() });
                 }
             }
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -267,23 +267,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             static readonly IMetricsHistogram MessagesHistogram = Util.Metrics.Metrics.Instance.CreateHistogram(
                 "message_size_bytes",
                 "Size of messages received by EdgeHub",
-                new List<string> { "id" });
+                new List<string> { "id", "ms_telemetry" });
 
             static readonly IMetricsCounter DirectMethodsCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "direct_methods",
                 "Direct methods routed through EdgeHub",
-                new List<string> { "from", "to" });
+                new List<string> { "from", "to", "ms_telemetry" });
 
             static readonly IMetricsCounter ReceivedMessagesCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "messages_received",
                 "Number of messages received from client",
-                new List<string> { "id", "route_output" });
+                new List<string> { "id", "route_output", "ms_telemetry" });
 
-            public static void AddMessageSize(long size, string id) => MessagesHistogram.Update(size, new[] { id });
+            public static void AddMessageSize(long size, string id) => MessagesHistogram.Update(size, new[] { id, true.ToString() });
 
-            public static void AddDirectMethod(string fromId, string toId) => DirectMethodsCounter.Increment(1, new[] { fromId, toId });
+            public static void AddDirectMethod(string fromId, string toId) => DirectMethodsCounter.Increment(1, new[] { fromId, toId, true.ToString() });
 
-            public static void AddReceivedMessage(string id, string output) => ReceivedMessagesCounter.Increment(1, new[] { id, output });
+            public static void AddReceivedMessage(string id, string output) => ReceivedMessagesCounter.Increment(1, new[] { id, output, true.ToString() });
         }
 
         static class MetricsV0

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/TwinsController.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/TwinsController.cs
@@ -135,9 +135,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             static readonly IMetricsTimer DirectMethodsTimer = Util.Metrics.Metrics.Instance.CreateTimer(
                 "direct_method_duration_seconds",
                 "Time taken to call direct method",
-                new List<string> { "from", "to" });
+                new List<string> { "from", "to", "ms_telemetry" });
 
-            public static IDisposable TimeDirectMethod(string fromId, string toId) => DirectMethodsTimer.GetTimer(new[] { fromId, toId });
+            public static IDisposable TimeDirectMethod(string fromId, string toId) => DirectMethodsTimer.GetTimer(new[] { fromId, toId, true.ToString() });
         }
     }
 }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceProxy.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceProxy.cs
@@ -164,7 +164,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             static readonly IMetricsCounter SentMessagesCounter = Util.Metrics.Metrics.Instance.CreateCounter(
                 "messages_sent",
                 "Messages sent from edge hub",
-                new List<string> { "from", "to", "from_route_output", "to_route_input", "priority" });
+                new List<string> { "from", "to", "from_route_output", "to_route_input", "priority", "ms_telemetry" });
 
             public static void AddSentMessage(IIdentity identity, IMessage message)
             {
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 string fromRouteOutput = message.GetOutput();
                 string toRouteInput = message.GetInput();
                 string priority = message.ProcessedPriority.ToString();
-                SentMessagesCounter.Increment(1, new[] { from, to, fromRouteOutput, toRouteInput, priority });
+                SentMessagesCounter.Increment(1, new[] { from, to, fromRouteOutput, toRouteInput, priority, true.ToString() });
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/checkpointers/Checkpointer.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/checkpointers/Checkpointer.cs
@@ -201,9 +201,9 @@ namespace Microsoft.Azure.Devices.Routing.Core.Checkpointers
             static readonly IMetricsGauge QueueLength = EdgeMetrics.Instance.CreateGauge(
                 "queue_length",
                 "Number of messages pending to be processed for the endpoint",
-                new List<string> { "endpoint", "priority" });
+                new List<string> { "endpoint", "priority", "ms_telemetry" });
 
-            public static void SetQueueLength(Checkpointer checkpointer) => QueueLength.Set(checkpointer.Proposed - checkpointer.Offset, new[] { checkpointer.EndpointId, checkpointer.Priority });
+            public static void SetQueueLength(Checkpointer checkpointer) => QueueLength.Set(checkpointer.Proposed - checkpointer.Offset, new[] { checkpointer.EndpointId, checkpointer.Priority, true.ToString() });
         }
     }
 }


### PR DESCRIPTION
Add ms_telemetry tag to edgehub metrics. This tag tells edgeAgent whether it should upload the metric through internal channels or not.