### PR TITLE
Refactor AMQP auth to use client auth-chain

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Concurrency;
     using Microsoft.Extensions.Logging;
+    using CoreConstants = Microsoft.Azure.Devices.Edge.Hub.Core.Constants;
 
     /// <summary>
     /// This class is used to get tokens from the Client on the CBS link. It generates
@@ -73,24 +74,42 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             Events.LinkRegistered(link);
         }
 
-        public async Task<bool> AuthenticateAsync(string id, Option<string> modelId)
+        public async Task<bool> AuthenticateAsync(string id, Option<string> modelId, Option<string> authChain)
         {
             try
             {
-                if (this.clientCredentialsMap.TryGetValue(id, out CredentialsInfo credentialsInfo))
+                // See if we received direct credentials for the target identity
+                CredentialsInfo credentialsInfo;
+                bool hasCredentials = this.clientCredentialsMap.TryGetValue(id, out credentialsInfo);
+
+                // Otherwise, this could be a child Edge acting OnBehalfOf of the target,
+                // in which case we would have the actor's credentials instead
+                if (!hasCredentials)
+                {
+                    Option<string> actorDeviceId = AuthChainHelpers.GetActorDeviceId(authChain);
+                    hasCredentials = actorDeviceId.Map(actor => this.clientCredentialsMap.TryGetValue(actor + $"/{CoreConstants.EdgeHubModuleId}", out credentialsInfo)).GetOrElse(false);
+                }
+
+                if (hasCredentials)
                 {
                     // Not -ve caching isAuthenticated here.
                     // If incorrect credentials are sent, then it authenticates every time and fails
                     // If correct credentials are sent later, then the authentication will succeed.
                     if (!credentialsInfo.IsAuthenticated)
                     {
-                        using (await credentialsInfo.AsyncLock.LockAsync())
+                        if (!credentialsInfo.IsAuthenticated)
                         {
-                            if (!credentialsInfo.IsAuthenticated)
-                            {
-                                credentialsInfo.ClientCredentials.ModelId = modelId;
-                                credentialsInfo.IsAuthenticated = await this.authenticator.AuthenticateAsync(credentialsInfo.ClientCredentials);
-                            }
+                            IClientCredentials clientCredentials = this.clientCredentialsFactory.GetWithSasToken(
+                                credentialsInfo.DeviceId,
+                                credentialsInfo.ModuleId.OrDefault(),
+                                string.Empty,
+                                credentialsInfo.Token,
+                                true,
+                                modelId,
+                                authChain);
+
+                            bool isAuthenticated = await this.authenticator.AuthenticateAsync(clientCredentials);
+                            credentialsInfo.IsAuthenticated.Set(isAuthenticated);
                         }
                     }
 
@@ -149,15 +168,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
             try
             {
-                SharedAccessSignature.Parse(iotHubHostName, token);
+                SharedAccessSignature sharedAccessSignature = SharedAccessSignature.Parse(iotHubHostName, token);
+                return (token, sharedAccessSignature.Audience);
             }
             catch (Exception e)
             {
                 throw new InvalidOperationException("Cbs message does not contain a valid token", e);
             }
-
-            string audience = message.ApplicationProperties.Map[CbsConstants.PutToken.Audience] as string;
-            return (token, audience);
         }
 
         internal static (string deviceId, string moduleId) ParseIds(string audience)
@@ -185,10 +202,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
         // Note: This method updates this.clientCredentialsMap, and should be invoked only within this.identitySyncLock
         internal async Task<(AmqpResponseStatusCode, string)> UpdateCbsToken(AmqpMessage message)
         {
-            IClientCredentials clientCredentials;
+            CredentialsInfo newCredentialsInfo;
+
             try
             {
-                clientCredentials = this.GetClientCredentials(message);
+                newCredentialsInfo = this.GetClientCredentialsInfo(message);
             }
             catch (Exception e) when (!ExceptionEx.IsFatal(e))
             {
@@ -196,37 +214,43 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 return (AmqpResponseStatusCode.BadRequest, e.Message);
             }
 
-            if (!this.clientCredentialsMap.TryGetValue(clientCredentials.Identity.Id, out CredentialsInfo credentialsInfo))
+            if (!this.clientCredentialsMap.TryGetValue(newCredentialsInfo.Id, out CredentialsInfo credentialsInfo))
             {
-                this.clientCredentialsMap[clientCredentials.Identity.Id] = new CredentialsInfo(clientCredentials);
+                this.clientCredentialsMap[newCredentialsInfo.Id] = newCredentialsInfo;
             }
             else
             {
-                using (await credentialsInfo.AsyncLock.LockAsync())
-                {
-                    credentialsInfo.ClientCredentials = clientCredentials;
-                }
+                // Atomically update the existing entry with the new token
+                credentialsInfo.Token.CompareAndSet(credentialsInfo.Token, newCredentialsInfo.Token);
 
                 if (credentialsInfo.IsAuthenticated)
                 {
+                    IClientCredentials clientCredentials = this.clientCredentialsFactory.GetWithSasToken(
+                        credentialsInfo.DeviceId,
+                        credentialsInfo.ModuleId.OrDefault(),
+                        string.Empty,
+                        credentialsInfo.Token,
+                        true,
+                        Option.None<string>(),
+                        Option.None<string>());
+
                     await this.credentialsCache.Add(clientCredentials);
-                    Events.CbsTokenUpdated(clientCredentials.Identity);
+                    Events.CbsTokenUpdated(credentialsInfo.Id);
                 }
                 else
                 {
-                    Events.CbsTokenNotUpdated(clientCredentials.Identity);
+                    Events.CbsTokenNotUpdated(credentialsInfo.Id);
                 }
             }
 
             return (AmqpResponseStatusCode.OK, AmqpResponseStatusCode.OK.ToString());
         }
 
-        internal IClientCredentials GetClientCredentials(AmqpMessage message)
+        internal CredentialsInfo GetClientCredentialsInfo(AmqpMessage message)
         {
             (string token, string audience) = ValidateAndParseMessage(this.iotHubHostName, message);
             (string deviceId, string moduleId) = ParseIds(audience);
-            IClientCredentials clientCredentials = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, string.Empty, token, true, Option.None<string>());
-            return clientCredentials;
+            return new CredentialsInfo(deviceId, Option.Maybe(moduleId), token);
         }
 
         internal ArraySegment<byte> GetDeliveryTag()
@@ -292,20 +316,25 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
         /// <summary>
         /// This type is deliberately mutable because of the use case.
         /// </summary>
-        class CredentialsInfo
+        internal class CredentialsInfo
         {
-            public CredentialsInfo(IClientCredentials clientCredentials)
+            public CredentialsInfo(string deviceId, Option<string> moduleId, string token)
             {
-                this.ClientCredentials = clientCredentials;
-                this.IsAuthenticated = false;
-                this.AsyncLock = new AsyncLock();
+                this.DeviceId = deviceId;
+                this.ModuleId = moduleId;
+                this.Token = new AtomicReference<string>(token);
+                this.IsAuthenticated = new AtomicBoolean(false);
             }
 
-            public IClientCredentials ClientCredentials { get; set; }
+            public string Id => this.ModuleId.Map(m => $"{this.DeviceId}/{m}").GetOrElse(this.DeviceId);
 
-            public bool IsAuthenticated { get; set; }
+            public string DeviceId { get; }
 
-            public AsyncLock AsyncLock { get; }
+            public Option<string> ModuleId { get; }
+
+            public AtomicReference<string> Token { get; set; }
+
+            public AtomicBoolean IsAuthenticated { get; set; }
         }
 
         static class Events
@@ -350,9 +379,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 Log.LogWarning((int)EventIds.ErrorGettingIdentity, e, $"Error authenticating token received on the Cbs link for {id}");
             }
 
-            public static void CbsTokenUpdated(IIdentity identity)
+            public static void CbsTokenUpdated(string id)
             {
-                Log.LogInformation((int)EventIds.TokenUpdated, $"Token updated for {identity.Id}");
+                Log.LogInformation((int)EventIds.TokenUpdated, $"Token updated for {id}");
             }
 
             public static void ErrorSendingResponse(Exception exception)
@@ -365,9 +394,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 Log.LogWarning((int)EventIds.ErrorHandlingTokenUpdate, exception, "Error handling token update");
             }
 
-            public static void CbsTokenNotUpdated(IIdentity identity)
+            public static void CbsTokenNotUpdated(string id)
             {
-                Log.LogDebug((int)EventIds.CbsTokenNotUpdated, $"Got a new token for an unauthenticated identity {identity.Id}, not updating credentials cache");
+                Log.LogDebug((int)EventIds.CbsTokenNotUpdated, $"Got a new token for an unauthenticated identity {id}, not updating credentials cache");
             }
         }
     }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/EdgeSaslPlainAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/EdgeSaslPlainAuthenticator.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 }
 
                 // TODO: Figure out where the device client type parameter value should come from.
-                IClientCredentials deviceIdentity = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, string.Empty, password, false, Option.None<string>());
+                IClientCredentials deviceIdentity = this.clientCredentialsFactory.GetWithSasToken(deviceId, moduleId, string.Empty, password, false, Option.None<string>(), Option.None<string>());
 
                 if (!await this.authenticator.AuthenticateAsync(deviceIdentity))
                 {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/EdgeX509Principal.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/EdgeX509Principal.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             this.clientCredentialsProvider = Preconditions.CheckNotNull(clientCredentialsProvider, nameof(clientCredentialsProvider));
         }
 
