### PR TITLE
[k8s] Allow Edge on K8s modules to join HostNetwork.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Constants.cs
@@ -84,5 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         public const string UnknownImage = "unknown";
 
         public const string HostIPC = "host";
+        public const string HostNetwork = "host";
+        public const string HostNetworkDnsPolicy = "ClusterFirstWithHostNet";
     }
 }

--- a/kubernetes/doc/edge-deployment-to-k8s-translations.md
+++ b/kubernetes/doc/edge-deployment-to-k8s-translations.md
@@ -47,6 +47,8 @@ objects that will be created.
 | createOptions.HostConfig.Privileged | [Deployment](#podtemplate) |
 | createOptions.HostConfig.Binds | [Deployment](#podtemplate) |
 | createOptions.HostConfig.Mounts | [Deployment](#podtemplate), [PersistentVolumeClaim](#persistentvolumeclaim) |
+| createOptions.HostConfig.IpcMode | [Deployment](#podtemplate) |
+| createOptions.HostConfig.NetworkMode | [Deployment](#podtemplate) |
 | createOptions.HostConfig.ExposedPorts | [Service](#service) |
 | createOptions.HostConfig.PortBindings | [Service](#service) |
 
@@ -174,6 +176,8 @@ Each IoT Edge Module will create one Deployment. This will run the module's spec
 - **serviceAccountName** = The module name, sanitized to be a K8s identifier. See [Module Authentication](rbac.md#module-authentication) for details.
 - **nodeSelector** = `settings.k8s-extensions.nodeSelector` Placed in spec as provided.
 - **hostIPC** = `settings.createOptions.HostConfig.IpcMode` if IpcMode=host, we will set hostIPC to true
+- **hostNetwork** = `settings.createOptions.HostConfig.NetworkMode` if NetworkMode=host, we will set hostNetwork to true
+- **dnsPolicy** = `settings.createOptions.HostConfig.NetworkMode` if NetworkMode=host, we will set hostNetwork to `ClusterFirstWithHostNet`
 
 ## Service
 ### metadata


### PR DESCRIPTION
Some modules need to be able to access the host Network on the cluster. This doesn't make a lot of sense for cloud-based clusters, but on-premises clusters, this is a useful function. This PR will allow a module which sets the NetworkMode to Host, to translate into the appropriate podSpec settings.

Translate Docker `createOptions.NetworkMode=Host` to `podSpec.hostNetwork=true`, `dnsPolicy=ClusterFirstWithHostNet`