### PR TITLE
Added mqtt-policy crate

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -1127,6 +1127,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "mqtt-policy"
+version = "0.1.0"
+dependencies = [
+ "assert_matches",
+ "bytes",
+ "lazy_static",
+ "mqtt-broker",
+ "mqtt3",
+ "policy",
+ "test-case",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
 name = "mqtt3"
 version = "0.1.0"
 dependencies = [

--- a/mqtt/Cargo.toml
+++ b/mqtt/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "mqtt-broker-tests-util",
     "mqtt-edgehub",
     "mqtt-generic",
+    "mqtt-policy",
     "mqttd",
     "policy"
 ]

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -24,7 +24,7 @@ regex = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 thiserror = "1.0"
-tokio = { version = "0.2", features = ["blocking", "stream", "sync", "tcp", "dns"] }
+tokio = { version = "0.2", features = ["blocking", "stream", "sync", "tcp", "dns", "io-util"] }
 tokio-io-timeout = "0.4"
 tokio-openssl = "0.4"
 tokio-util = { version = "0.2", features = ["codec"] }

--- a/mqtt/mqtt-broker/src/auth/authorization.rs
+++ b/mqtt/mqtt-broker/src/auth/authorization.rs
@@ -72,7 +72,7 @@ impl Authorizer for AllowAll {
 }
 
 /// Describes a client activity to authorized.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Activity {
     client_id: ClientId,
     client_info: ClientInfo,
@@ -110,7 +110,7 @@ impl Activity {
 }
 
 /// Describes a client operation to be authorized.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum Operation {
     Connect(Connect),
     Publish(Publish),
@@ -135,7 +135,7 @@ impl Operation {
 }
 
 /// Represents a client attempt to connect to the broker.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Connect {
     will: Option<Publication>,
 }
@@ -155,7 +155,7 @@ impl From<proto::Connect> for Connect {
 }
 
 /// Represents a publication description without payload to be used for authorization.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Publication {
     topic_name: String,
     qos: proto::QoS,
@@ -187,7 +187,7 @@ impl From<proto::Publication> for Publication {
 }
 
 /// Represents a client attempt to publish a new message on a specified MQTT topic.
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Publish {
     publication: Publication,
 }

