### PR TITLE
Fixed multiple vars issue in policy definition

### DIFF
--- a/mqtt/mqtt-policy/src/substituter.rs
+++ b/mqtt/mqtt-policy/src/substituter.rs
@@ -25,26 +25,33 @@ impl MqttSubstituter {
     }
 
     fn replace_variable(&self, value: &str, context: &Request<Activity>) -> String {
-        let mut result = value.to_owned();
-        if let Some(context) = context.context() {
-            for variable in VariableIter::new(value) {
-                result = match variable {
-                    crate::CLIENT_ID_VAR => replace(
-                        &result,
-                        variable,
-                        context.client_info().client_id().as_str(),
-                    ),
-                    crate::IDENTITY_VAR => {
-                        replace(&result, variable, context.client_info().auth_id().as_str())
-                    }
-                    crate::DEVICE_ID_VAR => replace(&result, variable, extract_device_id(&context)),
-                    crate::MODULE_ID_VAR => replace(&result, variable, extract_module_id(&context)),
-                    crate::EDGEHUB_ID_VAR => replace(&result, variable, self.device_id()),
-                    _ => result,
-                };
+        match context.context() {
+            Some(context) => {
+                let mut result = value.to_owned();
+                for variable in VariableIter::new(value) {
+                    result = match variable {
+                        crate::CLIENT_ID_VAR => replace(
+                            &result,
+                            variable,
+                            context.client_info().client_id().as_str(),
+                        ),
+                        crate::IDENTITY_VAR => {
+                            replace(&result, variable, context.client_info().auth_id().as_str())
+                        }
+                        crate::DEVICE_ID_VAR => {
+                            replace(&result, variable, extract_device_id(&context))
+                        }
+                        crate::MODULE_ID_VAR => {
+                            replace(&result, variable, extract_module_id(&context))
+                        }
+                        crate::EDGEHUB_ID_VAR => replace(&result, variable, self.device_id()),
+                        _ => result,
+                    };
+                }
+                result
             }
+            None => value.to_owned(),
         }
-        result
     }
 }
 

--- a/mqtt/mqtt-policy/src/substituter.rs
+++ b/mqtt/mqtt-policy/src/substituter.rs
@@ -25,23 +25,26 @@ impl MqttSubstituter {
     }
 
     fn replace_variable(&self, value: &str, context: &Request<Activity>) -> String {
+        let mut result = value.to_owned();
         if let Some(context) = context.context() {
-            if let Some(variable) = extract_variable(value) {
-                return match variable {
-                    crate::CLIENT_ID_VAR => {
-                        replace(value, variable, context.client_info().client_id().as_str())
-                    }
+            for variable in VariableIter::new(value) {
+                result = match variable {
+                    crate::CLIENT_ID_VAR => replace(
+                        &result,
+                        variable,
+                        context.client_info().client_id().as_str(),
+                    ),
                     crate::IDENTITY_VAR => {
-                        replace(value, variable, context.client_info().auth_id().as_str())
+                        replace(&result, variable, context.client_info().auth_id().as_str())
                     }
-                    crate::DEVICE_ID_VAR => replace(value, variable, extract_device_id(&context)),
-                    crate::MODULE_ID_VAR => replace(value, variable, extract_module_id(&context)),
-                    crate::EDGEHUB_ID_VAR => replace(value, variable, self.device_id()),
-                    _ => value.to_string(),
+                    crate::DEVICE_ID_VAR => replace(&result, variable, extract_device_id(&context)),
+                    crate::MODULE_ID_VAR => replace(&result, variable, extract_module_id(&context)),
+                    crate::EDGEHUB_ID_VAR => replace(&result, variable, self.device_id()),
+                    _ => result,
                 };
             }
         }
-        value.to_string()
+        result
     }
 }
 
@@ -57,13 +60,34 @@ impl Substituter for MqttSubstituter {
     }
 }
 
-pub(super) fn extract_variable(value: &str) -> Option<&str> {
-    if let Some(start) = value.find("{{") {
-        if let Some(end) = value.find("}}") {
-            return Some(&value[start..end + 2]);
-        }
+/// A simple iterator that returns all occurrences
+/// of variable substrings like `{{var_name}}` in the
+/// provided string value.
+#[derive(Debug)]
+pub(super) struct VariableIter<'a> {
+    value: &'a str,
+    index: usize,
+}
+
+impl<'a> VariableIter<'a> {
+    pub fn new(value: &'a str) -> Self {
+        Self { value, index: 0 }
     }
-    None
+}
+
+impl<'a> Iterator for VariableIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = &self.value[self.index..];
+        if let Some(start) = value.find("{{") {
+            if let Some(end) = value.find("}}") {
+                self.index = self.index + end + 2;
+                return Some(&value[start..end + 2]);
+            }
+        }
+        None
+    }
 }
 
 fn replace(value: &str, variable: &str, substitution: &str) -> String {
@@ -148,6 +172,26 @@ mod tests {
         "test_device_client_id", 
         "{{{}bad}}}"; 
         "bad variable")]
