### PR TITLE
[k8s] Experimental Service Options

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CombinedKubernetesConfigProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CombinedKubernetesConfigProvider.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
                 experimentalOptions.ForEach(parameters => createOptions.NodeSelector = parameters.NodeSelector);
                 experimentalOptions.ForEach(parameters => createOptions.Resources = parameters.Resources);
                 experimentalOptions.ForEach(parameters => createOptions.SecurityContext = parameters.SecurityContext);
+                experimentalOptions.ForEach(parameters => createOptions.ServiceOptions = parameters.ServiceOptions);
                 experimentalOptions.ForEach(parameters => createOptions.DeploymentStrategy = parameters.DeploymentStrategy);
             }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CreatePodParameters.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/CreatePodParameters.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
     using System.Linq;
     using k8s.Models;
     using Microsoft.Azure.Devices.Edge.Agent.Docker.Models;
+    using Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Service;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Json;
     using Newtonsoft.Json;
@@ -21,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             IEnumerable<string> cmd,
             IEnumerable<string> entrypoint,
             string workingDir)
-            : this(env?.ToList(), exposedPorts, hostConfig, image, labels, cmd?.ToList(), entrypoint?.ToList(), workingDir, null, null, null, null, null)
+            : this(env?.ToList(), exposedPorts, hostConfig, image, labels, cmd?.ToList(), entrypoint?.ToList(), workingDir, null, null, null, null, null, null)
         {
         }
 
@@ -39,6 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             V1ResourceRequirements resources,
             IReadOnlyList<KubernetesModuleVolumeSpec> volumes,
             V1PodSecurityContext securityContext,
+            KubernetesServiceOptions serviceOptions,
             V1DeploymentStrategy strategy)
         {
             this.Env = Option.Maybe(env);
@@ -53,6 +55,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             this.Resources = Option.Maybe(resources);
             this.Volumes = Option.Maybe(volumes);
             this.SecurityContext = Option.Maybe(securityContext);
+            this.ServiceOptions = Option.Maybe(serviceOptions);
             this.DeploymentStrategy = Option.Maybe(strategy);
         }
 
@@ -69,8 +72,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             V1ResourceRequirements resources = null,
             IReadOnlyList<KubernetesModuleVolumeSpec> volumes = null,
             V1PodSecurityContext securityContext = null,
+            KubernetesServiceOptions serviceOptions = null,
             V1DeploymentStrategy deploymentStrategy = null)
-            => new CreatePodParameters(env, exposedPorts, hostConfig, image, labels, cmd, entrypoint, workingDir, nodeSelector, resources, volumes, securityContext, deploymentStrategy);
+            => new CreatePodParameters(env, exposedPorts, hostConfig, image, labels, cmd, entrypoint, workingDir, nodeSelector, resources, volumes, securityContext, serviceOptions, deploymentStrategy);
 
         [JsonProperty("env", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<IReadOnlyList<string>>))]
@@ -107,6 +111,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         [JsonProperty("securityContext", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<V1PodSecurityContext>))]
         public Option<V1PodSecurityContext> SecurityContext { get; set; }
+
+        [JsonProperty("serviceOptions", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<KubernetesServiceOptions>))]
+        public Option<KubernetesServiceOptions> ServiceOptions { get; set; }
 
         [JsonProperty("strategy", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<V1DeploymentStrategy>))]

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesExperimentalCreatePodParameters.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesExperimentalCreatePodParameters.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
     using System.Collections.Generic;
     using k8s.Models;
     using Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment;
+    using Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Service;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json.Linq;
@@ -19,6 +20,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
         public Option<V1PodSecurityContext> SecurityContext { get; }
 
+        public Option<KubernetesServiceOptions> ServiceOptions { get; }
+
         public Option<V1DeploymentStrategy> DeploymentStrategy { get; }
 
         KubernetesExperimentalCreatePodParameters(
@@ -26,12 +29,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             Option<V1ResourceRequirements> resources,
             Option<IReadOnlyList<KubernetesModuleVolumeSpec>> volumes,
             Option<V1PodSecurityContext> securityContext,
+            Option<KubernetesServiceOptions> serviceOptions,
             Option<V1DeploymentStrategy> deploymentStrategy)
         {
             this.NodeSelector = nodeSelector;
             this.Resources = resources;
             this.Volumes = volumes;
             this.SecurityContext = securityContext;
+            this.ServiceOptions = serviceOptions;
             this.DeploymentStrategy = deploymentStrategy;
         }
 