-        public async Task<bool> AuthenticateAsync(string id, Option<string> modelId)
+        public async Task<bool> AuthenticateAsync(string id, Option<string> modelId, Option<string> authChain)
         {
             Preconditions.CheckNonWhiteSpace(id, nameof(id));
 
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 return false;
             }
 
-            IClientCredentials clientCredentials = this.clientCredentialsProvider.GetWithX509Cert(identity.deviceId, identity.moduleId, string.Empty, this.CertificateIdentity.Certificate, this.chainCertificates, modelId);
+            IClientCredentials clientCredentials = this.clientCredentialsProvider.GetWithX509Cert(identity.deviceId, identity.moduleId, string.Empty, this.CertificateIdentity.Certificate, this.chainCertificates, modelId, authChain);
 
             bool result = await this.authenticator.AuthenticateAsync(clientCredentials);
             if (!result)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/IAmqpAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/IAmqpAuthenticator.cs
@@ -6,6 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
     public interface IAmqpAuthenticator
     {
-        Task<bool> AuthenticateAsync(string id, Option<string> modelId);
+        Task<bool> AuthenticateAsync(string id, Option<string> modelId, Option<string> authChain);
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/IotHubAmqpProperty.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/IotHubAmqpProperty.cs
@@ -21,5 +21,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
         public static readonly AmqpSymbol ChannelCorrelationId = AmqpConstants.Vendor + ":channel-correlation-id";
         public static readonly AmqpSymbol GatewayReconnect = AmqpConstants.Vendor + ":gateway-reconnect";
         public static readonly AmqpSymbol ModelId = AmqpConstants.Vendor + ":model-id";
+        public static readonly AmqpSymbol AuthChain = AmqpConstants.Vendor + ":auth-chain";
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/SaslPrincipal.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/SaslPrincipal.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
         public bool IsInRole(string role) => throw new NotImplementedException();
 
-        public Task<bool> AuthenticateAsync(string id, Option<string> modelId) =>
+        public Task<bool> AuthenticateAsync(string id, Option<string> modelId, Option<string> authChain) =>
             Task.FromResult(
                 this.isAuthenticated &&
                 this.clientCredentials.Identity.Id.Equals(id));

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/LinkHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/linkhandlers/LinkHandler.cs
@@ -41,10 +41,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
             }
 
             string modelId = null;
-            if (this.Link.Settings?.Properties?.TryGetValue(IotHubAmqpProperty.ModelId, out modelId) ?? false)
-            {
-                this.ModelId = Option.Maybe(modelId);
-            }
+            this.Link.Settings?.Properties?.TryGetValue(IotHubAmqpProperty.ModelId, out modelId);
+            this.ModelId = Option.Maybe(modelId);
+
+            string authChain = null;
+            this.Link.Settings?.Properties?.TryGetValue<string>(IotHubAmqpProperty.AuthChain, out authChain);
+            this.AuthChain = Option.Maybe(authChain);
         }
 
         public IAmqpLink Link { get; }
@@ -67,7 +69,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
 
         protected Option<string> ClientVersion { get; }
 
-        public Option<string> ModelId { get; }
+        protected Option<string> ModelId { get; }
+
+        protected Option<string> AuthChain { get; }
 
         public async Task OpenAsync(TimeSpan timeout)
         {
@@ -110,7 +114,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.LinkHandlers
                 throw new InvalidOperationException($"Unable to find authentication mechanism for AMQP connection for identity {this.Identity.Id}");
             }
 
-            bool authenticated = await amqpAuth.AuthenticateAsync(this.Identity.Id, this.ModelId);
+            bool authenticated = await amqpAuth.AuthenticateAsync(this.Identity.Id, this.ModelId, this.AuthChain);
             if (authenticated)
             {
                 string productInfo = string.Empty;

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeCertificateAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeCertificateAuthenticator.cs
@@ -26,14 +26,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             this.trustBundle = Preconditions.CheckNotNull(trustBundle, nameof(trustBundle));
         }
 
-        // OnBehalfOf connections are currently not supported with x509 certs
-        protected override (Option<string> deviceId, Option<string> moduleId) GetActorId(ICertificateCredentials credentials) => (Option.None<string>(), Option.None<string>());
-
         // we return true here since a client certificates and its chain will be validated ValidateWithServiceIdentity
         // a possibility would be to check if things are null but that is already being done in CertificateCredentials
         protected override bool AreInputCredentialsValid(ICertificateCredentials credentials) => true;
 
-        protected override bool ValidateWithServiceIdentity(ServiceIdentity serviceIdentity, ICertificateCredentials certificateCredentials, Option<string> authChain)
+        protected override bool ValidateWithServiceIdentity(ServiceIdentity serviceIdentity, ICertificateCredentials certificateCredentials)
         {
             bool result;
             // currently authenticating modules via X.509 is disabled. all the necessary pieces to authenticate

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -31,19 +31,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             this.edgeHubHostName = Preconditions.CheckNotNull(edgeHubHostName, nameof(edgeHubHostName));
         }
 
-        protected override (Option<string> deviceId, Option<string> moduleId) GetActorId(ITokenCredentials credentials)
-        {
-            // Parse the deviceId and moduleId out of the token's audience
-            SharedAccessSignature sharedAccessSignature = SharedAccessSignature.Parse(this.iothubHostName, credentials.Token);
-            (string hostName, string deviceId, Option<string> moduleId) = this.ParseAudience(sharedAccessSignature.Audience);
-            return (Option.Some(deviceId), moduleId);
-        }
-
         protected override bool AreInputCredentialsValid(ITokenCredentials credentials) => this.TryGetSharedAccessSignature(credentials.Token, credentials.Identity, out SharedAccessSignature _);
 
-        protected override bool ValidateWithServiceIdentity(ServiceIdentity serviceIdentity, ITokenCredentials credentials, Option<string> authChain) =>
+        protected override bool ValidateWithServiceIdentity(ServiceIdentity serviceIdentity, ITokenCredentials credentials) =>
             this.TryGetSharedAccessSignature(credentials.Token, credentials.Identity, out SharedAccessSignature sharedAccessSignature)
-                ? this.ValidateCredentials(sharedAccessSignature, serviceIdentity, credentials.Identity, authChain)
+                ? this.ValidateCredentials(sharedAccessSignature, serviceIdentity, credentials.Identity)
                 : false;
 
         internal (string hostName, string deviceId, Option<string> moduleId) ParseAudience(string audience)
@@ -77,22 +69,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             return (hostName, deviceId, moduleId);
         }
 
-        internal bool ValidateAuthChain(string actorDeviceId, string targetId, string authChain)
-        {
-            if (AuthChainHelpers.ValidateAuthChain(actorDeviceId, targetId, authChain))
-            {
-                return true;
-            }
-            else
-            {
-                Events.InvalidAuthChain(targetId, authChain);
-                return false;
-            }
-        }
-
         internal bool ValidateAudienceIds(string audienceDeviceId, Option<string> audienceModuleId, IIdentity identity)
         {
-            string audienceId = audienceDeviceId + audienceModuleId.Map(id => "/" + id).GetOrElse(string.Empty);
+            string audienceId = audienceModuleId.Map(m => $"{audienceDeviceId}/{m}").GetOrElse(audienceDeviceId);
 
             if (!audienceModuleId.HasValue)
             {
@@ -133,7 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             return true;
         }
 
-        internal bool ValidateAudience(string audience, IIdentity identity, Option<string> authChain)
+        internal bool ValidateAudience(string audience, IIdentity identity)
         {
             string hostName;
             string deviceId;
@@ -149,21 +128,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
                 return false;
             }
 
-            if (authChain.HasValue)
+            // We need to the check the audience against the target identity
+            if (!this.ValidateAudienceIds(deviceId, moduleId, identity))
             {
-                // OnBehalfOf scenario, where we need to check the audience against the authchain
-                if (!this.ValidateAuthChain(deviceId, identity.Id, authChain.Expect(() => new InvalidOperationException())))
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                // Default scenario, we just need to the check the audience against the target identity
-                if (!this.ValidateAudienceIds(deviceId, moduleId, identity))
-                {
-                    return false;
-                }
+                return false;
             }
 
             if (string.IsNullOrWhiteSpace(hostName) ||
@@ -191,9 +159,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             }
         }
 
-        bool ValidateCredentials(SharedAccessSignature sharedAccessSignature, ServiceIdentity serviceIdentity, IIdentity identity, Option<string> authChain) =>
+        bool ValidateCredentials(SharedAccessSignature sharedAccessSignature, ServiceIdentity serviceIdentity, IIdentity identity) =>
             this.ValidateTokenWithSecurityIdentity(sharedAccessSignature, serviceIdentity) &&
-            this.ValidateAudience(sharedAccessSignature.Audience, identity, authChain) &&
+            this.ValidateAudience(sharedAccessSignature.Audience, identity) &&
             this.ValidateExpiry(sharedAccessSignature, identity);
 
         bool ValidateExpiry(SharedAccessSignature sharedAccessSignature, IIdentity identity)
