### PR TITLE
[mqtt] Implement syslog-like log formatter identical to edgehub

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -929,6 +929,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 dependencies = [
+ "owning_ref",
  "scopeguard",
 ]
 
@@ -1267,7 +1268,6 @@ name = "mqttd"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "atty",
  "chrono",
  "clap",
  "edgelet-client",
@@ -1281,6 +1281,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
 ]
 
@@ -1415,6 +1416,17 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
+dependencies = [
+ "lock_api 0.3.4",
+ "parking_lot_core 0.6.2",
+ "rustc_version",
+]
+
+[[package]]
+name = "parking_lot"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
@@ -1432,6 +1444,21 @@ dependencies = [
  "instant",
  "lock_api 0.4.1",
  "parking_lot_core 0.8.0",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b876b1b9e7ac6e1a74a6da34d25c42e17e8862aa409cbbbdcfc8d86c6f3bc62b"
+dependencies = [
+ "cfg-if",
+ "cloudabi 0.0.3",
+ "libc",
+ "redox_syscall",
+ "rustc_version",
+ "smallvec 0.6.13",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2420,6 +2447,7 @@ dependencies = [
  "lazy_static",
  "matchers",
  "owning_ref",
+ "parking_lot 0.9.0",
  "regex",
  "smallvec 0.6.13",
  "tracing-core",

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -35,7 +35,6 @@ uuid = { version = "0.8", features = ["v4"] }
 mqtt3 = { path = "../mqtt3", features = ["serde1"] }
 
 [dev-dependencies]
-atty = "0.2"
 bytes = "0.5"
 fail = { version = "0.3", features = ["failpoints"] }
 itertools = "0.9"

--- a/mqtt/mqttd/Cargo.toml
+++ b/mqtt/mqttd/Cargo.toml
@@ -7,14 +7,14 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0"
-atty = "0.2"
 chrono = "0.4"
 clap = "2.33"
 futures-util = { version = "0.3", features = ["sink"] }
 tokio = { version = "0.2", features = ["dns", "macros", "rt-threaded", "signal", "stream", "tcp", "time"] }
 thiserror = "1.0"
 tracing = "0.1"
-tracing-subscriber = "0.1"
+tracing-log = "0.1"
+tracing-subscriber = { version = "0.1", features = ["env-filter", "smallvec", "fmt", "chrono", "tracing-log", "parking_lot"], default-features = false }
 
 edgelet-client = { path = "../edgelet-client", optional = true }
 mqtt-bridge = { path = "../mqtt-bridge", optional = true }

--- a/mqtt/mqttd/src/tracing/edgehub.rs
+++ b/mqtt/mqttd/src/tracing/edgehub.rs
@@ -1,7 +1,7 @@
-use std::io;
-
 use tracing::Level;
 use tracing_subscriber::{fmt, EnvFilter};
+
+use super::Format;
 
 const BROKER_LOG_LEVEL_ENV: &str = "BROKER_LOG";
 
@@ -14,10 +14,9 @@ pub fn init() {
         .unwrap_or_else(|_| EnvFilter::new("info"));
 
     let subscriber = fmt::Subscriber::builder()
-        .with_ansi(atty::is(atty::Stream::Stderr))
         .with_max_level(Level::TRACE)
-        .with_writer(io::stderr)
         .with_env_filter(log_level)
+        .on_event(Format::default())
         .finish();
     let _ = tracing::subscriber::set_global_default(subscriber);
 }

--- a/mqtt/mqttd/src/tracing/format.rs
+++ b/mqtt/mqttd/src/tracing/format.rs
@@ -3,23 +3,23 @@ use std::marker::PhantomData;
 use tracing::{Event, Level};
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::fmt::{
-    time::ChronoUtc, time::FormatTime, Context, FormatEvent, NewVisitor,
+    time::ChronoLocal, time::FormatTime, Context, FormatEvent, NewVisitor,
 };
 
 /// Marker for `Format` that indicates that the syslog format should be used.
 pub(crate) struct Syslog;
 
 /// Custom event formatter.
-pub(crate) struct Format<F = Syslog, T = ChronoUtc> {
+pub(crate) struct Format<F = Syslog, T = ChronoLocal> {
     format: PhantomData<F>,
     timer: T,
 }
 
-impl Default for Format<Syslog, ChronoUtc> {
+impl Default for Format<Syslog, ChronoLocal> {
     fn default() -> Self {
         Format {
             format: PhantomData,
-            timer: ChronoUtc::with_format("%F %T.%3f %:z".into()),
+            timer: ChronoLocal::with_format("%F %T.%3f %:z".into()),
         }
     }
 }

--- a/mqtt/mqttd/src/tracing/format.rs
+++ b/mqtt/mqttd/src/tracing/format.rs
@@ -1,0 +1,117 @@
+use std::marker::PhantomData;
+
+use tracing::{Event, Level};
+use tracing_log::NormalizeEvent;
+use tracing_subscriber::fmt::{
+    time::ChronoUtc, time::FormatTime, Context, FormatEvent, NewVisitor,
+};
+
+/// Marker for `Format` that indicates that the syslog format should be used.
+pub(crate) struct Syslog;
+
+/// Custom event formatter.
+pub(crate) struct Format<F = Syslog, T = ChronoUtc> {
+    format: PhantomData<F>,
+    timer: T,
+}
+
+impl Default for Format<Syslog, ChronoUtc> {
+    fn default() -> Self {
+        Format {
+            format: PhantomData,
+            timer: ChronoUtc::with_format("%F %T.%3f %:z".into()),
+        }
+    }
+}
+
+impl<N, T> FormatEvent<N> for Format<Syslog, T>
+where
+    N: for<'a> NewVisitor<'a>,
+    T: FormatTime,
+{
+    fn format_event(
+        &self,
+        ctx: &Context<'_, N>,
+        writer: &mut dyn std::fmt::Write,
+        event: &Event<'_>,
+    ) -> std::fmt::Result {
+        let normalized_meta = event.normalized_metadata();
+        let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
+
+        let (fmt_level, fmt_ctx) = (FmtLevel::new(meta.level()), FullCtx::new(&ctx));
+
+        write!(writer, "<{}> ", fmt_level.syslog_level())?;
+        self.timer.format_time(writer)?;
+        write!(writer, "[{}] - [{}{}] ", fmt_level, fmt_ctx, meta.target(),)?;
+
+        {
+            let mut recorder = ctx.new_visitor(writer, true);
+            event.record(&mut recorder);
+        }
+
+        writeln!(writer)
+    }
+}
+
+/// Wrapper around `Level` to format it accordingly to `syslog` rules.
+struct FmtLevel<'a> {
+    level: &'a Level,
+}
+
+impl<'a> FmtLevel<'a> {
+    fn new(level: &'a Level) -> Self {
+        Self { level }
+    }
+
+    fn syslog_level(&self) -> i8 {
+        match *self.level {
+            Level::ERROR => 3,
+            Level::WARN => 4,
+            Level::INFO => 6,
+            Level::DEBUG | Level::TRACE => 7,
+        }
+    }
+}
+
+impl<'a> std::fmt::Display for FmtLevel<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self.level {
+            Level::TRACE => f.pad("TRCE"),
+            Level::DEBUG => f.pad("DBUG"),
+            Level::INFO => f.pad("INFO"),
+            Level::WARN => f.pad("WARN"),
+            Level::ERROR => f.pad("ERR!"),
+        }
+    }
+}
+
+/// Wrapper around log entry context to format entry.
+struct FullCtx<'a, N> {
+    ctx: &'a Context<'a, N>,
+}
+
+impl<'a, N: 'a> FullCtx<'a, N> {
+    fn new(ctx: &'a Context<'a, N>) -> Self {
+        Self { ctx }
+    }
+}
+
+impl<'a, N> std::fmt::Display for FullCtx<'a, N> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut seen = false;
+        self.ctx.visit_spans(|_, span| {
+            write!(f, "{}", span.name())?;
+            seen = true;
+
+            let fields = span.fields();
+            if !fields.is_empty() {
+                write!(f, "{{{}}}", fields)?;
+            }
+            ":".fmt(f)
+        })?;
+        if seen {
+            f.pad(" ")?;
+        }
+        Ok(())
+    }
+}

