### PR TITLE
Remove module user from diagnostics dockerfile

### DIFF
--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
@@ -7,8 +7,4 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-# Add an unprivileged user account for running the module
-RUN adduser -Ds /bin/sh moduleuser 
-USER moduleuser
-
 CMD echo "$(date --utc +"[%Y-%m-%d %H:%M:%S %:z]"): Module is intended to be used with docker run command"

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
@@ -7,7 +7,5 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER moduleuser
-
 CMD echo "$(date --utc +"[%Y-%m-%d %H:%M:%S %:z]"): Module is intended to be used with docker run command"
 

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
@@ -7,7 +7,5 @@ WORKDIR /app
 
 COPY $EXE_DIR/ ./
 
-USER moduleuser
-
 CMD echo "$(date --utc +"[%Y-%m-%d %H:%M:%S %:z]"): Module is intended to be used with docker run command"
 


### PR DESCRIPTION
This is a regression from the iotedge check proxy changes. Previously it ran as root since it accesses the mgmt uri. This change sets it as root again