### PR TITLE
[mqtt] Fix error when parsing unix path

### DIFF
--- a/mqtt/mqtt-edgehub/src/auth/authentication/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authentication/edgehub.rs
@@ -33,7 +33,7 @@ impl EdgeHubAuthenticator {
         let auth_req = EdgeHubAuthRequest::from_auth(&context);
         let body = serde_json::to_string(&auth_req).map_err(AuthenticateError::SerializeRequest)?;
         let req = Request::post(&self.url)
-            .header(header::CONTENT_TYPE, "application/json")
+            .header(header::CONTENT_TYPE, "application/json; charset=utf-8")
             .body(Body::from(body))
             .map_err(AuthenticateError::PrepareRequest)?;
 

--- a/mqtt/mqtt-edgehub/src/auth/authentication/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authentication/edgehub.rs
@@ -5,7 +5,7 @@ use std::{
 
 use async_trait::async_trait;
 use bytes::buf::BufExt;
-use http::StatusCode;
+use http::{header, StatusCode};
 use hyper::{body, client::HttpConnector, Body, Client, Request};
 use serde::{Deserialize, Serialize};
 use serde_repr::Deserialize_repr;
@@ -33,6 +33,7 @@ impl EdgeHubAuthenticator {
         let auth_req = EdgeHubAuthRequest::from_auth(&context);
         let body = serde_json::to_string(&auth_req).map_err(AuthenticateError::SerializeRequest)?;
         let req = Request::post(&self.url)
+            .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(body))
             .map_err(AuthenticateError::PrepareRequest)?;
 

--- a/mqtt/mqtt-edgehub/src/edgelet/mod.rs
+++ b/mqtt/mqtt-edgehub/src/edgelet/mod.rs
@@ -2,36 +2,30 @@ mod connect;
 mod workload;
 
 pub use connect::Connector;
-pub use workload::*;
+pub use workload::{CertificateResponse, ServerCertificateRequest, WorkloadClient};
 
-use std::{convert::TryInto, error::Error as StdError, fmt::Display};
+use std::error::Error as StdError;
 
-use http::{uri::InvalidUri, Uri};
+use http::Uri;
 use hyper::{client::HttpConnector, Client};
 #[cfg(unix)]
 use hyperlocal::UnixConnector;
-use url::Url;
+use url::{ParseError, Url};
 
-pub fn workload<U>(uri: &U) -> Result<WorkloadClient, Error>
-where
-    U: TryInto<Uri, Error = InvalidUri> + Display + Clone,
-{
-    let uri = uri
-        .clone()
-        .try_into()
-        .map_err(|e| Error::ParseUrl(uri.to_string(), e))?;
+pub fn workload(url: &str) -> Result<WorkloadClient, Error> {
+    let url = Url::parse(url).map_err(|e| Error::ParseUrl(url.to_string(), e))?;
 
-    let (connector, scheme) = match uri.scheme_str() {
+    let (connector, scheme) = match url.scheme() {
         #[cfg(unix)]
-        Some("unix") => (
+        "unix" => (
             Connector::Unix(UnixConnector),
-            Scheme::Unix(uri.path().to_string()),
+            Scheme::Unix(url.path().to_string()),
         ),
-        Some("http") => (
+        "http" => (
             Connector::Http(HttpConnector::new()),
-            Scheme::Http(uri.to_string()),
+            Scheme::Http(url.to_string()),
         ),
-        _ => return Err(Error::UnrecognizedUrlScheme(uri.to_string())),
+        _ => return Err(Error::UnrecognizedUrlScheme(url.to_string())),
     };
 
     let client = Client::builder().build(connector);
@@ -51,6 +45,7 @@ fn make_hyper_uri(scheme: &Scheme, path: &str) -> Result<Uri, Box<dyn StdError +
     }
 }
 
+#[derive(Debug)]
 pub(crate) enum Scheme {
     #[cfg(unix)]
     Unix(String),
@@ -84,8 +79,28 @@ pub enum ApiError {
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("could not parse URL: {0}. {1}")]
-    ParseUrl(String, #[source] InvalidUri),
+    ParseUrl(String, #[source] ParseError),
 
     #[error("unrecognized scheme {0}")]
     UnrecognizedUrlScheme(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use matches::assert_matches;
+
+    use super::workload;
+
+    #[test]
+    fn it_creates_workload_client_for_http() {
+        let client = workload("http://127.0.0.1:8000");
+        assert_matches!(client, Ok(_));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn it_creates_workload_client_for_unix() {
+        let client = workload("unix:///var/run/iotedge/workload.sock");
+        assert_matches!(client, Ok(_));
+    }
 }

--- a/mqtt/mqtt-edgehub/src/edgelet/workload/client.rs
+++ b/mqtt/mqtt-edgehub/src/edgelet/workload/client.rs
@@ -1,13 +1,15 @@
+use std::str;
+
 use bytes::buf::{Buf, BufExt};
 use chrono::{DateTime, Utc};
+use http::{Request, StatusCode};
 use hyper::{body, Body, Client};
 
 use crate::edgelet::{
     make_hyper_uri, ApiError, CertificateResponse, Connector, Scheme, ServerCertificateRequest,
 };
-use http::{Request, StatusCode};
-use std::str;
 
+#[derive(Debug)]
 pub struct WorkloadClient {
     client: Client<Connector>,
     scheme: Scheme,


### PR DESCRIPTION
Fixes error when parsing `unix://workload.sock` path.
Adds `Content-Type: application/json` for authenticator HTTP call