### PR TITLE
fix sas token generation

### DIFF
--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -235,9 +235,8 @@ hostname: "<ADD HOSTNAME HERE>"
 # Optional. This entry should only be specified for the host name of the 
 # parent edge device for nested edge sceanrio. This value is injected into 
 # Edge Agent and Edge Hub modules as environment value 'IOTEDGE_GATEWAYHOSTNAME',
-# and injected into custom module as environment value 'IOTEDGE_PARENTHOSTNAME'.
-# Regardless of case the parent_hostname is specified below, a lower case value
-# is used.
+# and injected into other module as environment value 'IOTEDGE_PARENTHOSTNAME'.
+# The parent_hostname value is converted to lower case before it is used.
 ###############################################################################
 
 #parent_hostname: "<ADD PARENT HOSTNAME HERE>"

--- a/edgelet/contrib/config/linux/debian/config.yaml
+++ b/edgelet/contrib/config/linux/debian/config.yaml
@@ -230,9 +230,8 @@ hostname: "<ADD HOSTNAME HERE>"
 # Optional. This entry should only be specified for the host name of the 
 # parent edge device for nested edge sceanrio. This value is injected into 
 # Edge Agent and Edge Hub modules as environment value 'IOTEDGE_GATEWAYHOSTNAME',
-# and injected into custom module as environment value 'IOTEDGE_PARENTHOSTNAME'.
-# Regardless of case the parent_hostname is specified below, a lower case value
-# is used.
+# and injected into other module as environment value 'IOTEDGE_PARENTHOSTNAME'.
+# The parent_hostname value is converted to lower case before it is used.
 ###############################################################################
 
 #parent_hostname: "<ADD PARENT HOSTNAME HERE>"

--- a/edgelet/contrib/config/linux/debian/config.yaml
+++ b/edgelet/contrib/config/linux/debian/config.yaml
@@ -224,6 +224,20 @@ agent:
 hostname: "<ADD HOSTNAME HERE>"
 
 ###############################################################################
+# Nested Edge parent hostname
+###############################################################################
+#
+# Optional. This entry should only be specified for the host name of the 
+# parent edge device for nested edge sceanrio. This value is injected into 
+# Edge Agent and Edge Hub modules as environment value 'IOTEDGE_GATEWAYHOSTNAME',
+# and injected into custom module as environment value 'IOTEDGE_PARENTHOSTNAME'.
+# Regardless of case the parent_hostname is specified below, a lower case value
+# is used.
+###############################################################################
+
+#parent_hostname: "<ADD PARENT HOSTNAME HERE>"
+
+###############################################################################
 # Watchdog settings
 ###############################################################################
 #

--- a/edgelet/edgelet-core/src/workload.rs
+++ b/edgelet/edgelet-core/src/workload.rs
@@ -5,7 +5,8 @@ use crate::certificate_properties::CertificateType;
 /// Trait to obtain configuration data needed by any implementation of the workload interface
 /// for module identity and certificate management.
 pub trait WorkloadConfig {
-    fn upstream_hostname(&self) -> &str;
+    fn iot_hub_name(&self) -> &str;
+    fn parent_hostname(&self) -> Option<&str>;
     fn device_id(&self) -> &str;
     fn get_cert_max_duration(&self, cert_type: CertificateType) -> i64;
 }

--- a/edgelet/edgelet-http-workload/src/server/cert/identity.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/identity.rs
@@ -49,7 +49,7 @@ where
                 let cn = module_id.to_string();
                 let alias = format!("{}identity", module_id);
                 let module_uri =
