### PR TITLE
[k8s public preview] Update branch with 1.0.9.3 fixes and k8s changes put in master

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/models/EnvVar.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/models/EnvVar.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Models
         public EnvVar(string key, string value)
         {
             this.Key = Preconditions.CheckNonWhiteSpace(key, nameof(key));
-            this.Value = Preconditions.CheckNonWhiteSpace(value, nameof(value));
+            this.Value = value ?? string.Empty;
         }
 
         public string Key { get; }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
         static readonly ITransientErrorDetectionStrategy AllButFatalErrorDetectionStrategy = new DelegateErrorDetectionStrategy(ex => ex.IsFatal() == false);
 
         static readonly RetryStrategy TransientRetryStrategy =
-            new ExponentialBackoff(5, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(4));
+            new ExponentialBackoff(3, TimeSpan.FromSeconds(2), TimeSpan.FromSeconds(60), TimeSpan.FromSeconds(4));
 
         readonly AsyncLock twinLock = new AsyncLock();
         readonly ISerde<DeploymentConfig> desiredPropertiesSerDe;
@@ -208,14 +208,16 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 });
         }
 
-        async Task<Option<Twin>> GetTwinFromIoTHub()
+        async Task<Option<Twin>> GetTwinFromIoTHub(bool retrying = false)
         {
+            IModuleClient moduleClient = null;
+
             try
             {
                 async Task<Twin> GetTwinFunc()
                 {
-                    Events.GettingModuleClient();
-                    IModuleClient moduleClient = await this.moduleConnection.GetOrCreateModuleClient();
+                    Events.GettingModuleClient(retrying);
+                    moduleClient = await this.moduleConnection.GetOrCreateModuleClient();
                     Events.GotModuleClient();
                     return await moduleClient.GetTwinAsync();
                 }
@@ -234,6 +236,21 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             catch (Exception e)
             {
                 Events.ErrorGettingTwin(e);
+
+                if (!retrying && moduleClient != null && !(e is TimeoutException))
+                {
+                    try
+                    {
+                        await moduleClient.CloseAsync();
+                    }
+                    catch (Exception e2)
+                    {
+                        Events.ErrorClosingModuleClientForRetry(e2);
+                    }
+
+                    return await this.GetTwinFromIoTHub(true);
+                }
+
                 return Option.None<Twin>();
             }
         }
@@ -331,7 +348,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 UpdatedReportedProperties,
                 ErrorUpdatingReportedProperties,
                 GotModuleClient,
-                GettingModuleClient
+                GettingModuleClient,
+                ErrorClosingModuleClient,
             }
 
             public static void DesiredPropertiesPatchFailed(Exception exception)
@@ -378,9 +396,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 Log.LogDebug((int)EventIds.ErrorUpdatingReportedProperties, ex, "Error updating reported properties in IoT Hub");
             }
 
-            public static void GettingModuleClient()
+            public static void GettingModuleClient(bool retrying)
             {
-                Log.LogDebug((int)EventIds.GettingModuleClient, "Getting module client to refresh the twin");
+                Log.LogDebug((int)EventIds.GettingModuleClient, $"Getting module client to refresh the twin with retrying set to {retrying}");
             }
 
             public static void GotModuleClient()
@@ -446,6 +464,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             internal static void RetryingGetTwin(RetryingEventArgs args)
             {
                 Log.LogDebug((int)EventIds.RetryingGetTwin, $"Edge agent is retrying GetTwinAsync. Attempt #{args.CurrentRetryCount}. Last error: {args.LastException?.Message}");
+            }
+
+            public static void ErrorClosingModuleClientForRetry(Exception e)
+            {
+                Log.LogWarning((int)EventIds.ErrorClosingModuleClient, e, "Error closing module client for retry");
             }
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEnvironmentOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEnvironmentOperator.cs
@@ -69,7 +69,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
                         // kick off a new watch
                         this.StartListPods();
                     },
-                    onError: Events.PodWatchFailed));
+                    onError: (ex) =>
+                    {
+                        Events.PodWatchFailed(ex);
+                        throw ex;
+                    }));
         }
 
         void HandlePodChangedAsync(WatchEventType type, V1Pod pod)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentOperator.cs
