### PR TITLE
Ondemand refresh for removed identities + refresh negative caching

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/LinkHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/LinkHandler.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.Amqp;
+    using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
@@ -76,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
         {
             if (!await this.Authenticate())
             {
-                throw new InvalidOperationException($"Unable to open {this.Type} link as the connection could not be authenticated");
+                throw new UnauthorizedException($"Unable to open {this.Type} link as the connection could not be authenticated");
             }
 
             this.DeviceListener = await this.connectionHandler.GetDeviceListener();

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnection.cs
@@ -148,6 +148,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 {
                     this.ConnectionStatusChangedHandler?.Invoke(this.Identity.Id, CloudConnectionStatus.DisconnectedTokenExpired);
                 }
+                else if (reason == ConnectionStatusChangeReason.Bad_Credential)
+                {
+                    this.ConnectionStatusChangedHandler?.Invoke(this.Identity.Id, CloudConnectionStatus.BadCredential);
+                }
                 else
                 {
                     this.ConnectionStatusChangedHandler?.Invoke(this.Identity.Id, CloudConnectionStatus.Disconnected);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -157,16 +157,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             catch (Exception ex)
             {
                 Events.ErrorCreatingCloudConnection(clientCredentials.Identity, ex);
-
-                if (ex is UnauthorizedException && this.nestedEdgeEnabled)
-                {
-                    // Auth failure is possible if one or more parent was
-                    // changed (e.g. a parent was removed), but our cache
-                    // hasn't been updated yet.
-                    Events.RefreshingAuthChain(clientCredentials.Identity, authChain);
-                    await this.deviceScopeIdentitiesCache.RefreshAuthChain(authChain);
-                }
-
                 return Try<ICloudConnection>.Failure(ex);
             }
         }
@@ -245,16 +235,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             catch (Exception ex)
             {
                 Events.ErrorCreatingCloudConnection(identity, ex);
-
-                if (ex is UnauthorizedException && this.nestedEdgeEnabled)
-                {
-                    // Auth failure is possible if one or more parent was
-                    // changed (e.g. a parent was removed), but our cache
-                    // hasn't been updated yet.
-                    Events.RefreshingAuthChain(identity, authChain);
-                    await this.deviceScopeIdentitiesCache.RefreshAuthChain(authChain);
-                }
-
                 return Try<ICloudConnection>.Failure(ex);
             }
         }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
     using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -162,6 +163,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                     {
                         await this.deviceConnectivityManager.CallTimedOut();
                     }
