### PR TITLE
Get cloud connection if adding device with subscriptions (#3201)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/SessionStatePersistenceProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/SessionStatePersistenceProvider.cs
@@ -64,6 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
                                 return (deviceSubscription, addSubscription);
                             });
+                    Events.ProcessingSessionSubscriptions(id, subscriptions);
 
                     await this.edgeHub.ProcessSubscriptions(id, subscriptions);
                 }
@@ -114,7 +115,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             enum EventIds
             {
                 UnknownSubscription = IdStart,
-                ErrorHandlingSubscription
+                ErrorHandlingSubscription,
+                ProcessingSessionSubscriptions
             }
 
             public static void UnknownTopicSubscription(string topicName, string id)
@@ -125,6 +127,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             public static void ErrorProcessingSubscriptions(string id, Exception exception)
             {
                 Log.LogWarning((int)EventIds.ErrorHandlingSubscription, exception, Invariant($"Error processing subscriptions for client {id}."));
+            }
+
+            internal static void ProcessingSessionSubscriptions(string id, IEnumerable<(DeviceSubscription, bool)> subscriptions)
+            {
+                string subscriptionString = string.Join(", ", subscriptions.Select(s => $"{s.Item1}"));
+                Log.LogDebug((int)EventIds.ProcessingSessionSubscriptions, $"Processing session subscriptions {subscriptionString} for client {id}: ");
             }
         }
     }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         /// 0. A cloud connection is established.
         /// 1. Device connects - a connection is added in the connection manager
         /// 2. Connection should have both cloud and device connections
-        /// 3. Device disconnects - the device connection is removed. Cloud connection stays.
+        /// 3. Device disconnects - the device connection is removed. Cloud connection is removed.
         /// 4. Connection manager should have a cloud connection, but no device connection.
         /// </summary>
         [Fact]
@@ -673,8 +673,36 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             // Arrange
             string deviceId = "d1";
-            var cloudConnectionProvider = Mock.Of<ICloudConnectionProvider>();
-            var credentialsCache = Mock.Of<ICredentialsCache>();
+            string iotHub = "foo.azure-devices.net";
+            string token = TokenHelper.CreateSasToken(iotHub);
+            var module1Credentials = new TokenCredentials(new DeviceIdentity(iotHub, deviceId), token, DummyProductInfo, true);
+            IClient client1 = GetDeviceClient();
+            IClient client2 = GetDeviceClient();
+            var messageConverterProvider = Mock.Of<IMessageConverterProvider>();
+            var deviceClientProvider = new Mock<IClientProvider>();
+            deviceClientProvider.SetupSequence(d => d.Create(It.IsAny<IIdentity>(), It.IsAny<ITokenProvider>(), It.IsAny<ITransportSettings[]>()))
+                .Returns(client1)
+                .Returns(client2);
+            var productInfoStore = Mock.Of<IProductInfoStore>();
+            ICredentialsCache credentialsCache = new CredentialsCache(new NullCredentialsCache());
+            await credentialsCache.Add(module1Credentials);
+            var edgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "edgeDevice/$edgeHub");
+            var cloudConnectionProvider = new CloudConnectionProvider(
+                messageConverterProvider,
+                1,
+                deviceClientProvider.Object,
+                Option.None<UpstreamProtocol>(),
+                Mock.Of<ITokenProvider>(),
+                Mock.Of<IDeviceScopeIdentitiesCache>(),
+                credentialsCache,
+                edgeHubIdentity,
+                TimeSpan.FromMinutes(60),
+                true,
+                TimeSpan.FromSeconds(20),
+                false,
+                Option.None<IWebProxy>(),
+                productInfoStore);
+            cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             var connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
             var identity = Mock.Of<IIdentity>(i => i.Id == deviceId);
@@ -733,6 +761,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Assert.Equal(2, subscriptions.Count);
             Assert.True(subscriptions[DeviceSubscription.Methods]);
             Assert.True(subscriptions[DeviceSubscription.C2D]);
+            Option<ICloudProxy> cloudProxy = await connectionManager.GetCloudConnection(deviceId);
+            Assert.True(cloudProxy.HasValue);
 
             // Act
             connectionManager.AddSubscription(deviceId, DeviceSubscription.DesiredPropertyUpdates);


### PR DESCRIPTION
Cherry-picked from: https://github.com/Azure/iotedge/pull/3201

We are seeing an issue where a module using the nodeJS moduleClient with MQTT and only subscribing to DirectMethods (no telemetry) is unable to receive any direct methods after ~45 minutes.

This happens because the module gets reauthenticated. With MQTT, the device connection must be dropped momentarily during reauth. When it goes back online, the ConnectionManager adds the DeviceConnection, but does not add the CloudConnection. Because there is no telemetry or twin actions, the cloud connection never gets established, and subscriptions for the device are never processed.

This PR will get the cloud connection if the device has any subscriptions when the device is re-added after reauth.
I've tested it with the nodeJS SDK with success.

I assume that the reason we weren't seeing this with C# SDK is that the C# SDK (incorrectly) resubscribes in this reauth case. It shouldn't need to resubscribe, though.