@@ -253,7 +221,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             {
                 InvalidHostName = IdStart,
                 InvalidAudience,
-                InvalidAuthChain,
                 IdMismatch,
                 KeysMismatch,
                 InvalidServiceIdentityType,
@@ -270,11 +237,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             public static void InvalidAudience(string audience, IIdentity identity)
             {
                 Log.LogWarning((int)EventIds.InvalidAudience, $"Error authenticating token for {identity.Id} because the audience {audience} is invalid.");
-            }
-
-            public static void InvalidAuthChain(string id, string authChain)
-            {
-                Log.LogWarning((int)EventIds.InvalidAuthChain, $"Error authenticating token for {id} because the auth-chain {authChain} is invalid.");
             }
 
             public static void IdMismatch(string audienceId, IIdentity identity, string deviceId)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/AuthChainHelpers.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/AuthChainHelpers.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Hub.Core
 {
     using System;
+    using System.Linq;
     using Microsoft.Azure.Devices.Edge.Util;
 
     public static class AuthChainHelpers
@@ -12,11 +13,46 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             return authChain.Split(new char[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
         }
 
+        public static Option<string> GetAuthTarget(Option<string> authChain)
+        {
+            if (!authChain.HasValue)
+            {
+                return Option.None<string>();
+            }
+
+            string authChainString = Preconditions.CheckNonWhiteSpace(authChain.OrDefault(), nameof(authChain));
+            string[] authChainIds = GetAuthChainIds(authChainString);
+
+            // The auth target is always the first element of the auth-chain
+            return authChainIds.FirstOption(id => true);
+        }
+
+        public static Option<string> GetActorDeviceId(Option<string> authChain)
+        {
+            if (!authChain.HasValue)
+            {
+                return Option.None<string>();
+            }
+
+            string authChainString = Preconditions.CheckNonWhiteSpace(authChain.OrDefault(), nameof(authChain));
+            string[] authChainIds = GetAuthChainIds(authChainString);
+
+            // OnBehalfOf must have at least 1 leaf/module and 1 Edge in the chain
+            if (authChainIds.Length <= 1)
+            {
+                return Option.None<string>();
+            }
+
+            // The actor Edge is always the last element in the chain
+            return Option.Some(authChainIds.Last());
+        }
+
         public static bool ValidateAuthChain(string actorDeviceId, string targetId, string authChain)
         {
             Preconditions.CheckNonWhiteSpace(actorDeviceId, nameof(actorDeviceId));
             Preconditions.CheckNonWhiteSpace(targetId, nameof(targetId));
             Preconditions.CheckNonWhiteSpace(actorDeviceId, nameof(actorDeviceId));
+
             string[] authChainIds = GetAuthChainIds(authChain);
 
             // Should have at least 1 element in the chain

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/PersistedTokenCredentialsCache.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/PersistedTokenCredentialsCache.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                     {
                         return Option.Some(
                             ParseTokenCredentialsData(identity, t)
-                                .GetOrElse(() => new TokenCredentials(identity, t, string.Empty, Option.None<string>(), false) as IClientCredentials));
+                                .GetOrElse(() => new TokenCredentials(identity, t, string.Empty, Option.None<string>(), Option.None<string>(), false) as IClientCredentials));
                     }
                     catch (Exception e)
                     {
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             {
                 var tokenCredentialsData = json.FromJson<TokenCredentialsData>();
                 Events.Retrieved(identity.Id);
-                return Option.Some(new TokenCredentials(identity, tokenCredentialsData.Token, string.Empty, Option.None<string>(), tokenCredentialsData.IsUpdatable) as IClientCredentials);
+                return Option.Some(new TokenCredentials(identity, tokenCredentialsData.Token, string.Empty, Option.None<string>(), Option.None<string>(), tokenCredentialsData.IsUpdatable) as IClientCredentials);
             }
             catch (Exception e)
             {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/ClientCredentialsFactory.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/ClientCredentialsFactory.cs
@@ -28,18 +28,18 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
             this.callerProductInfo = callerProductInfo;
         }
 
-        public IClientCredentials GetWithX509Cert(string deviceId, string moduleId, string deviceClientType, X509Certificate2 clientCertificate, IList<X509Certificate2> clientChainCertificate, Option<string> modelId)
+        public IClientCredentials GetWithX509Cert(string deviceId, string moduleId, string deviceClientType, X509Certificate2 clientCertificate, IList<X509Certificate2> clientChainCertificate, Option<string> modelId, Option<string> authChain)
         {
             string productInfo = string.Join(" ", deviceClientType, this.callerProductInfo).Trim();
             IIdentity identity = this.identityProvider.Create(deviceId, moduleId);
-            return new X509CertCredentials(identity, productInfo, modelId, clientCertificate, clientChainCertificate);
+            return new X509CertCredentials(identity, productInfo, modelId, authChain, clientCertificate, clientChainCertificate);
         }
 
-        public IClientCredentials GetWithSasToken(string deviceId, string moduleId, string deviceClientType, string token, bool updatable, Option<string> modelId)
+        public IClientCredentials GetWithSasToken(string deviceId, string moduleId, string deviceClientType, string token, bool updatable, Option<string> modelId, Option<string> authChain)
         {
             string productInfo = string.Join(" ", deviceClientType, this.callerProductInfo).Trim();
             IIdentity identity = this.identityProvider.Create(deviceId, moduleId);
-            return new TokenCredentials(identity, token, productInfo, modelId, updatable);
+            return new TokenCredentials(identity, token, productInfo, modelId, authChain, updatable);
         }
 
         public IClientCredentials GetWithConnectionString(string connectionString)
@@ -47,10 +47,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
             Preconditions.CheckNonWhiteSpace(connectionString, nameof(connectionString));
             IotHubConnectionStringBuilder iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(connectionString);
             IIdentity identity = this.identityProvider.Create(iotHubConnectionStringBuilder.DeviceId, iotHubConnectionStringBuilder.ModuleId);
-            return new SharedKeyCredentials(identity, connectionString, this.callerProductInfo, Option.None<string>());
+            return new SharedKeyCredentials(identity, connectionString, this.callerProductInfo, Option.None<string>(), Option.None<string>());
         }
 
         public IClientCredentials GetWithIotEdged(string deviceId, string moduleId) =>
-            new IotEdgedCredentials(this.identityProvider.Create(deviceId, moduleId), this.callerProductInfo, Option.None<string>());
+            new IotEdgedCredentials(this.identityProvider.Create(deviceId, moduleId), this.callerProductInfo, Option.None<string>(), Option.None<string>());
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/IClientCredentials.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/IClientCredentials.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
         string ProductInfo { get; }
 
-        Option<string> ModelId { get; set; }
+        Option<string> ModelId { get; }
+
+        Option<string> AuthChain { get; }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/IClientCredentialsFactory.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/IClientCredentialsFactory.cs
@@ -7,9 +7,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
     public interface IClientCredentialsFactory
     {
-        IClientCredentials GetWithX509Cert(string deviceId, string moduleId, string deviceClientType, X509Certificate2 clientCertificate, IList<X509Certificate2> clientChainCertificate, Option<string> modelId);
+        IClientCredentials GetWithX509Cert(string deviceId, string moduleId, string deviceClientType, X509Certificate2 clientCertificate, IList<X509Certificate2> clientChainCertificate, Option<string> modelId, Option<string> authChain);
 
-        IClientCredentials GetWithSasToken(string deviceId, string moduleId, string deviceClientType, string token, bool updatable, Option<string> modelId);
+        IClientCredentials GetWithSasToken(string deviceId, string moduleId, string deviceClientType, string token, bool updatable, Option<string> modelId, Option<string> authChain);
 
         IClientCredentials GetWithConnectionString(string connectionString);
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/IotEdgedCredentials.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/IotEdgedCredentials.cs
@@ -5,11 +5,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
     public class IotEdgedCredentials : IClientCredentials
     {
-        public IotEdgedCredentials(IIdentity identity, string productInfo, Option<string> modelId)
+        public IotEdgedCredentials(IIdentity identity, string productInfo, Option<string> modelId, Option<string> authChain)
         {
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.ProductInfo = productInfo ?? string.Empty;
             this.ModelId = modelId;
+            this.AuthChain = authChain;
             this.AuthenticationType = AuthenticationType.IoTEdged;
         }
 
@@ -19,6 +20,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
         public string ProductInfo { get; }
 
-        public Option<string> ModelId { get; set; }
+        public Option<string> ModelId { get; }
+
+        public Option<string> AuthChain { get; }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/SharedKeyCredentials.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/SharedKeyCredentials.cs
@@ -5,13 +5,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
     public class SharedKeyCredentials : ISharedKeyCredentials
     {
-        public SharedKeyCredentials(IIdentity identity, string connectionString, string productInfo, Option<string> modelId)
+        public SharedKeyCredentials(IIdentity identity, string connectionString, string productInfo, Option<string> modelId, Option<string> authChain)
         {
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.ConnectionString = Preconditions.CheckNonWhiteSpace(connectionString, nameof(connectionString));
             this.AuthenticationType = AuthenticationType.SasKey;
             this.ProductInfo = productInfo ?? string.Empty;
             this.ModelId = modelId;
+            this.AuthChain = authChain;
         }
 
         public IIdentity Identity { get; }
@@ -22,6 +23,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
         public string ProductInfo { get; }
 
-        public Option<string> ModelId { get; set; }
+        public Option<string> ModelId { get; }
+
+        public Option<string> AuthChain { get; }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/TokenCredentials.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/TokenCredentials.cs
@@ -5,13 +5,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
     public class TokenCredentials : ITokenCredentials
     {
-        public TokenCredentials(IIdentity identity, string token, string productInfo, Option<string> modelId, bool updatable)
+        public TokenCredentials(IIdentity identity, string token, string productInfo, Option<string> modelId, Option<string> authChain, bool updatable)
         {
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.Token = Preconditions.CheckNonWhiteSpace(token, nameof(token));
             this.AuthenticationType = AuthenticationType.Token;
             this.ProductInfo = productInfo ?? string.Empty;
             this.ModelId = modelId;
+            this.AuthChain = authChain;
             this.IsUpdatable = updatable;
         }
 
@@ -25,6 +26,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
         public string ProductInfo { get; }
 
-        public Option<string> ModelId { get; set; }
+        public Option<string> ModelId { get; }
+
+        public Option<string> AuthChain { get; }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/X509CertCredentials.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/identity/X509CertCredentials.cs
@@ -8,12 +8,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
     public class X509CertCredentials : ICertificateCredentials
     {
-        public X509CertCredentials(IIdentity identity, string productInfo, Option<string> modelId, X509Certificate2 clientCertificate, IList<X509Certificate2> clientCertificateChain)
+        public X509CertCredentials(IIdentity identity, string productInfo, Option<string> modelId, Option<string> authChain, X509Certificate2 clientCertificate, IList<X509Certificate2> clientCertificateChain)
         {
             this.Identity = Preconditions.CheckNotNull(identity, nameof(identity));
             this.AuthenticationType = AuthenticationType.X509Cert;
             this.ProductInfo = productInfo ?? string.Empty;
             this.ModelId = modelId;
+            this.AuthChain = authChain;
             this.ClientCertificate = Preconditions.CheckNotNull(clientCertificate, nameof(clientCertificate));
             this.ClientCertificateChain = Preconditions.CheckNotNull(clientCertificateChain, nameof(clientCertificateChain)).ToList();
         }
@@ -24,7 +25,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Identity
 
         public string ProductInfo { get; }
 
-        public Option<string> ModelId { get; set; }
+        public Option<string> ModelId { get; }
+
+        public Option<string> AuthChain { get; }
 
         public X509Certificate2 ClientCertificate { get; }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -36,9 +36,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
         {
             actorDeviceId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorDeviceId, nameof(actorDeviceId)));
             actorModuleId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorModuleId, nameof(actorModuleId)));
+            Preconditions.CheckNonWhiteSpace(request.AuthChain, nameof(request.AuthChain));
 
             IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-            HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), this.HttpContext);
+            HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), Option.Some(request.AuthChain), this.HttpContext);
 
             if (authResult.Authenticated)
             {
@@ -58,9 +59,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
         {
             actorDeviceId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorDeviceId, nameof(actorDeviceId)));
             actorModuleId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorModuleId, nameof(actorModuleId)));
