### PR TITLE
Pass SSL client certificate through API proxy to EdgeHub via custom header

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
         public const string ServiceApiIdHeaderKey = "x-ms-edge-moduleId";
         public const string OriginEdgeHeaderKey = "x-ms-edge-origin";
+        public const string ClientCertificateHeaderKey = "x-ms-edge-clientcert";
 
         public static readonly Version ConfigSchemaVersion = new Version("1.2.0");
     }

--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -70,9 +70,18 @@ http {
             proxy_ssl_trusted_certificate trustedCA.crt;
             proxy_ssl_verify_depth 7;
             proxy_ssl_verify       on;
-            proxy_set_header x-ms-edge-clientcert $ssl_client_escaped_cert;
             proxy_pass          https://${IOTEDGE_PARENTHOSTNAME}:${NGINX_DEFAULT_PORT}/$1$is_args$args;
         }
         #endif_tag ${IOTEDGE_PARENTHOSTNAME}
+
+        location ~^/(devices|twins)/(.*){
+            proxy_http_version 1.1;
+            resolver 127.0.0.11;
+            proxy_ssl_trusted_certificate trustedCA.crt;
+            proxy_ssl_verify_depth 7;
+            proxy_ssl_verify       on;
+            proxy_set_header x-ms-edge-clientcert $ssl_client_escaped_cert;
+            proxy_pass          https://$edgeHub;
+        }
     }
 }

--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -74,13 +74,10 @@ http {
         }
         #endif_tag ${IOTEDGE_PARENTHOSTNAME}
 
-        location ~^/(devices|twins)/(.*){
-            proxy_http_version 1.1;
-            resolver 127.0.0.11;
-            proxy_ssl_trusted_certificate trustedCA.crt;
-            proxy_ssl_verify_depth 7;
-            proxy_ssl_verify       on;
-            proxy_set_header x-ms-edge-clientcert $ssl_client_escaped_cert;
+        location ~^/(devices|twins)/(.*) {
+            proxy_http_version  1.1;
+            proxy_ssl_verify    off;
+            proxy_set_header    x-ms-edge-clientcert    $ssl_client_escaped_cert;
             proxy_pass          https://$edgeHub;
         }
     }

--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -17,7 +17,7 @@ http {
         ssl_certificate_key    private_key_server.pem; 
         ssl_client_certificate trustedCA.crt;
         #ssl_verify_depth 7;
-        #ssl_verify_client on;
+        ssl_verify_client optional_no_ca;
 
         #if_tag ${BLOB_UPLOAD_ROUTE_ADDRESS}
         if ($http_x_ms_version)
@@ -70,6 +70,7 @@ http {
             proxy_ssl_trusted_certificate trustedCA.crt;
             proxy_ssl_verify_depth 7;
             proxy_ssl_verify       on;
+            proxy_set_header x-ms-edge-clientcert $ssl_client_escaped_cert;
             proxy_pass          https://${IOTEDGE_PARENTHOSTNAME}:${NGINX_DEFAULT_PORT}/$1$is_args$args;
         }
         #endif_tag ${IOTEDGE_PARENTHOSTNAME}

--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -74,7 +74,7 @@ http {
         }
         #endif_tag ${IOTEDGE_PARENTHOSTNAME}
 
-        location ~^/(devices|twins)/(.*) {
+        location ~^/devices|twins/ {
             proxy_http_version  1.1;
             proxy_ssl_verify    off;
             proxy_set_header    x-ms-edge-clientcert    $ssl_client_escaped_cert;


### PR DESCRIPTION
This change makes nginx forward the client SSL cert to EdgeHub via a customer header, so that EdgeHub can parse it back into an X509Certificate2 when receiving the forwarded HTTP request and perform authentication.