+    #[test_case("{{{}bad}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "{{{}bad}"; 
+        "bad variable 2")]
+    #[test_case("{}bad}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "{}bad}}"; 
+        "bad variable 3")]
+    #[test_case("{{iot:this_device_id}}{{iot:module_id}}", 
+        "test_device_auth_id/test_module", 
+        "test_device_client_id", 
+        "edge_devicetest_module"; 
+        "multiple variable")]
+    #[test_case("namespace-{{iot:this_device_id}}/{{iot:module_id}}-suffix", 
+        "test_device_auth_id/test_module", 
+        "test_device_client_id", 
+        "namespace-edge_device/test_module-suffix"; 
+        "multiple variable substring")]
     fn visit_identity_test(input: &str, auth_id: &str, client_id: &str, expected: &str) {
         let request = Request::with_context(
             "some_identity",
@@ -225,6 +269,26 @@ mod tests {
         "test_device_client_id", 
         "{{{}bad}}}"; 
         "bad variable")]
+    #[test_case("{{{}bad}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "{{{}bad}"; 
+        "bad variable 2")]
+    #[test_case("{}bad}}", 
+        "test_device_auth_id", 
+        "test_device_client_id", 
+        "{}bad}}"; 
+        "bad variable 3")]
+    #[test_case("{{iot:this_device_id}}{{iot:module_id}}", 
+        "test_device_auth_id/test_module", 
+        "test_device_client_id", 
+        "edge_devicetest_module"; 
+        "multiple variable")]
+    #[test_case("namespace-{{iot:this_device_id}}/{{iot:module_id}}-suffix", 
+        "test_device_auth_id/test_module", 
+        "test_device_client_id", 
+        "namespace-edge_device/test_module-suffix"; 
+        "multiple variable substring")]
     fn visit_resource_test(input: &str, auth_id: &str, client_id: &str, expected: &str) {
         let request = Request::with_context(
             "some_identity",

--- a/mqtt/mqtt-policy/src/validator.rs
+++ b/mqtt/mqtt-policy/src/validator.rs
@@ -6,7 +6,7 @@ use lazy_static::lazy_static;
 use mqtt_broker::TopicFilter;
 use policy::{PolicyDefinition, PolicyValidator, Statement};
 
-use crate::{errors::Error, substituter};
+use crate::{errors::Error, substituter::VariableIter};
 
 /// MQTT-specific implementation of `PolicyValidator`. It checks the following rules:
 /// * Valid schema version.
@@ -78,7 +78,7 @@ fn visit_identity(value: &str) -> Result<(), Error> {
     if value.is_empty() {
         return Err(Error::InvalidIdentity(value.into()));
     }
-    if let Some(variable) = substituter::extract_variable(value) {
+    for variable in VariableIter::new(value) {
         if VALID_VARIABLES.get(variable).is_none() {
             return Err(Error::InvalidIdentityVariable(variable.into()));
         }
@@ -97,7 +97,7 @@ fn visit_resource(value: &str) -> Result<(), Error> {
     if value.is_empty() {
         return Err(Error::InvalidResource(value.into()));
     }
-    if let Some(variable) = substituter::extract_variable(value) {
+    for variable in VariableIter::new(value) {
         if VALID_VARIABLES.get(variable).is_none() {
             return Err(Error::InvalidResourceVariable(variable.into()));
         }


### PR DESCRIPTION
This PR fixes the issue where multiple vars in a string in policy definition didn't work.