+            Preconditions.CheckNonWhiteSpace(request.AuthChain, nameof(request.AuthChain));
 
             IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-            HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), this.HttpContext);
+            HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), Option.Some(request.AuthChain), this.HttpContext);
 
             if (authResult.Authenticated)
             {
@@ -77,7 +79,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
         async Task<EdgeHubScopeResult> HandleDevicesAndModulesInTargetDeviceScopeAsync(string actorDeviceId, string actorModuleId, NestedScopeRequest request)
         {
             Events.ReceivedScopeRequest(actorDeviceId, actorModuleId, request);
-            Preconditions.CheckNonWhiteSpace(request.AuthChain, nameof(request.AuthChain));
 
             if (!this.TryGetTargetDeviceId(request.AuthChain, out string targetDeviceId))
             {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/HttpRequestAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/HttpRequestAuthenticator.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
         }
 
-        public async Task<HttpAuthResult> AuthenticateAsync(string deviceId, Option<string> moduleId, HttpContext context)
+        public async Task<HttpAuthResult> AuthenticateAsync(string deviceId, Option<string> moduleId, Option<string> authChain, HttpContext context)
         {
             Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
             Preconditions.CheckNotNull(context, nameof(context));
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             if (clientCertificate != null)
             {
                 IList<X509Certificate2> certChain = context.GetClientCertificateChain();
-                clientCredentials = this.identityFactory.GetWithX509Cert(deviceId, moduleId.OrDefault(), string.Empty, clientCertificate, certChain, Option.None<string>());
+                clientCredentials = this.identityFactory.GetWithX509Cert(deviceId, moduleId.OrDefault(), string.Empty, clientCertificate, certChain, Option.None<string>(), authChain);
             }
             else
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                     return new HttpAuthResult(false, Events.AuthenticationFailed($"Cannot parse SharedAccessSignature because of the following error - {ex.Message}"));
                 }
 
-                clientCredentials = this.identityFactory.GetWithSasToken(deviceId, moduleId.OrDefault(), string.Empty, authHeader, false, Option.None<string>());
+                clientCredentials = this.identityFactory.GetWithSasToken(deviceId, moduleId.OrDefault(), string.Empty, authHeader, false, Option.None<string>(), authChain);
             }
 
             IIdentity identity = clientCredentials.Identity;

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/IHttpRequestAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/IHttpRequestAuthenticator.cs
@@ -19,6 +19,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
 
     public interface IHttpRequestAuthenticator
     {
-        Task<HttpAuthResult> AuthenticateAsync(string deviceId, Option<string> moduleId, HttpContext context);
+        Task<HttpAuthResult> AuthenticateAsync(string deviceId, Option<string> moduleId, Option<string> authChain, HttpContext context);
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/TwinsController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/TwinsController.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 if (actorDeviceId == currentEdgeDeviceId)
                 {
                     IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-                    HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), this.HttpContext);
+                    HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), Option.None<string>(), this.HttpContext);
 
                     if (authResult.Authenticated)
                     {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
                 if (!string.IsNullOrEmpty(password))
                 {
-                    deviceCredentials = this.clientCredentialsFactory.GetWithSasToken(clientInfo.DeviceId, clientInfo.ModuleId, clientInfo.DeviceClientType, password, false, clientInfo.ModelId);
+                    deviceCredentials = this.clientCredentialsFactory.GetWithSasToken(clientInfo.DeviceId, clientInfo.ModuleId, clientInfo.DeviceClientType, password, false, clientInfo.ModelId, Option.None<string>());
                 }
                 else if (this.remoteCertificate.HasValue)
                 {
@@ -71,7 +71,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                                 clientInfo.DeviceClientType,
                                 cert,
                                 this.remoteCertificateChain,
-                                clientInfo.ModelId);
+                                clientInfo.ModelId,
+                                Option.None<string>());
                         });
                 }
                 else

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/authentication/AuthAgentController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/authentication/AuthAgentController.cs
@@ -101,7 +101,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                                                                     clientInfo.DeviceClientType,
                                                                     request.Password,
                                                                     false,
-                                                                    clientInfo.ModelId));
+                                                                    clientInfo.ModelId,
+                                                                    Option.None<string>()));
                 }
                 else if (isCertificatePresent)
                 {
@@ -115,7 +116,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                                                                     clientInfo.DeviceClientType,
                                                                     certificate,
                                                                     chain,
-                                                                    clientInfo.ModelId));
+                                                                    clientInfo.ModelId,
+                                                                    Option.None<string>()));
                 }
                 else
                 {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/CbsNodeTest.cs
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
         }
 
         [Fact]
-        public void GetCredentialsInfoTest()
+        public void GetClientTokenTest()
         {
             // Arrange
             var amqpValue = new AmqpValue
@@ -154,12 +154,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var cbsNode = new CbsNode(identityFactory.Object, iotHubHostName, authenticator.Object, new NullCredentialsCache());
 
             // Act
-            CbsNode.CredentialsInfo credentialsInfo = cbsNode.GetClientCredentialsInfo(validAmqpMessage);
+            CbsNode.ClientToken clientToken = cbsNode.GetClientToken(validAmqpMessage);
 
             // Assert
-            Assert.NotNull(credentialsInfo);
-            Assert.Equal("device1/mod1", credentialsInfo.Id);
-            Assert.Equal(amqpValue.Value, credentialsInfo.Token.Value);
+            Assert.NotNull(clientToken);
+            Assert.Equal("device1/mod1", clientToken.Id);
+            Assert.Equal(amqpValue.Value, clientToken.Token);
         }
 
         [Fact]
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             validAmqpMessage.ApplicationProperties.Map[CbsConstants.Operation] = CbsConstants.PutToken.OperationValue;
             Option<string> authChain = Option.Some("device1;edge1");
 
