### PR TITLE
Remove deployment manifest minor version strict validation

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
 
             // Check major version and upper bound
             if (actualSchemaVersion.Major != ExpectedSchemaVersion.Major ||
-                actualSchemaVersion.Major > ExpectedSchemaVersion.Major)
+                actualSchemaVersion > ExpectedSchemaVersion)
             {
                 throw new InvalidSchemaVersionException($"The desired properties schema version {schemaVersion} is not compatible with the expected version {ExpectedSchemaVersion}");
             }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -165,33 +165,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             {
                 throw new InvalidSchemaVersionException($"The desired properties schema version {schemaVersion} is not compatible with the expected version {ExpectedSchemaVersion}");
             }
-
-            // Validate minor versions
-            if (actualSchemaVersion.Minor == 0)
-            {
-                // 1.0
-                //
-                // Module startup order is not supported
-                foreach (KeyValuePair<string, IModule> kvp in config.Modules)
-                {
-                    IModule moduleConfig = kvp.Value;
-
-                    if (moduleConfig.StartupOrder != Constants.DefaultStartupOrder)
-                    {
-                        throw new InvalidSchemaVersionException($"Module startup order is not supported in schema {actualSchemaVersion}, module: {moduleConfig.Name}, startupOrder: {moduleConfig.StartupOrder}");
-                    }
-                }
-            }
-            else if (actualSchemaVersion.Minor == 1)
-            {
-                // 1.1.0
-                //
-                // Everything from 1.0 is supported
-            }
-            else
-            {
-                throw new InvalidSchemaVersionException($"The deployment schema version {actualSchemaVersion} is not compatible with the expected version {ExpectedSchemaVersion}");
-            }
         }
 
         async Task ForceRefreshTwin()

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -1662,7 +1662,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             yield return new object[] { version_1_2, typeof(InvalidSchemaVersionException) };
             yield return new object[] { version_2_0, typeof(InvalidSchemaVersionException) };
             yield return new object[] { version_2_0_1, typeof(InvalidSchemaVersionException) };
-            yield return new object[] { version_schema_mismatch, typeof(InvalidSchemaVersionException) };
+            yield return new object[] { version_schema_mismatch, null };
         }
 
         static async Task SetAgentDesiredProperties(RegistryManager rm, string deviceId)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubDesiredProperties.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/EdgeHubDesiredProperties.cs
@@ -38,34 +38,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
             {
                 throw new InvalidSchemaVersionException($"The deployment schema version {this.SchemaVersion} is not compatible with the expected version {Core.Constants.ConfigSchemaVersion}");
             }
-
-            // Validate minor versions
-            if (version.Minor == 0)
-            {
-                // 1.0
-                //
-                // Routes cannot have priority or TTL
-                foreach (KeyValuePair<string, RouteConfiguration> kvp in this.Routes)
-                {
-                    RouteConfiguration route = kvp.Value;
-
-                    if (route.Priority != Routing.EdgeRouteFactory.DefaultPriority ||
-                        route.TimeToLiveSecs != 0)
-                    {
-                        throw new InvalidSchemaVersionException($"Route priority/TTL is not supported in schema {this.SchemaVersion}.");
-                    }
-                }
-            }
-            else if (version.Minor == 1)
-            {
-                // 1.1.0
-                //
-                // Everything from 1.0 is supported
-            }
-            else
-            {
-                throw new InvalidSchemaVersionException($"The deployment schema version {this.SchemaVersion} is not compatible with the expected version {Core.Constants.ConfigSchemaVersion}");
-            }
         }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/EdgeHubDesiredPropertiesTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/EdgeHubDesiredPropertiesTest.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Config
             yield return new object[] { version_1_2, typeof(InvalidSchemaVersionException) };
             yield return new object[] { version_2_0, typeof(InvalidSchemaVersionException) };
             yield return new object[] { version_2_0_1, typeof(InvalidSchemaVersionException) };
-            yield return new object[] { versionMismatch, typeof(InvalidSchemaVersionException) };
+            yield return new object[] { versionMismatch, null };
         }
 
         [Fact]


### PR DESCRIPTION
This removes manifest strict checking as per earlier design discussions.  Just removing the validation is not an ideal fix, as it allows people to enable 1.1 features while specifying a 1.0 version.  But this is the lowest possible risk change, later we'll need to version the JSON deserialization types so we only parse the elements relevant to a specific version, and ignore all the others.