### PR TITLE
Put limits on rqt data upload (#3561)

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -51,7 +51,10 @@ Included items must then not match any entries in the exclude list to remain inc
                 <ModulePath>.*stackexchange\..*</ModulePath>
                 <ModulePath>.*system.identitymodel\..*</ModulePath>
                 <ModulePath>.*system.reactive.*</ModulePath>
+                <ModulePath>.*system.linq.async.*</ModulePath>
                 <ModulePath>.*xunit\..*</ModulePath>
+                <ModulePath>.*edgex509authdownstreamdevice.*\..*</ModulePath>
+                <ModulePath>.*edgedownstreamdevice.*\..*</ModulePath>
                 <!-- test binaries -->
                 <ModulePath>.*test\..*</ModulePath>
                 <!-- test/sample edge modules -->

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/DiagnosticConfig.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/DiagnosticConfig.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics
         public readonly string MetricsStoragePath;
         public readonly TimeSpan ScrapeInterval;
         public readonly TimeSpan UploadInterval;
+        public readonly TimeSpan MaxUploadAge;
 
         public DiagnosticConfig(bool enabled, string storagePath, IConfiguration configuration)
         {
@@ -23,6 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics
             this.MetricsStoragePath = Path.Combine(Preconditions.CheckNotNull(storagePath, nameof(storagePath)), "metrics");
             this.ScrapeInterval = configuration.GetTimeSpan("MetricScrapeInterval", TimeSpan.FromHours(1));
             this.UploadInterval = configuration.GetTimeSpan("MetricUploadInterval", TimeSpan.FromDays(1));
+            this.MaxUploadAge = configuration.GetTimeSpan("MetricMaxUploadAge", TimeSpan.FromDays(7));
         }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.28.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="3.1.3" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Linq.Async" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/storage/MetricsStorage.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/storage/MetricsStorage.cs
@@ -5,19 +5,26 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Storage
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Runtime.CompilerServices;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Extensions.Logging;
 
     public class MetricsStorage : IMetricsStorage
     {
         readonly ISequentialStore<IEnumerable<Metric>> dataStore;
-        readonly HashSet<long> entriesToRemove = new HashSet<long>();
+        readonly TimeSpan maxMetricAge;
+        readonly HashSet<long> offsetsReturned = new HashSet<long>();
 
-        public MetricsStorage(ISequentialStore<IEnumerable<Metric>> sequentialStore)
+        static readonly ILogger Log = Logger.Factory.CreateLogger<MetricsStorage>();
+
+        public MetricsStorage(ISequentialStore<IEnumerable<Metric>> sequentialStore, TimeSpan maxMetricAge)
         {
             this.dataStore = Preconditions.CheckNotNull(sequentialStore, nameof(sequentialStore));
+            this.maxMetricAge = Preconditions.CheckNotNull(maxMetricAge, nameof(maxMetricAge));
         }
 
         public Task StoreMetricsAsync(IEnumerable<Metric> metrics)
@@ -27,15 +34,47 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Storage
 
         public async Task<IEnumerable<Metric>> GetAllMetricsAsync()
         {
-            return (await this.dataStore.GetBatch(0, 1000))
-                    .SelectMany(((long offset, IEnumerable<Metric> metrics) storeResult) =>
-                    {
-                        this.entriesToRemove.Add(storeResult.offset);
-                        return storeResult.metrics;
-                    });
+            // Note: async/await is needed b/c ToListAsync returns ValueTask instead of Task.
+            return await this.GetAllMetricsInternal().ToListAsync();
         }
 
-        public async Task RemoveAllReturnedMetricsAsync()
+        async IAsyncEnumerable<Metric> GetAllMetricsInternal([EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            HashSet<long> maxAgeEntriesToRemove = new HashSet<long>();
+            DateTime cutoff = DateTime.UtcNow - this.maxMetricAge;
+
+            foreach ((long offset, IEnumerable<Metric> metrics) in await this.dataStore.GetBatch(0, 1000, cancellationToken))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                // This makes the assumption that metrics are stored in batches with matching timestamps.
+                // This is the case b/c the metrics are stored immediately after being scraped.
+                if (metrics.First().TimeGeneratedUtc < cutoff)
+                {
+                    Log.LogInformation($"Deleted internal telemetry from {metrics.First().TimeGeneratedUtc} because it exceeded the max age of {this.maxMetricAge}");
+                    maxAgeEntriesToRemove.Add(offset);
+                }
+                else
+                {
+                    this.offsetsReturned.Add(offset);
+                    foreach (var metric in metrics)
+                    {
+                        yield return metric;
+                    }
+                }
+            }
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            // remove metrics past ttl
+            await this.RemoveOffsets(maxAgeEntriesToRemove);
+        }
+
+        public Task RemoveAllReturnedMetricsAsync()
+        {
+            return this.RemoveOffsets(this.offsetsReturned);
+        }
+
+        async Task RemoveOffsets(HashSet<long> entriesToRemove)
         {
             bool notLast = false;
             do
@@ -43,7 +82,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Storage
                 // Only delete entries in entriesToRemove. Also remove from entriesToRemove.
                 Task<bool> ShouldRemove(long offset, object _)
                 {
-                    return Task.FromResult(this.entriesToRemove.Remove(offset));
+                    return Task.FromResult(entriesToRemove.Remove(offset));
                 }
 
                 notLast = await this.dataStore.RemoveFirst(ShouldRemove);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DiagnosticsModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DiagnosticsModule.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                     IStoreProvider storeProvider = await c.Resolve<Task<IStoreProvider>>();
                     ISequentialStore<IEnumerable<Metric>> dataStore = await storeProvider.GetSequentialStore<IEnumerable<Metric>>("Metrics");
 
-                    return new MetricsStorage(dataStore) as IMetricsStorage;
+                    return new MetricsStorage(dataStore, this.diagnosticConfig.MaxUploadAge) as IMetricsStorage;
                 })
                 .As<Task<IMetricsStorage>>()
                 .SingleInstance();

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test/MetricsWorkerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test/MetricsWorkerTest.cs
@@ -7,9 +7,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Akka.Event;
     using Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Publisher;
     using Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Storage;
     using Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Util;
+    using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util.Metrics;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.Edge.Util.TransientFaultHandling;
@@ -332,6 +334,83 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test
             await worker.Upload(CancellationToken.None);
             Assert.Equal(maxRetries + 1, uploader.Invocations.Count); // It tries once, then retries maxRetryTimes.
             Assert.Single(storage.Invocations.Where(i => i.Method.Name == "RemoveAllReturnedMetricsAsync"));
+        }
+
+        [Fact]
+        public async Task TestUploadMaxAge()
+        {
+            /* Make fake data */
+            DateTime baseTime = DateTime.UtcNow;
+
+            // This will create 20 fake scrapes of 10 metrics each.
+            // Each has an offset equal to the hours since they were scraped.
+            IEnumerable<(long offset, IEnumerable<Metric> metrics)> fakeScrapes = Enumerable.Range(0, 20).Select(hoursAgo =>
+            {
+                DateTime scrapeTime = baseTime.AddHours(-1 * hoursAgo);
+                IEnumerable<Metric> data = Enumerable.Range(1, 10).Select(i => new Metric(scrapeTime, $"metric_{i}", 0, new Dictionary<string, string>()));
+
+                return ((long offset, IEnumerable<Metric> metrics))(hoursAgo, data);
+            }).ToArray();
+
+            /* Setup mocks */
+            var sequentialStoreMock = new Mock<ISequentialStore<IEnumerable<Metric>>>();
+
+            // mock retrieving data
+            sequentialStoreMock.Setup(s => s.GetBatch(It.IsAny<long>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ReturnsAsync(fakeScrapes);
+
+            // mock removing data
+            List<int> offsetsRemoved = new List<int>();
+            void GetOffsetToRemove(Func<long, IEnumerable<Metric>, Task<bool>> func)
+            {
+                // Note: .Result was used b/c moq `Callback` does not handle tasks.
+                IEnumerable<int> newOffsetsRemoved = AsyncEnumerable.Range(0, 100).WhereAwait(async i => await func(i, null)).ToListAsync().Result;
+
+                offsetsRemoved.AddRange(newOffsetsRemoved);
+            }
+
+            sequentialStoreMock.Setup(s => s.RemoveFirst(It.IsAny<Func<long, IEnumerable<Metric>, Task<bool>>>())).Callback((Action<Func<long, IEnumerable<Metric>, Task<bool>>>)GetOffsetToRemove).ReturnsAsync(false);
+
+            /* Test */
+            // No max age
+            var storageNoLimit = new MetricsStorage(sequentialStoreMock.Object, TimeSpan.FromDays(50));
+
+            // When metrics are returned, all 200 are there and none are removed from db.
+            var noLimitReturnedMetrics = (await storageNoLimit.GetAllMetricsAsync()).ToList();
+            Assert.Equal(200, noLimitReturnedMetrics.Count);
+            Assert.Empty(offsetsRemoved);
+
+            // all metrics are removed
+            await storageNoLimit.RemoveAllReturnedMetricsAsync();
+            TestUtilities.OrderlessCompare(Enumerable.Range(0, 20), offsetsRemoved);
+            offsetsRemoved.Clear();
+
+            // Only keep last 7 hours
+            var storageLast7Hours = new MetricsStorage(sequentialStoreMock.Object, TimeSpan.FromHours(7));
+
+            // When metrics are returned, all only last 7 scrapes of 10 are returned. Remaining 13 scrapes are deleted
+            var last7ReturnedMetrics = (await storageLast7Hours.GetAllMetricsAsync()).ToList();
+            Assert.Equal(70, last7ReturnedMetrics.Count);
+            TestUtilities.OrderlessCompare(Enumerable.Range(7, 13), offsetsRemoved);
+            offsetsRemoved.Clear();
+
+            // only returned metrics are removed
+            await storageLast7Hours.RemoveAllReturnedMetricsAsync();
+            TestUtilities.OrderlessCompare(Enumerable.Range(0, 7), offsetsRemoved);
+            offsetsRemoved.Clear();
+
+            // Only keep last 12 hours
+            var storageLast12Hours = new MetricsStorage(sequentialStoreMock.Object, TimeSpan.FromHours(12));
+
+            // When metrics are returned, all only last 12 scrapes of 10 are returned. Remaining 8 scrapes are deleted
+            var last12ReturnedMetrics = (await storageLast12Hours.GetAllMetricsAsync()).ToList();
+            Assert.Equal(120, last12ReturnedMetrics.Count);
+            TestUtilities.OrderlessCompare(Enumerable.Range(12, 8), offsetsRemoved);
+            offsetsRemoved.Clear();
+
+            // only returned metrics are removed
+            await storageLast12Hours.RemoveAllReturnedMetricsAsync();
+            TestUtilities.OrderlessCompare(Enumerable.Range(0, 12), offsetsRemoved);
+            offsetsRemoved.Clear();
         }
 
         class FakeRetryStrategy : RetryStrategy


### PR DESCRIPTION
This will not upload rqt data older than 1 week (default value, configurable with MetricMaxUploadAge).