+                }
+                else if (ex is UnauthorizedException)
+                {
+                    // Translate this into a disconnect for the upper layers to handle
+                    Events.OperationFailed(this.identity, operation, mappedException);
+                    this.connectionStatusChangedHandler?.Invoke(ConnectionStatus.Disconnected_Retrying, ConnectionStatusChangeReason.Bad_Credential);
                 }
                 else
                 {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/AuthChainHelpers.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/AuthChainHelpers.cs
@@ -2,12 +2,16 @@
 namespace Microsoft.Azure.Devices.Edge.Hub.Core
 {
     using System;
+    using System.Collections.Generic;
+    using System.Linq;
 
     public static class AuthChainHelpers
     {
+        public static string[] GetAuthChainIds(string authChain) => authChain.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
         public static bool ValidateAuthChain(string actorDeviceId, string targetId, string authChain)
         {
-            var authChainIds = authChain.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] authChainIds = GetAuthChainIds(authChain);
 
             // Should have at least 1 element in the chain
             if (authChainIds.Length < 1)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
@@ -141,6 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             Preconditions.CheckNonWhiteSpace(authChain, nameof(authChain));
 
             // Refresh each element in the auth-chain
+            Events.RefreshingAuthChain(authChain);
             string[] ids = AuthChainHelpers.GetAuthChainIds(authChain);
             await this.RefreshServiceIdentities(ids);
         }
@@ -373,6 +374,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 AddInScope,
                 RefreshingServiceIdentity,
                 SkipRefreshServiceIdentity,
+                RefreshingAuthChain,
                 GettingServiceIdentity
             }
 
@@ -429,6 +431,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public static void RefreshingServiceIdentity(string id) =>
                 Log.LogDebug((int)EventIds.RefreshingServiceIdentity, $"Refreshing service identity for {id}");
+
+            public static void RefreshingAuthChain(string authChain) =>
+                Log.LogDebug((int)EventIds.RefreshingAuthChain, $"Refreshing authChain {authChain}");
 
             internal static void SkipRefreshServiceIdentity(string id, DateTime lastRefreshTime, TimeSpan refreshDelay)
             {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Nito.AsyncEx;
+    using Org.BouncyCastle.Asn1;
 
     public sealed class DeviceScopeIdentitiesCache : IDeviceScopeIdentitiesCache
     {
@@ -20,25 +21,32 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         readonly IKeyValueStore<string, string> encryptedStore;
         readonly IServiceIdentityHierarchy serviceIdentityHierarchy;
         readonly Timer refreshCacheTimer;
-        readonly TimeSpan refreshRate;
+        readonly TimeSpan periodicRefreshRate;
+        readonly TimeSpan refreshDelay;
         readonly AsyncAutoResetEvent refreshCacheSignal = new AsyncAutoResetEvent();
         readonly AsyncManualResetEvent refreshCacheCompleteSignal = new AsyncManualResetEvent();
         readonly object refreshCacheLock = new object();
 
         Task refreshCacheTask;
+        DateTime cacheLastRefreshTime;
+        Dictionary<string, DateTime> identitiesLastRefreshTime;
 
         DeviceScopeIdentitiesCache(
             IServiceIdentityHierarchy serviceIdentityHierarchy,
             IServiceProxy serviceProxy,
             IKeyValueStore<string, string> encryptedStorage,
             IDictionary<string, StoredServiceIdentity> initialCache,
-            TimeSpan refreshRate)
+            TimeSpan periodicRefreshRate,
+            TimeSpan refreshDelay)
         {
             this.serviceIdentityHierarchy = serviceIdentityHierarchy;
             this.serviceProxy = serviceProxy;
             this.encryptedStore = encryptedStorage;
-            this.refreshRate = refreshRate;
-            this.refreshCacheTimer = new Timer(this.RefreshCache, null, TimeSpan.Zero, refreshRate);
+            this.periodicRefreshRate = periodicRefreshRate;
+            this.refreshDelay = refreshDelay;
+            this.refreshCacheTimer = new Timer(this.RefreshCache, null, TimeSpan.Zero, this.periodicRefreshRate);
+            this.identitiesLastRefreshTime = new Dictionary<string, DateTime>();
+            this.cacheLastRefreshTime = DateTime.MinValue;
 
             // Populate the serviceIdentityHierarchy
             foreach (KeyValuePair<string, StoredServiceIdentity> kvp in initialCache)
@@ -55,13 +63,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             IServiceIdentityHierarchy serviceIdentityHierarchy,
             IServiceProxy serviceProxy,
             IKeyValueStore<string, string> encryptedStorage,
-            TimeSpan refreshRate)
+            TimeSpan refreshRate,
+            TimeSpan refreshDelay)
         {
             Preconditions.CheckNotNull(serviceProxy, nameof(serviceProxy));
             Preconditions.CheckNotNull(encryptedStorage, nameof(encryptedStorage));
             Preconditions.CheckNotNull(serviceIdentityHierarchy, nameof(serviceIdentityHierarchy));
             IDictionary<string, StoredServiceIdentity> cache = await ReadCacheFromStore(encryptedStorage);
-            var deviceScopeIdentitiesCache = new DeviceScopeIdentitiesCache(serviceIdentityHierarchy, serviceProxy, encryptedStorage, cache, refreshRate);
+            var deviceScopeIdentitiesCache = new DeviceScopeIdentitiesCache(serviceIdentityHierarchy, serviceProxy, encryptedStorage, cache, refreshRate, refreshDelay);
             Events.Created();
             return deviceScopeIdentitiesCache;
         }
@@ -69,8 +78,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public void InitiateCacheRefresh()
         {
             Events.ReceivedRequestToRefreshCache();
-            this.refreshCacheCompleteSignal.Reset();
-            this.refreshCacheSignal.Set();
+
+            TimeSpan timeSinceLastRefresh = DateTime.UtcNow - this.cacheLastRefreshTime;
+
+            // Only refresh the cache if we haven't done so recently
+            if (timeSinceLastRefresh > this.refreshDelay)
+            {
+                this.refreshCacheCompleteSignal.Reset();
+                this.refreshCacheSignal.Set();
+
+                // Update the cache refresh timestamp
+                this.cacheLastRefreshTime = DateTime.UtcNow;
+            }
+            else
+            {
+                Events.SkipRefreshCache(this.cacheLastRefreshTime, this.refreshDelay);
+                this.refreshCacheCompleteSignal.Set();
+            }
         }
 
         public Task WaitForCacheRefresh(TimeSpan timeout) => this.refreshCacheCompleteSignal.WaitAsync(timeout);
@@ -79,11 +103,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         {
             try
             {
-                Events.RefreshingServiceIdentity(id);
-                Option<ServiceIdentity> serviceIdentity = await this.GetServiceIdentityFromService(id);
-                await serviceIdentity
-                    .Map(s => this.HandleNewServiceIdentity(s))
-                    .GetOrElse(() => this.HandleNoServiceIdentity(id));
+                if (await this.ShouldRefreshIdentity(id))
+                {
+                    Events.RefreshingServiceIdentity(id);
+                    Option<ServiceIdentity> serviceIdentity = await this.GetServiceIdentityFromService(id);
+                    await serviceIdentity
+                        .Map(s => this.HandleNewServiceIdentity(s))
+                        .GetOrElse(() => this.HandleNoServiceIdentity(id));
+
+                    // Update the timestamp for this identity so we
+                    // don't repeatedly refresh the same identity
+                    // in rapid succession.
+                    this.identitiesLastRefreshTime[id] = DateTime.UtcNow;
+                }
+                else
+                {
+                    Events.SkipRefreshServiceIdentity(id, this.identitiesLastRefreshTime[id], this.refreshDelay);
+                }
             }
             catch (Exception e)
             {
@@ -98,6 +134,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             {
                 await this.RefreshServiceIdentity(id);
             }
+        }
+
+        public async Task RefreshAuthChain(string authChain)
+        {
+            Preconditions.CheckNonWhiteSpace(authChain, nameof(authChain));
+
+            // Refresh each element in the auth-chain
+            string[] ids = AuthChainHelpers.GetAuthChainIds(authChain);
+            await this.RefreshServiceIdentities(ids);
         }
 
         public async Task<Option<ServiceIdentity>> GetServiceIdentity(string id)
@@ -145,13 +190,31 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             return cache;
         }
 
+        async Task<bool> ShouldRefreshIdentity(string id)
+        {
+            bool hasRefreshed = this.identitiesLastRefreshTime.TryGetValue(id, out DateTime lastRefreshTime);
+
+            // Only refresh an identity if we haven't done so recently
+            if (!hasRefreshed || DateTime.UtcNow - lastRefreshTime > this.refreshDelay)
+            {
+                return true;
+            }
+
+            // Identities can initially be created with no auth, and
+            // have their auth type updated later. In this case we
+            // must refresh the identity or we won't be able to auth
+            // incoming OnBehalfOf connections for those identities.
+            Option<ServiceIdentity> identityOption = await this.GetServiceIdentity(id);
+            return identityOption.Match(id => id.Authentication.Type == ServiceAuthenticationType.None, () => true);
+        }
+
         void RefreshCache(object state)
         {
             lock (this.refreshCacheLock)
             {
                 if (this.refreshCacheTask == null || this.refreshCacheTask.IsCompleted)
                 {
-                    Events.InitializingRefreshTask(this.refreshRate);
+                    Events.InitializingRefreshTask(this.periodicRefreshRate);
                     this.refreshCacheTask = this.RefreshCache();
                 }
             }
@@ -194,7 +257,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     Events.ErrorInRefreshCycle(e);
                 }
 
-                Events.DoneRefreshCycle(this.refreshRate);
+                Events.DoneRefreshCycle(this.periodicRefreshRate);
                 this.refreshCacheCompleteSignal.Set();
                 await this.IsReady();
             }