@@ -42,6 +47,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             public const string Resources = "Resources";
             public const string Volumes = "Volumes";
             public const string SecurityContext = "SecurityContext";
+            public const string ServiceOptions = "ServiceOptions";
             public const string DeploymentStrategy = "Strategy";
         }
 
@@ -74,10 +80,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             var securityContext = options.Get(ExperimentalParameterNames.SecurityContext)
                 .FlatMap(option => Option.Maybe(option.ToObject<V1PodSecurityContext>()));
 
+            var serviceOptions = options.Get(ExperimentalParameterNames.ServiceOptions)
+                .FlatMap(option => Option.Maybe(option.ToObject<KubernetesServiceOptions>()));
+
             var deploymentStrategy = options.Get(ExperimentalParameterNames.DeploymentStrategy)
                 .FlatMap(option => Option.Maybe(option.ToObject<V1DeploymentStrategy>()));
 
-            return new KubernetesExperimentalCreatePodParameters(nodeSelector, resources, volumes, securityContext, deploymentStrategy);
+            return new KubernetesExperimentalCreatePodParameters(nodeSelector, resources, volumes, securityContext, serviceOptions, deploymentStrategy);
         }
 
         static Dictionary<string, JToken> PrepareSupportedOptionsStore(JObject experimental)
@@ -103,6 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             ExperimentalParameterNames.Resources,
             ExperimentalParameterNames.Volumes,
             ExperimentalParameterNames.SecurityContext,
+            ExperimentalParameterNames.ServiceOptions,
             ExperimentalParameterNames.DeploymentStrategy
         };
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/service/KubernetesServiceOptions.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/service/KubernetesServiceOptions.cs
@@ -8,19 +8,19 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Service
 
     public class KubernetesServiceOptions
     {
-        public KubernetesServiceOptions(string type, string loadBalancerIP)
+        public KubernetesServiceOptions(string loadBalancerIP, string type)
         {
             PortMapServiceType serviceType;
-            this.Type = Enum.TryParse(type, true, out serviceType) ? Option.Some(serviceType) : Option.None<PortMapServiceType>();
             this.LoadBalancerIP = Option.Maybe(loadBalancerIP);
+            this.Type = Enum.TryParse(type, true, out serviceType) ? Option.Some(serviceType) : Option.None<PortMapServiceType>();
         }
-
-        [JsonProperty("Type", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
-        [JsonConverter(typeof(OptionConverter<PortMapServiceType>))]
-        public Option<PortMapServiceType> Type { get; }
 
         [JsonProperty("LoadBalancerIP", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
         [JsonConverter(typeof(OptionConverter<string>))]
         public Option<string> LoadBalancerIP { get; }
+
+        [JsonProperty("Type", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<PortMapServiceType>))]
+        public Option<PortMapServiceType> Type { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/service/KubernetesServiceOptions.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/service/KubernetesServiceOptions.cs
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Service
+{
+    using System;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Json;
+    using Newtonsoft.Json;
+
+    public class KubernetesServiceOptions
+    {
+        public KubernetesServiceOptions(string type, string loadBalancerIP)
+        {
+            PortMapServiceType serviceType;
+            this.Type = Enum.TryParse(type, true, out serviceType) ? Option.Some(serviceType) : Option.None<PortMapServiceType>();
+            this.LoadBalancerIP = Option.Maybe(loadBalancerIP);
+        }
+
+        [JsonProperty("Type", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<PortMapServiceType>))]
+        public Option<PortMapServiceType> Type { get; }
+
+        [JsonProperty("LoadBalancerIP", DefaultValueHandling = DefaultValueHandling.IgnoreAndPopulate)]
+        [JsonConverter(typeof(OptionConverter<string>))]
+        public Option<string> LoadBalancerIP { get; }
+    }
+}

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesExperimentalPodParametersTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesExperimentalPodParametersTest.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.False(parameters.NodeSelector.HasValue);
             Assert.False(parameters.Resources.HasValue);
             Assert.False(parameters.SecurityContext.HasValue);
+            Assert.False(parameters.ServiceOptions.HasValue);
             Assert.False(parameters.DeploymentStrategy.HasValue);
         }
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesExperimentalPodParametersTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesExperimentalPodParametersTest.cs
@@ -340,9 +340,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var parameters = KubernetesExperimentalCreatePodParameters.Parse(experimental).OrDefault();
 
             Assert.True(parameters.DeploymentStrategy.HasValue);
-            var deploymentStrategy = parameters.DeploymentStrategy.OrDefault();
-            Assert.Equal("RollingUpdate", deploymentStrategy.Type);
-            Assert.Equal("1", deploymentStrategy.RollingUpdate.MaxUnavailable);
+            parameters.DeploymentStrategy.ForEach(deploymentStrategy => Assert.Equal("RollingUpdate", deploymentStrategy.Type));
+            parameters.DeploymentStrategy.ForEach(deploymentStrategy => Assert.Equal("1", deploymentStrategy.RollingUpdate.MaxUnavailable));
         }
 
         [Fact]
@@ -356,9 +355,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var parameters = KubernetesExperimentalCreatePodParameters.Parse(experimental).OrDefault();
 
             Assert.True(parameters.ServiceOptions.HasValue);
-            var options = parameters.ServiceOptions.OrDefault();
-            Assert.False(options.Type.HasValue);
-            Assert.False(options.LoadBalancerIP.HasValue);
+            parameters.ServiceOptions.ForEach(options => Assert.False(options.Type.HasValue));
+            parameters.ServiceOptions.ForEach(options => Assert.False(options.LoadBalancerIP.HasValue));
         }
 
         [Fact]
@@ -372,12 +370,16 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var parameters = KubernetesExperimentalCreatePodParameters.Parse(experimental).OrDefault();
 
             Assert.True(parameters.ServiceOptions.HasValue);
-            var options = parameters.ServiceOptions.OrDefault();
-            Assert.True(options.Type.HasValue);
-            options.Type.ForEach(t => Assert.Equal(PortMapServiceType.NodePort, t));
-
-            Assert.True(options.LoadBalancerIP.HasValue);
-            options.LoadBalancerIP.ForEach(l => Assert.Equal("100.1.2.3", l));
+            parameters.ServiceOptions.ForEach(options =>
+            {
+                Assert.True(options.Type.HasValue);
+                options.Type.ForEach(t => Assert.Equal(PortMapServiceType.NodePort, t));
+            });
+            parameters.ServiceOptions.ForEach(options =>
+            {
+                Assert.True(options.LoadBalancerIP.HasValue);
+                options.LoadBalancerIP.ForEach(l => Assert.Equal("100.1.2.3", l));
+            });
         }
 
         [Fact]
