### PR TITLE
Make container registry config in end-to-end tests optional

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         {
             using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
             CancellationToken token = cts.Token;
-            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.FirstOrDefault());
 
             this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
                 Context.Current.InstallerPath,

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         protected async Task BeforeAllTestsAsync()
         {
             using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
-            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.FirstOrDefault());
             this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
                 Context.Current.InstallerPath,
                 Context.Current.EdgeAgentBootstrapImage,

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         protected async Task BeforeAllTestsAsync()
         {
             using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
-            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.FirstOrDefault());
             this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
                 Context.Current.InstallerPath,
                 Context.Current.EdgeAgentBootstrapImage,


### PR DESCRIPTION
The service deployment pipeline (`builds/service/service-deployment.yaml`) runs a single end-to-end test ("TempSensor") in an Azure pipeline. The IoT Hub team uses it to validate new deployments of their service. Since the pipeline only runs a single, basic test, it's context.json file is very simple:
```json
{
  "logFile": "/path/to/testoutput.log"
}
```
The pipeline has been running against 1.0.9, but now that 1.0.10 is released I tried to upgrade it. Something has changed during this release, and the "registries" object in context.json is no longer optional, causing a thrown exception in the fixtures. This change restores the correct behavior.