### PR TITLE
Add test for close on remove all links

### DIFF
--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/ConnectionHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/ConnectionHandlerTest.cs
@@ -249,6 +249,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 
             // Assert
             deviceListener.Verify(d => d.CloseAsync(), Times.Once);
+
+            // Act
+            await connectionHandler.GetDeviceListener();
+
+            // Assert
+            deviceListener.Verify(d => d.BindDeviceProxy(It.IsAny<IDeviceProxy>()), Times.Exactly(2));
         }
     }
 }


### PR DESCRIPTION
Added unit test for change related to subscription fix, it just checks that the device proxy is recreated after closing all links. Tests for subscription should be caught by E2E tests 