@@ -391,11 +393,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var parameters = KubernetesExperimentalCreatePodParameters.Parse(experimental).OrDefault();
 
             Assert.True(parameters.ServiceOptions.HasValue);
-            var options = parameters.ServiceOptions.OrDefault();
-            Assert.True(options.Type.HasValue);
-            options.Type.ForEach(t => Assert.Equal(PortMapServiceType.LoadBalancer, t));
-
-            Assert.False(options.LoadBalancerIP.HasValue);
+            parameters.ServiceOptions.ForEach(options =>
+            {
+                Assert.True(options.Type.HasValue);
+                options.Type.ForEach(t => Assert.Equal(PortMapServiceType.LoadBalancer, t));
+            });
+            parameters.ServiceOptions.ForEach(options => Assert.False(options.LoadBalancerIP.HasValue));
         }
 
         [Fact]
@@ -409,11 +412,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var parameters = KubernetesExperimentalCreatePodParameters.Parse(experimental).OrDefault();
 
             Assert.True(parameters.ServiceOptions.HasValue);
-            var options = parameters.ServiceOptions.OrDefault();
-            Assert.False(options.Type.HasValue);
-
-            Assert.True(options.LoadBalancerIP.HasValue);
-            options.LoadBalancerIP.ForEach(l => Assert.Equal("any old string", l));
+            parameters.ServiceOptions.ForEach(options => Assert.False(options.Type.HasValue));
+            parameters.ServiceOptions.ForEach(options =>
+            {
+                Assert.True(options.LoadBalancerIP.HasValue);
+                options.LoadBalancerIP.ForEach(l => Assert.Equal("any old string", l));
+            });
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesExperimentalPodParametersTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesExperimentalPodParametersTest.cs
@@ -414,6 +414,5 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             Assert.True(options.LoadBalancerIP.HasValue);
             options.LoadBalancerIP.ForEach(l => Assert.Equal("any old string", l));
         }
