### PR TITLE
[PnP] Fixing bug that broke integ tests

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionMetadata.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionMetadata.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public ConnectionMetadata(string productInfo, Option<string> modelId, string edgeProductInfo)
         {
-            Preconditions.CheckNonWhiteSpace(edgeProductInfo, nameof(edgeProductInfo));
+            Preconditions.CheckNotNull(edgeProductInfo, nameof(edgeProductInfo));
             this.ModelId = modelId;
             this.ProductInfo = productInfo;
             this.EdgeProductInfo = this.BuildEdgeProductInfo(productInfo, edgeProductInfo);

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -313,7 +313,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 });
 
             var credentialsCache = Mock.Of<ICredentialsCache>();
-            var metadataStore = Mock.Of<IMetadataStore>();
+            var metadataStore = new Mock<IMetadataStore>();
+            metadataStore.Setup(m => m.GetMetadata(It.IsAny<string>())).ReturnsAsync(new ConnectionMetadata("dummyValue"));
             ICloudConnectionProvider cloudConnectionProvider = new CloudConnectionProvider(
                 converters,
                 ConnectionPoolSize,
@@ -328,7 +329,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                metadataStore);
+                metadataStore.Object);
             cloudConnectionProvider.BindEdgeHub(edgeHub);
 
             var clientTokenProvider = new ClientTokenProvider(new SharedAccessKeySignatureProvider(sasKey), iotHubHostName, deviceId, TimeSpan.FromHours(1));

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -63,7 +63,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             var signatureProvider = new SharedAccessKeySignatureProvider(sasKey);
             var credentialsCache = Mock.Of<ICredentialsCache>();
             var metadataStore = new Mock<IMetadataStore>();
-            metadataStore.Setup(m => m.GetMetadata(It.IsAny<string>())).ReturnsAsync(new ConnectionMetadata("dummyValue")); var cloudConnectionProvider = new CloudConnectionProvider(
+            metadataStore.Setup(m => m.GetMetadata(It.IsAny<string>())).ReturnsAsync(new ConnectionMetadata("dummyValue"));
+            var cloudConnectionProvider = new CloudConnectionProvider(
                 messageConverterProvider,
                 1,
                 new ClientProvider(),

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -62,8 +62,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             string sasKey = ConnectionStringHelper.GetSharedAccessKey(deviceConnStr);
             var signatureProvider = new SharedAccessKeySignatureProvider(sasKey);
             var credentialsCache = Mock.Of<ICredentialsCache>();
-            var metadataStore = Mock.Of<IMetadataStore>();
-            var cloudConnectionProvider = new CloudConnectionProvider(
+            var metadataStore = new Mock<IMetadataStore>();
+            metadataStore.Setup(m => m.GetMetadata(It.IsAny<string>())).ReturnsAsync(new ConnectionMetadata("dummyValue")); var cloudConnectionProvider = new CloudConnectionProvider(
                 messageConverterProvider,
                 1,
                 new ClientProvider(),
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                metadataStore);
+                metadataStore.Object);
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             var connectionManager = new ConnectionManager(cloudConnectionProvider, Mock.Of<ICredentialsCache>(), identityProvider, deviceConnectivityManager);
 


### PR DESCRIPTION
The last pnp PR broke our integ tests because of two subtle bugs.

First is that the metadataStore needs to be mocked in two more places.
2nd is that I had a more stringent check in MetadataStore that broke some of the integ tests, since the integ tests use empty string as edgeProductInfo.

As I don't want to cause any breaking changes, I changed the metadataStore check to be the same as it was before (CheckNotNull instead of CheckNonWhitespace)