-            var actorEdgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "edge1/$edegHub");
+            var actorEdgeHubIdentity = Mock.Of<IIdentity>(i => i.Id == "edge1/$edgeHub");
             var clientCredentials = Mock.Of<IClientCredentials>(c => c.Identity == actorEdgeHubIdentity && c.AuthChain == authChain);
             var clientCredentialsFactory = new Mock<IClientCredentialsFactory>();
             clientCredentialsFactory.Setup(i => i.GetWithSasToken(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), true, It.IsAny<Option<string>>(), It.Is<Option<string>>(chain => chain == authChain)))

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/DeviceBoundLinkHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/DeviceBoundLinkHandlerTest.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             AmqpMessage receivedAmqpMessage = null;
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/EdgeSaslPlainAuthenticatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/EdgeSaslPlainAuthenticatorTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             const string UserId = "dev1/modules/mod1@sas.hub1";
             const string Password = "pwd";
 
-            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false, Option.None<string>()))
+            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false, Option.None<string>(), Option.None<string>()))
                 .Throws(new ApplicationException("Bad donut"));
 
             await Assert.ThrowsAsync<EdgeHubConnectionException>(() => saslAuthenticator.AuthenticateAsync(UserId, Password));
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             const string UserId = "dev1/modules/mod1@sas.hub1";
             const string Password = "pwd";
 
-            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false, Option.None<string>()))
+            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false, Option.None<string>(), Option.None<string>()))
                 .Returns(clientCredentials);
             Mock.Get(authenticator).Setup(a => a.AuthenticateAsync(clientCredentials))
                 .ReturnsAsync(false);
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             const string UserId = "dev1/modules/mod1@sas.hub1";
             const string Password = "pwd";
 
-            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false, Option.None<string>()))
+            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", "mod1", string.Empty, Password, false, Option.None<string>(), Option.None<string>()))
                 .Returns(clientCredentials);
             Mock.Get(authenticator).Setup(a => a.AuthenticateAsync(clientCredentials))
                 .ReturnsAsync(true);
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var amqpAuthenticator = principal as IAmqpAuthenticator;
             Assert.NotNull(amqpAuthenticator);
 
-            bool isAuthenticated = await amqpAuthenticator.AuthenticateAsync("dev1/mod1", Option.None<string>());
+            bool isAuthenticated = await amqpAuthenticator.AuthenticateAsync("dev1/mod1", Option.None<string>(), Option.None<string>());
             Assert.True(isAuthenticated);
         }
 
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             const string UserId = "dev1@sas.hub1";
             const string Password = "pwd";
 
-            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", string.Empty, string.Empty, Password, false, Option.None<string>()))
+            Mock.Get(clientCredentialsFactory).Setup(f => f.GetWithSasToken("dev1", string.Empty, string.Empty, Password, false, Option.None<string>(), Option.None<string>()))
                 .Returns(clientCredentials);
             Mock.Get(authenticator).Setup(a => a.AuthenticateAsync(clientCredentials))
                 .ReturnsAsync(true);
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var amqpAuthenticator = principal as IAmqpAuthenticator;
             Assert.NotNull(amqpAuthenticator);
 
-            bool isAuthenticated = await amqpAuthenticator.AuthenticateAsync("dev1", Option.None<string>());
+            bool isAuthenticated = await amqpAuthenticator.AuthenticateAsync("dev1", Option.None<string>(), Option.None<string>());
             Assert.True(isAuthenticated);
         }
     }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/EdgeX509PrincipalTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/EdgeX509PrincipalTest.cs
@@ -53,17 +53,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var cf = Mock.Of<IClientCredentialsFactory>();
 
             var principal = new EdgeX509Principal(identity, chain, auth, cf);
-            await Assert.ThrowsAsync<ArgumentException>(() => principal.AuthenticateAsync(null, Option.None<string>()));
-            await Assert.ThrowsAsync<ArgumentException>(() => principal.AuthenticateAsync(string.Empty, Option.None<string>()));
-            await Assert.ThrowsAsync<ArgumentException>(() => principal.AuthenticateAsync("   ", Option.None<string>()));
-            Assert.False(await principal.AuthenticateAsync("/   ", Option.None<string>()));
-            Assert.False(await principal.AuthenticateAsync("   /", Option.None<string>()));
-            Assert.False(await principal.AuthenticateAsync("   /   ", Option.None<string>()));
-            Assert.False(await principal.AuthenticateAsync("did/", Option.None<string>()));
-            Assert.False(await principal.AuthenticateAsync("did/   ", Option.None<string>()));
-            Assert.False(await principal.AuthenticateAsync("/mid", Option.None<string>()));
-            Assert.False(await principal.AuthenticateAsync("   /mid", Option.None<string>()));
-            Assert.False(await principal.AuthenticateAsync("did/mid/blah", Option.None<string>()));
+            await Assert.ThrowsAsync<ArgumentException>(() => principal.AuthenticateAsync(null, Option.None<string>(), Option.None<string>()));
+            await Assert.ThrowsAsync<ArgumentException>(() => principal.AuthenticateAsync(string.Empty, Option.None<string>(), Option.None<string>()));
+            await Assert.ThrowsAsync<ArgumentException>(() => principal.AuthenticateAsync("   ", Option.None<string>(), Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync("/   ", Option.None<string>(), Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync("   /", Option.None<string>(), Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync("   /   ", Option.None<string>(), Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync("did/", Option.None<string>(), Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync("did/   ", Option.None<string>(), Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync("/mid", Option.None<string>(), Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync("   /mid", Option.None<string>(), Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync("did/mid/blah", Option.None<string>(), Option.None<string>()));
         }
 
         [Fact]
@@ -86,11 +86,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                         string.Empty,
                         certificate,
                         chain,
+                        Option.None<string>(),
                         Option.None<string>()))
                 .Returns(clientCredentials);
             Mock.Get(authenticator).Setup(a => a.AuthenticateAsync(clientCredentials)).ReturnsAsync(false);
 
-            Assert.False(await principal.AuthenticateAsync($"{deviceId}/{moduleId}", Option.None<string>()));
+            Assert.False(await principal.AuthenticateAsync($"{deviceId}/{moduleId}", Option.None<string>(), Option.None<string>()));
         }
 
         [Fact]
@@ -113,11 +114,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                         string.Empty,
                         certificate,
                         chain,
+                        Option.None<string>(),
                         Option.None<string>()))
                 .Returns(clientCredentials);
             Mock.Get(authenticator).Setup(a => a.AuthenticateAsync(clientCredentials)).ReturnsAsync(true);
 
-            Assert.True(await principal.AuthenticateAsync($"{deviceId}", Option.None<string>()));
+            Assert.True(await principal.AuthenticateAsync($"{deviceId}", Option.None<string>(), Option.None<string>()));
         }
 
         [Fact]
@@ -140,11 +142,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                         string.Empty,
                         certificate,
                         chain,
+                        Option.None<string>(),
                         Option.None<string>()))
                 .Returns(clientCredentials);
             Mock.Get(authenticator).Setup(a => a.AuthenticateAsync(clientCredentials)).ReturnsAsync(true);
 
-            Assert.True(await principal.AuthenticateAsync($"{deviceId}/{moduleId}", Option.None<string>()));
+            Assert.True(await principal.AuthenticateAsync($"{deviceId}/{moduleId}", Option.None<string>(), Option.None<string>()));
         }
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/EventsLinkHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/EventsLinkHandlerTest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(
@@ -309,7 +309,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(
@@ -361,7 +361,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
 
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.Some(modelId))).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.Some(modelId), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/ReceivingLinkHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/ReceivingLinkHandlerTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var deviceListener = new Mock<IDeviceListener>();
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/SendingLinkHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/SendingLinkHandlerTest.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             AmqpMessage receivedAmqpMessage = null;
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/TwinReceivingLinkHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/TwinReceivingLinkHandlerTest.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                 .Returns(Task.CompletedTask);
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                 .Returns(Task.CompletedTask);
             var connectionHandler = Mock.Of<IConnectionHandler>(c => c.GetDeviceListener() == Task.FromResult(deviceListener.Object));
             var amqpAuthenticator = new Mock<IAmqpAuthenticator>();
-            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>())).ReturnsAsync(true);
+            amqpAuthenticator.Setup(c => c.AuthenticateAsync("d1", Option.None<string>(), Option.None<string>())).ReturnsAsync(true);
             Mock<ICbsNode> cbsNodeMock = amqpAuthenticator.As<ICbsNode>();
             ICbsNode cbsNode = cbsNodeMock.Object;
             var amqpConnection = Mock.Of<IAmqpConnection>(

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ClientTokenCloudConnectionTest.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(10));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), false);
+                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
             }
 
             IClient client = GetMockDeviceClient();
@@ -144,14 +144,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(3));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), false);
+                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
             }
 
             ITokenCredentials GetClientCredentialsWithNonExpiringToken()
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(10));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), false);
+                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
             }
 
             ITokenProvider tokenProvider = null;
@@ -213,14 +213,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(3));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), false);
+                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
             }
 
             ITokenCredentials GetClientCredentialsWithNonExpiringToken()
             {
                 string token = TokenHelper.CreateSasToken(iothubHostName, DateTime.UtcNow.AddMinutes(10));
                 var identity = new DeviceIdentity(iothubHostName, deviceId);
-                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), false);
+                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
             }
 
             ITokenProvider tokenProvider = null;
