### PR TITLE
mqtt bridge remove enableupstreambridge flag

### DIFF
--- a/mqtt/mqtt-bridge/src/settings.rs
+++ b/mqtt/mqtt-bridge/src/settings.rs
@@ -77,25 +77,17 @@ impl<'de> serde::Deserialize<'de> for BridgeSettings {
             messages,
         } = serde::Deserialize::deserialize(deserializer)?;
 
-        let upstream_connection_settings = nested_bridge
-            .filter(|nested_bridge| {
-                nested_bridge
-                    .enable_upstream_bridge()
-                    .unwrap_or("false")
-                    .to_lowercase()
-                    == "true"
-            })
-            .map(|nested_bridge| ConnectionSettings {
-                name: "$upstream".into(),
-                address: format!(
-                    "{}:{}",
-                    nested_bridge.gateway_hostname, DEFAULT_UPSTREAM_PORT
-                ),
-                subscriptions: upstream.subscriptions,
-                credentials: Credentials::Provider(nested_bridge),
-                clean_session: upstream.clean_session,
-                keep_alive: upstream.keep_alive,
-            });
+        let upstream_connection_settings = nested_bridge.map(|nested_bridge| ConnectionSettings {
+            name: "$upstream".into(),
+            address: format!(
+                "{}:{}",
+                nested_bridge.gateway_hostname, DEFAULT_UPSTREAM_PORT
+            ),
+            subscriptions: upstream.subscriptions,
+            credentials: Credentials::Provider(nested_bridge),
+            clean_session: upstream.clean_session,
+            keep_alive: upstream.keep_alive,
+        });
 
         Ok(BridgeSettings {
             upstream: upstream_connection_settings,
@@ -197,9 +189,6 @@ impl AuthenticationSettings {
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 pub struct CredentialProviderSettings {
-    #[serde(rename = "enableupstreambridge")]
-    enable_upstream_bridge: Option<String>,
-
     #[serde(rename = "iotedge_iothubhostname")]
     iothub_hostname: String,
 
@@ -220,10 +209,6 @@ pub struct CredentialProviderSettings {
 }
 
 impl CredentialProviderSettings {
-    pub fn enable_upstream_bridge(&self) -> Option<&str> {
-        self.enable_upstream_bridge.as_deref()
-    }
-
     pub fn iothub_hostname(&self) -> &str {
         &self.iothub_hostname
     }
@@ -392,8 +377,7 @@ mod tests {
 
     #[test]
     #[serial(env_settings)]
-    fn from_env_no_upstream_protcol() {
-        let _gateway_hostname = env::set_var("IOTEDGE_GATEWAYHOSTNAME", "upstream");
+    fn from_env_no_gateway_hostname() {
         let _device_id = env::set_var("IOTEDGE_DEVICEID", "device1");
         let _module_id = env::set_var("IOTEDGE_MODULEID", "m1");
         let _generation_id = env::set_var("IOTEDGE_MODULEGENERATIONID", "123");
@@ -415,7 +399,6 @@ mod tests {
         let _generation_id = env::set_var("IOTEDGE_MODULEGENERATIONID", "123");
         let _workload_uri = env::set_var("IOTEDGE_WORKLOADURI", "workload");
         let _iothub_hostname = env::set_var("IOTEDGE_IOTHUBHOSTNAME", "iothub");
-        let _enable_bridge = env::set_var("enableupstreambridge", "true");
 
         let settings = make_settings().unwrap();
         let upstream = settings.upstream().unwrap();

--- a/mqtt/mqtt-bridge/tests/config.json
+++ b/mqtt/mqtt-bridge/tests/config.json
@@ -5,7 +5,6 @@
     "iotedge_modulegenerationid": "321",
     "iotedge_workloaduri": "uri",
     "iotedge_iothubhostname": "iothub",
-    "enableupstreambridge": "true",
     "upstream": {
         "subscriptions": [
             {


### PR DESCRIPTION
If the broker is enabled and starts in edgehub mode and GatewayHostname is set, then bridge is enabled. 