### PR TITLE
Ordered start for authentication and mqtt bridge

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/authentication/AuthAgentController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/authentication/AuthAgentController.cs
@@ -45,12 +45,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                 return this.Json(GetErrorResult());
             }
 
-            // FIXME: this can be removed, one the broker skips authentication for special clients
-            if (this.IsSystemComponent(request))
-            {
-                return this.Json(this.AuthenticateSystemComponent(request));
-            }
-
             try
             {
                 var isAuthenticated = default(bool);
@@ -70,22 +64,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                 Events.ErrorProcessingRequest(e);
                 return this.Json(GetErrorResult());
             }
-        }
-
-        // FIXME: this can be removed, one the broker skips authentication for special clients
-        bool IsSystemComponent(AuthRequest request)
-        {
-            return string.Equals(request.Username, this.systemComponentIdProvider.EdgeHubBridgeId);
-        }
-
-        object AuthenticateSystemComponent(AuthRequest request)
-        {
-            return new
-            {
-                result = AuthAgentConstants.Authenticated,
-                identity = this.systemComponentIdProvider.EdgeHubBridgeId,
-                version = AuthAgentConstants.ApiVersion
-            };
         }
 
         Option<ClientInfo> GetIdsFromUsername(AuthRequest request)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/brokerConnection/MqttBrokerConnector.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/brokerConnection/MqttBrokerConnector.cs
@@ -115,7 +115,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                             c.MqttMsgPublishReceived -= this.ForwardPublish;
                             c.ConnectionClosed -= this.TriggerReconnect;
 
-                            c.Disconnect();
+                            if (c.IsConnected)
+                            {
+                                try
+                                {
+                                    c.Disconnect();
+                                }
+                                catch
+                                {
+                                    // swallowing: when the container is shutting down, it is possible that the broker disconnected.
+                                    // in those case an internal socket will be deleted and this Disconnect() call ends up in a
+                                    // Disposed() exception.
+                                }
+                            }
 
                             await this.StopForwardingLoopAsync();
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/OrderedProtocolHead.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/OrderedProtocolHead.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Service
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public class OrderedProtocolHead : IProtocolHead
+    {
+        readonly IList<IProtocolHead> underlyingProtocolHeads;
+
+        public OrderedProtocolHead(IList<IProtocolHead> underlyingProtocolHeads)
+        {
+            this.underlyingProtocolHeads = Preconditions.CheckNotNull(underlyingProtocolHeads, nameof(underlyingProtocolHeads));
+        }
+
+        public string Name => string.Join(", ", this.underlyingProtocolHeads.Select(ph => ph.Name));
+
+        public async Task StartAsync()
+        {
+            foreach (var protocolHead in this.underlyingProtocolHeads)
+            {
+                await protocolHead.StartAsync();
+            }
+        }
+
+        public async Task CloseAsync(CancellationToken token)
+        {
+            foreach (var protocolHead in this.underlyingProtocolHeads.Reverse())
+            {
+                await protocolHead.CloseAsync(token);
+            }
+        }
+
+        public void Dispose()
+        {
+            foreach (var protocolHead in this.underlyingProtocolHeads.Reverse())
+            {
+                protocolHead.Dispose();
+            }
+        }
+    }
+}

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Security.Authentication;
     using System.Threading;
     using System.Threading.Tasks;
@@ -163,14 +164,29 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 protocolHeads.Add(new HttpProtocolHead(hosting.WebHost));
             }
 
-            if (configuration.GetValue("authAgentSettings:enabled", true))
-            {
-                protocolHeads.Add(await container.Resolve<Task<AuthAgentProtocolHead>>());
-            }
-
+            var orderedProtocolHeads = new List<IProtocolHead>();
             if (configuration.GetValue("mqttBrokerSettings:enabled", true))
             {
-                protocolHeads.Add(container.Resolve<MqttBrokerProtocolHead>());
+                orderedProtocolHeads.Add(container.Resolve<MqttBrokerProtocolHead>());
+            }
+
+            if (configuration.GetValue("authAgentSettings:enabled", true))
+            {
+                orderedProtocolHeads.Add(await container.Resolve<Task<AuthAgentProtocolHead>>());
+            }
+
+            switch (orderedProtocolHeads.Count)
+            {
+                case 0:
+                    break;
+
+                case 1:
+                    protocolHeads.Add(orderedProtocolHeads.First());
+                    break;
+
+                default:
+                    protocolHeads.Add(new OrderedProtocolHead(orderedProtocolHeads));
+                    break;
             }
 
             return new EdgeHubProtocolHead(protocolHeads, logger);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
@@ -22,7 +22,7 @@
   },
   "mqttBrokerSettings": {
     "enabled": true,
-    "port": 1883,
+    "port": 1882,
     "url": "127.0.0.1"
   },
   "amqpSettings": {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/MqttBrokerModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/MqttBrokerModule.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
 
     class MqttBrokerModule : Module
     {
-        static readonly int defaultPort = 1883;
+        static readonly int defaultPort = 1882;
         static readonly string defaultUrl = "127.0.0.1";
 
         readonly IConfiguration config;


### PR DESCRIPTION
When edgeHub starts up, protocol heads start up parallel. In case of Authentication and mqtt bridge it could happen (and usually happened) that authentication came alive sooner. When a client connected after authentication came alive, but mqtt bridge had not, then the mqtt broker allowed the client to connect. When this client sent a message immediately, mqtt bridge was not subscribed to the necessary topics to handle the messages toward iothub. These messages got lost.
This change starts mqtt bride earlier and starts authentication only when everything is up. It does the reverse order on shutdown. 