### PR TITLE
Fix Subscription Processing Workaround (#3390)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -68,16 +68,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             Preconditions.CheckNotNull(deviceProxy, nameof(deviceProxy));
             ConnectedDevice device = this.GetOrCreateConnectedDevice(identity);
             Option<DeviceConnection> currentDeviceConnection = device.AddDeviceConnection(deviceProxy);
-            currentDeviceConnection.ForEach(async c =>
-                {
-                    // If we add a device connection that already has subscriptions, we will remake the cloud connection.
-                    // Otherwise the cloud connection won't get established until some other operation does it (i.e. telemetry)
-                    if (c.Subscriptions.Count > 0)
-                    {
-                        Events.GettingCloudConnectionForDeviceSubscriptions();
-                        await this.TryGetCloudConnection(identity.Id);
-                    }
-                });
             Events.NewDeviceConnection(identity);
             await currentDeviceConnection
                 .Filter(dc => dc.IsActive)


### PR DESCRIPTION
Removing a workaround that we added for 1.0.9 that fixed an issue we were having that when an MQTT identity with only subscriptions (no telemetry) reauthenticated, the identity wouldn't reconnect to the cloud. (PR of previous problem: https://github.com/Azure/iotedge/pull/3201)

The new way of doing this is to listen to when a device gets connected to EdgeHub and process subscriptions when it does.
To prevent a re-triggering of subscription processing when EdgeHub connects to the cloud on behalf of the device (this situation occurs during the device connecting to edgeHub flow), we use a ConcurrentDictionary to keep track of if subscription processing has already been kicked off for a DeviceConnecting. We check this in the other methods. 
This effectively ignores the Cloud Connection event trigger.

Cherry-picked from https://github.com/Azure/iotedge/pull/3390