### PR TITLE
Using self-host Windows Agent for E2E test framework

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
   - job: linux_arm32v7
 ################################################################################	
     displayName: Linux arm32v7
-
+    condition: eq(false, true)
     pool:
       name: $(pool.name)
       demands: rpi3-e2e-tests
@@ -44,7 +44,7 @@ jobs:
   - job: linux_amd64
 ################################################################################	
     displayName: Linux amd64
-
+    condition: eq(false, true)
     pool:
       vmImage: ubuntu-16.04
 
@@ -102,7 +102,7 @@ jobs:
   - job: centos7_amd64
 ################################################################################	
     displayName: CentOs7 amd64
-
+    condition: eq(false, true)
     pool:
       name: $(pool.name)
       demands:

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -76,7 +76,8 @@ jobs:
 
     steps:
     - pwsh: |
-        Remove-Item –path C:\ProgramData\iotedge\hsm –recurse
+        Remove-Item –path C:\ProgramData\iotedge\hsm\cert_keys\* –recurse
+        Remove-Item –path C:\ProgramData\iotedge\hsm\certs\* –recurse
       displayName: Clean up HSM previous run artifacts
 
     - template: templates/e2e-setup.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -101,7 +101,10 @@ jobs:
         netsh interface ipv6 show prefixpolicies
       displayName: Prefer IPv4
 
-    - template: templates/e2e-clear-docker-cached-images.yaml
+    - pwsh: |
+        docker -H npipe:////./pipe/iotedge_moby_engine system prune --volumes -af
+      displayName: clear cached docker images
+
     - template: templates/e2e-run.yaml
 
 ################################################################################	

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -76,8 +76,8 @@ jobs:
 
     steps:
     - pwsh: |
-        Remove-Item –path C:\ProgramData\iotedge\hsm\cert_keys\* –recurse
-        Remove-Item –path C:\ProgramData\iotedge\hsm\certs\* –recurse
+        Remove-Item –path C:\ProgramData\iotedge\hsm\cert_keys\* –recurse -ErrorAction SilentlyContinue
+        Remove-Item –path C:\ProgramData\iotedge\hsm\certs\* –recurse -ErrorAction SilentlyContinue
       displayName: Clean up HSM previous run artifacts
 
     - template: templates/e2e-setup.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -63,7 +63,11 @@ jobs:
     displayName: Windows amd64
 
     pool:
-      vmImage: windows-2019
+      name: $(pool.name)
+      demands:
+        - Agent.OS -equals Windows_NT
+        - Agent.OSArchitecture -equals X64
+        - run-new-e2e-tests -equals true
 
     variables:
       os: windows

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -75,6 +75,10 @@ jobs:
       artifactName: iotedged-windows
 
     steps:
+    - pwsh: |
+        Remove-Item –path C:\ProgramData\iotedge\hsm –recurse
+      displayName: Clean up HSM previous run artifacts
+
     - template: templates/e2e-setup.yaml
 
     - pwsh: |
@@ -96,6 +100,7 @@ jobs:
         netsh interface ipv6 show prefixpolicies
       displayName: Prefer IPv4
 
+    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
 ################################################################################	

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -22,7 +22,7 @@ jobs:
   - job: linux_arm32v7
 ################################################################################	
     displayName: Linux arm32v7
-    condition: eq(false, true)
+
     pool:
       name: $(pool.name)
       demands: rpi3-e2e-tests
@@ -44,7 +44,7 @@ jobs:
   - job: linux_amd64
 ################################################################################	
     displayName: Linux amd64
-    condition: eq(false, true)
+
     pool:
       vmImage: ubuntu-16.04
 
@@ -102,7 +102,7 @@ jobs:
   - job: centos7_amd64
 ################################################################################	
     displayName: CentOs7 amd64
-    condition: eq(false, true)
+
     pool:
       name: $(pool.name)
       demands:

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -101,10 +101,7 @@ jobs:
         netsh interface ipv6 show prefixpolicies
       displayName: Prefer IPv4
 
-    - pwsh: |
-        docker -H npipe:////./pipe/iotedge_moby_engine system prune --volumes -af
-      displayName: clear cached docker images
-
+    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
 ################################################################################	

--- a/builds/e2e/templates/e2e-clear-docker-cached-images.yaml
+++ b/builds/e2e/templates/e2e-clear-docker-cached-images.yaml
@@ -19,16 +19,31 @@ steps:
         | where { $_.Name -match 'Image$' } `
         | foreach { $_.Value }
 
-    # Pull required images
-    $images | foreach { sudo --preserve-env docker pull $_ }
+    if ($IsWindows)
+    {
+      # set docker command prefix
+      $dockerCommand="docker -H npipe:////./pipe/iotedge_moby_engine"
+
+      # Pull required images
+      $images | foreach { Invoke-Expression ( $dockerCommand + " pull $_" ) }
+    }
+    else
+    {
+      # set docker command prefix
+      $dockerCommand="sudo docker"
+
+      # Pull required images
+      $images | foreach { sudo --preserve-env docker pull $_ }
+    }
 
     # Remove old images
-    $remove = sudo docker images --format '{{.Repository}}:{{.Tag}}' `
+    $remove = Invoke-Expression ($dockerCommand + " images --format '{{.Repository}}:{{.Tag}}'") `
         | where { $images -notcontains $_ }
-    sudo docker rm -f $(docker ps -a -q)
-    $remove | foreach { sudo docker rmi $_ }
+    Invoke-Expression ($dockerCommand + " rm -f $(docker ps -a -q)")
+    $remove | foreach { Invoke-Expression ($dockerCommand + " rmi $_") }
 
     # Delete everything else
-    sudo docker network prune -f
-    sudo docker volume prune -f
+    Invoke-Expression ($dockerCommand + " network prune -f")
+    Invoke-Expression ($dockerCommand + " volume prune -f")
+    
   displayName: Clear Docker Cached images

--- a/builds/e2e/templates/e2e-clear-docker-cached-images.yaml
+++ b/builds/e2e/templates/e2e-clear-docker-cached-images.yaml
@@ -39,7 +39,7 @@ steps:
     # Remove old images
     $remove = Invoke-Expression ($dockerCommand + " images --format '{{.Repository}}:{{.Tag}}'") `
         | where { $images -notcontains $_ }
-    Invoke-Expression ($dockerCommand + " rm -f $(docker ps -a -q)")
+    Invoke-Expression ($dockerCommand + " rm -f $(Invoke-Expression ($dockerCommand + " ps -a -q"))")
     $remove | foreach { Invoke-Expression ($dockerCommand + " rmi $_") }
 
     # Delete everything else

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -1934,7 +1934,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         {
             var desiredProperties = new
             {
-                schemaVersion = "1.0",
+                schemaVersion = "1.1.0",
                 runtime = new
                 {
                     type = "docker",
@@ -2001,7 +2001,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         {
             var desiredProperties = new
             {
-                schemaVersion = "1.0",
+                schemaVersion = "1.1.0",
                 runtime = new
                 {
                     type = "docker",


### PR DESCRIPTION
When the end-to-end tests run on Windows hosted agents, all tests with modules that connect to edge hub fail. Tests that are only concerned with provisioning iotedged, or that use leaf devices to talk to edge hub, pass. The module-based tests all fail with:
```
Microsoft.Azure.Devices.Client.Exceptions.IotHubCommunicationException: Transient network error occurred, please retry.
 ---> System.Net.Sockets.SocketException (11001): No such host is known.
```
It has been difficult to figure out what's happening on the hosted agents since we can't debug them. We know the problem doesn't happen on custom Windows agents, so this change switches the pipeline to custom agents.