### PR TITLE
Reauthorize connections on policy update (#3823)

### DIFF
--- a/mqtt/mqtt-broker/src/auth/mod.rs
+++ b/mqtt/mqtt-broker/src/auth/mod.rs
@@ -6,7 +6,7 @@ pub use authentication::{
     DynAuthenticator,
 };
 pub use authorization::{
-    authorize_fn_ok, Activity, AllowAll, Authorization, Authorizer, Connect, DenyAll, Operation,
+    authorize_fn_ok, Activity, AllowAll, Authorization, Authorizer, DenyAll, Operation,
     Publication, Publish, Subscribe,
 };
 

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use tracing::info;
 
 use mqtt_broker::{
-    auth::{Activity, Authorization, Authorizer, Connect, Operation, Publish, Subscribe},
+    auth::{Activity, Authorization, Authorizer, Operation, Publish, Subscribe},
     AuthId, BrokerReadyEvent, BrokerReadyHandle, ClientId,
 };
 
@@ -44,11 +44,7 @@ where
     }
 
     #[allow(clippy::unused_self)]
-    fn authorize_connect(
-        &self,
-        activity: &Activity,
-        _connect: &Connect,
-    ) -> Result<Authorization, E> {
+    fn authorize_connect(&self, activity: &Activity) -> Result<Authorization, E> {
         match activity.client_info().auth_id() {
             // forbid anonymous clients to connect to the broker
             AuthId::Anonymous => Ok(Authorization::Forbidden(
@@ -254,7 +250,7 @@ where
 
     fn authorize(&self, activity: &Activity) -> Result<Authorization, Self::Error> {
         match activity.operation() {
-            Operation::Connect(connect) => self.authorize_connect(activity, &connect),
+            Operation::Connect => self.authorize_connect(activity),
             Operation::Publish(publish) => self.authorize_publish(activity, &publish),
             Operation::Subscribe(subscribe) => self.authorize_subscribe(activity, &subscribe),
         }

--- a/mqtt/mqtt-edgehub/src/auth/authorization/local.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/local.rs
@@ -44,8 +44,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use matches::assert_matches;
     use test_case::test_case;
 
@@ -81,18 +79,7 @@ mod tests {
     }
 
     fn connect_activity(peer_addr: &str) -> Activity {
-        let client_id = proto::ClientId::IdWithCleanSession("local-client".into());
-        let connect = proto::Connect {
-            username: None,
-            password: None,
-            will: None,
-            client_id,
-            keep_alive: Duration::from_secs(1),
-            protocol_name: mqtt3::PROTOCOL_NAME.to_string(),
-            protocol_level: mqtt3::PROTOCOL_LEVEL,
-        };
-
-        let operation = Operation::new_connect(connect);
+        let operation = Operation::new_connect();
         activity("client_id".into(), operation, peer_addr)
     }
 

--- a/mqtt/mqtt-edgehub/src/auth/authorization/mod.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/mod.rs
@@ -8,23 +8,11 @@ pub use local::LocalAuthorizer;
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use mqtt3::proto;
     use mqtt_broker::{auth::Activity, auth::Operation, AuthId, ClientInfo};
 
     pub(crate) fn connect_activity(client_id: &str, auth_id: impl Into<AuthId>) -> Activity {
-        let connect = proto::Connect {
-            username: None,
-            password: None,
-            will: None,
-            client_id: proto::ClientId::IdWithCleanSession(client_id.into()),
-            keep_alive: Duration::from_secs(1),
-            protocol_name: mqtt3::PROTOCOL_NAME.to_string(),
-            protocol_level: mqtt3::PROTOCOL_LEVEL,
-        };
-
-        let operation = Operation::new_connect(connect);
+        let operation = Operation::new_connect();
         activity(operation, client_id, auth_id)
     }
 

--- a/mqtt/mqtt-edgehub/src/auth/authorization/policy.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/policy.rs
@@ -117,7 +117,7 @@ fn identity(activity: &Activity) -> &str {
 
 fn operation(activity: &Activity) -> &str {
     match activity.operation() {
-        Operation::Connect(_) => "mqtt:connect",
+        Operation::Connect => "mqtt:connect",
         Operation::Publish(_) => "mqtt:publish",
         Operation::Subscribe(_) => "mqtt:subscribe",
     }
@@ -126,7 +126,7 @@ fn operation(activity: &Activity) -> &str {
 fn resource(activity: &Activity) -> &str {
     match activity.operation() {
         // this is intentional. mqtt:connect should have empty resource.
-        Operation::Connect(_) => "",
+        Operation::Connect => "",
         Operation::Publish(publish) => publish.publication().topic_name(),
         Operation::Subscribe(subscribe) => subscribe.topic_filter(),
     }

--- a/mqtt/mqtt-edgehub/tests/authorization.rs
+++ b/mqtt/mqtt-edgehub/tests/authorization.rs
@@ -32,7 +32,7 @@ async fn publish_not_allowed_identity_not_in_cache() {
     let broker = BrokerBuilder::default()
         .with_authorizer(DummyAuthorizer::new(EdgeHubAuthorizer::new(
             authorize_fn_ok(|activity| {
-                if matches!(activity.operation(), Operation::Connect(_)) {
+                if matches!(activity.operation(), Operation::Connect) {
                     Authorization::Allowed
                 } else {
                     Authorization::Forbidden("not allowed".to_string())
@@ -102,7 +102,7 @@ async fn auth_update_happy_case() {
     let broker = BrokerBuilder::default()
         .with_authorizer(DummyAuthorizer::new(EdgeHubAuthorizer::new(
             authorize_fn_ok(|activity| {
-                if matches!(activity.operation(), Operation::Connect(_)) {
+                if matches!(activity.operation(), Operation::Connect) {
                     Authorization::Allowed
                 } else {
                     Authorization::Forbidden("not allowed".to_string())
@@ -197,7 +197,7 @@ async fn disconnect_client_on_auth_update_reevaluates_subscriptions() {
     let broker = BrokerBuilder::default()
         .with_authorizer(DummyAuthorizer::new(
             EdgeHubAuthorizer::without_ready_handle(authorize_fn_ok(|activity| {
-                if matches!(activity.operation(), Operation::Connect(_)) {
+                if matches!(activity.operation(), Operation::Connect) {
                     Authorization::Allowed
                 } else {
                     Authorization::Forbidden("not allowed".to_string())

--- a/mqtt/mqtt-policy/src/lib.rs
+++ b/mqtt/mqtt-policy/src/lib.rs
@@ -28,8 +28,6 @@ pub(crate) const EDGEHUB_ID_VAR: &str = "{{iot:this_device_id}}";
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
     use bytes::Bytes;
     use mqtt3::proto;
     use mqtt_broker::{auth::Activity, auth::Operation, AuthId, ClientId, ClientInfo};
@@ -40,16 +38,8 @@ mod tests {
     ) -> Activity {
         let client_id = client_id.into();
         Activity::new(
-            ClientInfo::new(client_id.clone(), "127.0.0.1:80".parse().unwrap(), auth_id),
-            Operation::new_connect(proto::Connect {
-                username: None,
-                password: None,
-                will: None,
-                client_id: proto::ClientId::IdWithExistingSession(client_id.to_string()),
-                keep_alive: Duration::default(),
-                protocol_name: mqtt3::PROTOCOL_NAME.into(),
-                protocol_level: mqtt3::PROTOCOL_LEVEL,
-            }),
+            ClientInfo::new(client_id, "127.0.0.1:80".parse().unwrap(), auth_id),
+            Operation::new_connect(),
         )
     }
 

--- a/mqtt/mqtt-policy/src/matcher.rs
+++ b/mqtt/mqtt-policy/src/matcher.rs
@@ -31,7 +31,7 @@ impl ResourceMatcher for MqttTopicFilterMatcher {
             Some(context) => {
                 match context.operation() {
                     // special case for Connect operation, since it doesn't really have a "resource".
-                    Operation::Connect(_) => true,
+                    Operation::Connect => true,
                     // for pub or sub just match the topic filter.
                     _ => {
                         if let Ok(filter) = TopicFilter::from_str(policy) {


### PR DESCRIPTION
At the moment, when authorization policy changes, we re-authorize only subscriptions. \
In this PR:
- Added logic to re-authorize connections.
- Consolidated authorization log messages.