### PR TITLE
Add `always_reprovision_on_startup` setting to DPS  provisioning configuration

### DIFF
--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -65,6 +65,17 @@
 #                       The value should be specified as a URI.
 #                       Ex. when specifying a PEM encoded private key file, the URI
 #                       should be specified as file:///path/identity_key.pem
+#     always_reprovision_on_startup
+#                     - Optional. If set to false, The daemon will attempt to restore
+#                       the provisioning backup from a previous successful provisioning,
+#                       if any, and only attempt to provision with DPS if that fails.
+#                       Defaults to true, which means the daemon will always attempt to
+#                       provision with DPS, and only fall back to the provisioning backup
+#                       from a previous successful provisioning if the attempt fails.
+#
+#                       If setting this to false, it's recommended to also set
+#                       dynamic_reprovisioning (see below) to true, so that the device can
+#                       automatically reprovision itself if it needs to.
 #
 # External Settings
 #     endpoint - Required. Value of the endpoint used to retrieve device specific
@@ -107,6 +118,7 @@ provisioning:
 #   attestation:
 #     method: "tpm"
 #     registration_id: "<REGISTRATION_ID>"
+#   always_reprovision_on_startup: true
 #   dynamic_reprovisioning: false
 
 # DPS symmetric key provisioning configuration
@@ -118,6 +130,7 @@ provisioning:
 #     method: "symmetric_key"
 #     registration_id: "<REGISTRATION_ID>"
 #     symmetric_key: "<SYMMETRIC_KEY>"
+#   always_reprovision_on_startup: true
 #   dynamic_reprovisioning: false
 
 # DPS X.509 provisioning configuration
@@ -130,6 +143,7 @@ provisioning:
 #     registration_id: "<OPTIONAL REGISTRATION ID. LEAVE COMMENTED OUT TO REGISTER WITH CN OF identity_cert>"
 #     identity_cert: "<REQUIRED URI TO DEVICE IDENTITY CERTIFICATE>"
 #     identity_pk: "<REQUIRED URI TO DEVICE IDENTITY PRIVATE KEY>"
+#   always_reprovision_on_startup: true
 #   dynamic_reprovisioning: false
 
 # External provisioning configuration

--- a/edgelet/contrib/config/windows/config.yaml
+++ b/edgelet/contrib/config/windows/config.yaml
@@ -65,6 +65,17 @@
 #                       The value should be specified as a URI.
 #                       Ex. when specifying a PEM encoded private key file, the URI
 #                       should be specified as file:///C:/identity_key.pem
+#     always_reprovision_on_startup
+#                     - Optional. If set to false, The daemon will attempt to restore
+#                       the provisioning backup from a previous successful provisioning,
+#                       if any, and only attempt to provision with DPS if that fails.
+#                       Defaults to true, which means the daemon will always attempt to
+#                       provision with DPS, and only fall back to the provisioning backup
+#                       from a previous successful provisioning if the attempt fails.
+#
+#                       If setting this to false, it's recommended to also set
+#                       dynamic_reprovisioning (see below) to true, so that the device can
+#                       automatically reprovision itself if it needs to.
 #
 # External Settings
 #     endpoint - Required. Value of the endpoint used to retrieve device specific
@@ -107,6 +118,7 @@ provisioning:
 #   attestation:
 #     method: "tpm"
 #     registration_id: "<REGISTRATION_ID>"
+#   always_reprovision_on_startup: true
 #   dynamic_reprovisioning: false
 
 # DPS symmetric key provisioning configuration
@@ -118,6 +130,7 @@ provisioning:
 #     method: "symmetric_key"
 #     registration_id: "<REGISTRATION_ID>"
 #     symmetric_key: "<SYMMETRIC_KEY>"
+#   always_reprovision_on_startup: true
 #   dynamic_reprovisioning: false
 
 # DPS X.509 provisioning configuration
