### PR TITLE
Policy engine enhancements

### DIFF
--- a/mqtt/policy/src/core/builder.rs
+++ b/mqtt/policy/src/core/builder.rs
@@ -4,7 +4,6 @@ use serde::Deserialize;
 
 use crate::{
     core::{Effect as CoreEffect, EffectOrd, Identities, Operations, Resources},
-    validator::Field,
     Decision, DefaultResourceMatcher, DefaultSubstituter, DefaultValidator, Error, Policy,
     PolicyValidator, ResourceMatcher, Result, Substituter,
 };
@@ -94,17 +93,14 @@ where
     ///
     /// Any validation errors are collected and returned as `Error::ValidationSummary`.
     pub fn build(self) -> Result<Policy<M, S>> {
-        let mut definition: PolicyDefinition20201030 =
+        let mut definition: PolicyDefinition =
             serde_json::from_str(&self.json).map_err(Error::Deserializing)?;
 
         for (order, mut statement) in definition.statements.iter_mut().enumerate() {
             statement.order = order;
         }
 
-        let errors = self.validate(&definition);
-        if !errors.is_empty() {
-            return Err(Error::ValidationSummary(errors));
-        }
+        self.validate(&definition)?;
 
         let mut static_rules = Identities::new();
         let mut variable_rules = Identities::new();
@@ -122,42 +118,13 @@ where
         })
     }
 
