### PR TITLE
EdgeHub: Hardcode broker state directory to /tmp/mqttd

### DIFF
--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -40,5 +40,4 @@ EXPOSE 443/tcp
 USER edgehubuser	
 
 CMD echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Starting Edge Hub" && \
-    cd /tmp && \
     /usr/local/bin/watchdog

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -24,5 +24,4 @@ USER edgehubuser
 ENV OptimizeForPerformance false
 ENV MqttEventsProcessorThreadCount 1
 CMD echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Starting Edge Hub" && \
-    cd /tmp && \
     /usr/local/bin/watchdog

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -24,5 +24,4 @@ USER edgehubuser
 ENV OptimizeForPerformance false
 ENV MqttEventsProcessorThreadCount 1
 CMD echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Starting Edge Hub" && \
-    cd /tmp && \
     /usr/local/bin/watchdog

--- a/mqtt/mqttd/src/broker/mod.rs
+++ b/mqtt/mqttd/src/broker/mod.rs
@@ -2,7 +2,8 @@ mod bootstrap;
 mod shutdown;
 mod snapshot;
 
-use std::env;
+use std::fs;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use futures_util::pin_mut;
@@ -18,10 +19,15 @@ use mqtt_broker::{
 };
 use mqtt_broker_core::auth::Authorizer;
 
+const MQTTD_STATE_DIR: &str = "/tmp/mqttd";
+
 pub async fn run(config: BrokerConfig) -> Result<()> {
     info!("loading state...");
-    let state_dir = env::current_dir().expect("can't get cwd").join("state");
-    let mut persistor = FilePersistor::new(state_dir, VersionedFileFormat::default());
+    fs::create_dir(MQTTD_STATE_DIR).expect("can't create mqttd state dir");
+    let mut persistor = FilePersistor::new(
+        PathBuf::from(MQTTD_STATE_DIR),
+        VersionedFileFormat::default(),
+    );
     let state = persistor.load().await?;
     info!("state loaded.");
 

--- a/mqtt/mqttd/src/broker/mod.rs
+++ b/mqtt/mqttd/src/broker/mod.rs
@@ -2,8 +2,7 @@ mod bootstrap;
 mod shutdown;
 mod snapshot;
 
-use std::fs;
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 use anyhow::Result;
 use futures_util::pin_mut;


### PR DESCRIPTION
The edgehubuser inside the edgehub container only has permissions to write to /tmp. The dotnet application creates  /tmp/edgehub folder and writes to it. The broker should follow this pattern and create a storage directory /tmp/mqttd and write to it.