### PR TITLE
handle child $edgeHub as indirect client

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/DeviceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/DeviceProxy.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             // Although it is a direct client, it uses the indirect topics
             if (identity is ModuleIdentity moduleIdentity)
             {
-                if (string.Equals(moduleIdentity.ModuleId, "$edgeHub"))
+                if (string.Equals(moduleIdentity.ModuleId, Constants.EdgeHubModuleId))
                 {
                     this.isDirectClient = false;
                 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/DeviceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/DeviceProxy.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             // Although it is a direct client, it uses the indirect topics
             if (identity is ModuleIdentity moduleIdentity)
             {
-                if (string.Equals(moduleIdentity.DeviceId, "$edgeHub"))
+                if (string.Equals(moduleIdentity.ModuleId, "$edgeHub"))
                 {
                     this.isDirectClient = false;
                 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/DeviceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/DeviceProxy.cs
@@ -40,6 +40,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             this.isActive = new AtomicBoolean(true);
             this.isDirectClient = isDirectClient;
 
+            // when a child edge device connects, it uses $edgeHub identity.
+            // Although it is a direct client, it uses the indirect topics
+            if (identity is ModuleIdentity moduleIdentity)
+            {
+                if (string.Equals(moduleIdentity.DeviceId, "$edgeHub"))
+                {
+                    this.isDirectClient = false;
+                }
+            }
+
             Events.Created(this.Identity);
         }
 

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/DeviceProxyTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/DeviceProxyTest.cs
@@ -167,5 +167,28 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
 
             Assert.False(sut.IsActive);
         }
+
+        [Fact]
+        public async Task EdgeHubIsIndirect()
+        {
+            var connectionHandler = Mock.Of<IConnectionRegistry>();
+            var twinHandler = Mock.Of<ITwinHandler>();
+            var m2mHandler = Mock.Of<IModuleToModuleMessageHandler>();
+            var c2dHandler = Mock.Of<ICloud2DeviceMessageHandler>();
+            var directMethodHandler = Mock.Of<IDirectMethodHandler>();
+            var identity = new ModuleIdentity("hub", "device_id", "$edgeHub");
+
+            var twin = new EdgeMessage.Builder(new byte[0]).Build();
+
+            Mock.Get(twinHandler)
+                .Setup(h => h.SendTwinUpdate(It.IsAny<IMessage>(), It.Is<IIdentity>(i => i == identity), It.Is<bool>(d => d == false)))
+                .Returns(Task.CompletedTask);
+
+            var sut = new DeviceProxy(identity, true, connectionHandler, twinHandler, m2mHandler, c2dHandler, directMethodHandler);
+
+            await sut.SendTwinUpdate(twin);
+
+            Mock.Get(twinHandler).VerifyAll();
+        }
     }
 }


### PR DESCRIPTION
This is  quick fix to the issue that direct clients (e.g. devices, modules) use a different dialect sending their messages (e.g. twin update) than messages connecting indirectly, where the broker/bridge transforms their topics to have identity information a consistent structure for multilevel messaging.

When a client connects "indirectly" (meaning that the fact of the connection will be noticed by not by the connected client events published by the broker, but that the clients send messages without prior connection), they get a flag, so when edgeHub sends mqtt messages to them, it uses the right dialect.

Child $edgeHub is an exception - the bridge uses its identity to connect, so the parent will receive a connection attempt and sets the flag for $edgeHub as a directly connecting device. However $edgeHub itself is not connected directly (it uses the same bridged channel as other indirectly connected child devices) and it needs the appropriate 'indirect dialect'.

With this change the connected $edgeHub will receive the messages on appropriate topic.

Further improvement can be to monitor every client and set flags according to their subscriptions/messages. Created a ticket to investigate its benefits and develop it if makes sense.

