### PR TITLE
[mqtt] Rework shutdown for bridge and pumps (#3814)

### DIFF
--- a/mqtt/mqtt-bridge/src/bridge.rs
+++ b/mqtt/mqtt-bridge/src/bridge.rs
@@ -1,5 +1,8 @@
+use futures_util::{
+    future::{self, Either},
+    pin_mut,
+};
 use mqtt3::ShutdownError;
-use tokio::{select, sync::oneshot::Sender};
 use tracing::{debug, error, info, info_span};
 use tracing_futures::Instrument;
 
@@ -49,26 +52,6 @@ impl BridgeHandle {
                 .await?;
         }
 
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
-pub struct BridgeShutdownHandle {
-    local_shutdown: Sender<()>,
-    remote_shutdown: Sender<()>,
-}
-
-impl BridgeShutdownHandle {
-    // TODO: Remove when we implement bridge controller shutdown
-    #![allow(dead_code)]
-    pub async fn shutdown(self) -> Result<(), BridgeError> {
-        self.local_shutdown
-            .send(())
-            .map_err(BridgeError::ShutdownBridge)?;
-        self.remote_shutdown
-            .send(())
-            .map_err(BridgeError::ShutdownBridge)?;
         Ok(())
     }
 }
@@ -127,13 +110,15 @@ where
     S: StreamWakeableState + Send,
 {
     pub async fn run(self) -> Result<(), BridgeError> {
-        info!("Starting {} bridge...", self.connection_settings.name());
+        info!("Starting bridge...");
 
+        let shutdown_local_pump = self.local_pump.handle();
         let local_pump = self
             .local_pump
             .run()
             .instrument(info_span!("pump", name = "local"));
 
+        let shutdown_remote_pump = self.remote_pump.handle();
         let remote_pump = self
             .remote_pump
             .run()
@@ -144,19 +129,44 @@ where
             self.connection_settings.name()
         );
 
-        select! {
-            _ = local_pump => {
-                // TODO shutdown remote pump
-                // shutdown_handle.shutdown().await?;
-            }
+        pin_mut!(local_pump, remote_pump);
 
-            _ = remote_pump => {
-                // TODO shutdown local pump
-                // shutdown_handle.shutdown().await?;
+        match future::select(local_pump, remote_pump).await {
+            Either::Left((local_pump, remote_pump)) => {
+                if let Err(e) = local_pump {
+                    error!(error = %e, "local pump exited with error");
+                } else {
+                    info!("local pump exited");
+                }
+
+                debug!("shutting down remote pump...");
+                shutdown_remote_pump.shutdown().await;
+
+                if let Err(e) = remote_pump.await {
+                    error!(error = %e, "remote pump exited with error");
+                } else {
+                    info!("remote pump exited");
+                }
+            }
+            Either::Right((remote_pump, local_pump)) => {
+                if let Err(e) = remote_pump {
+                    error!(error = %e, "remote pump exited with error");
+                } else {
+                    info!("remote pump exited");
+                }
+
+                debug!("shutting down local pump...");
+                shutdown_local_pump.shutdown().await;
+
+                if let Err(e) = local_pump.await {
+                    error!(error = %e, "local pump exited with error");
+                } else {
+                    info!("local pump exited");
+                }
             }
         }
 
-        debug!("bridge {} stopped...", self.connection_settings.name());
+        info!("bridge stopped...");
         Ok(())
     }
 

--- a/mqtt/mqtt-bridge/src/pump/egress.rs
+++ b/mqtt/mqtt-bridge/src/pump/egress.rs
@@ -1,4 +1,4 @@
-use futures_util::{pin_mut, stream::StreamExt, FutureExt};
+use futures_util::{pin_mut, stream::StreamExt};
 use tokio::{select, sync::oneshot};
 use tracing::{debug, error, info};
 
@@ -49,22 +49,21 @@ where
     }
 
     /// Runs egress processing.
-    pub(crate) async fn run(self) {
+    pub(crate) async fn run(self) -> Result<(), EgressError> {
         let Egress {
             publish_handle,
             store,
-            shutdown_recv,
+            mut shutdown_recv,
             ..
         } = self;
 
         info!("starting egress publication processing...");
 
-        let mut shutdown = shutdown_recv.fuse();
-
-        // Take the stream of loaded messages and convert to a stream of futures which publish.
-        // Then convert to buffered stream so that we can have multiple in-flight and also limit number of publications.
-        let loader = store.loader();
-        let load_and_publish = loader
+        // Take the stream of loaded messages and convert to a stream of futures
+        // which publish. Then convert to buffered stream so that we can have
+        // multiple in-flight and also limit number of publications.
+        let publications = store
+            .loader()
             .filter_map(|loaded| {
                 let publish_handle = publish_handle.clone();
                 async {
@@ -80,15 +79,15 @@ where
                 }
             })
             .buffer_unordered(MAX_IN_FLIGHT);
-        pin_mut!(load_and_publish);
+        pin_mut!(publications);
 
         loop {
             select! {
-                _ = &mut shutdown => {
-                    info!(" received shutdown signal for egress messages");
+                _ = &mut shutdown_recv => {
+                    info!("received shutdown signal for egress messages");
                     break;
                 }
-                key = load_and_publish.select_next_some() => {
+                key = publications.select_next_some() => {
                     if let Err(e) = store.remove(key) {
                         error!(err = %e, "failed removing publication from store");
                     }
@@ -97,6 +96,7 @@ where
         }
 
         info!("finished egress publication processing");
+        Ok(())
     }
 }
 
@@ -122,3 +122,7 @@ impl EgressShutdownHandle {
         }
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("ingress error")]
+pub(crate) struct EgressError;

--- a/mqtt/mqtt-bridge/src/pump/ingress.rs
+++ b/mqtt/mqtt-bridge/src/pump/ingress.rs
@@ -33,10 +33,12 @@ where
     }
 
     /// Runs ingress processing.
-    pub(crate) async fn run(mut self) {
-        info!("starting ingress publication processing...",);
+    pub(crate) async fn run(mut self) -> Result<(), IngressError> {
+        info!("starting ingress publication processing...");
         self.client.handle_events().await;
         info!("finished ingress publication processing");
+
+        Ok(())
     }
 }
 
@@ -53,3 +55,7 @@ impl IngressShutdownHandle {
         }
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("ingress error")]
+pub(crate) struct IngressError;

--- a/mqtt/mqtt-bridge/src/pump/messages.rs
+++ b/mqtt/mqtt-bridge/src/pump/messages.rs
@@ -64,7 +64,7 @@ where
     }
 
     /// Runs control messages processing.
-    pub(crate) async fn run(mut self) {
+    pub(crate) async fn run(mut self) -> Result<(), MessageProcessorError> {
         info!("starting pump messages processor...");
         while let Some(message) = self.messages.next().await {
             match message {
@@ -131,6 +131,7 @@ where
         }
 
         info!("finished pump messages processor");
+        Ok(())
     }
 }
 
@@ -147,3 +148,7 @@ impl<M: 'static> MessagesProcessorShutdownHandle<M> {
         }
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+#[error("pump messages processor error")]
+pub(crate) struct MessageProcessorError;


### PR DESCRIPTION
`select!` macros does not support async operation in its branches. As a result, execution stops without making any progress. So I refactored awaiting for pumps and bridge itself.