### PR TITLE
Disable connection reauthenticator

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -99,12 +99,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             await configUpdater.Init(configSource);
 
             // TODO: Re-enable after adding disconnect support in MQTT Broker Adapter
-            //if (!Enum.TryParse(configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode)
-            //    || authenticationMode != AuthenticationMode.Cloud)
-            //{
-            //    ConnectionReauthenticator connectionReauthenticator = await container.Resolve<Task<ConnectionReauthenticator>>();
-            //    connectionReauthenticator.Init();
-            //}
+            /* if (!Enum.TryParse(configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode)
+                || authenticationMode != AuthenticationMode.Cloud)
+            {
+                ConnectionReauthenticator connectionReauthenticator = await container.Resolve<Task<ConnectionReauthenticator>>();
+                connectionReauthenticator.Init();
+            }
+            */
 
             TimeSpan shutdownWaitPeriod = TimeSpan.FromSeconds(configuration.GetValue("ShutdownWaitPeriod", DefaultShutdownWaitPeriod));
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(shutdownWaitPeriod, logger);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -98,12 +98,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             ConfigUpdater configUpdater = await container.Resolve<Task<ConfigUpdater>>();
             await configUpdater.Init(configSource);
 
-            if (!Enum.TryParse(configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode)
-                || authenticationMode != AuthenticationMode.Cloud)
-            {
-                ConnectionReauthenticator connectionReauthenticator = await container.Resolve<Task<ConnectionReauthenticator>>();
-                connectionReauthenticator.Init();
-            }
+            // TODO: Re-enable after adding disconnect support in MQTT Broker Adapter
+            //if (!Enum.TryParse(configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode)
+            //    || authenticationMode != AuthenticationMode.Cloud)
+            //{
+            //    ConnectionReauthenticator connectionReauthenticator = await container.Resolve<Task<ConnectionReauthenticator>>();
+            //    connectionReauthenticator.Init();
+            //}
 
             TimeSpan shutdownWaitPeriod = TimeSpan.FromSeconds(configuration.GetValue("ShutdownWaitPeriod", DefaultShutdownWaitPeriod));
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(shutdownWaitPeriod, logger);


### PR DESCRIPTION
MQTT Broker adapter in EdgeHub core does not support disconnecting connected clients. But the EdgeHub core marks clients as inactive if the client token has expired. So this change disables the EdgeHub reauthentication logic. It should be re-enabled once the disconnection logic in MQTT Broker/Adapter is ready.