### PR TITLE
Add support for OnBehalfOf connections in legacy MQTT protocol head

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ClientInfo.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ClientInfo.cs
@@ -6,17 +6,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
     public class ClientInfo
     {
-        public ClientInfo(string deviceId, string moduleId, string deviceClientType, Option<string> modelId)
+        public ClientInfo(string deviceId, string moduleId, string deviceClientType, Option<string> modelId, Option<string> authChain)
         {
             this.DeviceId = deviceId;
             this.ModuleId = moduleId;
             this.DeviceClientType = deviceClientType;
             this.ModelId = modelId;
+            this.AuthChain = authChain;
         }
 
         public string DeviceId { get; }
         public string ModuleId { get; }
         public string DeviceClientType { get; }
         public Option<string> ModelId { get; }
+        public Option<string> AuthChain { get; }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceIdentityProvider.cs
@@ -55,12 +55,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 {
                     deviceCredentials = this.clientCredentialsFactory.GetWithSasToken(clientInfo.DeviceId, clientInfo.ModuleId, clientInfo.DeviceClientType, password, false, clientInfo.ModelId, clientInfo.AuthChain);
 
+                    // For OnBehalfOf connections, we'll get the token for the actor EdgeHub instead
+                    // of the actual leaf/module, so we need to construct the credentials accordingly
                     Option<string> actorDeviceIdOption = AuthChainHelpers.GetActorDeviceId(clientInfo.AuthChain);
-                    actorDeviceIdOption.ForEach(actorDeviceId =>
-                    {
-                        // For OnBehalfOf connections, we'll get the token for the actor EdgeHub instead
-                        // of the actual leaf/module, so we need to construct the credentials accordingly
-                        actorCredentials = Option.Some(this.clientCredentialsFactory.GetWithSasToken(
+                    actorCredentials = actorDeviceIdOption.Map(actorDeviceId =>
+                        this.clientCredentialsFactory.GetWithSasToken(
                             actorDeviceId,
                             Microsoft.Azure.Devices.Edge.Hub.Core.Constants.EdgeHubModuleId,
                             clientInfo.DeviceClientType,
@@ -68,7 +67,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                             false,
                             clientInfo.ModelId,
                             clientInfo.AuthChain));
-                    });
                 }
                 else if (this.remoteCertificate.HasValue)
                 {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttUsernameParser.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttUsernameParser.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
         const string ApiVersionKey = "api-version";
         const string DeviceClientTypeKey = "DeviceClientType";
         const string ModelIdKey = "model-id";
+        const string AuthChain = "auth-chain";
 
         public ClientInfo Parse(string username)
         {
@@ -115,7 +116,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 modelIdOption = Option.Some(modelId);
             }
 
-            return new ClientInfo(deviceId, moduleId, deviceClientType, modelIdOption);
+            Option<string> authChainOption = Option.None<string>();
+            if (queryParameters.TryGetValue(AuthChain, out string authChain) && !string.IsNullOrWhiteSpace(authChain))
+            {
+                authChainOption = Option.Some(authChain);
+            }
+
+            return new ClientInfo(deviceId, moduleId, deviceClientType, modelIdOption, authChainOption);
         }
 
         static IDictionary<string, string> ParseDeviceClientType(string queryParameterString)


### PR DESCRIPTION
This change parses out the authchain from the username in the CONNECT packet, and constructs the credentials for the actor EdgeHub during an OnBehalfOf connection so that we can authenticate the token correctly.