### PR TITLE
Refactor Command handler and add handle_authorized_identities event (#3474)

### DIFF
--- a/mqtt/mqtt-broker/src/auth/authorization.rs
+++ b/mqtt/mqtt-broker/src/auth/authorization.rs
@@ -1,4 +1,4 @@
-use std::{convert::Infallible, error::Error as StdError};
+use std::{any::Any, convert::Infallible, error::Error as StdError};
 
 use mqtt3::proto;
 
@@ -11,6 +11,10 @@ pub trait Authorizer {
 
     /// Authorizes a MQTT client to perform some action.
     fn authorize(&self, activity: Activity) -> Result<Authorization, Self::Error>;
+
+    fn update(&self, _update: Box<dyn Any>) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 /// Authorization result.

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -86,6 +86,11 @@ where
                                 debug!("successfully disconnected client");
                             }
                         }
+                        SystemEvent::AuthorizationUpdate(update) => {
+                            if let Err(e) = self.authorizer.update(update) {
+                                warn!(message = "an error occurred updating authorization info", error = %e);
+                            }
+                        }
                     }
                 }
             }

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -30,6 +30,7 @@ mod transport;
 pub mod proptest;
 
 use std::{
+    any::Any,
     fmt::{Display, Formatter, Result as FmtResult},
     net::SocketAddr,
     sync::Arc,
@@ -239,7 +240,7 @@ pub enum SystemEvent {
     Shutdown,
     StateSnapshot(StateSnapshotHandle),
     ForceClientDisconnect(ClientId),
-    // ConfigUpdate,
+    AuthorizationUpdate(Box<dyn Any + Send + Sync>),
 }
 
 #[derive(Debug)]

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -1,9 +1,12 @@
+use std::any::Any;
 use std::{cell::RefCell, collections::HashMap, convert::Infallible};
 
+use crate::command::ServiceIdentity;
 use mqtt_broker::{
     auth::{Activity, Authorization, Authorizer, Connect, Operation, Publish, Subscribe},
     AuthId, ClientId, ClientInfo,
 };
+use tracing::debug;
 
 #[derive(Debug, Default)]
 pub struct EdgeHubAuthorizer {
@@ -171,6 +174,15 @@ impl Authorizer for EdgeHubAuthorizer {
         };
 
         Ok(auth)
+    }
+
+    fn update(&self, update: Box<dyn Any>) -> Result<(), Self::Error> {
+        let identities = update.as_ref();
+        if let Some(service_identities) = identities.downcast_ref::<ServiceIdentity>() {
+            debug!("{:?}", service_identities);
+            // TODO: fill in update method
+        }
+        Ok(())
     }
 }
 

--- a/mqtt/mqtt-edgehub/src/command.rs
+++ b/mqtt/mqtt-edgehub/src/command.rs
@@ -1,200 +1,132 @@
-use std::{collections::HashSet, time::Duration};
-
-use futures_util::future::BoxFuture;
+use serde::{Deserialize, Serialize};
 use serde_json::error::Error as SerdeError;
-use tokio::{net::TcpStream, stream::StreamExt};
-use tracing::{debug, error, info};
+use std::{collections::HashMap, fmt};
+use tracing::{debug, info};
 
-use mqtt3::{
-    proto, Client, Event, IoSource, ShutdownError, SubscriptionUpdateEvent, UpdateSubscriptionError,
-};
+use mqtt3::ReceivedPublication;
 use mqtt_broker::{BrokerHandle, ClientId, Error, Message, SystemEvent};
 
 const DISCONNECT_TOPIC: &str = "$edgehub/disconnect";
+const AUTHORIZED_IDENTITIES_TOPIC: &str = "$internal/identities";
 