@@ -130,6 +143,7 @@ provisioning:
 #     registration_id: "<OPTIONAL REGISTRATION ID. LEAVE COMMENTED OUT TO REGISTER WITH CN OF identity_cert>"
 #     identity_cert: "<REQUIRED URI TO DEVICE IDENTITY CERTIFICATE>"
 #     identity_pk: "<REQUIRED URI TO DEVICE IDENTITY PRIVATE KEY>"
+#   always_reprovision_on_startup: true
 #   dynamic_reprovisioning: false
 
 # External provisioning configuration

--- a/edgelet/edgelet-core/src/settings.rs
+++ b/edgelet/edgelet-core/src/settings.rs
@@ -323,6 +323,7 @@ pub struct Dps {
     global_endpoint: Url,
     scope_id: String,
     attestation: AttestationMethod,
+    always_reprovision_on_startup: bool,
 }
 
 impl<'de> serde::Deserialize<'de> for Dps {
@@ -338,6 +339,7 @@ impl<'de> serde::Deserialize<'de> for Dps {
             registration_id: Option<String>,
             #[serde(skip_serializing_if = "Option::is_none")]
             attestation: Option<AttestationMethod>,
+            always_reprovision_on_startup: Option<bool>,
         }
 
         let value: Inner = serde::Deserialize::deserialize(deserializer)?;
@@ -361,6 +363,7 @@ impl<'de> serde::Deserialize<'de> for Dps {
             global_endpoint: value.global_endpoint,
             scope_id: value.scope_id,
             attestation,
+            always_reprovision_on_startup: value.always_reprovision_on_startup.unwrap_or(true),
         })
     }
 }
@@ -376,6 +379,10 @@ impl Dps {
 
     pub fn attestation(&self) -> &AttestationMethod {
         &self.attestation
+    }
+
+    pub fn always_reprovision_on_startup(&self) -> bool {
+        self.always_reprovision_on_startup
     }
 }
 

--- a/edgelet/iotedged/src/lib.rs
+++ b/edgelet/iotedged/src/lib.rs
@@ -36,12 +36,12 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use failure::{Context, Fail, ResultExt};
-use futures::future::{Either, IntoFuture};
+use futures::future::Either;
 use futures::sync::oneshot::{self, Receiver};
 use futures::{future, Future, Stream};
 use hyper::server::conn::Http;
 use hyper::{Body, Request, Uri};
-use log::{debug, info, Level};
+use log::{debug, error, info, Level};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
@@ -73,7 +73,6 @@ use edgelet_http_mgmt::ManagementService;
 use edgelet_http_workload::WorkloadService;
 use edgelet_iothub::{HubIdentityManager, SasTokenSource};
 use edgelet_utils::log_failure;
-pub use error::{Error, ErrorKind, InitializeErrorReason};
 use hsm::tpm::Tpm;
 use hsm::ManageTpmKeys;
 use iothubservice::DeviceClient;
@@ -83,8 +82,9 @@ use provisioning::provisioning::{
     ProvisioningResult, ReprovisioningStatus,
 };
 
-use crate::error::ExternalProvisioningErrorReason;
-use crate::workload::WorkloadData;
+use error::ExternalProvisioningErrorReason;
+pub use error::{Error, ErrorKind, InitializeErrorReason};
+use workload::WorkloadData;
 
 const EDGE_RUNTIME_MODULEID: &str = "$edgeAgent";
 const EDGE_RUNTIME_MODULE_NAME: &str = "edgeAgent";
