### PR TITLE
Add ServiceIdentitiesUpdated event to DeviceScopeIdentitiesCache

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeIdentitiesCache.cs
@@ -318,8 +318,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 NotInScope,
                 AddInScope,
                 RefreshingServiceIdentity,
-                GettingServiceIdentity,
-                GettingAllIds
+                GettingServiceIdentity
             }
 
             public static void Created() =>
@@ -371,11 +370,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             internal static void InitializingRefreshTask(TimeSpan refreshRate) =>
                 Log.LogDebug((int)EventIds.InitializingRefreshTask, $"Initializing device scope identities cache refresh task to run every {refreshRate.TotalMinutes} minutes.");
-
-            internal static void GettingAllIds()
-            {
-                Log.LogDebug((int)EventIds.GettingAllIds, "Getting all IDs within hierarchy.");
-            }
         }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
@@ -27,6 +27,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         Task RefreshServiceIdentities(IEnumerable<string> ids);
 
-        Task RefreshServiceIdentity(string id, bool invokeServiceIdentitiesUpdated = true);
+        Task RefreshServiceIdentity(string id);
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IDeviceScopeIdentitiesCache.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         event EventHandler<ServiceIdentity> ServiceIdentityUpdated;
 
+        event EventHandler<IList<string>> ServiceIdentitiesUpdated;
+
         Task<Option<ServiceIdentity>> GetServiceIdentity(string id);
 
         Task<IList<ServiceIdentity>> GetDevicesAndModulesInTargetScopeAsync(string targetDeviceId);
@@ -25,6 +27,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         Task RefreshServiceIdentities(IEnumerable<string> ids);
 
-        Task RefreshServiceIdentity(string id);
+        Task RefreshServiceIdentity(string id, bool invokeServiceIdentitiesUpdated = true);
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceScopeIdentitiesCache.cs
@@ -49,14 +49,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public Task RefreshServiceIdentities(IEnumerable<string> deviceIds) => Task.CompletedTask;
 
-        public Task RefreshServiceIdentity(string deviceId, bool invokeServiceIdentitiesUpdated = true) => Task.CompletedTask;
+        public Task RefreshServiceIdentity(string deviceId) => Task.CompletedTask;
 
         public Task RefreshServiceIdentity(string deviceId, string moduleId) => Task.CompletedTask;
-
-        public Task<IList<string>> GetAllIds()
-        {
-            IList<string> list = new List<string>();
-            return Task.FromResult(list);
-        }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceScopeIdentitiesCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/NullDeviceScopeIdentitiesCache.cs
@@ -21,6 +21,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             remove { }
         }
 
+        public event EventHandler<IList<string>> ServiceIdentitiesUpdated
+        {
+            add { }
+            remove { }
+        }
+
         public Task<Option<ServiceIdentity>> GetServiceIdentity(string id)
             => Task.FromResult(Option.None<ServiceIdentity>());
 
@@ -43,8 +49,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public Task RefreshServiceIdentities(IEnumerable<string> deviceIds) => Task.CompletedTask;
 
-        public Task RefreshServiceIdentity(string deviceId) => Task.CompletedTask;
+        public Task RefreshServiceIdentity(string deviceId, bool invokeServiceIdentitiesUpdated = true) => Task.CompletedTask;
 
         public Task RefreshServiceIdentity(string deviceId, string moduleId) => Task.CompletedTask;
+
+        public Task<IList<string>> GetAllIds()
+        {
+            IList<string> list = new List<string>();
+            return Task.FromResult(list);
+        }
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(serviceIdentity1));
             deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId, true))
-                .Callback<string>(id => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
+                .Callback<string, bool>((id, _)  => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
                 .Returns(Task.CompletedTask);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(deviceId));
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId))
                 .ReturnsAsync(Option.Some(serviceIdentity1));
             deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId, true))
