### PR TITLE
Fix DeviceScope API AuthN (#3311)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Primitives;
     using Newtonsoft.Json;
 
     public class DeviceScopeController : Controller
@@ -58,7 +59,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
 
             if (!this.TryGetTargetDeviceId(request.AuthChain, out string targetDeviceId))
             {
-                Events.InvalidAuthchain(request.AuthChain);
+                Events.InvalidRequestAuthchain(request.AuthChain);
                 result.Status = HttpStatusCode.BadRequest;
                 return result;
             }
@@ -199,21 +200,48 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             if (actorModuleId != Constants.EdgeHubModuleId)
             {
                 // Only child EdgeHubs are allowed to act OnBehalfOf of devices/modules.
+                Events.AuthFail_BadActor(actorDeviceId, actorModuleId, targetId);
+                return false;
+            }
+
+            if (!this.Request.Headers.TryGetValue(Constants.ServiceApiIdHeaderKey, out StringValues clientIds) || clientIds.Count == 0)
+            {
+                // Must have presented Edge header for AuthN earlier
+                Events.AuthFail_NoHeader();
+                return false;
+            }
+
+            string clientId = clientIds.First();
+            string[] clientIdParts = clientId.Split(new[] { '/' }, 2, StringSplitOptions.RemoveEmptyEntries);
+            if (clientIdParts.Length != 2)
+            {
+                // Edge header should have been a module
+                Events.AuthFail_BadHeader(clientIds.First());
+                return false;
+            }
+
+            if (actorDeviceId != clientIdParts[0] || actorModuleId != clientIdParts[1])
+            {
+                // Actor from request should match actor from Edge header
+                Events.AuthFail_ActorMismatch(actorDeviceId, actorModuleId, clientIdParts[0], clientIdParts[1]);
                 return false;
             }
 
             // Actor device is claiming to be our child, and that the target device is its child.
             // So we should have an authchain already cached for the target device.
-            Option<string> targetAuthChain = await identitiesCache.GetAuthChain(targetId);
+            Option<string> targetAuthChainOption = await identitiesCache.GetAuthChain(targetId);
 
-            if (!targetAuthChain.HasValue)
+            if (!targetAuthChainOption.HasValue)
             {
+                Events.AuthFail_NoAuthChain(targetId);
                 return false;
             }
 
             // Validate the target auth-chain
-            if (!AuthChainHelpers.ValidateAuthChain(actorDeviceId, targetId, targetAuthChain.Expect(() => new InvalidOperationException())))
+            string targetAuthChain = targetAuthChainOption.Expect(() => new InvalidOperationException());
+            if (!AuthChainHelpers.ValidateAuthChain(actorDeviceId, targetId, targetAuthChain))
             {
+                Events.AuthFail_InvalidAuthChain(actorDeviceId, targetId, targetAuthChain);
                 return false;
             }
 
@@ -266,9 +294,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 ReceivedScopeRequest = IdStart,
                 ReceivedIdentityOnBehalfOfRequest,
                 SendingScopeResult,
-                AuthchainMismatch,
                 UnauthorizedActor,
-                InvalidAuthchain
+                InvalidRequestAuthchain,
+                AuthFail_BadActor,
+                AuthFail_NoHeader,
+                AuthFail_BadHeader,
+                AuthFail_ActorMismatch,
+                AuthFail_NoAuthChain,
+                AuthFail_InvalidAuthChain
             }
 
             public static void ReceivedScopeRequest(string actorDeviceId, string actorModuleId, NestedScopeRequest request)
@@ -291,9 +324,39 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 Log.LogError((int)EventIds.UnauthorizedActor, $"{actorDeviceId}/{actorModuleId} not authorized to act OnBehalfOf {targetDeviceId}");
             }
 
-            public static void InvalidAuthchain(string authChain)
+            public static void InvalidRequestAuthchain(string authChain)
             {
-                Log.LogError((int)EventIds.AuthchainMismatch, $"Invalid auth chain: {authChain}");
+                Log.LogError((int)EventIds.InvalidRequestAuthchain, $"Invalid auth chain: {authChain}");
+            }
+
+            public static void AuthFail_BadActor(string actorDeviceId, string actorModuleId, string targetId)
+            {
+                Log.LogError((int)EventIds.AuthFail_BadActor, $"{actorDeviceId}/{actorModuleId} not authorized to connect OnBehalfOf {targetId}");
+            }
+
+            public static void AuthFail_NoHeader()
+            {
+                Log.LogError((int)EventIds.AuthFail_NoHeader, $"Missing identity header in request");
+            }
+
+            public static void AuthFail_BadHeader(string header)
+            {
+                Log.LogError((int)EventIds.AuthFail_BadHeader, $"Bad identity header in request: {header}");
+            }
+
+            public static void AuthFail_ActorMismatch(string uriActorDevice, string uriActorModule, string headerActorDevice, string headerActorModule)
+            {
+                Log.LogError((int)EventIds.AuthFail_ActorMismatch, $"Mismatched actors, uri: {uriActorDevice}/{uriActorModule}, header: {headerActorDevice}/{headerActorModule}");
+            }
+
+            public static void AuthFail_NoAuthChain(string targetId)
+            {
+                Log.LogError((int)EventIds.AuthFail_NoAuthChain, $"No auth chain for target identity: {targetId}");
+            }
+
+            public static void AuthFail_InvalidAuthChain(string actorId, string targetId, string authChain)
+            {
+                Log.LogError((int)EventIds.AuthFail_InvalidAuthChain, $"Invalid auth chain, actor: {actorId}, target: {targetId}, auth chain: {authChain}");
             }
         }
     }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -47,6 +47,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
 
             // Act
+            controller.Request.Headers.Add(Constants.ServiceApiIdHeaderKey, $"{parentEdgeId}/$edgeHub");
             var request = new NestedScopeRequest(0, string.Empty, "edge2;edge1");
             await controller.GetDevicesAndModulesInTargetDeviceScopeAsync(parentEdgeId, "$edgeHub", request);
 
@@ -112,6 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
 
             // Act
+            controller.Request.Headers.Add(Constants.ServiceApiIdHeaderKey, $"{parentEdgeId}/$edgeHub");
             var request = new IdentityOnBehalfOfRequest(childEdgeId, moduleId, $"{childEdgeId};{parentEdgeId}");
             await controller.GetDeviceAndModuleOnBehalfOfAsync(parentEdgeId, "$edgeHub", request);
 
@@ -151,6 +153,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
 
             // Act
+            controller.Request.Headers.Add(Constants.ServiceApiIdHeaderKey, $"{parentEdgeId}/$edgeHub");
             var request = new IdentityOnBehalfOfRequest(deviceId, null, $"{deviceId};{childEdgeId};{parentEdgeId}");
             await controller.GetDeviceAndModuleOnBehalfOfAsync(parentEdgeId, "$edgeHub", request);
 


### PR DESCRIPTION
Cherry-pick DeviceScope API auth fix into preview.

Verify that actor from URI and "x-ms-edge-moduleId" header are the same