### PR TITLE
Document support bundle upload and new metrics

### DIFF
--- a/doc/BuiltInMetrics.md
+++ b/doc/BuiltInMetrics.md
@@ -3,26 +3,10 @@
 The IoT Edge Hub and Edge Agent module expose a number of metrics in the Prometheus exposition format that provide insights into its operational state.
 
 ## How to enable
+### Version 1.0.10+
+As of release 1.0.10, metrics are automatically exposed by default on http port **9600** of the Edge Hub and Edge Agent module. 
 
-As of release 1.0.9, metrics are exposed as an experimental feature available at http port **9600** of the Edge Hub and Edge Agent module. To enable, the following environment variables should be set for each module (make note of the double underscores):
-
-| Environment Variable Name                | value  |
-|------------------------------------------|--------|
-| `ExperimentalFeatures__Enabled`          | `true` |
-| `ExperimentalFeatures__EnableMetrics`    | `true` |
-
-### Windows Note (1.0.9 only)
-Metrics on Windows are not fully supported the 1.0.9 experimental release. Host metrics (cpu, memory and disk usage) will all show as 0. Moby metrics are supported. In addition, edgeHub must be started as a container administrator to expose metrics. 
-
-This is no longer required in the 1.0.10 release
-
-Add the following to EdgeHub createOptions (on Windows only):
-```JSON
-createOptions: {
-  "User": "ContainerAdministrator",
-  "ExposedPorts": {}
-}
-```
+If you wish to disable metrics, simply set the `MetricsEnabled` environment variable to false.
 
 ## Metrics
 
@@ -66,6 +50,10 @@ instance_number | A Guid representing the current runtime. On restart, all metri
 | `edgeAgent_module_start_total` | `module_name`, `module_version` | Number of times edgeAgent asked docker to start the module.  | Counter |
 | `edgeAgent_module_stop_total` | `module_name`, `module_version` | Number of times edgeAgent asked docker to stop the module. | Counter |
 | `edgeAgent_command_latency_seconds` | `command` | How long it took docker to execute the given command. Possible commands are: create, update,  remove, start, stop, restart | Gauge |
+| `edgeAgent_iothub_syncs_total` |  | The amount of times edgeAgent attempted to sync its twin with iotHub, both successful and unsuccessful. This incudes both agent requesting a twin and hub notifying of a twin update | Counter |
+| `edgeAgent_unsuccessful_iothub_syncs_total` |  | The amount of times edgeAgent failed to sync its twin with iotHub. | Counter |
+| `edgeAgent_deployment_time_seconds` |  | The amount of time it took to complete a new deployment after recieving a change. | Counter |
+| `edgeagent_direct_method_invocations_count` | `method_name` | Number of times a built-in edgeAgent direct method is called, such as Ping or Restart. | Counter |
 |||
 | `edgeAgent_host_uptime_seconds` || How long the host has been on | Gauge |
 | `edgeAgent_iotedged_uptime_seconds` || How long iotedged has been running | Gauge |
@@ -79,6 +67,9 @@ instance_number | A Guid representing the current runtime. On restart, all metri
 | `edgeAgent_total_network_out_bytes` | `module_name` | The amount of bytes sent to network | Gauge |
 | `edgeAgent_total_disk_read_bytes` | `module_name` | The amount of bytes read from the disk | Gauge |
 | `edgeAgent_total_disk_write_bytes` | `module_name` | The amount of bytes written to disk | Gauge |
+|||
+| `edgeAgent_metadata` | `edge_agent_version`, `experimental_features`, `host_information` | General metadata about the device. The value is always 0, information is encoded in the tags. Note `experimental_features` and `host_information` are json objects. `host_information` looks like ```{"OperatingSystemType": "linux", "Architecture": "x86_64", "Version": "1.0.10~dev20200803.4", "ServerVersion": "19.03.6", "KernelVersion": "5.0.0-25-generic", "OperatingSystem": "Ubuntu 18.04.4 LTS", "NumCpus": 6}```. Note `ServerVersion` is the Docker version and `Version` is the IoT Edge Security Daemon version. | Gauge |
+
 
 ### Collecting
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/metrics/DeploymentMetrics.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/metrics/DeploymentMetrics.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Metrics
                 new List<string> { "module_name", MetricsConstants.MsTelemetry });
 
             this.unsuccessfulSyncs = metricsProvider.CreateCounter(
-                "total_unsuccessful_iothub_syncs",
+                "unsuccessful_iothub_syncs",
                 "The amount of times edgeAgent failed to sync with iotHub",
                 new List<string> { MetricsConstants.MsTelemetry });
 
             this.totalSyncs = metricsProvider.CreateCounter(
-                "total_iothub_syncs",
+                "iothub_syncs",
                 "The amount of times edgeAgent attempted to sync with iotHub, both successful and unsuccessful",
                 new List<string> { MetricsConstants.MsTelemetry });
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/ExperimentalFeatures.cs
@@ -7,23 +7,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
 
     public class ExperimentalFeatures
     {
-        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool enableUploadLogs, bool enableGetLogs, bool enableUploadSupportBundle)
+        ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
-            this.EnableUploadLogs = enableUploadLogs;
-            this.EnableGetLogs = enableGetLogs;
-            this.EnableUploadSupportBundle = enableUploadSupportBundle;
         }
 
         public static ExperimentalFeatures Create(IConfiguration experimentalFeaturesConfig, ILogger logger)
         {
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
-            bool enableUploadLogs = enabled && experimentalFeaturesConfig.GetValue("enableUploadLogs", false);
-            bool enableGetLogs = enabled && experimentalFeaturesConfig.GetValue("enableGetLogs", false);
-            bool enableUploadSupportBundle = enabled && experimentalFeaturesConfig.GetValue("enableUploadSupportBundle", false);
-            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, enableUploadLogs, enableGetLogs, enableUploadSupportBundle);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions);
             logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
             return experimentalFeatures;
         }
