### PR TITLE
Fix iotedge support-bundle doesn't work if iotedged isn't running

### DIFF
--- a/edgelet/support-bundle/src/support_bundle.rs
+++ b/edgelet/support-bundle/src/support_bundle.rs
@@ -206,13 +206,24 @@ where
 
         let include_ms_only = self.include_ms_only;
 
-        self.runtime
+        let runtime_modules = self
+            .runtime
             .list_with_details()
-            .map_err(|err| Error::from(err.context(ErrorKind::ModuleRuntime)))
-            .map(|(module, _s)| module.name().to_owned())
-            .filter(move |name| !include_ms_only || MS_MODULES.iter().any(|ms| ms == name))
             .collect()
-            .map(|names| (names, self))
+            .then(move |result| {
+                future::ok(match result {
+                    Ok(modules) => modules
+                        .into_iter()
+                        .map(|(module, _s)| module.name().to_owned())
+                        .filter(move |name| {
+                            !include_ms_only || MS_MODULES.iter().any(|ms| ms == name)
+                        })
+                        .collect(),
+                    Err(_) => Vec::new(),
+                })
+            });
+
+        runtime_modules.map(|names| (names, self))
     }
 
     fn write_log_to_file(


### PR DESCRIPTION
Currently iotedge support-bundle will fail if iotedged isn't running. It should still collect host and docker logs.
For this fix, I'm catching the failed operation and return a empty list. This will not cause any problem in the execution of the functions and will produce the logs for all the others operations except for the operations that using the information produced by the runtime. 