### PR TITLE
Introduce CentOs7 to the new E2E test framework

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -35,47 +35,9 @@ jobs:
     timeoutInMinutes: 120
 
     steps:
-    - task: CmdLine@2
-      inputs:
-        script: 'sudo find . -type f -group root -execdir rm {} + && sudo find . -type d -group root -print0 | sudo xargs -0 /bin/rm -rf' 
-      displayName: Clean up files (as sudo)
-
+    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
-
-    - task: Docker@2
-      displayName: Docker login
-      inputs:
-        command: login
-        containerRegistry: iotedge-edgebuilds-acr
-
-    - pwsh: |
-        # We use a self-hosted agent for this job, so we need to clean up
-        # old docker images and containers to keep disk usage in check. But
-        # pull any required images for this test run first, to take advantage
-        # of cached layers from the old images (and also so that the pull
-        # operation doesn't count against each test's timeout period).
-
-        # Get images required for this run
-        $images = Get-Content -Encoding UTF8 '$(binDir)/context.json' `
-          | ConvertFrom-Json `
-          | foreach { $_.PSObject.Properties } `
-          | where { $_.Name -match 'Image$' } `
-          | foreach { $_.Value }
-
-        # Pull required images
-        $images | foreach { sudo --preserve-env docker pull $_ }
-
-        # Remove old images
-        $remove = sudo docker images --format '{{.Repository}}:{{.Tag}}' `
-          | where { $images -notcontains $_ }
-        sudo docker rm -f $(docker ps -a -q)
-        $remove | foreach { sudo docker rmi $_ }
-
-        # Delete everything else
-        sudo docker network prune -f
-        sudo docker volume prune -f
-      displayName: Cache docker images
-
+    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
 ################################################################################	
@@ -131,3 +93,26 @@ jobs:
       displayName: Prefer IPv4
 
     - template: templates/e2e-run.yaml
+
+################################################################################	
+  - job: centos7_amd64
+################################################################################	
+    displayName: CentOs7 amd64
+
+    pool:
+      name: $(pool.name)
+      demands:
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - run-new-e2e-tests -equals true
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-centos7-amd64
+
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml 

--- a/builds/e2e/templates/e2e-clean-directory.yaml
+++ b/builds/e2e/templates/e2e-clean-directory.yaml
@@ -1,0 +1,5 @@
+steps:
+- task: CmdLine@2
+  inputs:
+    script: 'sudo find . -type f -group root -execdir rm {} + && sudo find . -type d -group root -print0 | sudo xargs -0 /bin/rm -rf' 
+  displayName: Clean up files (as sudo)

--- a/builds/e2e/templates/e2e-clear-docker-cached-images.yaml
+++ b/builds/e2e/templates/e2e-clear-docker-cached-images.yaml
@@ -1,0 +1,34 @@
+steps:
+- task: Docker@2
+  displayName: Docker login
+  inputs:
+    command: login
+    containerRegistry: iotedge-edgebuilds-acr
+
+- pwsh: |
+    # We use a self-hosted agent for this job, so we need to clean up
+    # old docker images and containers to keep disk usage in check. But
+    # pull any required images for this test run first, to take advantage
+    # of cached layers from the old images (and also so that the pull
+    # operation doesn't count against each test's timeout period).
+
+    # Get images required for this run
+    $images = Get-Content -Encoding UTF8 '$(binDir)/context.json' `
+        | ConvertFrom-Json `
+        | foreach { $_.PSObject.Properties } `
+        | where { $_.Name -match 'Image$' } `
+        | foreach { $_.Value }
+
+    # Pull required images
+    $images | foreach { sudo --preserve-env docker pull $_ }
+
+    # Remove old images
+    $remove = sudo docker images --format '{{.Repository}}:{{.Tag}}' `
+        | where { $images -notcontains $_ }
+    sudo docker rm -f $(docker ps -a -q)
+    $remove | foreach { sudo docker rmi $_ }
+
+    # Delete everything else
+    sudo docker network prune -f
+    sudo docker volume prune -f
+  displayName: Clear Docker Cached images

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -15,7 +15,15 @@ steps:
     }
     else
     {
-      sudo --preserve-env dotnet vstest $testFile --logger:trx
+      # Unfortunately CentOs has some failing test that need to be worked on.
+      if ('$(Agent.Name)'.Contains('centos'))
+      {
+        sudo --preserve-env dotnet test $testFile --logger:trx --filter "TestCategory=CentOsSafe"
+      }
+      else
+      {
+        sudo --preserve-env dotnet vstest $testFile --logger:trx
+      }
     }
   displayName: Run tests
   env:

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -86,6 +86,7 @@ steps:
       '$(System.ArtifactsDirectory)/$(az.pipeline.images.artifacts)/artifactInfo.txt'
     $imageId = ($imageId -split '=')[1]
     $imageTag = "$imageId-$(os)-$(arch)"