@@ -31,11 +25,5 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
         public bool Enabled { get; }
 
         public bool DisableCloudSubscriptions { get; }
-
-        public bool EnableUploadLogs { get; }
-
-        public bool EnableGetLogs { get; }
-
-        public bool EnableUploadSupportBundle { get; }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
@@ -88,51 +88,42 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .As<IRequestManager>()
                 .SingleInstance();
 
-            if (this.experimentalFeatures.EnableUploadLogs)
-            {
-                // Task<IRequestHandler> - LogsUploadRequestHandler
-                builder.Register(
-                        async c =>
-                        {
-                            var requestUploader = c.Resolve<IRequestsUploader>();
-                            var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
-                            var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
-                            IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
-                            ILogsProvider logsProvider = await logsProviderTask;
-                            return new ModuleLogsUploadRequestHandler(requestUploader, logsProvider, runtimeInfoProvider) as IRequestHandler;
-                        })
-                    .As<Task<IRequestHandler>>()
-                    .SingleInstance();
-            }
+            // Task<IRequestHandler> - LogsUploadRequestHandler
+            builder.Register(
+                    async c =>
+                    {
+                        var requestUploader = c.Resolve<IRequestsUploader>();
+                        var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
+                        var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
+                        IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
+                        ILogsProvider logsProvider = await logsProviderTask;
+                        return new ModuleLogsUploadRequestHandler(requestUploader, logsProvider, runtimeInfoProvider) as IRequestHandler;
+                    })
+                .As<Task<IRequestHandler>>()
+                .SingleInstance();
 
-            if (this.experimentalFeatures.EnableGetLogs)
-            {
-                // Task<IRequestHandler> - LogsRequestHandler
-                builder.Register(
-                        async c =>
-                        {
-                            var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
-                            var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
-                            IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
-                            ILogsProvider logsProvider = await logsProviderTask;
-                            return new ModuleLogsRequestHandler(logsProvider, runtimeInfoProvider) as IRequestHandler;
-                        })
-                    .As<Task<IRequestHandler>>()
-                    .SingleInstance();
-            }
+            // Task<IRequestHandler> - LogsRequestHandler
+            builder.Register(
+                    async c =>
+                    {
+                        var runtimeInfoProviderTask = c.Resolve<Task<IRuntimeInfoProvider>>();
+                        var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
+                        IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
+                        ILogsProvider logsProvider = await logsProviderTask;
+                        return new ModuleLogsRequestHandler(logsProvider, runtimeInfoProvider) as IRequestHandler;
+                    })
+                .As<Task<IRequestHandler>>()
+                .SingleInstance();
 
-            if (this.experimentalFeatures.EnableUploadSupportBundle)
-            {
-                // Task<IRequestHandler> - SupportBundleRequestHandler
-                builder.Register(
-                        async c =>
-                        {
-                            await Task.Yield();
-                            return new SupportBundleRequestHandler(c.Resolve<IModuleManager>().GetSupportBundle, c.Resolve<IRequestsUploader>(), this.iotHubHostName) as IRequestHandler;
-                        })
-                    .As<Task<IRequestHandler>>()
-                    .SingleInstance();
-            }
+            // Task<IRequestHandler> - SupportBundleRequestHandler
+            builder.Register(
+                    async c =>
+                    {
+                        await Task.Yield();
+                        return new SupportBundleRequestHandler(c.Resolve<IModuleManager>().GetSupportBundle, c.Resolve<IRequestsUploader>(), this.iotHubHostName) as IRequestHandler;
+                    })
+                .As<Task<IRequestHandler>>()
+                .SingleInstance();
 
             // Task<IRequestHandler> - RestartRequestHandler
             builder.Register(


### PR DESCRIPTION
This also removes the experimental flags.

Note I didn't rename built-in-logs-pull.md since some documentation links to it: https://docs.microsoft.com/en-us/azure/iot-edge/how-to-edgeagent-direct-method#experimental-methods. We should probably update this as well.