--- a/mqtt/mqtt-broker/src/auth/authorization.rs
+++ b/mqtt/mqtt-broker/src/auth/authorization.rs
@@ -12,7 +12,7 @@ pub trait Authorizer {
     /// Authorizes a MQTT client to perform some action.
     fn authorize(&self, activity: Activity) -> Result<Authorization, Self::Error>;
 
-    fn update(&self, _update: Box<dyn Any>) -> Result<(), Self::Error> {
+    fn update(&mut self, _update: Box<dyn Any>) -> Result<(), Self::Error> {
         Ok(())
     }
 }
@@ -72,6 +72,7 @@ impl Authorizer for AllowAll {
 }
 
 /// Describes a client activity to authorized.
+#[derive(Clone, Debug)]
 pub struct Activity {
     client_id: ClientId,
     client_info: ClientInfo,
@@ -91,6 +92,10 @@ impl Activity {
         }
     }
 
+    pub fn client_id(&self) -> &ClientId {
+        &self.client_id
+    }
+
     pub fn client_info(&self) -> &ClientInfo {
         &self.client_info
     }
@@ -105,6 +110,7 @@ impl Activity {
 }
 
 /// Describes a client operation to be authorized.
+#[derive(Clone, Debug)]
 pub enum Operation {
     Connect(Connect),
     Publish(Publish),
@@ -129,6 +135,7 @@ impl Operation {
 }
 
 /// Represents a client attempt to connect to the broker.
+#[derive(Clone, Debug)]
 pub struct Connect {
     will: Option<Publication>,
 }
@@ -148,6 +155,7 @@ impl From<proto::Connect> for Connect {
 }
 
 /// Represents a publication description without payload to be used for authorization.
+#[derive(Clone, Debug)]
 pub struct Publication {
     topic_name: String,
     qos: proto::QoS,
@@ -179,6 +187,7 @@ impl From<proto::Publication> for Publication {
 }
 
 /// Represents a client attempt to publish a new message on a specified MQTT topic.
+#[derive(Clone, Debug)]
 pub struct Publish {
     publication: Publication,
 }
@@ -206,6 +215,7 @@ impl From<proto::Publish> for Publish {
 }
 
 /// Represents a client attempt to subscribe to a specified MQTT topic in order to received messages.
+#[derive(Clone, Debug)]
 pub struct Subscribe {
     topic_filter: String,
     qos: proto::QoS,

--- a/mqtt/mqtt-broker/src/auth/mod.rs
+++ b/mqtt/mqtt-broker/src/auth/mod.rs
@@ -27,6 +27,15 @@ pub enum AuthId {
     Identity(Identity),
 }
 
+impl AuthId {
+    pub fn as_str(&self) -> &str {
+        match self {
+            AuthId::Anonymous => "*",
+            AuthId::Identity(identity) => identity.as_str(),
+        }
+    }
+}
+
 impl Display for AuthId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {

--- a/mqtt/mqtt-broker/src/auth/mod.rs
+++ b/mqtt/mqtt-broker/src/auth/mod.rs
@@ -38,10 +38,7 @@ impl AuthId {
 
 impl Display for AuthId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        match self {
-            Self::Anonymous => write!(f, "*"),
-            Self::Identity(identity) => write!(f, "{}", identity),
-        }
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -176,7 +176,7 @@ impl Authorizer for EdgeHubAuthorizer {
         Ok(auth)
     }
 
-    fn update(&self, update: Box<dyn Any>) -> Result<(), Self::Error> {
+    fn update(&mut self, update: Box<dyn Any>) -> Result<(), Self::Error> {
         let identities = update.as_ref();
         if let Some(service_identities) = identities.downcast_ref::<ServiceIdentity>() {
             debug!("{:?}", service_identities);

--- a/mqtt/mqtt-policy/Cargo.toml
+++ b/mqtt/mqtt-policy/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "mqtt-policy"
+version = "0.1.0"
+authors = ["Azure IoT Edge Devs"]
+edition = "2018"
+description = "This crate contains MQTT specific plugins for authorization policy engine. See 'policy' crate."
+
+[dependencies]
+lazy_static = "1.4"
+tracing = "0.1"
+thiserror = "1.0"
+
+mqtt-broker = { path = "../mqtt-broker" }
+mqtt3 = { path = "../mqtt3" }
+policy = { path = "../policy" }
+
+[dev-dependencies]
+assert_matches = "1.3"
+bytes = "0.5"
+test-case = "1.0"

--- a/mqtt/mqtt-policy/src/errors.rs
+++ b/mqtt/mqtt-policy/src/errors.rs
@@ -1,0 +1,34 @@
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum Error {
+    #[error("One or several errors occurred validating MQTT broker policy definition: {0:?}.")]
+    ValidationSummary(Vec<Error>),
+
+    #[error("Unsupported schema version: {0}")]
+    UnsupportedVersion(String),
+
+    #[error("Identities list must not be empty")]
+    EmptyIdentities,
+
+    #[error("Operations list must not be empty")]
+    EmptyOperations,
+
+    #[error("Resources list must not be empty")]
+    EmptyResources,
+
+    #[error("Identity name is invalid: {0}")]
+    InvalidIdentity(String),
+
+    #[error("Resource (topic filter) is invalid: {0}")]
+    InvalidResource(String),
+
+    #[error("Unknown mqtt operation: {0}. List of supported operations: mqtt:publish, mqtt:subscribe, mqtt:connect")]
+    InvalidOperation(String),
+
+    #[error("Invalid identity variable name: {0}")]
+    InvalidIdentityVariable(String),
+
+    #[error("Invalid resource variable name: {0}")]
+    InvalidResourceVariable(String),
+}

--- a/mqtt/mqtt-policy/src/lib.rs
+++ b/mqtt/mqtt-policy/src/lib.rs
@@ -20,6 +20,13 @@ pub use crate::matcher::MqttTopicFilterMatcher;
 pub use crate::substituter::MqttSubstituter;
 pub use crate::validator::MqttValidator;
 
+pub(crate) const IDENTITY_VAR: &str = "{{iot:identity}}";
+pub(crate) const DEVICE_ID_VAR: &str = "{{iot:device_id}}";
+pub(crate) const MODULE_ID_VAR: &str = "{{iot:module_id}}";
+pub(crate) const CLIENT_ID_VAR: &str = "{{mqtt:client_id}}";
+pub(crate) const EDGEHUB_ID_VAR: &str = "{{iot:this_device_id}}";
+pub(crate) const TOPIC_VAR: &str = "{{mqtt:topic}}";
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;

--- a/mqtt/mqtt-policy/src/lib.rs
+++ b/mqtt/mqtt-policy/src/lib.rs
@@ -1,0 +1,69 @@
+#![deny(rust_2018_idioms, warnings)]
+#![deny(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::large_enum_variant,
+    clippy::similar_names,
+    clippy::module_name_repetitions,
+    clippy::use_self,
+    clippy::match_same_arms,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc
+)]
+
+mod errors;
+mod matcher;
+mod substituter;
+mod validator;
+
+pub use crate::matcher::MqttTopicFilterMatcher;
+pub use crate::substituter::MqttSubstituter;
+pub use crate::validator::MqttValidator;
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use bytes::Bytes;
+    use mqtt3::proto;
+    use mqtt_broker::{auth::Activity, auth::Operation, AuthId, ClientId, ClientInfo};
+
+    pub(crate) fn create_connect_activity(
+        client_id: impl Into<ClientId>,
+        auth_id: impl Into<AuthId>,
+    ) -> Activity {
+        let client_id = client_id.into();
+        Activity::new(
+            client_id.clone(),
+            ClientInfo::new("127.0.0.1:80".parse().unwrap(), auth_id),
+            Operation::new_connect(proto::Connect {
+                username: None,
+                password: None,
+                will: None,
+                client_id: proto::ClientId::IdWithExistingSession(client_id.to_string()),
+                keep_alive: Duration::default(),
+                protocol_name: mqtt3::PROTOCOL_NAME.into(),
+                protocol_level: mqtt3::PROTOCOL_LEVEL,
+            }),
+        )
+    }
+
+    pub(crate) fn create_publish_activity(
+        client_id: impl Into<ClientId>,
+        auth_id: impl Into<AuthId>,
+    ) -> Activity {
+        Activity::new(
+            client_id.into(),
+            ClientInfo::new("127.0.0.1:80".parse().unwrap(), auth_id),
+            Operation::new_publish(proto::Publish {
+                packet_identifier_dup_qos: proto::PacketIdentifierDupQoS::AtLeastOnce(
+                    proto::PacketIdentifier::new(1).unwrap(),
+                    false,
+                ),
+                retain: true,
+                topic_name: "/foo/bar".to_string(),
+                payload: Bytes::new(),
+            }),
+        )
+    }
+}

--- a/mqtt/mqtt-policy/src/matcher.rs
+++ b/mqtt/mqtt-policy/src/matcher.rs
@@ -1,0 +1,96 @@
+use std::str::FromStr;
+
+use mqtt_broker::{
+    auth::{Activity, Operation},
+    TopicFilter,
+};
+use policy::{Request, ResourceMatcher};
+
+/// This is MQTT-specific resource matcher that matches topics and topic filters
+/// according to MQTT spec.
+///
+/// # Example:
+/// ```json
+/// {
+///     "effect": "allow",
+///     "identities": ["client_1"],
+///     "operations": ["mqtt:publish"],
+///     "resources": ["floor1/#"]
+/// }
+/// ```
+/// The policy statement above will allow `client_1` to publish to any topic
+/// that matches "floor1/#" topic filter (like "floor1/station1/events")
+#[derive(Debug)]
+pub struct MqttTopicFilterMatcher;
+
+impl ResourceMatcher for MqttTopicFilterMatcher {
+    type Context = Activity;
+
+    fn do_match(&self, context: &Request<Activity>, input: &str, policy: &str) -> bool {
+        match context.context() {
+            Some(context) => {
+                match context.operation() {
+                    // special case for Connect operation, since it doesn't really have a "resource".
+                    Operation::Connect(_) => true,
+                    // for pub or sub just match the topic filter.
+                    _ => {
+                        if let Ok(filter) = TopicFilter::from_str(policy) {
+                            filter.matches(input)
+                        } else {
+                            false
+                        }
+                    }
+                }
+            }
+            None => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use policy::Request;
+
+    use crate::tests;
+
+    use super::*;
+
+    #[test_case("/foo", "/foo", true; "simple topic matches")]
+    #[test_case("/bar", "/foo", false; "simple topic doesn't match")]
+    #[test_case("/foo/bar", "/foo/#", true; "wildcard 1")]
+    #[test_case("/foo/bar", "/foo/+", true; "wildcard 2")]
+    #[test_case("#invalid", "/foo/+", false; "invalid topic")]
+    #[test_case("/foo", "#invalid", false; "invalid topic filter")]
+    fn do_match_test(input: &str, policy: &str, result: bool) {
+        let request = Request::with_context(
+            "some_identity",
+            "some_operation",
+            "some_resource",
+            tests::create_publish_activity("client_id", "auth_id"),
+        )
+        .unwrap();
+
+        // connect operation should match any input value.
+        assert_eq!(
+            result,
+            MqttTopicFilterMatcher.do_match(&request, input, policy)
+        );
+    }
+
+    #[test]
+    fn do_match_connect_activity_test() {
+        let request = Request::with_context(
+            "some_identity",
+            "some_operation",
+            "some_resource",
+            tests::create_connect_activity("client_id", "auth_id"),
+        )
+        .unwrap();
+
+        // connect operation should match any input value.
+        assert!(MqttTopicFilterMatcher.do_match(&request, "any_value", "ignored_value1"));
+        assert!(MqttTopicFilterMatcher.do_match(&request, "some_value", "ignored_value2"));
+    }
+}

--- a/mqtt/mqtt-policy/src/substituter.rs
+++ b/mqtt/mqtt-policy/src/substituter.rs
@@ -150,6 +150,11 @@ mod tests {
         "test_device_client_id", 
         "{{invalid}}"; 
         "invalid variable")]
+    #[test_case("{{{}bad}}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "{{{}bad}}}"; 
+        "bad variable")]
     fn visit_identity_test(input: &str, auth_id: &str, client_id: &str, expected: &str) {
         let request = Request::with_context(
             "some_identity",
@@ -232,6 +237,11 @@ mod tests {
         "test_device_client_id", 
         "{{invalid}}"; 
         "invalid variable")]
+    #[test_case("{{{}bad}}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "{{{}bad}}}"; 
+        "bad variable")]
     fn visit_resource_test(input: &str, auth_id: &str, client_id: &str, expected: &str) {
         let request = Request::with_context(
             "some_identity",

--- a/mqtt/mqtt-policy/src/substituter.rs
+++ b/mqtt/mqtt-policy/src/substituter.rs
@@ -1,0 +1,261 @@
+use mqtt_broker::auth::{Activity, Operation};
+use policy::{Request, Result, Substituter};
+
+#[allow(clippy::doc_markdown)]
+/// MQTT-specific implementation of `Substituter`. It replaces MQTT and IoT Hub specific variables:
+/// * `iot:identity`
+/// * `iot:device_id`
+/// * `iot:module_id`
+/// * `iot:client_id`
+/// * `iot:topic`
+#[derive(Debug)]
+pub struct MqttSubstituter {
+    device_id: String,
+}
+
+impl MqttSubstituter {
+    pub fn new(device_id: impl Into<String>) -> Self {
+        Self {
+            device_id: device_id.into(),
+        }
+    }
+
+    fn device_id(&self) -> &str {
+        &self.device_id
+    }
+
+    fn replace_variable(&self, value: &str, context: &Request<Activity>) -> String {
+        if let Some(context) = context.context() {
+            if let Some(variable) = extract_variable(value) {
+                return match variable {
+                    "{{mqtt:client_id}}" => replace(value, variable, context.client_id().as_str()),
+                    "{{iot:identity}}" => replace(
+                        value,
+                        variable,
+                        &context.client_info().auth_id().to_string(),
+                    ),
+                    "{{iot:device_id}}" => replace(value, variable, &extract_device_id(&context)),
+                    "{{iot:module_id}}" => replace(value, variable, &extract_module_id(&context)),
+                    "{{iot:this_device_id}}" => replace(value, variable, self.device_id()),
+                    "{{mqtt:topic}}" => replace_topic(value, variable, context),
+                    _ => value.to_string(),
+                };
+            }
+        }
+        value.to_string()
+    }
+}
+
+impl Substituter for MqttSubstituter {
+    type Context = Activity;
+
+    fn visit_identity(&self, value: &str, context: &Request<Self::Context>) -> Result<String> {
+        Ok(self.replace_variable(value, context))
+    }
+
+    fn visit_resource(&self, value: &str, context: &Request<Self::Context>) -> Result<String> {
+        Ok(self.replace_variable(value, context))
+    }
+}
+
+pub(super) fn extract_variable(value: &str) -> Option<&str> {
+    if let Some(start) = value.find("{{") {
+        if let Some(end) = value.find("}}") {
+            return Some(&value[start..end + 2]);
+        }
+    }
+    None
+}
+
+fn replace_topic(value: &str, variable: &str, context: &Activity) -> String {
+    match context.operation() {
+        Operation::Publish(publish) => replace(value, variable, publish.publication().topic_name()),
+        Operation::Subscribe(subscribe) => replace(value, variable, subscribe.topic_filter()),
+        _ => value.to_string(),
+    }
+}
+
+fn replace(value: &str, variable: &str, substitution: &str) -> String {
+    value.replace(variable, substitution)
+}
+
+fn extract_device_id(activity: &Activity) -> String {
+    let auth_id = activity.client_info().auth_id().to_string();
+    auth_id
+        .split('/')
+        .next()
+        .map(str::to_owned)
+        .unwrap_or_default()
+}
+
+fn extract_module_id(activity: &Activity) -> String {
+    let auth_id = activity.client_info().auth_id().to_string();
+    auth_id
+        .split('/')
+        .nth(1)
+        .map(str::to_owned)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use test_case::test_case;
+
+    use crate::tests;
+
+    use super::*;
+
+    #[test_case("{{iot:identity}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "test_device_auth_id"; 
+        "iot:identity variable")]
+    #[test_case("namespace-{{iot:identity}}-suffix", 
+        "test_device_auth_id",
+        "test_device_client_id", 
+        "namespace-test_device_auth_id-suffix"; 
+        "iot:identity variable substring")]
+    #[test_case("{{mqtt:client_id}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "test_device_client_id"; 
+        "mqtt:client_id variable")]
+    #[test_case("namespace-{{mqtt:client_id}}-suffix", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "namespace-test_device_client_id-suffix"; 
+        "mqtt:client_id variable substring")]
+    #[test_case("{{iot:device_id}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "test_device_auth_id"; 
+        "iot:device_id variable")]
+    #[test_case("namespace-{{iot:device_id}}-suffix", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "namespace-test_device_auth_id-suffix"; 
+        "iot:device_id variable substring")]
+    #[test_case("{{iot:module_id}}", 
+        "test_device_id/test_module_id", 
+        "test_device_client_id", 
+        "test_module_id"; 
+        "iot:module_id variable")]
+    #[test_case("namespace-{{iot:module_id}}-suffix", 
+        "test_device_id/test_module_id", 
+        "test_device_client_id", 
+        "namespace-test_module_id-suffix"; 
+        "iot:module_id variable substring")]
+    #[test_case("{{iot:this_device_id}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "edge_device"; 
+        "iot:this_device_id variable")]
+    #[test_case("namespace-{{iot:this_device_id}}-suffix", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "namespace-edge_device-suffix"; 
+        "iot:this_device_id variable substring")]
+    #[test_case("{{invalid}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "{{invalid}}"; 
+        "invalid variable")]
+    fn visit_identity_test(input: &str, auth_id: &str, client_id: &str, expected: &str) {
+        let request = Request::with_context(
+            "some_identity",
+            "some_operation",
+            "some_resource",
+            tests::create_connect_activity(client_id, auth_id),
+        )
+        .unwrap();
+
+        assert_eq!(
+            expected,
+            MqttSubstituter::new("edge_device")
+                .visit_identity(input, &request)
+                .unwrap()
+        );
+    }
+
+    #[test_case("{{iot:identity}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "test_device_auth_id"; 
+        "iot:identity variable")]
+    #[test_case("namespace-{{iot:identity}}-suffix", 
+        "test_device_auth_id",
+        "test_device_client_id", 
+        "namespace-test_device_auth_id-suffix"; 
+        "iot:identity variable substring")]
+    #[test_case("{{mqtt:client_id}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "test_device_client_id"; 
+        "mqtt:client_id variable")]
+    #[test_case("namespace-{{mqtt:client_id}}-suffix", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "namespace-test_device_client_id-suffix"; 
+        "mqtt:client_id variable substring")]
+    #[test_case("{{iot:device_id}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "test_device_auth_id"; 
+        "iot:device_id variable")]
+    #[test_case("namespace-{{iot:device_id}}-suffix", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "namespace-test_device_auth_id-suffix"; 
+        "iot:device_id variable substring")]
+    #[test_case("{{iot:module_id}}", 
+        "test_device_id/test_module_id", 
+        "test_device_client_id", 
+        "test_module_id"; 
+        "iot:module_id variable")]
+    #[test_case("namespace-{{iot:module_id}}-suffix", 
+        "test_device_id/test_module_id", 
+        "test_device_client_id", 
+        "namespace-test_module_id-suffix"; 
+        "iot:module_id variable substring")]
+    #[test_case("{{iot:this_device_id}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "edge_device"; 
+        "iot:this_device_id variable")]
+    #[test_case("namespace-{{iot:this_device_id}}-suffix", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "namespace-edge_device-suffix"; 
+        "iot:this_device_id variable substring")]
+    #[test_case("{{mqtt:topic}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "/foo/bar"; 
+        "mqtt:topic variable")]
+    #[test_case("namespace-{{mqtt:topic}}-suffix", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "namespace-/foo/bar-suffix"; 
+        "mqtt:topic variable substring")]
+    #[test_case("{{invalid}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "{{invalid}}"; 
+        "invalid variable")]
+    fn visit_resource_test(input: &str, auth_id: &str, client_id: &str, expected: &str) {
+        let request = Request::with_context(
+            "some_identity",
+            "some_operation",
+            "some_resource",
+            tests::create_publish_activity(client_id, auth_id),
+        )
+        .unwrap();
+
+        assert_eq!(
+            expected,
+            MqttSubstituter::new("edge_device")
+                .visit_resource(input, &request)
+                .unwrap()
+        );
+    }
+}

