### PR TITLE
Update EdgeAgent deployment schema validation to 1.1.0 (#3321)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
@@ -19,7 +20,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
 
     public class EdgeAgentConnection : IEdgeAgentConnection
     {
-        internal static readonly Version ExpectedSchemaVersion = new Version("1.0");
+        internal static readonly Version ExpectedSchemaVersion = new Version("1.1.0");
         static readonly TimeSpan DefaultConfigRefreshFrequency = TimeSpan.FromHours(1);
         static readonly TimeSpan DeviceClientInitializationWaitTime = TimeSpan.FromSeconds(5);
 
@@ -149,11 +150,47 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             }
         }
 
-        internal static void ValidateSchemaVersion(string schemaVersion)
+        internal static void ValidateSchemaVersion(DeploymentConfig config)
         {
-            if (ExpectedSchemaVersion.CompareMajorVersion(schemaVersion, "desired properties schema") != 0)
+            string schemaVersion = config.SchemaVersion;
+
+            if (string.IsNullOrWhiteSpace(schemaVersion) || !Version.TryParse(schemaVersion, out Version actualSchemaVersion))
             {
-                Events.MismatchedMinorVersions(schemaVersion, ExpectedSchemaVersion);
+                throw new InvalidSchemaVersionException($"Invalid desired properties schema version {schemaVersion}");
+            }
+
+            // Check major version and upper bound
+            if (actualSchemaVersion.Major != ExpectedSchemaVersion.Major ||
+                actualSchemaVersion.Major > ExpectedSchemaVersion.Major)
+            {
+                throw new InvalidSchemaVersionException($"The desired properties schema version {schemaVersion} is not compatible with the expected version {ExpectedSchemaVersion}");
+            }
+
+            // Validate minor versions
+            if (actualSchemaVersion.Minor == 0)
+            {
+                // 1.0
+                //
+                // Module startup order is not supported
+                foreach (KeyValuePair<string, IModule> kvp in config.Modules)
+                {
+                    IModule moduleConfig = kvp.Value;
+
+                    if (moduleConfig.StartupOrder != Constants.DefaultStartupOrder)
+                    {
+                        throw new InvalidSchemaVersionException($"Module startup order is not supported in schema {actualSchemaVersion}, module: {moduleConfig.Name}, startupOrder: {moduleConfig.StartupOrder}");
+                    }
+                }
+            }
+            else if (actualSchemaVersion.Minor == 1)
+            {
+                // 1.1.0
+                //
+                // Everything from 1.0 is supported
+            }
+            else
+            {
+                throw new InvalidSchemaVersionException($"The deployment schema version {actualSchemaVersion} is not compatible with the expected version {ExpectedSchemaVersion}");
             }
         }
 
@@ -342,7 +379,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             try
             {
                 // Do any validation on deploymentConfig if necessary
-                ValidateSchemaVersion(deploymentConfig.SchemaVersion);
+                ValidateSchemaVersion(deploymentConfig);
                 this.deploymentConfigInfo = Option.Some(new DeploymentConfigInfo(desiredProperties.Version, deploymentConfig));
                 Events.UpdatedDeploymentConfig();
             }
@@ -400,13 +437,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             public static void ConnectionStatusChanged(ConnectionStatus status, ConnectionStatusChangeReason reason)
             {
                 Log.LogDebug((int)EventIds.ConnectionStatusChanged, $"Connection status changed to {status} with reason {reason}");
-            }
-
-            public static void MismatchedMinorVersions(string receivedVersion, Version expectedVersion)
-            {
-                Log.LogWarning(
-                    (int)EventIds.MismatchedSchemaVersion,
-                    $"Desired properties schema version {receivedVersion} does not match expected schema version {expectedVersion}. Some settings may not be supported.");
             }
 
             public static void GotTwin(Twin twin)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
     using Microsoft.Azure.Devices.Edge.Agent.Core.Metrics;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Requests;
     using Microsoft.Azure.Devices.Edge.Agent.Core.Serde;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.Test;
     using Microsoft.Azure.Devices.Edge.Agent.Docker;
     using Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -1615,27 +1616,53 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         }
 
         [Theory]
