### PR TITLE
Update CbsNode to use correct audience for nested Edge

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
@@ -148,13 +148,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
             try
             {
-                string audience = message.ApplicationProperties.Map[CbsConstants.PutToken.Audience] as string;
-                return (token, audience);
+                SharedAccessSignature.Parse(iotHubHostName, token);
             }
             catch (Exception e)
             {
                 throw new InvalidOperationException("Cbs message does not contain a valid token", e);
             }
+
+            string audience = message.ApplicationProperties.Map[CbsConstants.PutToken.Audience] as string;
+            return (token, audience);
         }
 
         internal static (string deviceId, string moduleId) ParseIds(string audience)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
@@ -148,8 +148,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
             try
             {
-                SharedAccessSignature sharedAccessSignature = SharedAccessSignature.Parse(iotHubHostName, token);
-                return (token, sharedAccessSignature.Audience);
+                string audience = message.ApplicationProperties.Map[CbsConstants.PutToken.Audience] as string;
+                return (token, audience);
             }
             catch (Exception e)
             {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             };
             AmqpMessage validAmqpMessage = AmqpMessage.Create(amqpValue);
             validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Type] = "azure-devices.net:sastoken";
-            validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = "iothub";
+            validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = IoTHubHostName;
             validAmqpMessage.ApplicationProperties.Map[CbsConstants.Operation] = CbsConstants.PutToken.OperationValue;
 
             // Act
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             // Arrange
             AmqpMessage invalidAmqpMessage4 = AmqpMessage.Create(new AmqpValue { Value = "azure-devices.net:sastoken" });
             invalidAmqpMessage4.ApplicationProperties.Map[CbsConstants.PutToken.Type] = "azure-devices.net:sastoken";
-            invalidAmqpMessage4.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = "iothub";
+            invalidAmqpMessage4.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = IoTHubHostName;
             invalidAmqpMessage4.ApplicationProperties.Map[CbsConstants.Operation] = CbsConstants.PutToken.OperationValue;
             // Act/Assert
             Assert.Throws<InvalidOperationException>(() => CbsNode.ValidateAndParseMessage(IoTHubHostName, invalidAmqpMessage4));
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             };
             AmqpMessage validAmqpMessage = AmqpMessage.Create(amqpValue);
             validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Type] = "azure-devices.net:sastoken";
-            validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = "iothub";
+            validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = "edgehubtest1.azure-devices.net/devices/device1";
             validAmqpMessage.ApplicationProperties.Map[CbsConstants.Operation] = CbsConstants.PutToken.OperationValue;
 
             var clientCredentials = Mock.Of<IClientCredentials>();
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             };
             AmqpMessage validAmqpMessage = AmqpMessage.Create(amqpValue);
             validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Type] = "azure-devices.net:sastoken";
-            validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = "iothub";
+            validAmqpMessage.ApplicationProperties.Map[CbsConstants.PutToken.Audience] = "edgehubtest1.azure-devices.net/devices/device1";
             validAmqpMessage.ApplicationProperties.Map[CbsConstants.Operation] = CbsConstants.PutToken.OperationValue;
 
             var identity = Mock.Of<IIdentity>(i => i.Id == "device1/mod1");


### PR DESCRIPTION
CbsNode was previously parsing the audience from the authentication token.  This is incorrect for nested Edge, where we'll receive the token from one of the parent Edge devices instead of the original connecting device.