### PR TITLE
Put nested IServiceIdentityHierarchy implementation behind feature flag

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ServiceIdentityDictionary.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ServiceIdentityDictionary.cs
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
+    using Microsoft.Azure.Devices.Edge.Util;
+
+    /// <summary>
+    /// This is a simple dictionary implementation of IServiceIdentityHierarchy
+    /// that mirrors how the identity cache worked before nested Edge was added.
+    /// </summary>
+    public class ServiceIdentityDictionary : IServiceIdentityHierarchy
+    {
+        readonly string actorDeviceId;
+        readonly Dictionary<string, ServiceIdentity> identities;
+
+        public ServiceIdentityDictionary(string actorDeviceId)
+        {
+            this.actorDeviceId = Preconditions.CheckNonWhiteSpace(actorDeviceId, nameof(actorDeviceId));
+            this.identities = new Dictionary<string, ServiceIdentity>();
+        }
+
+        public string GetActorDeviceId() => this.actorDeviceId;
+
+        public Task<Option<string>> GetAuthChain(string id) => throw new NotImplementedException("Nested Edge not enabled");
+
+        public Task<Option<string>> GetEdgeAuthChain(string id) => throw new NotImplementedException("Nested Edge not enabled");
+
+        public Task<IList<ServiceIdentity>> GetImmediateChildren(string id) => throw new NotImplementedException("Nested Edge not enabled");
+
+        public Task InsertOrUpdate(ServiceIdentity identity)
+        {
+            Preconditions.CheckNotNull(identity, nameof(identity));
+            this.identities[identity.Id] = identity;
+            return Task.CompletedTask;
+        }
+
+        public Task Remove(string id)
+        {
+            Preconditions.CheckNonWhiteSpace(id, nameof(id));
+            this.identities.Remove(id);
+            return Task.CompletedTask;
+        }
+
+        public Task<bool> Contains(string id)
+        {
+            Preconditions.CheckNonWhiteSpace(id, nameof(id));
+            return Task.FromResult(this.identities.ContainsKey(id));
+        }
+
+        public Task<Option<ServiceIdentity>> Get(string id)
+        {
+            Preconditions.CheckNonWhiteSpace(id, nameof(id));
+            Option<ServiceIdentity> result = this.identities.TryGetValue(id, out ServiceIdentity identity)
+                  ? Option.Some(identity)
+                  : Option.None<ServiceIdentity>();
+            return Task.FromResult(result);
+        }
+
+        public Task<IList<string>> GetAllIds()
+        {
+            IList<string> result = this.identities.Select(kvp => kvp.Value.Id).ToList();
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             TimeSpan configUpdateFrequency = TimeSpan.FromSeconds(configUpdateFrequencySecs);
             bool checkEntireQueueOnCleanup = this.configuration.GetValue("CheckEntireQueueOnCleanup", false);
             bool closeCloudConnectionOnDeviceDisconnect = this.configuration.GetValue("CloseCloudConnectionOnDeviceDisconnect", true);
-            bool nestedEdgeEnabled = this.configuration.GetValue<bool>(Constants.ConfigKey.NestedEdgeEnabled);
+            bool nestedEdgeEnabled = this.configuration.GetValue<bool>(Constants.ConfigKey.NestedEdgeEnabled, false);
 
             builder.RegisterModule(
                 new RoutingModule(
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             Option<string> workloadUri = this.GetConfigurationValueIfExists<string>(Constants.ConfigKey.WorkloadUri);
             Option<string> workloadApiVersion = this.GetConfigurationValueIfExists<string>(Constants.ConfigKey.WorkloadAPiVersion);
             Option<string> moduleGenerationId = this.GetConfigurationValueIfExists<string>(Constants.ConfigKey.ModuleGenerationId);
-            bool nestedEdgeEnabled = this.configuration.GetValue<bool>(Constants.ConfigKey.NestedEdgeEnabled);
+            bool nestedEdgeEnabled = this.configuration.GetValue<bool>(Constants.ConfigKey.NestedEdgeEnabled, false);
             bool hasParentEdge = this.GetConfigurationValueIfExists<string>(Constants.ConfigKey.GatewayHostname).HasValue;
 
             if (!Enum.TryParse(this.configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode))

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/CommonModule.cs
@@ -299,12 +299,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                         {
                             var edgeHubTokenProvider = c.ResolveNamed<ITokenProvider>("EdgeHubServiceAuthTokenProvider");
                             var proxy = c.Resolve<Option<IWebProxy>>();
-                            var serviceIdentityTree = new ServiceIdentityTree(this.edgeDeviceId);
+
+                            IServiceIdentityHierarchy serviceIdentityHierarchy;
+                            if (this.nestedEdgeEnabled)
+                            {
+                                serviceIdentityHierarchy = new ServiceIdentityTree(this.edgeDeviceId);
+                            }
+                            else
+                            {
+                                serviceIdentityHierarchy = new ServiceIdentityDictionary(this.edgeDeviceId);
+                            }
+
                             string hostName = this.gatewayHostName.GetOrElse(this.iothubHostName);
-                            IDeviceScopeApiClientProvider securityScopesApiClientProvider = new DeviceScopeApiClientProvider(hostName, this.edgeDeviceId, this.edgeHubModuleId, 10, edgeHubTokenProvider, serviceIdentityTree, proxy);
+                            IDeviceScopeApiClientProvider securityScopesApiClientProvider = new DeviceScopeApiClientProvider(hostName, this.edgeDeviceId, this.edgeHubModuleId, 10, edgeHubTokenProvider, serviceIdentityHierarchy, proxy);
                             IServiceProxy serviceProxy = new ServiceProxy(securityScopesApiClientProvider, this.nestedEdgeEnabled);
                             IKeyValueStore<string, string> encryptedStore = await GetEncryptedStore(c, "DeviceScopeCache");
-                            deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(serviceIdentityTree, serviceProxy, encryptedStore, this.scopeCacheRefreshRate, this.scopeCacheRefreshDelay);
+                            deviceScopeIdentitiesCache = await DeviceScopeIdentitiesCache.Create(serviceIdentityHierarchy, serviceProxy, encryptedStore, this.scopeCacheRefreshRate, this.scopeCacheRefreshDelay);
                         }
                         else
                         {


### PR DESCRIPTION
This change adds a simple implementation of IServiceIdentityHierarchy backed by a flat dictionary, so we have something that reflects how DeviceScopeIdentitiesCache worked before.  This gets used if nested Edge feature flag is not enabled, as opposed to instantiating the more complex ServiceIdentityTree.