### PR TITLE
Update base image version to 1.0.5.1

### DIFF
--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm32v7
+ARG base_tag=3.1.5-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm64v8
+ARG base_tag=3.1.5-bionic-arm64v8
 ARG num_procs=4
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm32v7
+ARG base_tag=3.1.5-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm64v8
+ARG base_tag=3.1.5-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm32v7
+ARG base_tag=3.1.5-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm64v8
+ARG base_tag=3.1.5-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/scripts/linux/createArmBase.sh
+++ b/scripts/linux/createArmBase.sh
@@ -115,7 +115,7 @@ process_args()
         print_help_and_exit
     fi
 
-    if [[ "azureiotedge-module-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-hub-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-agent-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-iotedged-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-proxy-base" != ${DOCKER_IMAGENAME} ]]; then
+    if [[ "azureiotedge-module-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-hub-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-agent-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-iotedged-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-proxy-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-module-base-full" != ${DOCKER_IMAGENAME} ]]; then
         echo "Docker image name must be one of azureiotedge-module-base, azureiotedge-hub-base, azureiotedge-agent-base, azureiotedge-iotedged-base or azureiotedge-proxy-base"
         print_help_and_exit
     fi

--- a/scripts/linux/createArmBase.sh
+++ b/scripts/linux/createArmBase.sh
@@ -116,7 +116,7 @@ process_args()
     fi
 
     if [[ "azureiotedge-module-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-hub-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-agent-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-iotedged-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-proxy-base" != ${DOCKER_IMAGENAME} ]] && [[ "azureiotedge-module-base-full" != ${DOCKER_IMAGENAME} ]]; then
-        echo "Docker image name must be one of azureiotedge-module-base, azureiotedge-hub-base, azureiotedge-agent-base, azureiotedge-iotedged-base or azureiotedge-proxy-base"
+        echo "Docker image name must be one of azureiotedge-module-base, azureiotedge-module-base-full, azureiotedge-hub-base, azureiotedge-agent-base, azureiotedge-iotedged-base or azureiotedge-proxy-base"
         print_help_and_exit
     fi
 

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
 ARG base_tag=1.0.5.1-linux-arm64v8
-FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
+FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
-ARG base_tag=1.0.5-linux-arm64v8
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+ARG base_tag=1.0.5.1-linux-arm64v8
+FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm32v7
+ARG base_tag=3.1.5-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-bionic-arm64v8
+ARG base_tag=3.1.5-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
-ARG base_tag=1.0.5-linux-arm32v7
-FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rocksdb:${base_tag}
+ARG base_tag=1.0.5.1-linux-arm32v7
+FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
-ARG base_tag=1.0.5-linux-arm64v8
-FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rocksdb:${base_tag}
+ARG base_tag=1.0.5.1-linux-arm64v8
+FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm32v7
+ARG base_tag=1.0.5.1-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-linux-arm64v8
+ARG base_tag=1.0.5.1-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.


### PR DESCRIPTION
1. Base image update for ARM32 and ARM64 platforms for security vulnerability [USN-4377-1](https://lists.ubuntu.com/archives/ubuntu-security-announce/2020-June/005457.html)
3.1.5-bionic-arm32v7 -> 1.0.5.1-linux-arm32v7
3.1.5-bionic-arm64v8 -> 1.0.5.1-linux-arm64v8

2.  Rename `azureiotedge-module-base-rocksdb` to be `azureiotedge-module-base-full`