### PR TITLE
[TEST-ONLY] TRC triggers UploadLogs

### DIFF
--- a/test/modules/TestResultCoordinator/TestReportUtil.cs
+++ b/test/modules/TestResultCoordinator/TestReportUtil.cs
@@ -147,7 +147,7 @@ namespace TestResultCoordinator
 
             ServiceClient serviceClient = ServiceClient.CreateFromConnectionString(iotHubConnectionString);
             CloudToDeviceMethod uploadLogRequest =
-                new CloudToDeviceMethod("UploadModuleLogs")
+                new CloudToDeviceMethod("UploadLogs")
                     .SetPayloadJson($"{{ \"schemaVersion\": \"1.0\", \"sasUrl\": \"{blobContainerWriteUri.AbsoluteUri}\", \"items\": [{{ \"id\": \".*\", \"filter\": {{}} }}], \"encoding\": \"gzip\" }}");
 
             CloudToDeviceMethodResult uploadLogResponse = await serviceClient.InvokeDeviceMethodAsync(Settings.Current.DeviceId, "$edgeAgent", uploadLogRequest);


### PR DESCRIPTION
Due the to log upload method name change, the TRC triggers the new log upload method which doesn't exist in release 1.0.9 branch. This PR is a TEST ONLY PR to have TRC trigger the old upload method on the edgeAgent for release1.0.9.5's connectivity test.