### PR TITLE
[DRAFT] Set the default max open files to 5000, not unlimited.

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/RocksDbOptionsProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/RocksDbOptionsProvider.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
         const ulong DefaultMaxTotalWalSize = 512 * 1024 * 1024;
 
         const int DefaultMaxOpenFiles = 5000;
-        
+
         const ulong DefaultKeepLogFileNum = 1;
         // Log NOTHING to the log file.
         const StorageLogLevel DefaultLogLevel = StorageLogLevel.NONE;

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/RocksDbOptionsProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage.RocksDb/RocksDbOptionsProvider.cs
@@ -44,6 +44,9 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
         // Once write-ahead logs exceed this size, we will start forcing the flush of
         // column families whose memtables are backed by the oldest live WAL file
         const ulong DefaultMaxTotalWalSize = 512 * 1024 * 1024;
+
+        const int DefaultMaxOpenFiles = 5000;
+        
         const ulong DefaultKeepLogFileNum = 1;
         // Log NOTHING to the log file.
         const StorageLogLevel DefaultLogLevel = StorageLogLevel.NONE;
@@ -72,6 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb
                 .SetCreateMissingColumnFamilies();
 
             options.SetMaxTotalWalSize(this.maxTotalWalSize)
+                .SetMaxOpenFiles(DefaultMaxOpenFiles)
                 .SetKeepLogFileNum(DefaultKeepLogFileNum)
                 .SetInfoLogLevel((int)this.logLevel);
 


### PR DESCRIPTION
Set default to 500 max open files, not -1 which allows unlimited files open.  This is an experiment to get a user potentially unstuck form EdgeHub opening too many files.