### PR TITLE
[k8s] Environment Variables can be null or empty.

### DIFF
--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -13,7 +13,7 @@ use failure::{Fail, ResultExt};
 use futures::{Future, Stream};
 use serde_json;
 
-use edgelet_utils::{allow_null_map_values, ensure_not_empty_with_context, serialize_ordered};
+use edgelet_utils::{deserialize_map_with_default_values, ensure_not_empty_with_context, serialize_ordered};
 
 use crate::error::{Error, ErrorKind, Result};
 use crate::settings::RuntimeSettings;
@@ -146,7 +146,7 @@ pub struct ModuleSpec<T> {
     config: T,
     #[serde(default = "HashMap::new")]
     #[serde(serialize_with = "serialize_ordered")]
-    #[serde(deserialize_with = "allow_null_map_values")]
+    #[serde(deserialize_with = "deserialize_map_with_default_values")]
     env: HashMap<String, String>,
     #[serde(default)]
     #[serde(rename = "imagePullPolicy")]

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -13,7 +13,7 @@ use failure::{Fail, ResultExt};
 use futures::{Future, Stream};
 use serde_json;
 
-use edgelet_utils::{ensure_not_empty_with_context, serialize_ordered};
+use edgelet_utils::{allow_null_map_values, ensure_not_empty_with_context, serialize_ordered};
 
 use crate::error::{Error, ErrorKind, Result};
 use crate::settings::RuntimeSettings;
@@ -146,6 +146,7 @@ pub struct ModuleSpec<T> {
     config: T,
     #[serde(default = "HashMap::new")]
     #[serde(serialize_with = "serialize_ordered")]
+    #[serde(deserialize_with = "allow_null_map_values")]
     env: HashMap<String, String>,
     #[serde(default)]
     #[serde(rename = "imagePullPolicy")]

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -22,7 +22,9 @@ use std::collections::HashMap;
 pub use crate::error::{Error, ErrorKind};
 pub use crate::logging::log_failure;
 pub use crate::macros::ensure_not_empty_with_context;
-pub use crate::ser_de::{allow_null_map_values, serde_clone, serialize_ordered, string_or_struct};
+pub use crate::ser_de::{
+    deserialize_map_with_default_values, serde_clone, serialize_ordered, string_or_struct,
+};
 pub use crate::yaml_file_source::YamlFileSource;
 
 pub fn parse_query(query: &str) -> HashMap<&str, &str> {

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -22,7 +22,7 @@ use std::collections::HashMap;
 pub use crate::error::{Error, ErrorKind};
 pub use crate::logging::log_failure;
 pub use crate::macros::ensure_not_empty_with_context;
-pub use crate::ser_de::{serde_clone, serialize_ordered, string_or_struct};
+pub use crate::ser_de::{allow_null_map_values, serde_clone, serialize_ordered, string_or_struct};
 pub use crate::yaml_file_source::YamlFileSource;
 
 pub fn parse_query(query: &str) -> HashMap<&str, &str> {

--- a/edgelet/edgelet-utils/src/ser_de.rs
+++ b/edgelet/edgelet-utils/src/ser_de.rs
@@ -81,7 +81,9 @@ where
     sorted_map.serialize(serializer)
 }
 
-pub fn allow_null_map_values<'de, K, V, D>(deserializer: D) -> StdResult<HashMap<K, V>, D::Error>
+pub fn deserialize_map_with_default_values<'de, K, V, D>(
+    deserializer: D,
+) -> StdResult<HashMap<K, V>, D::Error>
 where
     K: Deserialize<'de> + Eq + std::hash::Hash,
     V: Deserialize<'de> + Default,
@@ -170,8 +172,8 @@ mod tests {
     #[derive(Debug, Deserialize, Serialize)]
     struct Setting {
         #[serde(serialize_with = "serialize_ordered")]
-        #[serde(deserialize_with = "allow_null_map_values")]
-        pub map: HashMap<String, String>,
+        #[serde(deserialize_with = "deserialize_map_with_default_values")]
+        map: HashMap<String, String>,
     }
 
     #[test]

--- a/edgelet/edgelet-utils/src/ser_de.rs
+++ b/edgelet/edgelet-utils/src/ser_de.rs
@@ -81,6 +81,63 @@ where
     sorted_map.serialize(serializer)
 }
 
+pub fn allow_null_map_values<'de, K, V, D>(deserializer: D) -> StdResult<HashMap<K, V>, D::Error>
+where
+    K: Deserialize<'de> + Eq + std::hash::Hash,
+    V: Deserialize<'de> + Default,
+    D: Deserializer<'de>,
+{
+    // Loosely derived from https://serde.rs/deserialize-map.html
+    // Create a MapVisitor which will read a map as HashMap<K,Option<V>
+    // In the case of a map we need generic type parameters K and V to be
+    // able to set the output type correctly, but don't require any state.
+    // This is an example of a "zero sized type" in Rust. The PhantomData
+    // keeps the compiler from complaining about unused generic type
+    // parameters.
+    struct OptionalValueVisitor<K, V> {
+        marker: PhantomData<fn() -> (K, V)>,
+    };
+
+    impl<K, V> OptionalValueVisitor<K, V> {
+        fn new() -> Self {
+            OptionalValueVisitor {
+                marker: PhantomData,
+            }
+        }
+    }
+
+    impl<'de, K, V> Visitor<'de> for OptionalValueVisitor<K, V>
+    where
+        K: Deserialize<'de> + Eq + std::hash::Hash,
+        V: Deserialize<'de>,
+    {
+        type Value = HashMap<K, Option<V>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("HashMap<String, Option<String>>")
+        }
+
+        fn visit_map<M>(self, visitor: M) -> StdResult<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            // `MapAccessDeserializer` is a wrapper that turns a `MapAccess`
+            // into a `Deserializer`, allowing it to be used as the input to T's
+            // `Deserialize` implementation. T then deserializes itself using
+            // the entries from the map visitor.
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(visitor))
+        }
+    }
+
+    let map = deserializer.deserialize_map(OptionalValueVisitor::new());
+    map.map(|mut hashmap| {
+        hashmap
+            .drain()
+            .map(|(k, v)| (k, v.unwrap_or_else(|| V::default())))
+            .collect()
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr;
@@ -110,10 +167,11 @@ mod tests {
         options: Options,
     }
 
-    #[derive(Debug, Serialize)]
+    #[derive(Debug, Deserialize, Serialize)]
     struct Setting {
         #[serde(serialize_with = "serialize_ordered")]
-        map: HashMap<String, String>,
+        #[serde(deserialize_with = "allow_null_map_values")]
+        pub map: HashMap<String, String>,
     }
 
     #[test]
@@ -193,5 +251,23 @@ mod tests {
 
         let s = serde_json::to_string(&map_container).unwrap();
         assert_eq!(s, setting_json);
+    }
+
+    #[test]
+    fn deserialize_allow_null() {
+        let setting_json = json!({
+            "map": {
+                "HAS_VALUE": "is a value",
+                "NO_VALUE": null,
+                "EMPTY": String::default(),
+            }
+        })
+        .to_string();
+
+        let s: Setting = serde_json::from_str(&setting_json).unwrap();
+
+        assert_eq!("is a value", s.map.get("HAS_VALUE").unwrap());
+        assert_eq!(&String::default(), s.map.get("NO_VALUE").unwrap());
+        assert_eq!(&String::default(), s.map.get("EMPTY").unwrap());
     }
 }

--- a/edgelet/edgelet-utils/src/yaml_file_source.rs
+++ b/edgelet/edgelet-utils/src/yaml_file_source.rs
@@ -116,26 +116,20 @@ fn from_yaml_value(uri: Option<&String>, value: Yaml) -> Result<Value, ConfigErr
 
             Ok(Value::new(uri, l))
         }