--- a/mqtt/mqtt-policy/src/validator.rs
+++ b/mqtt/mqtt-policy/src/validator.rs
@@ -112,6 +112,7 @@ fn visit_resource(value: &str) -> Result<(), Error> {
 }
 
 fn is_connect_op(statement: &Statement) -> bool {
+    // check that there is exactly one operation and it is mqtt:connect.
     statement.operations().len() == 1 && statement.operations()[0] == "mqtt:connect"
 }
 

--- a/mqtt/mqtt-policy/src/validator.rs
+++ b/mqtt/mqtt-policy/src/validator.rs
@@ -117,19 +117,19 @@ fn is_connect_op(statement: &Statement) -> bool {
 
 lazy_static! {
     static ref VALID_IDENTITY_VARIABLES: HashSet<String> = HashSet::from_iter(vec![
-        "{{iot:identity}}".into(),
-        "{{iot:device_id}}".into(),
-        "{{iot:module_id}}".into(),
-        "{{mqtt:client_id}}".into(),
-        "{{iot:this_device_id}}".into(),
+        crate::IDENTITY_VAR.into(),
+        crate::DEVICE_ID_VAR.into(),
+        crate::MODULE_ID_VAR.into(),
+        crate::CLIENT_ID_VAR.into(),
+        crate::EDGEHUB_ID_VAR.into(),
     ]);
     static ref VALID_RESOURCE_VARIABLES: HashSet<String> = HashSet::from_iter(vec![
-        "{{iot:identity}}".into(),
-        "{{iot:device_id}}".into(),
-        "{{iot:module_id}}".into(),
-        "{{mqtt:client_id}}".into(),
-        "{{iot:this_device_id}}".into(),
-        "{{mqtt:topic}}".into(),
+        crate::IDENTITY_VAR.into(),
+        crate::DEVICE_ID_VAR.into(),
+        crate::MODULE_ID_VAR.into(),
+        crate::CLIENT_ID_VAR.into(),
+        crate::EDGEHUB_ID_VAR.into(),
+        crate::TOPIC_VAR.into(),
     ]);
 }
 
@@ -166,6 +166,8 @@ mod tests {
                         "contoso.azure-devices.net/monitor_a"
                     ],
                     "operations": [
+                        "mqtt:connect",
+                        "mqtt:subscribe",
                         "mqtt:publish"
                     ],
                     "resources": [
@@ -318,5 +320,25 @@ mod tests {
                 Error::InvalidResourceVariable("{{invalid_res}}".into())
             ]
         );
+    }
+
+    #[test]
+    fn empty_resource_for_connect() {
+        let json = r#"{
+            "schemaVersion": "2020-10-30",
+            "statements": [
+                {
+                    "effect": "allow",
+                    "identities": [
+                        "contoso.azure-devices.net/monitor_a"
+                    ],
+                    "operations": [
+                        "mqtt:connect"
+                    ] 
+                }
+            ]
+        }"#;
+
+        assert!(MqttValidator.validate(&build_definition(json)).is_ok());
     }
 }

