### PR TITLE
Don't wait for policy yet.

### DIFF
--- a/mqtt/mqtt-broker/src/ready.rs
+++ b/mqtt/mqtt-broker/src/ready.rs
@@ -107,7 +107,6 @@ impl AwaitingEvents for BrokerReadyEvent {
     fn awaiting() -> HashSet<Self::Event> {
         let mut awaiting = HashSet::new();
         awaiting.insert(Self::AuthorizerReady);
-        awaiting.insert(Self::PolicyReady);
 
         awaiting
     }


### PR DESCRIPTION
I need to figure out how to set default policy for e2e and ci tests before I can enable waiting for the policy.