### PR TITLE
Fix iotedge check for http endpoints

### DIFF
--- a/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
@@ -62,24 +62,22 @@ namespace Diagnostics
 
         static async Task EdgeAgent(string managementUri)
         {
-            string modules;
             if (managementUri.EndsWith(".sock"))
             {
-                modules = GetSocket.GetSocketResponse(managementUri, "/modules/?api-version=2018-06-28");
+                string modules = GetSocket.GetSocketResponse(managementUri.TrimEnd('/'), "/modules/?api-version=2018-06-28");
+
+                if (!modules.StartsWith("HTTP/1.1 200 OK"))
+                {
+                    throw new Exception($"Got bad response: {modules}");
+                }
             }
             else
             {
                 using (var http = new HttpClient())
-                using (var response = await http.GetAsync(managementUri + "/modules/?api-version=2018-06-28"))
+                using (var response = await http.GetAsync(managementUri.TrimEnd('/') + "/modules/?api-version=2018-06-28"))
                 {
                     response.EnsureSuccessStatusCode();
-                    modules = await response.Content.ReadAsStringAsync();
                 }
-            }
-
-            if (!modules.StartsWith("HTTP/1.1 200 OK"))
-            {
-                throw new Exception($"Got bad response: {modules}");
             }
         }
 

--- a/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
@@ -64,11 +64,11 @@ namespace Diagnostics
         {
             if (managementUri.EndsWith(".sock"))
             {
-                string modules = GetSocket.GetSocketResponse(managementUri.TrimEnd('/'), "/modules/?api-version=2018-06-28");
+                string response = GetSocket.GetSocketResponse(managementUri.TrimEnd('/'), "/modules/?api-version=2018-06-28");
 
-                if (!modules.StartsWith("HTTP/1.1 200 OK"))
+                if (!response.StartsWith("HTTP/1.1 200 OK"))
                 {
-                    throw new Exception($"Got bad response: {modules}");
+                    throw new Exception($"Got bad response: {response}");
                 }
             }
             else


### PR DESCRIPTION
There were 2 problems: 
* The diagnostics module was checking the body for the status code in addition to the headers. This is because in the socket case the entire response is read as a string, unlike the http case. This mistaken check was removed
* The uri to check was sometimes passed in with a trailing `/`. This extra `/` is now trimmed.