@@ -203,7 +266,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         async Task IsReady()
         {
             Task refreshCacheSignalTask = this.refreshCacheSignal.WaitAsync();
-            Task sleepTask = Task.Delay(this.refreshRate);
+            Task sleepTask = Task.Delay(this.periodicRefreshRate);
             Task task = await Task.WhenAny(refreshCacheSignalTask, sleepTask);
             if (task == refreshCacheSignalTask)
             {
@@ -303,11 +366,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 StartingCycle,
                 DoneCycle,
                 ReceivedRequestToRefreshCache,
+                SkipRefreshCache,
                 RefreshSleepCompleted,
                 RefreshSignalled,
                 NotInScope,
                 AddInScope,
                 RefreshingServiceIdentity,
+                SkipRefreshServiceIdentity,
                 GettingServiceIdentity
             }
 
@@ -340,6 +405,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             public static void ReceivedRequestToRefreshCache() =>
                 Log.LogDebug((int)EventIds.ReceivedRequestToRefreshCache, "Received request to refresh cache.");
 
+            internal static void SkipRefreshCache(DateTime lastRefreshTime, TimeSpan refreshDelay)
+            {
+                TimeSpan timeSinceLastRefresh = DateTime.UtcNow - lastRefreshTime;
+                int secondsUntilNextRefresh = (int)(refreshDelay.TotalSeconds - timeSinceLastRefresh.TotalSeconds);
+                Log.LogDebug((int)EventIds.SkipRefreshCache, $"Skipping cache refresh, waiting {secondsUntilNextRefresh} until refreshing again.");
+            }
+
             public static void RefreshSignalled() =>
                 Log.LogDebug((int)EventIds.RefreshSignalled, "Device scope identities refresh is ready because a refresh was signalled.");
 
@@ -357,6 +429,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public static void RefreshingServiceIdentity(string id) =>
                 Log.LogDebug((int)EventIds.RefreshingServiceIdentity, $"Refreshing service identity for {id}");
+
+            internal static void SkipRefreshServiceIdentity(string id, DateTime lastRefreshTime, TimeSpan refreshDelay)
+            {
+                TimeSpan timeSinceLastRefresh = DateTime.UtcNow - lastRefreshTime;
+                int secondsUntilNextRefresh = (int)(refreshDelay.TotalSeconds - timeSinceLastRefresh.TotalSeconds);
+                Log.LogDebug((int)EventIds.SkipRefreshServiceIdentity, $"Skipping refresh for identity: {id}, waiting {secondsUntilNextRefresh} until refreshing again.");
+            }
 
             internal static void InitializingRefreshTask(TimeSpan refreshRate) =>
                 Log.LogDebug((int)EventIds.InitializingRefreshTask, $"Initializing device scope identities cache refresh task to run every {refreshRate.TotalMinutes} minutes.");

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
@@ -26,5 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         Task RefreshServiceIdentities(IEnumerable<string> ids);
 
         Task RefreshServiceIdentity(string id);
+
+        Task RefreshAuthChain(string authChain);
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceScopeIdentitiesCache.cs
@@ -46,5 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public Task RefreshServiceIdentity(string deviceId) => Task.CompletedTask;
 
         public Task RefreshServiceIdentity(string deviceId, string moduleId) => Task.CompletedTask;
+
+        public Task RefreshAuthChain(string authChain) => Task.CompletedTask;
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/cloud/CloudConnectionStatus.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/cloud/CloudConnectionStatus.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Cloud
 {
     public enum CloudConnectionStatus
     {
+        BadCredential,
         ConnectionEstablished,
         DisconnectedTokenExpired,
         Disconnected,

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -115,16 +115,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 targetId += "/" + request.TargetModuleId;
             }
 
-            // Try updating our cache and get the target identity first
-            IEdgeHub edgeHub = await this.edgeHubGetter;
-            IDeviceScopeIdentitiesCache identitiesCache = edgeHub.GetDeviceScopeIdentitiesCache();
-            Option<ServiceIdentity> targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
-
             // We must always forward the call further upstream first,
             // as this is invoked for refreshing an identity on-demand,
             // and we don't know whether our cache is out-of-date.
+            IEdgeHub edgeHub = await this.edgeHubGetter;
+            IDeviceScopeIdentitiesCache identitiesCache = edgeHub.GetDeviceScopeIdentitiesCache();
             await identitiesCache.RefreshServiceIdentity(targetId);
-            targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
+            Option<ServiceIdentity> targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
 
             if (!targetIdentity.HasValue)
             {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -218,6 +218,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             int scopeCacheRefreshRateSecs = this.configuration.GetValue("DeviceScopeCacheRefreshRateSecs", 3600);
             TimeSpan scopeCacheRefreshRate = TimeSpan.FromSeconds(scopeCacheRefreshRateSecs);
 
+            int scopeCacheRefreshDelaySecs = this.configuration.GetValue("DeviceScopeCacheRefreshDelaySecs", 120);
+            TimeSpan scopeCacheRefreshDelay = TimeSpan.FromSeconds(scopeCacheRefreshDelaySecs);
+
             string proxy = this.configuration.GetValue("https_proxy", string.Empty);
             string productInfo = GetProductInfo();
 
@@ -239,6 +242,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     workloadUri,
                     workloadApiVersion,
                     scopeCacheRefreshRate,
+                    scopeCacheRefreshDelay,
                     cacheTokens,
                     this.trustBundle,
                     proxy,

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Program.cs
@@ -100,13 +100,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             await configUpdater.Init(configSource);
 
             // TODO: Re-enable after adding disconnect support in MQTT Broker Adapter
-            /* if (!Enum.TryParse(configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode)
+            if (!Enum.TryParse(configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode)
                 || authenticationMode != AuthenticationMode.Cloud)
             {
                 ConnectionReauthenticator connectionReauthenticator = await container.Resolve<Task<ConnectionReauthenticator>>();
                 connectionReauthenticator.Init();
             }
-            */
 
             TimeSpan shutdownWaitPeriod = TimeSpan.FromSeconds(configuration.GetValue("ShutdownWaitPeriod", DefaultShutdownWaitPeriod));
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(shutdownWaitPeriod, logger);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
         readonly bool usePersistentStorage;
         readonly string storagePath;
         readonly TimeSpan scopeCacheRefreshRate;
+        readonly TimeSpan scopeCacheRefreshDelay;
         readonly Option<string> workloadUri;
         readonly Option<string> workloadApiVersion;
         readonly bool persistTokens;
@@ -65,6 +66,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             Option<string> workloadUri,
             Option<string> workloadApiVersion,
             TimeSpan scopeCacheRefreshRate,
+            TimeSpan scopeCacheRefreshDelay,
             bool persistTokens,
             IList<X509Certificate2> trustBundle,
             string proxy,
@@ -88,6 +90,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
             this.usePersistentStorage = usePersistentStorage;
             this.storagePath = storagePath;
             this.scopeCacheRefreshRate = scopeCacheRefreshRate;
+            this.scopeCacheRefreshDelay = scopeCacheRefreshDelay;
             this.workloadUri = workloadUri;
             this.workloadApiVersion = workloadApiVersion;
             this.persistTokens = persistTokens;
@@ -309,7 +312,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                             IDeviceScopeApiClientProvider securityScopesApiClientProvider = new DeviceScopeApiClientProvider(hostName, this.edgeDeviceId, this.edgeHubModuleId, 10, edgeHubTokenProvider, serviceIdentityTree, proxy);
                             IServiceProxy serviceProxy = new ServiceProxy(securityScopesApiClientProvider, this.nestedEdgeEnabled);
                             IKeyValueStore<string, string> encryptedStore = await GetEncryptedStore(c, "DeviceScopeCache");
-                            deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(serviceIdentityTree, serviceProxy, encryptedStore, this.scopeCacheRefreshRate);
+                            deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(serviceIdentityTree, serviceProxy, encryptedStore, this.scopeCacheRefreshRate, this.scopeCacheRefreshDelay);
                         }
                         else
                         {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -264,11 +264,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         var credentialsCacheTask = c.Resolve<Task<ICredentialsCache>>();
                         var identityProvider = c.Resolve<IIdentityProvider>();
                         var deviceConnectivityManager = c.Resolve<IDeviceConnectivityManager>();
+                        var deviceScopeIdentitiesCache = await c.Resolve<Task<IDeviceScopeIdentitiesCache>>();
                         ICloudConnectionProvider cloudConnectionProvider = await cloudConnectionProviderTask;
                         ICredentialsCache credentialsCache = await credentialsCacheTask;
                         IConnectionManager connectionManager = new ConnectionManager(
+                            this.edgeDeviceId,
                             cloudConnectionProvider,
                             credentialsCache,
+                            deviceScopeIdentitiesCache,
                             identityProvider,
                             deviceConnectivityManager,
                             this.maxConnectedClients,

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 true);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, Mock.Of<ICredentialsCache>(), new IdentityProvider(hostname), deviceConnectivityManager);
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, Mock.Of<ICredentialsCache>(), deviceScopeIdentitiesCache.Object, new IdentityProvider(hostname), deviceConnectivityManager);
 
             ITokenCredentials clientCredentials1 = GetClientCredentials(TimeSpan.FromSeconds(10));
             Try<ICloudProxy> cloudProxyTry1 = await connectionManager.CreateCloudConnectionAsync(clientCredentials1);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var cloudProviderMock = new Mock<ICloudConnectionProvider>();
             var credentialsManager = Mock.Of<ICredentialsCache>();
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudProviderMock.Object, credentialsManager, GetIdentityProvider(), deviceConnectivityManager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudProviderMock.Object, credentialsManager, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager);
 
             var deviceProxyMock1 = new Mock<IDeviceProxy>();
             deviceProxyMock1.SetupGet(dp => dp.IsActive).Returns(true);
