### PR TITLE
[mqtt] Fix broker server tracing span

### DIFF
--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -3,7 +3,7 @@ use std::convert::TryInto;
 use std::panic;
 
 use tokio::sync::mpsc::{self, Receiver, Sender};
-use tracing::{debug, error, info, span, warn, Level};
+use tracing::{debug, error, info, info_span, warn};
 
 use mqtt3::proto;
 use mqtt_broker_core::{
@@ -53,14 +53,14 @@ where
         while let Some(message) = self.messages.recv().await {
             match message {
                 Message::Client(client_id, event) => {
-                    let span = span!(Level::INFO, "broker", client_id = %client_id, event="client");
+                    let span = info_span!("broker", client_id = %client_id, event="client");
                     let _enter = span.enter();
                     if let Err(e) = self.process_message(client_id, event) {
                         warn!(message = "an error occurred processing a message", error = %e);
                     }
                 }
                 Message::System(event) => {
-                    let span = span!(Level::INFO, "broker", event = "system");
+                    let span = info_span!("broker", event = "system");
                     let _enter = span.enter();
                     match event {
                         SystemEvent::Shutdown => {

--- a/mqtt/mqtt-broker/src/connection.rs
+++ b/mqtt/mqtt-broker/src/connection.rs
@@ -19,7 +19,7 @@ use tokio::sync::{
 };
 use tokio_io_timeout::TimeoutStream;
 use tokio_util::codec::Framed;
-use tracing::{debug, info, span, trace, warn, Level};
+use tracing::{debug, info, info_span, trace, warn};
 use tracing_futures::Instrument;
 use uuid::Uuid;
 
@@ -122,7 +122,7 @@ where
             let client_id = client_id(&connect.client_id);
             let (sender, events) = mpsc::unbounded_channel();
             let connection_handle = ConnectionHandle::from_sender(sender);
-            let span = span!(Level::INFO, "connection", client_id=%client_id, remote_addr=%remote_addr, connection=%connection_handle);
+            let span = info_span!("connection", client_id=%client_id, remote_addr=%remote_addr, connection=%connection_handle);
 
             // async block to attach instrumentation context
             async {
@@ -166,7 +166,7 @@ where
                     Ok(Some(auth_id)) => Auth::Identity(auth_id),
                     Ok(None) => Auth::Unknown,
                     Err(e) => {
-                        warn!(message = "error authenticating client: {}", error =% *e);
+                        warn!(message = "error authenticating client", error =% *e);
                         Auth::Failure
                     }
                 };

--- a/mqtt/mqtt-broker/src/persist.rs
+++ b/mqtt/mqtt-broker/src/persist.rs
@@ -17,7 +17,7 @@ use bytes::Bytes;
 use fail::fail_point;
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
-use tracing::{debug, info, span, Level};
+use tracing::{debug, info, info_span};
 
 use mqtt3::proto::Publication;
 
@@ -359,7 +359,7 @@ where
         let seq = self.seq;
 
         let res = tokio::task::spawn_blocking(move || {
-            let span = span!(Level::INFO, "persistor", dir = %dir.display());
+            let span = info_span!("persistor", dir = %dir.display());
             let _guard = span.enter();
 
             if !dir.exists() {

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -213,7 +213,7 @@ where
 {
     let io = new_transport.await?;
     let addr = io.local_addr()?;
-    let span = info_span!("server", listener=%addr);
+    let span = info_span!("transport", listener=%addr);
 
     let inner_span = span.clone();
 
@@ -249,8 +249,8 @@ where
                 }
                 Either::Right((Some(Err(e)), _)) => {
                     warn!(
-                        "accept loop exiting due to an error - {}",
-                        DetailedErrorValue(&e)
+                        message = "accept loop exiting due to an error",
+                        error =% DetailedErrorValue(&e)
                     );
                     break;
                 }

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -7,7 +7,7 @@ use futures_util::{
     stream::StreamExt,
 };
 use tokio::sync::oneshot;
-use tracing::{debug, error, info, span, warn, Level};
+use tracing::{debug, error, info, info_span, warn};
 use tracing_futures::Instrument;
 
 use mqtt_broker_core::auth::{Authenticator, Authorizer};
@@ -213,50 +213,55 @@ where
 {
     let io = new_transport.await?;
     let addr = io.local_addr()?;
-    let span = span!(Level::INFO, "server", listener=%addr);
-    let _enter = span.enter();
+    let span = info_span!("server", listener=%addr);
 
-    let mut incoming = io.incoming();
+    let inner_span = span.clone();
 
-    info!("Listening on address {}", addr);
+    async move {
+        let mut incoming = io.incoming();
 
-    loop {
-        match future::select(&mut shutdown_signal, incoming.next()).await {
-            Either::Right((Some(Ok(stream)), _)) => {
-                let peer = stream.peer_addr()?;
+        info!("Listening on address {}", addr);
 
-                let broker_handle = handle.clone();
-                let span = span.clone();
-                let authenticator = authenticator.clone();
-                tokio::spawn(async move {
-                    if let Err(e) =
-                        connection::process(stream, peer, broker_handle, &*authenticator)
-                            .instrument(span)
-                            .await
-                    {
-                        warn!(message = "failed to process connection", error =% DetailedErrorValue(&e));
-                    }
-                });
-            }
-            Either::Left(_) => {
-                info!(
-                    "accept loop shutdown. no longer accepting connections on {}",
-                    addr
-                );
-                break;
-            }
-            Either::Right((Some(Err(e)), _)) => {
-                warn!(
-                    "accept loop exiting due to an error - {}",
-                    DetailedErrorValue(&e)
-                );
-                break;
-            }
-            Either::Right((None, _)) => {
-                warn!("accept loop exiting due to no more incoming connections (incoming returned None)");
-                break;
+        loop {
+            match future::select(&mut shutdown_signal, incoming.next()).await {
+                Either::Right((Some(Ok(stream)), _)) => {
+                    let peer = stream.peer_addr()?;
+
+                    let broker_handle = handle.clone();
+                    let span = inner_span.clone();
+                    let authenticator = authenticator.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) =
+                            connection::process(stream, peer, broker_handle, &*authenticator)
+                                .instrument(span)
+                                .await
+                        {
+                            warn!(message = "failed to process connection", error =% DetailedErrorValue(&e));
+                        }
+                    });
+                }
+                Either::Left(_) => {
+                    info!(
+                        "accept loop shutdown. no longer accepting connections on {}",
+                        addr
+                    );
+                    break;
+                }
+                Either::Right((Some(Err(e)), _)) => {
+                    warn!(
+                        "accept loop exiting due to an error - {}",
+                        DetailedErrorValue(&e)
+                    );
+                    break;
+                }
+                Either::Right((None, _)) => {
+                    warn!("accept loop exiting due to no more incoming connections (incoming returned None)");
+                    break;
+                }
             }
         }
+        Ok(())
     }
-    Ok(())
+    .instrument(span)
+    .await
 }


### PR DESCRIPTION
Instrument broker server with a span, that takes only information for the current transport.


> Jul 27 15:54:26.464  INFO server{listener=0.0.0.0:1883}: mqtt_broker::server: Listening on address 0.0.0.0:1883
Jul 27 15:54:26.464  INFO server{listener=0.0.0.0:8883}: mqtt_broker::server: Listening on address 0.0.0.0:8883
...
Jul 27 16:02:05.143  INFO mqtt_broker::server: server received shutdown signal
Jul 27 16:02:05.144  INFO mqtt_broker::server: shutting down accept loop...
Jul 27 16:02:05.144  INFO server{listener=0.0.0.0:1883}: mqtt_broker::server: accept loop shutdown. no longer accepting connections on 0.0.0.0:1883
Jul 27 16:02:05.144  INFO server{listener=0.0.0.0:8883}: mqtt_broker::server: accept loop shutdown. no longer accepting connections on 0.0.0.0:8883

instead of
> Jul 27 16:10:34.451  INFO server{listener=0.0.0.0:1883}: mqtt_broker::server: Listening on address 0.0.0.0:1883
Jul 27 16:10:34.451  INFO server{listener=0.0.0.0:1883}~~:server{listener=0.0.0.0:8883}~~: mqtt_broker::server: Listening on address 0.0.0.0:8883
...
Jul 27 16:11:17.708  INFO ~~server{listener=0.0.0.0:1883}:server{listener=0.0.0.0:8883}~~: mqtt_broker::server: server received shutdown signal
Jul 27 16:11:17.708  INFO ~~server{listener=0.0.0.0:1883}:server{listener=0.0.0.0:8883}~~: mqtt_broker::server: shutting down accept loop...
Jul 27 16:11:17.709  INFO server{listener=0.0.0.0:1883}:~~server{listener=0.0.0.0:8883}~~: mqtt_broker::server: accept loop shutdown. no longer accepting connections on 0.0.0.0:1883
Jul 27 16:11:17.709  INFO server{listener=0.0.0.0:1883}:~~server{listener=0.0.0.0:8883}~~: mqtt_broker::server: accept loop shutdown. no longer accepting connections on 0.0.0.0:8883
