### PR TITLE
Fix MQTT broker feature flags for ARM

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
@@ -21,7 +21,6 @@
     "TableQos2StatePersistenceProvider.StorageTableName": "mqttqos2"
   },
   "mqttBrokerSettings": {
-    "enabled": true,
     "port": 1882,
     "url": "127.0.0.1"
   },

--- a/edge-hub/watchdog/src/main.rs
+++ b/edge-hub/watchdog/src/main.rs
@@ -30,11 +30,11 @@ fn main() -> Result<()> {
     init_logging();
     info!("Starting Watchdog");
 
-    let experimental_features_enabled = std::env::var("experimentalFeatures:enabled")
+    let experimental_features_enabled = std::env::var("experimentalFeatures__enabled")
         .unwrap_or_else(|_| "false".to_string())
         == "true";
 
-    let mqtt_broker_enabled = std::env::var("experimentalFeatures:mqttBrokerEnabled")
+    let mqtt_broker_enabled = std::env::var("experimentalFeatures__mqttBrokerEnabled")
         .unwrap_or_else(|_| "false".to_string())
         == "true";
 


### PR DESCRIPTION
Nested env vars need to use double-underscore to denote levels (instead of colon) for consistent behavior across all platforms.  EdgeHub core already handles this implicitly via the ConfigurationBuilder, but the Rust implementation is trying to match the raw env var key string.