### PR TITLE
Resync leaf identities if an Edge gets re-parented

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/DeviceScopeAuthenticator.cs
@@ -134,8 +134,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             Option<string> authChain = await this.deviceScopeIdentitiesCache.GetAuthChain(authTarget);
             if (!authChain.HasValue)
             {
-                Events.NoAuthChain(authTarget);
-                return (false, false);
+                // The auth-target might be a new device that was recently added, and our
+                // cache might not have it yet. Try refreshing the target identity to see
+                // if we can get it from upstream.
+                Events.NoAuthChainResyncing(authTarget, actorDeviceId);
+                await this.deviceScopeIdentitiesCache.RefreshServiceIdentityOnBehalfOf(authTarget, actorDeviceId);
+                authChain = await this.deviceScopeIdentitiesCache.GetAuthChain(authTarget);
+
+                if (!authChain.HasValue)
+                {
+                    // Still don't have a valid auth-chain for the target, it must be
+                    // out of scope, so we're done here
+                    Events.NoAuthChain(authTarget);
+                    return (false, false);
+                }
             }
 
             // Check that the actor is authorized to connect OnBehalfOf of the target
@@ -146,9 +158,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 return (false, true);
             }
 
-            // Check credentials against the acting EdgeHub
+            // Check credentials against the acting EdgeHub, since we would have
+            // already refreshed the target identity on failure, there's no need
+            // to have AuthenticateWithServiceIdentity do it again.
             string actorEdgeHubId = actorDeviceId + $"/{Constants.EdgeHubModuleId}";
-            return await this.AuthenticateWithServiceIdentity(credentials, actorEdgeHubId, syncServiceIdentity);
+            return await this.AuthenticateWithServiceIdentity(credentials, actorEdgeHubId, false);
         }
 
         async Task<(bool isAuthenticated, bool serviceIdentityFound)> AuthenticateWithServiceIdentity(T credentials, string serviceIdentityId, bool syncServiceIdentity)
@@ -193,6 +207,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
                 AuthenticatedInScope,
                 InputCredentialsNotValid,
                 ResyncingServiceIdentity,
+                NoAuthChainResyncing,
                 AuthenticatingWithDeviceIdentity
             }
 
@@ -237,6 +252,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             public static void ResyncingServiceIdentity(IIdentity identity, string serviceIdentityId)
             {
                 Log.LogInformation((int)EventIds.ResyncingServiceIdentity, $"Unable to authenticate client {identity.Id} with cached service identity {serviceIdentityId}. Resyncing service identity...");
+            }
+
+            public static void NoAuthChainResyncing(string authTarget, string actorDevice)
+            {
+                Log.LogInformation((int)EventIds.NoAuthChainResyncing, $"No cached auth-chain when authenticating {actorDevice} OnBehalfOf {authTarget}. Resyncing service identity...");
             }
 
             public static void AuthenticatingWithDeviceIdentity(IModuleIdentity moduleIdentity)


### PR DESCRIPTION
When adding a new device that doesn't have its identity sync'ed down yet, we rely on the bottom-most Edge to send a refresh request, which would trigger a corresponding refresh on every Edge up the chain until the root sends the request to IoTHub.  Then on the way back every Edge would have the new device identity added to the cache.

But in case of reparenting, the bottom-most Edge will already have the leaf device identity, whereas the new parent Edge will not.  So the authentication will fail unless the parent Edge has logic to refresh the leaf device identity OnBehalfOf the bottom-most Edge.