### PR TITLE
[k8s] Discovered some problems with createOptions parsing.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -284,7 +284,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
         }
 
         static IEnumerable<V1EnvVar> ParseEnv(IReadOnlyList<string> env) =>
-            env.Select(hostEnv => hostEnv.Split('='))
+            env.Select(hostEnv =>
+                {
+                    int index = hostEnv.IndexOf('=');
+                    return (index <= 0) ?
+                            Array.Empty<string>() :
+                            new string[] { hostEnv.Substring(0, index), hostEnv.Substring(index + 1) };
+                })
                 .Where(keyValue => keyValue.Length == 2)
                 .Select(keyValue => new V1EnvVar(keyValue[0], keyValue[1]));
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/CombinedKubernetesConfigProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/CombinedKubernetesConfigProviderTest.cs
@@ -236,27 +236,45 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
 ]
 }";
 
+        const string CmdCreateOptionsLC =
+                    @"{
+""cmd"" : [
+  ""argument3"",
+  ""argument4""
+]
+}";
+
         [Fact]
         public void CmdEntryOptionsWillExist()
         {
             var runtimeInfo = new Mock<IRuntimeInfo<DockerRuntimeConfig>>();
             runtimeInfo.SetupGet(ri => ri.Config).Returns(new DockerRuntimeConfig("1.24", string.Empty));
 
-            var module = new Mock<IModule<DockerConfig>>();
-            module.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", CmdCreateOptions));
-            module.SetupGet(m => m.Name).Returns("mod1");
+            var module1 = new Mock<IModule<DockerConfig>>();
+            module1.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", CmdCreateOptions));
+            module1.SetupGet(m => m.Name).Returns("mod1");
+            var module2 = new Mock<IModule<DockerConfig>>();
+            module2.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", CmdCreateOptionsLC));
+            module2.SetupGet(m => m.Name).Returns("mod1");
 
             CombinedKubernetesConfigProvider provider = new CombinedKubernetesConfigProvider(new[] { new AuthConfig() }, new Uri("unix:///var/run/iotedgedworkload.sock"), new Uri("unix:///var/run/iotedgedmgmt.sock"), true);
 
             // Act
-            CombinedKubernetesConfig config = provider.GetCombinedConfig(module.Object, runtimeInfo.Object);
+            CombinedKubernetesConfig config1 = provider.GetCombinedConfig(module1.Object, runtimeInfo.Object);
+            CombinedKubernetesConfig config2 = provider.GetCombinedConfig(module2.Object, runtimeInfo.Object);
 
             // Assert
-            Assert.True(config.CreateOptions.Cmd.HasValue);
-            config.CreateOptions.Cmd.ForEach(cmd =>
+            Assert.True(config1.CreateOptions.Cmd.HasValue);
+            config1.CreateOptions.Cmd.ForEach(cmd =>
             {
                 Assert.Equal("argument1", cmd[0]);
                 Assert.Equal("argument2", cmd[1]);
+            });
+            Assert.True(config2.CreateOptions.Cmd.HasValue);
+            config2.CreateOptions.Cmd.ForEach(cmd =>
+            {
+                Assert.Equal("argument3", cmd[0]);
+                Assert.Equal("argument4", cmd[1]);
             });
         }
 
@@ -266,6 +284,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
   ""a-command""
 ]
 }";
+        const string EntryPointCreateOptionsLC =
+            @"{
+""entrypoint"" : [
+  ""a-command2""
+]
+}";
 
         [Fact]
         public void EntrypointOptionsWillExist()
@@ -273,23 +297,33 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var runtimeInfo = new Mock<IRuntimeInfo<DockerRuntimeConfig>>();
             runtimeInfo.SetupGet(ri => ri.Config).Returns(new DockerRuntimeConfig("1.24", string.Empty));
 