-    fn validate(&self, definition: &PolicyDefinition20201030) -> Vec<Error> {
-        definition
-            .statements
-            .iter()
-            .flat_map(|statement| {
-                let des_errors = self
-                    .validator
-                    .validate(Field::Description, &statement.description)
-                    .err();
-
-                let ids_errors = statement
-                    .identities
-                    .iter()
-                    .filter_map(|id| self.validator.validate(Field::Identities, id).err());
-
-                let ops_errors = statement
-                    .operations
-                    .iter()
-                    .filter_map(|op| self.validator.validate(Field::Operations, op).err());
-
-                let res_errors = statement
-                    .resources
-                    .iter()
-                    .filter_map(|res| self.validator.validate(Field::Resources, res).err());
-
-                ids_errors
-                    .chain(ops_errors)
-                    .chain(res_errors)
-                    .chain(des_errors)
-            })
-            .collect()
+    fn validate(&self, definition: &PolicyDefinition) -> Result<()> {
+        self.validator.validate(definition)
     }
 }
 
 fn process_statement(
-    statement: &Statement20201030,
+    statement: &Statement,
     static_rules: &mut Identities,
     variable_rules: &mut Identities,
 ) {
@@ -167,7 +134,7 @@ fn process_statement(
     variable_rules.merge(variable_ids);
 }
 
-fn process_identities(statement: &Statement20201030) -> (Identities, Identities) {
+fn process_identities(statement: &Statement) -> (Identities, Identities) {
     let mut static_ids = Identities::new();
     let mut variable_ids = Identities::new();
     for identity in &statement.identities {
@@ -191,7 +158,7 @@ fn process_identities(statement: &Statement20201030) -> (Identities, Identities)
     (static_ids, variable_ids)
 }
 
-fn process_operations(statement: &Statement20201030) -> (Operations, Operations) {
+fn process_operations(statement: &Statement) -> (Operations, Operations) {
     let mut static_ops = Operations::new();
     let mut variable_ops = Operations::new();
     for operation in &statement.operations {
@@ -215,7 +182,7 @@ fn process_operations(statement: &Statement20201030) -> (Operations, Operations)
     (static_ops, variable_ops)
 }
 
-fn process_resources(statement: &Statement20201030) -> (Resources, Resources) {
+fn process_resources(statement: &Statement) -> (Resources, Resources) {
     let mut static_res = Resources::new();
     let mut variable_res = Resources::new();
     if statement.resources.is_empty() {
@@ -244,38 +211,42 @@ fn is_variable_rule(value: &str) -> bool {
     VAR_PATTERN.is_match(value)
 }
 
+/// Represents a deserialized policy definition.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct PolicyDefinition20201030 {
-    statements: Vec<Statement20201030>,
+pub struct PolicyDefinition {
+    pub schema_version: String,
+    pub statements: Vec<Statement>,
 }
 
+/// Represents a statement in a policy definition.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct Statement20201030 {
+pub struct Statement {
     #[serde(default)]
     order: usize,
     #[serde(default)]
-    description: String,
-    effect: Effect20201030,
-    identities: Vec<String>,
-    operations: Vec<String>,
+    pub description: String,
+    pub effect: Effect,
+    pub identities: Vec<String>,
+    pub operations: Vec<String>,
     #[serde(default)]
-    resources: Vec<String>,
+    pub resources: Vec<String>,
 }
 
+/// Represents an effect on a statement.
 #[derive(Deserialize, Copy, Clone)]
 #[serde(rename_all = "camelCase")]
-enum Effect20201030 {
+pub enum Effect {
     Allow,
     Deny,
 }
 
-impl Into<EffectOrd> for &Statement20201030 {
+impl Into<EffectOrd> for &Statement {
     fn into(self) -> EffectOrd {
         match self.effect {
-            Effect20201030::Allow => EffectOrd::new(CoreEffect::Allow, self.order),
-            Effect20201030::Deny => EffectOrd::new(CoreEffect::Deny, self.order),
+            Effect::Allow => EffectOrd::new(CoreEffect::Allow, self.order),
+            Effect::Deny => EffectOrd::new(CoreEffect::Deny, self.order),
         }
     }
 }
@@ -689,18 +660,17 @@ mod tests {
             .with_default_decision(Decision::Denied)
             .build();
 
-        assert_matches!(result, Err(Error::ValidationSummary(errors)) if errors.len() == 8 );
+        assert_matches!(result, Err(Error::ValidationSummary(errors)) if errors.len() == 1 );
     }
 
     #[derive(Debug)]
     struct FailAllValidator;
 
     impl PolicyValidator for FailAllValidator {
-        fn validate(&self, field: Field, value: &str) -> Result<()> {
-            Err(Error::Validation(format!(
-                "Unable to parse value {:?} for field {:?}",
-                value, field
-            )))
+        fn validate(&self, _definition: &PolicyDefinition) -> Result<()> {
+            Err(Error::ValidationSummary(vec![Error::Validation(
+                "Unable to parse policy definition".to_string(),
+            )]))
         }
     }
 }

--- a/mqtt/policy/src/core/mod.rs
+++ b/mqtt/policy/src/core/mod.rs
@@ -348,6 +348,15 @@ impl From<EffectOrd> for Decision {
     }
 }
 
+impl From<&Statement> for EffectOrd {
+    fn from(statement: &Statement) -> Self {
+        match statement.effect() {
+            builder::Effect::Allow => EffectOrd::new(Effect::Allow, statement.order()),
+            builder::Effect::Deny => EffectOrd::new(Effect::Deny, statement.order()),
+        }
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;

--- a/mqtt/policy/src/core/mod.rs
+++ b/mqtt/policy/src/core/mod.rs
@@ -7,7 +7,7 @@ use crate::errors::Result;
 use crate::{substituter::Substituter, Error, ResourceMatcher};
 
 mod builder;
-pub use builder::PolicyBuilder;
+pub use builder::{PolicyBuilder, PolicyDefinition, Statement};
 
 /// Policy engine. Represents a read-only set of rules and can
 /// evaluate `Request` based on those rules.
@@ -26,15 +26,15 @@ pub struct Policy<R, S> {
     variable_rules: BTreeMap<String, Operations>,
 }
 
-impl<R, S> Policy<R, S>
+impl<R, S, RC> Policy<R, S>
 where
-    R: ResourceMatcher,
-    S: Substituter,
+    R: ResourceMatcher<Context = RC>,
+    S: Substituter<Context = RC>,
 {
     /// Evaluates the provided `&Request` and produces the `Decision`.
     ///
     /// If no rules match the `&Request` - the default `Decision` is returned.
-    pub fn evaluate(&self, request: &Request) -> Result<Decision> {
+    pub fn evaluate(&self, request: &Request<RC>) -> Result<Decision> {
         match self.eval_static_rules(request) {
             // static rules not defined. Need to check variable rules.
             Ok(EffectOrd {
@@ -76,7 +76,7 @@ where
         }
     }
 
-    fn eval_static_rules(&self, request: &Request) -> Result<EffectOrd> {
+    fn eval_static_rules(&self, request: &Request<RC>) -> Result<EffectOrd> {
         // lookup an identity
         match self.static_rules.get(&request.identity) {
             // identity exists. Look up operations.
@@ -100,7 +100,7 @@ where
         }
     }
 
-    fn eval_variable_rules(&self, request: &Request) -> Result<EffectOrd> {
+    fn eval_variable_rules(&self, request: &Request<RC>) -> Result<EffectOrd> {
         for (identity, operations) in &self.variable_rules {
             // process identity variables.
             let identity = self.substituter.visit_identity(identity, request)?;
@@ -223,18 +223,39 @@ impl From<BTreeMap<String, EffectOrd>> for Resources {
 
 /// Represents a request that needs to be `evaluate`d by `Policy` engine.
 #[derive(Debug)]
-pub struct Request {
+pub struct Request<RC> {
     identity: String,
     operation: String,
     resource: String,
+
+    /// Optional request context that can be used for request processing.
+    context: Option<RC>,
 }
 
-impl Request {
+impl<RC> Request<RC> {
     /// Creates a new `Request`. Returns an error if either identity or operation is an empty string.
     pub fn new(
         identity: impl Into<String>,
         operation: impl Into<String>,
         resource: impl Into<String>,
+    ) -> Result<Self> {
+        Self::create(identity, operation, resource, None)
+    }
+
+    pub fn with_context(
+        identity: impl Into<String>,
+        operation: impl Into<String>,
+        resource: impl Into<String>,
+        context: RC,
+    ) -> Result<Self> {
+        Self::create(identity, operation, resource, Some(context))
+    }
+
+    fn create(
+        identity: impl Into<String>,
+        operation: impl Into<String>,
+        resource: impl Into<String>,
+        context: Option<RC>,
     ) -> Result<Self> {
         let (identity, operation, resource) = (identity.into(), operation.into(), resource.into());
 
@@ -250,7 +271,12 @@ impl Request {
             identity,
             operation,
             resource,
+            context,
         })
+    }
+
+    pub fn context(&self) -> Option<&RC> {
+        self.context.as_ref()
     }
 }
 
@@ -401,12 +427,7 @@ pub(crate) mod tests {
         }"#;
 
         // assert default allow
-        let request = Request::new(
-            "contoso.azure-devices.net/some_other_device",
-            "write",
-            "resource_1",
-        )
-        .unwrap();
+        let request = Request::new("other_actor", "write", "resource_1").unwrap();
 
         let allow_default_policy = PolicyBuilder::from_json(json)
             .with_default_decision(Decision::Allowed)
@@ -570,11 +591,13 @@ pub(crate) mod tests {
     struct TestSubstituter;
 
     impl Substituter for TestSubstituter {
-        fn visit_identity(&self, _value: &str, context: &Request) -> Result<String> {
+        type Context = ();
+
+        fn visit_identity(&self, _value: &str, context: &Request<Self::Context>) -> Result<String> {
             Ok(context.identity.clone())
         }
 
-        fn visit_resource(&self, _value: &str, context: &Request) -> Result<String> {
+        fn visit_resource(&self, _value: &str, context: &Request<Self::Context>) -> Result<String> {
             Ok(context.resource.clone())
         }
     }

--- a/mqtt/policy/src/lib.rs
+++ b/mqtt/policy/src/lib.rs
@@ -17,8 +17,8 @@ mod matcher;
 mod substituter;
 mod validator;
 
-pub use crate::core::PolicyBuilder;
 pub use crate::core::{Decision, Policy, Request};
+pub use crate::core::{PolicyBuilder, PolicyDefinition, Statement};
 pub use crate::errors::{Error, Result};
 pub use crate::matcher::{DefaultResourceMatcher, ResourceMatcher};
 pub use crate::substituter::{DefaultSubstituter, Substituter};

--- a/mqtt/policy/src/matcher.rs
+++ b/mqtt/policy/src/matcher.rs
@@ -2,16 +2,21 @@ use crate::core::Request;
 
 /// Trait to extend `Policy` engine core resource matching.
 pub trait ResourceMatcher {
+    /// The type of the context associated with the request.
+    type Context;
+
     /// This method is being called by `Policy` when it tries to match a `Request` to
     /// a resource in the policy rules.
-    fn do_match(&self, context: &Request, input: &str, policy: &str) -> bool;
+    fn do_match(&self, context: &Request<Self::Context>, input: &str, policy: &str) -> bool;
 }
 
 #[derive(Debug)]
 pub struct DefaultResourceMatcher;
 
 impl ResourceMatcher for DefaultResourceMatcher {
-    fn do_match(&self, _context: &Request, input: &str, policy: &str) -> bool {
+    type Context = ();
+
+    fn do_match(&self, _context: &Request<Self::Context>, input: &str, policy: &str) -> bool {
         input == policy
     }
 }

--- a/mqtt/policy/src/substituter.rs
+++ b/mqtt/policy/src/substituter.rs
@@ -2,22 +2,42 @@ use crate::{Error, Request};
 
 /// Trait to extend `Policy` variable rules resolution.
 pub trait Substituter {
+    /// The type of the context associated with the request.
+    type Context;
+
     /// This method is called by `Policy` on every `Request` for every variable identity rule.
-    fn visit_identity(&self, value: &str, context: &Request) -> Result<String, Error>;
+    fn visit_identity(
+        &self,
+        value: &str,
+        context: &Request<Self::Context>,
+    ) -> Result<String, Error>;
 
     /// This method is called by `Policy` on every `Request` for every variable resource rule.
-    fn visit_resource(&self, value: &str, context: &Request) -> Result<String, Error>;
+    fn visit_resource(
+        &self,
+        value: &str,
+        context: &Request<Self::Context>,
+    ) -> Result<String, Error>;
 }
 
 #[derive(Debug)]
 pub struct DefaultSubstituter;
 
 impl Substituter for DefaultSubstituter {
-    fn visit_identity(&self, value: &str, _context: &Request) -> Result<String, Error> {
+    type Context = ();
+    fn visit_identity(
+        &self,
+        value: &str,
+        _context: &Request<Self::Context>,
+    ) -> Result<String, Error> {
         Ok(value.to_string())
     }
 
-    fn visit_resource(&self, value: &str, _context: &Request) -> Result<String, Error> {
+    fn visit_resource(
+        &self,
+        value: &str,
+        _context: &Request<Self::Context>,
+    ) -> Result<String, Error> {
         Ok(value.to_string())
     }
 }

--- a/mqtt/policy/src/validator.rs
+++ b/mqtt/policy/src/validator.rs
@@ -1,27 +1,19 @@
-use crate::errors::Result;
+use crate::{errors::Result, PolicyDefinition};
 
 /// Trait to extend `PolicyBuilder` validation for policy definition.
 pub trait PolicyValidator {
-    /// This method is being called by `PolicyBuilder` on every filed in policy definition
+    /// This method is being called by `PolicyBuilder` for policy definition
     /// while `Policy` is being constructed.
     ///
-    /// If a field fails the validation, the error is returned.
-    fn validate(&self, field: Field, value: &str) -> Result<()>;
-}
-
-#[derive(Debug)]
-pub enum Field {
-    Identities,
-    Operations,
-    Resources,
-    Description,
+    /// If a policy definitions fails the validation, the error is returned.
+    fn validate(&self, definition: &PolicyDefinition) -> Result<()>;
 }
 
 #[derive(Debug)]
 pub struct DefaultValidator;
 
 impl PolicyValidator for DefaultValidator {
-    fn validate(&self, _field: Field, _value: &str) -> Result<()> {
+    fn validate(&self, _definition: &PolicyDefinition) -> Result<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
As part of the work to integrate policy engine into MQTT broker, I'm doing some enhancements:
- Added Context as an associated type to the Request. That context will have info needed for proper work of Substituter.
   - In case of MQTT broker, `type Context = auth::Activity`, and `MqttSubstituter` will get access to `Activity` struct to extract identity and other related info.
- Changed Validator to accept the whole statement to make validation more flexible.

This is the first PR in a series of PRs that yet to come. Just wanted to push it in smaller chunks.