+
     $context = @{
       dpsIdScope = '$(dps.idScope)'
       edgeAgentImage = "$imagePrefix-agent:$imageTag";

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IOsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IOsPlatform.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     {
         Task<string> CollectDaemonLogsAsync(DateTime testStartTime, string filePrefix, CancellationToken token);
 
-        IEdgeDaemon CreateEdgeDaemon(Option<string> installerPath, Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry);
+        Task<IEdgeDaemon> CreateEdgeDaemonAsync(Option<string> installerPath, Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry, CancellationToken token);
 
         // After calling this function, the following files will be available under {scriptPath}:
         //  certs/iot-device-{deviceId}-full-chain.cert.pem

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/OsPlatform.cs
@@ -24,7 +24,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
             return daemonLog;
         }
 
-        public IEdgeDaemon CreateEdgeDaemon(Option<string> _, Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry) => new EdgeDaemon(bootstrapAgentImage, bootstrapRegistry);
+        public async Task<IEdgeDaemon> CreateEdgeDaemonAsync(
+            Option<string> _,
+            Option<string> bootstrapAgentImage,
+            Option<Registry> bootstrapRegistry,
+            CancellationToken token) => await EdgeDaemon.CreateAsync(bootstrapAgentImage, bootstrapRegistry, token);
 
         public async Task<IdCertificates> GenerateIdentityCertificatesAsync(string deviceId, string scriptPath, CancellationToken token)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -1,0 +1,100 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+
+    public enum SupportedPackageExtension
+    {
+        Deb,
+        Rpm
+    }
+
+    public class PackageManagement
+    {
+        readonly string os;
+        readonly string version;
+        readonly SupportedPackageExtension packageExtension;
+        public string IotedgeServices { get; }
+
+        public PackageManagement(string os, string version, SupportedPackageExtension extension)
+        {
+            this.os = os;
+            this.version = version;
+            this.packageExtension = extension;
+            this.IotedgeServices = extension switch
+            {
+                SupportedPackageExtension.Deb => "iotedge.mgmt.socket iotedge.socket iotedge.service",
+                SupportedPackageExtension.Rpm => "iotedge.service",
+                _ => throw new NotImplementedException($"Unknown package extension '.{this.packageExtension}'")
+            };
+        }
+
+        public string[] GetInstallCommandsFromLocal(string path)
+        {
+            string[] packages = Directory
+                .GetFiles(path, $"*.{this.packageExtension.ToString().ToLower()}")
+                .Where(p => !p.Contains("debug"))
+                .ToArray();
+
+            return this.packageExtension switch
+            {
+                SupportedPackageExtension.Deb => new[]
+                {
+                    "set -e",
+                    $"dpkg --force-confnew -i {string.Join(' ', packages)}",
+                    $"apt-get install -f"
+                },
+                SupportedPackageExtension.Rpm => new[]
+                {
+                    "set -e",
+                    $"yum install -y {string.Join(' ', packages)}",
+                    "pathToSystemdConfig=$(systemctl cat iotedge | head -n 1)",
+                    "sed 's/=on-failure/=no/g' ${pathToSystemdConfig#?} > ~/override.conf",
+                    "sudo mv -f ~/override.conf ${pathToSystemdConfig#?}",
+                    "sudo systemctl daemon-reload"
+                },
+                _ => throw new NotImplementedException($"Don't know how to install daemon on for '.{this.packageExtension}'"),
+            };
+        }
+
+        public string[] GetInstallCommandsFromMicrosoftProd() => this.packageExtension switch
+        {
+            SupportedPackageExtension.Deb => new[]
+            {
+                // Based on instructions at:
+                // https://github.com/MicrosoftDocs/azure-docs/blob/058084949656b7df518b64bfc5728402c730536a/articles/iot-edge/how-to-install-iot-edge-linux.md
+                // TODO: 8/30/2019 support curl behind a proxy
+                $"curl https://packages.microsoft.com/config/{this.os}/{this.version}/multiarch/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
+                "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
+                $"apt-get update",
+                $"apt-get install --yes iotedge"
+            },
+            SupportedPackageExtension.Rpm => new[]
+            {
+                $"rpm -iv --replacepkgs https://packages.microsoft.com/config/{this.os}/{this.version}/packages-microsoft-prod.rpm",
+                $"yum updateinfo",
+                $"yum install --yes iotedge",
+                "pathToSystemdConfig=$(systemctl cat iotedge | head -n 1)",
+                "sed 's/=on-failure/=no/g' ${pathToSystemdConfig#?} > ~/override.conf",
+                "sudo mv -f ~/override.conf ${pathToSystemdConfig#?}",
+                "sudo systemctl daemon-reload"
+            },
+            _ => throw new NotImplementedException($"Don't know how to install daemon on for '.{this.packageExtension}'"),
+        };
+
+        public string[] GetUninstallCommands() => this.packageExtension switch
+        {
+            SupportedPackageExtension.Deb => new[]
+            {
+                "apt-get purge --yes libiothsm-std iotedge"
+            },
+            SupportedPackageExtension.Rpm => new[]
+            {
+                "yum remove -y --remove-leaves libiothsm-std iotedge"
+            },
+            _ => throw new NotImplementedException($"Don't know how to uninstall daemon on for '.{this.packageExtension}'")
+        };
+    }
+}

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/OsPlatform.cs
@@ -31,7 +31,12 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
             return daemonLog;
         }
 