-            var module = new Mock<IModule<DockerConfig>>();
-            module.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", EntryPointCreateOptions));
-            module.SetupGet(m => m.Name).Returns("mod1");
+            var module1 = new Mock<IModule<DockerConfig>>();
+            module1.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", EntryPointCreateOptions));
+            module1.SetupGet(m => m.Name).Returns("mod1");
+            var module2 = new Mock<IModule<DockerConfig>>();
+            module2.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", EntryPointCreateOptionsLC));
+            module2.SetupGet(m => m.Name).Returns("mod1");
 
             CombinedKubernetesConfigProvider provider = new CombinedKubernetesConfigProvider(new[] { new AuthConfig() }, new Uri("unix:///var/run/iotedgedworkload.sock"), new Uri("unix:///var/run/iotedgedmgmt.sock"), true);
 
             // Act
-            CombinedKubernetesConfig config = provider.GetCombinedConfig(module.Object, runtimeInfo.Object);
+            CombinedKubernetesConfig config1 = provider.GetCombinedConfig(module1.Object, runtimeInfo.Object);
+            CombinedKubernetesConfig config2 = provider.GetCombinedConfig(module2.Object, runtimeInfo.Object);
 
             // Assert
-            Assert.True(config.CreateOptions.Entrypoint.HasValue);
-            config.CreateOptions.Entrypoint.ForEach(ep => Assert.Equal("a-command", ep[0]));
+            Assert.True(config1.CreateOptions.Entrypoint.HasValue);
+            config1.CreateOptions.Entrypoint.ForEach(ep => Assert.Equal("a-command", ep[0]));
+            Assert.True(config2.CreateOptions.Entrypoint.HasValue);
+            config2.CreateOptions.Entrypoint.ForEach(ep => Assert.Equal("a-command2", ep[0]));
         }
 
         const string WorkingDirCreateOptions =
     @"{
 ""WorkingDir"" : ""a-directory""
+}";
+        const string WorkingDirCreateOptionsLC =
+    @"{
+""workingdir"" : ""a-directory2""
 }";
 
         [Fact]
@@ -298,18 +332,24 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var runtimeInfo = new Mock<IRuntimeInfo<DockerRuntimeConfig>>();
             runtimeInfo.SetupGet(ri => ri.Config).Returns(new DockerRuntimeConfig("1.24", string.Empty));
 
-            var module = new Mock<IModule<DockerConfig>>();
-            module.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", WorkingDirCreateOptions));
-            module.SetupGet(m => m.Name).Returns("mod1");
+            var module1 = new Mock<IModule<DockerConfig>>();
+            module1.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", WorkingDirCreateOptions));
+            module1.SetupGet(m => m.Name).Returns("mod1");
+            var module2 = new Mock<IModule<DockerConfig>>();
+            module2.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest", WorkingDirCreateOptionsLC));
+            module2.SetupGet(m => m.Name).Returns("mod1");
 
             CombinedKubernetesConfigProvider provider = new CombinedKubernetesConfigProvider(new[] { new AuthConfig() }, new Uri("unix:///var/run/iotedgedworkload.sock"), new Uri("unix:///var/run/iotedgedmgmt.sock"), true);
 
             // Act
-            CombinedKubernetesConfig config = provider.GetCombinedConfig(module.Object, runtimeInfo.Object);
+            CombinedKubernetesConfig config1 = provider.GetCombinedConfig(module1.Object, runtimeInfo.Object);
+            CombinedKubernetesConfig config2 = provider.GetCombinedConfig(module2.Object, runtimeInfo.Object);
 
             // Assert
-            Assert.True(config.CreateOptions.WorkingDir.HasValue);
-            config.CreateOptions.WorkingDir.ForEach(wd => Assert.Equal("a-directory", wd));
+            Assert.True(config1.CreateOptions.WorkingDir.HasValue);
+            config1.CreateOptions.WorkingDir.ForEach(wd => Assert.Equal("a-directory", wd));
+            Assert.True(config2.CreateOptions.WorkingDir.HasValue);
+            config2.CreateOptions.WorkingDir.ForEach(wd => Assert.Equal("a-directory2", wd));
         }
 
         const string InvalidCmdCreateOptions =

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -797,6 +797,38 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         }
 
         [Fact]
