### PR TITLE
M2M fix - property parsing problems

### DIFF
--- a/mqtt/mqtt-edgehub/src/topic/translation.rs
+++ b/mqtt/mqtt-edgehub/src/topic/translation.rs
@@ -267,7 +267,7 @@ translate_c2d! {
         },
         to_external {
             format!("\\$edgehub/{}/{}/inputs/(?P<path>.+)", DEVICE_ID, MODULE_ID),
-            {|captures: regex::Captures<'_>| format!("devices/{}/modules/{}/{}", &captures["device_id"], &captures["module_id"], &captures["path"])}
+            {|captures: regex::Captures<'_>| format!("devices/{}/modules/{}/inputs/{}", &captures["device_id"], &captures["module_id"], &captures["path"])}
         }
     }
 }
@@ -524,7 +524,7 @@ mod tests {
                 "$edgehub/device_1/module_a/inputs/route_1/%24.cdid=device_1&%24.cmid=module_a"
             ),
             Some(
-                "devices/device_1/modules/module_a/route_1/%24.cdid=device_1&%24.cmid=module_a"
+                "devices/device_1/modules/module_a/inputs/route_1/%24.cdid=device_1&%24.cmid=module_a"
                     .to_owned()
             )
         );

--- a/mqtt/mqtt-edgehub/tests/delivery.rs
+++ b/mqtt/mqtt-edgehub/tests/delivery.rs
@@ -56,7 +56,7 @@ async fn it_sends_delivery_confirmation_for_m2m_messages() {
     assert_eq!(
         module.publications().next().await,
         Some(ReceivedPublication {
-            topic_name: "devices/device-1/modules/module-1/telemetry/?rid=1".into(),
+            topic_name: "devices/device-1/modules/module-1/inputs/telemetry/?rid=1".into(),
             dup: false,
             qos: QoS::AtLeastOnce,
             retain: false,


### PR DESCRIPTION
M2M messages could go through, but the parameters encoded in the topic were miss-parsed due to a missing /inputs/ tag 