@@ -119,7 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache.Object, GetIdentityProvider(), deviceConnectivityManager);
 
             Option<ICloudProxy> returnedValue = await connectionManager.GetCloudConnection(deviceCredentials1.Identity.Id);
             Assert.False(returnedValue.HasValue);
@@ -165,8 +166,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var credentialsManager = Mock.Of<ICredentialsCache>();
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
 
-            var connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsManager, GetIdentityProvider(), deviceConnectivityManager);
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsManager, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager);
             Try<ICloudProxy> module1CloudProxy = await connectionManager.CreateCloudConnectionAsync(module1Credentials);
             Assert.True(module1CloudProxy.Success);
             Assert.NotNull(module1CloudProxy.Value);
@@ -203,8 +205,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var credentialsManager = Mock.Of<ICredentialsCache>();
             var deviceConnectivityManager = new DeviceConnectivityManager();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
 
-            var connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsManager, GetIdentityProvider(), deviceConnectivityManager);
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsManager, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager);
             Try<ICloudProxy> module1CloudProxy = await connectionManager.CreateCloudConnectionAsync(module1Credentials);
             Assert.True(module1CloudProxy.Success);
             Assert.NotNull(module1CloudProxy.Value);
@@ -279,7 +282,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             cloudConnectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsManager, GetIdentityProvider(), deviceConnectivityManager);
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsManager, deviceScopeIdentitiesCache.Object, GetIdentityProvider(), deviceConnectivityManager);
             Try<ICloudProxy> cloudProxyTry = await connectionManager.CreateCloudConnectionAsync(deviceCredentials);
             Assert.True(cloudProxyTry.Success);
             TimeSpan defaultMessageAckTimeout = TimeSpan.FromSeconds(30);
@@ -334,7 +337,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var credentialsCache = Mock.Of<ICredentialsCache>();
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudProxyProviderMock.Object, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudProxyProviderMock.Object, credentialsCache, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager);
 
             Task<Try<ICloudProxy>> getCloudProxyTask1 = connectionManager.GetOrCreateCloudConnectionAsync(module1Credentials);
             Task<Try<ICloudProxy>> getCloudProxyTask2 = connectionManager.GetOrCreateCloudConnectionAsync(module2Credentials);
@@ -393,7 +397,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 modelIdStore);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache.Object, GetIdentityProvider(), deviceConnectivityManager);
 
             Task<Try<ICloudProxy>> getCloudProxyTask1 = connectionManager.CreateCloudConnectionAsync(module1Credentials);
             Task<Try<ICloudProxy>> getCloudProxyTask2 = connectionManager.CreateCloudConnectionAsync(module1Credentials);
