### PR TITLE
Changing name of tests and adding missing Unit attribute

### DIFF
--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/BrokerServiceIdentityTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/BrokerServiceIdentityTest.cs
@@ -2,8 +2,11 @@
 namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
 {
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Newtonsoft.Json;
     using Xunit;
+
+    [Unit]
     public class BrokerServiceIdentityTest
     {
         [Fact]

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ScopeIdentitiesHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ScopeIdentitiesHandlerTest.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Moq;
     using Newtonsoft.Json;
     using System.Collections.Generic;
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
     using System.Threading.Tasks;
     using Xunit;
 
+    [Unit]
     public class ScopeIdentitiesHandlerTest
     {
         const string Topic = "$internal/identities";

--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
-        public async Task DeviceClient()
+        public async Task PlugAndPlayDeviceClient()
         {
             CancellationToken token = this.TestToken;
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
-        public async Task ModuleClient()
+        public async Task PlugAndPlayModuleClient()
         {
             CancellationToken token = this.TestToken;
             string loadGenImage = Context.Current.LoadGenImage.Expect(() => new ArgumentException("loadGenImage parameter is required for Priority Queues test"));


### PR DESCRIPTION
Changing name of Module and Device client tests to PlugAndPlayModuleClient and PlugAndPlayDeviceClient

Also adding Unit attribute on unit tests that are missing it