-
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
@@ -82,10 +82,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
         [Fact]
         public void CreateServiceSetsServiceOptions()
         {
-            var serviceOptions = new KubernetesServiceOptions("nodeport", "loadBalancerIP");
+            var serviceOptions = new KubernetesServiceOptions("loadBalancerIP", "nodeport");
             var module = CreateKubernetesModule(CreatePodParameters.Create(exposedPorts: ExposedPorts, serviceOptions: serviceOptions));
-            var mapper = new KubernetesServiceMapper(PortMapServiceType.LoadBalancer);
+            var mapper = new KubernetesServiceMapper(PortMapServiceType.ClusterIP);
+
             Option<V1Service> result = mapper.CreateService(CreateIdentity, module, DefaultLabels);
+
             Assert.True(result.HasValue);
             var service = result.OrDefault();
             Assert.Equal(PortMapServiceType.NodePort.ToString(), service.Spec.Type);
@@ -93,28 +95,47 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
         }
 
         [Fact]
-        public void CreateServiceSetsServiceOptionsNoIPOnNullLoadBalancerIP()
+        public void CreateServiceSetsServiceOptionsOverridesSetDefault()
         {
-            var serviceOptions = new KubernetesServiceOptions("nodeport", null);
-            var module = CreateKubernetesModule(CreatePodParameters.Create(exposedPorts: ExposedPorts, serviceOptions: serviceOptions));
+            var serviceOptions = new KubernetesServiceOptions("loadBalancerIP", "clusterIP");
+            var module = CreateKubernetesModule(CreatePodParameters.Create(hostConfig: HostPorts, serviceOptions: serviceOptions));
             var mapper = new KubernetesServiceMapper(PortMapServiceType.LoadBalancer);
+
             Option<V1Service> result = mapper.CreateService(CreateIdentity, module, DefaultLabels);
+
             Assert.True(result.HasValue);
             var service = result.OrDefault();
-            Assert.Equal(PortMapServiceType.NodePort.ToString(), service.Spec.Type);
+            Assert.Equal(PortMapServiceType.ClusterIP.ToString(), service.Spec.Type);
+            Assert.Equal("loadBalancerIP", service.Spec.LoadBalancerIP);
+        }
+
+        [Fact]
+        public void CreateServiceSetsServiceOptionsNoIPOnNullLoadBalancerIP()
+        {
+            var serviceOptions = new KubernetesServiceOptions(null, "loadBalancer");
+            var module = CreateKubernetesModule(CreatePodParameters.Create(exposedPorts: ExposedPorts, serviceOptions: serviceOptions));
+            var mapper = new KubernetesServiceMapper(PortMapServiceType.ClusterIP);
+
+            Option<V1Service> result = mapper.CreateService(CreateIdentity, module, DefaultLabels);
+
+            Assert.True(result.HasValue);
+            var service = result.OrDefault();
+            Assert.Equal(PortMapServiceType.LoadBalancer.ToString(), service.Spec.Type);
             Assert.Null(service.Spec.LoadBalancerIP);
         }
 
         [Fact]
         public void CreateServiceSetsServiceOptionsSetDefaultOnNullType()
         {
-            var serviceOptions = new KubernetesServiceOptions(null, "loadBalancerIP");
-            var module = CreateKubernetesModule(CreatePodParameters.Create(exposedPorts: ExposedPorts, serviceOptions: serviceOptions));
+            var serviceOptions = new KubernetesServiceOptions("loadBalancerIP", null);
+            var module = CreateKubernetesModule(CreatePodParameters.Create(hostConfig: HostPorts, serviceOptions: serviceOptions));
             var mapper = new KubernetesServiceMapper(PortMapServiceType.LoadBalancer);
+
             Option<V1Service> result = mapper.CreateService(CreateIdentity, module, DefaultLabels);
+
             Assert.True(result.HasValue);
             var service = result.OrDefault();
-            Assert.Equal(PortMapServiceType.ClusterIP.ToString(), service.Spec.Type);
+            Assert.Equal(PortMapServiceType.LoadBalancer.ToString(), service.Spec.Type);
             Assert.Equal("loadBalancerIP", service.Spec.LoadBalancerIP);
         }
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
@@ -145,7 +145,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
             Assert.Equal(PortMapServiceType.LoadBalancer.ToString(), service.Spec.Type);
         }
 