@@ -442,7 +446,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var credentialsCache = new Mock<ICredentialsCache>(MockBehavior.Strict);
             credentialsCache.Setup(c => c.Get(identity)).ReturnsAsync(Option.None<IClientCredentials>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudProxyProviderMock.Object, credentialsCache.Object, GetIdentityProvider(), deviceConnectivityManager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudProxyProviderMock.Object, credentialsCache.Object, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager);
             await connectionManager.AddDeviceConnection(deviceCredentials.Identity, deviceProxy.Object);
             Try<ICloudProxy> cloudProxyTry = await connectionManager.GetOrCreateCloudConnectionAsync(deviceCredentials);
 
@@ -481,7 +486,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             credentialsCache.Setup(c => c.Get(deviceIdentity)).ReturnsAsync(Option.Some((IClientCredentials)updatedDeviceCredentials));
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudProxyProviderMock.Object, credentialsCache.Object, GetIdentityProvider(), deviceConnectivityManager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudProxyProviderMock.Object, credentialsCache.Object, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager);
             await connectionManager.AddDeviceConnection(deviceCredentials.Identity, deviceProxy.Object);
             Try<ICloudProxy> cloudProxyTry = await connectionManager.GetOrCreateCloudConnectionAsync(deviceCredentials);
 
@@ -531,7 +537,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 modelIdStore);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache.Object, GetIdentityProvider(), deviceConnectivityManager);
 
             string token1 = TokenHelper.CreateSasToken("foo.azure-devices.net", DateTime.UtcNow.AddHours(2));
             var deviceCredentials = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token1, DummyProductInfo, true);
@@ -596,7 +602,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 modelIdStore);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache.Object, GetIdentityProvider(), deviceConnectivityManager);
 
             string token1 = TokenHelper.CreateSasToken("foo.azure-devices.net", DateTime.UtcNow.AddHours(2));
             var deviceCredentials1 = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token1, DummyProductInfo, true);
@@ -639,7 +645,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
             var credentialsCache = Mock.Of<ICredentialsCache>();
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudProviderMock.Object, credentialsCache, GetIdentityProvider(), deviceConnectivityManager, 2);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudProviderMock.Object, credentialsCache, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager, 2);
 
             await connectionManager.AddDeviceConnection(deviceIdentity1, deviceProxy1);
             await connectionManager.AddDeviceConnection(deviceIdentity2, deviceProxy2);
@@ -655,8 +662,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var cloudConnectionProvider = Mock.Of<ICloudConnectionProvider>();
             var credentialsCache = Mock.Of<ICredentialsCache>();
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
 
-            var connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager);
             var identity = Mock.Of<IIdentity>(i => i.Id == deviceId);
 
             // Act
@@ -733,7 +741,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 modelIdStore);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivityManager);
             var identity = Mock.Of<IIdentity>(i => i.Id == deviceId);
             bool isProxyActive = true;
             // ReSharper disable once PossibleUnintendedReferenceComparison
@@ -812,7 +821,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var cloudConnectionProvider = Mock.Of<ICloudConnectionProvider>();
             var credentialsCache = Mock.Of<ICredentialsCache>();
             var deviceConnectivitymanager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivitymanager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache, GetIdentityProvider(), deviceConnectivitymanager);
 
             var deviceProxies = new List<IDeviceProxy>();
             for (int i = 0; i < 10; i++)
@@ -911,7 +921,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 modelIdStore);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache.Object, GetIdentityProvider(), deviceConnectivityManager);
 
             // Act
             Option<ICloudProxy> getCloudProxyTask = await connectionManager.GetCloudConnection(module1Credentials.Identity.Id);
@@ -974,7 +984,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 modelIdStore);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, credentialsCache, deviceScopeIdentitiesCache.Object, GetIdentityProvider(), deviceConnectivityManager);
 
             // Act
             Task<Option<ICloudProxy>> getCloudProxyTask1 = connectionManager.GetCloudConnection(module1Credentials.Identity.Id);
@@ -1049,8 +1059,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var module1Identity = Mock.Of<IModuleIdentity>(m => m.Id == module1Credentials.Identity.Id);
             var moduleProxy1 = Mock.Of<IDeviceProxy>(m => m.IsActive);
             IConnectionManager connectionManager = new ConnectionManager(
+                "edge1",
                 cloudConnectionProvider,
                 credentialsCache,
+                deviceScopeIdentitiesCache.Object,
                 GetIdentityProvider(),
                 deviceConnectivityManager,
                 closeCloudConnectionOnDeviceDisconnect: closeCloudConnectionOnDeviceDisconnect);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
@@ -733,7 +733,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             serviceProxy.Setup(s => s.GetServiceIdentity(It.Is<string>(id => id == id1))).ReturnsAsync(Option.Some(si1_initial));
 
             // Act
-            int refreshDelaySec = 5;
+            int refreshDelaySec = 10;
             var updatedIdentities = new List<ServiceIdentity>();
             IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(refreshDelaySec));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
@@ -817,7 +817,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Returns(iterator.Object);
 
             // Act
-            int refreshDelaySec = 5;
+            int refreshDelaySec = 10;
             var updatedIdentities = new List<ServiceIdentity>();
             IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(refreshDelaySec));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceScopeIdentitiesCacheTest.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             await store.Put(si2.Id, storedSi2.ToJson());
 
             // Act
-            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1));
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
             Option<ServiceIdentity> receivedServiceIdentity1 = await deviceScopeIdentitiesCache.GetServiceIdentity("d1");
             Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity("d2/m1");
 
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var removedIdentities = new List<string>();
 
             // Act
-            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromSeconds(8));
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromSeconds(8), TimeSpan.FromSeconds(0));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
             deviceScopeIdentitiesCache.ServiceIdentityRemoved += (sender, s) => removedIdentities.Add(s);
 
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var removedIdentities = new List<string>();
 
             // Act
-            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromSeconds(7));
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromSeconds(7), TimeSpan.FromSeconds(0));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
             deviceScopeIdentitiesCache.ServiceIdentityRemoved += (sender, s) => removedIdentities.Add(s);
 
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var removedIdentities = new List<string>();
 
             // Act
-            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1));
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
             deviceScopeIdentitiesCache.ServiceIdentityRemoved += (sender, s) => removedIdentities.Add(s);
 
