### PR TITLE
Removed message handling race-conditions and allowing empty subscription change message

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/IMessageConsumer.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/IMessageConsumer.cs
@@ -8,6 +8,5 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
     {
         Task<bool> HandleAsync(MqttPublishInfo publishInfo);
         IReadOnlyCollection<string> Subscriptions { get; }
-        void ProducerStopped();
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/ConnectionHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/ConnectionHandler.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
     using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Text;
-    using System.Threading.Channels;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
@@ -27,9 +26,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
         readonly ISystemComponentIdProvider systemComponentIdProvider;
         readonly DeviceProxy.Factory deviceProxyFactory;
 
-        readonly Channel<MqttPublishInfo> notifications;
-        readonly Task processingLoop;
-
         AsyncLock guard = new AsyncLock();
 
         // Normal dictionary would be sufficient because of the locks, however we need AddOrUpdate()
@@ -44,15 +40,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             this.identityProvider = Preconditions.CheckNotNull(identityProvider);
             this.systemComponentIdProvider = Preconditions.CheckNotNull(systemComponentIdProvider);
             this.deviceProxyFactory = Preconditions.CheckNotNull(deviceProxyFactory);
-
-            this.notifications = Channel.CreateUnbounded<MqttPublishInfo>(
-                                    new UnboundedChannelOptions
-                                    {
-                                        SingleReader = true,
-                                        SingleWriter = true
-                                    });
-
-            this.processingLoop = this.StartProcessingLoop();
         }
 
         public IReadOnlyCollection<string> Subscriptions => subscriptions;
@@ -88,27 +75,23 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             }
         }
 
-        public Task<bool> HandleAsync(MqttPublishInfo publishInfo)
+        public async Task<bool> HandleAsync(MqttPublishInfo publishInfo)
         {
-            switch (publishInfo.Topic)
+            if (string.Equals(publishInfo.Topic, TopicDeviceConnected))
             {
-                case TopicDeviceConnected:
-                    if (!this.notifications.Writer.TryWrite(publishInfo))
-                    {
-                        Events.ErrorEnqueueingNotification();
-                    }
-
-                    return Task.FromResult(true);
-
-                default:
-                    return Task.FromResult(false);
+                try
+                {
+                    await this.HandleDeviceConnectedAsync(publishInfo);
+                    return true;
+                }
+                catch (Exception e)
+                {
+                    Events.ErrorProcessingNotification(e);
+                    return false;
+                }
             }
-        }
 
-        public void ProducerStopped()
-        {
-            this.notifications.Writer.Complete();
-            this.processingLoop.Wait();
+            return false;
         }
 
         async Task HandleDeviceConnectedAsync(MqttPublishInfo mqttPublishInfo)
@@ -232,37 +215,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             return Option.Some(result);
         }
 
-        bool IsSystemComponent(string id)
-        {
-            return string.Equals(id, this.systemComponentIdProvider.EdgeHubBridgeId);
-        }
-
-        Task StartProcessingLoop()
-        {
-            var loopTask = Task.Run(
-                                async () =>
-                                {
-                                    Events.ProcessingLoopStarted();
-
-                                    while (await this.notifications.Reader.WaitToReadAsync())
-                                    {
-                                        var publishInfo = await this.notifications.Reader.ReadAsync();
-
-                                        try
-                                        {
-                                            await this.HandleDeviceConnectedAsync(publishInfo);
-                                        }
-                                        catch (Exception e)
-                                        {
-                                            Events.ErrorProcessingNotification(e);
-                                        }
-                                    }
-
-                                    Events.ProcessingLoopStopped();
-                                });
-
-            return loopTask;
-        }
+        bool IsSystemComponent(string id) => string.Equals(id, this.systemComponentIdProvider.EdgeHubBridgeId);
 
         static class Events
         {
@@ -276,9 +229,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                 UnknownClientDisconnected,
                 ExistingClientAdded,
                 BlockingDependencyInjection,
-                ProcessingLoopStarted,
-                ProcessingLoopStopped,
-                ErrorEnqueueingNotification,
                 ErrorProcessingNotification,
                 FailedToObtainConnectionProvider
             }
