### PR TITLE
Update agent schema version in E2E test

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -1669,7 +1669,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         {
             var dp = new
             {
-                schemaVersion = "1.0",
+                schemaVersion = "1.1.0",
                 runtime = new
                 {
                     type = "docker",
@@ -1787,7 +1787,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         {
             var dp = new
             {
-                schemaVersion = "1.0",
+                schemaVersion = "1.1.0",
                 runtime = new
                 {
                     type = "docker",


### PR DESCRIPTION
We've rev'ed the default schema version to 1.1, so the test data need to be updated to match.