@@ -381,7 +381,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             {
                 string token = TokenHelper.CreateSasToken(hostname, DateTime.UtcNow.AddSeconds(tokenExpiryDuration.TotalSeconds));
                 var identity = new DeviceIdentity(hostname, deviceId);
-                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), false);
+                return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
             }
 
             IDeviceProxy GetMockDeviceProxy()
@@ -512,7 +512,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         {
             string token = TokenHelper.CreateSasToken(hostname);
             var identity = new DeviceIdentity(hostname, deviceId);
-            return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), false);
+            return new TokenCredentials(identity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
         }
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceIdentity.Id)))
                 .ReturnsAsync(Option.Some(deviceIdentity.Id));
             string token = TokenHelper.CreateSasToken(IotHubHostName, DateTime.UtcNow.AddMinutes(10));
-            var tokenCreds = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), false);
+            var tokenCreds = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
 
             // Act
             Try<ICloudConnection> cloudProxy = await cloudConnectionProvider.Connect(tokenCreds, null);
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceIdentity.Id)))
                 .ReturnsAsync(Option.Some(deviceIdentity.Id));
             string token = TokenHelper.CreateSasToken(IotHubHostName, DateTime.UtcNow.AddMinutes(10));
-            var tokenCreds = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), false);
+            var tokenCreds = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
 
             // Act
             Try<ICloudConnection> cloudProxy = await cloudConnectionProvider.Connect(tokenCreds, null);
@@ -265,7 +265,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             // Arrange
             var deviceIdentity = Mock.Of<IDeviceIdentity>(m => m.Id == "d1");
             string token = TokenHelper.CreateSasToken(IotHubHostName, DateTime.UtcNow.AddMinutes(10));
-            var tokenCreds = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), false);
+            var tokenCreds = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
 
             var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>(MockBehavior.Strict);
             var deviceServiceIdentity = new ServiceIdentity(deviceIdentity.Id, "1234", new string[0], new ServiceAuthentication(ServiceAuthenticationType.CertificateAuthority), ServiceIdentityStatus.Disabled);
@@ -313,7 +313,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             // Arrange
             var deviceIdentity = Mock.Of<IDeviceIdentity>(m => m.Id == "d1");
             string token = TokenHelper.CreateSasToken(IotHubHostName, DateTime.UtcNow.AddMinutes(10));
-            var tokenCreds = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), false);
+            var tokenCreds = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
 
             var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>(MockBehavior.Strict);
             deviceScopeIdentitiesCache.Setup(d => d.GetServiceIdentity(It.Is<string>(i => i == deviceIdentity.Id)))

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var clientTokenProvider = new ClientTokenProvider(new SharedAccessKeySignatureProvider(sasKey), iotHubHostName, deviceId, TimeSpan.FromHours(1));
             string token = await clientTokenProvider.GetTokenAsync(Option.None<TimeSpan>());
             var deviceIdentity = new DeviceIdentity(iotHubHostName, deviceId);
-            var clientCredentials = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), false);
+            var clientCredentials = new TokenCredentials(deviceIdentity, token, string.Empty, Option.None<string>(), Option.None<string>(), false);
 
             Try<ICloudConnection> cloudConnection = await cloudConnectionProvider.Connect(clientCredentials, (_, __) => { });
             Assert.True(cloudConnection.Success);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudTokenAuthenticatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudTokenAuthenticatorTest.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         {
             // Arrange
             var deviceIdentity = Mock.Of<IDeviceIdentity>(d => d.Id == "d1" && d.DeviceId == "d1");
-            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty, Option.None<string>(), false);
+            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty, Option.None<string>(), Option.None<string>(), false);
             var cloudProxy = Mock.Of<ICloudProxy>(c => c.OpenAsync() == Task.FromResult(true));
             var connectionManager = Mock.Of<IConnectionManager>(c => c.CreateCloudConnectionAsync(credentials) == Task.FromResult(Try.Success(cloudProxy)));
             IAuthenticator cloudAuthenticator = new CloudTokenAuthenticator(connectionManager, IotHubHostName);
@@ -40,7 +40,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
         {
             // Arrange
             var deviceIdentity = Mock.Of<IDeviceIdentity>(d => d.Id == "d1" && d.DeviceId == "d1");
-            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty, Option.None<string>(), false);
+            IClientCredentials credentials = new TokenCredentials(deviceIdentity, Guid.NewGuid().ToString(), string.Empty, Option.None<string>(), Option.None<string>(), false);
             var connectionManager = Mock.Of<IConnectionManager>(c => c.CreateCloudConnectionAsync(credentials) == Task.FromResult(Try<ICloudProxy>.Failure(new TimeoutException())));
             IAuthenticator cloudAuthenticator = new CloudTokenAuthenticator(connectionManager, IotHubHostName);
 

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/TokenCacheAuthenticatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/TokenCacheAuthenticatorTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), false);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             var tokenCredentialsAuthenticator = new TokenCacheAuthenticator(new CloudTokenAuthenticator(connectionManager, iothubHostName), credentialsStore.Object, iothubHostName);
 
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), false);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             var storedTokenCredentials = Mock.Of<ITokenCredentials>(c => c.Token == sasToken);
             var credentialsStore = new Mock<ICredentialsCache>();
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), false);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             string sasToken2 = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId") + "a";
             var storedTokenCredentials = Mock.Of<ITokenCredentials>(c => c.Token == sasToken2);
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId", expired: true);
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), false);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             var storedTokenCredentials = Mock.Of<ITokenCredentials>(c => c.Token == sasToken);
             var credentialsStore = new Mock<ICredentialsCache>();

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -152,10 +152,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string iotHubHostName = "iotHubName";
             string edgeDeviceId = "edge";
             string edgeDeviceConnStr = "dummyConnStr";
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module1"), "xyz", DummyProductInfo, Option.None<string>(), false);
-            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module2"), "xyz", DummyProductInfo, Option.None<string>(), false);
-            var edgeDeviceCredentials = new SharedKeyCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), edgeDeviceConnStr, "abc", Option.None<string>());
-            var device1Credentials = new TokenCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), "pqr", DummyProductInfo, Option.None<string>(), false);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module1"), "xyz", DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
+            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module2"), "xyz", DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
+            var edgeDeviceCredentials = new SharedKeyCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), edgeDeviceConnStr, "abc", Option.None<string>(), Option.None<string>());
+            var device1Credentials = new TokenCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), "pqr", DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             var cloudConnectionProvider = Mock.Of<ICloudConnectionProvider>();
             Mock.Get(cloudConnectionProvider)
@@ -189,9 +189,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             string iotHubHostName = "iotHubName";
             string edgeDeviceId = "edge";
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module1"), "xyz", DummyProductInfo, Option.None<string>(), false);
-            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module2"), "xyz", DummyProductInfo, Option.None<string>(), false);
-            var device1Credentials = new TokenCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), "pqr", DummyProductInfo, Option.None<string>(), false);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module1"), "xyz", DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
+            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, "module2"), "xyz", DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
+            var device1Credentials = new TokenCredentials(new DeviceIdentity(iotHubHostName, edgeDeviceId), "pqr", DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             var cloudConnectionProvider = Mock.Of<ICloudConnectionProvider>();
             Action<string, CloudConnectionStatus> callback = null;
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 .Callback(() => deviceProxyMock1.SetupGet(dp => dp.IsActive).Returns(false))
                 .Returns(Task.FromResult(true));
 
-            var deviceCredentials = new TokenCredentials(new DeviceIdentity("iotHub", deviceId), "token", "abc", Option.None<string>(), false);
+            var deviceCredentials = new TokenCredentials(new DeviceIdentity("iotHub", deviceId), "token", "abc", Option.None<string>(), Option.None<string>(), false);
             var deviceScopeIdentitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceId))).ReturnsAsync(Option.Some(deviceId));
 
@@ -317,8 +317,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string module2Id = "module2";
             string iotHubHostName = "iotHub";
 
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, module1Id), DummyToken, DummyProductInfo, Option.None<string>(), false);
-            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, module2Id), DummyToken, DummyProductInfo, Option.None<string>(), false);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, module1Id), DummyToken, DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
+            var module2Credentials = new TokenCredentials(new ModuleIdentity(iotHubHostName, edgeDeviceId, module2Id), DummyToken, DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             var cloudProxyMock1 = Mock.Of<ICloudProxy>();
             var cloudConnectionMock1 = Mock.Of<ICloudConnection>(cp => cp.IsActive && cp.CloudProxy == Option.Some(cloudProxyMock1));
@@ -357,7 +357,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string edgeDeviceId = "edgeDevice";
             string module1Id = "module1";
 
-            var module1Credentials = new TokenCredentials(new ModuleIdentity("iotHub", edgeDeviceId, module1Id), "token", DummyProductInfo, Option.None<string>(), false);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity("iotHub", edgeDeviceId, module1Id), "token", DummyProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             IClient client1 = GetDeviceClient();
             IClient client2 = GetDeviceClient();
@@ -421,7 +421,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             string device = "device1";
             var identity = new DeviceIdentity("iotHub", device);
-            var deviceCredentials = new TokenCredentials(identity, "dummyToken", DummyProductInfo, Option.None<string>(), true);
+            var deviceCredentials = new TokenCredentials(identity, "dummyToken", DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
 
             Action<string, CloudConnectionStatus> callback = null;
             var cloudProxy = Mock.Of<ICloudProxy>(c => c.IsActive);
@@ -456,8 +456,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             string device = "device1";
             var deviceIdentity = new DeviceIdentity("iotHub", device);
-            IClientCredentials deviceCredentials = new TokenCredentials(deviceIdentity, "dummyToken", DummyProductInfo, Option.None<string>(), true);
-            ITokenCredentials updatedDeviceCredentials = new TokenCredentials(deviceIdentity, "dummyToken", DummyProductInfo, Option.None<string>(), true);
+            IClientCredentials deviceCredentials = new TokenCredentials(deviceIdentity, "dummyToken", DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
+            ITokenCredentials updatedDeviceCredentials = new TokenCredentials(deviceIdentity, "dummyToken", DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
 
             Action<string, CloudConnectionStatus> callback = null;
             var cloudProxy = Mock.Of<ICloudProxy>(c => c.IsActive);
@@ -530,7 +530,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
 
             string token1 = TokenHelper.CreateSasToken("foo.azure-devices.net", DateTime.UtcNow.AddHours(2));
-            var deviceCredentials = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token1, DummyProductInfo, Option.None<string>(), true);
+            var deviceCredentials = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token1, DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
             var deviceProxy = Mock.Of<IDeviceProxy>(d => d.IsActive);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceCredentials.Identity.Id))).ReturnsAsync(Option.Some(deviceCredentials.Identity.Id));
 