--- a/mqtt/mqttd/src/tracing/generic.rs
+++ b/mqtt/mqttd/src/tracing/generic.rs
@@ -1,7 +1,7 @@
-use std::io;
-
 use tracing::Level;
-use tracing_subscriber::{fmt, EnvFilter};
+use tracing_subscriber::{fmt::Subscriber, EnvFilter};
+
+use super::Format;
 
 const BROKER_LOG_LEVEL_ENV: &str = "BROKER_LOG";
 
@@ -10,11 +10,10 @@ pub fn init() {
         .or_else(|_| EnvFilter::try_from_default_env())
         .unwrap_or_else(|_| EnvFilter::new("info"));
 
-    let subscriber = fmt::Subscriber::builder()
-        .with_ansi(atty::is(atty::Stream::Stderr))
+    let subscriber = Subscriber::builder()
         .with_max_level(Level::TRACE)
-        .with_writer(io::stderr)
         .with_env_filter(log_level)
+        .on_event(Format::default())
         .finish();
     let _ = tracing::subscriber::set_global_default(subscriber);
 }

--- a/mqtt/mqttd/src/tracing/mod.rs
+++ b/mqtt/mqttd/src/tracing/mod.rs
@@ -9,3 +9,6 @@ mod generic;
 
 #[cfg(all(not(feature = "edgehub"), feature = "generic"))]
 pub use generic::init;
