### PR TITLE
Fixing error messages

### DIFF
--- a/edge-modules/api-proxy-module/rust-sdk/azure-iot-mqtt/src/device.rs
+++ b/edge-modules/api-proxy-module/rust-sdk/azure-iot-mqtt/src/device.rs
@@ -153,9 +153,7 @@ impl futures_core::Stream for Client {
 				State::WaitingForSubscriptions { reset_session, acked } =>
 					if *reset_session {
 						match std::pin::Pin::new(&mut this.inner).poll_next(cx) {
-							std::task::Poll::Ready(Some(Ok(mqtt3::Event::NewConnection { .. }))) => (),
-
-							std::task::Poll::Ready(Some(Ok(mqtt3::Event::Disconnected(_)))) => (),
+							std::task::Poll::Ready(Some(Ok(mqtt3::Event::NewConnection { .. }))) | std::task::Poll::Ready(Some(Ok(mqtt3::Event::Disconnected(_)))) => (),
 
 							std::task::Poll::Ready(Some(Ok(mqtt3::Event::Publication(publication)))) => match InternalMessage::parse(publication, &this.c2d_prefix) {
  								Ok(InternalMessage::CloudToDevice(message)) =>

--- a/edge-modules/api-proxy-module/rust-sdk/azure-iot-mqtt/src/module.rs
+++ b/edge-modules/api-proxy-module/rust-sdk/azure-iot-mqtt/src/module.rs
@@ -215,7 +215,7 @@ impl futures_core::Stream for Client {
 				State::WaitingForSubscriptions { reset_session, acked } =>
 					if *reset_session {
 						match std::pin::Pin::new(&mut this.inner).poll_next(cx) {
-							std::task::Poll::Ready(Some(Ok(mqtt3::Event::NewConnection { .. }))) => (),
+							std::task::Poll::Ready(Some(Ok(mqtt3::Event::NewConnection { .. }))) | std::task::Poll::Ready(Some(Ok(mqtt3::Event::Disconnected(_)))) => (),
 
 							std::task::Poll::Ready(Some(Ok(mqtt3::Event::Publication(publication)))) => match InternalMessage::parse(publication) {
 								Ok(InternalMessage::DirectMethod { name, payload, request_id }) =>
@@ -237,7 +237,7 @@ impl futures_core::Stream for Client {
 								}
                             },
 
-                            std::task::Poll::Ready(Some(Ok(mqtt3::Event::Disconnected(_)))) => (),
+
 
 							std::task::Poll::Ready(Some(Err(err))) => return std::task::Poll::Ready(Some(Err(err))),
 

--- a/edge-modules/api-proxy-module/src/main.rs
+++ b/edge-modules/api-proxy-module/src/main.rs
@@ -26,7 +26,8 @@ use shutdown_handle::ShutdownHandle;
 async fn main() -> Result<()> {
     env_logger::builder().filter_level(LevelFilter::Info).init();
 
-    let notify_need_reload_api_proxy = Arc::new(Notify::new());
+    let notify_config_reload_api_proxy = Arc::new(Notify::new());
+    let notify_cert_reload_api_proxy = Arc::new(Notify::new());
 
     let client = config_monitor::get_sdk_client()?;
     let mut shutdown_sdk = client
@@ -39,13 +40,13 @@ async fn main() -> Result<()> {
     let (twin_state_poll_handle, twin_state_poll_shutdown_handle) =
         config_monitor::report_twin_state(report_twin_state_handle);
     let (config_monitor_handle, config_monitor_shutdown_handle) =
-        config_monitor::start(client, notify_need_reload_api_proxy.clone())
+        config_monitor::start(client, notify_config_reload_api_proxy.clone())
             .context("Failed running config monitor")?;
     let (cert_monitor_handle, cert_monitor_shutdown_handle) =
-        certs_monitor::start(notify_need_reload_api_proxy.clone())
+        certs_monitor::start(notify_cert_reload_api_proxy.clone())
             .context("Failed running certificates monitor")?;
     let (nginx_controller_handle, nginx_controller_shutdown_handle) =
-        nginx_controller_start(notify_need_reload_api_proxy)
+        nginx_controller_start(notify_config_reload_api_proxy, notify_cert_reload_api_proxy)
             .context("Failed running nginx controller")?;
 
     //If one task closes, clean up everything
@@ -79,7 +80,8 @@ async fn main() -> Result<()> {
 }
 
 pub fn nginx_controller_start(
-    notify_need_reload_api_proxy: Arc<Notify>,
+    notify_config_reload_api_proxy: Arc<Notify>,
+    notify_cert_reload_api_proxy: Arc<Notify>,
 ) -> Result<(JoinHandle<Result<()>>, ShutdownHandle), Error> {
     let program_path = "/usr/sbin/nginx";
     let args = vec![
@@ -97,10 +99,10 @@ pub fn nginx_controller_start(
     let shutdown_handle = ShutdownHandle(shutdown_signal.clone());
 
     let monitor_loop: JoinHandle<Result<()>> = tokio::spawn(async move {
-        //Wait for certificate rotation
         //This is just to avoid error at the beginning when nginx tries to start
-        //but configuration is not ready
-        notify_need_reload_api_proxy.notified().await;
+        //Wait for configuration and for certs to be ready.
+        notify_config_reload_api_proxy.notified().await;
+        notify_cert_reload_api_proxy.notified().await;
 
         loop {
             //Make sure proxy is stopped by sending stop command. Otherwise port will be blocked
@@ -121,18 +123,19 @@ pub fn nginx_controller_start(
                 .with_context(|| format!("Failed to start {} process.", name))
                 .context("Cannot start proxy!")?;
 
-            let signal_restart_nginx = notify_need_reload_api_proxy.notified();
+            // Restart nginx on new config, new cert or crash.
+            let cert_reload = notify_cert_reload_api_proxy.notified();
+            let config_reload = notify_config_reload_api_proxy.notified();
+            futures::pin_mut!(cert_reload, config_reload);
+            let signal_restart_nginx = future::select(cert_reload, config_reload);
             futures::pin_mut!(child_nginx, signal_restart_nginx);
-
-            //Wait for: either a signal to restart(cert rotation, new config) or the child to crash.
             let restart_proxy = future::select(child_nginx, signal_restart_nginx);
-            //Shutdown on ctrl+c or on signal
 
+            //Shutdown on ctrl+c or on signal
             let wait_shutdown_ctrl_c = shutdown::shutdown();
             futures::pin_mut!(wait_shutdown_ctrl_c);
             let wait_shutdown_signal = shutdown_signal.notified();
             futures::pin_mut!(wait_shutdown_signal);
-
             let wait_shutdown = future::select(wait_shutdown_ctrl_c, wait_shutdown_signal);
 
             match future::select(wait_shutdown, restart_proxy).await {


### PR DESCRIPTION
API proxy generates error messages at startup.
This should allow nginx to wait that config is ready before starting. Thus avoiding confusing error messages.