### PR TITLE
Fix for wsl2

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -371,6 +371,7 @@ function Initialize-IoTEdge {
     Set-Hostname
     if ($ContainerOs -eq 'Linux') {
         Set-ListenConnectUriForLinuxContainers
+        Disable-IoTEdgeMoby
     }
     else {
         Set-CorrectProgramData
@@ -989,7 +990,7 @@ function Install-Packages(
     $restartNeeded = $false
 
     if (-not $Update) {
-        if (-not (Test-IotCore)) {
+        if ((-not (Test-IotCore)) -or (-not ($ContainerOs -eq 'Linux'))) {
             $result = Get-WindowsOptionalFeature -Online -FeatureName 'Containers'
             if ($result -and ($result.State -ne 'Enabled')) {
                 $result = Enable-WindowsOptionalFeature -FeatureName 'Containers' -Online -NoRestart
@@ -1961,6 +1962,12 @@ function Set-ListenConnectUriForLinuxContainers {
 
     Set-MachineEnvironmentVariable 'IOTEDGE_HOST' "${listenAddress}:15580" 
     $env:IOTEDGE_HOST = "${listenAddress}:15580"
+}
+
+function Disable-IoTEdgeMoby {
+    Invoke-Native "sc config iotedge depend= """ 
+    Invoke-Native "sc config iotedge-moby start= disabled" 
+    Invoke-Native "sc stop iotedge-moby" 
 }
 
 function Set-CorrectProgramData {

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -1967,7 +1967,7 @@ function Set-ListenConnectUriForLinuxContainers {
 function Disable-IoTEdgeMoby {
     Invoke-Native "sc config iotedge depend= """"" 
     Invoke-Native "sc config iotedge-moby start= disabled" 
-    Invoke-Native "sc stop iotedge-moby" 
+    Stop-Service iotedge-moby
 }
 
 function Set-CorrectProgramData {

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -990,7 +990,7 @@ function Install-Packages(
     $restartNeeded = $false
 
     if (-not $Update) {
-        if ((-not (Test-IotCore)) -or (-not ($ContainerOs -eq 'Linux'))) {
+        if ((-not (Test-IotCore)) -and ($ContainerOs -eq 'Windows')) {
             $result = Get-WindowsOptionalFeature -Online -FeatureName 'Containers'
             if ($result -and ($result.State -ne 'Enabled')) {
                 $result = Enable-WindowsOptionalFeature -FeatureName 'Containers' -Online -NoRestart
@@ -1965,7 +1965,7 @@ function Set-ListenConnectUriForLinuxContainers {
 }
 
 function Disable-IoTEdgeMoby {
-    Invoke-Native "sc config iotedge depend= """ 
+    Invoke-Native "sc config iotedge depend= """"" 
     Invoke-Native "sc config iotedge-moby start= disabled" 
     Invoke-Native "sc stop iotedge-moby" 
 }

--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -1965,8 +1965,8 @@ function Set-ListenConnectUriForLinuxContainers {
 }
 
 function Disable-IoTEdgeMoby {
-    Invoke-Native "sc config iotedge depend= """"" 
-    Invoke-Native "sc config iotedge-moby start= disabled" 
+    Invoke-Native 'sc config iotedge depend= ""' 
+    Invoke-Native 'sc config iotedge-moby start= disabled' 
     Stop-Service iotedge-moby
 }
 


### PR DESCRIPTION
Built-in Moby engine is not used in LCOW configuration. However, the service remains active and consumes the DNS port (53) that caused WSL2 to fail (https://github.com/microsoft/WSL/issues/4929).

This PR makes two simple changes when running w/ LCOW:  (a) disables the built-in Moby engine  and (b) removes the iotedge service dependency. It also doesn't enable the "Containers" Windows feature which is only required for Windows containers.