### PR TITLE
Fixes for certificate properties

### DIFF
--- a/edgelet/edgelet-core/src/certificate_properties.rs
+++ b/edgelet/edgelet-core/src/certificate_properties.rs
@@ -24,7 +24,8 @@ pub struct CertificateProperties {
     certificate_type: CertificateType,
     alias: String,
     issuer: CertificateIssuer,
-    san_entries: Option<Vec<String>>,
+    dns_san_entries: Option<Vec<String>>,
+    ip_entries: Option<Vec<String>>,
 }
 
 impl CertificateProperties {
@@ -40,7 +41,8 @@ impl CertificateProperties {
             certificate_type,
             alias,
             issuer: CertificateIssuer::DefaultCa,
-            san_entries: None,
+            dns_san_entries: None,
+            ip_entries: None,
         }
     }
 
@@ -89,12 +91,21 @@ impl CertificateProperties {
         self
     }
 
-    pub fn san_entries(&self) -> Option<&[String]> {
-        self.san_entries.as_ref().map(AsRef::as_ref)
+    pub fn dns_san_entries(&self) -> Option<&[String]> {
+        self.dns_san_entries.as_ref().map(AsRef::as_ref)
     }
 
-    pub fn with_san_entries(mut self, entries: Vec<String>) -> Self {
-        self.san_entries = Some(entries);
+    pub fn with_dns_san_entries(mut self, entries: Vec<String>) -> Self {
+        self.dns_san_entries = Some(entries);
+        self
+    }
+
+    pub fn ip_entries(&self) -> Option<&[String]> {
+        self.ip_entries.as_ref().map(AsRef::as_ref)
+    }
+
+    pub fn with_ip_entries(mut self, entries: Vec<String>) -> Self {
+        self.ip_entries = Some(entries);
         self
     }
 }
@@ -117,7 +128,7 @@ mod tests {
         assert_eq!(&CertificateType::Client, c.certificate_type());
         assert_eq!("alias", c.alias());
         assert_eq!(&CertificateIssuer::DefaultCa, c.issuer());
-        assert_eq!(true, c.san_entries().is_none());
+        assert_eq!(true, c.dns_san_entries().is_none());
     }
 
     #[test]
@@ -134,12 +145,12 @@ mod tests {
         .with_validity_in_secs(240)
         .with_alias("Andrew Johnson".to_string())
         .with_issuer(CertificateIssuer::DeviceCa)
-        .with_san_entries(input_sans.clone());
+        .with_dns_san_entries(input_sans.clone());
         assert_eq!(&240, c.validity_in_secs());
         assert_eq!("bafflegab", c.common_name());
         assert_eq!(&CertificateType::Ca, c.certificate_type());
         assert_eq!("Andrew Johnson", c.alias());
         assert_eq!(&CertificateIssuer::DeviceCa, c.issuer());
-        assert_eq!(&*input_sans, c.san_entries().unwrap());
+        assert_eq!(&*input_sans, c.dns_san_entries().unwrap());
     }
 }

--- a/edgelet/edgelet-http-workload/src/server/cert/identity.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/identity.rs
@@ -94,7 +94,7 @@ where
                     CertificateType::Client,
                     alias.clone(),
                 )
-                .with_san_entries(sans);
+                .with_dns_san_entries(sans);
                 Ok((alias, props))
             })
             .and_then(move |(alias, props)| {

--- a/edgelet/edgelet-http-workload/src/server/cert/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/mod.rs
@@ -167,15 +167,26 @@ fn generate_key_and_csr(
     let mut extensions = openssl::stack::Stack::new()?;
     extensions.push(extended_key_usage)?;
 
-    if props.san_entries().is_some() {
+    if props.dns_san_entries().is_some() || props.ip_entries().is_some() {
         let mut subject_alt_name = openssl::x509::extension::SubjectAlternativeName::new();
-        props
-            .san_entries()
-            .expect("san entries unexpectedly empty")
-            .iter()
-            .for_each(|s| {
-                subject_alt_name.dns(s);
-            });
+        if props.dns_san_entries().is_some() {
+            props
+                .dns_san_entries()
+                .expect("dns san entries unexpectedly empty")
+                .iter()
+                .for_each(|s| {
+                    subject_alt_name.dns(s);
+                });
+        }
+        if props.ip_entries().is_some() {
+            props
+                .ip_entries()
+                .expect("ip san entries unexpectedly empty")
+                .iter()
+                .for_each(|s| {
+                    subject_alt_name.ip(s);
+                });
+        }
         let san = subject_alt_name.build(&csr.x509v3_context(None))?;
         extensions.push(san)?;
     }

--- a/edgelet/edgelet-http-workload/src/server/cert/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/mod.rs
@@ -169,20 +169,12 @@ fn generate_key_and_csr(
 
     if props.dns_san_entries().is_some() || props.ip_entries().is_some() {
         let mut subject_alt_name = openssl::x509::extension::SubjectAlternativeName::new();
-        props
-            .dns_san_entries()
-            .into_iter()
-            .flatten()
-            .for_each(|s| {
-                subject_alt_name.dns(s);
-            });
-        props
-            .ip_entries()
-            .into_iter()
-            .flatten()
-            .for_each(|s| {
-                subject_alt_name.ip(s);
-            });
+        props.dns_san_entries().into_iter().flatten().for_each(|s| {
+            subject_alt_name.dns(s);
+        });
+        props.ip_entries().into_iter().flatten().for_each(|s| {
+            subject_alt_name.ip(s);
+        });
         let san = subject_alt_name.build(&csr.x509v3_context(None))?;
         extensions.push(san)?;
     }

--- a/edgelet/edgelet-http-workload/src/server/cert/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/mod.rs
@@ -169,24 +169,20 @@ fn generate_key_and_csr(
 
     if props.dns_san_entries().is_some() || props.ip_entries().is_some() {
         let mut subject_alt_name = openssl::x509::extension::SubjectAlternativeName::new();
-        if props.dns_san_entries().is_some() {
-            props
-                .dns_san_entries()
-                .expect("dns san entries unexpectedly empty")
-                .iter()
-                .for_each(|s| {
-                    subject_alt_name.dns(s);
-                });
-        }
-        if props.ip_entries().is_some() {
-            props
-                .ip_entries()
-                .expect("ip san entries unexpectedly empty")
-                .iter()
-                .for_each(|s| {
-                    subject_alt_name.ip(s);
-                });
-        }
+        props
+            .dns_san_entries()
+            .into_iter()
+            .flatten()
+            .for_each(|s| {
+                subject_alt_name.dns(s);
+            });
+        props
+            .ip_entries()
+            .into_iter()
+            .flatten()
+            .for_each(|s| {
+                subject_alt_name.ip(s);
+            });
         let san = subject_alt_name.build(&csr.x509v3_context(None))?;
         extensions.push(san)?;
     }


### PR DESCRIPTION
Server and identity certificates had their FQDNs incorrectly sanitized (dot character removed). Also, IPs were being dropped in certificate properties.
The method names have been refactored to match intent as well.