@@ -567,9 +567,8 @@ where
                     AttestationMethod::Tpm(ref tpm) => {
                         info!("Starting provisioning edge device via TPM...");
                         let (tpm_instance, dps_tpm) =
-                            dps_tpm_provision_init(&dps, hyper_client.clone(), tpm)?;
+                            dps_tpm_provision_init(&dps, hyper_client.clone(), tpm, dps_path)?;
                         let (key_store, provisioning_result, root_key) = dps_tpm_provision(
-                            dps_path,
                             &mut tokio_runtime,
                             hsm_lock,
                             tpm_instance,
@@ -591,10 +590,10 @@ where
                             &dps,
                             hyper_client.clone(),
                             symmetric_key_info,
+                            dps_path,
                         )?;
                         let (key_store, provisioning_result, root_key) =
                             dps_symmetric_key_provision(
-                                dps_path,
                                 &mut tokio_runtime,
                                 memory_hsm,
                                 &dps_symmetric_key,
@@ -621,12 +620,12 @@ where
                             x509_info,
                             hybrid_identity_key,
                             &id_data.common_name,
+                            dps_path,
                         )?;
 
                         let (key_store, provisioning_result, root_key) = dps_x509_provision(
                             memory_hsm,
                             &dps_x509,
-                            dps_path,
                             &mut tokio_runtime,
                             id_data.thumbprint.clone(),
                         )?;
@@ -1515,16 +1514,13 @@ where
 
     // This mpsc sender/receiver is used for getting notifications from the mgmt service
     // indicating that the daemon should shut down and attempt to reprovision the device.
-    let mgmt_stop_and_reprovision_signaled = mgmt_stop_and_reprovision_rx
-        .then(|res| match res {
-            Ok(_) => Err(None),
-            Err(_) => Err(Some(Error::from(ErrorKind::ManagementService))),
-        })
-        .for_each(move |_x: Option<Error>| Ok(()))
-        .then(|res| match res {
-            Ok(_) | Err(None) => Ok(None),
-            Err(Some(e)) => Err(Some(e)),
-        });
+    let mgmt_stop_and_reprovision_signaled =
+        mgmt_stop_and_reprovision_rx
+            .into_future()
+            .then(|res| match res {
+                Ok((Some(()), _)) | Ok((None, _)) => Ok(()),
+                Err(((), _)) => Err(Error::from(ErrorKind::ManagementService)),
+            });
 
     let mgmt_stop_and_reprovision_signaled = if settings.provisioning().dynamic_reprovisioning() {
         futures::future::Either::B(mgmt_stop_and_reprovision_signaled)
@@ -1533,25 +1529,22 @@ where
     };
 
     let edge_rt_with_mgmt_signal = edge_rt.select2(mgmt_stop_and_reprovision_signaled).then(
-        |res: Result<
-            Either<((), _), (Option<Error>, _)>,
-            Either<(Error, _), (Option<Error>, _)>,
-        >| {
-            // A -> EdgeRt Future
-            // B -> Mgmt Stop and Reprovision Signal Future
-            match res {
-                Ok(Either::A((_x, _y))) => {
-                    Ok((StartApiReturnStatus::Shutdown, false)).into_future()
-                }
-                Ok(Either::B((_x, _y))) => {
-                    debug!("Shutdown with device reprovisioning.");
-                    Ok((StartApiReturnStatus::Shutdown, true)).into_future()
-                }
-                Err(Either::A((err, _y))) => Err(err).into_future(),
-                Err(Either::B((err, _y))) => {
-                    debug!("The mgmt shutdown and reprovision signal failed.");
-                    Err(err.unwrap()).into_future()
-                }
+        |res| match res {
+            Ok(Either::A((_edge_rt_ok, _mgmt_stop_and_reprovision_signaled_future))) => {
+                info!("Edge runtime will stop because of the shutdown signal.");
+                future::ok((StartApiReturnStatus::Shutdown, false))
+            }
+            Ok(Either::B((_mgmt_stop_and_reprovision_signaled_ok, _edge_rt_future))) => {
+                info!("Edge runtime will stop because of the device reprovisioning signal.");
+                future::ok((StartApiReturnStatus::Shutdown, true))
+            }
+            Err(Either::A((edge_rt_err, _mgmt_stop_and_reprovision_signaled_future))) => {
+                error!("Edge runtime will stop because the shutdown signal raised an error.");
+                future::err(edge_rt_err)
+            },
+            Err(Either::B((mgmt_stop_and_reprovision_signaled_err, _edge_rt_future))) => {
+                error!("Edge runtime will stop because the device reprovisioning signal raised an error.");
+                future::err(mgmt_stop_and_reprovision_signaled_err)
             }
         },
     );
@@ -1567,12 +1560,17 @@ where
             // A -> EdgeRt + Mgmt Stop and Reprovision Signal Future
             // B -> Restart Signal Future
             match res {
-                Ok(Either::A((x, _))) => Ok((StartApiReturnStatus::Shutdown, x.1)).into_future(),
-                Ok(Either::B(_)) => Ok((StartApiReturnStatus::Restart, false)).into_future(),
-                Err(Either::A((err, _))) => Err(err).into_future(),
+                Ok(Either::A((
+                    (start_api_return_status, should_reprovision),
+                    _restart_rx_future,
+                ))) => future::ok((start_api_return_status, should_reprovision)),
+                Ok(Either::B((_restart_rx_ok, _edge_rt_future))) => {
+                    future::ok((StartApiReturnStatus::Restart, false))
+                }
+                Err(Either::A((err, _))) => future::err(err),
                 Err(Either::B(_)) => {
                     debug!("The restart signal failed, shutting down.");
-                    Ok((StartApiReturnStatus::Shutdown, false)).into_future()
+                    future::ok((StartApiReturnStatus::Shutdown, false))
                 }
             }
         });
@@ -1673,7 +1671,8 @@ fn dps_x509_provision_init<HC>(
     x509_info: &X509AttestationInfo,
     hybrid_identity_key: Option<Vec<u8>>,
     common_name: &str,
-) -> Result<(MemoryKeyStore, DpsX509Provisioning<HC>), Error>
+    backup_path: PathBuf,
+) -> Result<(MemoryKeyStore, impl Provision<Hsm = MemoryKeyStore>), Error>
 where
     HC: 'static + ClientImpl,
 {
@@ -1690,7 +1689,7 @@ where
     memory_hsm
         .activate_identity_key(KeyIdentity::Device, "primary".to_string(), key_bytes)
         .context(ErrorKind::ActivateSymmetricKey)?;
-    let dps_x509 = DpsX509Provisioning::new(
+    let provisioner = DpsX509Provisioning::new(
         hyper_client,
         dps.global_endpoint().clone(),
         dps.scope_id().to_string(),
@@ -1700,24 +1699,24 @@ where
     .context(ErrorKind::Initialize(
         InitializeErrorReason::DpsProvisioningClient,
     ))?;
+    let always_reprovision_on_startup = dps.always_reprovision_on_startup();
+    let provisioner =
+        BackupProvisioning::new(provisioner, backup_path, !always_reprovision_on_startup);
 
-    Ok((memory_hsm, dps_x509))
+    Ok((memory_hsm, provisioner))
 }
 
 #[allow(clippy::too_many_arguments)]
-fn dps_x509_provision<HC>(
+fn dps_x509_provision<P>(
     memory_hsm: MemoryKeyStore,
-    dps: &DpsX509Provisioning<HC>,
-    backup_path: PathBuf,
+    provisioner: &P,
     tokio_runtime: &mut tokio::runtime::Runtime,
     cert_thumbprint: String,
 ) -> Result<(DerivedKeyStore<MemoryKey>, ProvisioningResult, MemoryKey), Error>
 where
-    HC: 'static + ClientImpl,
+    P: Provision<Hsm = MemoryKeyStore>,
 {
-    let provision_with_file_backup = BackupProvisioning::new(dps, backup_path);
-
-    let provision = provision_with_file_backup
+    let provision = provisioner
         .provision(memory_hsm.clone())
         .map_err(|err| {
             Error::from(err.context(ErrorKind::Initialize(
@@ -1826,7 +1825,8 @@ fn dps_symmetric_key_provision_init<HC>(
     provisioning: &Dps,
     hyper_client: HC,
     key: &SymmetricKeyAttestationInfo,
-) -> Result<(MemoryKeyStore, DpsSymmetricKeyProvisioning<HC>), Error>
+    backup_path: PathBuf,
+) -> Result<(MemoryKeyStore, impl Provision<Hsm = MemoryKeyStore>), Error>
 where
     HC: 'static + ClientImpl,
 {
@@ -1838,7 +1838,7 @@ where
         .activate_identity_key(KeyIdentity::Device, "primary".to_string(), key_bytes)
         .context(ErrorKind::ActivateSymmetricKey)?;
 
-    let dps = DpsSymmetricKeyProvisioning::new(
+    let provisioner = DpsSymmetricKeyProvisioning::new(
         hyper_client,
         provisioning.global_endpoint().clone(),
         provisioning.scope_id().to_string(),
@@ -1848,22 +1848,22 @@ where
     .context(ErrorKind::Initialize(
         InitializeErrorReason::DpsProvisioningClient,
     ))?;
-    Ok((memory_hsm, dps))
+    let always_reprovision_on_startup = provisioning.always_reprovision_on_startup();
+    let provisioner =
+        BackupProvisioning::new(provisioner, backup_path, !always_reprovision_on_startup);
+    Ok((memory_hsm, provisioner))
 }
 
-fn dps_symmetric_key_provision<HC>(
-    backup_path: PathBuf,
+fn dps_symmetric_key_provision<P>(
     tokio_runtime: &mut tokio::runtime::Runtime,
     memory_hsm: MemoryKeyStore,
-    dps: &DpsSymmetricKeyProvisioning<HC>,
+    provisioner: &P,
 ) -> Result<(DerivedKeyStore<MemoryKey>, ProvisioningResult, MemoryKey), Error>
 where
-    HC: 'static + ClientImpl,
+    P: Provision<Hsm = MemoryKeyStore>,
 {
-    let provision_with_file_backup = BackupProvisioning::new(dps, backup_path);
-
     let provision =
-        provision_with_file_backup
+        provisioner
             .provision(memory_hsm.clone())
             .map_err(|err| {
                 Error::from(err.context(ErrorKind::Initialize(
@@ -1886,7 +1886,8 @@ fn dps_tpm_provision_init<HC>(
     provisioning: &Dps,
     hyper_client: HC,
     tpm_attestation_info: &TpmAttestationInfo,
-) -> Result<(Tpm, DpsTpmProvisioning<HC>), Error>
+    backup_path: PathBuf,
+) -> Result<(Tpm, impl Provision<Hsm = TpmKeyStore>), Error>
 where
     HC: 'static + ClientImpl,
 {
@@ -1914,7 +1915,7 @@ where
     let srk_result = tpm.get_srk().context(ErrorKind::Initialize(
         InitializeErrorReason::DpsProvisioningClient,
     ))?;
-    let dps = DpsTpmProvisioning::new(
+    let provisioner = DpsTpmProvisioning::new(
         hyper_client,
         provisioning.global_endpoint().clone(),
         provisioning.scope_id().to_string(),
@@ -1926,24 +1927,25 @@ where
     .context(ErrorKind::Initialize(
         InitializeErrorReason::DpsProvisioningClient,
     ))?;
-    Ok((tpm, dps))
+    let always_reprovision_on_startup = provisioning.always_reprovision_on_startup();
+    let provisioner =
+        BackupProvisioning::new(provisioner, backup_path, !always_reprovision_on_startup);
+    Ok((tpm, provisioner))
 }
 
-fn dps_tpm_provision<HC>(
-    backup_path: PathBuf,
+fn dps_tpm_provision<P>(
     tokio_runtime: &mut tokio::runtime::Runtime,
     hsm_lock: Arc<HsmLock>,
     tpm: Tpm,
-    dps: &DpsTpmProvisioning<HC>,
+    provisioner: &P,
 ) -> Result<(DerivedKeyStore<TpmKey>, ProvisioningResult, TpmKey), Error>
 where
-    HC: 'static + ClientImpl,
+    P: Provision<Hsm = TpmKeyStore>,
 {
     let tpm_hsm = TpmKeyStore::from_hsm(tpm, hsm_lock).context(ErrorKind::Initialize(
         InitializeErrorReason::DpsProvisioningClient,
     ))?;
-    let provision_with_file_backup = BackupProvisioning::new(dps, backup_path);
-    let provision = provision_with_file_backup
+    let provision = provisioner
         .provision(tpm_hsm.clone())
         .map_err(|err| {
             Error::from(err.context(ErrorKind::Initialize(

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -1833,7 +1833,7 @@ function Set-ProvisioningMode {
                 $selectionRegex += '\s*#?\s*identity_cert:\s".*"\s*#?\s*identity_pk:\s".*"'
             }
 
-            $selectionRegex += '\s*#?\s*dynamic_reprovisioning:\s*.*'
+            $selectionRegex += '\s*#?\s*always_reprovision_on_startup:\s*.*\s*#?\s*dynamic_reprovisioning:\s*.*'
             $replacementContent = @(
                 'provisioning:',
                 '  source: ''dps''',
@@ -1857,6 +1857,7 @@ function Set-ProvisioningMode {
             }
 
             $replacementContent += "  dynamic_reprovisioning: $DynamicReprovisioning"
+            $replacementContent += '  always_reprovision_on_startup: true'
             $configurationYaml = $configurationYaml -replace $selectionRegex, ($replacementContent -join "`n")
 
             $selectionRegex = '(?:[^\S\n]*#[^\S\n]*)?provisioning:\s*#?\s*source:\s*".*"\s*#?\s*device_connection_string:\s*".*"\s*#?\s*dynamic_reprovisioning:\s*.*'


### PR DESCRIPTION
Cherry-pick from master of 1254c76b9b8109b3b3fb0311ced00242fbb2164c

Before this change, when using any of the DPS provisioning methods,
iotedged would always reprovision with DPS on startup. It would maintain
a provisioning backup, but this backup was only used if the provisioning
with DPS failed for any reason.

If the new setting in this change is set to false, iotedged will first attempt
to restore the backup, and only reprovision with DPS if that fails.

The primary reason this was done was due to a quirk of DPS-TPM provisioning.
`iotedged`, or rather `utpm` as used by `libiothsm-std`, reserves a single slot
on the TPM to store keys. However DPS-TPM provisioning involves two keys that
must be loaded in the TPM - the initial challenge key and the final
device identity key. Thus the DPS-TPM provisioning method must store
the challenge key in the same slot that occupied
the previous device identity key. However, if the second part of
DPS-TPM provisioning fails and `iotedged` never receives
the new device identity key, the previous device identity key is
irrevocably lost even if the rest of the information can be restored from
the provisioning backup.

This creates a problem when modules request their SAS tokens to be signed
so they can talk to Edge Hub, `iotedged` will derive their module identity keys
using the device identity key that is actually the challenge key.
However Edge Hub will validate the SAS tokens against the module identity keys
that it received from IoT Hub, which were derived using the previous
device identity key. So Edge Hub will reject the modules' SAS tokens.

With this change, and if the setting has been set to false, `iotedged` won't
attempt the DPS-TPM provisioning at all, so the "previous" device identity key
in the TPM will remain.

One last thing to be handled carefully is the reprovisioning trigger.
If the device identity was deleted from IoT Hub, then before this change
the reprovision on startup would've caught it. With this change, the only way
it can be detected is when Edge Agent fails to connect to IoT Hub and thus
triggers a reprovision using the management API. However triggering the
reprovision using the management API is itself opt-in using
the `dynamic_reprovisioning` config flag.

Note that the `always_reprovision_on_startup` seting defaults to true
to retain the original behavior of always reprovisioning on startup,
for backward-compatiblity. However it is not expected that there would be
any problems from setting it to false.

Also note that this change makes `BackupProvisioning` generic over
the underlying provisioner (as it was always intended to be) rather than being
an internal detail of the three DPS provisioning methods. This means it could
be used for other provisioning methods like external in the future.
In this case, the `always_reprovision_on_startup` config would be moved
from being DPS-specific to applying to all provisioning methods. Luckily,
this can be done without any backward-incompatible changes to the config,
because the provisioning method parameters are already flattened, so that
the `always_reprovision_on_startup` flag is already at the top-level of
the provisioning settings.