### PR TITLE
[mqtt] Unblock external transports when Authorizer ready

### DIFF
--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -16,6 +16,7 @@ mod broker;
 mod connection;
 mod error;
 mod persist;
+mod ready;
 mod server;
 mod session;
 pub mod settings;
@@ -60,6 +61,11 @@ pub use crate::snapshot::{
 };
 pub use crate::subscription::{Segment, Subscription, TopicFilter};
 pub use crate::tls::ServerCertificate;
+pub use ready::BrokerReadyEvent;
+
+pub type BrokerReady = ready::BrokerReady<ready::BrokerReadyEvent>;
+pub type BrokerReadySignal = ready::BrokerReadySignal<ready::BrokerReadyEvent>;
+pub type BrokerReadyHandle = ready::BrokerReadyHandle<ready::BrokerReadyEvent>;
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
 pub struct ClientId(Arc<String>);

--- a/mqtt/mqtt-broker/src/ready.rs
+++ b/mqtt/mqtt-broker/src/ready.rs
@@ -57,7 +57,7 @@ where
     }
 }
 
-/// A handle to await all readiness events collected buy the handle.
+/// A handle to await all readiness events collected by the handle.
 pub struct BrokerReadySignal<E>(Receiver<E>);
 
 impl<E> BrokerReadySignal<E>