-pub struct ShutdownHandle {
-    client_shutdown: mqtt3::ShutdownHandle,
+pub trait Command {
+    fn topic(&self) -> String;
+    fn handle(
+        &self,
+        broker_handle: &mut BrokerHandle,
+        received_publication: &ReceivedPublication,
+    ) -> Result<(), HandleEventError>;
 }
 
-impl ShutdownHandle {
-    pub async fn shutdown(mut self) -> Result<(), CommandHandlerError> {
-        debug!("signaling command handler shutdown");
-        self.client_shutdown
-            .shutdown()
-            .await
-            .map_err(CommandHandlerError::ShutdownClient)?;
+struct Disconnect {
+    topic: String,
+}
 
-        Ok(())
+struct AuthorizedIdentities {
+    topic: String,
+}
+
+impl Command for Disconnect {
+    fn topic(&self) -> String {
+        self.topic.clone()
     }
-}
 
-pub struct BrokerConnection {
-    address: String,
-}
+    fn handle(
+        &self,
+        broker_handle: &mut BrokerHandle,
+        received_publication: &ReceivedPublication,
+    ) -> Result<(), HandleEventError> {
+        let client_id: ClientId = serde_json::from_slice(&received_publication.payload)
+            .map_err(HandleEventError::ParseClientId)?;
 
-impl IoSource for BrokerConnection {
-    type Io = TcpStream;
-    type Error = std::io::Error;
-    type Future = BoxFuture<'static, Result<(TcpStream, Option<String>), std::io::Error>>;
+        info!("received disconnection request for client {}", client_id);
 
-    fn connect(&mut self) -> Self::Future {
-        let address = self.address.clone();
-        Box::pin(async move {
-            let io = TcpStream::connect(address).await;
-            io.map(|io| (io, None))
-        })
-    }
-}
+        if let Err(e) = broker_handle.send(Message::System(SystemEvent::ForceClientDisconnect(
+            client_id.clone(),
+        ))) {
+            return Err(HandleEventError::DisconnectSignal(e));
+        }
 
-pub struct CommandHandler {
-    broker_handle: BrokerHandle,
-    client: Client<BrokerConnection>,
-}
-
-impl CommandHandler {
-    pub async fn new(
-        broker_handle: BrokerHandle,
-        address: String,
-        device_id: &str,
-    ) -> Result<Self, CommandHandlerError> {
-        let client_id = format!("{}/$edgeHub/$broker", device_id);
-
-        let mut client = Client::new(
-            Some(client_id),
-            None,
-            None,
-            BrokerConnection { address },
-            Duration::from_secs(1),
-            Duration::from_secs(60),
+        info!(
+            "succeeded sending broker signal to disconnect client{}",
+            client_id
         );
-
-        let subscribe_topics = &[DISCONNECT_TOPIC.to_string()];
-        subscribe(&mut client, subscribe_topics).await?;
-
-        Ok(CommandHandler {
-            broker_handle,
-            client,
-        })
-    }
-
-    pub fn shutdown_handle(&self) -> Result<ShutdownHandle, ShutdownError> {
-        Ok(ShutdownHandle {
-            client_shutdown: self.client.shutdown_handle()?,
-        })
-    }
-
-    pub async fn run(mut self) {
-        debug!("starting command handler");
-
-        loop {
-            match self.client.try_next().await {
-                Ok(Some(event)) => {
-                    if let Err(e) = self.handle_event(event).await {
-                        error!(message = "error processing command handler event", error = %e);
-                    }
-                }
-                Ok(None) => {
-                    debug!("command handler mqtt client disconnected");
-                    break;
-                }
-                Err(e) => {
-                    error!("failure polling command handler client {}", error = e);
-                }
-            }
-        }
-
-        debug!("command handler stopped");
-    }
-
-    async fn handle_event(&mut self, event: Event) -> Result<(), HandleDisconnectError> {
-        if let Event::Publication(publication) = event {
-            let client_id: ClientId = serde_json::from_slice(&publication.payload)
-                .map_err(HandleDisconnectError::ParseClientId)?;
-
-            info!("received disconnection request for client {}", client_id);
-
-            if let Err(e) =
-                self.broker_handle
-                    .send(Message::System(SystemEvent::ForceClientDisconnect(
-                        client_id.clone(),
-                    )))
-            {
-                return Err(HandleDisconnectError::SignalError(e));
-            }
-
-            info!(
-                "succeeded sending broker signal to disconnect client{}",
-                client_id
-            );
-        }
-
         Ok(())
     }
 }
 
-async fn subscribe(
-    client: &mut mqtt3::Client<BrokerConnection>,
-    topics: &[String],
-) -> Result<(), CommandHandlerError> {
-    debug!("command handler subscribing to disconnect topic");
-    let subscriptions = topics.iter().map(|topic| proto::SubscribeTo {
-        topic_filter: topic.to_string(),
-        qos: proto::QoS::AtLeastOnce,
-    });
-
-    for subscription in subscriptions {
-        client
-            .subscribe(subscription)
-            .map_err(CommandHandlerError::SubscribeFailure)?;
+impl Command for AuthorizedIdentities {
+    fn topic(&self) -> String {
+        self.topic.clone()
     }
 
-    let mut subacks: HashSet<_> = topics.iter().map(Clone::clone).collect();
+    fn handle(
+        &self,
+        broker_handle: &mut BrokerHandle,
+        publication: &ReceivedPublication,
+    ) -> Result<(), HandleEventError> {
+        info!("received authorized identities from edgeHub.");
+        let array: Vec<ServiceIdentity> = serde_json::from_slice(&publication.payload)
+            .map_err(HandleEventError::ParseAuthorizedIdentities)?;
+        debug!("authorized identities: {:?}.", array);
+        if let Err(e) = broker_handle.send(Message::System(SystemEvent::AuthorizationUpdate(
+            Box::new(array),
+        ))) {
+            return Err(HandleEventError::SendAuthorizedIdentitiesToBroker(e));
+        }
 
-    while let Some(event) = client
-        .try_next()
-        .await
-        .map_err(CommandHandlerError::PollClientFailure)?
-    {
-        if let Event::SubscriptionUpdates(subscriptions) = event {
-            for subscription in subscriptions {
-                if let SubscriptionUpdateEvent::Subscribe(sub) = subscription {
-                    subacks.remove(&sub.topic_filter);
-                }
-            }
+        info!("succeeded sending authorized identity scopes to broker",);
+        Ok(())
+    }
+}
 
-            if subacks.is_empty() {
-                debug!("command handler successfully subscribed to disconnect topic");
-                return Ok(());
+pub fn init_commands() -> HashMap<String, Box<dyn Command + Send>> {
+    let mut commands: HashMap<String, Box<dyn Command + Send>> = HashMap::new();
+    commands.insert(
+        DISCONNECT_TOPIC.to_string(),
+        Box::new(Disconnect {
+            topic: DISCONNECT_TOPIC.to_string(),
+        }),
+    );
+    commands.insert(
+        AUTHORIZED_IDENTITIES_TOPIC.to_string(),
+        Box::new(AuthorizedIdentities {
+            topic: AUTHORIZED_IDENTITIES_TOPIC.to_string(),
+        }),
+    );
+    commands
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ServiceIdentity {
+    #[serde(rename = "Identity")]
+    identity: String,
+    #[serde(rename = "AuthChain")]
+    auth_chain: Option<String>,
+}
+
+impl fmt::Display for ServiceIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.auth_chain {
+            Some(auth_chain) => {
+                write!(f, "Identity: {}; Auth_Chain: {}", self.identity, auth_chain)
             }
+            None => write!(f, "Identity: {}", self.identity),
         }
     }
-
-    error!("command handler failed to subscribe to disconnect topic");
-    Err(CommandHandlerError::MissingSubacks(
-        subacks.into_iter().collect::<Vec<_>>(),
-    ))
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum CommandHandlerError {
-    #[error("failed to receive expected subacks for command topics: {0:?}")]
-    MissingSubacks(Vec<String>),
-
-    #[error("failed to subscribe command handler to command topic")]
-    SubscribeFailure(#[from] UpdateSubscriptionError),
-
-    #[error("failed to poll client when validating command handler subscriptions")]
-    PollClientFailure(#[from] mqtt3::Error),
-
-    #[error("failed to signal shutdown for command handler")]
-    ShutdownClient(#[from] mqtt3::ShutdownError),
-}
-
-#[derive(Debug, thiserror::Error)]
-enum HandleDisconnectError {
+pub enum HandleEventError {
     #[error("failed to parse client id from message payload")]
-    ParseClientId(#[from] SerdeError),
+    ParseClientId(SerdeError),
 
-    #[error("failed sending broker signal to disconnect client")]
-    SignalError(#[from] Error),
+    #[error("failed to parse authorized identities from message payload")]
+    ParseAuthorizedIdentities(SerdeError),
+
+    #[error("failed while sending authorized identities to broker")]
+    SendAuthorizedIdentitiesToBroker(Error),
+
+    #[error("failed while sending broker signal to disconnect client")]
+    DisconnectSignal(Error),
 }

--- a/mqtt/mqtt-edgehub/src/command_handler.rs
+++ b/mqtt/mqtt-edgehub/src/command_handler.rs
@@ -1,0 +1,182 @@
+use mqtt3::proto::QoS::AtLeastOnce;
+use std::collections::HashMap;
+use std::{collections::HashSet, time::Duration};
+
+use futures_util::future::BoxFuture;
+use tokio::{net::TcpStream, stream::StreamExt};
+use tracing::{debug, error};
+
+use crate::command::{Command, HandleEventError};
+use mqtt3::{
+    proto, Client, Event, IoSource, ShutdownError, SubscriptionUpdateEvent, UpdateSubscriptionError,
+};
+use mqtt_broker::BrokerHandle;
+
+pub struct BrokerConnection {
+    address: String,
+}
+
+impl IoSource for BrokerConnection {
+    type Io = TcpStream;
+    type Error = std::io::Error;
+    type Future = BoxFuture<'static, Result<(TcpStream, Option<String>), std::io::Error>>;
+
+    fn connect(&mut self) -> Self::Future {
+        let address = self.address.clone();
+        Box::pin(async move {
+            let io = TcpStream::connect(address).await;
+            io.map(|io| (io, None))
+        })
+    }
+}
+
+pub struct ShutdownHandle {
+    client_shutdown: mqtt3::ShutdownHandle,
+}
+
+impl ShutdownHandle {
+    pub async fn shutdown(mut self) -> Result<(), CommandHandlerError> {
+        debug!("signaling command handler shutdown");
+        self.client_shutdown
+            .shutdown()
+            .await
+            .map_err(CommandHandlerError::ShutdownClient)?;
+
+        Ok(())
+    }
+}
+
+pub struct CommandHandler {
+    broker_handle: BrokerHandle,
+    client: Client<BrokerConnection>,
+    commands: HashMap<String, Box<dyn Command + Send>>,
+}
+
+impl CommandHandler {
+    pub async fn new(
+        broker_handle: BrokerHandle,
+        address: String,
+        device_id: &str,
+        commands: HashMap<String, Box<dyn Command + Send>>,
+    ) -> Result<Self, CommandHandlerError> {
+        let client_id = format!("{}/$edgeHub/$broker", device_id);
+
+        let mut client = Client::new(
+            Some(client_id),
+            None,
+            None,
+            BrokerConnection { address },
+            Duration::from_secs(1),
+            Duration::from_secs(60),
+        );
+
+        let subscribe_topics = commands.keys().cloned().collect::<Vec<_>>();
+        subscribe(&mut client, subscribe_topics).await?;
+
+        Ok(CommandHandler {
+            broker_handle,
+            client,
+            commands,
+        })
+    }
+
+    pub fn shutdown_handle(&self) -> Result<ShutdownHandle, ShutdownError> {
+        Ok(ShutdownHandle {
+            client_shutdown: self.client.shutdown_handle()?,
+        })
+    }
+
+    pub async fn run(mut self) {
+        debug!("starting command handler");
+
+        loop {
+            match self.client.try_next().await {
+                Ok(Some(event)) => {
+                    if let Err(e) = self.handle_event(event).await {
+                        error!(message = "error processing command handler event", error = %e);
+                    }
+                }
+                Ok(None) => {
+                    debug!("command handler mqtt client disconnected");
+                    break;
+                }
+                Err(e) => {
+                    error!("failure polling command handler client {}", error = e);
+                }
+            }
+        }
+
+        debug!("command handler stopped");
+    }
+
+    async fn handle_event(&mut self, event: Event) -> Result<(), HandleEventError> {
+        if let Event::Publication(publication) = event {
+            return match self.commands.get(&publication.topic_name) {
+                Some(command) => (*command).handle(&mut self.broker_handle, &publication),
+                None => Ok(()),
+            };
+        }
+        Ok(())
+    }
+}
+
+async fn subscribe(
+    client: &mut mqtt3::Client<BrokerConnection>,
+    topics: Vec<String>,
+) -> Result<(), CommandHandlerError> {
+    let subscriptions = topics.iter().map(|topic| proto::SubscribeTo {
+        topic_filter: topic.to_string(),
+        qos: AtLeastOnce,
+    });
+    debug!(
+        "command handler subscribing to topics: {}",
+        topics.join(", ")
+    );
+
+    for subscription in subscriptions {
+        client
+            .subscribe(subscription)
+            .map_err(CommandHandlerError::SubscribeFailure)?;
+    }
+
+    let mut subacks: HashSet<_> = topics.iter().map(Clone::clone).collect();
+
+    while let Some(event) = client
+        .try_next()
+        .await
+        .map_err(CommandHandlerError::PollClientFailure)?
+    {
+        if let Event::SubscriptionUpdates(subscriptions) = event {
+            for subscription in subscriptions {
+                if let SubscriptionUpdateEvent::Subscribe(sub) = subscription {
+                    subacks.remove(&sub.topic_filter);
+                }
+            }
+
+            if subacks.is_empty() {
+                debug!("command handler successfully subscribed to disconnect topic");
+                return Ok(());
+            }
+        }
+    }
+
+    error!("command handler failed to subscribe to disconnect topic");
+    Err(CommandHandlerError::MissingSubacks(
+        subacks.into_iter().collect::<Vec<_>>(),
+    ))
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CommandHandlerError {
+    #[error("failed to receive expected subacks for command topics: {0:?}")]
+    MissingSubacks(Vec<String>),
+
+    #[error("failed to subscribe command handler to command topic")]
+    SubscribeFailure(#[from] UpdateSubscriptionError),
+
+    #[error("failed to poll client when validating command handler subscriptions")]
+    PollClientFailure(#[from] mqtt3::Error),
+
+    #[error("failed to signal shutdown for command handler")]
+    ShutdownClient(#[from] mqtt3::ShutdownError),
+}

--- a/mqtt/mqtt-edgehub/src/lib.rs
+++ b/mqtt/mqtt-edgehub/src/lib.rs
@@ -13,6 +13,7 @@
 
 pub mod auth;
 pub mod command;
+pub mod command_handler;
 pub mod connection;
 pub mod settings;
 pub mod topic;

--- a/mqtt/mqtt-edgehub/tests/command.rs
+++ b/mqtt/mqtt-edgehub/tests/command.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
+use std::collections::HashMap;
 
 use futures_util::StreamExt;
 use mqtt3::{proto::ClientId, ShutdownError};
-use tokio::{task::JoinHandle, time};
+use tokio::task::JoinHandle;
 
 use mqtt_broker::{auth::AllowAll, BrokerBuilder, BrokerHandle};
 use mqtt_broker_tests_util::{
@@ -10,8 +10,12 @@ use mqtt_broker_tests_util::{
     packet_stream::PacketStream,
     server::{start_server, DummyAuthenticator},
 };
-use mqtt_edgehub::command::{CommandHandler, ShutdownHandle};
+use mqtt_edgehub::{
+    command::{init_commands, Command},
+    command_handler::{CommandHandler, ShutdownHandle},
+};
 
+const DISCONNECT_TOPIC: &str = "$edgehub/disconnect";
 const TEST_SERVER_ADDRESS: &str = "localhost:5555";
 
 /// Scenario:
@@ -27,8 +31,9 @@ async fn disconnect_client() {
 
     let server_handle = start_server(broker, DummyAuthenticator::anonymous());
 
+    let commands = init_commands();
     let (command_handler_shutdown_handle, join_handle) =
-        start_command_handler(broker_handle, TEST_SERVER_ADDRESS.to_string())
+        start_command_handler(broker_handle, TEST_SERVER_ADDRESS.to_string(), commands)
             .await
             .expect("could not start command handler");
 
@@ -45,7 +50,7 @@ async fn disconnect_client() {
         .with_client_id(ClientId::IdWithCleanSession("$edgehub".into()))
         .build();
 
-    let topic = "$edgehub/disconnect";
+    let topic = DISCONNECT_TOPIC;
     edgehub_client
         .publish_qos1(topic, r#""test-client""#, false)
         .await;
@@ -65,9 +70,10 @@ async fn disconnect_client() {
 async fn start_command_handler(
     broker_handle: BrokerHandle,
     system_address: String,
+    commands: HashMap<String, Box<dyn Command + Send>>,
 ) -> Result<(ShutdownHandle, JoinHandle<()>), ShutdownError> {
     let device_id = "test-device";
-    let command_handler = CommandHandler::new(broker_handle, system_address, device_id)
+    let command_handler = CommandHandler::new(broker_handle, system_address, device_id, commands)
         .await
         .unwrap();
     let shutdown_handle: ShutdownHandle = command_handler.shutdown_handle().unwrap();

--- a/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
@@ -187,7 +187,8 @@ async fn start_sidecars(
         let device_id = env::var(DEVICE_ID_ENV)?;
         let commands: HashMap<String, Box<dyn Command + Send>> = init_commands();
         let command_handler =
-            CommandHandler::new(broker_handle, system_address, device_id.as_str(), commands).await?;
+            CommandHandler::new(broker_handle, system_address, device_id.as_str(), commands)
+                .await?;
         let command_handler_shutdown_handle = command_handler.shutdown_handle()?;
 
         let command_handler_join_handle = tokio::spawn(command_handler.run());

--- a/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
@@ -1,3 +1,5 @@
+use mqtt_edgehub::command::Command;
+use std::collections::HashMap;
 use std::{
     env,
     future::Future,
@@ -27,7 +29,8 @@ use mqtt_broker::{
 };
 use mqtt_edgehub::{
     auth::{EdgeHubAuthenticator, EdgeHubAuthorizer, LocalAuthenticator, LocalAuthorizer},
-    command::CommandHandler,
+    command::init_commands,
+    command_handler::CommandHandler,
     connection::MakeEdgeHubPacketProcessor,
     settings::Settings,
 };
@@ -182,8 +185,9 @@ async fn start_sidecars(
 
     let sidecars = tokio::spawn(async move {
         let device_id = env::var(DEVICE_ID_ENV)?;
+        let commands: HashMap<String, Box<dyn Command + Send>> = init_commands();
         let command_handler =
-            CommandHandler::new(broker_handle, system_address, device_id.as_str()).await?;
+            CommandHandler::new(broker_handle, system_address, device_id.as_str(), commands).await?;
         let command_handler_shutdown_handle = command_handler.shutdown_handle()?;
 
         let command_handler_join_handle = tokio::spawn(command_handler.run());


### PR DESCRIPTION
Cherry-pick from iiot (#3474): 

Refactoring CommandHandler to take multiple commands. Also, adding a new Command, handle_authorized_identities, that will intake authorized identities as a payload from edgeHub, convert it to ServiceIdentity objects and send that to the broker as a SystemEvent.

Currently, the broker just has a dummy implementation for this SystemEvent.

We do this because edgeHub does the authorization for all identities, and the broker just receives it from edgeHub whenever the edgeHub cache is updated.