@@ -73,7 +73,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
                         // kick off a new watch
                         this.StartListEdgeDeployments();
                     },
-                    onError: Events.EdgeDeploymentWatchFailed));
+                    onError: (ex) =>
+                    {
+                        Events.EdgeDeploymentWatchFailed(ex);
+                        throw ex;
+                    }));
         }
 
         internal async Task EdgeDeploymentOnEventHandlerAsync(WatchEventType type, EdgeDeploymentDefinition item)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.workloadUri = Preconditions.CheckNotNull(workloadUri, nameof(workloadUri));
             this.dockerAuthConfig = Preconditions.CheckNotNull(dockerAuthConfig, nameof(dockerAuthConfig));
             this.upstreamProtocol = Preconditions.CheckNotNull(upstreamProtocol, nameof(upstreamProtocol));
-            this.productInfo = productInfo;
+            this.productInfo = productInfo.Map(p => $"{p} (Kubernetes)");
             this.defaultMapServiceType = defaultMapServiceType;
             this.enableServiceCallTracing = enableServiceCallTracing;
             this.useMountSourceForVolumeName = useMountSourceForVolumeName;

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -915,7 +915,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         }
 
         [Integration]
-        [Fact]
+        [Fact(Skip = "Investigating. Temporarily disabled to unblock CI pipeline.")]
         public async Task EdgeAgentConnectionStatusTest()
         {
             // Arrange

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -1406,6 +1406,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             var edgeAgent = new Mock<IEdgeAgentModule>();
             var edgeHub = new Mock<IEdgeHubModule>();
             var retryStrategy = new Mock<RetryStrategy>(new object[] { false });
+            var deviceManager = new Mock<IDeviceManager>();
 
             var deploymentConfig = new DeploymentConfig(
                 "1.0",
@@ -1462,7 +1463,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
 
             // Act
-            IEdgeAgentConnection connection = new EdgeAgentConnection(moduleClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), true, TimeSpan.FromHours(1), retryStrategy.Object);
+            IEdgeAgentConnection connection = new EdgeAgentConnection(moduleClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), deviceManager.Object, true, TimeSpan.FromHours(1), retryStrategy.Object);
 
             // Assert
             // The connection hasn't been created yet. So wait for it.

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -1273,7 +1273,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 receivedDeploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
 
                 // Assert
