### PR TITLE
Choose artifacts from master builds by default

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -5,12 +5,14 @@ resources:
   pipelines:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
+    branch: master
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
+    branch: master
     trigger:
       branches:
       - master


### PR DESCRIPTION
Currently, if you manually launch the end-to-end tests build pipeline without specifying build IDs for the "Build Images" and "Edgelet Packages" pipeline artifacts, it will simply choose the latest successful builds, regardless of what branch they were built from. By default it should choose the most recent successful builds from the master branch. If someone needs builds from a different branch they can specify the IDs when they launch the pipeline.