### PR TITLE
Environment variable in image name

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerConfig.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerConfig.cs
@@ -15,8 +15,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
     {
         // This is not the actual docker image regex, but a less strict version.
         const string ImageRegexPattern = @"^(?<repo>([^/]*/)*)(?<image>[^/:]+)(?<tag>:[^/:]+)?$";
-
+        // Check if it's prefix is "$upstream" and replace with environment variable.
+        const string ImageUpstreamRegexPattern = @"^\$upstream(?<path>:[1-9].*)";
         static readonly Regex ImageRegex = new Regex(ImageRegexPattern);
+        static readonly Regex ImageUpstreamRegex = new Regex(ImageUpstreamRegexPattern);
         readonly CreateContainerParameters createOptions;
 
         public DockerConfig(string image)
@@ -87,8 +89,39 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
 
         internal static string ValidateAndGetImage(string image)
         {
+            return ValidateAndGetImage(image, new EnvironmentWrapper());
+        }
+
+        internal static string ValidateAndGetImage(string image, IEnvironmentWrapper env)
+        {
             image = Preconditions.CheckNonWhiteSpace(image, nameof(image)).Trim();
+
+            if (image[0] == '$')
+            {
+                Match matchHost = ImageUpstreamRegex.Match(image);
+                if (matchHost.Success
+                    && (matchHost.Groups["path"]?.Length > 0)
+                    && (env != null))
+                {
+                    string hostAddress = env.GetVariable(Core.Constants.GatewayHostnameVariableName);
+
+                    if (hostAddress != null)
+                    {
+                        image = hostAddress + matchHost.Groups["path"].Value;
+                    }
+                    else
+                    {
+                        throw new InvalidOperationException($"Could not find environment variable: {Core.Constants.GatewayHostnameVariableName}");
+                    }
+                }
+                else
+                {
+                    throw new InvalidOperationException($"Image {image} is not in the right format. If your intention is to use an environment variable, check the port is specified.");
+                }
+            }
+
             Match match = ImageRegex.Match(image);
+
             if (match.Success)
             {
                 if (match.Groups["tag"]?.Length > 0)
@@ -202,6 +235,19 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             }
 
             public override bool CanConvert(Type objectType) => objectType == typeof(DockerConfig);
+        }
+    }
+
+    internal interface IEnvironmentWrapper
+    {
+        string GetVariable(string variableName);
+    }
+
+    internal class EnvironmentWrapper : IEnvironmentWrapper
+    {
+        public string GetVariable(string variableName)
+        {
+            return Environment.GetEnvironmentVariable(variableName);
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerConfigTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/DockerConfigTest.cs
@@ -36,6 +36,28 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         static readonly DockerConfig Config16 = new DockerConfig("image1:42", @"{""Env"": [""k1=v1"", ""k2=v2"", ""k3=v3""], ""HostConfig"": {""PortBindings"": {""43/udp"": [{""HostPort"": ""43""}], ""42/tcp"": [{""HostPort"": ""42""}]}}}", Option.Some("4562124545"));
         static readonly DockerConfig ConfigUnknown = new DockerConfig("unknown");
         static readonly DockerConfig ConfigUnknownExpected = new DockerConfig("unknown:latest");
+        internal class MockEnvironment : IEnvironmentWrapper
+        {
+            public Dictionary<string, string> Map = new Dictionary<string, string>();
+
+            public string GetVariable(string variableName)
+            {
+                if (this.Map.ContainsKey(variableName))
+                {
+                    return this.Map[variableName];
+                }
+                else
+                {
+                    return null;
+                }
+            }
+
+            public void SetVariable(string variableName, string value)
+            {
+                // Check for entry not existing and add to dictionary
+               this.Map[variableName] = value;
+            }
+        }
 
         static readonly string Extended9 = @"
         {
@@ -201,6 +223,29 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             else
             {
                 string updatedImage = DockerConfig.ValidateAndGetImage(image);
+                Assert.Equal(result, updatedImage);
+            }
+        }
+
+        [Theory]
+        [InlineData("$upstream:9000/comp/ea:tag1", "parentaddress:9000/comp/ea:tag1", null, "IOTEDGE_GATEWAYHOSTNAME", "parentaddress")]
+        [InlineData("$upstream:9000/ea:tag1", "parentaddress:9000/ea:tag1", null, "IOTEDGE_GATEWAYHOSTNAME", "parentaddress")]
+        [InlineData("$upstream:9000/comp/ea:tag1", null, typeof(InvalidOperationException), "dummyValue", "parentaddress")]
+        [InlineData("$dummy:9000/comp/ea:tag1", null, typeof(InvalidOperationException), "IOTEDGE_GATEWAYHOSTNAME", "parentaddress")]
+        [InlineData("$upstream:/comp/ea:tag1", null, typeof(InvalidOperationException), "IOTEDGE_GATEWAYHOSTNAME", "parentaddress")]
+        [InlineData("$upstream:08/comp/ea:tag1", null, typeof(InvalidOperationException), "IOTEDGE_GATEWAYHOSTNAME", "parentaddress")]
+        public void TestValidateAndGetImageWithEnvVariableInHostAddress(string image, string result, Type expectedException, string variableName, string value)
+        {
+            MockEnvironment mock_env = new MockEnvironment();
+            mock_env.SetVariable(variableName, value);
+
+            if (expectedException != null)
+            {
+                Assert.Throws(expectedException, () => DockerConfig.ValidateAndGetImage(image, mock_env));
+            }
+            else
+            {
+                string updatedImage = DockerConfig.ValidateAndGetImage(image, mock_env);
                 Assert.Equal(result, updatedImage);
             }
         }


### PR DESCRIPTION
Edge Agent can now dereference env var in image name.
For example:
$upstream:8000/azureiotedge-hub:1.0.10-private-preview
will be evaluated as
parenthostname:8000/azureiotedge-hub:1.0.10-private-preview