-                moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(5));
+                moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(7));
                 Assert.True(receivedDeploymentConfigInfo.HasValue);
                 Assert.False(receivedDeploymentConfigInfo.OrDefault().Exception.HasValue);
                 Assert.Equal(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
@@ -1393,6 +1393,90 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 Assert.Equal(deploymentConfig2, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
                 Assert.NotEqual(deploymentConfig, receivedDeploymentConfigInfo.OrDefault().DeploymentConfig);
             }
+        }
+
+        [Fact]
+        [Unit]
+        public async Task GetDeploymentConfigInfoAsync_CreateNewModuleClientWhenGetTwinThrowsMoreThanRetryCount()
+        {
+            // Arrange
+            var moduleClient = new Mock<IModuleClient>();
+            var serde = new Mock<ISerde<DeploymentConfig>>();
+            var runtime = new Mock<IRuntimeInfo>();
+            var edgeAgent = new Mock<IEdgeAgentModule>();
+            var edgeHub = new Mock<IEdgeHubModule>();
+            var retryStrategy = new Mock<RetryStrategy>(new object[] { false });
+
+            var deploymentConfig = new DeploymentConfig(
+                "1.0",
+                runtime.Object,
+                new SystemModules(edgeAgent.Object, edgeHub.Object),
+                ImmutableDictionary<string, IModule>.Empty);
+
+            var moduleClientProvider = new Mock<IModuleClientProvider>();
+            moduleClientProvider.Setup(p => p.Create(It.IsAny<ConnectionStatusChangesHandler>()))
+                .ReturnsAsync(moduleClient.Object);
+
+            serde.Setup(s => s.Deserialize(It.IsAny<string>())).Returns(deploymentConfig);
+            // var retryStrategy = new FixedInterval(1, TimeSpan.FromMilliseconds(1));
+            retryStrategy.Setup(rs => rs.GetShouldRetry())
+                .Returns(
+                    (int retryCount, Exception lastException, out TimeSpan delay) =>
+                    {
+                        if (retryCount >= 1)
+                        {
+                            delay = TimeSpan.Zero;
+                            return false;
+                        }
+
+                        delay = TimeSpan.Zero;
+                        return true;
+                    });
+
+            var twin = new Twin
+            {
+                Properties = new TwinProperties
+                {
+                    Desired = new TwinCollection(
+                        JObject.FromObject(
+                            new Dictionary<string, object>
+                            {
+                                { "$version", 10 },
+
+                                // This is here to prevent the "empty" twin error from being thrown.
+                                { "MoreStuff", "MoreStuffHereToo" }
+                            }).ToString()),
+                    Reported = new TwinCollection()
+                }
+            };
+
+            moduleClient.SetupSequence(d => d.GetTwinAsync())
+                .ThrowsAsync(new InvalidOperationException())
+                .ThrowsAsync(new InvalidOperationException())
+                .ReturnsAsync(twin);
+            moduleClient.Setup(d => d.SetDesiredPropertyUpdateCallbackAsync(It.IsAny<DesiredPropertyUpdateCallback>()))
+                .Returns(Task.CompletedTask);
+            moduleClient.Setup(d => d.SetMethodHandlerAsync(It.IsAny<string>(), It.IsAny<MethodCallback>()))
+                .Returns(Task.CompletedTask);
+
+            IEnumerable<IRequestHandler> requestHandlers = new List<IRequestHandler> { new PingRequestHandler() };
+
+            // Act
+            IEdgeAgentConnection connection = new EdgeAgentConnection(moduleClientProvider.Object, serde.Object, new RequestManager(requestHandlers, DefaultRequestTimeout), true, TimeSpan.FromHours(1), retryStrategy.Object);
+
+            // Assert
+            // The connection hasn't been created yet. So wait for it.
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Act
+            Option<DeploymentConfigInfo> deploymentConfigInfo = await connection.GetDeploymentConfigInfoAsync();
+
+            // Assert
+            Assert.True(deploymentConfigInfo.HasValue);
+            moduleClient.Verify(m => m.GetTwinAsync(), Times.Exactly(3));
+            moduleClient.Verify(m => m.CloseAsync(), Times.Once);
+            Assert.Equal(10, deploymentConfigInfo.OrDefault().Version);
+            Assert.Equal(deploymentConfigInfo.OrDefault().DeploymentConfig, deploymentConfig);
         }
 
         [Theory]

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/PortAndProtocolTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/PortAndProtocolTest.cs
@@ -31,9 +31,26 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [Fact]
         public void UnableToParseInvalidPort()
         {
-            var result = PortAndProtocol.Parse("1a23/HTTP");
+            var result = PortAndProtocol.Parse("1a23/TCP");
 
             Assert.Equal(Option.None<PortAndProtocol>(), result);
+        }
+
+        [Fact]
+        public void UnableToParseTooManyParts()
+        {
+            var result = PortAndProtocol.Parse("10/tcp/udp");
+
+            Assert.Equal(Option.None<PortAndProtocol>(), result);
+        }
+
+        [Fact]
+        public void DefaultProtocolIsTCP()
+        {
+            var result = PortAndProtocol.Parse("3434").OrDefault();
+
+            Assert.Equal(3434, result.Port);
+            Assert.Equal("TCP", result.Protocol);
         }
 
         [Theory]

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -29,7 +29,7 @@
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="3.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/edge-modules/DirectMethodCloudSender/DirectMethodCloudSender.csproj
+++ b/edge-modules/DirectMethodCloudSender/DirectMethodCloudSender.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/DirectMethodReceiver/DirectMethodReceiver.csproj
+++ b/edge-modules/DirectMethodReceiver/DirectMethodReceiver.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/DirectMethodSender/DirectMethodSender.csproj
+++ b/edge-modules/DirectMethodSender/DirectMethodSender.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
+++ b/edge-modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-modules/ModuleRestarter/ModuleRestarter.csproj
+++ b/edge-modules/ModuleRestarter/ModuleRestarter.csproj
@@ -34,7 +34,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
+++ b/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/TemperatureFilter/TemperatureFilter.csproj
+++ b/edge-modules/TemperatureFilter/TemperatureFilter.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.0" />

