### PR TITLE
Document support bundle upload and new metrics

### DIFF
--- a/doc/BuiltInMetrics.md
+++ b/doc/BuiltInMetrics.md
@@ -4,7 +4,7 @@ The IoT Edge Hub and Edge Agent module expose a number of metrics in the Prometh
 
 ## How to enable
 ### Version 1.0.10+
-As of release 1.0.10, metrics are exposed automatically exposed by default on http port **9600** of the Edge Hub and Edge Agent module. 
+As of release 1.0.10, metrics are automatically exposed by default on http port **9600** of the Edge Hub and Edge Agent module. 
 
 If you wish to disable metrics, simply set the `MetricsEnabled` environment variable to false.
 

--- a/doc/BuiltInMetrics.md
+++ b/doc/BuiltInMetrics.md
@@ -4,30 +4,9 @@ The IoT Edge Hub and Edge Agent module expose a number of metrics in the Prometh
 
 ## How to enable
 ### Version 1.0.10+
-As of release 1.0.10, metrics are exposed automatically exposed on http port **9600** of the Edge Hub and Edge Agent module. 
+As of release 1.0.10, metrics are exposed automatically exposed by default on http port **9600** of the Edge Hub and Edge Agent module. 
 
 If you wish to disable metrics, simply set the `MetricsEnabled` environment variable to false.
-
-### Version 1.0.9
-As of release 1.0.9, metrics are exposed as an experimental feature available at http port **9600** of the Edge Hub and Edge Agent module. To enable, the following environment variables should be set for each module (make note of the double underscores):
-
-| Environment Variable Name                | value  |
-|------------------------------------------|--------|
-| `ExperimentalFeatures__Enabled`          | `true` |
-| `ExperimentalFeatures__EnableMetrics`    | `true` |
-
-### Windows Note (1.0.9 only)
-Metrics on Windows are not fully supported the 1.0.9 experimental release. Host metrics (cpu, memory and disk usage) will all show as 0. Moby metrics are supported. In addition, edgeHub must be started as a container administrator to expose metrics. 
-
-This is no longer required in the 1.0.10 release
-
-Add the following to EdgeHub createOptions (on Windows only):
-```JSON
-createOptions: {
-  "User": "ContainerAdministrator",
-  "ExposedPorts": {}
-}
-```
 
 ## Metrics
 

--- a/doc/BuiltInMetrics.md
+++ b/doc/BuiltInMetrics.md
@@ -3,7 +3,12 @@
 The IoT Edge Hub and Edge Agent module expose a number of metrics in the Prometheus exposition format that provide insights into its operational state.
 
 ## How to enable
+### Version 1.0.10+
+As of release 1.0.10, metrics are exposed automatically exposed on http port **9600** of the Edge Hub and Edge Agent module. 
 
+If you wish to disable metrics, simply set the `MetricsEnabled` environment variable to false.
+
+### Version 1.0.9
 As of release 1.0.9, metrics are exposed as an experimental feature available at http port **9600** of the Edge Hub and Edge Agent module. To enable, the following environment variables should be set for each module (make note of the double underscores):
 
 | Environment Variable Name                | value  |
@@ -66,6 +71,10 @@ instance_number | A Guid representing the current runtime. On restart, all metri
 | `edgeAgent_module_start_total` | `module_name`, `module_version` | Number of times edgeAgent asked docker to start the module.  | Counter |
 | `edgeAgent_module_stop_total` | `module_name`, `module_version` | Number of times edgeAgent asked docker to stop the module. | Counter |
 | `edgeAgent_command_latency_seconds` | `command` | How long it took docker to execute the given command. Possible commands are: create, update,  remove, start, stop, restart | Gauge |
+| `edgeAgent_iothub_syncs_total` |  | The amount of times edgeAgent attempted to sync its twin with iotHub, both successful and unsuccessful. This incudes both agent requesting a twin and hub notifying of a twin update | Counter |
+| `edgeAgent_unsuccessful_iothub_syncs_total` |  | The amount of times edgeAgent failed to sync its twin with iotHub. | Counter |
+| `edgeAgent_deployment_time_seconds` |  | The amount of time it took to complete a new deployment after recieving a change. | Counter |
+| `edgeagent_direct_method_invocations_count` | `method_name` | Number of times a built-in edgeAgent direct method is called, such as Ping or Restart. | Counter |
 |||
 | `edgeAgent_host_uptime_seconds` || How long the host has been on | Gauge |
 | `edgeAgent_iotedged_uptime_seconds` || How long iotedged has been running | Gauge |
