### PR TITLE
Expose unix domain sockets as parameters

### DIFF
--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -278,6 +278,10 @@ function process_args() {
     print_highlighted_message 'Process arguments'
     saveNextArg=0
     BYPASS_EDGE_INSTALLATION=""
+    CONNECT_MANAGEMENT_URI=""
+    CONNECT_WORKLOAD_URI=""
+    LISTEN_MANAGEMENT_URI=""
+    LISTEN_WORKLOAD_URI=""
     for arg in "$@"
     do
         if [ $saveNextArg -eq 1 ]; then
@@ -415,6 +419,18 @@ function process_args() {
         elif [ $saveNextArg -eq 44 ]; then
             RUNTIME_LOG_LEVEL="$arg"
             saveNextArg=0
+        elif [ $saveNextArg -eq 45 ]; then
+            CONNECT_MANAGEMENT_URI="$arg"
+            saveNextArg=0
+        elif [ $saveNextArg -eq 46 ]; then
+            CONNECT_WORKLOAD_URI="$arg"
+            saveNextArg=0
+        elif [ $saveNextArg -eq 47 ]; then
+            LISTEN_MANAGEMENT_URI="$arg"
+            saveNextArg=0
+        elif [ $saveNextArg -eq 48 ]; then
+            LISTEN_WORKLOAD_URI="$arg"
+            saveNextArg=0
         else
             case "$arg" in
                 '-h' | '--help' ) usage;;
@@ -462,6 +478,10 @@ function process_args() {
                 '-testInfo' ) saveNextArg=42;;
                 '-testStartDelay' ) saveNextArg=43;;
                 '-runtimeLogLevel' ) saveNextArg=44;;
+                '-connectManagementUri' ) saveNextArg=45;;
+                '-connectWorkloadUri' ) saveNextArg=46;;
+                '-listenManagementUri' ) saveNextArg=47;;
+                '-listenWorkloadUri' ) saveNextArg=48;;
                 '-bypassEdgeInstallation' ) BYPASS_EDGE_INSTALLATION="--bypass-edge-installation";;
                 '-cleanAll' ) CLEAN_ALL=1;;
                 * ) usage;;
@@ -564,6 +584,10 @@ function run_directmethod_test()
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" \
         --initialize-with-agent-artifact "$INITIALIZE_WITH_AGENT_ARTIFACT" \
         --verify-data-from-module "DirectMethodSender" \
+        --use-connect-management-uri="$CONNECT_MANAGEMENT_URI" \
+        --use-connect-workload-uri="$CONNECT_WORKLOAD_URI" \
+        --use-listen-management-uri="$LISTEN_MANAGEMENT_URI" \
+        --use-listen-workload-uri="$LISTEN_WORKLOAD_URI" \
         $BYPASS_EDGE_INSTALLATION \
         -l "$deployment_working_file" && ret=$? || ret=$?
 
