### PR TITLE
MQTT Perf tests: Added missing -topics param for subscribers

### DIFF
--- a/builds/misc/templates/mqtt-perf-test-case.yaml
+++ b/builds/misc/templates/mqtt-perf-test-case.yaml
@@ -57,7 +57,7 @@ jobs:
   steps:
   - checkout: none
   - script: |
-      $(benchmarkToolPath)/mqtt-benchmark -sub -broker $(brokerEndpoint) -runId $(runId) -caseId ${{ parameters['id'] }} -clients ${{ parameters['subscribers'] }} -duration $(test.duration) -qos ${{ parameters['qos'] }} -dop $(clientDop) -quiet -panic
+      $(benchmarkToolPath)/mqtt-benchmark -sub -broker $(brokerEndpoint) -runId $(runId) -caseId ${{ parameters['id'] }} -clients ${{ parameters['subscribers'] }} -duration $(test.duration) -topics ${{ parameters['topics'] }} -qos ${{ parameters['qos'] }} -dop $(clientDop) -quiet -panic
     displayName: 'Running test case'
     env:
       LOGANALYTICS_CUSTOMER_ID: $(logs.workspaceid)


### PR DESCRIPTION
It looks like we've been missing this parameter for a while. It does affect all tests cases where number of topics > 1. Let's fix it and see how that would affect the numbers for those test cases.