@@ -375,7 +375,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var removedIdentities = new List<string>();
 
             // Act
-            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1));
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
             deviceScopeIdentitiesCache.ServiceIdentityRemoved += (sender, s) => removedIdentities.Add(s);
 
@@ -441,7 +441,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var removedIdentities = new List<string>();
 
             // Act
-            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1));
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
             deviceScopeIdentitiesCache.ServiceIdentityRemoved += (sender, s) => removedIdentities.Add(s);
 
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var removedIdentities = new List<string>();
 
             // Act
-            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1));
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
             deviceScopeIdentitiesCache.ServiceIdentityRemoved += (sender, s) => removedIdentities.Add(s);
 
@@ -559,7 +559,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var removedIdentities = new List<string>();
 
             // Act
-            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1));
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
             deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
             deviceScopeIdentitiesCache.ServiceIdentityRemoved += (sender, s) => removedIdentities.Add(s);
 
@@ -591,7 +591,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             serviceProxy.Setup(s => s.GetServiceIdentity("d2")).ReturnsAsync(Option.Some(si_device));
             serviceProxy.Setup(s => s.GetServiceIdentity("d1", "m1")).ReturnsAsync(Option.Some(si_module));
 
-            DeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1));
+            DeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
 
             // Act
             Option<ServiceIdentity> deviceServiceIdentity = await deviceScopeIdentitiesCache.GetServiceIdentityFromService("d2");
@@ -630,13 +630,222 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var serviceProxy = new Mock<IServiceProxy>();
             serviceProxy.Setup(s => s.GetServiceIdentitiesIterator()).Returns(identitiesIterator.Object);
 