@@ -694,6 +718,10 @@ function run_dps_provisioning_test() {
         -n "$(hostname)" \
         -tw "$E2E_TEST_DIR/artifacts/core-linux/e2e_test_files/twin_test_tempSensor.json" \
         --optimize_for_performance="$optimize_for_performance" \
+        --use-connect-management-uri="$CONNECT_MANAGEMENT_URI" \
+        --use-connect-workload-uri="$CONNECT_WORKLOAD_URI" \
+        --use-listen-management-uri="$LISTEN_MANAGEMENT_URI" \
+        --use-listen-workload-uri="$LISTEN_WORKLOAD_URI" \
         $BYPASS_EDGE_INSTALLATION \
         $dps_command_flags \
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" && ret=$? || ret=$? \
@@ -731,6 +759,10 @@ function run_longhaul_test() {
         --leave-running=All \
         -l "$deployment_working_file" \
         --runtime-log-level "$RUNTIME_LOG_LEVEL" \
+        --use-connect-management-uri="$CONNECT_MANAGEMENT_URI" \
+        --use-connect-workload-uri="$CONNECT_WORKLOAD_URI" \
+        --use-listen-management-uri="$LISTEN_MANAGEMENT_URI" \
+        --use-listen-workload-uri="$LISTEN_WORKLOAD_URI" \
         $BYPASS_EDGE_INSTALLATION \
         --no-verify && ret=$? || ret=$?
 
@@ -764,6 +796,10 @@ function run_quickstartcerts_test() {
         --initialize-with-agent-artifact "$INITIALIZE_WITH_AGENT_ARTIFACT" \
         --leave-running=Core \
         --optimize_for_performance="$optimize_for_performance" \
+        --use-connect-management-uri="$CONNECT_MANAGEMENT_URI" \
+        --use-connect-workload-uri="$CONNECT_WORKLOAD_URI" \
+        --use-listen-management-uri="$LISTEN_MANAGEMENT_URI" \
+        --use-listen-workload-uri="$LISTEN_WORKLOAD_URI" \
         $BYPASS_EDGE_INSTALLATION \
         --no-verify && ret=$? || ret=$?
 
@@ -811,6 +847,10 @@ function run_stress_test() {
         --leave-running=All \
         -l "$deployment_working_file" \
         --runtime-log-level "$RUNTIME_LOG_LEVEL" \
+        --use-connect-management-uri="$CONNECT_MANAGEMENT_URI" \
+        --use-connect-workload-uri="$CONNECT_WORKLOAD_URI" \
+        --use-listen-management-uri="$LISTEN_MANAGEMENT_URI" \
+        --use-listen-workload-uri="$LISTEN_WORKLOAD_URI" \
         $BYPASS_EDGE_INSTALLATION \
         --no-verify && ret=$? || ret=$?
 
@@ -843,6 +883,10 @@ function run_tempfilter_test() {
         --verify-data-from-module "tempFilter" \
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" \
         --initialize-with-agent-artifact "$INITIALIZE_WITH_AGENT_ARTIFACT" \
+        --use-connect-management-uri="$CONNECT_MANAGEMENT_URI" \
+        --use-connect-workload-uri="$CONNECT_WORKLOAD_URI" \
+        --use-listen-management-uri="$LISTEN_MANAGEMENT_URI" \
+        --use-listen-workload-uri="$LISTEN_WORKLOAD_URI" \
         $BYPASS_EDGE_INSTALLATION \
         -l "$deployment_working_file" && ret=$? || ret=$?
 
@@ -875,6 +919,10 @@ function run_tempfilterfunctions_test() {
         --verify-data-from-module "tempFilterFunctions" \
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" \
         --initialize-with-agent-artifact "$INITIALIZE_WITH_AGENT_ARTIFACT" \
+        --use-connect-management-uri="$CONNECT_MANAGEMENT_URI" \
+        --use-connect-workload-uri="$CONNECT_WORKLOAD_URI" \
+        --use-listen-management-uri="$LISTEN_MANAGEMENT_URI" \
+        --use-listen-workload-uri="$LISTEN_WORKLOAD_URI" \
         $BYPASS_EDGE_INSTALLATION \
         -l "$deployment_working_file" && ret=$? || ret=$?
 
@@ -906,6 +954,10 @@ function run_tempsensor_test() {
         -n "$(hostname)" \
         -tw "$E2E_TEST_DIR/artifacts/core-linux/e2e_test_files/twin_test_tempSensor.json" \
         --optimize_for_performance="$optimize_for_performance" \
+        --use-connect-management-uri="$CONNECT_MANAGEMENT_URI" \
+        --use-connect-workload-uri="$CONNECT_WORKLOAD_URI" \
+        --use-listen-management-uri="$LISTEN_MANAGEMENT_URI" \
+        --use-listen-workload-uri="$LISTEN_WORKLOAD_URI" \
         $BYPASS_EDGE_INSTALLATION \
         -t "$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label" && ret=$? || ret=$? \
         --initialize-with-agent-artifact "$INITIALIZE_WITH_AGENT_ARTIFACT"
@@ -1097,6 +1149,10 @@ function usage() {
     echo ' -testInfo                                      Contains comma delimiter test information, e.g. build number and id, source branches of build, edgelet and images.' 
     echo ' -testStartDelay                                Tests start after delay for applicable modules'
     echo ' -runtimeLogLevel                               Value of RuntimeLogLevel envivronment variable for EdgeAgent in Long Haul and Stress tests [Default: debug] (EdgeHub RuntimeLogLevel is set implicitly set to be the same with edgeAgent)'
+    echo ' -connectManagementUri                          Customize connect management socket'
+    echo ' -connectWorkloadUri                            Customize connect workload socket'
+    echo ' -listenManagementUri                           Customize listen management socket'
+    echo ' -listenWorkloadUri                             Customize listen workload socket'
     echo ' -bypassEdgeInstallation                        Skip installing iotedge (if already preinstalled)'
     exit 1;
 }

--- a/smoke/IotEdgeQuickstart/Program.cs
+++ b/smoke/IotEdgeQuickstart/Program.cs
@@ -84,6 +84,18 @@ Defaults:
         [Option("-h|--use-http=<hostname>", Description = "Modules talk to iotedged via tcp instead of unix domain socket")]
         public (bool useHttp, string hostname) UseHttp { get; } = (false, string.Empty);
 
+        [Option("--use-connect-management-uri=<connect_management_uri>", Description = "Modules talk to a custom connect management socket (default is unix:///var/run/iotedge/mgmt.sock)")]
+        public string ConnectManagementUri { get; } = string.Empty;
+
+        [Option("--use-connect-workload-uri=<connect_workload_uri>", Description = "Modules talk to a custom connect workload socket (default is unix:///var/run/iotedge/workload.sock)")]
+        public string ConnectWorkloadUri { get; } = string.Empty;
+
+        [Option("--use-listen-management-uri=<listen_management_uri>", Description = "Modules talk to a custom listen management socket (default is fd://iotedge.mgmt.socket)")]
+        public string ListenManagementUri { get; } = string.Empty;
+
+        [Option("--use-listen-workload-uri=<listen_workload_uri>", Description = "Modules talk to a custom listen workload socket (default is fd://iotedge.socket)")]
+        public string ListenWorkloadUri { get; } = string.Empty;
+
         [Option("-n|--edge-hostname", Description = "Edge device's hostname")]
         public string EdgeHostname { get; } = "quickstart";
 
@@ -209,7 +221,9 @@ Defaults:
                                 ? Option.Some(string.IsNullOrEmpty(hostname) ? new HttpUris() : new HttpUris(hostname))
                                 : Option.None<HttpUris>();
 
-                            bootstrapper = new IotedgedLinux(this.BootstrapperArchivePath, credentials, uris, proxy, upstreamProtocolOption, !this.BypassEdgeInstallation);
+                            UriSocks socks = new UriSocks(this.ConnectManagementUri, this.ConnectWorkloadUri, this.ListenManagementUri, this.ListenWorkloadUri);
+
+                            bootstrapper = new IotedgedLinux(this.BootstrapperArchivePath, credentials, uris, socks, proxy, upstreamProtocolOption, !this.BypassEdgeInstallation);
                         }
 
                         break;

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -70,15 +70,17 @@ namespace IotEdgeQuickstart.Details
         readonly string archivePath;
         readonly Option<RegistryCredentials> credentials;
         readonly Option<HttpUris> httpUris;
+        readonly UriSocks uriSocks;
         readonly Option<string> proxy;
         readonly Option<UpstreamProtocolType> upstreamProtocol;
         readonly bool requireEdgeInstallation;
 
-        public IotedgedLinux(string archivePath, Option<RegistryCredentials> credentials, Option<HttpUris> httpUris, Option<string> proxy, Option<UpstreamProtocolType> upstreamProtocol, bool requireEdgeInstallation)
+        public IotedgedLinux(string archivePath, Option<RegistryCredentials> credentials, Option<HttpUris> httpUris, UriSocks uriSocks, Option<string> proxy, Option<UpstreamProtocolType> upstreamProtocol, bool requireEdgeInstallation)
         {
             this.archivePath = archivePath;
             this.credentials = credentials;
             this.httpUris = httpUris;
+            this.uriSocks = uriSocks;
             this.proxy = proxy;
             this.upstreamProtocol = upstreamProtocol;
             this.requireEdgeInstallation = requireEdgeInstallation;
@@ -266,10 +268,11 @@ namespace IotEdgeQuickstart.Details
             }
             else
             {
-                doc.ReplaceOrAdd("connect.management_uri", "unix:///var/run/iotedge/mgmt.sock");
-                doc.ReplaceOrAdd("connect.workload_uri", "unix:///var/run/iotedge/workload.sock");
-                doc.ReplaceOrAdd("listen.management_uri", "fd://iotedge.mgmt.socket");
-                doc.ReplaceOrAdd("listen.workload_uri", "fd://iotedge.socket");
+                UriSocks socks = this.uriSocks;
+                doc.ReplaceOrAdd("connect.management_uri", socks.ConnectManagement);
+                doc.ReplaceOrAdd("connect.workload_uri", socks.ConnectWorkload);
+                doc.ReplaceOrAdd("listen.management_uri", socks.ListenManagement);
+                doc.ReplaceOrAdd("listen.workload_uri", socks.ListenWorkload);
             }
 
             if (!string.IsNullOrEmpty(deviceCaCert) && !string.IsNullOrEmpty(deviceCaPk) && !string.IsNullOrEmpty(deviceCaCerts))

--- a/smoke/IotEdgeQuickstart/details/UriSocks.cs
+++ b/smoke/IotEdgeQuickstart/details/UriSocks.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace IotEdgeQuickstart.Details
+{
+    internal class UriSocks
+    {
+        public UriSocks(string ConnectManagementUri, string ConnectWorkloadUri, string ListenManagementUri, string ListenWorkloadUri)
+        {
+            this.ConnectManagement = string.IsNullOrEmpty(ConnectManagementUri) ? "unix:///var/run/iotedge/mgmt.sock" : ConnectManagementUri;
+            this.ConnectWorkload = string.IsNullOrEmpty(ConnectWorkloadUri) ? "unix:///var/run/iotedge/workload.sock" : ConnectWorkloadUri;
+            this.ListenManagement = string.IsNullOrEmpty(ListenManagementUri) ? "fd://iotedge.mgmt.socket" : ListenManagementUri;
+            this.ListenWorkload = string.IsNullOrEmpty(ListenWorkloadUri) ? "fd://iotedge.socket" : ListenWorkloadUri;
+        }
+
+        public string ConnectManagement { get; }
+
+        public string ConnectWorkload { get; }
+
+        public string ListenManagement { get; }
+
+        public string ListenWorkload { get; }
+    }
+}


### PR DESCRIPTION
Mariner (Linux) uses different sockets than Ubuntu.
This change accommodates for the difference by exposing the unix domain sockets as optional parameters which can be customized.