@@ -79,6 +88,9 @@ instance_number | A Guid representing the current runtime. On restart, all metri
 | `edgeAgent_total_network_out_bytes` | `module_name` | The amount of bytes sent to network | Gauge |
 | `edgeAgent_total_disk_read_bytes` | `module_name` | The amount of bytes read from the disk | Gauge |
 | `edgeAgent_total_disk_write_bytes` | `module_name` | The amount of bytes written to disk | Gauge |
+|||
+| `edgeAgent_metadata` | `edge_agent_version`, `experimental_features`, `host_information` | General metadata about the device. The value is always 0, information is encoded in the tags. Note `experimental_features` and `host_information` are json objects. `host_information` looks like ```{"OperatingSystemType": "linux", "Architecture": "x86_64", "Version": "1.0.10~dev20200803.4", "ServerVersion": "19.03.6", "KernelVersion": "5.0.0-25-generic", "OperatingSystem": "Ubuntu 18.04.4 LTS", "NumCpus": 6}```. Note `ServerVersion` is the Docker version and `Version` is the IoT Edge Security Daemon version. | Gauge |
+
 
 ### Collecting
 

--- a/doc/built-in-logs-pull.md
+++ b/doc/built-in-logs-pull.md
@@ -11,16 +11,6 @@ IoT Edge supports native retrieval of module logs and upload to Azure Blob Stora
 ### Version 1.0.10+
 As of release 1.0.10, these direct methods are no longer experimental and are always available. 
 