-                .Callback<string>(id => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
+                .Callback<string, bool>((id, _) => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
                 .Returns(Task.CompletedTask);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(deviceId));

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity2 = new ServiceIdentity(deviceId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Enabled);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(serviceIdentity1));
-            deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId))
+            deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId, true))
                 .Callback<string>(id => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
                 .Returns(Task.CompletedTask);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId)))
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.True(isAuthenticated);
             Mock.Get(underlyingAuthenticator).VerifyAll();
             deviceScopeIdentitiesCache.Verify(d => d.GetServiceIdentity(deviceId), Times.Exactly(2));
-            deviceScopeIdentitiesCache.Verify(d => d.RefreshServiceIdentity(deviceId), Times.Once);
+            deviceScopeIdentitiesCache.Verify(d => d.RefreshServiceIdentity(deviceId, true), Times.Once);
         }
 
         [Fact]
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity2 = new ServiceIdentity(deviceId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Enabled);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId))
                 .ReturnsAsync(Option.Some(serviceIdentity1));
-            deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId))
+            deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId, true))
                 .Callback<string>(id => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
                 .Returns(Task.CompletedTask);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId)))
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.False(isAuthenticated);
             Mock.Get(underlyingAuthenticator).VerifyAll();
             deviceScopeIdentitiesCache.Verify(d => d.GetServiceIdentity(deviceId), Times.Once);
-            deviceScopeIdentitiesCache.Verify(d => d.RefreshServiceIdentity(deviceId), Times.Never);
+            deviceScopeIdentitiesCache.Verify(d => d.RefreshServiceIdentity(deviceId, true), Times.Never);
         }
 
         [Fact]

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(serviceIdentity1));
             deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId, true))
-                .Callback<string, bool>((id, _)  => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
+                .Callback<string, bool>((id, _) => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
                 .Returns(Task.CompletedTask);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(deviceId));

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity2 = new ServiceIdentity(deviceId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Enabled);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(serviceIdentity1));
-            deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId, true))
-                .Callback<string, bool>((id, _) => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
+            deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId))
+                .Callback<string>((id) => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
                 .Returns(Task.CompletedTask);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(deviceId));
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.True(isAuthenticated);
             Mock.Get(underlyingAuthenticator).VerifyAll();
             deviceScopeIdentitiesCache.Verify(d => d.GetServiceIdentity(deviceId), Times.Exactly(2));
-            deviceScopeIdentitiesCache.Verify(d => d.RefreshServiceIdentity(deviceId, true), Times.Once);
+            deviceScopeIdentitiesCache.Verify(d => d.RefreshServiceIdentity(deviceId), Times.Once);
         }
 
         [Fact]
@@ -102,8 +102,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var serviceIdentity2 = new ServiceIdentity(deviceId, "1234", new string[0], new ServiceAuthentication(new SymmetricKeyAuthentication(key, GetKey())), ServiceIdentityStatus.Enabled);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId))
                 .ReturnsAsync(Option.Some(serviceIdentity1));
-            deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId, true))
-                .Callback<string, bool>((id, _) => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
+            deviceScopeIdentitiesCache.Setup(d => d.RefreshServiceIdentity(deviceId))
+                .Callback<string>((id) => deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(deviceId)).ReturnsAsync(Option.Some(serviceIdentity2)))
                 .Returns(Task.CompletedTask);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId)))
                 .ReturnsAsync(Option.Some(deviceId));
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.False(isAuthenticated);
             Mock.Get(underlyingAuthenticator).VerifyAll();
             deviceScopeIdentitiesCache.Verify(d => d.GetServiceIdentity(deviceId), Times.Once);
-            deviceScopeIdentitiesCache.Verify(d => d.RefreshServiceIdentity(deviceId, true), Times.Never);
+            deviceScopeIdentitiesCache.Verify(d => d.RefreshServiceIdentity(deviceId), Times.Never);
         }
 
         [Fact]


### PR DESCRIPTION
Adding ServiceIdentitiesUpdated event to DeviceScopeIdentitiesCache. This event will be used by MessageProducer to get all identities from the current nested edge hierarchy to pass to the mqtt broker for IoTHub topic authorization. 