-            var deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(serviceIdentityHierarchy.Object, serviceProxy.Object, store, TimeSpan.FromHours(1));
+            var deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(serviceIdentityHierarchy.Object, serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
 
             // Act
             Option<string> authChainActual = await deviceScopeIdentitiesCache.GetAuthChain(leafId);
 
             // Assert
             Assert.True(authChainActual.Contains(authChain));
+        }
+
+        [Fact]
+        public async Task RefreshAuthChainTest()
+        {
+            // Arrange
+            var store = GetEntityStore("cache");
+            var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
+
+            string id1 = "d1";
+            string id2 = "d2";
+            string id3 = "d3";
+            var si1_initial = new ServiceIdentity(id1, null, "d1_scope", Enumerable.Empty<string>(), "1234", new List<string>() { Constants.IotEdgeIdentityCapability }, serviceAuthenticationNone, ServiceIdentityStatus.Enabled);
+            var si1_updated = new ServiceIdentity(id1, null, "d1_scope", Enumerable.Empty<string>(), "1234", new List<string>() { Constants.IotEdgeIdentityCapability }, serviceAuthenticationNone, ServiceIdentityStatus.Disabled);
+            var si2 = new ServiceIdentity(id2, null, "d2_scope", new List<string>() { "d1_scope" }, "1234", new List<string>() { Constants.IotEdgeIdentityCapability }, serviceAuthenticationNone, ServiceIdentityStatus.Enabled);
+            var si3 = new ServiceIdentity(id3, null, null, new List<string>() { "d2_scope" }, "1234", Enumerable.Empty<string>(), serviceAuthenticationNone, ServiceIdentityStatus.Enabled);
+
+            var iterator1 = new Mock<IServiceIdentitiesIterator>();
+            iterator1.SetupSequence(i => i.HasNext)
+                .Returns(true)
+                .Returns(false);
+            iterator1.SetupSequence(i => i.GetNext())
+                .ReturnsAsync(
+                    new List<ServiceIdentity>
+                    {
+                        si1_initial,
+                        si2,
+                        si3
+                    });
+
+            var serviceProxy = new Mock<IServiceProxy>();
+            serviceProxy.Setup(s => s.GetServiceIdentitiesIterator())
+                .Returns(iterator1.Object);
+
+            var updatedIdentities = new List<ServiceIdentity>();
+            var removedIdentities = new List<string>();
+
+            // Act
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(0));
+            deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
+            deviceScopeIdentitiesCache.ServiceIdentityRemoved += (sender, s) => removedIdentities.Add(s);
+
+            // Wait for initial refresh to complete
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Setup updated response
+            serviceProxy.Setup(s => s.GetServiceIdentity(It.Is<string>(id => id == id1))).ReturnsAsync(Option.Some(si1_updated));
+            serviceProxy.Setup(s => s.GetServiceIdentity(It.Is<string>(id => id == id2))).ReturnsAsync(Option.None<ServiceIdentity>());
+            serviceProxy.Setup(s => s.GetServiceIdentity(It.Is<string>(id => id == id3))).ReturnsAsync(Option.None<ServiceIdentity>());
+
+            // Refresh the authchain
+            await deviceScopeIdentitiesCache.RefreshAuthChain($"{id3};{id2};{id1}");
+
+            Option<ServiceIdentity> receivedServiceIdentity1 = await deviceScopeIdentitiesCache.GetServiceIdentity(id1);
+            Option<ServiceIdentity> receivedServiceIdentity2 = await deviceScopeIdentitiesCache.GetServiceIdentity(id2);
+            Option<ServiceIdentity> receivedServiceIdentity3 = await deviceScopeIdentitiesCache.GetServiceIdentity(id3);
+            Option<string> authchain2 = await deviceScopeIdentitiesCache.GetAuthChain(id2);
+            Option<string> authchain3 = await deviceScopeIdentitiesCache.GetAuthChain(id3);
+
+            // Assert
+            Assert.True(si1_updated.Equals(receivedServiceIdentity1.OrDefault()));
+            Assert.False(receivedServiceIdentity2.HasValue);
+            Assert.False(receivedServiceIdentity3.HasValue);
+            Assert.False(authchain2.HasValue);
+            Assert.False(authchain3.HasValue);
+        }
+
+        [Fact]
+        public async Task RefreshIdentityNegativeCachingTest()
+        {
+            // Arrange
+            var store = GetEntityStore("cache");
+            var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
+            var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
+
+            string id1 = "d1";
+            var si1_initial = new ServiceIdentity(id1, null, "d1_scope", Enumerable.Empty<string>(), "1234", new List<string>() { Constants.IotEdgeIdentityCapability }, serviceAuthenticationSas, ServiceIdentityStatus.Enabled);
+            var si1_updated = new ServiceIdentity(id1, null, "d1_scope", Enumerable.Empty<string>(), "4321", new List<string>() { Constants.IotEdgeIdentityCapability }, serviceAuthenticationNone, ServiceIdentityStatus.Disabled);
+
+            var iterator1 = new Mock<IServiceIdentitiesIterator>();
+            iterator1.SetupSequence(i => i.HasNext)
+                .Returns(true)
+                .Returns(false);
+            iterator1.SetupSequence(i => i.GetNext())
+                .ReturnsAsync(
+                    new List<ServiceIdentity>
+                    {
+                        si1_initial,
+                    });
+
+            var serviceProxy = new Mock<IServiceProxy>();
+            serviceProxy.Setup(s => s.GetServiceIdentitiesIterator())
+                .Returns(iterator1.Object);
+            serviceProxy.Setup(s => s.GetServiceIdentity(It.Is<string>(id => id == id1))).ReturnsAsync(Option.Some(si1_initial));
+
+            // Act
+            int refreshDelaySec = 5;
+            var updatedIdentities = new List<ServiceIdentity>();
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(refreshDelaySec));
+            deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
+
+            // Wait for initial refresh to complete
+            await Task.Delay(TimeSpan.FromSeconds(3));
+
+            // Refresh the identity to trigger the delay
+            await deviceScopeIdentitiesCache.RefreshServiceIdentity(id1);
+
+            // Setup updated response
+            serviceProxy.Setup(s => s.GetServiceIdentity(It.Is<string>(id => id == id1))).ReturnsAsync(Option.Some(si1_updated));
+
+            // Refresh again without waiting
+            await deviceScopeIdentitiesCache.RefreshServiceIdentity(id1);
+            Option<ServiceIdentity> receivedServiceIdentity = await deviceScopeIdentitiesCache.GetServiceIdentity(id1);
+
+            // Should be the same as initial value, as we're still in the delay period
+            Assert.True(si1_initial.Equals(receivedServiceIdentity.OrDefault()));
+
+            // Wait for delay to expire and try again
+            await Task.Delay(TimeSpan.FromSeconds(refreshDelaySec));
+            await deviceScopeIdentitiesCache.RefreshServiceIdentity(id1);
+            receivedServiceIdentity = await deviceScopeIdentitiesCache.GetServiceIdentity(id1);
+
+            // Should be updated now
+            Assert.True(si1_updated.Equals(receivedServiceIdentity.OrDefault()));
+
+            // Flip the response back again and refresh again without waiting
+            serviceProxy.Setup(s => s.GetServiceIdentity(It.Is<string>(id => id == id1))).ReturnsAsync(Option.Some(si1_initial));
+            await deviceScopeIdentitiesCache.RefreshServiceIdentity(id1);
+            receivedServiceIdentity = await deviceScopeIdentitiesCache.GetServiceIdentity(id1);
+
+            // Refresh delay should have been ignored due to AuthenticationType.None
+            Assert.True(si1_initial.Equals(receivedServiceIdentity.OrDefault()));
+        }
+
+        [Fact]
+        public async Task RefreshCacheNegativeCachingTest()
+        {
+            // Arrange
+            var store = GetEntityStore("cache");
+            var serviceAuthenticationNone = new ServiceAuthentication(ServiceAuthenticationType.None);
+            var serviceAuthenticationSas = new ServiceAuthentication(new SymmetricKeyAuthentication(GetKey(), GetKey()));
+
+            string id1 = "d1";
+            var si1_initial = new ServiceIdentity(id1, null, "d1_scope", Enumerable.Empty<string>(), "1234", new List<string>() { Constants.IotEdgeIdentityCapability }, serviceAuthenticationSas, ServiceIdentityStatus.Enabled);
+            var si1_updated = new ServiceIdentity(id1, null, "d1_scope", Enumerable.Empty<string>(), "4321", new List<string>() { Constants.IotEdgeIdentityCapability }, serviceAuthenticationNone, ServiceIdentityStatus.Disabled);
+
+            var iterator = new Mock<IServiceIdentitiesIterator>();
+            iterator.SetupSequence(i => i.HasNext)
+                .Returns(true)
+                .Returns(false)
+                .Returns(true)
+                .Returns(false);
+            iterator.SetupSequence(i => i.GetNext())
+                .ReturnsAsync(
+                    new List<ServiceIdentity>
+                    {
+                        si1_initial,
+                    })
+                .ReturnsAsync(
+                    new List<ServiceIdentity>
+                    {
+                        si1_initial,
+                    });
+
+            var iterator_updated = new Mock<IServiceIdentitiesIterator>();
+            iterator_updated.SetupSequence(i => i.HasNext)
+                .Returns(true)
+                .Returns(false);
+            iterator_updated.SetupSequence(i => i.GetNext())
+                .ReturnsAsync(
+                    new List<ServiceIdentity>
+                    {
+                        si1_updated,
+                    });
+
+            var serviceProxy = new Mock<IServiceProxy>();
+            serviceProxy.Setup(s => s.GetServiceIdentitiesIterator())
+                .Returns(iterator.Object);
+
+            // Act
+            int refreshDelaySec = 5;
+            var updatedIdentities = new List<ServiceIdentity>();
+            IDeviceScopeIdentitiesCache deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(new ServiceIdentityTree("deviceId"), serviceProxy.Object, store, TimeSpan.FromHours(1), TimeSpan.FromSeconds(refreshDelaySec));
+            deviceScopeIdentitiesCache.ServiceIdentityUpdated += (sender, identity) => updatedIdentities.Add(identity);
+
+            // Wait for initial refresh to complete
+            deviceScopeIdentitiesCache.InitiateCacheRefresh();
+            await deviceScopeIdentitiesCache.WaitForCacheRefresh(TimeSpan.FromMinutes(1));
+
+            // Setup the updated response
+            serviceProxy.Setup(s => s.GetServiceIdentitiesIterator())
+                .Returns(iterator_updated.Object);
+
+            // Trigger another refresh without waiting
+            deviceScopeIdentitiesCache.InitiateCacheRefresh();
+            await deviceScopeIdentitiesCache.WaitForCacheRefresh(TimeSpan.FromMinutes(1));
+            Option<ServiceIdentity> receivedServiceIdentity = await deviceScopeIdentitiesCache.GetServiceIdentity(id1);
+
+            // Should be the same as initial value, as we're still in the delay period
+            Assert.True(si1_initial.Equals(receivedServiceIdentity.OrDefault()));
+
+            // Wait for delay to expire and try again
+            await Task.Delay(TimeSpan.FromSeconds(refreshDelaySec));
+            deviceScopeIdentitiesCache.InitiateCacheRefresh();
+            await deviceScopeIdentitiesCache.WaitForCacheRefresh(TimeSpan.FromMinutes(1));
+            receivedServiceIdentity = await deviceScopeIdentitiesCache.GetServiceIdentity(id1);
+
+            // Should be updated now
+            Assert.True(si1_updated.Equals(receivedServiceIdentity.OrDefault()));
         }
 
         static string GetKey() => Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString()));

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/RetryingCloudProxyTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(connectionProvider, credentialsCache.Object, identityProvider.Object, deviceConnectivityManager);
+            var connectionManager = new ConnectionManager("edge1", connectionProvider, credentialsCache.Object, deviceScopeIdentitiesCache.Object, identityProvider.Object, deviceConnectivityManager);
             var messagesToSend = new List<IMessage>();
             for (int i = 0; i < 10; i++)
             {
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(connectionProvider, credentialsCache.Object, identityProvider.Object, deviceConnectivityManager);
+            var connectionManager = new ConnectionManager("edge1", connectionProvider, credentialsCache.Object, deviceScopeIdentitiesCache.Object, identityProvider.Object, deviceConnectivityManager);
 
             // Act
             Option<ICloudProxy> cloudProxyOption = await connectionManager.GetCloudConnection(Id);
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             connectionProvider.BindEdgeHub(edgeHub.Object);
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(connectionProvider, credentialsCache.Object, identityProvider.Object, deviceConnectivityManager);
+            var connectionManager = new ConnectionManager("edge1", connectionProvider, credentialsCache.Object, deviceScopeIdentitiesCache.Object, identityProvider.Object, deviceConnectivityManager);
 
             async Task<ICloudProxy> GetCloudProxy(IConnectionManager cm)
             {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingEdgeHubTest.cs
@@ -264,9 +264,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             // ICloudConnectionProvider
             var cloudConnection = Mock.Of<ICloudConnection>(c => c.IsActive && c.CloudProxy == Option.Some(cloudProxy.Object));
             var cloudConnectionProvider = new Mock<ICloudConnectionProvider>();
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
             cloudConnectionProvider.Setup(c => c.Connect(It.IsAny<IClientCredentials>(), It.IsAny<Action<string, CloudConnectionStatus>>()))
                 .ReturnsAsync(Try.Success(cloudConnection));
-            var connectionManager = new ConnectionManager(cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), new IdentityProvider("myIotHub"), Mock.Of<IDeviceConnectivityManager>());
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), deviceScopeIdentitiesCache, new IdentityProvider("myIotHub"), Mock.Of<IDeviceConnectivityManager>());
 
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
@@ -350,7 +351,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             cloudConnectionProvider.Setup(c => c.Connect(It.IsAny<IClientCredentials>(), It.IsAny<Action<string, CloudConnectionStatus>>()))
                 .ReturnsAsync(Try.Success(cloudConnection));
             var deviceConnectivitymanager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), new IdentityProvider("myIotHub"), deviceConnectivitymanager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), deviceScopeIdentitiesCache, new IdentityProvider("myIotHub"), deviceConnectivitymanager);
 
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
 
