### PR TITLE
Update the base image for 1.0.9 arm32

### DIFF
--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.16-bionic-arm32v7
+ARG base_tag=2.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 RUN apt-get update && \

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.16-bionic-arm32v7
+ARG base_tag=2.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-modules/DirectMethodCloudSender/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodCloudSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodCloudSender/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodCloudSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-preview013-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.16-bionic-arm32v7
+ARG base_tag=2.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rocksdb:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rocksdb:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.16-bionic-arm32v7
+ARG base_tag=2.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \

--- a/edge-modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rocksdb:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rocksdb:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.4-linux-arm32v7
+ARG base_tag=1.0.6-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.


### PR DESCRIPTION
Update the base image for 1.0.9 arm32 for security vulnerability [USN-4377-1](https://lists.ubuntu.com/archives/ubuntu-security-announce/2020-June/005457.html)
2.1.19-bionic-arm32v7 -> 1.0.4.1-linux-arm32v7