### PR TITLE
Use new NestedEdge APIs for refreshing module identity

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
@@ -98,9 +98,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         {
             string id = $"{deviceId}/{moduleId}";
             Option<ScopeResult> scopeResult = Option.None<ScopeResult>();
+
             try
             {
-                ScopeResult res = await this.securityScopesApiClientProvider.CreateDeviceScopeClient().GetIdentityAsync(deviceId, moduleId);
+                IDeviceScopeApiClient client;
+                if (this.nestedEdgeEnabled)
+                {
+                    client = this.securityScopesApiClientProvider.CreateNestedDeviceScopeClient();
+                }
+                else
+                {
+                    client = this.securityScopesApiClientProvider.CreateDeviceScopeClient();
+                }
+
+                ScopeResult res = await client.GetIdentityAsync(deviceId, moduleId);
                 scopeResult = Option.Maybe(res);
                 Events.IdentityScopeResultReceived(id);
             }


### PR DESCRIPTION
The service proxy module identity refresh logic wasn't forked correctly to use the new HTTP client when nested edge is enabled, so when it tries to refresh a new module it's still sending the old API request to the parent Edge.