### PR TITLE
Allow missing auth-chain for out of scope leaf device connections

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -91,7 +91,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 if (this.nestedEdgeEnabled)
                 {
                     Option<string> authChainMaybe = await this.deviceScopeIdentitiesCache.GetAuthChain(clientCredentials.Identity.Id);
-                    authChain = authChainMaybe.Expect(() => new InvalidOperationException($"No auth chain for the client identity: {clientCredentials.Identity.Id}"));
+
+                    // It's possible to have no auth-chain for out-of-scope leaf devices connecting through
+                    // us as a gateway. In this case we let the upstream connection happen anyways, as any
+                    // unauthorized attempt here would be denied by IoTHub.
+                    authChain = authChainMaybe.OrDefault();
                 }
 
                 // Get the transport settings

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/NestedDeviceScopeApiClient.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/NestedDeviceScopeApiClient.cs
@@ -161,10 +161,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 .GetOrElse(() => new HttpClient());
             using (var msg = new HttpRequestMessage(HttpMethod.Post, uri))
             {
-                // Get the auth-chain for the EdgeHub we're acting OnBehalfOf
-                string onBehalfOfEdgeHub = $"{onBehalfOfDevice}/{Constants.EdgeHubModuleId}";
-                Option<string> maybeAuthChain = await this.serviceIdentityHierarchy.GetEdgeAuthChain(onBehalfOfEdgeHub);
-                string authChain = maybeAuthChain.Expect(() => new InvalidOperationException($"No valid authentication chain for {onBehalfOfEdgeHub}"));
+                // Get the auth-chain for the Edge we're acting OnBehalfOf
+                Option<string> maybeAuthChain = await this.serviceIdentityHierarchy.GetAuthChain(onBehalfOfDevice);
+                string authChain = maybeAuthChain.Expect(() => new InvalidOperationException($"No valid authentication chain for {onBehalfOfDevice}"));
 
                 // We must pass the origin Edge ID along upstream, so the root
                 // can know which Edge to act OnBehalfOf when calling IoT Hub


### PR DESCRIPTION
In the scenario where an out of scope leaf connects to an Edge gateway, we're still supposed to allow the upstream connection as long as IoT Hub can authenticates its device token.  In this case, we'll never have an auth-chain for the connecting leaf because it's not our descendent, so we can't enforce strict auth-chain checking here.