-        public IEdgeDaemon CreateEdgeDaemon(Option<string> installerPath, Option<string> bootstrapAgentImage, Option<Registry> bootstrapRegistry) => new EdgeDaemon(installerPath, bootstrapAgentImage, bootstrapRegistry);
+        public Task<IEdgeDaemon> CreateEdgeDaemonAsync(
+            Option<string> installerPath,
+            Option<string> bootstrapAgentImage,
+            Option<Registry> bootstrapRegistry,
+            CancellationToken _) =>
+            Task.FromResult(new EdgeDaemon(installerPath, bootstrapAgentImage, bootstrapRegistry) as IEdgeDaemon);
 
         public async Task<IdCertificates> GenerateIdentityCertificatesAsync(string deviceId, string scriptPath, CancellationToken token)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     class Device : SasManualProvisioningFixture
     {
         [Test]
+        [Category("CentOsSafe")]
         public async Task QuickstartCerts()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string DefaultSensorImage = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0";
 
         [Test]
+        [Category("CentOsSafe")]
         public async Task TempSensor()
         {
             string sensorImage = Context.Current.TempSensorImage.GetOrElse(DefaultSensorImage);
@@ -63,6 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("CentOsSafe")]
         public async Task TempFilter()
         {
             const string filterName = "tempFilter";
@@ -135,6 +137,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("CentOsSafe")]
         public async Task ModuleToModuleDirectMethod(
             [Values] Protocol protocol)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("CentOsSafe")]
         public async Task DpsSymmetricKey()
         {
             string idScope = Context.Current.DpsIdScope.Expect(() => new InvalidOperationException("Missing DPS ID scope"));

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -15,23 +15,21 @@ namespace Microsoft.Azure.Devices.Edge.Test
     [SetUpFixture]
     public class SetupFixture
     {
-        readonly IEdgeDaemon daemon;
-        IotHub iotHub;
-
-        public SetupFixture()
-        {
-            Option<Registry> bootstrapRegistry =
-                Option.Maybe(Context.Current.Registries.First());
-            this.daemon = OsPlatform.Current.CreateEdgeDaemon(Context.Current.InstallerPath, Context.Current.EdgeAgentBootstrapImage, bootstrapRegistry);
-            this.iotHub = new IotHub(
-                Context.Current.ConnectionString,
-                Context.Current.EventHubEndpoint,
-                Context.Current.Proxy);
-        }
+        IEdgeDaemon daemon;
 
         [OneTimeSetUp]
         public async Task BeforeAllAsync()
         {
+            using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
+            CancellationToken token = cts.Token;
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+
+            this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
+                Context.Current.InstallerPath,
+                Context.Current.EdgeAgentBootstrapImage,
+                bootstrapRegistry,
+                token);
+
             await Profiler.Run(
                 async () =>
                 {
@@ -45,37 +43,29 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     Context.Current.LogFile.ForEach(f => loggerConfig.WriteTo.File(f));
                     Log.Logger = loggerConfig.CreateLogger();
 
-                    using (var cts = new CancellationTokenSource(Context.Current.SetupTimeout))
-                    {
-                        CancellationToken token = cts.Token;
+                    // Install IoT Edge, and do some basic configuration
+                    await this.daemon.UninstallAsync(token);
+                    await this.daemon.InstallAsync(Context.Current.PackagePath, Context.Current.Proxy, token);
 
-                        // Install IoT Edge, and do some basic configuration
-                        await this.daemon.UninstallAsync(token);
-                        await this.daemon.InstallAsync(
-                            Context.Current.PackagePath,
-                            Context.Current.Proxy,
-                            token);
+                    await this.daemon.ConfigureAsync(
+                        config =>
+                        {
+                            var msg = string.Empty;
+                            var props = new object[] { };
 
-                        await this.daemon.ConfigureAsync(
-                            config =>
+                            config.SetDeviceHostname(Dns.GetHostName());
+                            Context.Current.Proxy.ForEach(proxy =>
                             {
-                                var msg = string.Empty;
-                                var props = new object[] { };
+                                config.AddHttpsProxy(proxy);
+                                msg = "with proxy '{ProxyUri}'";
+                                props = new object[] { proxy.ToString() };
+                            });
+                            config.Update();
 
-                                config.SetDeviceHostname(Dns.GetHostName());
-                                Context.Current.Proxy.ForEach(proxy =>
-                                {
-                                    config.AddHttpsProxy(proxy);
-                                    msg = "with proxy '{ProxyUri}'";
-                                    props = new object[] { proxy.ToString() };
-                                });
-                                config.Update();
-
-                                return Task.FromResult((msg, props));
-                            },
-                            token,
-                            restart: false);
-                    }
+                            return Task.FromResult((msg, props));
+                        },
+                        token,
+                        restart: false);
                 },
                 "Completed end-to-end test setup");
         }
