### PR TITLE
Fix quantiles for Duration and Timer

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsDuration.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsDuration.cs
@@ -18,12 +18,10 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
                 {
                     Objectives = new[]
                     {
-                        new QuantileEpsilonPair(0.5, 0.05),
-                        new QuantileEpsilonPair(0.9, 0.05),
-                        new QuantileEpsilonPair(0.95, 0.01),
+                        new QuantileEpsilonPair(0.1, 0.01),
+                        new QuantileEpsilonPair(0.5, 0.01),
+                        new QuantileEpsilonPair(0.9, 0.01),
                         new QuantileEpsilonPair(0.99, 0.01),
-                        new QuantileEpsilonPair(0.999, 0.01),
-                        new QuantileEpsilonPair(0.9999, 0.01),
                     },
                     LabelNames = labelNames.ToArray()
                 });

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsTimer.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsTimer.cs
@@ -19,12 +19,10 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
                 {
                     Objectives = new[]
                     {
-                        new QuantileEpsilonPair(0.5, 0.05),
-                        new QuantileEpsilonPair(0.9, 0.05),
-                        new QuantileEpsilonPair(0.95, 0.01),
+                        new QuantileEpsilonPair(0.1, 0.01),
+                        new QuantileEpsilonPair(0.5, 0.01),
+                        new QuantileEpsilonPair(0.9, 0.01),
                         new QuantileEpsilonPair(0.99, 0.01),
-                        new QuantileEpsilonPair(0.999, 0.01),
-                        new QuantileEpsilonPair(0.9999, 0.01),
                     },
                     LabelNames = labelNames.ToArray()
                 });


### PR DESCRIPTION
We want to use 0.1, 0.5, 0.9, 0.99 quantiles for all our metrics. This was updated for Histogram metric in this commit f85b838 but was not updated for Duration/Timer. This PR takes care of that.