### PR TITLE
GetDeviceAndModuleOnBehalfOf in EdgeHub

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceScopeApiClientProvider.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceScopeApiClientProvider.cs
@@ -49,13 +49,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 this.retryStrategy);
         }
 
-        public IDeviceScopeApiClient CreateNestedDeviceScopeClient(Option<string> continuationToken)
+        public IDeviceScopeApiClient CreateNestedDeviceScopeClient()
         {
             return new NestedDeviceScopeApiClient(
                 this.iotHubHostName,
                 this.actorEdgeDeviceId,
                 this.moduleId,
-                continuationToken,
+                Option.None<string>(),
                 this.batchSize,
                 this.edgeHubTokenProvider,
                 this.serviceIdentityHierarchy,

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/IDeviceScopeApiClientProvider.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/IDeviceScopeApiClientProvider.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
     {
         IDeviceScopeApiClient CreateDeviceScopeClient();
 
-        IDeviceScopeApiClient CreateNestedDeviceScopeClient(Option<string> continuationLink);
+        IDeviceScopeApiClient CreateNestedDeviceScopeClient();
 
         IDeviceScopeApiClient CreateOnBehalfOf(string childDeviceId, Option<string> continuationLink);
     }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/NestedDeviceScopeApiClient.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/NestedDeviceScopeApiClient.cs
@@ -49,10 +49,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             Option<string> continuationToken,
             int batchSize,
             ITokenProvider edgeHubTokenProvider,
-            IServiceIdentityHierarchy serviceIdentityTree,
+            IServiceIdentityHierarchy serviceIdentityHierarchy,
             Option<IWebProxy> proxy,
             RetryStrategy retryStrategy = null)
-            : this(iotHubHostName, deviceId, deviceId, moduleId, continuationToken, batchSize, edgeHubTokenProvider, serviceIdentityTree, proxy, retryStrategy)
+            : this(iotHubHostName, deviceId, deviceId, moduleId, continuationToken, batchSize, edgeHubTokenProvider, serviceIdentityHierarchy, proxy, retryStrategy)
         {
         }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             Option<string> continuationToken,
             int batchSize,
             ITokenProvider edgeHubTokenProvider,
-            IServiceIdentityHierarchy serviceIdentityTree,
+            IServiceIdentityHierarchy serviceIdentityHierarchy,
             Option<IWebProxy> proxy,
             RetryStrategy retryStrategy = null)
         {
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             this.continuationToken = Preconditions.CheckNotNull(continuationToken);
             this.batchSize = Preconditions.CheckRange(batchSize, 0, 1000, nameof(batchSize));
             this.edgeHubTokenProvider = Preconditions.CheckNotNull(edgeHubTokenProvider, nameof(edgeHubTokenProvider));
-            this.serviceIdentityHierarchy = Preconditions.CheckNotNull(serviceIdentityTree, nameof(serviceIdentityTree));
+            this.serviceIdentityHierarchy = Preconditions.CheckNotNull(serviceIdentityHierarchy, nameof(serviceIdentityHierarchy));
             this.proxy = Preconditions.CheckNotNull(proxy, nameof(proxy));
             this.retryStrategy = retryStrategy ?? TransientRetryStrategy;
         }
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         internal Uri GetNestedScopeServiceUri()
         {
-            // The URI is always always in the context of the actor device
+            // The URI is always in the context of the actor device
             string relativeUri = GetDevicesAndModulesInTargetScopeUriFormat.FormatInvariant(this.actorEdgeDeviceId, this.moduleId, NestedApiVersion);
             var uri = new Uri(this.iotHubBaseHttpUri, relativeUri);
             return uri;
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
         internal Uri GetIdentityOnBehalfOfServiceUri()
         {
-            // The URI is always always in the context of the actor device
+            // The URI is always in the context of the actor device
             string relativeUri = GetDeviceAndModuleOnBehalfOfUriFormat.FormatInvariant(this.actorEdgeDeviceId, this.moduleId, NestedApiVersion);
             var uri = new Uri(this.iotHubBaseHttpUri, relativeUri);
             return uri;

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
@@ -39,7 +39,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             Option<ScopeResult> scopeResult = Option.None<ScopeResult>();
             try
             {
-                ScopeResult res = await this.securityScopesApiClientProvider.CreateDeviceScopeClient().GetIdentityAsync(deviceId, null);
+                IDeviceScopeApiClient client;
+
+                if (this.nestedEdgeEnabled)
+                {
+                    client = this.securityScopesApiClientProvider.CreateNestedDeviceScopeClient(Option.None<string>());
+                }
+                else
+                {
+                    client = this.securityScopesApiClientProvider.CreateDeviceScopeClient();
+                }
+
+                ScopeResult res = await client.GetIdentityAsync(deviceId, null);
                 scopeResult = Option.Maybe(res);
                 Events.IdentityScopeResultReceived(deviceId);
             }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 
                 if (this.nestedEdgeEnabled)
                 {
-                    client = this.securityScopesApiClientProvider.CreateNestedDeviceScopeClient(Option.None<string>());
+                    client = this.securityScopesApiClientProvider.CreateNestedDeviceScopeClient();
                 }
                 else
                 {
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 this.clientProvider = Preconditions.CheckNotNull(securityScopesApiClientProvider);
 
                 // Put the first node (the actor device) into the queue
-                this.actorClient = this.clientProvider.CreateNestedDeviceScopeClient(Option.None<string>());
+                this.actorClient = this.clientProvider.CreateNestedDeviceScopeClient();
                 this.remainingEdgeNodes = new Queue<IDeviceScopeApiClient>();
                 this.remainingEdgeNodes.Enqueue(this.actorClient);
             }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -79,33 +79,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
 
         internal bool ValidateAuthChain(string actorDeviceId, string targetId, string authChain)
         {
-            var authChainIds = authChain.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
-
-            // The first element of the authChain should be the target identity
-            if (authChainIds[0] != targetId)
+            if (AuthChainHelpers.ValidateAuthChain(actorDeviceId, targetId, authChain))
+            {
+                return true;
+            }
+            else
             {
                 Events.InvalidAuthChain(targetId, authChain);
                 return false;
             }
-
-            // The actor device should be in the authChain
-            bool targetAuthChainHasActor = false;
-            foreach (string id in authChainIds)
-            {
-                if (id == actorDeviceId)
-                {
-                    targetAuthChainHasActor = true;
-                    break;
-                }
-            }
-
-            if (!targetAuthChainHasActor)
-            {
-                Events.InvalidAuthChain(targetId, authChain);
-                return false;
-            }
-
-            return true;
         }
 
         internal bool ValidateAudienceIds(string audienceDeviceId, Option<string> audienceModuleId, IIdentity identity)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/AuthChainHelpers.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/AuthChainHelpers.cs
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System;
+
+    public class AuthChainHelpers
+    {
+        public static bool ValidateAuthChain(string actorDeviceId, string targetId, string authChain)
+        {
+            var authChainIds = authChain.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Should have at least 1 element in the chain
+            if (authChainIds.Length < 1)
+            {
+                return false;
+            }
+
+            // The first element of the authChain should be the target identity
+            if (authChainIds[0] != targetId)
+            {
+                return false;
+            }
+
+            // The actor device should be in the authChain
+            bool targetAuthChainHasActor = false;
+            foreach (string id in authChainIds)
+            {
+                if (id == actorDeviceId)
+                {
+                    targetAuthChainHasActor = true;
+                    break;
+                }
+            }
+
+            if (!targetAuthChainHasActor)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/AuthChainHelpers.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/AuthChainHelpers.cs
@@ -3,7 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 {
     using System;
 
-    public class AuthChainHelpers
+    public static class AuthChainHelpers
     {
         public static bool ValidateAuthChain(string actorDeviceId, string targetId, string authChain)
         {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
@@ -138,7 +138,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             Option<string> authChain = await this.deviceScopeIdentitiesCache.GetAuthChain(credentials.Identity.Id);
             if (!authChain.HasValue)
             {
-                // Target identity is not in our nested hierarchy
+                Events.NoAuthChain(credentials.Identity);
                 return (false, false);
             }
 
@@ -170,6 +170,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             {
                 ErrorAuthenticating = IdStart,
                 ServiceIdentityNotFound,
+                NoAuthChain,
                 AuthenticatedInScope,
                 InputCredentialsNotValid,
                 ResyncingServiceIdentity,
@@ -185,6 +186,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             public static void ServiceIdentityNotFound(IIdentity identity)
             {
                 Log.LogDebug((int)EventIds.ServiceIdentityNotFound, $"Service identity for {identity.Id} not found. Using underlying authenticator to authenticate");
+            }
+
+            public static void NoAuthChain(IIdentity identity)
+            {
+                Log.LogDebug((int)EventIds.NoAuthChain, $"Could not get valid auth-chain for service identity {identity.Id}");
             }
 
             public static void AuthenticatedInScope(IIdentity identity, bool isAuthenticated)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 return (false, false);
             }
 
-            return await this.AuthenticateWithServiceIdentity(credentials, actorEdgeHubId, true, authChain);
+            return await this.AuthenticateWithServiceIdentity(credentials, actorEdgeHubId, syncServiceIdentity, authChain);
         }
 
         async Task<(bool isAuthenticated, bool serviceIdentityFound)> AuthenticateWithServiceIdentity(T credentials, string serviceIdentityId, bool syncServiceIdentity, Option<string> authChain)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
@@ -105,21 +105,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public Task<Option<string>> GetAuthChain(string targetId) => this.serviceIdentityHierarchy.GetAuthChain(targetId);
 
-        public async Task<IList<ServiceIdentity>> GetDevicesAndModulesInTargetScopeAsync(string targetDeviceId)
-        {
-            Preconditions.CheckNonWhiteSpace(targetDeviceId, nameof(targetDeviceId));
-
-            // The result is the target device itself and all its immediate children
-            IList<ServiceIdentity> results = await this.serviceIdentityHierarchy.GetImmediateChildren(targetDeviceId);
-
-            if (results.Count > 0)
-            {
-                Option<ServiceIdentity> targetDevice = await this.serviceIdentityHierarchy.Get(targetDeviceId);
-                results.Add(targetDevice.Expect(() => new InvalidOperationException($"Child identities exist but there's no parent: {targetDeviceId}")));
-            }
-
-            return results;
-        }
+        public async Task<IList<ServiceIdentity>> GetDevicesAndModulesInTargetScopeAsync(string targetDeviceId) => await this.serviceIdentityHierarchy.GetImmediateChildren(targetDeviceId);
 
         public void Dispose()
         {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
@@ -40,5 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         Task<Option<string>> GetAuthChainForIdentity(string id);
 
         Task<IList<ServiceIdentity>> GetDevicesAndModulesInTargetScopeAsync(string requestedDeviceId);
+
+        Task<Option<ServiceIdentity>> GetIdentityAsync(string targetIdentityId);
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IServiceIdentityHierarchy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IServiceIdentityHierarchy.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         Task<Option<ServiceIdentity>> Get(string id);
         Task<IList<string>> GetAllIds();
         Task<Option<string>> GetAuthChain(string id);
+        Task<Option<string>> GetEdgeAuthChain(string id);
         Task<IList<ServiceIdentity>> GetImmediateChildren(string id);
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IdentityOnBehalfOfRequest.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IdentityOnBehalfOfRequest.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// This is an object to encapsulate JSON serialization of the
+    /// GetDeviceAndModuleOnBehalfOf POST request.
+    /// </summary>
+    public class IdentityOnBehalfOfRequest
+    {
+        [JsonProperty(PropertyName = "targetDeviceId", Required = Required.Always)]
+        public string TargetDeviceId { get; }
+
+        [JsonProperty(PropertyName = "targetModuleId", NullValueHandling = NullValueHandling.Ignore)]
+        public string TargetModuleId { get; }
+
+        [JsonProperty(PropertyName = "authChain", Required = Required.Always)]
+        public string AuthChain { get; }
+
+        public IdentityOnBehalfOfRequest(string targetDeviceId, string targetModuleId, string authChain)
+        {
+            this.TargetDeviceId = Preconditions.CheckNonWhiteSpace(targetDeviceId, nameof(targetDeviceId));
+            this.TargetModuleId = targetModuleId;
+            this.AuthChain = Preconditions.CheckNonWhiteSpace(authChain, nameof(authChain));
+        }
+    }
+}

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -151,6 +151,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
         public Task<IList<ServiceIdentity>> GetDevicesAndModulesInTargetScopeAsync(string targetDeviceId)
             => this.deviceScopeIdentitiesCache.GetDevicesAndModulesInTargetScopeAsync(targetDeviceId);
 
+        public Task<Option<ServiceIdentity>> GetIdentityAsync(string targetId)
+            => this.deviceScopeIdentitiesCache.GetServiceIdentity(targetId);
+
         public void Dispose()
         {
             this.Dispose(true);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/EdgeHubScopeModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/EdgeHubScopeModule.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http
             string generationId,
             AuthenticationMechanism authentication)
         {
-            this.Id = Preconditions.CheckNonWhiteSpace(moduleId, nameof(deviceId));
+            this.Id = Preconditions.CheckNonWhiteSpace(moduleId, nameof(moduleId));
             this.DeviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
             this.GenerationId = Preconditions.CheckNonWhiteSpace(generationId, nameof(generationId));
             this.Authentication = Preconditions.CheckNotNull(authentication);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Mvc;
+    using Microsoft.Azure.Devices.Common;
     using Microsoft.Azure.Devices.Edge.Hub.CloudProxy;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
@@ -34,43 +35,39 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             actorModuleId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorModuleId, nameof(actorModuleId)));
             Preconditions.CheckArgument(actorModuleId == Constants.EdgeHubModuleId);
 
-            EdgeHubScopeResult result = await this.HandleDevicesAndModulesInTargetDeviceScope(actorDeviceId, actorModuleId, request);
+            EdgeHubScopeResult result = await this.HandleDevicesAndModulesInTargetDeviceScope(actorDeviceId, request);
             await this.SendResponse(result);
         }
 
-        async Task<EdgeHubScopeResult> HandleDevicesAndModulesInTargetDeviceScope(string actorDeviceId, string actorModuleId, NestedScopeRequest request)
+        [HttpPost]
+        [Route("devices/{actorDeviceId}/modules/{actorModuleId}/getDeviceAndModuleOnBehalfOf")]
+        public async Task GetDeviceAndModuleOnBehalfOf([FromRoute] string actorDeviceId, [FromRoute] string actorModuleId, [FromBody] IdentityOnBehalfOfRequest request)
+        {
+            actorDeviceId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorDeviceId, nameof(actorDeviceId)));
+            actorModuleId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorModuleId, nameof(actorModuleId)));
+            Preconditions.CheckArgument(actorModuleId == Constants.EdgeHubModuleId);
+
+            EdgeHubScopeResult result = await this.HandleGetDeviceAndModuleOnBehalfOf(actorDeviceId, request);
+            await this.SendResponse(result);
+        }
+
+        async Task<EdgeHubScopeResult> HandleDevicesAndModulesInTargetDeviceScope(string actorDeviceId, NestedScopeRequest request)
         {
             Events.ReceivedScopeRequest(actorDeviceId, request);
+            Preconditions.CheckNonWhiteSpace(request.AuthChain, nameof(request.AuthChain));
 
             EdgeHubScopeResult result = new EdgeHubScopeResult();
 
-            // Parse the target device ID from the authchain
-            if (!ValidateChainAndGetTargetDeviceId(actorDeviceId, request.AuthChain, out string targetDeviceId))
+            if (!this.TryGetTargetDeviceId(request.AuthChain, out string targetDeviceId))
             {
                 Events.InvalidAuthchain(request.AuthChain);
                 result.Status = HttpStatusCode.BadRequest;
                 return result;
             }
 
-            // Actor device is claiming to be our child, and that the target device is its child.
-            // So we should have an authchain already cached for the target device.
+            // Check that the actor device is authorized to act OnBehalfOf the target
             IEdgeHub edgeHub = await this.edgeHubGetter;
-            Option<string> targetAuthChainOption = await edgeHub.GetAuthChainForIdentity(targetDeviceId);
-            string targetAuthChain = targetAuthChainOption.Expect(() => new UnauthorizedAccessException($"{targetDeviceId} is not a child of this Edge device"));
-
-            // The actor device should be somewhere in the target device's authchain
-            var targetAuthChainIds = targetAuthChain.Split(';', StringSplitOptions.RemoveEmptyEntries);
-            bool targetAuthChainHasActor = false;
-            foreach (string id in targetAuthChainIds)
-            {
-                if (id == actorDeviceId)
-                {
-                    targetAuthChainHasActor = true;
-                    break;
-                }
-            }
-
-            if (!targetAuthChainHasActor)
+            if (!await this.AuthorizeActorDevice(edgeHub, actorDeviceId, targetDeviceId))
             {
                 Events.UnauthorizedActor(actorDeviceId, targetDeviceId);
                 result.Status = HttpStatusCode.Unauthorized;
@@ -84,6 +81,93 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             result.Status = HttpStatusCode.OK;
 
             return result;
+        }
+
+        async Task<EdgeHubScopeResult> HandleGetDeviceAndModuleOnBehalfOf(string actorDeviceId, IdentityOnBehalfOfRequest request)
+        {
+            Events.ReceivedIdentityOnBehalfOfRequest(actorDeviceId, request);
+            Preconditions.CheckNonWhiteSpace(request.TargetDeviceId, nameof(request.TargetDeviceId));
+
+            EdgeHubScopeResult result = new EdgeHubScopeResult();
+
+            bool isModule = false;
+            string targetId = request.TargetDeviceId;
+            if (!request.TargetModuleId.IsNullOrWhiteSpace())
+            {
+                isModule = true;
+                targetId += "/" + request.TargetModuleId;
+            }
+
+            // Check that the actor device is authorized to act OnBehalfOf the target
+            IEdgeHub edgeHub = await this.edgeHubGetter;
+            if (!await this.AuthorizeActorDevice(edgeHub, actorDeviceId, targetId))
+            {
+                Events.UnauthorizedActor(actorDeviceId, targetId);
+                result.Status = HttpStatusCode.Unauthorized;
+                return result;
+            }
+
+            // Get the target identity
+            var identityList = new List<ServiceIdentity>();
+            Option<ServiceIdentity> identity = await edgeHub.GetIdentityAsync(targetId);
+            identity.ForEach(i => identityList.Add(i));
+
+            // If the target is a module, we also need to
+            // include the parent device as well to match
+            // IoT Hub API behavior
+            if (isModule)
+            {
+                Option<ServiceIdentity> device = await edgeHub.GetIdentityAsync(request.TargetDeviceId);
+                device.ForEach(i => identityList.Add(i));
+            }
+
+            Events.SendingScopeResult(identityList);
+            result = MakeResultFromIdentities(identityList);
+            result.Status = HttpStatusCode.OK;
+
+            return result;
+        }
+
+        bool TryGetTargetDeviceId(string authChain, out string targetDeviceId)
+        {
+            targetDeviceId = string.Empty;
+
+            // The target device is the first ID in the provided authchain,
+            // which could be a module ID of the format "deviceId/moduleId".
+            var actorAuthChainIds = authChain.Split(';', StringSplitOptions.RemoveEmptyEntries);
+
+            if (actorAuthChainIds.Length > 0)
+            {
+                var ids = actorAuthChainIds[0].Split('/', StringSplitOptions.RemoveEmptyEntries);
+
+                if (ids.Length > 0)
+                {
+                    targetDeviceId = ids[0];
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        async Task<bool> AuthorizeActorDevice(IEdgeHub edgeHub, string actorDeviceId, string targetId)
+        {
+            // Actor device is claiming to be our child, and that the target device is its child.
+            // So we should have an authchain already cached for the target device.
+            Option<string> targetAuthChain = await edgeHub.GetAuthChainForIdentity(targetId);
+
+            if (!targetAuthChain.HasValue)
+            {
+                return false;
+            }
+
+            // Validate the the target auth-chain
+            if (!AuthChainHelpers.ValidateAuthChain(actorDeviceId, targetId, targetAuthChain.Expect(() => new InvalidOperationException())))
+            {
+                return false;
+            }
+
+            return true;
         }
 
         async Task SendResponse(EdgeHubScopeResult result)
@@ -100,32 +184,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
 
                 await this.Response.Body.WriteAsync(resultUtf8Bytes, 0, resultUtf8Bytes.Length);
             }
-        }
-
-        internal static bool ValidateChainAndGetTargetDeviceId(string actorDeviceId, string authChain, out string targetDeviceId)
-        {
-            targetDeviceId = string.Empty;
-            var actorAuthChainIds = authChain.Split(';', StringSplitOptions.RemoveEmptyEntries);
-
-            // Should have at least 1 element in the chain
-            if (actorAuthChainIds.Length < 1)
-            {
-                return false;
-            }
-
-            // The actor device is the one that sent the request, so the last element
-            // of the auth-chain should always be the actor device's ID
-            if (!actorDeviceId.Equals(actorAuthChainIds.LastOrDefault()))
-            {
-                return false;
-            }
-
-            // The target device ID is the first device ID in the chain, which could be a module ID
-            // of the format "deviceId/moduleId"
-            var ids = actorAuthChainIds[0].Split('/', StringSplitOptions.RemoveEmptyEntries).ToList();
-            targetDeviceId = ids[0];
-
-            return true;
         }
 
         static EdgeHubScopeResult MakeResultFromIdentities(IList<ServiceIdentity> identities)
@@ -156,6 +214,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             enum EventIds
             {
                 ReceivedScopeRequest = IdStart,
+                ReceivedIdentityOnBehalfOfRequest,
                 SendingScopeResult,
                 AuthchainMismatch,
                 UnauthorizedActor,
@@ -167,14 +226,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 Log.LogInformation((int)EventIds.ReceivedScopeRequest, $"Received get scope request: actorDevice: {actorDeviceId}, authChain: {request.AuthChain}, continuationLink: {request.ContinuationLink}, pageSize: {request.PageSize}");
             }
 
+            public static void ReceivedIdentityOnBehalfOfRequest(string actorDeviceId, IdentityOnBehalfOfRequest request)
+            {
+                Log.LogInformation((int)EventIds.ReceivedIdentityOnBehalfOfRequest, $"Received get scope request: actorDevice: {actorDeviceId}, authChain: {request.AuthChain}, targetDevice: {request.TargetDeviceId}, targetModule: {request.TargetModuleId}");
+            }
+
             public static void SendingScopeResult(IList<ServiceIdentity> identities)
             {
-                Log.LogInformation((int)EventIds.SendingScopeResult, $"Sending ScopeResult: {string.Join(", ", identities.Select(identity => identity.Id))}");
+                Log.LogInformation((int)EventIds.SendingScopeResult, $"Sending ScopeResult: [{string.Join(", ", identities.Select(identity => identity.Id))}]");
             }
 
             public static void UnauthorizedActor(string actorDeviceId, string targetDeviceId)
             {
-                Log.LogError((int)EventIds.UnauthorizedActor, $"{actorDeviceId} not authorized to call OnBehalfOf {targetDeviceId}");
+                Log.LogError((int)EventIds.UnauthorizedActor, $"{actorDeviceId} not authorized to act OnBehalfOf {targetDeviceId}");
             }
 
             public static void InvalidAuthchain(string authChain)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/AuthChainHelpersTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/AuthChainHelpersTest.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
+{
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Xunit;
+
+    [Unit]
+    public class AuthChainHelpersTest
+    {
+        [Fact]
+        public void ValidateChainTest()
+        {
+            // Correct case
+            Assert.True(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", "leaf1;edge1;edgeRoot"));
+
+            // Unauthorized actor
+            Assert.False(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", "leaf1;edge2;edgeRoot"));
+
+            // Bad target
+            Assert.False(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", "leaf2;edge1;edgeRoot"));
+
+            // Invalid format
+            Assert.False(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", ";"));
+        }
+    }
+}

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -25,14 +25,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
     [Unit]
     public class DeviceScopeControllerTest
     {
-        static readonly string actorId = "edge1";
-        static readonly string targetId = "edge2";
-        static readonly string targetAuthChain = "edge2;edge1;edgeroot";
-
         [Fact]
-        public async Task NestedDeviceScopeRoundtripTest()
+        public async Task GetDevicesAndModulesInTargetDeviceScope_RoundTripTest()
         {
             // Setup ServiceIdentity results
+            string parentEdgeId = "edge1";
+            string childEdgeId = "edge2";
             string deviceId = "device1";
             string moduleId = "module1";
             string deviceScope = "deviceScope1";
@@ -44,11 +42,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var resultDeviceIdentity = new ServiceIdentity(deviceId, null, deviceScope, new List<string>() { parentScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultModuleIdentity = new ServiceIdentity(deviceId, moduleId, null, new List<string>() { deviceScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultIdentities = new List<ServiceIdentity>() { resultDeviceIdentity, resultModuleIdentity };
-            var controller = MakeController(resultIdentities);
+            var authChainMapping = new Dictionary<string, string>();
+            authChainMapping.Add(childEdgeId, "edge2;edge1;edgeroot");
+            var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
 
             // Act
             var request = new NestedScopeRequest(0, string.Empty, "edge2;edge1");
-            await controller.GetDevicesAndModulesInTargetDeviceScope(actorId, "$edgeHub", request);
+            await controller.GetDevicesAndModulesInTargetDeviceScope(parentEdgeId, "$edgeHub", request);
 
             // Verify EdgeHub result types
             var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };
@@ -76,26 +76,128 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         }
 
         [Fact]
-        public async void ValidateChainAndGetTargetDeviceIdTest()
+        public void GetDevicesAndModulesInTargetDeviceScope_UnauthorizedActorTest()
         {
+            string targetEdgeId = "edge2";
             var resultIdentities = new List<ServiceIdentity>();
-            var controller = MakeController(resultIdentities);
+            var authChainMapping = new Dictionary<string, string>();
+            authChainMapping.Add(targetEdgeId, targetEdgeId + ";edge1;edgeroot");
+            var controller = MakeController(targetEdgeId, resultIdentities, authChainMapping);
 
             var request = new NestedScopeRequest(0, string.Empty, "edge2;edge1");
             Assert.Throws<AggregateException>(() => controller.GetDevicesAndModulesInTargetDeviceScope("edge1", "notEdgeHub", request).Wait());
-
-            request = new NestedScopeRequest(0, string.Empty, "edge2;edge2");
-            await controller.GetDevicesAndModulesInTargetDeviceScope("edge1", "$edgeHub", request);
-            Assert.Equal((int)HttpStatusCode.BadRequest, controller.HttpContext.Response.StatusCode);
         }
 
-        private static DeviceScopeController MakeController(IList<ServiceIdentity> resultIdentities)
+        [Fact]
+        public async Task GetModuleOnBehalfOf()
+        {
+            // Setup ServiceIdentity results
+            string parentEdgeId = "edge1";
+            string childEdgeId = "edge2";
+            string moduleId = "module1";
+            string deviceScope = "deviceScope1";
+            string parentScope = "parentScope1";
+            string generationId = "generation1";
+            string primaryKey = "t3LtII3CppvtVqycKp9bo043vCEgWbGBJAzXZNmoBXo=";
+            string secondaryKey = "kT4ac4PpH5UY0vA1JpLQWOu2yG6qKoqwvzee3j1Z3bA=";
+            var authentication = new ServiceAuthentication(new SymmetricKeyAuthentication(primaryKey, secondaryKey));
+            var resultDeviceIdentity = new ServiceIdentity(childEdgeId, null, deviceScope, new List<string>() { parentScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
+            var resultModuleIdentity = new ServiceIdentity(childEdgeId, moduleId, null, new List<string>() { deviceScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
+            var resultIdentities = new List<ServiceIdentity>() { resultDeviceIdentity, resultModuleIdentity };
+            var authChainMapping = new Dictionary<string, string>();
+            string targetId = childEdgeId + "/" + moduleId;
+            authChainMapping.Add(targetId, targetId + ";edge2;edge1;edgeroot");
+            var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
+
+            // Act
+            var request = new IdentityOnBehalfOfRequest(childEdgeId, moduleId, "edge2;edge1");
+            await controller.GetDeviceAndModuleOnBehalfOf(parentEdgeId, "$edgeHub", request);
+
+            // Verify EdgeHub result types
+            var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };
+            var expectedDeviceIdentities = new List<EdgeHubScopeDevice>() { new EdgeHubScopeDevice(childEdgeId, generationId, DeviceStatus.Enabled, expectedAuth, new DeviceCapabilities(), deviceScope, new List<string> { parentScope }) };
+            var expectedModuleIdentities = new List<EdgeHubScopeModule>() { new EdgeHubScopeModule(moduleId, childEdgeId, generationId, expectedAuth) };
+            var responseExpected = new EdgeHubScopeResult() { Devices = expectedDeviceIdentities, Modules = expectedModuleIdentities };
+            var responseExpectedJson = JsonConvert.SerializeObject(responseExpected);
+
+            var responseActualBytes = GetResponseBodyBytes(controller);
+            var responseActualJson = Encoding.UTF8.GetString(responseActualBytes);
+
+            Assert.Equal((int)HttpStatusCode.OK, controller.HttpContext.Response.StatusCode);
+            Assert.Equal(responseExpectedJson, responseActualJson);
+        }
+
+        [Fact]
+        public async Task GetDeviceOnBehalfOf()
+        {
+            // Setup ServiceIdentity results
+            string parentEdgeId = "edge1";
+            string childEdgeId = "edge2";
+            string deviceId = "device1";
+            string moduleId = "module1";
+            string deviceScope = "deviceScope1";
+            string parentScope = "parentScope1";
+            string generationId = "generation1";
+            string primaryKey = "t3LtII3CppvtVqycKp9bo043vCEgWbGBJAzXZNmoBXo=";
+            string secondaryKey = "kT4ac4PpH5UY0vA1JpLQWOu2yG6qKoqwvzee3j1Z3bA=";
+            var authentication = new ServiceAuthentication(new SymmetricKeyAuthentication(primaryKey, secondaryKey));
+            var resultDeviceIdentity = new ServiceIdentity(deviceId, null, deviceScope, new List<string>() { parentScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
+            var resultModuleIdentity = new ServiceIdentity(deviceId, moduleId, null, new List<string>() { deviceScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
+            var resultIdentities = new List<ServiceIdentity>() { resultDeviceIdentity, resultModuleIdentity };
+            var authChainMapping = new Dictionary<string, string>();
+            authChainMapping.Add(deviceId, "device1;edge2;edge1;edgeroot");
+            var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
+
+            // Act
+            var request = new IdentityOnBehalfOfRequest(deviceId, null, "device1;edge2;edge1");
+            await controller.GetDeviceAndModuleOnBehalfOf(parentEdgeId, "$edgeHub", request);
+
+            // Verify EdgeHub result types
+            var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };
+            var expectedDeviceIdentities = new List<EdgeHubScopeDevice>() { new EdgeHubScopeDevice(deviceId, generationId, DeviceStatus.Enabled, expectedAuth, new DeviceCapabilities(), deviceScope, new List<string> { parentScope }) };
+            var responseExpected = new EdgeHubScopeResult() { Devices = expectedDeviceIdentities, Modules = new List<EdgeHubScopeModule>() };
+            var responseExpectedJson = JsonConvert.SerializeObject(responseExpected);
+
+            var responseActualBytes = GetResponseBodyBytes(controller);
+            var responseActualJson = Encoding.UTF8.GetString(responseActualBytes);
+
+            Assert.Equal((int)HttpStatusCode.OK, controller.HttpContext.Response.StatusCode);
+            Assert.Equal(responseExpectedJson, responseActualJson);
+        }
+
+        [Fact]
+        public void ValidateChainTest()
+        {
+            // Correct case
+            Assert.True(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", "leaf1;edge1;edgeRoot"));
+
+            // Unauthorized actor
+            Assert.False(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", "leaf1;edge2;edgeRoot"));
+
+            // Bad target
+            Assert.False(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", "leaf2;edge1;edgeRoot"));
+
+            // Invalid format
+            Assert.False(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", ";"));
+        }
+
+        private static DeviceScopeController MakeController(string targetEdgeId, IList<ServiceIdentity> resultIdentities, IDictionary<string, string> authChains)
         {
             var edgeHub = new Mock<IEdgeHub>();
-            edgeHub.Setup(e => e.GetAuthChainForIdentity(It.Is<string>(i => i == targetId)))
-                .ReturnsAsync(Option.Some<string>(targetAuthChain));
-            edgeHub.Setup(e => e.GetDevicesAndModulesInTargetScopeAsync(It.Is<string>(id => id == targetId)))
+            edgeHub.Setup(e => e.GetDevicesAndModulesInTargetScopeAsync(It.Is<string>(id => id == targetEdgeId)))
                 .ReturnsAsync(resultIdentities);
+
+            foreach (KeyValuePair<string, string> entry in authChains)
+            {
+                edgeHub.Setup(e => e.GetAuthChainForIdentity(It.Is<string>(i => i == entry.Key)))
+                .ReturnsAsync(Option.Some<string>(entry.Value));
+            }
+
+            foreach (ServiceIdentity identity in resultIdentities)
+            {
+                edgeHub.Setup(e => e.GetIdentityAsync(It.Is<string>(id => id == identity.Id)))
+                .ReturnsAsync(Option.Some(identity));
+            }
 
             var controller = new DeviceScopeController(Task.FromResult(edgeHub.Object));
             SetupControllerContext(controller);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
 
             // Act
             var request = new NestedScopeRequest(0, string.Empty, "edge2;edge1");
-            await controller.GetDevicesAndModulesInTargetDeviceScope(parentEdgeId, "$edgeHub", request);
+            await controller.GetDevicesAndModulesInTargetDeviceScopeAsync(parentEdgeId, "$edgeHub", request);
 
             // Verify EdgeHub result types
             var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var controller = MakeController(targetEdgeId, resultIdentities, authChainMapping);
 
             var request = new NestedScopeRequest(0, string.Empty, "edge2;edge1");
-            controller.GetDevicesAndModulesInTargetDeviceScope("edge1", "notEdgeHub", request).Wait();
+            controller.GetDevicesAndModulesInTargetDeviceScopeAsync("edge1", "notEdgeHub", request).Wait();
 
             Assert.Equal((int)HttpStatusCode.Unauthorized, controller.HttpContext.Response.StatusCode);
         }
@@ -108,12 +108,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var resultIdentities = new List<ServiceIdentity>() { resultDeviceIdentity, resultModuleIdentity };
             var authChainMapping = new Dictionary<string, string>();
             string targetId = childEdgeId + "/" + moduleId;
-            authChainMapping.Add(targetId, targetId + ";edge2;edge1;edgeroot");
+            authChainMapping.Add(targetId, $"{targetId};{childEdgeId};{parentEdgeId};edgeroot");
             var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
 
             // Act
-            var request = new IdentityOnBehalfOfRequest(childEdgeId, moduleId, "edge2;edge1");
-            await controller.GetDeviceAndModuleOnBehalfOf(parentEdgeId, "$edgeHub", request);
+            var request = new IdentityOnBehalfOfRequest(childEdgeId, moduleId, $"{childEdgeId};{parentEdgeId}");
+            await controller.GetDeviceAndModuleOnBehalfOfAsync(parentEdgeId, "$edgeHub", request);
 
             // Verify EdgeHub result types
             var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };
@@ -147,12 +147,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var resultModuleIdentity = new ServiceIdentity(deviceId, moduleId, null, new List<string>() { deviceScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultIdentities = new List<ServiceIdentity>() { resultDeviceIdentity, resultModuleIdentity };
             var authChainMapping = new Dictionary<string, string>();
-            authChainMapping.Add(deviceId, "device1;edge2;edge1;edgeroot");
+            authChainMapping.Add(deviceId, $"{deviceId};{childEdgeId};{parentEdgeId};edgeroot");
             var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
 
             // Act
-            var request = new IdentityOnBehalfOfRequest(deviceId, null, "device1;edge2;edge1");
-            await controller.GetDeviceAndModuleOnBehalfOf(parentEdgeId, "$edgeHub", request);
+            var request = new IdentityOnBehalfOfRequest(deviceId, null, $"{deviceId};{childEdgeId};{parentEdgeId}");
+            await controller.GetDeviceAndModuleOnBehalfOfAsync(parentEdgeId, "$edgeHub", request);
 
             // Verify EdgeHub result types
             var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -85,7 +85,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var controller = MakeController(targetEdgeId, resultIdentities, authChainMapping);
 
             var request = new NestedScopeRequest(0, string.Empty, "edge2;edge1");
-            Assert.Throws<AggregateException>(() => controller.GetDevicesAndModulesInTargetDeviceScope("edge1", "notEdgeHub", request).Wait());
+            controller.GetDevicesAndModulesInTargetDeviceScope("edge1", "notEdgeHub", request).Wait();
+
+            Assert.Equal((int)HttpStatusCode.Unauthorized, controller.HttpContext.Response.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
This change adds logic to use the new GetDeviceAndModuleOnBehalfOf API when calling upstream, and exposes the same REST endpoint for downstream Edge devices.