### PR TITLE
fix subscription

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ClientConnectionHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ClientConnectionHandler.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             using (await this.initializationLock.LockAsync())
             {
                 await this.deviceListener.ForEachAsync(d => d.CloseAsync());
+                this.deviceListener = Option.None<IDeviceListener>();
             }
         }
 


### PR DESCRIPTION
SubscriptionProcessor was modified to send subscriptions upstream only when there is a change to the subscription or if there is a  new device connection. For amqp when the device disconnects all links are closed, but device listener was still valid and when the device reconnects is not considered as new connection