### PR TITLE
[k8s] prepare for beta11 release

### DIFF
--- a/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for installing CRD for Azure IoT Edge on Kubernetes
 name: edge-kubernetes-crd
-version: 0.2.8
+version: 0.2.9

--- a/kubernetes/charts/edge-kubernetes/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for running Azure IoT Edge on Kubernetes
 name: edge-kubernetes
-version: 0.2.8
+version: 0.2.9

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -2,7 +2,7 @@
 iotedged:
   image:
     repository: azureiotedge/azureiotedge-iotedged
-    tag: 0.1.0-beta10
+    tag: 0.1.0-beta11
     pullPolicy: Always
   nodeSelector: {}
   # Volumes which support ownership management are modified to be owned and 
@@ -101,7 +101,7 @@ iotedged:
 iotedgedProxy:
   image:
     repository: azureiotedge/azureiotedge-proxy
-    tag: 0.1.0-beta10
+    tag: 0.1.0-beta11
     pullPolicy: Always
 
 # Edge Agent image configuration
@@ -115,7 +115,7 @@ edgeAgent:
   containerName: edgeagent
   image:
     repository: azureiotedge/azureiotedge-agent
-    tag: 0.1.0-beta10
+    tag: 0.1.0-beta11
     pullPolicy: Always
   hostname: "localhost"
   env:


### PR DESCRIPTION
Update chart for version and image tag.

Changes merged into beta11:
[k8s] Set resource limits and requests for Edge runtime components (#3666)
[k8s public preview] Have EdgeDeploymentOperator report status to Agent (#3232)
[k8s] Update Helm charts to allow for correct proxy settings. (#3641) 
[k8s] Add all root CA certs to TLS connections (#3616)
[k8s] Allow Edge on K8s modules to join HostNetwork. (#3618)
