### PR TITLE
[mqtt] Revert mockall version to the one from crates.io

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -1040,8 +1040,9 @@ dependencies = [
 
 [[package]]
 name = "mockall"
-version = "0.8.0"
-source = "git+https://github.com/asomers/mockall?rev=21bd10b#21bd10bef3284543e79a455d713e9416b5c376b4"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf52bd480d59ec342893c9c64ace644b4bbb1e184f8217312f0282107a372e4d"
 dependencies = [
  "cfg-if",
  "downcast",
@@ -1054,8 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "mockall_derive"
-version = "0.8.0"
-source = "git+https://github.com/asomers/mockall?rev=21bd10b#21bd10bef3284543e79a455d713e9416b5c376b4"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f060c7e8d81fa8cf7bfd4a2cc183402d1066c9cba56998e2807b109d8c0ec"
 dependencies = [
  "cfg-if",
  "proc-macro2",

--- a/mqtt/mqtt3/Cargo.toml
+++ b/mqtt/mqtt3/Cargo.toml
@@ -12,8 +12,7 @@ futures-channel = { version = "0.3", features = ["sink"] }
 futures-sink = "0.3"
 futures-util = { version = "0.3", features = ["sink"] }
 log = "0.4"
-# TODO change it back when the fix go into a new release https://github.com/asomers/mockall/issues/212
-mockall = { git = "https://github.com/asomers/mockall", rev = "21bd10b"}
+mockall = "0.8"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 tokio = { version = "0.2", features = ["time"] }
 tokio-util = { version = "0.2", features = ["codec"] }


### PR DESCRIPTION
Revert mockall version to the one from crates.io