### PR TITLE
Remove await from support bundle autofac construction (#3453)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
@@ -117,10 +117,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
 
             // Task<IRequestHandler> - SupportBundleRequestHandler
             builder.Register(
-                    async c =>
+                    c =>
                     {
-                        await Task.Yield();
-                        return new SupportBundleRequestHandler(c.Resolve<IModuleManager>().GetSupportBundle, c.Resolve<IRequestsUploader>(), this.iotHubHostName) as IRequestHandler;
+                        IRequestHandler handler = new SupportBundleRequestHandler(c.Resolve<IModuleManager>().GetSupportBundle, c.Resolve<IRequestsUploader>(), this.iotHubHostName);
+                        return Task.FromResult(handler);
                     })
                 .As<Task<IRequestHandler>>()
                 .SingleInstance();


### PR DESCRIPTION
Autofac inconsistently breaks if you await before resolving something.

Cherry-pick: https://github.com/Azure/iotedge/commit/7c1706a19b1abc9256827c92f783d7f31bc6f806