+
+mod format;
+use format::Format;


### PR DESCRIPTION
Implement syslog-like log formatter identical to edgehub.

Before:
```
Oct 22 12:37:08.500  INFO mqttd::broker::bootstrap::generic: using default settings
Oct 22 12:37:08.501  INFO mqttd::broker: loading state...
Oct 22 12:37:08.502  INFO mqtt_broker::persist: loading state from file /tmp/mqttd/state.dat.
Oct 22 12:37:08.502  INFO mqttd::broker: state loaded.
Oct 22 12:37:08.502  INFO mqttd::broker::bootstrap::generic: no sidecars to start
Oct 22 12:37:08.503  INFO mqttd::broker::bootstrap::generic: starting server...
Oct 22 12:37:08.504  INFO server{listener=0.0.0.0:1883}: mqtt_broker::server: Listening on address 0.0.0.0:1883
```
After
```
<6> 2020-10-22 23:43:18.402 +00:00 [INFO] - [mqttd::broker::bootstrap::generic] loading settings from a file contrib/edgehub/broker.json
<6> 2020-10-22 23:43:18.403 +00:00 [INFO] - [mqttd::broker] loading state...
<6> 2020-10-22 23:43:18.403 +00:00 [INFO] - [mqtt_broker::persist] loading state from file /tmp/mqttd/state.dat.
<6> 2020-10-22 23:43:18.403 +00:00 [INFO] - [mqttd::broker] state loaded.
<6> 2020-10-22 23:43:18.403 +00:00 [INFO] - [mqttd::broker::bootstrap::generic] no sidecars to start
<6> 2020-10-22 23:43:18.403 +00:00 [INFO] - [mqttd::broker::bootstrap::generic] starting server...
<6> 2020-10-22 23:43:18.404 +00:00 [INFO] - [server{listener=0.0.0.0:1883}: mqtt_broker::server] Listening on address 0.0.0.0:1883
```