### PR TITLE
[mqtt] Use unique client id for bridge connections to local broker

### DIFF
--- a/mqtt/mqtt-bridge/src/bridge.rs
+++ b/mqtt/mqtt-bridge/src/bridge.rs
@@ -96,7 +96,7 @@ impl Bridge<WakingMemoryStore> {
                     &system_address,
                     settings.keep_alive(),
                     settings.clean_session(),
-                    Credentials::Anonymous(format!("{}/$edgeHub/$bridge", device_id,)),
+                    Credentials::Anonymous(format!("{}/{}/$bridge", settings.name(), device_id,)),
                 ))
                 .with_rules(settings.forwards());
             })


### PR DESCRIPTION
I made a change that doesn't work for the multi-bridge scenario. The current implementation will work for public preview, but I would rather fix it now.