### PR TITLE
[k8s] Have EdgeDeploymentOperator report status to Agent.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/configsources/ConfigOperationFailureException.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/configsources/ConfigOperationFailureException.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Core.ConfigSources
+{
+    using System;
+
+    [Serializable]
+    public class ConfigOperationFailureException : Exception
+    {
+        public ConfigOperationFailureException(string message)
+            : base(message)
+        {
+        }
+
+        public ConfigOperationFailureException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentOperator.cs
@@ -92,7 +92,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
                 {
                     Events.EdgeDeploymentWatchFailed(ex);
                     await this.ReportDeploymentFailure(ex, item);
-                    throw;
                 }
             }
         }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentStatusCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/EdgeDeploymentStatusCommand.cs
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Agent.Core;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.ConfigSources;
+    using Microsoft.Azure.Devices.Edge.Agent.Kubernetes;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    public class EdgeDeploymentStatusCommand : ICommand
+    {
+        readonly Option<EdgeDeploymentStatus> activeStatus;
+
+        public string Id => "EdgeDeploymentStatusCommand";
+
+        public EdgeDeploymentStatusCommand(
+            Option<EdgeDeploymentStatus> activeStatus)
+        {
+            this.activeStatus = activeStatus;
+        }
+
+        public Task ExecuteAsync(CancellationToken token)
+        {
+            // If the EdgeDeployment operator fails, report this to the plan executor
+            // as an exception.
+            this.activeStatus.ForEach(status =>
+                {
+                    if (status.State != EdgeDeploymentStatusType.Success)
+                    {
+                        throw new ConfigOperationFailureException(status.Message);
+                    }
+                });
+            return Task.CompletedTask;
+        }
+
+        public Task UndoAsync(CancellationToken token) => Task.CompletedTask;
+
+        EdgeDeploymentStatusType CurrentStatus() => this.activeStatus.Map(s => s.State).GetOrElse(() => EdgeDeploymentStatusType.Success);
+
+        public string Show() => $"Report EdgeDeployment status: [{this.CurrentStatus()}]";
+
+        public override string ToString() => this.Show();
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/planners/KubernetesPlanner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/planners/KubernetesPlanner.cs
@@ -95,6 +95,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Planners
                 {
                     planCommand
                 };
+                await activeDeployment.ForEachAsync(async edgeDeployment =>
+                {
+                    var deploymentStatusCommand = new EdgeDeploymentStatusCommand(edgeDeployment.Status);
+                    var statusCommand = await this.commandFactory.WrapAsync(deploymentStatusCommand);
+                    planList.Add(statusCommand);
+                });
                 Events.PlanCreated(planList);
                 plan = new Plan(planList);
             }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/EdgeDeploymentStatusCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/EdgeDeploymentStatusCommandTest.cs
