### PR TITLE
iotedged agent spec environment variables can be null or empty [iiot branch]

### DIFF
--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -13,7 +13,7 @@ use failure::{Fail, ResultExt};
 use futures::{Future, Stream};
 use serde_derive::Serialize;
 
-use edgelet_utils::ensure_not_empty_with_context;
+use edgelet_utils::{deserialize_map_with_default_values, ensure_not_empty_with_context};
 
 use crate::error::{Error, ErrorKind, Result};
 use crate::settings::RuntimeSettings;
@@ -144,6 +144,7 @@ pub struct ModuleSpec<T> {
     type_: String,
     config: T,
     #[serde(default = "BTreeMap::new")]
+    #[serde(deserialize_with = "deserialize_map_with_default_values")]
     env: BTreeMap<String, String>,
     #[serde(default)]
     #[serde(rename = "imagePullPolicy")]

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -23,7 +23,7 @@ use std::{collections::HashMap, net::IpAddr, str::FromStr};
 pub use crate::error::{Error, ErrorKind};
 pub use crate::logging::log_failure;
 pub use crate::macros::ensure_not_empty_with_context;
-pub use crate::ser_de::{serde_clone, string_or_struct};
+pub use crate::ser_de::{deserialize_map_with_default_values, serde_clone, string_or_struct};
 pub use crate::yaml_file_source::YamlFileSource;
 
 pub fn parse_query(query: &str) -> HashMap<&str, &str> {

--- a/edgelet/edgelet-utils/src/ser_de.rs
+++ b/edgelet/edgelet-utils/src/ser_de.rs
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft. All rights reserved.
 
+use std::collections::{BTreeMap, HashMap};
 use std::fmt;
 use std::marker::PhantomData;
 use std::result::Result as StdResult;
@@ -66,14 +67,73 @@ where
         .context(ErrorKind::SerdeClone)?)
 }
 
+pub fn deserialize_map_with_default_values<'de, K, V, D>(
+    deserializer: D,
+) -> StdResult<BTreeMap<K, V>, D::Error>
+where
+    K: Deserialize<'de> + Eq + std::hash::Hash + std::cmp::Ord,
+    V: Deserialize<'de> + Default,
+    D: Deserializer<'de>,
+{
+    // Loosely derived from https://serde.rs/deserialize-map.html
+    // Create a MapVisitor which will read a map as HashMap<K,Option<V>
+    // In the case of a map we need generic type parameters K and V to be
+    // able to set the output type correctly, but don't require any state.
+    // This is an example of a "zero sized type" in Rust. The PhantomData
+    // keeps the compiler from complaining about unused generic type
+    // parameters.
+    struct OptionalValueVisitor<K, V> {
+        marker: PhantomData<fn() -> (K, V)>,
+    };
+
+    impl<K, V> OptionalValueVisitor<K, V> {
+        fn new() -> Self {
+            OptionalValueVisitor {
+                marker: PhantomData,
+            }
+        }
+    }
+
+    impl<'de, K, V> Visitor<'de> for OptionalValueVisitor<K, V>
+    where
+        K: Deserialize<'de> + Eq + std::hash::Hash + std::cmp::Ord,
+        V: Deserialize<'de>,
+    {
+        type Value = HashMap<K, Option<V>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str("HashMap<String, Option<String>>")
+        }
+
+        fn visit_map<M>(self, visitor: M) -> StdResult<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            // `MapAccessDeserializer` is a wrapper that turns a `MapAccess`
+            // into a `Deserializer`, allowing it to be used as the input to T's
+            // `Deserialize` implementation. T then deserializes itself using
+            // the entries from the map visitor.
+            Deserialize::deserialize(de::value::MapAccessDeserializer::new(visitor))
+        }
+    }
+
+    let map = deserializer.deserialize_map(OptionalValueVisitor::new());
+    map.map(|mut optional_value_map| {
+        optional_value_map
+            .drain()
+            .map(|(k, v)| (k, v.unwrap_or_else(V::default)))
+            .collect()
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use std::str::FromStr;
+    use std::{collections::BTreeMap, str::FromStr};
 
     use serde_derive::{Deserialize, Serialize};
     use serde_json::json;
 
-    use super::{serde_clone, string_or_struct, StdResult};
+    use super::{deserialize_map_with_default_values, serde_clone, string_or_struct, StdResult};
 
     #[derive(Debug, Deserialize)]
     struct Options {
@@ -150,5 +210,29 @@ mod tests {
         let c2 = serde_clone(&c1).unwrap();
         assert_eq!(c1.name, c2.name);
         assert_eq!(c1.age, c2.age);
+    }
+
+    #[derive(Debug, Deserialize, Serialize)]
+    struct Setting {
+        #[serde(deserialize_with = "deserialize_map_with_default_values")]
+        map: BTreeMap<String, String>,
+    }
+
+    #[test]
+    fn deserialize_allow_null() {
+        let setting_json = json!({
+            "map": {
+                "HAS_VALUE": "is a value",
+                "NO_VALUE": null,
+                "EMPTY": String::default(),
+            }
+        })
+        .to_string();
+
+        let s: Setting = serde_json::from_str(&setting_json).unwrap();
+
+        assert_eq!("is a value", s.map.get("HAS_VALUE").unwrap());
+        assert_eq!(&String::default(), s.map.get("NO_VALUE").unwrap());
+        assert_eq!(&String::default(), s.map.get("EMPTY").unwrap());
     }
 }


### PR DESCRIPTION
In config.yaml for iotedged, customer set an environment variable in agent bootstrap like this:
```yaml
agent:
  name: "edgeAgent"
  type: "docker"
  env:
    https_proxy:
```
Technically, this is acceptable for environment variables - a null value actually gets translated to "https_proxy=" in the docker API. This PR allows null values in config.yaml, and in the ModuleSpec.

For JSON, use a deserialization function to read env vars as optional, then transform empty entries into default values.
For YAML config, don't return an error in Yaml::Null case, transform it into ValueKind::Nil.