-                    prepare_cert_uri_module(cfg.upstream_hostname(), cfg.device_id(), module_id);
+                    prepare_cert_uri_module(cfg.iot_hub_name(), cfg.device_id(), module_id);
 
                 req.into_body().concat2().then(|body| {
                     let body =
@@ -163,7 +163,8 @@ mod tests {
     }
 
     struct TestWorkloadConfig {
-        upstream_hostname: String,
+        iot_hub_name: String,
+        parent_hostname: Option<String>,
         device_id: String,
         duration: i64,
     }
@@ -174,7 +175,8 @@ mod tests {
             assert!(MAX_DURATION_SEC < (i64::max_value() as u64));
 
             TestWorkloadConfig {
-                upstream_hostname: String::from("zaphods_hub"),
+                iot_hub_name: String::from("zaphods_hub"),
+                parent_hostname: None,
                 device_id: String::from("marvins_device"),
                 duration: MAX_DURATION_SEC as i64,
             }
@@ -195,8 +197,12 @@ mod tests {
     }
 
     impl WorkloadConfig for TestWorkloadData {
-        fn upstream_hostname(&self) -> &str {
-            self.data.upstream_hostname.as_str()
+        fn iot_hub_name(&self) -> &str {
+            self.data.iot_hub_name.as_str()
+        }
+
+        fn parent_hostname(&self) -> Option<&str> {
+            self.data.parent_hostname.as_deref()
         }
 
         fn device_id(&self) -> &str {

--- a/edgelet/edgelet-http-workload/src/server/cert/server.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/server.rs
@@ -174,7 +174,8 @@ mod tests {
     }
 
     struct TestWorkloadConfig {
-        upstream_hostname: String,
+        iot_hub_name: String,
+        parent_hostname: Option<String>,
         device_id: String,
         duration: i64,
     }
@@ -185,7 +186,8 @@ mod tests {
             assert!(MAX_DURATION_SEC < (i64::max_value() as u64));
 
             TestWorkloadConfig {
-                upstream_hostname: String::from("zaphods_hub"),
+                iot_hub_name: String::from("zaphods_hub"),
+                parent_hostname: None,
                 device_id: String::from("marvins_device"),
                 duration: MAX_DURATION_SEC as i64,
             }
@@ -206,8 +208,12 @@ mod tests {
     }
 
     impl WorkloadConfig for TestWorkloadData {
-        fn upstream_hostname(&self) -> &str {
-            self.data.upstream_hostname.as_str()
+        fn iot_hub_name(&self) -> &str {
+            self.data.iot_hub_name.as_str()
+        }
+
+        fn parent_hostname(&self) -> Option<&str> {
+            self.data.parent_hostname.as_deref()
         }
 
         fn device_id(&self) -> &str {

--- a/edgelet/edgelet-http-workload/tests/dns-san.rs
+++ b/edgelet/edgelet-http-workload/tests/dns-san.rs
@@ -65,14 +65,19 @@ impl<'a> From<&'a Error> for ModuleRuntimeErrorReason {
 
 #[derive(Clone)]
 struct Config {
-    upstream_hostname: String,
+    iot_hub_name: String,
+    parent_hostname: Option<String>,
     device_id: String,
     cert_max_duration: i64,
 }
 
 impl WorkloadConfig for Config {
-    fn upstream_hostname(&self) -> &str {
-        &self.upstream_hostname
+    fn iot_hub_name(&self) -> &str {
+        &self.iot_hub_name
+    }
+
+    fn parent_hostname(&self) -> Option<&str> {
+        &self.parent_hostname
     }
 
     fn device_id(&self) -> &str {
@@ -175,7 +180,8 @@ fn create_workload_service(module_id: &str) -> (WorkloadService, Crypto) {
         Ok(ModuleRuntimeState::default().with_status(ModuleStatus::Running)),
     )));
     let config = Config {
-        upstream_hostname: "hub1".to_string(),
+        iot_hub_name: "hub1".to_string(),
+        parent_hostname: None,
         device_id: "d1".to_string(),
         cert_max_duration: 10_000_000,
     };

--- a/edgelet/edgelet-http-workload/tests/dns-san.rs
+++ b/edgelet/edgelet-http-workload/tests/dns-san.rs
@@ -77,7 +77,7 @@ impl WorkloadConfig for Config {
     }
 
     fn parent_hostname(&self) -> Option<&str> {
-        &self.parent_hostname
+        self.parent_hostname.as_deref()
     }
 
     fn device_id(&self) -> &str {

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -362,7 +362,8 @@ where
                 )?;
 
                 let cfg = WorkloadData::new(
-                    (&settings.parent_hostname().unwrap_or($provisioning_result.hub_name())).to_string(),
+                    $provisioning_result.hub_name().to_string(),
+                    settings.parent_hostname().map(String::from),
                     $provisioning_result.device_id().to_string(),
                     IOTEDGE_ID_CERT_MAX_DURATION_SECS,
                     IOTEDGE_SERVER_CERT_MAX_DURATION_SECS,
@@ -1421,15 +1422,15 @@ where
     <M::ModuleRuntime as Authenticator>::Error: Fail + Sync,
     for<'r> &'r <M::ModuleRuntime as ModuleRuntime>::Error: Into<ModuleRuntimeErrorReason>,
 {
-    let upstream_hostname = workload_config.upstream_hostname().to_string();
+    let iot_hub_name = workload_config.iot_hub_name().to_string();
     let device_id = workload_config.device_id().to_string();
-    let hostname = format!("https://{}", upstream_hostname);
-    let token_source = SasTokenSource::new(upstream_hostname.clone(), device_id.clone(), root_key);
+    let token_source = SasTokenSource::new(iot_hub_name.clone(), device_id.clone(), root_key);
+    let upstream_gateway = format!("https://{}", workload_config.parent_hostname().unwrap_or(&iot_hub_name));
     let http_client = HttpClient::new(
         hyper_client,
         Some(token_source),
         IOTHUB_API_VERSION.to_string(),
-        Url::parse(&hostname).context(ErrorKind::Initialize(InitializeErrorReason::HttpClient))?,
+        Url::parse(&upstream_gateway).context(ErrorKind::Initialize(InitializeErrorReason::HttpClient))?,
     )
     .context(ErrorKind::Initialize(InitializeErrorReason::HttpClient))?;
     let device_client = DeviceClient::new(http_client, device_id.clone())
@@ -1494,7 +1495,7 @@ where
     let edge_rt = start_runtime::<_, _, M>(
         runtime.clone(),
         &id_man,
-        &upstream_hostname,
+        &iot_hub_name,
         &device_id,
         &settings,
         runt_rx,

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -1425,12 +1425,16 @@ where
     let iot_hub_name = workload_config.iot_hub_name().to_string();
     let device_id = workload_config.device_id().to_string();
     let token_source = SasTokenSource::new(iot_hub_name.clone(), device_id.clone(), root_key);
-    let upstream_gateway = format!("https://{}", workload_config.parent_hostname().unwrap_or(&iot_hub_name));
+    let upstream_gateway = format!(
+        "https://{}",
+        workload_config.parent_hostname().unwrap_or(&iot_hub_name)
+    );
     let http_client = HttpClient::new(
         hyper_client,
         Some(token_source),
         IOTHUB_API_VERSION.to_string(),
-        Url::parse(&upstream_gateway).context(ErrorKind::Initialize(InitializeErrorReason::HttpClient))?,
+        Url::parse(&upstream_gateway)
+            .context(ErrorKind::Initialize(InitializeErrorReason::HttpClient))?,
     )
     .context(ErrorKind::Initialize(InitializeErrorReason::HttpClient))?;
     let device_client = DeviceClient::new(http_client, device_id.clone())

--- a/edgelet/iotedged/src/workload.rs
+++ b/edgelet/iotedged/src/workload.rs
@@ -22,7 +22,7 @@ impl WorkloadConfigData {
     ) -> Self {
         WorkloadConfigData {
             iot_hub_name,
-            parent_hostname, 
+            parent_hostname,
             device_id,
             id_cert_max_duration,
             srv_cert_max_duration,
@@ -78,7 +78,7 @@ impl WorkloadConfig for WorkloadData {
     fn iot_hub_name(&self) -> &str {
         self.data.iot_hub_name()
     }
-    
+
     fn parent_hostname(&self) -> Option<&str> {
         self.data.parent_hostname()
     }

--- a/edgelet/iotedged/src/workload.rs
+++ b/edgelet/iotedged/src/workload.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone)]
 struct WorkloadConfigData {
-    upstream_hostname: String,
+    iot_hub_name: String,
+    parent_hostname: Option<String>,
     device_id: String,
     id_cert_max_duration: i64,
     srv_cert_max_duration: i64,
@@ -13,21 +14,27 @@ struct WorkloadConfigData {
 
 impl WorkloadConfigData {
     pub fn new(
-        upstream_hostname: String,
+        iot_hub_name: String,
+        parent_hostname: Option<String>,
         device_id: String,
         id_cert_max_duration: i64,
         srv_cert_max_duration: i64,
     ) -> Self {
         WorkloadConfigData {
-            upstream_hostname,
+            iot_hub_name,
+            parent_hostname, 
             device_id,
             id_cert_max_duration,
             srv_cert_max_duration,
         }
     }
 
-    pub fn upstream_hostname(&self) -> &str {
-        &self.upstream_hostname
+    pub fn iot_hub_name(&self) -> &str {
+        &self.iot_hub_name
+    }
+
+    pub fn parent_hostname(&self) -> Option<&str> {
+        self.parent_hostname.as_deref()
     }
 
     pub fn device_id(&self) -> &str {
@@ -50,13 +57,15 @@ pub struct WorkloadData {
 
 impl WorkloadData {
     pub fn new(
-        upstream_hostname: String,
+        iot_hub_name: String,
+        parent_hostname: Option<String>,
         device_id: String,
         id_cert_max_duration: i64,
         srv_cert_max_duration: i64,
     ) -> Self {
         let w = WorkloadConfigData::new(
-            upstream_hostname,
+            iot_hub_name,
+            parent_hostname,
             device_id,
             id_cert_max_duration,
             srv_cert_max_duration,
@@ -66,8 +75,12 @@ impl WorkloadData {
 }
 
 impl WorkloadConfig for WorkloadData {
-    fn upstream_hostname(&self) -> &str {
-        self.data.upstream_hostname()
+    fn iot_hub_name(&self) -> &str {
+        self.data.iot_hub_name()
+    }
+    
+    fn parent_hostname(&self) -> Option<&str> {
+        self.data.parent_hostname()
     }
 
     fn device_id(&self) -> &str {


### PR DESCRIPTION
Always use iot hub name for token generation and use parent hostname as upstream gateway for registry api call if it is provided, otherwise use iot hub name.