### PR TITLE
Fix edgehub container misconfiguration

### DIFF
--- a/edge-hub/watchdog/src/child.rs
+++ b/edge-hub/watchdog/src/child.rs
@@ -83,13 +83,13 @@ impl ChildProcess {
 pub fn run(
     name: impl Into<String>,
     program: impl Into<String>,
-    args: impl Into<String>,
+    args: Vec<String>,
     should_shutdown: Arc<AtomicBool>,
 ) -> Result<JoinHandle<()>> {
     let name = name.into();
 
     let child = Command::new(program.into())
-        .arg(args.into())
+        .args(args)
         .stdout(Stdio::inherit())
         .spawn()
         .with_context(|| format!("Failed to start {:?} process.", name))?;

--- a/edge-hub/watchdog/src/main.rs
+++ b/edge-hub/watchdog/src/main.rs
@@ -34,16 +34,16 @@ fn main() -> Result<()> {
         .context("Failed to register sigterm listener. Shutting down.")?;
 
     let edgehub_handle = run(
-        "Edge Hub".to_string(),
-        "dotnet".to_string(),
-        "/app/Microsoft.Azure.Devices.Edge.Hub.Service.dll".to_string(),
+        "Edge Hub",
+        "dotnet",
+        vec!["/app/Microsoft.Azure.Devices.Edge.Hub.Service.dll".to_string()],
         Arc::clone(&should_shutdown),
     )?;
 
     let broker_handle = match run(
-        "MQTT Broker".to_string(),
-        "/usr/local/bin/mqttd".to_string(),
-        "-c /app/mqttd/production.json".to_string(),
+        "MQTT Broker",
+        "/usr/local/bin/mqttd",
+        vec!["-c".to_string(), "/app/mqttd/production.json".to_string()],
         Arc::clone(&should_shutdown),
     ) {
         Ok(handle) => Some(handle),

--- a/edge-hub/watchdog/src/main.rs
+++ b/edge-hub/watchdog/src/main.rs
@@ -36,7 +36,7 @@ fn main() -> Result<()> {
     let edgehub_handle = run(
         "Edge Hub",
         "dotnet",
-        vec!["/app/Microsoft.Azure.Devices.Edge.Hub.Service.dll".to_string()],
+        vec!["/app/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.dll".to_string()],
         Arc::clone(&should_shutdown),
     )?;
 


### PR DESCRIPTION
The build images pipeline produces an edgehub image, but we need to fix two issues:
- path misconfiguration with the EdgeHub dlls
- arguments passed to the broker are not done with the correct function, leading to a faulty space in the resulting argument