### PR TITLE
[mqtt] Rework shutdown for bridge and pumps

### DIFF
--- a/mqtt/mqtt-bridge/src/pump/egress.rs
+++ b/mqtt/mqtt-bridge/src/pump/egress.rs
@@ -1,4 +1,4 @@
-use futures_util::{pin_mut, stream::StreamExt, FutureExt};
+use futures_util::{pin_mut, stream::StreamExt};
 use tokio::{select, sync::oneshot};
 use tracing::{debug, error, info};
 
@@ -49,22 +49,21 @@ where
     }
 
     /// Runs egress processing.
-    pub(crate) async fn run(self) {
+    pub(crate) async fn run(self) -> Result<(), EgressError> {
         let Egress {
             publish_handle,
             store,
-            shutdown_recv,
+            mut shutdown_recv,
             ..
         } = self;
 
         info!("starting egress publication processing...");
 
-        let mut shutdown = shutdown_recv.fuse();
-
-        // Take the stream of loaded messages and convert to a stream of futures which publish.
-        // Then convert to buffered stream so that we can have multiple in-flight and also limit number of publications.
-        let loader = store.loader();
-        let load_and_publish = loader
+        // Take the stream of loaded messages and convert to a stream of futures
+        // which publish. Then convert to buffered stream so that we can have
+        // multiple in-flight and also limit number of publications.
+        let publications = store
+            .loader()
             .filter_map(|loaded| {
                 let publish_handle = publish_handle.clone();
                 async {
@@ -80,15 +79,15 @@ where
                 }
             })
             .buffer_unordered(MAX_IN_FLIGHT);
-        pin_mut!(load_and_publish);
+        pin_mut!(publications);
 
         loop {
             select! {
-                _ = &mut shutdown => {
-                    info!(" received shutdown signal for egress messages");
+                _ = &mut shutdown_recv => {
+                    info!("received shutdown signal for egress messages");
                     break;
                 }
-                key = load_and_publish.select_next_some() => {
+                key = publications.select_next_some() => {
                     if let Err(e) = store.remove(key) {
                         error!(err = %e, "failed removing publication from store");
                     }
@@ -97,6 +96,7 @@ where
         }
 
         info!("finished egress publication processing");
+        Ok(())
     }
 }
 
@@ -122,3 +122,7 @@ impl EgressShutdownHandle {
         }
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("ingress error")]
+pub(crate) struct EgressError;

--- a/mqtt/mqtt-bridge/src/pump/ingress.rs
+++ b/mqtt/mqtt-bridge/src/pump/ingress.rs
@@ -33,10 +33,12 @@ where
     }
 
     /// Runs ingress processing.
-    pub(crate) async fn run(mut self) {
+    pub(crate) async fn run(mut self) -> Result<(), IngressError> {
         info!("starting ingress publication processing...",);
         self.client.handle_events().await;
         info!("finished ingress publication processing");
+
+        Ok(())
     }
 }
 
@@ -53,3 +55,7 @@ impl IngressShutdownHandle {
         }
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("ingress error")]
+pub(crate) struct IngressError;

--- a/mqtt/mqtt-bridge/src/pump/ingress.rs
+++ b/mqtt/mqtt-bridge/src/pump/ingress.rs
@@ -34,7 +34,7 @@ where
 
     /// Runs ingress processing.
     pub(crate) async fn run(mut self) -> Result<(), IngressError> {
-        info!("starting ingress publication processing...",);
+        info!("starting ingress publication processing...");
         self.client.handle_events().await;
         info!("finished ingress publication processing");
 

--- a/mqtt/mqtt-bridge/src/pump/messages.rs
+++ b/mqtt/mqtt-bridge/src/pump/messages.rs
@@ -64,7 +64,7 @@ where
     }
 
     /// Runs control messages processing.
-    pub(crate) async fn run(mut self) {
+    pub(crate) async fn run(mut self) -> Result<(), MessageProcessorError> {
         info!("starting pump messages processor...");
         while let Some(message) = self.messages.next().await {
             match message {
@@ -131,6 +131,7 @@ where
         }
 
         info!("finished pump messages processor");
+        Ok(())
     }
 }
 
@@ -147,3 +148,7 @@ impl<M: 'static> MessagesProcessorShutdownHandle<M> {
         }
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("pump messages processor error")]
+pub(crate) struct MessageProcessorError;

--- a/mqtt/mqtt-bridge/src/pump/mod.rs
+++ b/mqtt/mqtt-bridge/src/pump/mod.rs
@@ -3,18 +3,22 @@ mod egress;
 mod ingress;
 mod messages;
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, error::Error as StdError, sync::Arc};
 
 pub use builder::Builder;
 use egress::Egress;
+use futures_util::{
+    future::{self, Either},
+    pin_mut,
+};
 use ingress::Ingress;
 use messages::MessagesProcessor;
 pub use messages::PumpMessageHandler;
 
 use mockall::automock;
 use parking_lot::Mutex;
-use tokio::{join, pin, select, sync::mpsc};
-use tracing::{error, info};
+use tokio::sync::mpsc;
+use tracing::{debug, error, info};
 
 use crate::{
     bridge::BridgeError,
@@ -31,8 +35,13 @@ pub fn channel<M: 'static>() -> (PumpHandle<M>, mpsc::Receiver<PumpMessage<M>>) 
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("unable to send command to pump")]
-pub struct PumpError;
+pub enum PumpError {
+    #[error("unable to send command to pump")]
+    Send,
+
+    #[error("error ocurred when running pump")]
+    Run(Box<dyn StdError + Send + Sync>),
+}
 
 /// Pump is used to connect to either local broker or remote brokers
 /// (including the upstream edge device)
