### PR TITLE
Disable schedule

### DIFF
--- a/builds/misc/mqtt-perf.yaml
+++ b/builds/misc/mqtt-perf.yaml
@@ -16,13 +16,6 @@
 
 trigger: none
 pr: none
-schedules:
-  - cron: "0 6 * * *"
-    displayName: Pacific Time (UTC-7) Nightly Build
-    branches:
-      include:
-      - iiot
-    always: true
 
 # github repo for our fork of mqtt-benchmark tool.
 resources:


### PR DESCRIPTION
We need to disable schedule for perf tests for now in master. We will re-enable it later after private preview.