### PR TITLE
Remove redundant AuthZ from DeviceScopeController

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -38,6 +38,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             actorModuleId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorModuleId, nameof(actorModuleId)));
             Preconditions.CheckNonWhiteSpace(request.AuthChain, nameof(request.AuthChain));
 
+            if (actorModuleId != Constants.EdgeHubModuleId)
+            {
+                // Only child EdgeHubs are allowed to act OnBehalfOf of devices/modules.
+                var result = new EdgeHubScopeResultError(HttpStatusCode.Unauthorized, Events.UnauthorizedActor(actorDeviceId, actorModuleId));
+                await this.SendResponse(result.Status, JsonConvert.SerializeObject(result));
+            }
+
             IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
             HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), Option.Some(request.AuthChain), this.HttpContext);
 
@@ -60,6 +67,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             actorDeviceId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorDeviceId, nameof(actorDeviceId)));
             actorModuleId = WebUtility.UrlDecode(Preconditions.CheckNonWhiteSpace(actorModuleId, nameof(actorModuleId)));
             Preconditions.CheckNonWhiteSpace(request.AuthChain, nameof(request.AuthChain));
+
+            if (actorModuleId != Constants.EdgeHubModuleId)
+            {
+                // Only child EdgeHubs are allowed to act OnBehalfOf of devices/modules.
+                var result = new EdgeHubScopeResultError(HttpStatusCode.Unauthorized, Events.UnauthorizedActor(actorDeviceId, actorModuleId));
+                await this.SendResponse(result.Status, JsonConvert.SerializeObject(result));
+            }
 
             IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
             HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), Option.Some(request.AuthChain), this.HttpContext);
@@ -85,15 +99,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 return new EdgeHubScopeResultError(HttpStatusCode.BadRequest, Events.InvalidRequestAuthchain(request.AuthChain));
             }
 
-            // Check that the actor device is authorized to act OnBehalfOf the target
+            // Get the children of the target device and the target device itself;
             IEdgeHub edgeHub = await this.edgeHubGetter;
             IDeviceScopeIdentitiesCache identitiesCache = edgeHub.GetDeviceScopeIdentitiesCache();
-            if (!await this.AuthorizeActorAsync(identitiesCache, actorDeviceId, actorModuleId, targetDeviceId))
-            {
-                return new EdgeHubScopeResultError(HttpStatusCode.Unauthorized, Events.UnauthorizedActor(actorDeviceId, actorModuleId, targetDeviceId));
-            }
-
-            // Get the children of the target device and the target device itself;
             IList<ServiceIdentity> identities = await identitiesCache.GetDevicesAndModulesInTargetScopeAsync(targetDeviceId);
             Option<ServiceIdentity> targetDevice = await identitiesCache.GetServiceIdentity(targetDeviceId);
             targetDevice.ForEach(d => identities.Add(d));
@@ -143,13 +151,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 identitiesCache.InitiateCacheRefresh();
                 await identitiesCache.WaitForCacheRefresh(TimeSpan.FromSeconds(100));
                 targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
-            }
-
-            // Now that our cache is up-to-date, check that the actor device is
-            // authorized to act OnBehalfOf the target
-            if (!await this.AuthorizeActorAsync(identitiesCache, actorDeviceId, actorModuleId, targetId))
-            {
-                return new EdgeHubScopeResultError(HttpStatusCode.Unauthorized, Events.UnauthorizedActor(actorDeviceId, actorModuleId, targetId));
             }
 
             // Add the identity to the result
@@ -208,36 +209,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             return false;
         }
 
-        async Task<bool> AuthorizeActorAsync(IDeviceScopeIdentitiesCache identitiesCache, string actorDeviceId, string actorModuleId, string targetId)
-        {
-            if (actorModuleId != Constants.EdgeHubModuleId)
-            {
-                // Only child EdgeHubs are allowed to act OnBehalfOf of devices/modules.
-                Events.AuthFail_BadActor(actorDeviceId, actorModuleId, targetId);
-                return false;
-            }
-
-            // Actor device is claiming to be our child, and that the target device is its child.
-            // So we should have an authchain already cached for the target device.
-            Option<string> targetAuthChainOption = await identitiesCache.GetAuthChain(targetId);
-
-            if (!targetAuthChainOption.HasValue)
-            {
-                Events.AuthFail_NoAuthChain(targetId);
-                return false;
-            }
-
-            // Validate the target auth-chain
-            string targetAuthChain = targetAuthChainOption.Expect(() => new InvalidOperationException());
-            if (!AuthChainHelpers.ValidateAuthChain(actorDeviceId, targetId, targetAuthChain))
-            {
-                Events.AuthFail_InvalidAuthChain(actorDeviceId, targetId, targetAuthChain);
-                return false;
-            }
-
-            return true;
-        }
-
         async Task SendResponse(HttpStatusCode status, string responseJson)
         {
             this.Response.StatusCode = (int)status;
@@ -280,11 +251,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 SendingScopeResult,
                 UnauthorizedActor,
                 InvalidRequestAuthchain,
-                AuthFail_BadActor,
                 AuthFail_NoHeader,
                 AuthFail_BadHeader,
                 AuthFail_ActorMismatch,
-                AuthFail_NoAuthChain,
                 AuthFail_InvalidAuthChain
             }
 
