### PR TITLE
[mqtt] Make server certificate optional in config

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -1053,7 +1053,6 @@ dependencies = [
  "mqtt-edgehub",
  "native-tls",
  "serde_json",
- "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -1053,6 +1053,7 @@ dependencies = [
  "mqtt-edgehub",
  "native-tls",
  "serde_json",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1845,18 +1846,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+checksum = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+checksum = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/mqtt/mqtt-broker/src/configuration/mod.rs
+++ b/mqtt/mqtt-broker/src/configuration/mod.rs
@@ -173,7 +173,7 @@ pub struct TlsTransport {
     addr: String,
 
     #[serde(rename = "certificate")]
-    cert_path: PathBuf,
+    cert_path: Option<PathBuf>,
 }
 
 impl TlsTransport {
@@ -181,8 +181,8 @@ impl TlsTransport {
         &self.addr
     }
 
-    pub fn cert_path(&self) -> &Path {
-        &self.cert_path
+    pub fn cert_path(&self) -> Option<&Path> {
+        self.cert_path.as_deref()
     }
 }
 

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -1,4 +1,4 @@
-use std::{error::Error as StdError, future::Future, path::Path, sync::Arc};
+use std::{error::Error as StdError, future::Future, sync::Arc};
 
 use futures_util::future::BoxFuture;
 use futures_util::{
@@ -6,6 +6,7 @@ use futures_util::{
     pin_mut,
     stream::StreamExt,
 };
+use native_tls::Identity;
 use tokio::sync::oneshot;
 use tracing::{debug, error, info, span, warn, Level};
 use tracing_futures::Instrument;
@@ -55,16 +56,13 @@ where
     pub fn tls<N>(
         &mut self,
         addr: &str,
-        cert_path: &Path,
+        identity: Identity,
         authenticator: N,
     ) -> Result<&mut Self, Error>
     where
         N: Authenticator<Error = Box<dyn StdError>> + Send + Sync + 'static,
     {
-        let make_transport = Box::pin(Transport::new_tls(
-            addr.to_string(),
-            cert_path.to_path_buf(),
-        ));
+        let make_transport = Box::pin(Transport::new_tls(addr.to_string(), identity));
         self.transports
             .push((make_transport, Arc::new(authenticator)));
 

--- a/mqtt/mqtt-edgehub/Cargo.toml
+++ b/mqtt/mqtt-edgehub/Cargo.toml
@@ -13,6 +13,7 @@ http = "0.2"
 hyper = "0.13"
 futures-util = "0.3"
 lazy_static = "1.4"
+native-tls = "0.2"
 openssl = "0.10"
 regex = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }

--- a/mqtt/mqttd/Cargo.toml
+++ b/mqtt/mqttd/Cargo.toml
@@ -23,7 +23,6 @@ anyhow = "1.0"
 [dev-dependencies]
 mockito = "0.25"
 serde_json = "1.0"
-tempfile = "3"
 
 [features]
 default = ["edgehub"]

--- a/mqtt/mqttd/Cargo.toml
+++ b/mqtt/mqttd/Cargo.toml
@@ -19,6 +19,7 @@ mqtt-broker-core = { path = "../mqtt-broker-core" }
 mqtt-edgehub = { path = "../mqtt-edgehub", optional = true }
 chrono = "0.4"
 anyhow = "1.0"
+thiserror = "1.0"
 
 [dev-dependencies]
 mockito = "0.25"

--- a/mqtt/mqttd/Cargo.toml
+++ b/mqtt/mqttd/Cargo.toml
@@ -6,20 +6,20 @@ authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0"
 atty = "0.2"
+chrono = "0.4"
 clap = "2.33"
 futures-util = { version = "0.3", features = ["sink"] }
 tokio = { version = "0.2", features = ["dns", "macros", "rt-threaded", "signal", "stream", "tcp", "time"] }
 native-tls = "0.2"
+thiserror = "1.0"
 tracing = "0.1"
 tracing-subscriber = "0.1"
 
 mqtt-broker = { path = "../mqtt-broker", default-features = false }
 mqtt-broker-core = { path = "../mqtt-broker-core" }
 mqtt-edgehub = { path = "../mqtt-edgehub", optional = true }
-chrono = "0.4"
-anyhow = "1.0"
-thiserror = "1.0"
 
 [dev-dependencies]
 mockito = "0.25"

--- a/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
@@ -1,12 +1,15 @@
-use std::{env, fs, future::Future, path::Path};
+use std::{convert::TryInto, env, future::Future};
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use chrono::{DateTime, Duration, Utc};
 
 use futures_util::{
     future::{self, Either},
     pin_mut, FutureExt,
 };
+use tokio::time;
+use tracing::{info, warn};
+
 use mqtt_broker::{Broker, BrokerBuilder, BrokerConfig, BrokerSnapshot, Server};
 use mqtt_broker_core::auth::Authorizer;
 use mqtt_edgehub::{
@@ -14,8 +17,6 @@ use mqtt_edgehub::{
     edgelet,
     tls::ServerCertificate,
 };
-use tokio::time;
-use tracing::{info, warn};
 
 pub async fn broker(
     config: &BrokerConfig,
@@ -51,9 +52,23 @@ where
 
     let renewal_signal = match config.transports().tls() {
         Some(tls) => {
-            let identity = download_server_certificate(tls.cert_path()).await?;
+            let identity = match tls.cert_path() {
+                Some(path) => {
+                    info!("loading identity from {}", path.display());
+                    ServerCertificate::from_file(path).context(anyhow!(
+                        "unable to import server certificate from file {}",
+                        path.display()
+                    ))?
+                }
+                None => {
+                    info!("downloading identity from edgelet");
+                    download_server_certificate()
+                        .await
+                        .context(anyhow!("unable to download certificate from edgelet"))?
+                }
+            };
             let renew_at = identity.not_after();
-            server.tls(tls.addr(), tls.cert_path(), authenticator.clone())?;
+            server.tls(tls.addr(), identity.try_into()?, authenticator.clone())?;
 
             let renewal_signal = server_certificate_renewal(renew_at);
             Either::Left(renewal_signal)
@@ -94,7 +109,7 @@ pub const MODULE_GENERATION_ID: &str = "IOTEDGE_MODULEGENERATIONID";
 
 pub const CERTIFICATE_VALIDITY_DAYS: i64 = 90;
 
-async fn download_server_certificate(path: impl AsRef<Path>) -> Result<ServerCertificate> {
+async fn download_server_certificate() -> Result<ServerCertificate> {
     let uri = env::var(WORKLOAD_URI)?;
     let hostname = env::var(EDGE_DEVICE_HOST_NAME)?;
     let module_id = env::var(MODULE_ID)?;
@@ -114,8 +129,7 @@ async fn download_server_certificate(path: impl AsRef<Path>) -> Result<ServerCer
     }
 
     if let Some(private_key) = cert.private_key().bytes() {
-        let identity = ServerCertificate::try_from(cert.certificate(), private_key)?;
-        fs::write(path, &identity)?;
+        let identity = ServerCertificate::from_pem_pair(cert.certificate(), private_key)?;
         Ok(identity)
     } else {
         bail!("missing private key");
@@ -166,12 +180,8 @@ mod tests {
         env::set_var(MODULE_ID, "$edgeHub");
         env::set_var(MODULE_GENERATION_ID, "12345678");
 
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("identity.pem");
-
-        let res = download_server_certificate(&path).await;
+        let res = download_server_certificate().await;
         assert!(res.is_ok());
-        assert!(path.exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
In `edgehub` mode broker always tries to download server certificate from edgelet which is troublesome during development.

Make a path to a server certificate optional for both modes. When the `certificate` is missing in the config
* in `edgehub` mode it skips downloading server certificate from edgelet and tries to load it from a file
* in `generic` mode it returns an error