### PR TITLE
Fix Api version set in "IOTEDGE_APIVERSION" to current Workload

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
@@ -169,13 +169,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
                 }
 
                 envVars.Add(new EnvVar(Constants.ModeKey, Constants.IotedgedMode));
-            }
 
-            // Set the edgelet's api version
-            string apiVersion = configSource.Configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
-            if (!string.IsNullOrEmpty(apiVersion))
+                string apiVersion = configSource.Configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
+                if (!string.IsNullOrEmpty(apiVersion))
+                {
+                    envVars.Add(new EnvVar(Constants.EdgeletApiVersionVariableName, apiVersion));
+                }
+            }
+            else
             {
-                envVars.Add(new EnvVar(Constants.EdgeletApiVersionVariableName, apiVersion));
+                // Fix the api version for modules to current Workload API version.
+                envVars.Add(new EnvVar(Constants.EdgeletApiVersionVariableName, Constants.WorkloadApiVersion));
             }
 
             return envVars;


### PR DESCRIPTION
We discovered that a customer is using the `IOTEDGE_APIVERSION` environment variable to get the latest edgelet api version.  The api version has progressed, but the module's code cannot parse the latest api version.  This causes the module to crash.

The workload API (at the time of this PR) has not had a schema change since 2019-01-30.  It would make sense to fix it to this value for 1.0.10 for this customer and potentially others using `IOTEDGE_APIVERSION`. 

This env var is set to the current workload version for all modules except edgeAgent, which still get the highest available edgelet API version.

We are recommending all module developer use a fixed API version string for accessing the workload API.