-
         [Fact]
         public void CreateServiceHostPortsCreatesHostportService()
         {

--- a/kubernetes/doc/create-options.md
+++ b/kubernetes/doc/create-options.md
@@ -148,7 +148,7 @@ A `securityContext` section of config used to apply a pod security context to a 
 
 EdgeAgent creates a service for each module that exposes one or more ports. Default service types (typically ClusterIp) are assigned to the service.  This does not allow the use to mix service types on an edge deployment. If provided, the `serviceOptions.type` field will override the `type` option for the module's ServiceSpec. Also, if provided, the `serviceOptions.loadBalancerIP` field will be assigned to the `loadBalancerIP` field.
 
-`EdgeAgent` doesn't do any translations or interpretations of values but simply assigns value from module deployment to `type` and `loadBalancerIP` parameter of a service spec.
+`EdgeAgent` doesn't do any translations or interpretations of values but simply assigns value from module deployment to `type` and `loadBalancerIP` parameter of a service spec. Valid `type` options are "ClusterIP", "NodePort", and "LoadBalancer."
 
 ### CreateOptions
 
@@ -158,6 +158,7 @@ EdgeAgent creates a service for each module that exposes one or more ports. Defa
     "serviceOptions" : {
       "loadBalancerIP" : "100.23.201.78",
       "type" : "LoadBalancer"
+    }
   }
 }
 ```

--- a/kubernetes/doc/create-options.md
+++ b/kubernetes/doc/create-options.md
@@ -22,6 +22,7 @@ We added CreateOptions for experimental features on Kubernetes. These options "o
     "resources": [{...}],
     "nodeSelector": {...},
     "securityContext": {...},
+    "service-options": {...},
     "strategy": {...}
   }
 }
@@ -139,6 +140,24 @@ A `securityContext` section of config used to apply a pod security context to a 
       "runAsUser": "1000",
       ...
     }
+  }
+}
+```
+
+## Apply Service options
+
+EdgeAgent creates a service for each module that exposes one or more ports. Default service types (typically ClusterIp) are assigned to the service.  This does not allow the use to mix service types on an edge deployment. If provided, the `serviceOptions.type` field will override the `type` option for the module's ServiceSpec. Also, if provided, the `serviceOptions.loadBalancerIP` field will be assigned to the `loadBalancerIP` field.
+
+`EdgeAgent` doesn't do any translations or interpretations of values but simply assigns value from module deployment to `type` and `loadBalancerIP` parameter of a service spec.
+
+### CreateOptions
+
+```json
+{
+  "k8s-experimental": {
+    "serviceOptions" : {
+      "loadBalancerIP" : "100.23.201.78",
+      "type" : "LoadBalancer"
   }
 }
 ```

--- a/kubernetes/doc/edge-deployment-to-k8s-translations.md
+++ b/kubernetes/doc/edge-deployment-to-k8s-translations.md
@@ -184,9 +184,11 @@ Each IoT Edge Module will create one Deployment. This will run the module's spec
     - then `settings.createOptions.Lables` will be added to the service's annotations.
 
 ##### spec (ServiceSpec)
-- **type** = ClusterIP if only exposed ports (`settings.createOptions.HostConfig.ExposedPorts`) are 
-  set. If port bindings (`settings.createOptions.HostConfig.PortBindings`) are set, runtime will use
-  the default set by `portMappingServiceType` on runtime startup, default is ClusterIP.
+- **type** = Set according to this priority:
+     1. `type` from `settings.k8s-extensions.serviceOptions.type`. 
+     2. ClusterIP if only exposed ports (`settings.createOptions.HostConfig.ExposedPorts`) are set. 
+     3. If port bindings (`settings.createOptions.HostConfig.PortBindings`) are set, runtime will use the default set by `portMappingServiceType` on runtime startup, default is ClusterIP.
+- **loadBalancerIP** = `loadBalancerIP` from `settings.k8s-extensions.serviceOptions.loadBalancerIP`.
 - **ports** = a list of port bindings
     - **port** = Exposed port if source is `settings.createOptions.HostConfig.ExposedPorts`, 
       host port if source is `settings.createOptions.HostConfig.PortBindings`
@@ -253,3 +255,4 @@ Extensions available:
 - [Setting CPU and Memory limits](create-options.md#cpu-memory-and-device-resources)
 - [Assigning Modules to Nodes](create-options.md#assigning-modules-to-nodes)
 - [Applying Pod Security Context](create-options.md#apply-pod-security-context)
+- [Applying Service Options](create-options.md#apply-service-options)


### PR DESCRIPTION
Added another `k8s-experimental` section called `serviceOptions`. I has 2 fields, `type` and `LoadBalancerIP`.

`type` will be used as Service type if a Service is created.

`loadBalancerIP` is put into the `loadBalancerIP` field in the Service, if a service is created.

This allows individual modules to override default Service settings.