-        // 1. Yaml NULL - Option::None will transform into ValueKind::Nil
-        Yaml::Null => Ok(Value::new(uri, None::<String>)),
+        // 1. Yaml NULL
         // 2. BadValue – It shouldn't be possible to hit BadValue as this only happens when
         //               using the index trait badly or on a type error but we send back nil.
         // 3. Alias – No idea what to do with this and there is a note in the lib that its
         //            not fully supported yet anyway
-        //
-        // The original function returns `Value::new(uri, ValueKind::Nil)` here.
-        // Since `ValueKind` is private, we have to return Err instead. It shouldn't be a problem for our use case
-        // since we don't expect null / bad value / alias.
-        value => Err(ConfigError::Foreign(Box::new(
-            YamlFileSourceError::UnrecognizedYamlValue(value),
-        ))),
+        // All of these return ValueKind::Nil in original, so use
+        //    Option::None to transform into ValueKind::Nil
+        _ => Ok(Value::new(uri, None::<String>)),
     }
 }
 
 #[derive(Debug)]
 enum YamlFileSourceError {
     MoreThanOneDocument,
-    UnrecognizedYamlValue(Yaml),
 }
 
 impl std::fmt::Display for YamlFileSourceError {
@@ -143,9 +137,6 @@ impl std::fmt::Display for YamlFileSourceError {
         match self {
             YamlFileSourceError::MoreThanOneDocument => {
                 write!(f, "more than one YAML document provided")
-            }
-            YamlFileSourceError::UnrecognizedYamlValue(value) => {
-                write!(f, "unrecognized YAML value {:?}", value)
             }
         }
     }

--- a/edgelet/edgelet-utils/src/yaml_file_source.rs
+++ b/edgelet/edgelet-utils/src/yaml_file_source.rs
@@ -116,8 +116,8 @@ fn from_yaml_value(uri: Option<&String>, value: Yaml) -> Result<Value, ConfigErr
 
             Ok(Value::new(uri, l))
         }
-
-        // 1. Yaml NULL
+        // 1. Yaml NULL - Option::None will transform into ValueKind::Nil
+        Yaml::Null => Ok(Value::new(uri, None::<String>)),
         // 2. BadValue – It shouldn't be possible to hit BadValue as this only happens when
         //               using the index trait badly or on a type error but we send back nil.
         // 3. Alias – No idea what to do with this and there is a note in the lib that its


### PR DESCRIPTION
In config.yaml for iotedged, customer set an environment variable in agent bootstrap like this:
```yaml
agent:
  name: "edgeAgent"
  type: "docker"
  env:
    https_proxy:
```
Technically, this is acceptable for environment variables - a null value actually gets translated to "https_proxy=" in the docker API. This PR allows null values in config.yaml, and in the ModuleSpec.

For JSON, use a deserialization function to read env vars as optional, then transform empty entries into default values.
For YAML config, don't return an error in Yaml::Null case, transform it into ValueKind::Nil.