--- a/edge-modules/TwinTester/TwinTester.csproj
+++ b/edge-modules/TwinTester/TwinTester.csproj
@@ -21,7 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
   </ItemGroup>
 

--- a/edge-modules/load-gen/load-gen.csproj
+++ b/edge-modules/load-gen/load-gen.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.2.0" />

--- a/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
+++ b/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
@@ -15,6 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.20.3-asc-edge" />
+	<PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
   </ItemGroup>
 </Project>

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -436,6 +436,14 @@ function process_args() {
     echo 'Required parameters are provided'
 }
 
+function get_hash() {
+    # TODO: testHelper.sh needs to be shared across build pipelines
+    local length=$1
+    local hash=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c $length)
+
+    echo "$hash"
+}
+
 function run_all_tests()
 {
     local funcRet=0
@@ -653,7 +661,7 @@ function run_longhaul_test() {
     print_highlighted_message "Run Long Haul test for $image_architecture_label"
     test_setup
 
-    local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-longhaul"
+    local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-longhaul-$(get_hash 8)"
 
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run Long Haul test with -d '$device_id' started at $test_start_time"
@@ -729,7 +737,7 @@ function run_stress_test() {
     print_highlighted_message "Run Stress test for $image_architecture_label"
     test_setup
 
-    local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-stress"
+    local device_id="$RELEASE_LABEL-Linux-$image_architecture_label-stress-$(get_hash 8)"
 
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run Stress test with -d '$device_id' started at $test_start_time"

--- a/scripts/windows/test/Run-E2ETest.ps1
+++ b/scripts/windows/test/Run-E2ETest.ps1
@@ -341,6 +341,11 @@ Function GetImageArchitectureLabel
     Throw "Can't find image architecture label for $Architecture"
 }
 
+Function GetHash
+{
+    return -join ((48..57) + (65..90) + (97..122) | Get-Random -Count $args[0] | % {[char]$_})
+}
+
 Function GetLongHaulDeploymentFilename
 {
     If (GetImageArchitectureLabel -eq "amd64")
@@ -967,7 +972,7 @@ Function RunLongHaulTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "${ReleaseLabel}-Windows-${Architecture}-longHaul"
+    $deviceId = "${ReleaseLabel}-Windows-${Architecture}-longHaul-$(GetHash 8)"
     PrintHighlightedMessage "Run Long Haul test with -d ""$deviceId"" started at $testStartAt"
 
     $testCommand = "&$IotEdgeQuickstartExeTestPath ``
@@ -998,7 +1003,7 @@ Function RunStressTest
     TestSetup
 
     $testStartAt = Get-Date
-    $deviceId = "${ReleaseLabel}-Windows-${Architecture}-stress"
+    $deviceId = "${ReleaseLabel}-Windows-${Architecture}-stress-$(GetHash 8)"
     PrintHighlightedMessage "Run Stress test with -d ""$deviceId"" started at $testStartAt"
 
     $testCommand = "&$IotEdgeQuickstartExeTestPath ``

--- a/smoke/LeafDevice/LeafDevice.csproj
+++ b/smoke/LeafDevice/LeafDevice.csproj
@@ -30,7 +30,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeCoverage" Version="15.9.0" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Condition="'$(DotNet_Runtime)' != 'netcoreapp3.0'">
     <TargetFramework>netcoreapp2.1</TargetFramework>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.19.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.1" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.23.2" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.3" />


### PR DESCRIPTION
Applies:
Update 1.0.9 to have unique device ID in LH and Stress tests (#3033)
Phlin/edge agent get twin fix (#3075)
Upgrade Microsoft.Azure.Devices.Client from 1.23.1 to 1.23.2 (#3098)
Disable this test, same as what we did in master branch. (#3102)
Allow environment variables to be empty or whitespace. (#2777)
Add "(Kubernetes)" to ProductInfo. (#2811)
[k8s] Default Service protocol to "TCP" (#2929)
[k8s] throw exception on watch error. (#2928) 

Some 1.0.9.3 fixes only applied to EdgeHub, and we don't release EdgeHub Images for this branch.
