### PR TITLE
Revert "Fix edgeHub restart by supporting version"

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerEnvironment.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerEnvironment.cs
@@ -94,8 +94,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                             dockerModule.ImagePullPolicy,
                             dockerModule.StartupOrder,
                             dockerModule.ConfigurationInfo,
-                            dockerModule.Env,
-                            dockerModule.Version);
+                            dockerModule.Env);
                         break;
 
                     case Core.Constants.EdgeAgentModuleName:
@@ -113,8 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
                             lastExitTime,
                             dockerModule.ImagePullPolicy,
                             dockerModule.ConfigurationInfo,
-                            env,
-                            dockerModule.Version);
+                            env);
                         break;
 
                     default:

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/DockerModule.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
         public string Name { get; set; }
 
         [JsonProperty(PropertyName = "version")]
-        public string Version { get; }
+        public virtual string Version { get; }
 
         [JsonProperty(PropertyName = "status")]
         public virtual ModuleStatus DesiredStatus { get; }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/EdgeAgentDockerRuntimeModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/EdgeAgentDockerRuntimeModule.cs
@@ -48,7 +48,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             this.DesiredStatus = ModuleStatus.Running;
             this.RestartCount = 0;
             this.LastRestartTimeUtc = DateTime.MinValue;
+            this.Version = version ?? string.Empty;
         }
+
+        [JsonIgnore]
+        public override string Version { get; }
 
         [JsonIgnore]
         public override ModuleStatus DesiredStatus { get; }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/EdgeHubDockerRuntimeModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/EdgeHubDockerRuntimeModule.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             // assignment becomes a no-op.  In order to fix this we need to assign
             // this here again so that the correct property assignment happens for real!
             this.RestartPolicy = Preconditions.CheckIsDefined(restartPolicy);
+            this.Version = version ?? string.Empty;
         }
 
         [JsonConstructor]
@@ -97,6 +98,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             DefaultValueHandling = DefaultValueHandling.Populate)]
         [DefaultValue(RestartPolicy.Always)]
         public override RestartPolicy RestartPolicy { get; }
+
+        [JsonIgnore]
+        public override string Version { get; }
 
         public override IModule WithRuntimeStatus(ModuleStatus newStatus) => new EdgeHubDockerRuntimeModule(
             this.DesiredStatus,

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/EdgeAgentDockerRuntimeModuleTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/EdgeAgentDockerRuntimeModuleTest.cs
@@ -52,8 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
                         imageHash = "someSha",
                         createOptions = "{}"
                     },
-                    env = new { },
-                    version = string.Empty
+                    env = new { }
                 });
 
             Assert.True(JToken.DeepEquals(expected, json));

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/EdgeHubDockerRuntimeModuleTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/EdgeHubDockerRuntimeModuleTest.cs
@@ -50,7 +50,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
   ""lastRestartTimeUtc"": ""0001-01-01T00:00:00"",
   ""runtimeStatus"": ""running"",
   ""type"": ""docker"",
-  ""version"": """",
   ""settings"": {
     ""image"": ""edg0eHubImage:latest"",
     ""createOptions"": ""{}""
@@ -215,7 +214,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
   ""lastRestartTimeUtc"": ""0001-01-01T00:00:00"",
   ""runtimeStatus"": ""running"",
   ""type"": ""docker"",
-  ""version"": """",
   ""settings"": {
     ""image"": ""edg0eHubImage:latest"",
     ""createOptions"": ""{}""


### PR DESCRIPTION
Reverts Azure/iotedge#3405 : Fix edgeHub restart by supporting version

We don't want to expose the `version` 
