### PR TITLE
[mqtt] Remove reqwest dependency in favor of hyper

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -375,25 +375,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
-name = "dtoa"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
-
-[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ac63f94732332f44fe654443c46f6375d1939684c17b0afb6cb56b0456e171"
-dependencies = [
- "cfg-if",
-]
 
 [[package]]
 name = "env_logger"
@@ -725,19 +710,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3adcd308402b9553630734e9c36b77a7e48b3821251ca2493e8cd596763aafaa"
-dependencies = [
- "bytes",
- "hyper",
- "native-tls",
- "tokio",
- "tokio-tls",
-]
-
-[[package]]
 name = "hyperlocal"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -895,22 +867,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2684d4c2e97d99848d30b324b00c8fcc7e5c897b7cbb5819b09e7c90e8baf212"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1053,7 +1009,6 @@ dependencies = [
  "native-tls",
  "openssl",
  "regex",
- "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -1601,41 +1556,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b82c9238b305f26f53443e3a4bc8528d64b8d0bee408ec949eb7bf5635ec680"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "hyper",
- "hyper-tls",
- "js-sys",
- "lazy_static",
- "log",
- "mime",
- "mime_guess",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-tls",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
 name = "rustc_version"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1771,18 +1691,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_urlencoded"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
-dependencies = [
- "dtoa",
- "itoa",
- "serde",
- "url",
 ]
 
 [[package]]
@@ -2040,16 +1948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a70f4fcd7b3b24fb194f837560168208f669ca8cb70d0c4b862944452396343"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2157,15 +2055,6 @@ name = "try-lock"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
-
-[[package]]
-name = "unicase"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
-dependencies = [
- "version_check",
-]
 
 [[package]]
 name = "unicode-bidi"
@@ -2284,8 +2173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c2dc4aa152834bc334f506c1a06b866416a8b6697d5c9f75b9a689c8486def0"
 dependencies = [
  "cfg-if",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 
@@ -2302,18 +2189,6 @@ dependencies = [
  "quote",
  "syn",
  "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64487204d863f109eb77e8462189d111f27cb5712cc9fdb3461297a76963a2f6"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -2397,15 +2272,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winreg"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
-dependencies = [
- "winapi 0.3.8",
-]
 
 [[package]]
 name = "ws2_32-sys"

--- a/mqtt/mqtt-edgehub/Cargo.toml
+++ b/mqtt/mqtt-edgehub/Cargo.toml
@@ -16,7 +16,6 @@ futures-util = "0.3"
 lazy_static = "1.4"
 openssl = "0.10"
 regex = "1"
-reqwest = { version = "0.10", features = ["json"] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 serde_repr = "0.1"

--- a/mqtt/mqtt-edgehub/src/auth/authentication/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authentication/edgehub.rs
@@ -4,7 +4,9 @@ use std::{
 };
 
 use async_trait::async_trait;
-use reqwest::Client;
+use bytes::buf::BufExt;
+use http::StatusCode;
+use hyper::{body, client::HttpConnector, Body, Client, Request};
 use serde::{Deserialize, Serialize};
 use serde_repr::Deserialize_repr;
 
@@ -14,7 +16,7 @@ const API_VERSION: &str = "2020-04-20";
 
 #[derive(Clone)]
 pub struct EdgeHubAuthenticator {
-    client: Client,
+    client: Client<HttpConnector>,
     url: String,
 }
 
@@ -28,30 +30,33 @@ impl EdgeHubAuthenticator {
         &self,
         context: AuthenticationContext,
     ) -> Result<Option<AuthId>, AuthenticateError> {
-        let req = EdgeHubAuthRequest::from_auth(&context);
+        let auth_req = EdgeHubAuthRequest::from_auth(&context);
+        let body = serde_json::to_string(&auth_req).map_err(AuthenticateError::SerializeRequest)?;
+        let req = Request::post(&self.url)
+            .body(Body::from(body))
+            .map_err(AuthenticateError::PrepareRequest)?;
 
-        let response = self
+        let http_res = self
             .client
-            .post(&self.url)
-            .json(&req)
-            .send()
+            .request(req)
             .await
             .map_err(AuthenticateError::SendRequest)?;
 
-        if response.status() != reqwest::StatusCode::OK {
-            return Err(AuthenticateError::ProcessResponse);
+        if http_res.status() != StatusCode::OK {
+            return Err(AuthenticateError::UnsuccessfullResponse(http_res.status()));
         }
 
-        let response = response
-            .json::<EdgeHubAuthResponse>()
+        let body = body::aggregate(http_res)
             .await
-            .map_err(|_| AuthenticateError::ProcessResponse)?;
+            .map_err(AuthenticateError::ReadResponse)?;
+        let auth_res: EdgeHubAuthResponse = serde_json::from_reader(body.reader())
+            .map_err(AuthenticateError::DeserializeResponse)?;
 
-        if response.version != API_VERSION {
-            return Err(AuthenticateError::ApiVersion(response.version));
+        if auth_res.version != API_VERSION {
+            return Err(AuthenticateError::ApiVersion(auth_res.version));
         }
 
-        response.try_into()
+        auth_res.try_into()
     }
 }
 
@@ -111,13 +116,10 @@ impl TryFrom<EdgeHubAuthResponse> for Option<AuthId> {
     type Error = AuthenticateError;
 
     fn try_from(value: EdgeHubAuthResponse) -> Result<Self, Self::Error> {
-        match value.result {
-            EdgeHubResultCode::Authenticated => value
-                .identity
-                .map_or(Err(AuthenticateError::ProcessResponse), |identity| {
-                    Ok(Some(identity.into()))
-                }),
-            EdgeHubResultCode::Unauthenticated => Ok(None),
+        match (value.result, value.identity) {
+            (EdgeHubResultCode::Authenticated, Some(identity)) => Ok(Some(identity.into())),
+            (EdgeHubResultCode::Authenticated, None) => Err(AuthenticateError::InvalidResponse),
+            (EdgeHubResultCode::Unauthenticated, _) => Ok(None),
         }
     }
 }
@@ -125,14 +127,29 @@ impl TryFrom<EdgeHubAuthResponse> for Option<AuthId> {
 /// Authentication error.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthenticateError {
-    #[error("failed to send request: {0}.")]
-    SendRequest(#[from] reqwest::Error),
+    #[error("failed to serialize request.")]
+    SerializeRequest(#[source] serde_json::Error),
+
+    #[error("failed to prepare request.")]
+    PrepareRequest(#[source] http::Error),
+
+    #[error("failed to send request.")]
+    SendRequest(#[source] hyper::Error),
+
+    #[error("received unsuccessful status code: {0}")]
+    UnsuccessfullResponse(http::StatusCode),
 
     #[error("failed to process response.")]
-    ProcessResponse,
+    ReadResponse(#[source] hyper::Error),
 
-    #[error("not supported response version {0}.")]
+    #[error("failed to deserialize response.")]
+    DeserializeResponse(#[source] serde_json::Error),
+
+    #[error("not supported response version.")]
     ApiVersion(String),
+
+    #[error("not supported response body.")]
+    InvalidResponse,
 }
 
 #[cfg(test)]

--- a/mqtt/mqtt-edgehub/src/edgelet/mod.rs
+++ b/mqtt/mqtt-edgehub/src/edgelet/mod.rs
@@ -9,7 +9,7 @@ use std::{convert::TryInto, error::Error as StdError, fmt::Display};
 use http::{uri::InvalidUri, Uri};
 use hyper::{client::HttpConnector, Client};
 use hyperlocal::UnixConnector;
-use reqwest::Url;
+use url::Url;
 
 pub fn workload<U>(uri: &U) -> Result<WorkloadClient, Error>
 where

--- a/mqtt/mqtt-edgehub/src/edgelet/workload/client.rs
+++ b/mqtt/mqtt-edgehub/src/edgelet/workload/client.rs
@@ -9,12 +9,12 @@ use http::{Request, StatusCode};
 use std::str;
 
 pub struct WorkloadClient {
-    client: Client<Connector, Body>,
+    client: Client<Connector>,
     scheme: Scheme,
 }
 
 impl WorkloadClient {
-    pub(crate) fn new(client: Client<Connector, Body>, scheme: Scheme) -> Self {
+    pub(crate) fn new(client: Client<Connector>, scheme: Scheme) -> Self {
         Self { client, scheme }
     }
 


### PR DESCRIPTION
Avoid multiple HTTP clients in the workspace. Remove reqwestdependency in favor of hyper.