@@ -85,14 +75,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
             () => Profiler.Run(
                 async () =>
                 {
-                    using (var cts = new CancellationTokenSource(Context.Current.TeardownTimeout))
+                    using var cts = new CancellationTokenSource(Context.Current.TeardownTimeout);
+                    CancellationToken token = cts.Token;
+                    await this.daemon.StopAsync(token);
+                    foreach (EdgeDevice device in Context.Current.DeleteList.Values)
                     {
-                        CancellationToken token = cts.Token;
-                        await this.daemon.StopAsync(token);
-                        foreach (EdgeDevice device in Context.Current.DeleteList.Values)
-                        {
-                            await device.MaybeDeleteIdentityAsync(token);
-                        }
+                        await device.MaybeDeleteIdentityAsync(token);
                     }
                 },
                 "Completed end-to-end test teardown"),

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/BaseFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/BaseFixture.cs
@@ -15,13 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         Profiler profiler;
         DateTime testStartTime;
 
-        protected CancellationToken TestToken
-        {
-            get
-            {
-                return this.cts.Token;
-            }
-        }
+        protected CancellationToken TestToken => this.cts.Token;
 
         [SetUp]
         protected void BeforeEachTest()
@@ -43,10 +37,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
                     if (TestContext.CurrentContext.Result.Outcome != ResultState.Ignored)
                     {
-                        using (var cts = new CancellationTokenSource(Context.Current.TeardownTimeout))
-                        {
-                            await NUnitLogs.CollectAsync(this.testStartTime, cts.Token);
-                        }
+                        using var cts = new CancellationTokenSource(Context.Current.TeardownTimeout);
+                        await NUnitLogs.CollectAsync(this.testStartTime, cts.Token);
                     }
                 },
                 "Completed test teardown");

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
@@ -2,18 +2,26 @@
 namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 {
     using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Util;
+    using NUnit.Framework;
 
     public class DeviceProvisioningFixture : BaseFixture
     {
-        protected readonly IEdgeDaemon daemon;
+        protected IEdgeDaemon daemon;
 
-        public DeviceProvisioningFixture()
+        [OneTimeSetUp]
+        protected async Task BeforeAllTestsAsync()
         {
-            Option<Registry> bootstrapRegistry =
-                Option.Maybe(Context.Current.Registries.First());
-            this.daemon = OsPlatform.Current.CreateEdgeDaemon(Context.Current.InstallerPath, Context.Current.EdgeAgentBootstrapImage, bootstrapRegistry);
+            using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+            this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
+                Context.Current.InstallerPath,
+                Context.Current.EdgeAgentBootstrapImage,
+                bootstrapRegistry,
+                cts.Token);
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Util;
+    using NUnit.Framework;
 
     // NUnit's [Timeout] attribute isn't supported in .NET Standard
     // and even if it were, it doesn't run the teardown method when
@@ -15,18 +16,27 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
     // we have our own timeout mechanism.
     public class ManualProvisioningFixture : BaseFixture
     {
-        protected readonly IEdgeDaemon daemon;
         protected readonly IotHub iotHub;
+        protected IEdgeDaemon daemon;
 
         public ManualProvisioningFixture()
         {
-            Option<Registry> bootstrapRegistry =
-                Option.Maybe(Context.Current.Registries.First());
-            this.daemon = OsPlatform.Current.CreateEdgeDaemon(Context.Current.InstallerPath, Context.Current.EdgeAgentBootstrapImage, bootstrapRegistry);
             this.iotHub = new IotHub(
                 Context.Current.ConnectionString,
                 Context.Current.EventHubEndpoint,
                 Context.Current.Proxy);
+        }
+
+        [OneTimeSetUp]
+        protected async Task BeforeAllTestsAsync()
+        {
+            using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+            this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
+                Context.Current.InstallerPath,
+                Context.Current.EdgeAgentBootstrapImage,
+                bootstrapRegistry,
+                cts.Token);
         }
 
         protected async Task ConfigureDaemonAsync(


### PR DESCRIPTION
Introduce CentOs7 to the new E2E test framework
The tests suit includes: 
- QuickstartCerts()
- TempSensor()
- TempFilter()
- ModuleToModuleDirectMethod(Amqp)
- ModuleToModuleDirectMethod(AmqpWs)
- ModuleToModuleDirectMethod(Mqtt)
- ModuleToModuleDirectMethod(MqttWs)
- DpsSymmetricKey()
	
Work in-progress tests (Upcoming PRs):
- TempFilterFunc()
- PriorityQueueModuleToHubMessages()
- PriorityQueueModuleToModuleMessages()
- PriorityQueueTimeToLive()
- ValidateMetrics()

Cherry-picked: https://github.com/Azure/iotedge/commit/f38a6d7a46fcde27db465b7d801572864a8f0491