-### Version 1.0.8/1.0.9
-As of [1.0.8 release](https://github.com/Azure/azure-iotedge/releases/tag/1.0.8) of IoT Edge, this capability is available as an experimental feature. To enable it, the following environment variables need to be set for the edgeAgent (make note of the double underscores):
-
-| Environment Variable Name                | value  |
-|------------------------------------------|--------|
-| `ExperimentalFeatures__Enabled`          | `true` |
-| `ExperimentalFeatures__EnableUploadLogs` | `true` |
-
-Due to certain design limitations, settings for the Edge Agent do not take affect unless its image is also changed (as of 1.0.8 release). If you are using the default Edge Agent settings, change the image to use a specific tag along with the environment variables above, e.g. `mcr.microsoft.com/azureiotedge-agent:1.0.8`.
-
 ## Recommended logging format
 
 For best compatibility with this feature, the recommended logging format is:

--- a/doc/built-in-logs-pull.md
+++ b/doc/built-in-logs-pull.md
@@ -1,12 +1,17 @@
-# Built-in logs collation and upload capability
+# Built-in diagnostics collection and upload capability
 
 IoT Edge supports native retrieval of module logs and upload to Azure Blob Storage. Users can access this functionality via direct method calls to the Edge Agent module. The following methods are available in support of this:
 
-- UploadLogs
-- GetTaskStatus
+- [UploadLogs](#UploadLogs)
+- [GetTaskStatus](#GetTaskStatus)
+- [GetLogs](#GetLogs)
+- [UploadSupportBundle](#UploadSupportBundle)
 
 ## Feature enabling
+### Version 1.0.10+
+As of release 1.0.10, these direct methods are no longer experimental and are always available. 
 
+### Version 1.0.8/1.0.9
 As of [1.0.8 release](https://github.com/Azure/azure-iotedge/releases/tag/1.0.8) of IoT Edge, this capability is available as an experimental feature. To enable it, the following environment variables need to be set for the edgeAgent (make note of the double underscores):
 
 | Environment Variable Name                | value  |
@@ -14,7 +19,7 @@ As of [1.0.8 release](https://github.com/Azure/azure-iotedge/releases/tag/1.0.8)
 | `ExperimentalFeatures__Enabled`          | `true` |
 | `ExperimentalFeatures__EnableUploadLogs` | `true` |
 
-> Due to certain design limitations, settings for the Edge Agent do not take affect unless its image is also changed (as of 1.0.8 release). If you are using the default Edge Agent settings, change the image to use a specific tag along with the environment variables above, e.g. `mcr.microsoft.com/azureiotedge-agent:1.0.8`.
+Due to certain design limitations, settings for the Edge Agent do not take affect unless its image is also changed (as of 1.0.8 release). If you are using the default Edge Agent settings, change the image to use a specific tag along with the environment variables above, e.g. `mcr.microsoft.com/azureiotedge-agent:1.0.8`.
 
 ## Recommended logging format
 
@@ -42,6 +47,7 @@ This method accepts a JSON payload with the following schema:
                 "filter": {
                     "tail": int, 
                     "since": int,
+                    "until": int
                     "loglevel": int, 
                     "regex": "regex string" 
                 }
@@ -60,6 +66,7 @@ This method accepts a JSON payload with the following schema:
 | filter        | JSON section | Log filters to apply to the modules matching the `id` regular expression in the tuple.                                                                                                                                                               |
 | tail          | integer      | Number of log lines in the past to retrieve starting from the latest. OPTIONAL.                                                                                                                                                                               |
 | since         | integer      | Only return logs since this time, as a duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes), rfc3339 timestamp, or UNIX timestamp.  If both `tail` and `since` are specified, first the logs using the `since` value are retrieved and then `tail` value of those are returned. OPTIONAL.|
+| until         | integer      | Only return logs before the specified time, as a rfc3339 timestamp, UNIX timestamp, or duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes). OPTIONAL.|
 | loglevel      | integer      | Filter log lines less than or equal to specified loglevel. Log lines should follow recommended logging format and use [Syslog severity level](https://en.wikipedia.org/wiki/Syslog#Severity_level) standard. OPTIONAL.                                                                                                                |
 | regex         | string       | Filter log lines which have content that match the specified regular expression using [.NET Regular Expressions](https://docs.microsoft.com/en-us/dotnet/standard/base-types/regular-expressions) format. OPTIONAL.                                            |
 | encoding      | string       | Either `gzip` or `none`. Default is `none`.                                                                                                                                                                                                          |
@@ -154,13 +161,28 @@ The status of upload logs request can be queried using the `correlationId` retur
 The response is in the same format as `UploadLogs`.
 
 ## GetLogs
+Returns the requested logs in the response of the direct method.
 
->Available in release 1.0.9
+This method accepts a JSON payload very similar to **UploadLogs** except it doesn't have the "sasUrl" key. The logs content is truncated to the response size limit of direct methods which is currently 128KB.
 
-To enable this feature, an additional environment needs to be set for the edgeAgent:
+## UploadSupportBundle
+This runs the `iotedge support bundle` command and uploads the resulting zip file to the blob store specified by sasUrl. It uses the same response schema as [Upload Logs](#UploadLogs). 
 
-| Environment Variable Name                | value  |
-|------------------------------------------|--------|
-| `ExperimentalFeatures__EnableGetLogs`    | `true` |
+### Request Schema
+```
+{    
+    "schemaVersion": "1.0",
+    "sasUrl": "Full path to SAS url",
+    "since": "2d",
+    "until": "1d",
+    "edgeRuntimeOnly": false
+}
+```
 
-This method accepts a JSON payload very similar to **UploadLogs** except it doesn't have the "sasUrl" key since the matching logs are returned inline in the response of the direct method. The logs content is truncated to the response size limit of direct methods which is currently 128KB.
+| Name | Type | Description |
+|-|-|-|
+| schemaVersion | string | Set to `1.0` |
+| sasURL | string (URI) | [Shared Access Signature URL with write access to Azure Blob Storage container](https://blogs.msdn.microsoft.com/jpsanders/2017/10/12/easily-create-a-sas-to-download-a-file-from-azure-storage-using-azure-storage-explorer/)
+| since | integer | Only return logs since this time, as a duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes), rfc3339 timestamp, or UNIX timestamp. OPTIONAL. |
+| until | integer | Only return logs before the specified time, as a rfc3339 timestamp, UNIX timestamp, or duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes). OPTIONAL.|
+| edgeRuntimeOnly | boolean | If true, only return logs from Edge Agent, Edge Hub and the Edge Security Daemon. **Edge Hub logs may still contain PII**. Default: false.  OPTIONAL.|

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/metrics/DeploymentMetrics.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/metrics/DeploymentMetrics.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Metrics
                 new List<string> { "module_name", MetricsConstants.MsTelemetry });
 
             this.unsuccessfulSyncs = metricsProvider.CreateCounter(
-                "total_unsuccessful_iothub_syncs",
+                "unsuccessful_iothub_syncs",
                 "The amount of times edgeAgent failed to sync with iotHub",
                 new List<string> { MetricsConstants.MsTelemetry });
 
             this.totalSyncs = metricsProvider.CreateCounter(
-                "total_iothub_syncs",
+                "iothub_syncs",
                 "The amount of times edgeAgent attempted to sync with iotHub, both successful and unsuccessful",
                 new List<string> { MetricsConstants.MsTelemetry });
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
@@ -7,23 +7,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
 
     public class ExperimentalFeatures
     {
-        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool enableUploadLogs, bool enableGetLogs, bool enableUploadSupportBundle)
+        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
-            this.EnableUploadLogs = enableUploadLogs;
-            this.EnableGetLogs = enableGetLogs;
-            this.EnableUploadSupportBundle = enableUploadSupportBundle;
         }
 
         public static ExperimentalFeatures Create(IConfiguration experimentalFeaturesConfig, ILogger logger)
         {
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
-            bool enableUploadLogs = enabled && experimentalFeaturesConfig.GetValue("enableUploadLogs", false);
-            bool enableGetLogs = enabled && experimentalFeaturesConfig.GetValue("enableGetLogs", false);
-            bool enableUploadSupportBundle = enabled && experimentalFeaturesConfig.GetValue("enableUploadSupportBundle", false);
-            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, enableUploadLogs, enableGetLogs, enableUploadSupportBundle);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions);
             logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
             return experimentalFeatures;
         }
@@ -31,11 +25,5 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
         public bool Enabled { get; }
 
         public bool DisableCloudSubscriptions { get; }
-
-        public bool EnableUploadLogs { get; }
-
-        public bool EnableGetLogs { get; }
-
-        public bool EnableUploadSupportBundle { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
@@ -88,51 +88,42 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .As<IRequestManager>()
                 .SingleInstance();
 
-            if (this.experimentalFeatures.EnableUploadLogs)
-            {
-                // Task<IRequestHandler> - LogsUploadRequestHandler
-                builder.Register(
-                        async c =>
-                        {
-                            var requestUploader = c.Resolve<IRequestsUploader>();
-                            var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
-                            var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
-                            IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
-                            ILogsProvider logsProvider = await logsProviderTask;
-                            return new ModuleLogsUploadRequestHandler(requestUploader, logsProvider, runtimeInfoProvider) as IRequestHandler;
-                        })
-                    .As<Task<IRequestHandler>>()
-                    .SingleInstance();
-            }
+            // Task<IRequestHandler> - LogsUploadRequestHandler
+            builder.Register(
+                    async c =>
+                    {
+                        var requestUploader = c.Resolve<IRequestsUploader>();
+                        var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
+                        var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
+                        IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
+                        ILogsProvider logsProvider = await logsProviderTask;
+                        return new ModuleLogsUploadRequestHandler(requestUploader, logsProvider, runtimeInfoProvider) as IRequestHandler;
+                    })
+                .As<Task<IRequestHandler>>()
+                .SingleInstance();
 
-            if (this.experimentalFeatures.EnableGetLogs)
-            {
-                // Task<IRequestHandler> - LogsRequestHandler
-                builder.Register(
-                        async c =>
-                        {
-                            var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
-                            var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
-                            IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
-                            ILogsProvider logsProvider = await logsProviderTask;
-                            return new ModuleLogsRequestHandler(logsProvider, runtimeInfoProvider) as IRequestHandler;
-                        })
-                    .As<Task<IRequestHandler>>()
-                    .SingleInstance();
-            }
+            // Task<IRequestHandler> - LogsRequestHandler
+            builder.Register(
+                    async c =>
+                    {
+                        var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
+                        var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
+                        IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
+                        ILogsProvider logsProvider = await logsProviderTask;
+                        return new ModuleLogsRequestHandler(logsProvider, runtimeInfoProvider) as IRequestHandler;
+                    })
+                .As<Task<IRequestHandler>>()
+                .SingleInstance();
 
-            if (this.experimentalFeatures.EnableUploadSupportBundle)
-            {
-                // Task<IRequestHandler> - SupportBundleRequestHandler
-                builder.Register(
-                        async c =>
-                        {
-                            await Task.Yield();
-                            return new SupportBundleRequestHandler(c.Resolve<IModuleManager>().GetSupportBundle, c.Resolve<IRequestsUploader>(), this.iotHubHostName) as IRequestHandler;
-                        })
-                    .As<Task<IRequestHandler>>()
-                    .SingleInstance();
-            }
+            // Task<IRequestHandler> - SupportBundleRequestHandler
+            builder.Register(
+                    async c =>
+                    {
+                        await Task.Yield();
+                        return new SupportBundleRequestHandler(c.Resolve<IModuleManager>().GetSupportBundle, c.Resolve<IRequestsUploader>(), this.iotHubHostName) as IRequestHandler;
+                    })
+                .As<Task<IRequestHandler>>()
+                .SingleInstance();
 
             // Task<IRequestHandler> - RestartRequestHandler
             builder.Register(


### PR DESCRIPTION
This also removes the experimental flags.

Note I didn't rename built-in-logs-pull.md since some documentation links to it: https://docs.microsoft.com/en-us/azure/iot-edge/how-to-edgeagent-direct-method#experimental-methods. We should probably update this as well.