### PR TITLE
Refresh identities cache if edgeAgent/edgeHub has empty auth-type

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const string InternalOriginInterface = "internal";
         public const string DownstreamOriginInterface = "downstream";
 
+        public const string EdgeAgentModuleId = "$edgeAgent";
         public const string EdgeHubModuleId = "$edgeHub";
         public const string IotEdgeIdentityCapability = "iotEdge";
         public const string ServiceIdentityRefreshMethodName = "RefreshDeviceScopeIdentityCache";

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const string InternalOriginInterface = "internal";
         public const string DownstreamOriginInterface = "downstream";
 
-        public const string EdgeAgentModuleId = "$edgeAgent";
         public const string EdgeHubModuleId = "$edgeHub";
         public const string IotEdgeIdentityCapability = "iotEdge";
         public const string ServiceIdentityRefreshMethodName = "RefreshDeviceScopeIdentityCache";

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             IDeviceScopeIdentitiesCache identitiesCache = edgeHub.GetDeviceScopeIdentitiesCache();
             Option<ServiceIdentity> targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
 
-            if (!targetIdentity.HasValue)
+            if (this.NeedToRefreshIdentity(targetIdentity))
             {
                 // Identity doesn't exist, this can happen if the target identity
                 // is newly created in IoT Hub. In this case, we try to refresh
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 await identitiesCache.RefreshServiceIdentity(targetId);
                 targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
 
-                if (!targetIdentity.HasValue)
+                if (this.NeedToRefreshIdentity(targetIdentity))
                 {
                     // Identity still doesn't exist. It's possible that we're nested,
                     // so we need to refresh our identity cache to satisfy the prior
@@ -153,6 +153,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             result.Status = HttpStatusCode.OK;
 
             return result;
+        }
+
+        bool NeedToRefreshIdentity(Option<ServiceIdentity> identityOption)
+        {
+            // Default refresh to true if we don't have the identity yet.
+            bool needToRefresh = true;
+
+            identityOption.ForEach(id =>
+            {
+                // Identities can initially be created with no auth, and
+                // have their auth type updated later. In this case we
+                // must refresh the identity or we won't be able to auth
+                // incoming OnBehalfOf connections for those identities.
+                needToRefresh = id.Authentication.Type == ServiceAuthenticationType.None;
+            });
+
+            return needToRefresh;
         }
 
         bool TryGetTargetDeviceId(string authChain, out string targetDeviceId)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             IDeviceScopeIdentitiesCache identitiesCache = edgeHub.GetDeviceScopeIdentitiesCache();
             Option<ServiceIdentity> targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
 
-            if (this.NeedToRefreshIdentity(targetIdentity))
+            if (this.IsRefreshIdentityNeeded(targetIdentity))
             {
                 // Identity doesn't exist, this can happen if the target identity
                 // is newly created in IoT Hub. In this case, we try to refresh
@@ -115,7 +115,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 await identitiesCache.RefreshServiceIdentity(targetId);
                 targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
 
-                if (this.NeedToRefreshIdentity(targetIdentity))
+                if (this.IsRefreshIdentityNeeded(targetIdentity))
                 {
                     // Identity still doesn't exist. It's possible that we're nested,
                     // so we need to refresh our identity cache to satisfy the prior
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             return result;
         }
 
-        bool NeedToRefreshIdentity(Option<ServiceIdentity> identityOption)
+        bool IsRefreshIdentityNeeded(Option<ServiceIdentity> identityOption)
         {
             // Default refresh to true if we don't have the identity yet.
             bool needToRefresh = true;


### PR DESCRIPTION
The system modules can be initially created with no auth-type, and have the SAS keys get added later.  In this case, we must refresh the identity cache so get the latest credentials for the edgeHub/edgeAgent, otherwise we won't be able to authenticate incoming downstream Edge connections.