--- a/mqtt/mqtt-policy/src/validator.rs
+++ b/mqtt/mqtt-policy/src/validator.rs
@@ -1,0 +1,322 @@
+use std::collections::HashSet;
+use std::{iter::FromIterator, str::FromStr};
+
+use lazy_static::lazy_static;
+
+use mqtt_broker::TopicFilter;
+use policy::{PolicyDefinition, PolicyValidator, Statement};
+
+use crate::{errors::Error, substituter};
+
+/// MQTT-specific implementation of `PolicyValidator`. It checks the following rules:
+/// * Valid schema version.
+/// * Presence of all elements in the policy definition (identities, operations, resources)
+/// * Valid list of operations: mqtt:connect, mqtt:publish, mqtt:subscribe.
+/// * Valid topic filter structure.
+/// * Valid variable names.
+#[derive(Debug)]
+pub struct MqttValidator;
+
+impl PolicyValidator for MqttValidator {
+    type Error = Error;
+
+    fn validate(&self, definition: &PolicyDefinition) -> Result<(), Error> {
+        match definition.schema_version().as_ref() {
+            "2020-10-30" => visit_definition(definition),
+            version => Err(Error::UnsupportedVersion(version.into())),
+        }
+    }
+}
+
+fn visit_definition(definition: &PolicyDefinition) -> Result<(), Error> {
+    let errors = definition
+        .statements()
+        .iter()
+        .flat_map(|statement| {
+            let statement_errors = visit_statement(statement);
+            let identity_errors = statement
+                .identities()
+                .iter()
+                .filter_map(|i| visit_identity(i).err());
+            let operation_errors = statement
+                .operations()
+                .iter()
+                .filter_map(|o| visit_operation(o).err());
+            let resource_errors = statement
+                .resources()
+                .iter()
+                .filter_map(|r| visit_resource(r).err());
+
+            statement_errors
+                .into_iter()
+                .chain(identity_errors)
+                .chain(operation_errors)
+                .chain(resource_errors)
+                .collect::<Vec<_>>()
+        })
+        .collect::<Vec<_>>();
+
+    if !errors.is_empty() {
+        return Err(Error::ValidationSummary(errors));
+    }
+    Ok(())
+}
+
+fn visit_statement(statement: &Statement) -> Vec<Error> {
+    let mut result = vec![];
+    if statement.identities().is_empty() {
+        result.push(Error::EmptyIdentities);
+    }
+    if statement.operations().is_empty() {
+        result.push(Error::EmptyOperations);
+    }
+    // resources list can be empty only for connect operation.
+    if statement.resources().is_empty() && !is_connect_op(statement) {
+        result.push(Error::EmptyResources);
+    }
+    result
+}
+
+fn visit_identity(value: &str) -> Result<(), Error> {
+    if value.is_empty() {
+        return Err(Error::InvalidIdentity(value.into()));
+    }
+    if let Some(variable) = substituter::extract_variable(value) {
+        if VALID_IDENTITY_VARIABLES.get(variable).is_none() {
+            return Err(Error::InvalidIdentityVariable(variable.into()));
+        }
+    }
+    Ok(())
+}
+
+fn visit_operation(value: &str) -> Result<(), Error> {
+    match value {
+        "mqtt:publish" | "mqtt:subscribe" | "mqtt:connect" => Ok(()),
+        _ => Err(Error::InvalidOperation(value.into())),
+    }
+}
+
+fn visit_resource(value: &str) -> Result<(), Error> {
+    if value.is_empty() {
+        return Err(Error::InvalidResource(value.into()));
+    }
+    if let Some(variable) = substituter::extract_variable(value) {
+        if VALID_RESOURCE_VARIABLES.get(variable).is_none() {
+            return Err(Error::InvalidResourceVariable(variable.into()));
+        }
+    }
+    if TopicFilter::from_str(value).is_err() {
+        return Err(Error::InvalidResource(value.into()));
+    }
+    Ok(())
+}
+
+fn is_connect_op(statement: &Statement) -> bool {
+    statement.operations().len() == 1 && statement.operations()[0] == "mqtt:connect"
+}
+
+lazy_static! {
+    static ref VALID_IDENTITY_VARIABLES: HashSet<String> = HashSet::from_iter(vec![
+        "{{iot:identity}}".into(),
+        "{{iot:device_id}}".into(),
+        "{{iot:module_id}}".into(),
+        "{{mqtt:client_id}}".into(),
+        "{{iot:this_device_id}}".into(),
+    ]);
+    static ref VALID_RESOURCE_VARIABLES: HashSet<String> = HashSet::from_iter(vec![
+        "{{iot:identity}}".into(),
+        "{{iot:device_id}}".into(),
+        "{{iot:module_id}}".into(),
+        "{{mqtt:client_id}}".into(),
+        "{{iot:this_device_id}}".into(),
+        "{{mqtt:topic}}".into(),
+    ]);
+}
+
+#[cfg(test)]
+mod tests {
+    use assert_matches::assert_matches;
+
+    use policy::PolicyDefinition;
+
+    use super::*;
+
+    impl Error {
+        /// Helper method to extract error summary.
+        fn into_summary(self) -> Vec<Error> {
+            match self {
+                Error::ValidationSummary(errors) => errors,
+                _ => panic!("Not a ValidationSummary variant"),
+            }
+        }
+    }
+
+    fn build_definition(json: &str) -> PolicyDefinition {
+        PolicyDefinition::from_json(json).expect("Unable to build definition from json")
+    }
+
+    #[test]
+    fn successful_validation() {
+        let json = r#"{
+            "schemaVersion": "2020-10-30",
+            "statements": [
+                {
+                    "effect": "allow",
+                    "identities": [
+                        "contoso.azure-devices.net/monitor_a"
+                    ],
+                    "operations": [
+                        "mqtt:publish"
+                    ],
+                    "resources": [
+                        "topic/a"
+                    ]
+                }
+            ]
+        }"#;
+
+        assert_matches!(MqttValidator.validate(&build_definition(json)), Ok(()));
+    }
+
+    #[test]
+    fn unsupported_schema_version() {
+        let json = r#"{
+            "schemaVersion": "invalid!!!",
+            "statements": [
+                {
+                    "effect": "allow",
+                    "identities": [
+                        "contoso.azure-devices.net/monitor_a"
+                    ],
+                    "operations": [
+                        "mqtt:publish"
+                    ],
+                    "resources": [
+                        "topic/a"
+                    ]
+                }
+            ]
+        }"#;
+
+        assert_eq!(
+            MqttValidator.validate(&build_definition(json)),
+            Err(Error::UnsupportedVersion("invalid!!!".into()))
+        );
+    }
+
+    #[test]
+    fn invalid_operation() {
+        let json = r#"{
+            "schemaVersion": "2020-10-30",
+            "statements": [
+                {
+                    "effect": "allow",
+                    "identities": [
+                        "contoso.azure-devices.net/monitor_a"
+                    ],
+                    "operations": [
+                        "invalid"
+                    ],
+                    "resources": [
+                        "topic/a"
+                    ]
+                }
+            ]
+        }"#;
+
+        let err = MqttValidator.validate(&build_definition(json)).unwrap_err();
+        assert_eq!(
+            err.into_summary(),
+            vec![Error::InvalidOperation("invalid".into())]
+        );
+    }
+
+    #[test]
+    fn empty_elements() {
+        let json = r#"{
+            "schemaVersion": "2020-10-30",
+            "statements": [
+                {
+                    "effect": "allow",
+                    "identities": [
+                    ],
+                    "operations": [
+                    ],
+                    "resources": [
+                    ]
+                }
+            ]
+        }"#;
+
+        let err = MqttValidator.validate(&build_definition(json)).unwrap_err();
+        assert_eq!(
+            err.into_summary(),
+            vec![
+                Error::EmptyIdentities,
+                Error::EmptyOperations,
+                Error::EmptyResources
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_strings() {
+        let json = r#"{
+            "schemaVersion": "2020-10-30",
+            "statements": [
+                {
+                    "effect": "allow",
+                    "identities": [
+                        ""
+                    ],
+                    "operations": [
+                        ""
+                    ],
+                    "resources": [
+                        ""
+                    ]
+                }
+            ]
+        }"#;
+
+        let err = MqttValidator.validate(&build_definition(json)).unwrap_err();
+        assert_eq!(
+            err.into_summary(),
+            vec![
+                Error::InvalidIdentity("".into()),
+                Error::InvalidOperation("".into()),
+                Error::InvalidResource("".into())
+            ]
+        );
+    }
+
+    #[test]
+    fn invalid_variables() {
+        let json = r#"{
+            "schemaVersion": "2020-10-30",
+            "statements": [
+                {
+                    "effect": "allow",
+                    "identities": [
+                        "{{invalid_id}}"
+                    ],
+                    "operations": [
+                        "mqtt:publish"
+                    ],
+                    "resources": [
+                        "{{invalid_res}}"
+                    ]
+                }
+            ]
+        }"#;
+
+        let err = MqttValidator.validate(&build_definition(json)).unwrap_err();
+        assert_eq!(
+            err.into_summary(),
+            vec![
+                Error::InvalidIdentityVariable("{{invalid_id}}".into()),
+                Error::InvalidResourceVariable("{{invalid_res}}".into())
+            ]
+        );
+    }
+}


### PR DESCRIPTION
This is a second to last PR in a series of PRs to integrate Policy Engine into the Broker.

In this PR I've added a crate that contains MQTT specific implementation of Policy engine plugins.