@@ -99,7 +108,7 @@ where
     /// Attempts to start all routines in the same task in parallel and
     /// waits for any of them to finish. It sends shutdown to other ones
     /// and waits until all of them stopped.
-    pub async fn run(mut self) {
+    pub async fn run(mut self) -> Result<(), PumpError> {
         info!("starting pump...");
 
         let shutdown_egress = self.egress.handle();
@@ -111,34 +120,106 @@ where
         let shutdown_messages = self.messages.handle();
         let messages = self.messages.run();
 
-        pin!(egress, ingress, messages);
+        pin_mut!(egress, ingress, messages);
 
-        select! {
-            _= &mut egress => {
-                error!("egress stopped unexpectedly");
-                shutdown_ingress.shutdown().await;
-                shutdown_messages.shutdown().await;
+        match future::select(messages, future::select(egress, ingress)).await {
+            Either::Left((messages, publications)) => {
+                if let Err(e) = messages {
+                    debug!(error = %e, "pump messages processor exited with error");
+                } else {
+                    debug!("pump messages processor exited");
+                }
 
-                join!(ingress, messages);
+                debug!("shutting down both ingress and egress...");
 
-            },
-            _= &mut ingress => {
-                error!("ingress stopped unexpectedly");
-                shutdown_egress.shutdown().await;
-                shutdown_messages.shutdown().await;
-
-                join!(egress, messages);
-            },
-            _= &mut messages => {
-                info!("stopping pump");
                 shutdown_ingress.shutdown().await;
                 shutdown_egress.shutdown().await;
 
-                join!(egress, ingress);
+                match publications.await {
+                    Either::Left((egress, ingress)) => {
+                        if let Err(e) = egress {
+                            debug!(error = %e, "egress processing exited with error");
+                        } else {
+                            debug!("egress processing exited");
+                        }
+
+                        if let Err(e) = ingress.await {
+                            error!(error = %e, "ingress processing exited with error");
+                        } else {
+                            info!("ingress processing exited")
+                        }
+                    }
+                    Either::Right((ingress, egress)) => {
+                        if let Err(e) = ingress {
+                            debug!(error = %e, "ingress processing exited with error");
+                        } else {
+                            debug!("ingress processing exited");
+                        }
+
+                        if let Err(e) = egress.await {
+                            error!(error = %e, "egress processing exited with error");
+                        } else {
+                            info!("egress processing exited")
+                        }
+                    }
+                }
+
+                Ok(())
             }
-        };
+            Either::Right((Either::Left((egress, ingress)), messages)) => {
+                if let Err(e) = &egress {
+                    debug!(error = %e, "egress processing exited with error");
+                } else {
+                    debug!("egress processing exited");
+                }
+
+                debug!("shutting down ingress...");
+                shutdown_ingress.shutdown().await;
+                if let Err(e) = ingress.await {
+                    error!(error = %e, "ingress processing exited with error");
+                } else {
+                    info!("ingress processing exited")
+                }
+
+                debug!("shutting down pump messages processor...");
+                shutdown_messages.shutdown().await;
+                if let Err(e) = messages.await {
+                    debug!(error = %e, "pump messages processor exited with error");
+                } else {
+                    debug!("pump messages processor exited");
+                }
+
+                egress.map_err(|e| PumpError::Run(e.into()))
+            }
+            Either::Right((Either::Right((ingress, egress)), messages)) => {
+                if let Err(e) = &ingress {
+                    debug!(error = %e, "ingress processing exited with error");
+                } else {
+                    debug!("ingress processing exited");
+                }
+
+                debug!("shutting down egress...");
+                shutdown_egress.shutdown().await;
+                if let Err(e) = egress.await {
+                    error!(error = %e, "egress processing exited with error");
+                } else {
+                    info!("egress processing exited")
+                }
+
+                debug!("shutting down pump messages processor...");
+                shutdown_messages.shutdown().await;
+                if let Err(e) = messages.await {
+                    debug!(error = %e, "pump messages processor exited with error");
+                } else {
+                    debug!("pump messages processor exited");
+                }
+
+                ingress.map_err(|e| PumpError::Run(e.into()))
+            }
+        }?;
 
         info!("stopped pump");
+        Ok(())
     }
 }
 
@@ -164,7 +245,14 @@ impl<M: 'static> PumpHandle<M> {
 
     /// Sends a control message to a pump.
     pub async fn send(&mut self, message: PumpMessage<M>) -> Result<(), PumpError> {
-        self.sender.send(message).await.map_err(|_| PumpError)
+        self.sender.send(message).await.map_err(|_| PumpError::Send)
+    }
+
+    /// Sends a shutdown control message to a pump.
+    pub async fn shutdown(mut self) {
+        if let Err(e) = self.send(PumpMessage::Shutdown).await {
+            error!(error = %e, "unable to request shutdown for pump.");
+        }
     }
 }
 


### PR DESCRIPTION
`select!` macros does not support async operation in its branches. As a result execution stops without making any proggress. So I refactored awaiting for pumps and bridge itself.