### PR TITLE
Drop legacy installer support from Windows installation script

### DIFF
--- a/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+++ b/scripts/windows/setup/IotEdgeSecurityDaemon.ps1
@@ -1606,7 +1606,7 @@ function Validate-GatewaySettings {
 }
 
 function Get-DpsProvisioningSettings {
-$attestationMethod = ''
+    $attestationMethod = ''
     if ($DpsTpm) {
         $attestationMethod = 'tpm'
     }


### PR DESCRIPTION
This change removes support for uninstalling/updating legacy installations of Azure IoT Edge on Windows. This change was created to help resolve a customer issue where detection of IoT Edge installation was not working properly.

Note that we were not able to repro the original issue and do not have RCA. This change however helped to resolve the issue for the customer. The legacy installer have been used prior to introducing native Windows packages. The legacy installations can be still removed using the older version of this script.

Testing, I tested this change by merging it onto the released version of the script and only on Windows Server. Testing this specific version against released IoT Edge runtime fails due to unrelated changes that are not supported by the released bits. Please let me know if more testing is needed from my side or the pipelines will handle it.