@@ -287,9 +237,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             public static void BadIdentityFormat(string identity) => Log.LogError((int)EventIds.BadIdentityFormat, $"Bad identity format: {identity}");
             public static void UnknownClientDisconnected(string identity) => Log.LogWarning((int)EventIds.UnknownClientDisconnected, $"Received disconnect notification about a not-connected client {identity}");
             public static void ExistingClientAdded(string identity) => Log.LogWarning((int)EventIds.ExistingClientAdded, $"Received connect notification about a already-connected client {identity}");
-            public static void ProcessingLoopStarted() => Log.LogInformation((int)EventIds.ProcessingLoopStarted, "Processing loop started");
-            public static void ProcessingLoopStopped() => Log.LogInformation((int)EventIds.ProcessingLoopStopped, "Processing loop stopped");
-            public static void ErrorEnqueueingNotification() => Log.LogError((int)EventIds.ErrorEnqueueingNotification, "Error enqueueing notification");
             public static void ErrorProcessingNotification(Exception e) => Log.LogError((int)EventIds.ErrorProcessingNotification, e, "Error processing [Connect] notification");
             public static void FailedToObtainConnectionProvider() => Log.LogError((int)EventIds.FailedToObtainConnectionProvider, "Failed to obtain ConnectionProvider");
         }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/MessageConfirmingHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/MessageConfirmingHandler.cs
@@ -19,14 +19,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
 
         protected async Task ConfirmMessageAsync(IMessage message, IIdentity identity)
         {
-            var proxy = default(IDeviceListener);
+            var listener = default(IDeviceListener);
             try
             {
-                proxy = (await this.connectionRegistry.GetDeviceListenerAsync(identity)).Expect(() => new Exception($"No device listener found for {identity.Id}"));
+                listener = (await this.connectionRegistry.GetDeviceListenerAsync(identity)).Expect(() => new Exception($"No device listener found for {identity.Id}"));
             }
             catch (Exception)
             {
-                Events.MissingProxy(identity.Id);
+                Events.MissingListener(identity.Id);
                 return;
             }
 
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             try
             {
                 lockToken = message.SystemProperties[SystemProperties.LockToken];
-                await proxy.ProcessMessageFeedbackAsync(lockToken, FeedbackStatus.Complete);
+                await listener.ProcessMessageFeedbackAsync(lockToken, FeedbackStatus.Complete);
             }
             catch (Exception ex)
             {
@@ -64,11 +64,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
 
             enum EventIds
             {
-                MissingProxy = IdStart,
+                MissingListener = IdStart,
                 FailedToConfirm
             }
 
-            public static void MissingProxy(string id) => Log.LogError((int)EventIds.MissingProxy, $"Missing device listener for {id}");
+            public static void MissingListener(string id) => Log.LogError((int)EventIds.MissingListener, $"Missing device listener for {id}");
             public static void FailedToConfirm(Exception ex, string lockToken, string id) => Log.LogError((int)EventIds.FailedToConfirm, ex, $"Cannot confirm back delivered message to {id} with token {lockToken}");
         }
     }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/SubscriptionChangeHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/SubscriptionChangeHandler.cs
@@ -77,7 +77,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
 
             if (subscriptionList == null)
             {
-                Events.BadPayloadFormat();
+                // This case is valid and sent by the broker (as an empty string) when a client disconnects.
+                // The meaning of the message is to remove subscriptions, but as the client is disconnecting
+                // in a moment, we don't do anything. In fact, the disconnect message is supposed to arrive
+                // first, and then this change notification gets ignored as it does not have related client.
                 return true;
             }
 
@@ -168,7 +171,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             }
 
             public static void BadPayloadFormat(Exception e) => Log.LogError((int)EventIds.BadPayloadFormat, e, "Bad payload format: cannot deserialize subscription update");
-            public static void BadPayloadFormat() => Log.LogError((int)EventIds.BadPayloadFormat, "Bad payload format: cannot deserialize subscription update");
             public static void FailedToChangeSubscriptionState(Exception e, string subscription, string id) => Log.LogError((int)EventIds.FailedToChangeSubscriptionState, e, $"Failed to change subscrition status {subscription} for {id}");
             public static void HandlingSubscriptionChange(string content) => Log.LogDebug((int)EventIds.HandlingSubscriptionChange, $"Handling subscription change {content}");
         }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/MqttBridgeComponentDiscovery.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/MqttBridgeComponentDiscovery.cs
