### PR TITLE
[mqtt] Custom Debug implementation for broker events

### DIFF
--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -58,6 +58,7 @@ where
                     }
                 }
                 Message::System(event) => {
+                    debug!("incoming system event: {:?}", event);
                     let span = info_span!("broker", event = "system");
                     let _enter = span.enter();
                     match event {
@@ -194,7 +195,7 @@ where
         client_id: ClientId,
         event: ClientEvent,
     ) -> Result<(), Error> {
-        debug!("incoming: {:?}", event);
+        debug!("incoming client event: {:?}", event);
         let result = match event {
             ClientEvent::ConnReq(connreq) => self.process_connect(client_id, connreq),
             ClientEvent::ConnAck(_) => {

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -32,7 +32,7 @@ pub mod proptest;
 
 use std::{
     any::Any,
-    fmt::{Display, Formatter, Result as FmtResult},
+    fmt::{Debug, Display, Formatter, Result as FmtResult},
     net::SocketAddr,
     sync::Arc,
 };
@@ -180,11 +180,20 @@ impl ConnReq {
     }
 }
 
-#[derive(Debug)]
 pub enum Auth {
     Identity(AuthId),
     Unknown,
     Failure,
+}
+
+impl Debug for Auth {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Auth::Identity(id) => f.write_fmt(format_args!("\"{}\"", id)),
+            Auth::Unknown => f.write_str("Unknown"),
+            Auth::Failure => f.write_str("Failure"),
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -193,7 +202,6 @@ pub enum Publish {
     QoS12(proto::PacketIdentifier, proto::Publish),
 }
 
-#[derive(Debug)]
 pub enum ClientEvent {
     /// Connect request
     ConnReq(ConnReq),
@@ -252,7 +260,115 @@ pub enum ClientEvent {
     PubComp(proto::PubComp),
 }
 
-#[derive(Debug)]
+impl Debug for ClientEvent {
+    #[allow(clippy::too_many_lines)]
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            ClientEvent::ConnReq(connreq) => f
+                .debug_struct("ConnReq")
+                .field("client_id", &connreq.client_id().as_str())
+                .field("connect", &connreq.connect())
+                .field("auth", &connreq.auth())
+                .finish(),
+            ClientEvent::ConnAck(connack) => f
+                .debug_struct("ConnAck")
+                .field("session_present", &connack.session_present)
+                .field("return_code", &connack.return_code)
+                .finish(),
+            ClientEvent::Disconnect(_) => f.write_str("Disconnect"),
+            ClientEvent::DropConnection => f.write_str("DropConnection"),
+            ClientEvent::CloseSession => f.write_str("CloseSession"),
+            ClientEvent::PingReq(_) => f.write_str("PingReq"),
+            ClientEvent::PingResp(_) => f.write_str("PingResp"),
+            ClientEvent::Subscribe(sub) => f
+                .debug_struct("Subscribe")
+                .field("id", &sub.packet_identifier.get())
+                .field("qos", &sub.subscribe_to)
+                .finish(),
+            ClientEvent::SubAck(suback) => f
+                .debug_struct("SubAck")
+                .field("id", &suback.packet_identifier.get())
+                .field("qos", &suback.qos)
+                .finish(),
+            ClientEvent::Unsubscribe(unsub) => f
+                .debug_struct("Unsubscribe")
+                .field("id", &unsub.packet_identifier.get())
+                .field("topic", &unsub.unsubscribe_from)
+                .finish(),
+            ClientEvent::UnsubAck(unsuback) => f
+                .debug_struct("UnsubAck")
+                .field("id", &unsuback.packet_identifier.get())
+                .finish(),
+            ClientEvent::PublishFrom(publish, _) => {
+                let (qos, id, dup) = match publish.packet_identifier_dup_qos {
+                    proto::PacketIdentifierDupQoS::AtMostOnce => {
+                        (proto::QoS::AtMostOnce, None, false)
+                    }
+                    proto::PacketIdentifierDupQoS::AtLeastOnce(id, dup) => {
+                        (proto::QoS::AtLeastOnce, Some(id.get()), dup)
+                    }
+                    proto::PacketIdentifierDupQoS::ExactlyOnce(id, dup) => {
+                        (proto::QoS::ExactlyOnce, Some(id.get()), dup)
+                    }
+                };
+                f.debug_struct("PublishFrom")
+                    .field("qos", &qos)
+                    .field("id", &id)
+                    .field("dup", &dup)
+                    .field("retain", &publish.retain)
+                    .field("topic_name", &publish.topic_name)
+                    .field("payload", &publish.payload)
+                    .finish()
+            }
+            ClientEvent::PublishTo(publish) => {
+                let publish = match publish {
+                    Publish::QoS0(_, publish) => publish,
+                    Publish::QoS12(_, publish) => publish,
+                };
+                let (qos, id, dup) = match publish.packet_identifier_dup_qos {
+                    proto::PacketIdentifierDupQoS::AtMostOnce => {
+                        (proto::QoS::AtMostOnce, None, false)
+                    }
+                    proto::PacketIdentifierDupQoS::AtLeastOnce(id, dup) => {
+                        (proto::QoS::AtLeastOnce, Some(id.get()), dup)
+                    }
+                    proto::PacketIdentifierDupQoS::ExactlyOnce(id, dup) => {
+                        (proto::QoS::ExactlyOnce, Some(id.get()), dup)
+                    }
+                };
+                f.debug_struct("PublishTo")
+                    .field("qos", &qos)
+                    .field("id", &id)
+                    .field("dup", &dup)
+                    .field("retain", &publish.retain)
+                    .field("topic_name", &publish.topic_name)
+                    .field("payload", &publish.payload)
+                    .finish()
+            }
+            ClientEvent::PubAck0(packet_identifier) => f
+                .debug_struct("PubAck0")
+                .field("id", &packet_identifier.get())
+                .finish(),
+            ClientEvent::PubAck(puback) => f
+                .debug_struct("PubAck")
+                .field("id", &puback.packet_identifier.get())
+                .finish(),
+            ClientEvent::PubRec(pubrec) => f
+                .debug_struct("PubRec")
+                .field("id", &pubrec.packet_identifier.get())
+                .finish(),
+            ClientEvent::PubRel(pubrel) => f
+                .debug_struct("PubRel")
+                .field("id", &pubrel.packet_identifier.get())
+                .finish(),
+            ClientEvent::PubComp(pubcomp) => f
+                .debug_struct("PubComp")
+                .field("id", &pubcomp.packet_identifier.get())
+                .finish(),
+        }
+    }
+}
+
 pub enum SystemEvent {
     /// An event for a broker to stop processing incoming event and exit.
     Shutdown,
@@ -268,6 +384,21 @@ pub enum SystemEvent {
     /// The main difference is `ClientEvent::Publish` it doesn't require
     /// ClientId of sender to be passed along with the event.
     Publish(Publication),
+}
+
+impl Debug for SystemEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            SystemEvent::Shutdown => f.write_str("Shutdown"),
+            SystemEvent::StateSnapshot(_) => f.write_str("StateSnapshot"),
+            SystemEvent::AuthorizationUpdate(update) => {
+                f.debug_tuple("AuthorizationUpdate").field(&update).finish()
+            }
+            SystemEvent::Publish(publication) => {
+                f.debug_tuple("Publish").field(&publication).finish()
+            }
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/mqtt/mqtt3/src/proto/packet.rs
+++ b/mqtt/mqtt3/src/proto/packet.rs
@@ -144,8 +144,6 @@ impl std::fmt::Debug for Connect {
             .field("will", &self.will)
             .field("client_id", &self.client_id)
             .field("keep_alive", &self.keep_alive)
-            .field("protocol_name", &self.protocol_name)
-            .field("protocol_level", &self.protocol_level)
             .finish()
     }
 }
@@ -874,7 +872,7 @@ pub struct SubscribeTo {
 /// The level of reliability for a publication
 ///
 /// Ref: 4.3 Quality of Service levels and protocol flows
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(feature = "serde1", derive(Deserialize, Serialize))]
 pub enum QoS {
     AtMostOnce,
@@ -889,6 +887,12 @@ impl From<QoS> for u8 {
             QoS::AtLeastOnce => 0x01,
             QoS::ExactlyOnce => 0x02,
         }
+    }
+}
+
+impl std::fmt::Debug for QoS {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_fmt(format_args!("{}", u8::from(*self)))
     }
 }
 


### PR DESCRIPTION
Implemented Debug for `ClientEvent` and `SystemEvent` to reduce noise in logs.

Before:
```
ConnReq(ConnReq { client_id: ClientId("test-client"), peer_addr: 127.0.0.1:8080, connect: Connect { username: Some("test-client/?api-version=v3"), will: None, client_id: IdWithCleanSession("test"), keep_alive: 2s }, auth: "test-client", handle: ConnectionHandle { id: 90c51c14-5aac-455d-9878-ad20c88346fe, sender: UnboundedSender { chan: Tx { inner: Chan { tx: Tx { block_tail: 0x7f262c000c00, tail_position: 0 }, semaphore: 1, rx_waker: AtomicWaker, tx_count: 1, rx_fields: "..." }, permit: () } } } })
ConnAck(ConnAck { session_present: true, return_code: Refused(Other(100)) })
Disconnect(Disconnect)
DropConnection
CloseSession
PingReq(PingReq)
PingResp(PingResp)
Subscribe(Subscribe { packet_identifier: PacketIdentifier(2), subscribe_to: [SubscribeTo { topic_filter: "/foo/#", qos: 1 }] })
SubAck(SubAck { packet_identifier: PacketIdentifier(3), qos: [Failure, Success(0), Success(1), Success(2)] })
Unsubscribe(Unsubscribe { packet_identifier: PacketIdentifier(4), unsubscribe_from: ["/foo", "/bar"] })
UnsubAck(UnsubAck { packet_identifier: PacketIdentifier(5) })
PublishFrom(Publish { packet_identifier_dup_qos: AtLeastOnce(PacketIdentifier(6), true), retain: true, topic_name: "/foo/bar", payload: b"hello" }, None)
PublishTo(QoS12(PacketIdentifier(7), Publish { packet_identifier_dup_qos: AtLeastOnce(PacketIdentifier(8), true), retain: true, topic_name: "/foo/bar", payload: b"hello" }))
PubAck0(PacketIdentifier(9))
PubAck(PubAck { packet_identifier: PacketIdentifier(10) })
PubRec(PubRec { packet_identifier: PacketIdentifier(11) })
PubRel(PubRel { packet_identifier: PacketIdentifier(12) })
PubComp(PubComp { packet_identifier: PacketIdentifier(13) })
```

After
```
ConnReq { client_id: "test-client", connect: Connect { username: Some("test-client/?api-version=v3"), will: None, client_id: IdWithCleanSession("test"), keep_alive: 2s }, auth: "test-client" }
ConnAck { session_present: true, return_code: Refused(Other(100)) }
Disconnect
DropConnection
CloseSession
PingReq
PingResp
Subscribe { id: 2, qos: [SubscribeTo { topic_filter: "/foo/#", qos: 1 }] }
SubAck { id: 3, qos: [Failure, Success(0), Success(1), Success(2)] }
Unsubscribe { id: 4, topic: ["/foo", "/bar"] }
UnsubAck { id: 5 }
PublishFrom { qos: 1, id: Some(6), dup: true, retain: true, topic: "/foo/bar", payload: b"hello" }
PublishTo { qos: 1, id: Some(8), dup: true, retain: true, topic: "/foo/bar", payload: b"hello" }
PubAck0 { id: 9 }
PubAck { id: 10 }
PubRec { id: 11 }
PubRel { id: 12 }
PubComp { id: 13 }
```