--- a/mqtt/mqtt-broker/src/ready.rs
+++ b/mqtt/mqtt-broker/src/ready.rs
@@ -1,0 +1,180 @@
+use std::{collections::HashSet, fmt::Display, hash::Hash};
+
+use tokio::sync::broadcast::{self, Receiver, RecvError, Sender};
+use tracing::{debug, warn};
+
+/// `BrokerReady` component acts as a intermidiate entity to determine whether
+/// `Broker` is ready to serve external clients. It awaits on several events
+/// from components Broker depends on.
+///
+/// Notes: Authenticator and Authorizer both needs some data which not
+/// available when process started. They receive it using internal
+/// communication channels. Once data is loaded and components initialized
+/// they send corresponding events to the `BrokerReady` which in turn unblocks
+/// external transports.
+pub struct BrokerReady<E> {
+    event_send: Sender<E>,
+}
+
+impl<E> Default for BrokerReady<E> {
+    fn default() -> Self {
+        let (event_send, _) = broadcast::channel(5);
+        Self { event_send }
+    }
+}
+
+impl<E> BrokerReady<E> {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn handle(&self) -> BrokerReadyHandle<E> {
+        BrokerReadyHandle(self.event_send.clone())
+    }
+
+    pub fn signal(&self) -> BrokerReadySignal<E> {
+        BrokerReadySignal(self.event_send.subscribe())
+    }
+}
+
+/// A handle to send readiness signals to `BrokerReady`.
+pub struct BrokerReadyHandle<E>(Sender<E>);
+
+impl<E> BrokerReadyHandle<E>
+where
+    E: Clone + Display,
+{
+    pub fn send(&mut self, event: E) {
+        loop {
+            let event = event.clone();
+            debug!("sending broker ready event {}", event);
+
+            // attempt to send event until all recepients receive it
+            if matches!(self.0.send(event), Ok(recv) if recv == self.0.receiver_count()) {
+                break;
+            }
+        }
+    }
+}
+
+/// A handle to await all readiness events collected buy the handle.
+pub struct BrokerReadySignal<E>(Receiver<E>);
+
+impl<E> BrokerReadySignal<E>
+where
+    E: Display + Clone + Eq + Hash + AwaitingEvents<Event = E>,
+{
+    /// Blocks execution and awaits when all required events are received, or
+    /// error occurred.
+    pub async fn wait(mut self) -> Result<(), BrokerReadyError> {
+        let mut awaiting = E::awaiting();
+
+        while !awaiting.is_empty() {
+            match self.0.recv().await {
+                Ok(event) => {
+                    if !awaiting.remove(&event) {
+                        warn!("received duplicating event {}", event);
+                    }
+                }
+                Err(RecvError::Lagged(count)) => {
+                    warn!("lagged to receive all events by {} events", count);
+                }
+                Err(RecvError::Closed) => {
+                    return Err(BrokerReadyError::Closed);
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A trait to define a set of all events required by the `BrokerReady` to
+/// receive in order to consider broker as ready to serve external clients.
+pub trait AwaitingEvents {
+    type Event;
+
+    fn awaiting() -> HashSet<Self::Event>;
+}
+
+/// Broker readiness events.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BrokerReadyEvent {
+    AuthorizerReady,
+}
+
+impl AwaitingEvents for BrokerReadyEvent {
+    type Event = Self;
+
+    fn awaiting() -> HashSet<Self::Event> {
+        let mut awaiting = HashSet::new();
+        awaiting.insert(Self::AuthorizerReady);
+
+        awaiting
+    }
+}
+
+impl Display for BrokerReadyEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AuthorizerReady => write!(f, "Authorizer Ready"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum BrokerReadyError {
+    #[error("close channel")]
+    Closed,
+}
+
+#[cfg(test)]
+mod tests {
+    use matches::assert_matches;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn it_unblocks_when_all_events_received() {
+        let ready = BrokerReady::<TestEvent>::new();
+
+        let mut sender1 = ready.handle();
+        let mut sender2 = ready.handle();
+
+        let join1 = tokio::spawn(ready.signal().wait());
+        let join2 = tokio::spawn(ready.signal().wait());
+
+        sender1.send(TestEvent::Event1);
+        sender2.send(TestEvent::Event2);
+
+        assert_matches!(join1.await, Ok(Ok(())));
+        assert_matches!(join2.await, Ok(Ok(())));
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+    enum TestEvent {
+        Event1,
+        Event2,
+    }
+
+    impl AwaitingEvents for TestEvent {
+        type Event = Self;
+
+        fn awaiting() -> HashSet<Self::Event> {
+            let mut awaiting = HashSet::new();
+            awaiting.insert(Self::Event1);
+            awaiting.insert(Self::Event2);
+
+            awaiting
+        }
+    }
+
+    impl Display for TestEvent {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            match self {
+                Self::Event1 => write!(f, "e1"),
+                Self::Event2 => write!(f, "e2"),
+            }
+        }
+    }
+}

--- a/mqtt/mqtt-broker/src/ready.rs
+++ b/mqtt/mqtt-broker/src/ready.rs
@@ -7,7 +7,7 @@ use tracing::{debug, warn};
 /// `Broker` is ready to serve external clients. It awaits on several events
 /// from components Broker depends on.
 ///
-/// Notes: Authenticator and Authorizer both needs some data which not
+/// Notes: Authenticator and Authorizer both needs some data which is not
 /// available when process started. They receive it using internal
 /// communication channels. Once data is loaded and components initialized
 /// they send corresponding events to the `BrokerReady` which in turn unblocks

--- a/mqtt/mqtt-broker/src/ready.rs
+++ b/mqtt/mqtt-broker/src/ready.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, fmt::Display, hash::Hash};
 
 use tokio::sync::broadcast::{self, Receiver, RecvError, Sender};
-use tracing::{debug, warn};
+use tracing::{debug, error, warn};
 
 /// `BrokerReady` component acts as a intermidiate entity to determine whether
 /// `Broker` is ready to serve external clients. It awaits on several events
@@ -45,14 +45,9 @@ where
     E: Clone + Display,
 {
     pub fn send(&mut self, event: E) {
-        loop {
-            let event = event.clone();
-            debug!("sending broker ready event {}", event);
-
-            // attempt to send event until all recepients receive it
-            if matches!(self.0.send(event), Ok(recv) if recv == self.0.receiver_count()) {
-                break;
-            }
+        debug!("sending broker ready event {}", event);
+        if self.0.send(event).is_err() {
+            error!("no active receiver found")
         }
     }
 }

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -30,6 +30,10 @@ where
         Self::create(authorizer, Some(broker_ready))
     }
 
+    pub fn without_ready_handle(authorizer: Z) -> Self {
+        Self::create(authorizer, None)
+    }
+
     fn create(authorizer: Z, broker_ready: Option<BrokerReadyHandle>) -> Self {
         Self {
             iothub_allowed_topics: RefCell::default(),
@@ -405,7 +409,7 @@ mod tests {
     #[test_case(&tests::subscribe_activity("device-1", "device-1", "topic"); "generic MQTT topic subscribe")]
     fn it_delegates_to_inner(activity: &Activity) {
         let inner = authorize_fn_ok(|_| Authorization::Forbidden("not allowed inner".to_string()));
-        let authorizer = EdgeHubAuthorizer::create(inner, None);
+        let authorizer = EdgeHubAuthorizer::without_ready_handle(inner);
 
         let auth = authorizer.authorize(&activity);
 
@@ -485,7 +489,7 @@ mod tests {
     where
         Z: Authorizer,
     {
-        let mut authorizer = EdgeHubAuthorizer::create(inner, None);
+        let mut authorizer = EdgeHubAuthorizer::without_ready_handle(inner);
 
         let service_identity = IdentityUpdate {
             identity: "device-1".to_string(),

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -265,20 +265,22 @@ where
             Ok(update) => {
                 debug!("authorizer update received. Identities: {:?}", update);
 
+                // update identities cache
                 self.identities_cache = update
                     .0
                     .into_iter()
                     .map(|id| (id.identity().into(), id))
                     .collect();
+
+                // signal that authorizer has been initialized
+                if let Some(mut broker_ready) = self.broker_ready.take() {
+                    broker_ready.send(BrokerReadyEvent::AuthorizerReady);
+                }
             }
             Err(update) => {
                 self.inner.update(update)?;
             }
         };
-
-        if let Some(mut broker_ready) = self.broker_ready.take() {
-            broker_ready.send(BrokerReadyEvent::AuthorizerReady);
-        }
 
         Ok(())
     }

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 
 use mqtt_broker::{
     auth::{Activity, Authorization, Authorizer, Connect, Operation, Publish, Subscribe},
-    AuthId, ClientId,
+    AuthId, BrokerReadyEvent, BrokerReadyHandle, ClientId,
 };
 
 /// `EdgeHubAuthorizer` implements authorization rules for iothub-specific primitives.
@@ -14,11 +14,11 @@ use mqtt_broker::{
 /// telemetry messages, etc...
 ///
 /// For non-iothub-specific primitives it delegates the request to an inner authorizer (`PolicyAuthorizer`).
-#[derive(Debug)]
 pub struct EdgeHubAuthorizer<Z> {
     iothub_allowed_topics: RefCell<HashMap<ClientId, Vec<String>>>,
     identities_cache: HashMap<ClientId, IdentityUpdate>,
     inner: Z,
+    broker_ready: Option<BrokerReadyHandle>,
 }
 
 impl<Z, E> EdgeHubAuthorizer<Z>
@@ -26,11 +26,16 @@ where
     Z: Authorizer<Error = E>,
     E: StdError,
 {
-    pub fn new(authorizer: Z) -> Self {
+    pub fn new(authorizer: Z, broker_ready: BrokerReadyHandle) -> Self {
+        Self::create(authorizer, Some(broker_ready))
+    }
+
+    fn create(authorizer: Z, broker_ready: Option<BrokerReadyHandle>) -> Self {
         Self {
             iothub_allowed_topics: RefCell::default(),
             identities_cache: HashMap::default(),
             inner: authorizer,
+            broker_ready,
         }
     }
 
@@ -266,6 +271,11 @@ where
                 self.inner.update(update)?;
             }
         };
+
+        if let Some(mut broker_ready) = self.broker_ready.take() {
+            broker_ready.send(BrokerReadyEvent::AuthorizerReady);
+        }
+
         Ok(())
     }
 }
@@ -395,7 +405,7 @@ mod tests {
     #[test_case(&tests::subscribe_activity("device-1", "device-1", "topic"); "generic MQTT topic subscribe")]
     fn it_delegates_to_inner(activity: &Activity) {
         let inner = authorize_fn_ok(|_| Authorization::Forbidden("not allowed inner".to_string()));
-        let authorizer = EdgeHubAuthorizer::new(inner);
+        let authorizer = EdgeHubAuthorizer::create(inner, None);
 
         let auth = authorizer.authorize(&activity);
 
@@ -475,7 +485,7 @@ mod tests {
     where
         Z: Authorizer,
     {
-        let mut authorizer = EdgeHubAuthorizer::new(inner);
+        let mut authorizer = EdgeHubAuthorizer::create(inner, None);
 
         let service_identity = IdentityUpdate {
             identity: "device-1".to_string(),

--- a/mqtt/mqtt-edgehub/src/command/authorized_identities.rs
+++ b/mqtt/mqtt-edgehub/src/command/authorized_identities.rs
@@ -33,7 +33,7 @@ impl Command for AuthorizedIdentitiesCommand {
     }
 
     fn handle(&mut self, publication: &ReceivedPublication) -> Result<(), Self::Error> {
-        info!("received authorized identities from edgeHub.");
+        info!("received authorized identities from EdgeHub.");
         let update: AuthorizerUpdate = serde_json::from_slice(&publication.payload)
             .map_err(Error::ParseAuthorizedIdentities)?;
 

--- a/mqtt/mqtt-edgehub/src/command/policy_update.rs
+++ b/mqtt/mqtt-edgehub/src/command/policy_update.rs
@@ -30,7 +30,7 @@ impl Command for PolicyUpdateCommand {
     }
 
     fn handle(&mut self, publication: &ReceivedPublication) -> Result<(), Self::Error> {
-        info!("received policy update from edgeHub.");
+        info!("received policy update from EdgeHub.");
         let identities: Vec<PolicyUpdate> =
             serde_json::from_slice(&publication.payload).map_err(Error::ParsePolicyUpdate)?;
 

--- a/mqtt/mqtt-edgehub/tests/authorization.rs
+++ b/mqtt/mqtt-edgehub/tests/authorization.rs
@@ -5,7 +5,9 @@ use mqtt3::{
     proto::ClientId, proto::Packet, proto::PacketIdentifier, proto::QoS, proto::Subscribe,
     proto::SubscribeTo,
 };
-use mqtt_broker::{auth::authorize_fn_ok, auth::Authorization, auth::Operation, BrokerBuilder};
+use mqtt_broker::{
+    auth::authorize_fn_ok, auth::Authorization, auth::Operation, BrokerBuilder, BrokerReady,
+};
 use mqtt_broker_tests_util::{
     client::TestClientBuilder,
     packet_stream::PacketStream,
@@ -30,6 +32,7 @@ use common::DummyAuthorizer;
 async fn disconnect_client_on_auth_update() {
     // Start broker with DummyAuthorizer that allows everything from CommandHandler and $edgeHub,
     // but otherwise passes authorization along to EdgeHubAuthorizer
+    let broker_ready = BrokerReady::new();
     let broker = BrokerBuilder::default()
         .with_authorizer(DummyAuthorizer::new(EdgeHubAuthorizer::new(
             authorize_fn_ok(|activity| {
@@ -39,6 +42,7 @@ async fn disconnect_client_on_auth_update() {
                     Authorization::Forbidden("not allowed".to_string())
                 }
             }),
+            broker_ready.handle(),
         )))
         .build();
     let broker_handle = broker.handle();

--- a/mqtt/mqtt-edgehub/tests/authorization.rs
+++ b/mqtt/mqtt-edgehub/tests/authorization.rs
@@ -5,13 +5,11 @@ use mqtt3::{
     proto::ClientId, proto::Packet, proto::PacketIdentifier, proto::QoS, proto::Subscribe,
     proto::SubscribeTo,
 };
-use mqtt_broker::{
-    auth::authorize_fn_ok, auth::Authorization, auth::Operation, BrokerBuilder, BrokerReady,
-};
+use mqtt_broker::{auth::authorize_fn_ok, auth::Authorization, auth::Operation, BrokerBuilder};
 use mqtt_broker_tests_util::{
     client::TestClientBuilder,
     packet_stream::PacketStream,
-    server::{start_server, DummyAuthenticator},
+    server::{self, DummyAuthenticator},
 };
 use mqtt_edgehub::{
     auth::EdgeHubAuthorizer, auth::IdentityUpdate, command::AuthorizedIdentitiesCommand,
@@ -32,22 +30,20 @@ use common::DummyAuthorizer;
 async fn disconnect_client_on_auth_update() {
     // Start broker with DummyAuthorizer that allows everything from CommandHandler and $edgeHub,
     // but otherwise passes authorization along to EdgeHubAuthorizer
-    let broker_ready = BrokerReady::new();
     let broker = BrokerBuilder::default()
-        .with_authorizer(DummyAuthorizer::new(EdgeHubAuthorizer::new(
-            authorize_fn_ok(|activity| {
+        .with_authorizer(DummyAuthorizer::new(
+            EdgeHubAuthorizer::without_ready_handle(authorize_fn_ok(|activity| {
                 if matches!(activity.operation(), Operation::Connect(_)) {
                     Authorization::Allowed
                 } else {
                     Authorization::Forbidden("not allowed".to_string())
                 }
-            }),
-            broker_ready.handle(),
-        )))
+            })),
+        ))
         .build();
     let broker_handle = broker.handle();
 
-    let server_handle = start_server(broker, DummyAuthenticator::with_id("device-1"));
+    let server_handle = server::start_server(broker, DummyAuthenticator::with_id("device-1"));
 
     // start command handler with AuthorizedIdentitiesCommand
     let command = AuthorizedIdentitiesCommand::new(&broker_handle);

--- a/mqtt/mqttd/src/broker/bootstrap/generic.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/generic.rs
@@ -12,7 +12,8 @@ use super::SidecarManager;
 use mqtt_broker::{
     auth::{authenticate_fn_ok, AllowAll, Authorizer},
     settings::BrokerConfig,
-    AuthId, Broker, BrokerBuilder, BrokerHandle, BrokerSnapshot, Error, Server, ServerCertificate,BrokerReady
+    AuthId, Broker, BrokerBuilder, BrokerHandle, BrokerReady, BrokerSnapshot, Error, Server,
+    ServerCertificate,
 };
 use mqtt_generic::settings::{CertificateConfig, ListenerConfig, Settings};
 
@@ -34,7 +35,7 @@ where
 pub async fn broker(
     config: &BrokerConfig,
     state: Option<BrokerSnapshot>,
-    _: &BrokerReady
+    _: &BrokerReady,
 ) -> Result<Broker<impl Authorizer>, Error> {
     let broker = BrokerBuilder::default()
         .with_authorizer(AllowAll)
@@ -49,7 +50,7 @@ pub async fn start_server<Z, F>(
     config: Settings,
     broker: Broker<Z>,
     shutdown_signal: F,
-    _: BrokerReady
+    _: BrokerReady,
 ) -> Result<BrokerSnapshot>
 where
     Z: Authorizer + Send + 'static,

--- a/mqtt/mqttd/src/broker/bootstrap/generic.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/generic.rs
@@ -12,7 +12,7 @@ use super::SidecarManager;
 use mqtt_broker::{
     auth::{authenticate_fn_ok, AllowAll, Authorizer},
     settings::BrokerConfig,
-    AuthId, Broker, BrokerBuilder, BrokerHandle, BrokerSnapshot, Error, Server, ServerCertificate,
+    AuthId, Broker, BrokerBuilder, BrokerHandle, BrokerSnapshot, Error, Server, ServerCertificate,BrokerReady
 };
 use mqtt_generic::settings::{CertificateConfig, ListenerConfig, Settings};
 
@@ -34,6 +34,7 @@ where
 pub async fn broker(
     config: &BrokerConfig,
     state: Option<BrokerSnapshot>,
+    _: &BrokerReady
 ) -> Result<Broker<impl Authorizer>, Error> {
     let broker = BrokerBuilder::default()
         .with_authorizer(AllowAll)
@@ -48,6 +49,7 @@ pub async fn start_server<Z, F>(
     config: Settings,
     broker: Broker<Z>,
     shutdown_signal: F,
+    _: BrokerReady
 ) -> Result<BrokerSnapshot>
 where
     Z: Authorizer + Send + 'static,


### PR DESCRIPTION
Encapsulate the exact mechanism to notify protocols to start serving external clients with `BrokerReady` component.
`BrokerReady` consist of two parts: `BrokerReadyHandle` and `BrokerReadySignal`.
`BrokerReadyHandle` - a handle to send readiness events.
`BrokerReadySignal` - await for all required readiness events collected and then proceeds.

It is only one readiness event required so far: `EdgeHubAuthorizer` is updated with initial device scopes. However, it can be more.