@@ -545,7 +545,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Assert.Equal(deviceProxy, connectionManager.GetDeviceConnection(deviceCredentials.Identity.Id).OrDefault());
 
             string token2 = TokenHelper.CreateSasToken("foo.azure-devices.net", DateTime.UtcNow.AddHours(2));
-            deviceCredentials = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token2, DummyProductInfo, Option.None<string>(), true);
+            deviceCredentials = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token2, DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
 
             Try<ICloudProxy> receivedCloudProxy2 = await connectionManager.CreateCloudConnectionAsync(deviceCredentials);
             Assert.True(receivedCloudProxy2.Success);
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             IConnectionManager connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
 
             string token1 = TokenHelper.CreateSasToken("foo.azure-devices.net", DateTime.UtcNow.AddHours(2));
-            var deviceCredentials1 = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token1, DummyProductInfo, Option.None<string>(), true);
+            var deviceCredentials1 = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token1, DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
             var deviceProxy = Mock.Of<IDeviceProxy>(d => d.IsActive);
             deviceScopeIdentitiesCache.Setup(d => d.GetAuthChain(It.Is<string>(i => i == deviceCredentials1.Identity.Id))).ReturnsAsync(Option.Some(deviceCredentials1.Identity.Id));
 
@@ -606,7 +606,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Assert.Equal(deviceProxy, connectionManager.GetDeviceConnection(deviceCredentials1.Identity.Id).OrDefault());
 
             string token2 = TokenHelper.CreateSasToken("foo.azure-devices.net", DateTime.UtcNow.AddHours(2));
-            var deviceCredentials2 = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token2, DummyProductInfo, Option.None<string>(), true);
+            var deviceCredentials2 = new TokenCredentials(new DeviceIdentity("iotHub", "Device1"), token2, DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
 
             Try<ICloudProxy> receivedCloudProxy2 = await connectionManager.CreateCloudConnectionAsync(deviceCredentials2);
             Assert.False(receivedCloudProxy2.Success);
@@ -697,7 +697,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string deviceId = "d1";
             string iotHub = "foo.azure-devices.net";
             string token = TokenHelper.CreateSasToken(iotHub);
-            var module1Credentials = new TokenCredentials(new DeviceIdentity(iotHub, deviceId), token, DummyProductInfo, Option.None<string>(), true);
+            var module1Credentials = new TokenCredentials(new DeviceIdentity(iotHub, deviceId), token, DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
             IClient client1 = GetDeviceClient();
             IClient client2 = GetDeviceClient();
             var messageConverterProvider = Mock.Of<IMessageConverterProvider>();
@@ -870,7 +870,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string module1Id = "module1";
             string iotHub = "foo.azure-devices.net";
             string token = TokenHelper.CreateSasToken(iotHub);
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHub, edgeDeviceId, module1Id), token, DummyProductInfo, Option.None<string>(), true);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHub, edgeDeviceId, module1Id), token, DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
 
             IClient client1 = GetDeviceClient();
             IClient client2 = GetDeviceClient();
@@ -933,7 +933,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string edgeDeviceId = "edgeDevice";
             string module1Id = "module1";
             string token = TokenHelper.CreateSasToken(IotHubHostName);
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(IotHubHostName, edgeDeviceId, module1Id), token, DummyProductInfo, Option.None<string>(), true);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity(IotHubHostName, edgeDeviceId, module1Id), token, DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
             IClient client1 = GetDeviceClient();
             IClient client2 = GetDeviceClient();
             var messageConverterProvider = Mock.Of<IMessageConverterProvider>();
@@ -1006,7 +1006,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string module1Id = "module1";
             string iotHub = "foo.azure-devices.net";
             string token = TokenHelper.CreateSasToken(iotHub);
-            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHub, edgeDeviceId, module1Id), token, DummyProductInfo, Option.None<string>(), true);
+            var module1Credentials = new TokenCredentials(new ModuleIdentity(iotHub, edgeDeviceId, module1Id), token, DummyProductInfo, Option.None<string>(), Option.None<string>(), true);
 
             IClient client1 = GetDeviceClient();
             var messageConverterProvider = Mock.Of<IMessageConverterProvider>();

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionProviderTest.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
         {
             var connectionManager = Mock.Of<IConnectionManager>();
             var edgeHub = Mock.Of<IEdgeHub>();
-            var moduleCredentials = new TokenCredentials(new ModuleIdentity("hub", "device", "module"), "token", "productInfo", Option.None<string>(), false);
+            var moduleCredentials = new TokenCredentials(new ModuleIdentity("hub", "device", "module"), "token", "productInfo", Option.None<string>(), Option.None<string>(), false);
 
             var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout);
             Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity, Option.None<string>()));
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var edgeHub = Mock.Of<IEdgeHub>();
             var clientCertificate = new X509Certificate2();
             var clientCertChain = new List<X509Certificate2>();
-            var moduleCredentials = new X509CertCredentials(new ModuleIdentity("hub", "device", "module"), string.Empty, Option.None<string>(), clientCertificate, clientCertChain);
+            var moduleCredentials = new X509CertCredentials(new ModuleIdentity("hub", "device", "module"), string.Empty, Option.None<string>(), Option.None<string>(), clientCertificate, clientCertChain);
 
             var connectionProvider = new ConnectionProvider(connectionManager, edgeHub, DefaultMessageAckTimeout);
             Assert.NotNull(await connectionProvider.GetDeviceListenerAsync(moduleCredentials.Identity, Option.None<string>()));

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/IdentityFactoryTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/IdentityFactoryTest.cs
@@ -59,31 +59,37 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string iothubHostName = "iothub1.azure.net";
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
+            Option<string> modelId = Option.Some("modelId1");
+            Option<string> authChain = Option.Some("device1;edge1");
 
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName), callerProductInfo);
 
             // device test
             string deviceId = "device1";
             string deviceClientType = "customDeviceClient1";
-            IClientCredentials identityTry1 = identityFactory.GetWithSasToken(deviceId, null, deviceClientType, sasToken, false, Option.None<string>());
+            IClientCredentials identityTry1 = identityFactory.GetWithSasToken(deviceId, null, deviceClientType, sasToken, false, modelId, authChain);
             Assert.IsType<DeviceIdentity>(identityTry1.Identity);
             Assert.IsType<TokenCredentials>(identityTry1);
             Assert.Equal(sasToken, (identityTry1 as ITokenCredentials)?.Token);
             Assert.Equal("device1", identityTry1.Identity.Id);
             Assert.Equal($"customDeviceClient1 {callerProductInfo}", identityTry1.ProductInfo);
             Assert.Equal(AuthenticationType.Token, identityTry1.AuthenticationType);
+            Assert.Equal(modelId, identityTry1.ModelId);
+            Assert.Equal(authChain, identityTry1.AuthChain);
 
             // module test
             deviceId = "device1";
             string moduleId = "module1";
             deviceClientType = "customDeviceClient2";
-            IClientCredentials identityTry2 = identityFactory.GetWithSasToken(deviceId, moduleId, deviceClientType, sasToken, false, Option.None<string>());
+            IClientCredentials identityTry2 = identityFactory.GetWithSasToken(deviceId, moduleId, deviceClientType, sasToken, false, modelId, authChain);
             Assert.IsType<ModuleIdentity>(identityTry2.Identity);
             Assert.IsType<TokenCredentials>(identityTry2);
             Assert.Equal(sasToken, (identityTry2 as ITokenCredentials)?.Token);
             Assert.Equal("device1/module1", identityTry2.Identity.Id);
             Assert.Equal($"customDeviceClient2 {callerProductInfo}", identityTry2.ProductInfo);
             Assert.Equal(AuthenticationType.Token, identityTry2.AuthenticationType);