-        [Unit]
-        [InlineData("1.0", null)]
-        [InlineData("1.1", null)]
-        [InlineData("1.2", null)]
-        [InlineData("1.3", null)]
-        [InlineData("1", typeof(InvalidSchemaVersionException))]
-        [InlineData("", typeof(InvalidSchemaVersionException))]
-        [InlineData(null, typeof(InvalidSchemaVersionException))]
-        [InlineData("0.1", typeof(InvalidSchemaVersionException))]
-        [InlineData("2.0", typeof(InvalidSchemaVersionException))]
-        [InlineData("2.1", typeof(InvalidSchemaVersionException))]
-        public void SchemaVersionCheckTest(string schemaVersion, Type expectedException)
+        [MemberData(nameof(GetDeploymentForSchemas))]
+        public void SchemaVersionCheckTest(DeploymentConfig deployment, Type expectedException)
         {
             if (expectedException != null)
             {
-                Assert.Throws(expectedException, () => EdgeAgentConnection.ValidateSchemaVersion(schemaVersion));
+                Assert.Throws(expectedException, () => EdgeAgentConnection.ValidateSchemaVersion(deployment));
             }
             else
             {
-                EdgeAgentConnection.ValidateSchemaVersion(schemaVersion);
+                EdgeAgentConnection.ValidateSchemaVersion(deployment);
             }
+        }
+
+        public static IEnumerable<object[]> GetDeploymentForSchemas()
+        {
+            var modulesWithDefaultStartupOrder =
+                new Dictionary<string, IModule>
+                {
+                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultStartupOrder, null, null) },
+                    { "mod2", new TestModule("mod2", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultStartupOrder, null, null) }
+                };
+
+            var modulesWithCustomStartupOrder =
+                new Dictionary<string, IModule>
+                {
+                    { "mod1", new TestModule("mod1", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 0, null, null) },
+                    { "mod2", new TestModule("mod2", "1.0", "docker", ModuleStatus.Running, new TestConfig("boo"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, 10, null, null) }
+                };
+            var version_0_1 = new DeploymentConfig("0.1", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithDefaultStartupOrder.ToImmutableDictionary());
+            var version_1 = new DeploymentConfig("1", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithDefaultStartupOrder.ToImmutableDictionary());
+            var version_1_0 = new DeploymentConfig("1.0", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithDefaultStartupOrder.ToImmutableDictionary());
+            var version_1_1 = new DeploymentConfig("1.1", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithCustomStartupOrder.ToImmutableDictionary());
+            var version_1_1_0 = new DeploymentConfig("1.1.0", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithCustomStartupOrder.ToImmutableDictionary());
+            var version_1_2 = new DeploymentConfig("1.2", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithDefaultStartupOrder.ToImmutableDictionary());
+            var version_2_0 = new DeploymentConfig("2.0", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithDefaultStartupOrder.ToImmutableDictionary());
+            var version_2_0_1 = new DeploymentConfig("2.0.1", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithDefaultStartupOrder.ToImmutableDictionary());
+            var version_schema_mismatch = new DeploymentConfig("1.0", UnknownRuntimeInfo.Instance, new SystemModules(UnknownEdgeAgentModule.Instance, UnknownEdgeHubModule.Instance), modulesWithCustomStartupOrder.ToImmutableDictionary());
+
+            yield return new object[] { version_0_1, typeof(InvalidSchemaVersionException) };
+            yield return new object[] { version_1, typeof(InvalidSchemaVersionException) };
+            yield return new object[] { version_1_0, null };
+            yield return new object[] { version_1_1, null };
+            yield return new object[] { version_1_1_0, null };
+            yield return new object[] { version_1_2, typeof(InvalidSchemaVersionException) };
+            yield return new object[] { version_2_0, typeof(InvalidSchemaVersionException) };
+            yield return new object[] { version_2_0_1, typeof(InvalidSchemaVersionException) };
+            yield return new object[] { version_schema_mismatch, typeof(InvalidSchemaVersionException) };
         }
 
         static async Task SetAgentDesiredProperties(RegistryManager rm, string deviceId)


### PR DESCRIPTION
Cherry pick from release/1.0.10 branch:
https://github.com/Azure/iotedge/commit/08348af6e042d6b32a94fa8462c150e677184a18