### PR TITLE
[mqtt] Refactor tracing initialization

### DIFF
--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -26,9 +26,6 @@ WORKDIR /app
 
 COPY Microsoft.Azure.Devices.Edge.Hub.Service/ ./
 
-# Set broker log level
-ENV RUST_LOG=info
-
 # Expose MQTT, AMQP and HTTPS ports	
 EXPOSE 1883/tcp
 EXPOSE 8883/tcp	

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -9,9 +9,6 @@ WORKDIR /app
 
 COPY Microsoft.Azure.Devices.Edge.Hub.Service/ ./
 
-# Set broker log level
-ENV RUST_LOG=info
-
 # Expose MQTT, AMQP and HTTPS ports
 EXPOSE 1883/tcp
 EXPOSE 8883/tcp

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -9,9 +9,6 @@ WORKDIR /app
 
 COPY Microsoft.Azure.Devices.Edge.Hub.Service/ ./
 
-# Set broker log level
-ENV RUST_LOG=info
-
 # Expose MQTT, AMQP and HTTPS ports
 EXPOSE 1883/tcp
 EXPOSE 8883/tcp

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -26,7 +26,6 @@ ARG MQTTDUSER_ID=1000
 
 RUN adduser -Du ${MQTTDUSER_ID} mqttduser
 
-ENV RUST_LOG=info
 EXPOSE 1883/tcp
 EXPOSE 8883/tcp
 

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -26,7 +26,6 @@ ARG MQTTDUSER_ID=1000
 
 RUN adduser -Du ${MQTTDUSER_ID} mqttduser
 
-ENV RUST_LOG=info
 EXPOSE 1883/tcp
 EXPOSE 8883/tcp
 

--- a/mqtt/mqttd/src/lib.rs
+++ b/mqtt/mqttd/src/lib.rs
@@ -12,3 +12,4 @@
 )]
 
 pub mod broker;
+pub mod tracing;

--- a/mqtt/mqttd/src/main.rs
+++ b/mqtt/mqttd/src/main.rs
@@ -1,21 +1,13 @@
-use std::{env, io, path::PathBuf};
+use std::{env, path::PathBuf};
 
 use anyhow::Result;
 use clap::{crate_description, crate_name, crate_version, App, Arg};
-use tracing::Level;
-use tracing_subscriber::{fmt, EnvFilter};
 
-use mqttd::broker;
+use mqttd::{broker, tracing};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let subscriber = fmt::Subscriber::builder()
-        .with_ansi(atty::is(atty::Stream::Stderr))
-        .with_max_level(Level::TRACE)
-        .with_writer(io::stderr)
-        .with_env_filter(EnvFilter::from_default_env())
-        .finish();
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    tracing::init();
 
     let config_path = create_app()
         .get_matches()

--- a/mqtt/mqttd/src/tracing/edgehub.rs
+++ b/mqtt/mqttd/src/tracing/edgehub.rs
@@ -1,0 +1,23 @@
+use std::io;
+
+use tracing::Level;
+use tracing_subscriber::{fmt, EnvFilter};
+
+const BROKER_LOG_LEVEL_ENV: &str = "BROKER_LOG";
+
+const EDGE_HUB_LOG_LEVEL_ENV: &str = "RuntimeLogLevel";
+
+pub fn init() {
+    let log_level = EnvFilter::try_from_env(BROKER_LOG_LEVEL_ENV)
+        .or_else(|_| EnvFilter::try_from_env(EDGE_HUB_LOG_LEVEL_ENV))
+        .or_else(|_| EnvFilter::try_from_default_env())
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let subscriber = fmt::Subscriber::builder()
+        .with_ansi(atty::is(atty::Stream::Stderr))
+        .with_max_level(Level::TRACE)
+        .with_writer(io::stderr)
+        .with_env_filter(log_level)
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}

--- a/mqtt/mqttd/src/tracing/generic.rs
+++ b/mqtt/mqttd/src/tracing/generic.rs
@@ -1,0 +1,20 @@
+use std::io;
+
+use tracing::Level;
+use tracing_subscriber::{fmt, EnvFilter};
+
+const BROKER_LOG_LEVEL_ENV: &str = "BROKER_LOG";
+
+pub fn init() {
+    let log_level = EnvFilter::try_from_env(BROKER_LOG_LEVEL_ENV)
+        .or_else(|_| EnvFilter::try_from_default_env())
+        .unwrap_or_else(|_| EnvFilter::new("info"));
+
+    let subscriber = fmt::Subscriber::builder()
+        .with_ansi(atty::is(atty::Stream::Stderr))
+        .with_max_level(Level::TRACE)
+        .with_writer(io::stderr)
+        .with_env_filter(log_level)
+        .finish();
+    let _ = tracing::subscriber::set_global_default(subscriber);
+}

--- a/mqtt/mqttd/src/tracing/mod.rs
+++ b/mqtt/mqttd/src/tracing/mod.rs
@@ -2,10 +2,10 @@
 mod edgehub;
 
 #[cfg(feature = "edgehub")]
-pub use edgehub::{broker, config, start_server};
+pub use edgehub::init;
 
 #[cfg(all(not(feature = "edgehub"), feature = "generic"))]
 mod generic;
 
 #[cfg(all(not(feature = "edgehub"), feature = "generic"))]
-pub use generic::{broker, config, start_server};
+pub use generic::init;


### PR DESCRIPTION
For `edgehub` mode try to read tracing configuration from ENV in the sequence`BROKER_LOG` -> `RuntimeLogLevel` -> `RUST_LOG`. Fallback to `info`.

`RuntimeLogLevel` is the Edge Hub configuration. It will help keep broker logging in sync with Edge Hub. But also allows to configure broker logging level separately.

For `generic` mode try to read tracing configuration from ENV in the sequence`BROKER_LOG` -> `RUST_LOG`. Fallback to `info`.