### PR TITLE
Fix Image Version in Dockerfiles (Restore Azure/iotedge#3144)

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -1,4 +1,5 @@
 ARG base_tag=3.1.4-alpine3.11
+# base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -1,4 +1,5 @@
 ARG base_tag=3.1.4-alpine3.11
+# base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.17-alpine3.11
+ARG base_tag=3.1.4-alpine3.11
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.17-nanoserver-1809
+ARG base_tag=3.1.4-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.2-windows-arm32v7
+ARG base_tag=1.0.5-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/ModuleRestarter/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.2-windows-arm32v7
+ARG base_tag=1.0.5-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=3.1.4-alpine3.11
-FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
+# base dockerfile is located at \edge-util\docker\linux\amd64
+FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 

--- a/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=3.1.4-alpine3.11
-FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
+# base dockerfile is located at \edge-util\docker\linux\amd64
+FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 

--- a/test/modules/TwinTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG base_tag=3.1.4-alpine3.11
-FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
+# base dockerfile is located at \edge-util\docker\linux\amd64
+FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 


### PR DESCRIPTION
Fix Base Image Version in Dockerfiles (Restore Azure/iotedge#3144)
Previously merged at https://github.com/Azure/iotedge/commit/42f7ef0a6c61880cf6fa46912b66ee67d2824d60