### PR TITLE
Enable twin encrypt by default (#3189)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/TwinStoreEntity.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/TwinStoreEntity.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
         public TwinStoreEntity(Twin twin, TwinCollection reportedPropertiesPatch)
         {
             this.Twin = Option.Maybe(twin);
-            this.ReportedPropertiesPatch = reportedPropertiesPatch?.Count != 0
+            this.ReportedPropertiesPatch = reportedPropertiesPatch != null && reportedPropertiesPatch.Count != 0
                 ? Option.Some(reportedPropertiesPatch)
                 : Option.None<TwinCollection>();
         }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 .GetOrElse(false);
             int maxUpstreamBatchSize = this.configuration.GetValue("MaxUpstreamBatchSize", 10);
             int upstreamFanOutFactor = this.configuration.GetValue("UpstreamFanOutFactor", 10);
-            bool encryptTwinStore = this.configuration.GetValue("EncryptTwinStore", false);
+            bool encryptTwinStore = this.configuration.GetValue("EncryptTwinStore", true);
             int configUpdateFrequencySecs = this.configuration.GetValue("ConfigRefreshFrequencySecs", 3600);
             TimeSpan configUpdateFrequency = TimeSpan.FromSeconds(configUpdateFrequencySecs);
             bool checkEntireQueueOnCleanup = this.configuration.GetValue("CheckEntireQueueOnCleanup", false);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -603,7 +603,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                 twinStoreOption = encryptionProvider.Map(
                     e =>
                     {
-                        IEntityStore<string, string> underlyingEntityStore = storeProvider.GetEntityStore<string, string>($"underlying{entityName}");
+                        IEntityStore<string, string> underlyingEntityStore = storeProvider.GetEntityStore<string, string>($"underlying{entityName}", entityName);
                         IKeyValueStore<string, string> es = new UpdatableEncryptedStore<string, string>(underlyingEntityStore, e);
                         ITypeMapper<string, string> keyMapper = new JsonMapper<string>();
                         ITypeMapper<TwinStoreEntity, string> valueMapper = new JsonMapper<TwinStoreEntity>();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/TwinStoreEntityTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/TwinStoreEntityTest.cs
@@ -12,6 +12,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
     [Unit]
     public class TwinStoreEntityTest
     {
+        [Theory]
+        [Unit]
+        [InlineData("{\"Twin\":null}")]
+        [InlineData("{\"ReportedPropertiesPatch\":null}")]
+        [InlineData("{}")]
+        public void NullPropertiesTest(string json)
+        {
+            var deserializedObject = JsonConvert.DeserializeObject<TwinStoreEntity>(json);
+            Assert.False(deserializedObject.Twin.HasValue);
+            Assert.False(deserializedObject.ReportedPropertiesPatch.HasValue);
+        }
+
         [Fact]
         public void RoundtripEmptyTest()
         {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -195,7 +195,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     false,
                     10,
                     10,
-                    false,
+                    true,
                     TimeSpan.FromHours(1),
                     checkEntireQueueOnCleanup,
                     experimentalFeatures,

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/DbStoreProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/DbStoreProvider.cs
@@ -57,6 +57,13 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
             return entityDbStore;
         }
 
+        public Option<IDbStore> GetIfExistsDbStore(string partitionName)
+        {
+            Preconditions.CheckNonWhiteSpace(partitionName, nameof(partitionName));
+            this.entityDbStoreDictionary.TryGetValue(partitionName, out IDbStore entityDbStore);
+            return Option.Maybe(entityDbStore);
+        }
+
         public IDbStore GetDbStore() => this.GetDbStore(DefaultPartitionName);
 
         public void RemoveDbStore(string partitionName)

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/DbStoreProviderDecorator.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/DbStoreProviderDecorator.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             return this.dbStoreProvider.GetDbStore(partitionName);
         }
 
+        public Option<IDbStore> GetIfExistsDbStore(string partitionName)
+        {
+            return this.dbStoreProvider.GetIfExistsDbStore(partitionName);
+        }
+
         public virtual IDbStore GetDbStore()
         {
             return this.dbStoreProvider.GetDbStore();

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/IDbStoreProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/IDbStoreProvider.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 {
     using System;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Util;
 
     /// <summary>
     /// Provides DB Key/Value store.
@@ -10,6 +11,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
     public interface IDbStoreProvider : IDisposable
     {
         IDbStore GetDbStore(string partitionName);
+
+        Option<IDbStore> GetIfExistsDbStore(string partitionName);
 
         IDbStore GetDbStore();
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/IStoreProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/IStoreProvider.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
     {
         IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName);
 
+        IEntityStore<TK, TV> GetEntityStore<TK, TV>(string backwardCompatibleEntityName, string entityName);
+
         Task<ISequentialStore<T>> GetSequentialStore<T>(string entityName);
 
         Task<ISequentialStore<T>> GetSequentialStore<T>(string entityName, long defaultHeadOffset);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/InMemoryDbStoreProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/InMemoryDbStoreProvider.cs
@@ -34,6 +34,14 @@ namespace Microsoft.Azure.Devices.Edge.Storage
             return dbStore;
         }
 
+        public Option<IDbStore> GetIfExistsDbStore(string partitionName)
+        {
+            Preconditions.CheckNonWhiteSpace(partitionName, nameof(partitionName));
+            this.partitionDbStoreDictionary.TryGetValue(partitionName, out IDbStore entityDbStore);
+
+            return Option.Maybe(entityDbStore);
+        }
+
         public IDbStore GetDbStore() => this.GetDbStore(DefaultPartitionName);
 
         public void RemoveDbStore(string partitionName)

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/EntityStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/EntityStoreTest.cs
@@ -15,5 +15,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
         protected override IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
             => this.storeProvider.GetEntityStore<TK, TV>(entityName);
+
+        protected override IEntityStore<TK, TV> GetEntityStore<TK, TV>(string backwardCompatibilityEntityName, string entityName)
+           => this.storeProvider.GetEntityStore<TK, TV>(backwardCompatibilityEntityName, entityName);
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/TestRocksDbStoreProvider.cs
@@ -36,6 +36,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
 
         public IDbStore GetDbStore(string partitionName) => this.rocksDbStoreProvider.GetDbStore(partitionName);
 
+        public Option<IDbStore> GetIfExistsDbStore(string partitionName) => this.rocksDbStoreProvider.GetIfExistsDbStore(partitionName);
+
         public IDbStore GetDbStore() => this.rocksDbStoreProvider.GetDbStore("default");
 
         public void RemoveDbStore(string partitionName) => throw new NotImplementedException();

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EntityStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EntityStoreTest.cs
@@ -12,5 +12,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
 
         protected override IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName)
             => this.storeProvider.GetEntityStore<TK, TV>(entityName);
+
+        protected override IEntityStore<TK, TV> GetEntityStore<TK, TV>(string backwardCompatibilityEntityName, string entityName)
+            => this.storeProvider.GetEntityStore<TK, TV>(backwardCompatibilityEntityName, entityName);
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EntityStoreTestBase.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/EntityStoreTestBase.cs
@@ -119,7 +119,28 @@ namespace Microsoft.Azure.Devices.Edge.Storage.Test
             Assert.Equal(getUpdatedValue.OrDefault(), updatedValue);
         }
 
+        [Fact]
+        [Unit]
+        public void BackwardCompatibleStoreName_ShouldReturnOlderEntityStore()
+        {
+            this.GetEntityStore<string, string>("olderTestEntity");
+            IEntityStore<string, string> entityStore = this.GetEntityStore<string, string>("olderTestEntity", "TestEntity");
+
+            Assert.Equal("olderTestEntity", entityStore.EntityName);
+        }
+
+        [Fact]
+        [Unit]
+        public void BackwardCompatibleStoreName_ShouldReturnNewEntity()
+        {
+            IEntityStore<string, string> entityStore = this.GetEntityStore<string, string>("underlyingTestEntity", "newTestEntity");
+
+            Assert.Equal("newTestEntity", entityStore.EntityName);
+        }
+
         protected abstract IEntityStore<TK, TV> GetEntityStore<TK, TV>(string entityName);
+
+        protected abstract IEntityStore<TK, TV> GetEntityStore<TK, TV>(string backwardCompatibilityEntityName, string entityName);
 
         public class Key
         {


### PR DESCRIPTION
Enable twin encryption by default.
TwinStore is using EdgeTwin as entity name when it is not encrypted and underlyingEdgeTwin for the entity name when is encrypted. Because of that even if we it has implemented a way to update from uncrypted to encrypted data is actually not doing that because the store is different. I updated the code to use underlyingEdgeTwin  if it already exist and use EdgeTwin if underlyingEdgeTwin  was never created, that way data from unencrypted store is updated to encrypted while it is accessed.

Please note: if customer changes from encrypted to unencrypted data won't be recovered. In this case if edgeHub is set  to unencrypted and immediately after it goes offline it won't be able to get the configuration from store.