### PR TITLE
Fix metrics upload (#3737)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/publisher/EdgeRuntimeDiagnosticsUpload.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/publisher/EdgeRuntimeDiagnosticsUpload.cs
@@ -31,10 +31,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Publisher
         {
             Preconditions.CheckNotNull(metrics, nameof(metrics));
 
+            // ToArray is used at the end to ensure the batching process is only run once.
             Message[] messagesToSend = this.BatchAndBuildMessages(metrics.ToArray()).ToArray();
             try
             {
-                await this.edgeAgentConnection.SendEventBatchAsync(messagesToSend);
+                await Task.WhenAll(messagesToSend.Select(this.edgeAgentConnection.SendEventAsync));
             }
             catch (Exception ex) when (ex.HasTimeoutException())
             {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -128,7 +128,29 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             }
         }
 
-        public async Task SendEventBatchAsync(IEnumerable<Message> messages)
+        //// public async Task SendEventBatchAsync(IEnumerable<Message> messages)
+        //// {
+        ////    Events.UpdatingReportedProperties();
+        ////    try
+        ////    {
+        ////        Option<IModuleClient> moduleClient = this.moduleConnection.GetModuleClient();
+        ////        if (!moduleClient.HasValue)
+        ////        {
+        ////            Events.SendEventClientEmpty();
+        ////            return;
+        ////        }
+
+        ////        await moduleClient.ForEachAsync(d => d.SendEventBatchAsync(messages));
+        ////        Events.SendEvent();
+        ////    }
+        ////    catch (Exception e)
+        ////    {
+        ////        Events.ErrorSendingEvent(e);
+        ////        throw;
+        ////    }
+        //// }
+
+        public async Task SendEventAsync(Message message)
         {
             Events.UpdatingReportedProperties();
             try
@@ -140,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                     return;
                 }
 
-                await moduleClient.ForEachAsync(d => d.SendEventBatchAsync(messages));
+                await moduleClient.ForEachAsync(d => d.SendEventAsync(message));
                 Events.SendEvent();
             }
             catch (Exception e)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/IEdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/IEdgeAgentConnection.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
 
         Task UpdateReportedPropertiesAsync(TwinCollection patch);
 
-        Task SendEventBatchAsync(IEnumerable<Message> messages);
+        //// Task SendEventBatchAsync(IEnumerable<Message> messages);
+
+        Task SendEventAsync(Message message);
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/IModuleClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/IModuleClient.cs
@@ -26,7 +26,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
 
         Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties);
 
-        Task SendEventBatchAsync(IEnumerable<Message> messages);
+        //// Task SendEventBatchAsync(IEnumerable<Message> messages);
+
+        Task SendEventAsync(Message message);
 
         ////Task<DeviceStreamRequest> WaitForDeviceStreamRequestAsync(CancellationToken cancellationToken);
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClient.cs
@@ -110,12 +110,26 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
             }
         }
 
-        public async Task SendEventBatchAsync(IEnumerable<Message> messages)
+        //// public async Task SendEventBatchAsync(IEnumerable<Message> messages)
+        //// {
+        ////    try
+        ////    {
+        ////        this.inactivityTimer.Reset();
+        ////        await this.inner.SendEventBatchAsync(messages);
+        ////    }
+        ////    catch (Exception e)
+        ////    {
+        ////        await this.HandleException(e);
+        ////        throw;
+        ////    }
+        //// }
+
+        public async Task SendEventAsync(Message message)
         {
             try
             {
                 this.inactivityTimer.Reset();
-                await this.inner.SendEventBatchAsync(messages);
+                await this.inner.SendEventAsync(message);
             }
             catch (Exception e)
             {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/ISdkModuleClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/ISdkModuleClient.cs
@@ -27,7 +27,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient
 
         Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties);
 
-        Task SendEventBatchAsync(IEnumerable<Message> messages);
+        //// Task SendEventBatchAsync(IEnumerable<Message> messages);
+
+        Task SendEventAsync(Message message);
 
         ////Task<Client.DeviceStreamRequest> WaitForDeviceStreamRequestAsync(CancellationToken cancellationToken);
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/WrappingSdkModuleClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/WrappingSdkModuleClient.cs
@@ -64,7 +64,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient
         public Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties)
             => this.sdkModuleClient.UpdateReportedPropertiesAsync(reportedProperties);
 
-        public Task SendEventBatchAsync(IEnumerable<Message> messages) => this.sdkModuleClient.SendEventBatchAsync(messages);
+        //// public Task SendEventBatchAsync(IEnumerable<Message> messages) => this.sdkModuleClient.SendEventBatchAsync(messages);
+
+        public Task SendEventAsync(Message message) => this.sdkModuleClient.SendEventAsync(message);
 
         ////public Task<DeviceStreamRequest> WaitForDeviceStreamRequestAsync(CancellationToken cancellationToken)
         ////    => this.sdkModuleClient.WaitForDeviceStreamRequestAsync(cancellationToken);


### PR DESCRIPTION
One of the changes to edgeAgent cause the SendEventBatchAsync function of the module sdk to stop working correctly. This pr removes the call to SendEventBatchAsync and replaces it with multiple calls to SendEventAsync. 

The main difference between the 2 is that SendEventBatchAsync is transactional, while iterative SendEventAsync is not. Because the metrics worker will do a full retry on upload failure, this means that if the metrics upload fails partway through a batch, metrics could be duplicated. I am not worried about this in practice, because:
* Metrics being batched should be fairly rare, only happening when a device is offline for an extended period of time (>3 days)
* In addition to batching being rare, the upload still needs to fail partway through a batch for data to be duplicated.
* Any duplicate data is easy to de-dupe since it has a unique instance guid and timestamp