@@ -303,9 +272,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 Log.LogInformation((int)EventIds.SendingScopeResult, $"Sending ScopeResult for {targetId}: [{string.Join(", ", identities.Select(identity => identity.Id))}]");
             }
 
-            public static string UnauthorizedActor(string actorDeviceId, string actorModuleId, string targetDeviceId)
+            public static string UnauthorizedActor(string actorDeviceId, string actorModuleId)
             {
-                string msg = $"{actorDeviceId}/{actorModuleId} not authorized to act OnBehalfOf {targetDeviceId}";
+                string msg = $"{actorDeviceId}/{actorModuleId} not authorized to establish OnBehalfOf connection";
                 Log.LogError((int)EventIds.UnauthorizedActor, msg);
                 return msg;
             }
@@ -315,16 +284,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 string msg = $"Invalid auth chain: {authChain}";
                 Log.LogError((int)EventIds.InvalidRequestAuthchain, msg);
                 return msg;
-            }
-
-            public static void AuthFail_BadActor(string actorDeviceId, string actorModuleId, string targetId)
-            {
-                Log.LogError((int)EventIds.AuthFail_BadActor, $"{actorDeviceId}/{actorModuleId} not authorized to connect OnBehalfOf {targetId}");
-            }
-
-            public static void AuthFail_NoAuthChain(string targetId)
-            {
-                Log.LogError((int)EventIds.AuthFail_NoAuthChain, $"No auth chain for target identity: {targetId}");
             }
 
             public static void AuthFail_InvalidAuthChain(string actorId, string targetId, string authChain)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/HttpRequestAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/HttpRequestAuthenticator.cs
@@ -32,9 +32,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             this.iotHubName = Preconditions.CheckNonWhiteSpace(iotHubName, nameof(iotHubName));
         }
 
-        public async Task<HttpAuthResult> AuthenticateAsync(string deviceId, Option<string> moduleId, Option<string> authChain, HttpContext context)
+        public async Task<HttpAuthResult> AuthenticateAsync(string actorDeviceId, Option<string> actorModuleId, Option<string> authChain, HttpContext context)
         {
-            Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
+            Preconditions.CheckNonWhiteSpace(actorDeviceId, nameof(actorDeviceId));
             Preconditions.CheckNotNull(context, nameof(context));
 
             IClientCredentials clientCredentials;
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             if (clientCertificate != null)
             {
                 IList<X509Certificate2> certChain = context.GetClientCertificateChain();
-                clientCredentials = this.identityFactory.GetWithX509Cert(deviceId, moduleId.OrDefault(), string.Empty, clientCertificate, certChain, Option.None<string>(), authChain);
+                clientCredentials = this.identityFactory.GetWithX509Cert(actorDeviceId, actorModuleId.OrDefault(), string.Empty, clientCertificate, certChain, Option.None<string>(), authChain);
             }
             else
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                     return new HttpAuthResult(false, Events.AuthenticationFailed($"Cannot parse SharedAccessSignature because of the following error - {ex.Message}"));
                 }
 
-                clientCredentials = this.identityFactory.GetWithSasToken(deviceId, moduleId.OrDefault(), string.Empty, authHeader, false, Option.None<string>(), authChain);
+                clientCredentials = this.identityFactory.GetWithSasToken(actorDeviceId, actorModuleId.OrDefault(), string.Empty, authHeader, false, Option.None<string>(), authChain);
             }
 
             IIdentity identity = clientCredentials.Identity;

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -76,21 +76,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         }
 
         [Fact]
-        public void GetDevicesAndModulesInTargetDeviceScope_UnauthorizedActorTest()
-        {
-            string targetEdgeId = "edge2";
-            var resultIdentities = new List<ServiceIdentity>();
-            var authChainMapping = new Dictionary<string, string>();
-            authChainMapping.Add(targetEdgeId, targetEdgeId + ";edge1;edgeroot");
-            var controller = MakeController(targetEdgeId, resultIdentities, authChainMapping);
-
-            var request = new NestedScopeRequest(0, string.Empty, "edge2;edge1");
-            controller.GetDevicesAndModulesInTargetDeviceScopeAsync("edge1", "notEdgeHub", request).Wait();
-
-            Assert.Equal((int)HttpStatusCode.Unauthorized, controller.HttpContext.Response.StatusCode);
-        }
-
-        [Fact]
         public async Task GetModuleOnBehalfOf()
         {
             // Setup ServiceIdentity results


### PR DESCRIPTION
OnBehalfOf AuthZ is now centrally handled by DeviceScopeAuthenticator, so there's no need for the individual controller implementations to handle it anymore.