### PR TITLE
Recognize the new DPS registration substatus that indicates cloud identity did not change.

### DIFF
--- a/edgelet/dps/src/dps.rs
+++ b/edgelet/dps/src/dps.rs
@@ -1,3 +1,0 @@
-// Copyright (c) Microsoft. All rights reserved.
-
-pub const DPS_API_VERSION: &str = "2018-11-01";

--- a/edgelet/dps/src/lib.rs
+++ b/edgelet/dps/src/lib.rs
@@ -10,7 +10,6 @@
     clippy::use_self
 )]
 
-pub mod dps;
 pub mod error;
 mod model;
 pub mod registration;
@@ -22,4 +21,4 @@ pub use model::{
 };
 pub use registration::{DpsClient, DpsTokenSource};
 
-pub const DPS_API_VERSION: &str = "2018-11-01";
+pub const DPS_API_VERSION: &str = "2019-04-15";

--- a/edgelet/dps/src/registration.rs
+++ b/edgelet/dps/src/registration.rs
@@ -670,7 +670,7 @@ mod tests {
 
     #[test]
     fn server_register_with_sym_key_auth_success() {
-        let expected_uri = "https://global.azure-devices-provisioning.net/scope/registrations/reg/register?api-version=2018-11-01";
+        let expected_uri = "https://global.azure-devices-provisioning.net/scope/registrations/reg/register?api-version=2019-04-15";
         let handler = move |req: Request<Body>| {
             let (
                 http::request::Parts {
@@ -734,7 +734,7 @@ mod tests {
 
     #[test]
     fn server_register_with_x509_auth_success() {
-        let expected_uri = "https://global.azure-devices-provisioning.net/scope/registrations/reg/register?api-version=2018-11-01";
+        let expected_uri = "https://global.azure-devices-provisioning.net/scope/registrations/reg/register?api-version=2019-04-15";
         let handler = move |req: Request<Body>| {
             let (
                 http::request::Parts {
@@ -1203,7 +1203,7 @@ mod tests {
 
     #[test]
     fn get_operation_status_success() {
-        let expected_uri = "https://global.azure-devices-provisioning.net/scope_id/registrations/reg/operations/operation?api-version=2018-11-01";
+        let expected_uri = "https://global.azure-devices-provisioning.net/scope_id/registrations/reg/operations/operation?api-version=2019-04-15";
         let handler = move |req: Request<Body>| {
             let (http::request::Parts { method, uri, .. }, _body) = req.into_parts();
             assert_eq!(uri, expected_uri);


### PR DESCRIPTION
This commit replaces the "deviceDataUpdated" speculatively added by
1750d178585c1ae69c33893e6e7d15e1269e376b with the actual substatus that
DPS has added. The semantics are still the same.