### PR TITLE
[k8s public preview] Pull in 1.0.9.4 fixes, update images and Helm charts

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.13-alpine3.10
+ARG base_tag=2.1.17-alpine3.10
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6-linux-arm32v7
+ARG base_tag=1.0.4.1.k8s-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=2.1.16-bionic-arm32v7
+ARG base_tag=2.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 RUN apt-get update && \

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         readonly IAvailabilityMetric availabilityMetric;
         IEnvironment environment;
         DeploymentConfigInfo currentConfig;
+        DeploymentStatus status;
 
         public Agent(
             IConfigSource configSource,
@@ -58,6 +59,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
             this.environment = this.environmentProvider.Create(this.currentConfig.DeploymentConfig);
             this.encryptionProvider = Preconditions.CheckNotNull(encryptionProvider, nameof(encryptionProvider));
             this.availabilityMetric = Preconditions.CheckNotNull(availabilityMetric, nameof(availabilityMetric));
+            this.status = DeploymentStatus.Unknown;
             Events.AgentCreated();
         }
 
@@ -109,7 +111,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public async Task ReconcileAsync(CancellationToken token)
         {
-            DeploymentStatus status = DeploymentStatus.Unknown;
             ModuleSet moduleSetToReport = null;
             using (await this.reconcileLock.LockAsync(token))
             {
@@ -126,7 +127,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                     DeploymentConfig deploymentConfig = deploymentConfigInfo.DeploymentConfig;
                     if (deploymentConfig.Equals(DeploymentConfig.Empty))
                     {
-                        status = DeploymentStatus.Success;
+                        this.status = DeploymentStatus.Success;
                     }
                     else
                     {
@@ -142,7 +143,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
                         if (plan.IsEmpty)
                         {
-                            status = DeploymentStatus.Success;
+                            this.status = DeploymentStatus.Success;
                         }
                         else
                         {
@@ -152,7 +153,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                                 await this.UpdateCurrentConfig(deploymentConfigInfo);
                                 if (result)
                                 {
-                                    status = DeploymentStatus.Success;
+                                    this.status = DeploymentStatus.Success;
                                 }
                             }
                             catch (Exception ex) when (!ex.IsFatal())
@@ -169,28 +170,28 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
                     switch (ex)
                     {
                         case ConfigEmptyException _:
-                            status = new DeploymentStatus(DeploymentStatusCode.ConfigEmptyError, ex.Message);
+                            this.status = new DeploymentStatus(DeploymentStatusCode.ConfigEmptyError, ex.Message);
                             Events.EmptyConfig(ex);
                             break;
 
                         case InvalidSchemaVersionException _:
-                            status = new DeploymentStatus(DeploymentStatusCode.InvalidSchemaVersion, ex.Message);
+                            this.status = new DeploymentStatus(DeploymentStatusCode.InvalidSchemaVersion, ex.Message);
                             Events.InvalidSchemaVersion(ex);
                             break;
 
                         case ConfigFormatException _:
-                            status = new DeploymentStatus(DeploymentStatusCode.ConfigFormatError, ex.Message);
+                            this.status = new DeploymentStatus(DeploymentStatusCode.ConfigFormatError, ex.Message);
                             Events.InvalidConfigFormat(ex);
                             break;
 
                         default:
-                            status = new DeploymentStatus(DeploymentStatusCode.Failed, ex.Message);
+                            this.status = new DeploymentStatus(DeploymentStatusCode.Failed, ex.Message);
                             Events.UnknownFailure(ex);
                             break;
                     }
                 }
 
-                await this.reporter.ReportAsync(token, moduleSetToReport, await this.environment.GetRuntimeInfoAsync(), this.currentConfig.Version, status);
+                await this.reporter.ReportAsync(token, moduleSetToReport, await this.environment.GetRuntimeInfoAsync(), this.currentConfig.Version, this.status);
                 Events.FinishedReconcile();
             }
         }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             {
                 Events.ErrorGettingTwin(e);
 
-                if (!retrying && moduleClient != null && !(e is TimeoutException))
+                if (!retrying && moduleClient != null)
                 {
                     try
                     {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/WrappingSdkModuleClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/WrappingSdkModuleClient.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
@@ -14,7 +15,18 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient
         public WrappingSdkModuleClient(ModuleClient sdkModuleClient)
             => this.sdkModuleClient = Preconditions.CheckNotNull(sdkModuleClient, nameof(sdkModuleClient));
 
-        public Task OpenAsync() => this.sdkModuleClient.OpenAsync();
+        public Task OpenAsync()
+        {
+            try
+            {
+                return this.sdkModuleClient.OpenAsync();
+            }
+            catch (Exception)
+            {
+                this.sdkModuleClient?.Dispose();
+                throw;
+            }
+        }
 
         public void SetConnectionStatusChangesHandler(ConnectionStatusChangesHandler statusChangesHandler)
             => this.sdkModuleClient.SetConnectionStatusChangesHandler(statusChangesHandler);
@@ -47,6 +59,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient
         ////    return await EdgeClientWebSocket.Connect(deviceStreamRequest.Url, deviceStreamRequest.AuthorizationToken, cancellationToken);
         ////}
 
-        public Task CloseAsync() => this.sdkModuleClient.CloseAsync();
+        public Task CloseAsync()
+        {
+            this.sdkModuleClient.Dispose();
+            return Task.CompletedTask;
+        }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
@@ -524,6 +524,121 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         }
 
         [Fact]
+        public async void ReconcileAsyncExecuteAsyncIncompleteDefaulsUnknown()
+        {
+            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var currentModule = new TestModule("current", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var commandList = new List<ICommand>
+            {
+                new Mock<ICommand>().Object,
+                new Mock<ICommand>().Object,
+            };
+            var testPlan = new Plan(commandList);
+            var token = default(CancellationToken);
+            var runtimeInfo = Mock.Of<IRuntimeInfo>();
+            var deploymentConfig = new DeploymentConfig("1.0", runtimeInfo, new SystemModules(null, null), new Dictionary<string, IModule> { ["desired"] = desiredModule });
+            var deploymentConfigInfo = new DeploymentConfigInfo(0, deploymentConfig);
+            ModuleSet desiredSet = deploymentConfig.GetModuleSet();
+            ModuleSet currentSet = ModuleSet.Create(currentModule);
+
+            var mockConfigSource = new Mock<IConfigSource>();
+            var mockEnvironment = new Mock<IEnvironment>();
+            var mockPlanner = new Mock<IPlanner>();
+            var mockPlanRunner = new Mock<IPlanRunner>();
+            var mockReporter = new Mock<IReporter>();
+            var mockModuleIdentityLifecycleManager = new Mock<IModuleIdentityLifecycleManager>();
+            var configStore = Mock.Of<IEntityStore<string, string>>();
+            var mockEnvironmentProvider = Mock.Of<IEnvironmentProvider>(m => m.Create(It.IsAny<DeploymentConfig>()) == mockEnvironment.Object);
+            var serde = Mock.Of<ISerde<DeploymentConfigInfo>>();
+            var encryptionDecryptionProvider = Mock.Of<IEncryptionProvider>();
+            var availabilityMetric = Mock.Of<IAvailabilityMetric>();
+
+            mockConfigSource.Setup(cs => cs.GetDeploymentConfigInfoAsync())
+                .ReturnsAsync(deploymentConfigInfo);
+            mockEnvironment.Setup(env => env.GetModulesAsync(token))
+                .ReturnsAsync(currentSet);
+            mockModuleIdentityLifecycleManager.Setup(m => m.GetModuleIdentitiesAsync(desiredSet, currentSet))
+                .ReturnsAsync(ImmutableDictionary<string, IModuleIdentity>.Empty);
+            mockPlanner.Setup(pl => pl.PlanAsync(It.IsAny<ModuleSet>(), currentSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty))
+                .Returns(Task.FromResult(testPlan));
+            mockModuleIdentityLifecycleManager.Setup(m => m.GetModuleIdentitiesAsync(It.IsAny<ModuleSet>(), currentSet))
+                .Returns(Task.FromResult((IImmutableDictionary<string, IModuleIdentity>)ImmutableDictionary<string, IModuleIdentity>.Empty));
+            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), DeploymentStatus.Unknown))
+                .Returns(Task.CompletedTask);
+            mockPlanRunner.SetupSequence(m => m.ExecuteAsync(It.IsAny<long>(), It.IsAny<Plan>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(false);
+            var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider, mockPlanner.Object, mockPlanRunner.Object, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider, availabilityMetric);
+
+            await agent.ReconcileAsync(token);
+
+            mockEnvironment.Verify(env => env.GetModulesAsync(token), Times.Once());
+            mockPlanner.Verify(pl => pl.PlanAsync(It.IsAny<ModuleSet>(), currentSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty), Times.Once());
+            mockPlanRunner.VerifyAll();
+            mockReporter.VerifyAll();
+        }
+
+        [Fact]
+        public async void ReconcileAsyncExecuteAsyncIncompleteReportsLastState()
+        {
+            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var currentModule = new TestModule("current", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var commandList = new List<ICommand>
+            {
+                new Mock<ICommand>().Object,
+                new Mock<ICommand>().Object,
+            };
+            var testPlan = new Plan(commandList);
+            var token = default(CancellationToken);
+            var runtimeInfo = Mock.Of<IRuntimeInfo>();
+            var deploymentConfig = new DeploymentConfig("1.0", runtimeInfo, new SystemModules(null, null), new Dictionary<string, IModule> { ["desired"] = desiredModule });
+            var deploymentConfigInfo = new DeploymentConfigInfo(0, deploymentConfig);
+            ModuleSet desiredSet = deploymentConfig.GetModuleSet();
+            ModuleSet currentSet = ModuleSet.Create(currentModule);
+            var statuses = new List<DeploymentStatusCode>();
+
+            var mockConfigSource = new Mock<IConfigSource>();
+            var mockEnvironment = new Mock<IEnvironment>();
+            var mockPlanner = new Mock<IPlanner>();
+            var mockPlanRunner = new Mock<IPlanRunner>();
+            var mockReporter = new Mock<IReporter>();
+            var mockModuleIdentityLifecycleManager = new Mock<IModuleIdentityLifecycleManager>();
+            var configStore = Mock.Of<IEntityStore<string, string>>();
+            var mockEnvironmentProvider = Mock.Of<IEnvironmentProvider>(m => m.Create(It.IsAny<DeploymentConfig>()) == mockEnvironment.Object);
+            var serde = Mock.Of<ISerde<DeploymentConfigInfo>>();
+            var encryptionDecryptionProvider = Mock.Of<IEncryptionProvider>();
+            var availabilityMetric = Mock.Of<IAvailabilityMetric>();
+
+            mockConfigSource.Setup(cs => cs.GetDeploymentConfigInfoAsync())
+                .ReturnsAsync(deploymentConfigInfo);
+            mockEnvironment.Setup(env => env.GetModulesAsync(token))
+                .ReturnsAsync(currentSet);
+            mockModuleIdentityLifecycleManager.Setup(m => m.GetModuleIdentitiesAsync(desiredSet, currentSet))
+                .ReturnsAsync(ImmutableDictionary<string, IModuleIdentity>.Empty);
+            mockPlanner.Setup(pl => pl.PlanAsync(It.IsAny<ModuleSet>(), currentSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty))
+                .Returns(Task.FromResult(testPlan));
+            mockModuleIdentityLifecycleManager.Setup(m => m.GetModuleIdentitiesAsync(It.IsAny<ModuleSet>(), currentSet))
+                .Returns(Task.FromResult((IImmutableDictionary<string, IModuleIdentity>)ImmutableDictionary<string, IModuleIdentity>.Empty));
+            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.IsAny<DeploymentStatus>()))
+                .Callback((CancellationToken _t, ModuleSet _m, IRuntimeInfo _r, long _v, DeploymentStatus d) => statuses.Add(d.Code))
+                .Returns(Task.CompletedTask);
+            // First call represents a command failure, 2nd call represents an execution backoff.
+            mockPlanRunner.SetupSequence(m => m.ExecuteAsync(It.IsAny<long>(), It.IsAny<Plan>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new Exception("generic exception"))
+                .ReturnsAsync(false);
+            var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider, mockPlanner.Object, mockPlanRunner.Object, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider, availabilityMetric);
+
+            await agent.ReconcileAsync(token);
+            await agent.ReconcileAsync(token);
+
+            mockEnvironment.Verify(env => env.GetModulesAsync(token), Times.Exactly(2));
+            mockPlanner.Verify(pl => pl.PlanAsync(It.IsAny<ModuleSet>(), currentSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty), Times.Exactly(2));
+            mockPlanRunner.VerifyAll();
+            mockReporter.Verify(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), It.IsAny<DeploymentStatus>()), Times.Exactly(2));
+            Assert.Equal(DeploymentStatusCode.Failed, statuses[0]);
+            Assert.Equal(DeploymentStatusCode.Failed, statuses[1]);
+        }
+
+        [Fact]
         public async Task ReportShutdownAsyncConfigTest()
         {
             // Arrange

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
@@ -526,8 +526,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         [Fact]
         public async void ReconcileAsyncExecuteAsyncIncompleteDefaulsUnknown()
         {
-            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
-            var currentModule = new TestModule("current", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, new ConfigurationInfo("1"), null);
+            var currentModule = new TestModule("current", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, new ConfigurationInfo("1"), null);
             var commandList = new List<ICommand>
             {
                 new Mock<ICommand>().Object,
@@ -580,8 +580,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
         [Fact]
         public async void ReconcileAsyncExecuteAsyncIncompleteReportsLastState()
         {
-            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
-            var currentModule = new TestModule("current", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultPriority, new ConfigurationInfo("1"), null);
+            var desiredModule = new TestModule("desired", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, new ConfigurationInfo("1"), null);
+            var currentModule = new TestModule("current", "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, new ConfigurationInfo("1"), null);
             var commandList = new List<ICommand>
             {
                 new Mock<ICommand>().Object,

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -101,7 +101,7 @@ impl ModuleRegistry for DockerModuleRuntime {
                 let json = serde_json::to_string(a).with_context(|_| {
                     ErrorKind::RegistryOperation(RegistryOperation::PullImage(image.clone()))
                 })?;
-                Ok(base64::encode(&json))
+                Ok(base64::encode_config(&json, base64::URL_SAFE))
             },
         );
 

--- a/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for installing CRD for Azure IoT Edge on Kubernetes
 name: edge-kubernetes-crd
-version: 0.2.7
+version: 0.2.8

--- a/kubernetes/charts/edge-kubernetes/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for running Azure IoT Edge on Kubernetes
 name: edge-kubernetes
-version: 0.2.7
+version: 0.2.8

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -2,7 +2,7 @@
 iotedged:
   image:
     repository: azureiotedge/azureiotedge-iotedged
-    tag: 0.1.0-beta9
+    tag: 0.1.0-beta10
     pullPolicy: Always
   nodeSelector: {}
   # Volumes which support ownership management are modified to be owned and 
@@ -101,7 +101,7 @@ iotedged:
 iotedgedProxy:
   image:
     repository: azureiotedge/azureiotedge-proxy
-    tag: 0.1.0-beta9
+    tag: 0.1.0-beta10
     pullPolicy: Always
 
 # Edge Agent image configuration
@@ -115,7 +115,7 @@ edgeAgent:
   containerName: edgeagent
   image:
     repository: azureiotedge/azureiotedge-agent
-    tag: 0.1.0-beta9
+    tag: 0.1.0-beta10
     pullPolicy: Always
   hostname: "localhost"
   env:


### PR DESCRIPTION

Cherry-pick:
- Fix edge agent connection 1.0.9 (#3172) 
- Edgelet unable to pull using certain passwords - cherry-pick into 1.0.9. (#3206) (#3209)
- Agent reported state as "406" when modules are in backoff. (#3244) 

Could not cherry-pick "Update the base image for 1.0.9 arm32 (#3191)" as-is so made the changes to Dockerfiles manually.

Updated helm charts for beta10 and increased the Helm chart version.