### PR TITLE
Fixed potentialy zombie task in TestClient.

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -495,6 +495,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +524,23 @@ name = "futures-core"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
 
 [[package]]
 name = "futures-macro"
@@ -543,10 +575,13 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project",
  "pin-utils",
  "proc-macro-hack",
@@ -989,6 +1024,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "bytes",
+ "futures",
  "futures-util",
  "lazy_static",
  "mqtt-broker",

--- a/mqtt/mqtt-broker-tests-util/Cargo.toml
+++ b/mqtt/mqtt-broker-tests-util/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 bytes = "0.5"
+futures = "0.3"
 futures-util = { version = "0.3", features = ["sink"] }
 lazy_static = "1.4"
 tokio = { version = "0.2", features = ["blocking", "stream", "sync", "tcp", "dns"] }

--- a/mqtt/mqtt-broker-tests-util/src/client.rs
+++ b/mqtt/mqtt-broker-tests-util/src/client.rs
@@ -239,15 +239,15 @@ where
         let (sub_sender, sub_receiver) = mpsc::unbounded_channel();
         let (conn_sender, conn_receiver) = mpsc::unbounded_channel();
 
-        let (termination_handle, tx) = mpsc::channel::<()>(1);
+        let (termination_handle, termination_receiver) = mpsc::channel::<()>(1);
 
         let event_loop_handle = tokio::spawn(async move {
-            let mut tx = tx.fuse();
+            let mut termination_receiver = termination_receiver.fuse();
             let mut client = client.fuse();
 
             loop {
                 select! {
-                    signal = tx.next() => {
+                    _ = termination_receiver.next() => {
                         return;
                     }
                     event = client.next() => {


### PR DESCRIPTION
In current code, even when we return from the async block in TestClient, it looks like that `event_loop` task remains running.

This is an attempt to fix it.