+            Assert.Equal(modelId, identityTry2.ModelId);
+            Assert.Equal(authChain, identityTry2.AuthChain);
         }
 
         [Fact]
@@ -96,11 +102,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string deviceClientType = "customDeviceClient1";
             var clientCertificate = TestCertificateHelper.GenerateSelfSignedCert("some_cert");
             var clientCertChain = new List<X509Certificate2>() { clientCertificate };
+            Option<string> modelId = Option.Some("modelId1");
+            Option<string> authChain = Option.Some("device1;edge1");
 
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName), callerProductInfo);
 
             // device test
-            IClientCredentials identityTry1 = identityFactory.GetWithX509Cert(deviceId, null, deviceClientType, clientCertificate, clientCertChain, Option.None<string>());
+            IClientCredentials identityTry1 = identityFactory.GetWithX509Cert(deviceId, null, deviceClientType, clientCertificate, clientCertChain, modelId, authChain);
             Assert.IsType<DeviceIdentity>(identityTry1.Identity);
             Assert.IsType<X509CertCredentials>(identityTry1);
             Assert.Equal(clientCertificate, (identityTry1 as ICertificateCredentials)?.ClientCertificate);
@@ -108,9 +116,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Assert.Equal("device1", identityTry1.Identity.Id);
             Assert.Equal($"customDeviceClient1 {callerProductInfo}", identityTry1.ProductInfo);
             Assert.Equal(AuthenticationType.X509Cert, identityTry1.AuthenticationType);
+            Assert.Equal(modelId, identityTry1.ModelId);
+            Assert.Equal(authChain, identityTry1.AuthChain);
 
             // module test
-            IClientCredentials identityTry2 = identityFactory.GetWithX509Cert(deviceId, moduleId, deviceClientType, clientCertificate, clientCertChain, Option.None<string>());
+            IClientCredentials identityTry2 = identityFactory.GetWithX509Cert(deviceId, moduleId, deviceClientType, clientCertificate, clientCertChain, modelId, authChain);
             Assert.IsType<ModuleIdentity>(identityTry2.Identity);
             Assert.IsType<X509CertCredentials>(identityTry2);
             Assert.Equal(clientCertificate, (identityTry2 as ICertificateCredentials)?.ClientCertificate);
@@ -118,6 +128,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Assert.Equal("device1/module1", identityTry2.Identity.Id);
             Assert.Equal($"customDeviceClient1 {callerProductInfo}", identityTry2.ProductInfo);
             Assert.Equal(AuthenticationType.X509Cert, identityTry1.AuthenticationType);
+            Assert.Equal(modelId, identityTry2.ModelId);
+            Assert.Equal(authChain, identityTry2.AuthChain);
         }
 
         static string GetRandomString(int length)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/PersistedTokenCredentialsCacheTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/PersistedTokenCredentialsCacheTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), true);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), Option.None<string>(), true);
 
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), false);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), Option.None<string>(), false);
 
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
@@ -80,7 +80,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
             var clientCertificate = new X509Certificate2();
             var clientCertChain = new List<X509Certificate2>();
-            var credentials = new X509CertCredentials(identity, callerProductInfo, Option.None<string>(), clientCertificate, clientCertChain);
+            var credentials = new X509CertCredentials(identity, callerProductInfo, Option.None<string>(), Option.None<string>(), clientCertificate, clientCertChain);
 
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             string callerProductInfo = "productInfo";
             string sasToken = TokenHelper.CreateSasToken($"{iothubHostName}/devices/device1/modules/moduleId");
             var identity = Mock.Of<IIdentity>(i => i.Id == "d1");
-            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), true);
+            var credentials = new TokenCredentials(identity, sasToken, callerProductInfo, Option.None<string>(), Option.None<string>(), true);
 
             var dbStoreProvider = new InMemoryDbStoreProvider();
             IStoreProvider storeProvider = new StoreProvider(dbStoreProvider);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/routing/RoutingTest.cs
@@ -486,10 +486,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Routing
         }
 
         static IClientCredentials SetupDeviceIdentity(string deviceId) =>
-            new TokenCredentials(new DeviceIdentity("iotHub", deviceId), Guid.NewGuid().ToString(), string.Empty, Option.None<string>(), false);
+            new TokenCredentials(new DeviceIdentity("iotHub", deviceId), Guid.NewGuid().ToString(), string.Empty, Option.None<string>(), Option.None<string>(), false);
 
         static IClientCredentials SetupModuleCredentials(string moduleId, string deviceId) =>
-            new TokenCredentials(new ModuleIdentity("iotHub", deviceId, moduleId), Guid.NewGuid().ToString(), string.Empty, Option.None<string>(), false);
+            new TokenCredentials(new ModuleIdentity("iotHub", deviceId, moduleId), Guid.NewGuid().ToString(), string.Empty, Option.None<string>(), Option.None<string>(), false);
 
         class IoTHub
         {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             }
 
             var authenticator = new Mock<IHttpRequestAuthenticator>();
-            authenticator.Setup(a => a.AuthenticateAsync(It.IsAny<string>(), It.IsAny<Option<string>>(), It.IsAny<HttpContext>()))
+            authenticator.Setup(a => a.AuthenticateAsync(It.IsAny<string>(), It.IsAny<Option<string>>(), It.IsAny<Option<string>>(), It.IsAny<HttpContext>()))
                 .ReturnsAsync(new HttpAuthResult(true, string.Empty));
 
             var controller = new DeviceScopeController(Task.FromResult(edgeHub.Object), Task.FromResult(authenticator.Object));

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/HttpRequestAuthenticatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/HttpRequestAuthenticatorTest.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.True(result.Authenticated);
             Assert.Equal(string.Empty, result.ErrorMessage);
         }
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.False(result.Authenticated);
             Assert.Equal("Invalid authorization header count", result.ErrorMessage);
         }
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.False(result.Authenticated);
             Assert.Equal("Invalid Authorization header. Only SharedAccessSignature is supported.", result.ErrorMessage);
         }
@@ -99,7 +99,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.False(result.Authenticated);
             Assert.Equal("Cannot parse SharedAccessSignature because of the following error - The specified SAS token is expired", result.ErrorMessage);
         }
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.True(result.Authenticated);
             Assert.Equal(string.Empty, result.ErrorMessage);
         }
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.False(result.Authenticated);
             Assert.Equal("Unable to authenticate device with Id device_2/module_1", result.ErrorMessage);
         }
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.True(result.Authenticated);
             Assert.Equal(string.Empty, result.ErrorMessage);
         }
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.True(result.Authenticated);
             Assert.Equal(string.Empty, result.ErrorMessage);
         }
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.True(result.Authenticated);
             Assert.Equal(string.Empty, result.ErrorMessage);
         }
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var identityFactory = new ClientCredentialsFactory(new IdentityProvider(iothubHostName));
 
             var httpRequestAuthenticator = new HttpRequestAuthenticator(authenticator.Object, identityFactory, iothubHostName);
-            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), httpContext);
+            HttpAuthResult result = await httpRequestAuthenticator.AuthenticateAsync(deviceId, Option.Some(moduleId), Option.None<string>(), httpContext);
             Assert.False(result.Authenticated);
             Assert.Equal("Unable to authenticate device with Id device_2/module_1", result.ErrorMessage);
         }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/TwinsControllerTest.cs
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         private static TwinsController SetupController(Task<IEdgeHub> edgeHubGetter)
         {
             var authenticator = new Mock<IHttpRequestAuthenticator>();
-            authenticator.Setup(a => a.AuthenticateAsync(It.IsAny<string>(), It.IsAny<Option<string>>(), It.IsAny<HttpContext>()))
+            authenticator.Setup(a => a.AuthenticateAsync(It.IsAny<string>(), It.IsAny<Option<string>>(), It.IsAny<Option<string>>(), It.IsAny<HttpContext>()))
                 .ReturnsAsync(new HttpAuthResult(true, string.Empty));
 
             var controller = new TwinsController(edgeHubGetter, Task.FromResult(authenticator.Object), CreateLetThroughValidator());

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ConnectionHandlerTests.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ConnectionHandlerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             var identityProvider = new IdentityProvider("hub");
             var systemComponentIdProvider = new SystemComponentIdProvider(
                                                     new TokenCredentials(
-                                                            new ModuleIdentity("hub", "device1", "$edgeHub"), "token", "prodinfo", Option.Some<string>("x"), false));
+                                                            new ModuleIdentity("hub", "device1", "$edgeHub"), "token", "prodinfo", Option.Some("x"), Option.None<string>(), false));
 
             var identity = identityProvider.Create("device_test");
 


### PR DESCRIPTION
This change refactors the AMQP OnBehalfOf auth to fully use the client auth-chain.

Previously we made OnBehalfOf auth work by getting the actor from the token and the auth target from the audience property of the UpdateToken message on the CBS link.  But it turns out this isn't compatible with older SDKs, where the audience property wasn't set correctly.

So now we get both pieces of information from the client provided auth-chain, which gives us an explicit way to distinguish between "normal" auth and OnBehalfOf auth.  This conveniently removes any dependency we had on the token payload, and will help enable OnBehalfOf cert-based auth in the future.

MQTT path is unmodified, because it does not have a concept of OnBehalfOf AuthN, and AuthZ is performed by the broker.