### PR TITLE
Added FeatureFlagAuthorizer to wrap PolicyAuthorizer

### DIFF
--- a/mqtt/mqtt-broker/src/ready.rs
+++ b/mqtt/mqtt-broker/src/ready.rs
@@ -107,6 +107,7 @@ impl AwaitingEvents for BrokerReadyEvent {
     fn awaiting() -> HashSet<Self::Event> {
         let mut awaiting = HashSet::new();
         awaiting.insert(Self::AuthorizerReady);
+        awaiting.insert(Self::PolicyReady);
 
         awaiting
     }

--- a/mqtt/mqtt-edgehub/src/auth/authorization/feature.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/feature.rs
@@ -1,6 +1,6 @@
-use std::{env, error::Error as StdError};
+use std::{any::Any, env, error::Error as StdError};
 
-use mqtt_broker::auth::{Authorization, Authorizer};
+use mqtt_broker::auth::{Activity, Authorization, Authorizer};
 
 pub struct FeatureFlagAuthorizer<Z: Authorizer> {
     inner: Z,
@@ -32,10 +32,7 @@ where
 {
     type Error = E;
 
-    fn authorize(
-        &self,
-        activity: &mqtt_broker::auth::Activity,
-    ) -> Result<mqtt_broker::auth::Authorization, Self::Error> {
+    fn authorize(&self, activity: &Activity) -> Result<Authorization, Self::Error> {
         if self.enabled {
             self.inner.authorize(activity)
         } else {
@@ -43,7 +40,7 @@ where
         }
     }
 
-    fn update(&mut self, update: Box<dyn std::any::Any>) -> Result<(), Self::Error> {
+    fn update(&mut self, update: Box<dyn Any>) -> Result<(), Self::Error> {
         self.inner.update(update)
     }
 }

--- a/mqtt/mqtt-edgehub/src/auth/authorization/feature.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/feature.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, env, error::Error as StdError};
+use std::{any::Any, env, error::Error as StdError, ffi::OsStr};
 
 use mqtt_broker::auth::{Activity, Authorization, Authorizer};
 
@@ -18,7 +18,7 @@ where
     Z: Authorizer<Error = E>,
     E: StdError,
 {
-    pub fn new(feature_flag: String, inner: Z) -> Self {
+    pub fn new(feature_flag: impl AsRef<OsStr>, inner: Z) -> Self {
         let enabled = env::var(feature_flag).unwrap_or_default().to_lowercase() == "true";
 
         Self { inner, enabled }

--- a/mqtt/mqtt-edgehub/src/auth/authorization/feature.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/feature.rs
@@ -1,0 +1,49 @@
+use std::{env, error::Error as StdError};
+
+use mqtt_broker::auth::{Authorization, Authorizer};
+
+pub struct FeatureFlagAuthorizer<Z: Authorizer> {
+    inner: Z,
+    enabled: bool,
+}
+
+/// A simple wrapper that, if enabled
+/// delegates the call to the inner `Authorizer`,
+/// and if disabled, allows all operations.
+///
+/// Used to isolate `PolicyAuthorizer` with feature flag
+/// to simplify end-to-end tests.
+impl<Z, E> FeatureFlagAuthorizer<Z>
+where
+    Z: Authorizer<Error = E>,
+    E: StdError,
+{
+    pub fn new(feature_flag: String, inner: Z) -> Self {
+        let enabled = env::var(feature_flag).unwrap_or_default().to_lowercase() == "true";
+
+        Self { inner, enabled }
+    }
+}
+
+impl<Z, E> Authorizer for FeatureFlagAuthorizer<Z>
+where
+    Z: Authorizer<Error = E>,
+    E: StdError,
+{
+    type Error = E;
+
+    fn authorize(
+        &self,
+        activity: &mqtt_broker::auth::Activity,
+    ) -> Result<mqtt_broker::auth::Authorization, Self::Error> {
+        if self.enabled {
+            self.inner.authorize(activity)
+        } else {
+            Ok(Authorization::Allowed)
+        }
+    }
+
+    fn update(&mut self, update: Box<dyn std::any::Any>) -> Result<(), Self::Error> {
+        self.inner.update(update)
+    }
+}

--- a/mqtt/mqtt-edgehub/src/auth/authorization/mod.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/mod.rs
@@ -1,9 +1,11 @@
 mod edgehub;
+mod feature;
 mod local;
 mod policy;
 
 pub use self::policy::{PolicyAuthorizer, PolicyUpdate};
 pub use edgehub::{AuthorizerUpdate, EdgeHubAuthorizer, IdentityUpdate};
+pub use feature::FeatureFlagAuthorizer;
 pub use local::LocalAuthorizer;
 
 #[cfg(test)]

--- a/mqtt/mqtt-edgehub/src/auth/mod.rs
+++ b/mqtt/mqtt-edgehub/src/auth/mod.rs
@@ -3,6 +3,6 @@ mod authorization;
 
 pub use authentication::{EdgeHubAuthenticator, LocalAuthenticator};
 pub use authorization::{
-    AuthorizerUpdate, EdgeHubAuthorizer, IdentityUpdate, LocalAuthorizer, PolicyAuthorizer,
-    PolicyUpdate,
+    AuthorizerUpdate, EdgeHubAuthorizer, FeatureFlagAuthorizer, IdentityUpdate, LocalAuthorizer,
+    PolicyAuthorizer, PolicyUpdate,
 };

--- a/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
@@ -21,7 +21,10 @@ use mqtt_broker::{
 };
 use mqtt_edgehub::{
     auth::PolicyAuthorizer,
-    auth::{EdgeHubAuthenticator, EdgeHubAuthorizer, LocalAuthenticator, LocalAuthorizer},
+    auth::{
+        EdgeHubAuthenticator, EdgeHubAuthorizer, FeatureFlagAuthorizer, LocalAuthenticator,
+        LocalAuthorizer,
+    },
     command::{
         AuthorizedIdentitiesCommand, BridgeUpdateCommand, CommandHandler, CommandHandlerError,
         DisconnectCommand, PolicyUpdateCommand, ShutdownHandle,

--- a/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
@@ -16,11 +16,11 @@ use tracing::{error, info, warn};
 use super::SidecarManager;
 use mqtt_bridge::{settings::BridgeSettings, BridgeController};
 use mqtt_broker::{
-    auth::{AllowAll, Authorizer},
-    Broker, BrokerBuilder, BrokerConfig, BrokerHandle, BrokerReady, BrokerSnapshot, Server,
-    ServerCertificate,
+    auth::Authorizer, Broker, BrokerBuilder, BrokerConfig, BrokerHandle, BrokerReady,
+    BrokerSnapshot, Server, ServerCertificate,
 };
 use mqtt_edgehub::{
+    auth::PolicyAuthorizer,
     auth::{EdgeHubAuthenticator, EdgeHubAuthorizer, LocalAuthenticator, LocalAuthorizer},
     command::{
         AuthorizedIdentitiesCommand, BridgeUpdateCommand, CommandHandler, CommandHandlerError,
@@ -31,6 +31,8 @@ use mqtt_edgehub::{
 };
 
 const DEVICE_ID_ENV: &str = "IOTEDGE_DEVICEID";
+
+const POLICY_ENABLED_ENV: &str = "experimentalFeatures:policyEngineEnabled";
 
 pub fn config<P>(config_path: Option<P>) -> Result<Settings>
 where
@@ -52,8 +54,15 @@ pub async fn broker(
     state: Option<BrokerSnapshot>,
     broker_ready: &BrokerReady,
 ) -> Result<Broker<impl Authorizer>> {
-    // TODO: Use AllowAll as bottom level authorizer until Policies are sent over from EdgeHub
-    let authorizer = LocalAuthorizer::new(EdgeHubAuthorizer::new(AllowAll, broker_ready.handle()));
+    let device_id = env::var(DEVICE_ID_ENV).context(DEVICE_ID_ENV)?;
+
+    let authorizer = LocalAuthorizer::new(EdgeHubAuthorizer::new(
+        FeatureFlagAuthorizer::new(
+            POLICY_ENABLED_ENV,
+            PolicyAuthorizer::new(device_id, broker_ready.handle()),
+        ),
+        broker_ready.handle(),
+    ));
 
     let broker = BrokerBuilder::default()
         .with_authorizer(authorizer)


### PR DESCRIPTION
Since policy engine requires default configuration, we needed to wrap `PolicyAuthorizer` with a feature flag, so it does not interfere with existing e2e tests. Otherwise all existing e2e tests needs to be fixed to include policy engine configuration.