@@ -426,7 +428,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
                 .ReturnsAsync(Try.Success(cloudConnection));
 
             var deviceConnectivitymanager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), new IdentityProvider("myIotHub"), deviceConnectivitymanager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), deviceScopeIdentitiesCache, new IdentityProvider("myIotHub"), deviceConnectivitymanager);
 
             IInvokeMethodHandler invokeMethodHandler = new InvokeMethodHandler(connectionManager);
             var subscriptionProcessor = new SubscriptionProcessor(connectionManager, invokeMethodHandler, Mock.Of<IDeviceConnectivityManager>());

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -431,7 +431,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
             cloudConnectionProvider.Setup(c => c.Connect(It.IsAny<IClientCredentials>(), It.IsAny<Action<string, CloudConnectionStatus>>())).ReturnsAsync(Try.Success(cloudConnection));
 
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), new IdentityProvider(iotHubName), deviceConnectivityManager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            IConnectionManager connectionManager = new ConnectionManager("edge1", cloudConnectionProvider.Object, Mock.Of<ICredentialsCache>(), deviceScopeIdentitiesCache, new IdentityProvider(iotHubName), deviceConnectivityManager);
             var routingMessageConverter = new RoutingMessageConverter();
             RouteFactory routeFactory = new EdgeRouteFactory(new EndpointFactory(connectionManager, routingMessageConverter, edgeDeviceId, 10, 10));
             IEnumerable<Route> routesList = routeFactory.Create(routes).ToList();

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -162,6 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     Option.None<string>(),
                     Option.None<string>(),
                     TimeSpan.FromHours(1),
+                    TimeSpan.FromSeconds(0),
                     false,
                     this.trustBundle,
                     string.Empty,

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -81,7 +81,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 productInfoStore,
                 modelIdStore);
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
-            var connectionManager = new ConnectionManager(cloudConnectionProvider, Mock.Of<ICredentialsCache>(), identityProvider, deviceConnectivityManager);
+            var deviceScopeIdentitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>();
+            var connectionManager = new ConnectionManager("edge1", cloudConnectionProvider, Mock.Of<ICredentialsCache>(), deviceScopeIdentitiesCache, identityProvider, deviceConnectivityManager);
 
             try
             {


### PR DESCRIPTION
This change adds refresh logic that triggers on MQTT/AMQP auth failures from upstream, which can be caused by an authchain getting invalidated when one or more device in the chain was removed/disabled from IoT Hub.

To prevent the root Edge from hammering IoT Hub as a result of this refresh logic, I've also added negative caching and limit the refresh rate to once every 2min at most.

If an authchain becomes invalidate as part of this refresh, we don't explicitly drop the corresponding downstream connection, and instead let it get handled by the eventual re-auth.