+        public void EnvModuleSettingsParseCorrectly()
+        {
+            var env = new List<string>
+            {
+                "a=b",
+                "HAS_SPACES=this variable has spaces",
+                "B=b=c",
+                "BASE64_TEXT=YmFzZTY0Cg==",
+                "==not a valid env var",
+            };
+            var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "Module1", Mock.Of<ICredentials>());
+            var config = new KubernetesConfig("image", CreatePodParameters.Create(env: env), Option.Some(new AuthConfig("user-registry1")));
+            var module = new KubernetesModule("module1", "v1", "docker", ModuleStatus.Running, RestartPolicy.Always, DefaultConfigurationInfo, EnvVarsDict, config, ImagePullPolicy.OnCreate, EdgeletModuleOwner);
+            var labels = new Dictionary<string, string>();
+            var features = new Dictionary<string, bool>
+            {
+                ["feature1"] = true,
+                ["feature2"] = false
+            };
+            var mapper = CreateMapper(runAsNonRoot: true, useMountSourceForVolumeName: true, storageClassName: "scname", proxyImagePullSecretName: "secret name", experimentalFeatures: features);
+
+            var deployment = mapper.CreateDeployment(identity, module, labels);
+
+            var container = deployment.Spec.Template.Spec.Containers.Single(c => c.Name == "module1");
+            Assert.Equal("b", container.Env.Single(e => e.Name == "a").Value);
+            Assert.Equal("this variable has spaces", container.Env.Single(e => e.Name == "HAS_SPACES").Value);
+            Assert.Equal("b=c", container.Env.Single(e => e.Name == "B").Value);
+            Assert.Equal("YmFzZTY0Cg==", container.Env.Single(e => e.Name == "BASE64_TEXT").Value);
+            Assert.Null(container.Env.SingleOrDefault(e => e.Value.EndsWith("valid env var")));
+        }
+
+        [Fact]
         public void EdgeAgentEnvSettingsHaveLotsOfStuff()
         {
             var identity = new ModuleIdentity("hostname", "gatewayhost", "deviceid", "$edgeAgent", Mock.Of<ICredentials>());

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesDeploymentMapperTest.cs
@@ -802,6 +802,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var env = new List<string>
             {
                 "a=b",
+                "ALL_EQUALS=====",
                 "HAS_SPACES=this variable has spaces",
                 "B=b=c",
                 "BASE64_TEXT=YmFzZTY0Cg==",
@@ -822,6 +823,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
 
             var container = deployment.Spec.Template.Spec.Containers.Single(c => c.Name == "module1");
             Assert.Equal("b", container.Env.Single(e => e.Name == "a").Value);
+            Assert.Equal("====", container.Env.Single(e => e.Name == "ALL_EQUALS").Value);
             Assert.Equal("this variable has spaces", container.Env.Single(e => e.Name == "HAS_SPACES").Value);
             Assert.Equal("b=c", container.Env.Single(e => e.Name == "B").Value);
             Assert.Equal("YmFzZTY0Cg==", container.Env.Single(e => e.Name == "BASE64_TEXT").Value);


### PR DESCRIPTION
Two problems were discovered today:

1. cmd, entrypoint, workingdir should be looked up in a case-insensitive manner.
The code extracting these settings was strictly using the capitalization in Docker spec. (`Cmd`, `EntryPoint`, `WorkingDir`).

2. environment variables in createOptions should allow "=" inside the value.
Environment variables in Docker are allowed to have "=" in them, like this:
```sh
$ docker run -it --rm --env "A===" ubuntu:18.04 
root@d3303984b9fc:/# echo $A
==
root@d3303984b9fc:/# 
```
The code extracting environment variables is not doing this correctly.