### PR TITLE
Fixing bug where transportSettings isn't passed in correctly

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ClientProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ClientProvider.cs
@@ -24,15 +24,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             if (identity is IModuleIdentity)
             {
                 ModuleClient moduleClient = options.Match(
-                    o => ModuleClient.Create(identity.IotHubHostName, authenticationMethod, o),
-                    () => ModuleClient.Create(identity.IotHubHostName, authenticationMethod));
+                    o => ModuleClient.Create(identity.IotHubHostName, authenticationMethod, transportSettings, o),
+                    () => ModuleClient.Create(identity.IotHubHostName, authenticationMethod, transportSettings));
                 return new ModuleClientWrapper(moduleClient);
             }
             else if (identity is IDeviceIdentity)
             {
                 DeviceClient deviceClient = options.Match(
-                    o => DeviceClient.Create(identity.IotHubHostName, authenticationMethod, o),
-                    () => DeviceClient.Create(identity.IotHubHostName, authenticationMethod));
+                    o => DeviceClient.Create(identity.IotHubHostName, authenticationMethod, transportSettings, o),
+                    () => DeviceClient.Create(identity.IotHubHostName, authenticationMethod, transportSettings));
                 return new DeviceClientWrapper(deviceClient);
             }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
@@ -163,7 +163,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             enum EventIds
             {
                 AttemptingTransport = IdStart,
-                AttemptingTransportWithModelId,
                 TransportConnected
             }
 


### PR DESCRIPTION
I introduced a bug in my last PR, where we won't pass in transportSettings. This will always use a default transportSettings, which is AMQP by default.

PR fixes it.
Also small other fix - added Event that doesn't link to anything, so I'm removing it