@@ -1,0 +1,55 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
+{
+    using System.Threading;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.ConfigSources;
+    using Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+
+    using Xunit;
+
+    [Unit]
+    public class EdgeDeploymentStatusCommandTest
+    {
+        [Fact]
+        public async void ExecuteAyncSuccessWithNoStatus()
+        {
+            EdgeDeploymentStatusCommand noStatus = new EdgeDeploymentStatusCommand(Option.None<EdgeDeploymentStatus>());
+
+            await noStatus.ExecuteAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async void ExecuteAyncSuccessWithSuccessStatus()
+        {
+            EdgeDeploymentStatus success = EdgeDeploymentStatus.Success("200 OK");
+            EdgeDeploymentStatusCommand successStatus = new EdgeDeploymentStatusCommand(Option.Some(success));
+
+            await successStatus.ExecuteAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async void ExecuteAsyncThrowsWithFailureStatus()
+        {
+            EdgeDeploymentStatus failure = EdgeDeploymentStatus.Failure("failure message");
+            EdgeDeploymentStatusCommand failStatus = new EdgeDeploymentStatusCommand(Option.Some(failure));
+
+            await Assert.ThrowsAsync<ConfigOperationFailureException>(() => failStatus.ExecuteAsync(CancellationToken.None));
+        }
+
+        [Fact]
+        public void CurrentStatusReflectsDeploymentStatus()
+        {
+            EdgeDeploymentStatusCommand noStatus = new EdgeDeploymentStatusCommand(Option.None<EdgeDeploymentStatus>());
+            EdgeDeploymentStatus success = EdgeDeploymentStatus.Success("200 OK");
+            EdgeDeploymentStatusCommand successStatus = new EdgeDeploymentStatusCommand(Option.Some(success));
+            EdgeDeploymentStatus failure = EdgeDeploymentStatus.Failure("failure message");
+            EdgeDeploymentStatusCommand failStatus = new EdgeDeploymentStatusCommand(Option.Some(failure));
+
+            Assert.Equal($"Report EdgeDeployment status: [{EdgeDeploymentStatusType.Success}]", noStatus.Show());
+            Assert.Equal($"Report EdgeDeployment status: [{EdgeDeploymentStatusType.Success}]", successStatus.Show());
+            Assert.Equal($"Report EdgeDeployment status: [{EdgeDeploymentStatusType.Failure}]", failStatus.Show());
+        }
+    }
+}

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/EdgeDeploymentOperatorTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/EdgeDeploymentOperatorTest.cs
@@ -172,8 +172,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                 client,
                 controller);
 
-            Exception ex = await Assert.ThrowsAsync<Exception>(() => edgeOperator.EdgeDeploymentOnEventHandlerAsync(WatchEventType.Added, edgeDefinition));
-            Assert.Equal(controllerException, ex);
+            await edgeOperator.EdgeDeploymentOnEventHandlerAsync(WatchEventType.Added, edgeDefinition);
             Assert.True(reportedStatus.HasValue);
             Assert.Equal(expectedStatus, reportedStatus.OrDefault());
             Mock.Get(controller).VerifyAll();
@@ -184,9 +183,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
         public async void StatusIsFailedWithSpecialMessageWhenHttpExceptionIsThrown()
         {
             HttpOperationException controllerException = new HttpOperationException(ExceptionMessage)
-                {
-                    Request = new HttpRequestMessageWrapper(new HttpRequestMessage(HttpMethod.Put, new Uri("http://valid-uri")), "content")
-                };
+            {
+                Request = new HttpRequestMessageWrapper(new HttpRequestMessage(HttpMethod.Put, new Uri("http://valid-uri")), "content")
+            };
             Option<EdgeDeploymentStatus> reportedStatus = Option.None<EdgeDeploymentStatus>();
             EdgeDeploymentStatus expectedStatus = EdgeDeploymentStatus.Failure($"{controllerException.Request.Method} [{controllerException.Request.RequestUri}]({controllerException.Message})");
             var edgeDefinition = new EdgeDeploymentDefinition("v1", "EdgeDeployment", new V1ObjectMeta(name: ResourceName), new List<KubernetesModule>(), null);
@@ -216,8 +215,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                 client,
                 controller);
 
-            HttpOperationException ex = await Assert.ThrowsAsync<HttpOperationException>(() => edgeOperator.EdgeDeploymentOnEventHandlerAsync(WatchEventType.Added, edgeDefinition));
-            Assert.Equal(controllerException, ex);
+            await edgeOperator.EdgeDeploymentOnEventHandlerAsync(WatchEventType.Added, edgeDefinition);
             Assert.True(reportedStatus.HasValue);
             Assert.Equal(expectedStatus, reportedStatus.OrDefault());
             Mock.Get(controller).VerifyAll();


### PR DESCRIPTION
Instead of allowing Agent to crash on Edge Deployment failure, the
failure that was reported to edge Deployment status will get reported
back in the EdgeAgent's twin.  This more closely follows how single
device Edge Agent operates.