### PR TITLE
Allow test context without container registry info

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         {
             using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
             CancellationToken token = cts.Token;
-            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.FirstOrDefault());
 
             this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
                 Context.Current.InstallerPath,

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/DeviceProvisioningFixture.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         protected async Task BeforeAllTestsAsync()
         {
             using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
-            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.FirstOrDefault());
             this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
                 Context.Current.InstallerPath,
                 Context.Current.EdgeAgentBootstrapImage,

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         protected async Task BeforeAllTestsAsync()
         {
             using var cts = new CancellationTokenSource(Context.Current.SetupTimeout);
-            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.First());
+            Option<Registry> bootstrapRegistry = Option.Maybe(Context.Current.Registries.FirstOrDefault());
             this.daemon = await OsPlatform.Current.CreateEdgeDaemonAsync(
                 Context.Current.InstallerPath,
                 Context.Current.EdgeAgentBootstrapImage,


### PR DESCRIPTION
The end-to-end tests were designed so that most of the parameters in context.json are optional. For example, if your context.json file contains nothing more than an empty JSON object ("{}") and you've defined the variables `E2E_IOT_HUB_CONNECTION_STRING` and `E2E_EVENT_HUB_ENDPOINT` in your environment, then the TempSensor test should pass:

```bash
read -s E2E_IOT_HUB_CONNECTION_STRING
export E2E_IOT_HUB_CONNECTION_STRING
read -s E2E_EVENT_HUB_ENDPOINT
export E2E_EVENT_HUB_ENDPOINT
sudo --preserve-env dotnet test --filter TempSensor test/Microsoft.Azure.Devices.Edge.Test
```
But somewhere along that way, that behavior broke. Today if I run the TempSensor test with an empty context.json, I get an exception in `SetupFixture` because the "registry" value was not specified. Container registry information is optional; if not given, public images can still be used (e.g. mcr.microsoft.com/azureiotedge-agent:1.0).

This change makes "registry" optional again.