### PR TITLE
[mqtt] Pump subscribes to initial topics for  (#3828)

### DIFF
--- a/mqtt/mqtt-bridge/src/client.rs
+++ b/mqtt/mqtt-bridge/src/client.rs
@@ -298,8 +298,16 @@ where
         }
     }
 
-    pub async fn handle_events(&mut self) {
-        debug!("polling bridge client");
+    pub async fn run(&mut self) -> Result<(), ClientError> {
+        let default_topics = self.event_handler.subscriptions();
+        self.subscribe(default_topics).await?;
+
+        self.handle_events().await;
+        Ok(())
+    }
+
+    async fn handle_events(&mut self) {
+        debug!("polling bridge client...");
 
         while let Some(event) = self.client.try_next().await.unwrap_or_else(|e| {
             // TODO: handle the error by recreating the connection
@@ -313,15 +321,14 @@ where
         }
     }
 
-    pub async fn subscribe(&mut self, topics: &[String]) -> Result<(), ClientError> {
-        info!("subscribing to topics");
-        let subscriptions = topics.iter().map(|topic| proto::SubscribeTo {
-            topic_filter: topic.to_string(),
+    async fn subscribe(&mut self, topics: Vec<String>) -> Result<(), ClientError> {
+        info!("subscribing to topics {:?}...", topics);
+        let subscriptions = topics.into_iter().map(|topic| proto::SubscribeTo {
+            topic_filter: topic,
             qos: DEFAULT_QOS,
         });
 
         for subscription in subscriptions {
-            debug!("subscribing to topic {}", subscription.topic_filter);
             self.client
                 .subscribe(subscription)
                 .map_err(ClientError::Subscribe)?;
@@ -455,6 +462,12 @@ impl UpdateSubscriptionHandle {
 #[async_trait]
 pub trait MqttEventHandler {
     type Error: Display;
+
+    /// Returns a list of subscriptions for a MQTT client to subscribe to
+    /// when client starts.
+    fn subscriptions(&self) -> Vec<String> {
+        vec![]
+    }
 
     /// Handles MQTT client event and returns marker which determines whether
     /// an event handler fully handled an event.

--- a/mqtt/mqtt-bridge/src/controller.rs
+++ b/mqtt/mqtt-bridge/src/controller.rs
@@ -75,21 +75,6 @@ impl BridgeController {
                     // bridge running before sending initial settings
                     let task = tokio::spawn(upstream_bridge);
 
-                    // send initial subscription configuration
-                    if let Err(e) =
-                        self.handle
-                            .send(BridgeControllerUpdate::from_bridge_topic_rules(
-                                &bridge_name,
-                                &upstream_settings.subscriptions(),
-                                &upstream_settings.forwards(),
-                            ))
-                    {
-                        error!(
-                            "failed to send initial subscriptions for {}. {}",
-                            bridge_name, e
-                        );
-                    }
-
                     bridge_tasks.push(task);
                 }
                 Err(e) => {

--- a/mqtt/mqtt-bridge/src/messages.rs
+++ b/mqtt/mqtt-bridge/src/messages.rs
@@ -84,7 +84,7 @@ impl<S> StoreMqttEventHandler<S> {
         if let Some(mapper) = self.topic_mappers_updates.get(sub) {
             self.topic_mappers.insert(sub.to_owned(), mapper);
         } else {
-            debug!("subscription ack for {} not expected", sub);
+            warn!("unexpected subscription ack for {}", sub);
         };
     }
 
@@ -92,7 +92,7 @@ impl<S> StoreMqttEventHandler<S> {
         if self.topic_mappers_updates.contains_key(sub) {
             self.topic_mappers.remove(sub);
         } else {
-            debug!("unsubscription ack for {} not expected", sub);
+            warn!("unexpected subscription/rejected ack for {}", sub);
         };
     }
 }
@@ -103,6 +103,10 @@ where
     S: StreamWakeableState + Send,
 {
     type Error = BridgeError;
+
+    fn subscriptions(&self) -> Vec<String> {
+        self.topic_mappers_updates.subscriptions()
+    }
 
     async fn handle(&mut self, event: Event) -> Result<Handled, Self::Error> {
         match &event {

--- a/mqtt/mqtt-bridge/src/pump/ingress.rs
+++ b/mqtt/mqtt-bridge/src/pump/ingress.rs
@@ -35,7 +35,7 @@ where
     /// Runs ingress processing.
     pub(crate) async fn run(mut self) -> Result<(), IngressError> {
         info!("starting ingress publication processing...");
-        self.client.handle_events().await;
+        self.client.run().await?;
         info!("finished ingress publication processing");
 
         Ok(())
@@ -57,5 +57,7 @@ impl IngressShutdownHandle {
 }
 
 #[derive(Debug, thiserror::Error)]
-#[error("ingress error")]
-pub(crate) struct IngressError;
+pub(crate) enum IngressError {
+    #[error("mqtt client error. {0}")]
+    MqttClient(#[from] crate::client::ClientError),
+}

--- a/mqtt/mqtt-bridge/src/pump/mod.rs
+++ b/mqtt/mqtt-bridge/src/pump/mod.rs
@@ -3,18 +3,18 @@ mod egress;
 mod ingress;
 mod messages;
 
-use std::{collections::HashMap, error::Error as StdError, sync::Arc};
-
 pub use builder::Builder;
 use egress::Egress;
-use futures_util::{
-    future::{self, Either},
-    pin_mut,
-};
 use ingress::Ingress;
 use messages::MessagesProcessor;
 pub use messages::PumpMessageHandler;
 
+use std::{collections::HashMap, error::Error as StdError, sync::Arc};
+
+use futures_util::{
+    future::{self, Either},
+    pin_mut,
+};
 use mockall::automock;
 use parking_lot::Mutex;
 use tokio::sync::mpsc;
@@ -278,5 +278,13 @@ impl TopicMapperUpdates {
 
     pub fn contains_key(&self, topic_filter: &str) -> bool {
         self.0.lock().contains_key(topic_filter)
+    }
+
+    pub fn subscriptions(&self) -> Vec<String> {
+        self.0
+            .lock()
+            .values()
+            .map(TopicMapper::subscribe_to)
+            .collect()
     }
 }

--- a/mqtt/mqtt-bridge/src/upstream/events/remote.rs
+++ b/mqtt/mqtt-bridge/src/upstream/events/remote.rs
@@ -80,7 +80,7 @@ impl RemoteUpstreamPumpEventHandler {
 
         match self.remote_sub_handle.subscribe(subscribe_to).await {
             Ok(_) => {
-                if let Some(existing) = self.subscriptions.insert(command_id, &topic_filter) {
+                if let Some(existing) = self.subscriptions.insert(&topic_filter, command_id) {
                     warn!("duplicating sub request found for {}", existing);
                 }
             }
@@ -104,7 +104,7 @@ impl RemoteUpstreamPumpEventHandler {
             .await
         {
             Ok(_) => {
-                if let Some(existing) = self.subscriptions.insert(command_id, &topic_filter) {
+                if let Some(existing) = self.subscriptions.insert(&topic_filter, command_id) {
                     warn!("duplicating unsub request found for {}", existing);
                 }
             }

--- a/mqtt/mqtt-bridge/src/upstream/mod.rs
+++ b/mqtt/mqtt-bridge/src/upstream/mod.rs
@@ -46,6 +46,12 @@ where
 {
     type Error = BridgeError;
 
+    fn subscriptions(&self) -> Vec<String> {
+        let mut subscriptions = self.rpc.subscriptions();
+        subscriptions.extend(self.messages.subscriptions());
+        subscriptions
+    }
+
     async fn handle(&mut self, event: Event) -> Result<Handled, Self::Error> {
         // try to handle as RPC command first
         match self.rpc.handle(event).await? {
@@ -88,6 +94,13 @@ where
     S: StreamWakeableState + Send,
 {
     type Error = BridgeError;
+
+    fn subscriptions(&self) -> Vec<String> {
+        let mut subscriptions = self.messages.subscriptions();
+        subscriptions.extend(self.rpc.subscriptions());
+        subscriptions.extend(self.connectivity.subscriptions());
+        subscriptions
+    }
 
     async fn handle(&mut self, event: Event) -> Result<Handled, Self::Error> {
         // try to handle incoming connectivity event

--- a/mqtt/mqtt-bridge/src/upstream/rpc/local.rs
+++ b/mqtt/mqtt-bridge/src/upstream/rpc/local.rs
@@ -34,6 +34,10 @@ impl LocalRpcMqttEventHandler {
 impl MqttEventHandler for LocalRpcMqttEventHandler {
     type Error = RpcError;
 
+    fn subscriptions(&self) -> Vec<String> {
+        vec!["$edgehub/rpc/+".into()]
+    }
+
     async fn handle(&mut self, event: Event) -> Result<Handled, Self::Error> {
         if let Event::Publication(publication) = &event {
             if let Some(command_id) = capture_command_id(&publication.topic_name) {

--- a/mqtt/mqtt-bridge/src/upstream/rpc/mod.rs
+++ b/mqtt/mqtt-bridge/src/upstream/rpc/mod.rs
@@ -114,7 +114,7 @@ pub struct RpcSubscriptions(Arc<Mutex<HashMap<String, CommandId>>>);
 
 impl RpcSubscriptions {
     /// Stores topic filter to command identifier mapping.
-    pub fn insert(&self, id: CommandId, topic_filter: &str) -> Option<CommandId> {
+    pub fn insert(&self, topic_filter: &str, id: CommandId) -> Option<CommandId> {
         self.0.lock().insert(topic_filter.into(), id)
     }
 

--- a/mqtt/mqtt-bridge/src/upstream/rpc/remote.rs
+++ b/mqtt/mqtt-bridge/src/upstream/rpc/remote.rs
@@ -219,9 +219,9 @@ mod tests {
     #[tokio::test]
     async fn it_send_event_when_subscription_update_received() {
         let subscriptions = RpcSubscriptions::default();
-        subscriptions.insert("1".into(), "/foo/subscribed");
-        subscriptions.insert("2".into(), "/foo/rejected");
-        subscriptions.insert("3".into(), "/foo/unsubscribed");
+        subscriptions.insert("/foo/subscribed", "1".into());
+        subscriptions.insert("/foo/rejected", "2".into());
+        subscriptions.insert("/foo/unsubscribed", "3".into());
 
         let (local_pump, mut rx) = pump::channel();
         let mut handler = RemoteRpcMqttEventHandler::new(subscriptions, local_pump);
@@ -255,7 +255,7 @@ mod tests {
     #[tokio::test]
     async fn it_returns_partially_handled_when_has_non_rpc() {
         let subscriptions = RpcSubscriptions::default();
-        subscriptions.insert("1".into(), "/foo/rpc");
+        subscriptions.insert("/foo/rpc", "1".into());
 
         let (local_pump, mut rx) = pump::channel();
         let mut handler = RemoteRpcMqttEventHandler::new(subscriptions, local_pump);


### PR DESCRIPTION
Implemented missed subscriptions to RPC command topic from Local Pump event handler. 
Refactor to **automatically** subscribe to default topics for both Pumps subscriptions from default settings and for RPC command