### PR TITLE
make the broker send the current subscription list when a client connects

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -412,9 +412,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 lock (this.deviceProxyLock)
                 {
                     Option<DeviceConnection> currentValue = this.DeviceConnection;
-                    ConcurrentDictionary<DeviceSubscription, bool> subscriptions = this.DeviceConnection.Map(d => d.Subscriptions)
-                        .GetOrElse(new ConcurrentDictionary<DeviceSubscription, bool>());
-                    this.DeviceConnection = Option.Some(new DeviceConnection(deviceProxy, subscriptions));
+                    this.DeviceConnection = Option.Some(new DeviceConnection(deviceProxy, new ConcurrentDictionary<DeviceSubscription, bool>()));
                     return currentValue;
                 }
             }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -747,9 +747,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // Assert
             Assert.True(subscriptionsOption.HasValue);
             subscriptions = subscriptionsOption.OrDefault();
-            Assert.Equal(2, subscriptions.Count);
-            Assert.True(subscriptions[DeviceSubscription.Methods]);
-            Assert.True(subscriptions[DeviceSubscription.C2D]);
+            Assert.Equal(0, subscriptions.Count);
 
             // Act
             connectionManager.AddSubscription(deviceId, DeviceSubscription.DesiredPropertyUpdates);
@@ -759,9 +757,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             // Assert
             Assert.True(subscriptionsOption.HasValue);
             subscriptions = subscriptionsOption.OrDefault();
-            Assert.Equal(4, subscriptions.Count);
-            Assert.True(subscriptions[DeviceSubscription.Methods]);
-            Assert.True(subscriptions[DeviceSubscription.C2D]);
+            Assert.Equal(2, subscriptions.Count);
             Assert.True(subscriptions[DeviceSubscription.DesiredPropertyUpdates]);
             Assert.True(subscriptions[DeviceSubscription.ModuleMessages]);
         }

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -302,7 +302,11 @@ where
                     session.send(event)?;
                 }
 
+                let subscriptions =
+                    StateChange::new_subscription_change(&client_id, Some(&session)).try_into()?;
+
                 self.publish_all(StateChange::new_connection_change(&self.sessions).try_into()?)?;
+                self.publish_all(subscriptions)?;
             }
             OpenSession::DuplicateSession(mut old_session, ack) => {
                 // Drop the old connection

--- a/mqtt/mqtt-broker/tests/translation.rs
+++ b/mqtt/mqtt-broker/tests/translation.rs
@@ -221,6 +221,9 @@ async fn test_twin_with_client_id(client_id: &str) {
         .with_client_id(ClientId::IdWithCleanSession(client_id.into()))
         .build();
 
+    // wait till device_1 gets connected before edge_hub starts listening to changes
+    device_1.connections().recv().await;
+
     // Core subscribes
     edge_hub_core
         .subscribe("$edgehub/+/twin/get/#", QoS::AtLeastOnce)


### PR DESCRIPTION
The broker and edgehub needs a common state of the subscriptions of a client. in case of persistent sessions, when a client comes back, it already has a (previously established) subscription state. To avoid state-mismatches, it is best to store this state in one place, and the best place for that is in the broker. That means that when a client comes back, EdgeHub will not know the already established subscriptions. In order to let it know, the broker should send it when a client connects.