### PR TITLE
Fix: Edgelet unable to pull using certain passwords - cherry-pick into 1.0.10. (#3206)

### DIFF
--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -108,7 +108,7 @@ impl ModuleRegistry for DockerModuleRuntime {
                 let json = serde_json::to_string(a).with_context(|_| {
                     ErrorKind::RegistryOperation(RegistryOperation::PullImage(image.clone()))
                 })?;
-                Ok(base64::encode(&json))
+                Ok(base64::encode_config(&json, base64::URL_SAFE))
             },
         );
 

--- a/edgelet/edgelet-docker/tests/runtime.rs
+++ b/edgelet/edgelet-docker/tests/runtime.rs
@@ -407,12 +407,12 @@ fn image_pull_with_invalid_creds_handler(req: Request<Body>) -> ResponseFuture {
         .headers()
         .get_all("X-Registry-Auth")
         .into_iter()
-        .map(|bytes| base64::decode(bytes).unwrap())
+        .map(|bytes| base64::decode_config(bytes, base64::URL_SAFE).unwrap())
         .map(|raw| str::from_utf8(&raw).unwrap().to_owned())
         .collect::<String>();
     let auth_config: AuthConfig = serde_json::from_str(&auth_str).unwrap();
-    assert_eq!(auth_config.username(), Some("u1"));
-    assert_eq!(auth_config.password(), Some("wrong_password"));
+    assert_eq!(auth_config.username(), Some("us1"));
+    assert_eq!(auth_config.password(), Some("ac?ac~aaac???"));
     assert_eq!(auth_config.email(), Some("u1@bleh.com"));
     assert_eq!(auth_config.serveraddress(), Some("svr1"));
 
@@ -459,9 +459,10 @@ fn image_pull_with_invalid_creds_fails() {
 
     let task = DockerModuleRuntime::make_runtime(settings, provisioning_result(), crypto())
         .and_then(|runtime| {
+            // password is written to guarantee base64 encoding has '-' and/or '_'
             let auth = AuthConfig::new()
-                .with_username("u1".to_string())
-                .with_password("wrong_password".to_string())
+                .with_username("us1".to_string())
+                .with_password("ac?ac~aaac???".to_string())
                 .with_email("u1@bleh.com".to_string())
                 .with_serveraddress("svr1".to_string());
             let config = DockerConfig::new(
@@ -594,7 +595,7 @@ fn image_pull_with_creds_handler(req: Request<Body>) -> ResponseFuture {
         .headers()
         .get_all("X-Registry-Auth")
         .into_iter()
-        .map(|bytes| base64::decode(bytes).unwrap())
+        .map(|bytes| base64::decode_config(bytes, base64::URL_SAFE).unwrap())
         .map(|raw| str::from_utf8(&raw).unwrap().to_owned())
         .collect::<String>();
     let auth_config: AuthConfig = serde_json::from_str(&auth_str).unwrap();


### PR DESCRIPTION
Some passwords (especially generated passwords) can be used by docker CLI, but not by Edgelet. There is a chance of this  happening when passwords contain `?` or `~`.

It's not explicitly stated in the [Docker API](https://docs.docker.com/engine/api/v1.40/#section/Authentication), but the [code](https://github.com/docker/cli/blob/master/cli/command/registry.go#L50) is written such that the `X-Registry-Auth` header is expected to be URL safe (RFC 4648) base64.