@@ -10,22 +10,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
 
     public class MqttBridgeComponentDiscovery : IComponentDiscovery
     {
-        readonly ILogger logger;
-
         public IReadOnlyCollection<IMessageProducer> Producers { get; private set; }
         public IReadOnlyCollection<IMessageConsumer> Consumers { get; private set; }
 
         public static Type[] CandidateInterfaces { get; } = new[] { typeof(IMessageProducer), typeof(IMessageConsumer) };
 
-        public MqttBridgeComponentDiscovery(ILogger logger)
+        MqttBridgeComponentDiscovery(IReadOnlyCollection<IMessageProducer> producers, IReadOnlyCollection<IMessageConsumer> consumers)
         {
-            this.logger = Preconditions.CheckNotNull(logger);
-
-            this.Producers = new IMessageProducer[0];
-            this.Consumers = new IMessageConsumer[0];
+            this.Producers = Preconditions.CheckNotNull(producers);
+            this.Consumers = Preconditions.CheckNotNull(consumers);
         }
 
-        public void Discover(IComponentContext context)
+        public static MqttBridgeComponentDiscovery Discover(IComponentContext context)
         {
             var componentInstances = GetCandidateTypes().Select(t => context.Resolve(t));
 
@@ -37,18 +33,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                 if (component is IMessageProducer producer)
                 {
                     producers.Add(producer);
-                    this.logger.LogDebug("Added class [{0}] as producer", producer.GetType().Name);
                 }
 
                 if (component is IMessageConsumer consumer)
                 {
                     consumers.Add(consumer);
-                    this.logger.LogDebug("Added class [{0}] as consumer", consumer.GetType().Name);
                 }
             }
 
-            this.Producers = producers;
-            this.Consumers = consumers;
+            return new MqttBridgeComponentDiscovery(producers, consumers);
         }
 
         public static IEnumerable<Type> GetCandidateTypes()

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/MqttBrokerModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/MqttBrokerModule.cs
@@ -48,22 +48,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                    .SingleInstance();
 
             builder.Register(c => new SystemComponentIdProvider(c.ResolveNamed<IClientCredentials>("EdgeHubCredentials")))
-                    .As<ISystemComponentIdProvider>()
-                    .SingleInstance();
+                   .As<ISystemComponentIdProvider>()
+                   .SingleInstance();
 
-            builder.Register(
-                        c =>
-                        {
-                            var loggerFactory = c.Resolve<ILoggerFactory>();
-                            ILogger logger = loggerFactory.CreateLogger(typeof(MqttBridgeComponentDiscovery));
-
-                            var discovery = new MqttBridgeComponentDiscovery(logger);
-                            discovery.Discover(c);
-
-                            return discovery;
-                        })
-                .As<IComponentDiscovery>()
-                .SingleInstance();
+            builder.Register(c => MqttBridgeComponentDiscovery.Discover(c))
+                   .As<IComponentDiscovery>()
+                   .SingleInstance();
 
             builder.RegisterType<MqttBrokerConnector>()
                    .AsImplementedInterfaces()

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/concurrency/AtomicLong.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/concurrency/AtomicLong.cs
@@ -27,6 +27,8 @@ namespace Microsoft.Azure.Devices.Edge.Util.Concurrency
 
         public long Increment() => Interlocked.Increment(ref this.underlying);
 
+        public long Decrement() => Interlocked.Decrement(ref this.underlying);
+
         public long CompareAndSet(long expected, long result)
         {
             return Interlocked.CompareExchange(ref this.underlying, result, expected);


### PR DESCRIPTION
In the previous preview there where two significant errors
- Some message handlers had its own processing loop (with a queue), and because of that it could happen that a message generated later got processed sooner. As a specific example, it could happen that a "connected" message was generated before "subscribed", but then the "subscribed" message was processed earlier, but the processing did not know about the connecting client and ignored the subscriptions. Now the separate queues are removed (which was introduced as a performance optimization)
- The broker sent an empty "subscription changed" message before a client disconnected, and the edgeHub-bridge did not handle that