### PR TITLE
Fixed on-behalf-of authorization

### DIFF
--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -1,5 +1,7 @@
 use std::{any::Any, cell::RefCell, collections::HashMap, error::Error as StdError, fmt};
 
+use lazy_static::lazy_static;
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use tracing::info;
 
@@ -19,6 +21,7 @@ pub struct EdgeHubAuthorizer<Z> {
     identities_cache: HashMap<ClientId, IdentityUpdate>,
     inner: Z,
     broker_ready: Option<BrokerReadyHandle>,
+    device_id: String,
 }
 
 impl<Z, E> EdgeHubAuthorizer<Z>
@@ -26,20 +29,21 @@ where
     Z: Authorizer<Error = E>,
     E: StdError,
 {
-    pub fn new(authorizer: Z, broker_ready: BrokerReadyHandle) -> Self {
-        Self::create(authorizer, Some(broker_ready))
+    pub fn new(authorizer: Z, device_id: String, broker_ready: BrokerReadyHandle) -> Self {
+        Self::create(authorizer, device_id, Some(broker_ready))
     }
 
-    pub fn without_ready_handle(authorizer: Z) -> Self {
-        Self::create(authorizer, None)
+    pub fn without_ready_handle(authorizer: Z, device_id: String) -> Self {
+        Self::create(authorizer, device_id, None)
     }
 
-    fn create(authorizer: Z, broker_ready: Option<BrokerReadyHandle>) -> Self {
+    fn create(authorizer: Z, device_id: String, broker_ready: Option<BrokerReadyHandle>) -> Self {
         Self {
             iothub_allowed_topics: RefCell::default(),
             identities_cache: HashMap::default(),
             inner: authorizer,
             broker_ready,
+            device_id,
         }
     }
 
@@ -76,12 +80,6 @@ where
         if is_iothub_topic(topic) {
             // run authorization rules for publication to IoTHub topic
             self.authorize_iothub_topic(activity, topic)
-        } else if is_forbidden_topic(topic) {
-            // forbid any clients to access restricted topics
-            Ok(Authorization::Forbidden(format!(
-                "{} is forbidden topic filter",
-                topic
-            )))
         } else {
             // delegate to inner authorizer for to any non-iothub topics.
             self.inner.authorize(activity)
@@ -98,12 +96,6 @@ where
         if is_iothub_topic(topic) {
             // run authorization rules for subscription to IoTHub topic
             self.authorize_iothub_topic(activity, topic)
-        } else if is_forbidden_topic_filter(topic) {
-            // forbid any clients to access restricted topics
-            Ok(Authorization::Forbidden(format!(
-                "{} is forbidden topic filter",
-                topic
-            )))
         } else {
             // delegate to inner authorizer for to any non-iothub topics.
             self.inner.authorize(activity)
@@ -118,9 +110,23 @@ where
             ),
             // allow authenticated clients with client_id == auth_id and accessing its own IoTHub topic
             AuthId::Identity(identity) if identity == activity.client_id() => {
-                if self.is_iothub_topic_allowed(activity.client_id(), topic)
-                    && self.check_authorized_cache(activity.client_id(), topic)
-                {
+                // actor id is either client id of a leaf/edge device or on-behalf-of id (when
+                // child edge acting on behalf of it's own children).
+                let actor_id = get_actor_id(topic);
+
+                let edgehub_ok = match actor_id {
+                    Some(actor_id) => {
+                        self.is_iothub_topic_valid(&actor_id, topic)
+                            && self.is_iothub_operation_authorized(
+                                &actor_id,
+                                activity.client_id(),
+                                &self.device_id,
+                            )
+                    }
+                    None => false,
+                };
+
+                if edgehub_ok {
                     Authorization::Allowed
                 } else {
                     // check if iothub policy is overridden by a custom policy.
@@ -141,7 +147,7 @@ where
         })
     }
 
-    fn is_iothub_topic_allowed(&self, client_id: &ClientId, topic: &str) -> bool {
+    fn is_iothub_topic_valid(&self, client_id: &ClientId, topic: &str) -> bool {
         let mut iothub_allowed_topics = self.iothub_allowed_topics.borrow_mut();
         let allowed_topics = iothub_allowed_topics
             .entry(client_id.clone())
@@ -152,54 +158,75 @@ where
             .any(|allowed_topic| topic.starts_with(allowed_topic))
     }
 
-    fn check_authorized_cache(&self, client_id: &ClientId, topic: &str) -> bool {
-        match get_on_behalf_of_id(topic) {
-            Some(on_behalf_of_id) if client_id == &on_behalf_of_id => {
-                self.identities_cache.contains_key(client_id)
+    fn is_iothub_operation_authorized(
+        &self,
+        actor_id: &ClientId,
+        client_id: &ClientId,
+        edgehub_id: &str,
+    ) -> bool {
+        if actor_id == client_id {
+            // if actor = client, it means it is a regular leaf/edge device request.
+            // check that it is in the current edgehub auth chain.
+            //
+            // [edgehub] <- [actor = client (leaf or child edge)]
+            match self.identities_cache.get(actor_id) {
+                Some(identity) => identity
+                    .auth_chain()
+                    .map_or(false, |auth_chain| auth_chain.contains(edgehub_id)),
+                None => false,
             }
-            Some(on_behalf_of_id) => self
-                .identities_cache
-                .get(&on_behalf_of_id)
-                .and_then(IdentityUpdate::auth_chain)
-                .map_or(false, |auth_chain| auth_chain.contains(client_id.as_str())),
-            None => {
-                // If there is no on_behalf_of_id, we are dealing with a legacy topic
-                // The client_id must still be in the identities cache
-                self.identities_cache.contains_key(client_id)
-            }
+        } else {
+            // if actor != client, it means it is an on-behalf-of request.
+            // check that:
+            // - actor_id is in the auth chain for client_id (that client
+            //   making a request can actually do it on behalf of the actor)
+            // - check that actor_id is in the auth chain for current edgehub.
+            // - check that client_id is in the auth chain for current edgehub.
+            //
+            // [edgehub] <- [client (child edgehub)] <- [actor (grandchild)]
+
+            let parent_ok = match self.identities_cache.get(actor_id) {
+                Some(identity) => identity.auth_chain().map_or(false, |auth_chain| {
+                    auth_chain.contains(&client_id.as_str().replace("/$edgeHub", ""))
+                }),
+                None => false,
+            };
+
+            let actor_ok = match self.identities_cache.get(actor_id) {
+                Some(identity) => identity
+                    .auth_chain()
+                    .map_or(false, |auth_chain| auth_chain.contains(edgehub_id)),
+                None => false,
+            };
+
+            let client_ok = match self.identities_cache.get(client_id) {
+                Some(identity) => identity
+                    .auth_chain()
+                    .map_or(false, |auth_chain| auth_chain.contains(edgehub_id)),
+                None => false,
+            };
+
+            parent_ok && actor_ok && client_ok
         }
     }
 }
 
-fn get_on_behalf_of_id(topic: &str) -> Option<ClientId> {
-    // topics without the new topic format cannot have on_behalf_of_ids
-    if !topic.starts_with("$iothub/clients") {
-        return None;
+fn get_actor_id(topic: &str) -> Option<ClientId> {
+    lazy_static! {
+        static ref TOPIC_PATTERN: Regex = Regex::new(r"^(\$edgehub|\$iothub)/(?P<device_id>[^/\+\#]+)(/(?P<module_id>[^/\+\#]+))?/(messages|twin|methods|inputs|outputs)")
+                .expect("failed to create new Regex from pattern");
     }
-    let topic_parts = topic.split('/').collect::<Vec<_>>();
-    let device_id = topic_parts.get(2);
-    let module_id = match topic_parts.get(3) {
-        Some(s) if *s == "modules" => topic_parts.get(4),
-        _ => None,
-    };
 
-    match (device_id, module_id) {
-        (Some(device_id), Some(module_id)) => Some(format!("{}/{}", device_id, module_id).into()),
-        (Some(device_id), None) => Some((*device_id).into()),
-        _ => None,
+    match TOPIC_PATTERN.captures(topic) {
+        Some(captures) => match (captures.name("device_id"), captures.name("module_id")) {
+            (Some(device_id), None) => Some(device_id.as_str().into()),
+            (Some(device_id), Some(module_id)) => {
+                Some(format!("{}/{}", device_id.as_str(), module_id.as_str()).into())
+            }
+            (_, _) => None,
+        },
+        None => None,
     }
-}
-
-const FORBIDDEN_TOPIC_FILTER_PREFIXES: [&str; 2] = ["#", "$"];
-
-fn is_forbidden_topic_filter(topic_filter: &str) -> bool {
-    FORBIDDEN_TOPIC_FILTER_PREFIXES
-        .iter()
-        .any(|prefix| topic_filter.starts_with(prefix))
-}
-
-fn is_forbidden_topic(topic_filter: &str) -> bool {
-    topic_filter.starts_with('$')
 }
 
 const IOTHUB_TOPICS_PREFIX: [&str; 2] = ["$edgehub/", "$iothub/"];
@@ -332,8 +359,8 @@ mod tests {
 
     use super::{AuthorizerUpdate, EdgeHubAuthorizer, IdentityUpdate};
 
-    #[test_case(&tests::connect_activity("device-1", AuthId::Anonymous); "anonymous clients")]
-    #[test_case(&tests::connect_activity("device-1", "device-2"); "different auth_id and client_id")]
+    #[test_case(&tests::connect_activity("leaf-1", AuthId::Anonymous); "anonymous clients")]
+    #[test_case(&tests::connect_activity("leaf-1", "leaf-2"); "different auth_id and client_id")]
     fn it_forbids_to_connect(activity: &Activity) {
         let authorizer = authorizer(AllowAll);
 
@@ -342,36 +369,23 @@ mod tests {
         assert_matches!(auth, Ok(Authorization::Forbidden(_)));
     }
 
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/device-1/messages/events"); "device events")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/messages/events"); "edge module events")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/device-1/messages/c2d/post"); "device C2D messages")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/messages/c2d/post"); "edge module C2D messages")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/device-1/twin/desired"); "device update desired properties")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/twin/desired"); "edge module update desired properties")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/device-1/twin/reported"); "device update reported properties")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/twin/reported"); "edge module update reported properties")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/device-1/twin/get"); "device twin request")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/twin/get"); "edge module twin request")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/device-1/twin/res"); "device twin response")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/inputs/route1"); "edge module access M2M inputs")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/outputs/route1"); "edge module access M2M outputs")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/device-1/messages/events"); "iothub telemetry")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/messages/events"); "iothub telemetry with moduleId")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/device-1/messages/c2d/post"); "iothub c2d messages")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/messages/c2d/post"); "iothub c2d messages with moduleId")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/device-1/twin/desired"); "iothub update desired properties")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/twin/desired"); "iothub update desired properties with moduleId")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/device-1/twin/reported"); "iothub update reported properties")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/twin/reported"); "iothub update reported properties with moduleId")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/device-1/twin/get"); "iothub device twin request")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/twin/get"); "iothub module twin request")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/device-1/twin/res"); "iothub device twin response")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/twin/res"); "iothub module twin response")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/device-1/methods/post"); "iothub device DM request")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/methods/post"); "iothub module DM request")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/device-1/methods/res"); "iothub device DM response")]
-    #[test_case(&tests::subscribe_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/methods/res"); "iothub module DM response")]
-    fn it_allows_to_subscribe_to(activity: &Activity) {
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/messages/events"); "device events")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/messages/c2d/post"); "device C2D messages")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/twin/desired"); "device update desired properties")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/twin/reported"); "device update reported properties")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/twin/get"); "device twin request")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/twin/res"); "device twin response")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/methods/post"); "device DM request")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/methods/res"); "device DM response")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/leaf-1/messages/events"); "iothub telemetry")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/leaf-1/messages/c2d/post"); "iothub c2d messages")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/leaf-1/twin/desired"); "iothub update desired properties")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/leaf-1/twin/reported"); "iothub update reported properties")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/leaf-1/twin/get"); "iothub device twin request")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/leaf-1/twin/res"); "iothub device twin response")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/leaf-1/methods/post"); "iothub device DM request")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/leaf-1/methods/res"); "iothub device DM response")]
+    fn it_allows_to_subscribe_for_leaf(activity: &Activity) {
         let authorizer = authorizer(DenyAll);
 
         let auth = authorizer.authorize(&activity);
@@ -379,27 +393,60 @@ mod tests {
         assert_matches!(auth, Ok(Authorization::Allowed));
     }
 
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "#"); "everything")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$SYS/connected"); "SYS topics")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$CUSTOM/topic"); "any special topics")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$upstream/#"); "everything with upstream prefixed")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$downstream/#"); "everything with downstream prefixed")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-2", "$edgehub/device-1/twin/get"); "twin request for another client")]
-    #[test_case(&tests::subscribe_activity("device-1", AuthId::Anonymous, "$edgehub/device-1/twin/get"); "twin request by anonymous client")]
-    fn it_forbids_to_subscribe_to(activity: &Activity) {
-        let authorizer = authorizer(AllowAll);
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/messages/events"); "edge module events")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/messages/c2d/post"); "edge module C2D messages")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/desired"); "edge module update desired properties")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/reported"); "edge module update reported properties")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/get"); "edge module twin request")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/methods/post"); "module DM request")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/methods/res"); "module DM response")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/inputs/route1"); "edge module access M2M inputs")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/outputs/route1"); "edge module access M2M outputs")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/messages/events"); "iothub telemetry with moduleId")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/messages/c2d/post"); "iothub c2d messages with moduleId")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/desired"); "iothub update desired properties with moduleId")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/reported"); "iothub update reported properties with moduleId")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/get"); "iothub module twin request")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/res"); "iothub module twin response")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/methods/post"); "iothub module DM request")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/methods/res"); "iothub module DM response")]
+    fn it_allows_to_subscribe_for_on_behalf_of_module(activity: &Activity) {
+        let authorizer = authorizer(DenyAll);
 
         let auth = authorizer.authorize(&activity);
 
-        assert_matches!(auth, Ok(Authorization::Forbidden(_)));
+        assert_matches!(auth, Ok(Authorization::Allowed));
     }
 
-    #[test_case(&tests::connect_activity("device-1", "device-1"); "identical auth_id and client_id")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "topic"); "generic MQTT topic publish")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "topic"); "generic MQTT topic subscribe")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/messages/events"); "edge module events")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/messages/c2d/post"); "edge module C2D messages")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/twin/desired"); "edge module update desired properties")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/twin/reported"); "edge module update reported properties")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/twin/get"); "edge module twin request")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/methods/post"); "module DM request")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/methods/res"); "module DM response")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/messages/events"); "iothub telemetry with moduleId")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/messages/c2d/post"); "iothub c2d messages with moduleId")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/twin/desired"); "iothub update desired properties with moduleId")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/twin/reported"); "iothub update reported properties with moduleId")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/twin/get"); "iothub module twin request")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/twin/res"); "iothub module twin response")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/methods/post"); "iothub module DM request")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/methods/res"); "iothub module DM response")]
+    fn it_allows_to_subscribe_for_on_behalf_of_leaf(activity: &Activity) {
+        let authorizer = authorizer(DenyAll);
+
+        let auth = authorizer.authorize(&activity);
+
+        assert_matches!(auth, Ok(Authorization::Allowed));
+    }
+
+    #[test_case(&tests::connect_activity("edge-1/$edgeHub", "edge-1/$edgeHub"); "identical auth_id and client_id")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "topic"); "generic MQTT topic publish")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "topic"); "generic MQTT topic subscribe")]
     fn it_delegates_to_inner(activity: &Activity) {
         let inner = authorize_fn_ok(|_| Authorization::Forbidden("not allowed inner".to_string()));
-        let authorizer = EdgeHubAuthorizer::without_ready_handle(inner);
+        let authorizer = EdgeHubAuthorizer::without_ready_handle(inner, "edgehub_id".into());
 
         let auth = authorizer.authorize(&activity);
 
@@ -407,13 +454,13 @@ mod tests {
         assert_matches!(auth, Ok(auth) if auth == Authorization::Forbidden("not allowed inner".to_string()));
     }
 
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$edgehub/some/topic"); "arbitrary edgehub prefixed topic")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/some/topic"); "arbitrary iothub prefixed topic")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/#"); "everything with edgehub prefixed")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$iothub/#"); "everything with iothub prefixed")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/device-2/twin/get"); "twin request for another device")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/+/twin/get"); "twin request for arbitrary device")]
-    #[test_case(&tests::subscribe_activity("device-1", "device-1", "$edgehub/device-1/twin/+"); "both twin operations")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/some/topic"); "arbitrary edgehub prefixed topic")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/some/topic"); "arbitrary iothub prefixed topic")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/#"); "everything with edgehub prefixed")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$iothub/#"); "everything with iothub prefixed")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/leaf-2/twin/get"); "twin request for another device")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/+/twin/get"); "twin request for arbitrary device")]
+    #[test_case(&tests::subscribe_activity("leaf-1", "leaf-1", "$edgehub/edge-1/twin/+"); "both twin operations")]
     fn iothub_primitives_overridden_by_inner(activity: &Activity) {
         // these primitives must be denied, but overridden by AllowAll
         let authorizer = authorizer(AllowAll);
@@ -423,37 +470,23 @@ mod tests {
         assert_matches!(auth, Ok(Authorization::Allowed));
     }
 
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$edgehub/device-1/messages/events"); "device events")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/messages/events"); "edge module events")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$edgehub/device-1/messages/c2d/post"); "device C2D messages")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/messages/c2d/post"); "edge module C2D messages")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$edgehub/device-1/twin/desired"); "device update desired properties")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/twin/desired"); "edge module update desired properties")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$edgehub/device-1/twin/reported"); "device update reported properties")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/twin/reported"); "edge module update reported properties")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$edgehub/device-1/twin/get"); "device twin request")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/twin/get"); "edge module twin request")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$edgehub/device-1/twin/res"); "device twin response")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/twin/res"); "edge module twin response")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/outputs/route1"); "edge module access M2M outputs")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$edgehub/device-1/module-a/inputs/route1"); "edge module access M2M inputs")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/device-1/messages/events"); "iothub telemetry")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/messages/events"); "iothub telemetry with moduleId")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/device-1/messages/c2d/post"); "iothub c2d messages")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/messages/c2d/post"); "iothub c2d messages with moduleId")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/device-1/twin/desired"); "iothub update desired properties")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/twin/desired"); "iothub update desired properties with moduleId")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/device-1/twin/reported"); "iothub update reported properties")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/twin/reported"); "iothub update reported properties with moduleId")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/device-1/twin/get"); "iothub device twin request")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/twin/get"); "iothub module twin request")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/device-1/twin/res"); "iothub device twin response")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/twin/res"); "iothub module twin response")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/device-1/methods/post"); "iothub device DM request")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/methods/post"); "iothub module DM request")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$iothub/device-1/methods/res"); "iothub device DM response")]
-    #[test_case(&tests::publish_activity("device-1/module-a", "device-1/module-a", "$iothub/device-1/module-a/methods/res"); "iothub module DM response")]
-    fn it_allows_to_publish_to(activity: &Activity) {
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/messages/events"); "device events")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/messages/c2d/post"); "device C2D messages")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/twin/desired"); "device update desired properties")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/twin/reported"); "device update reported properties")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/twin/get"); "device twin request")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/twin/res"); "device twin response")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/methods/post"); "device DM request")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$edgehub/leaf-1/methods/res"); "device DM response")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/leaf-1/messages/events"); "iothub telemetry")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/leaf-1/messages/c2d/post"); "iothub c2d messages")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/leaf-1/twin/desired"); "iothub update desired properties")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/leaf-1/twin/reported"); "iothub update reported properties")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/leaf-1/twin/get"); "iothub device twin request")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/leaf-1/twin/res"); "iothub device twin response")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/leaf-1/methods/post"); "iothub device DM request")]
+    #[test_case(&tests::publish_activity("leaf-1", "leaf-1", "$iothub/leaf-1/methods/res"); "iothub device DM response")]
+    fn it_allows_to_publish_for_leaf(activity: &Activity) {
         let authorizer = authorizer(DenyAll);
 
         let auth = authorizer.authorize(&activity);
@@ -461,38 +494,86 @@ mod tests {
         assert_matches!(auth, Ok(Authorization::Allowed));
     }
 
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$downstream/some/topic"); "any downstream prefixed topics")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$upstream/some/topic"); "any upstream prefixed topics")]
-    #[test_case(&tests::publish_activity("device-1", "device-2", "$edgehub/device-1/twin/get"); "twin request for another client")]
-    #[test_case(&tests::publish_activity("device-1", AuthId::Anonymous, "$edgehub/device-1/twin/get"); "twin request by anonymous client")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$SYS/foo"); "any system topic")]
-    #[test_case(&tests::publish_activity("device-1", "device-1", "$CUSTOM/foo"); "any special topic")]
-    fn it_forbids_to_publish_to(activity: &Activity) {
-        let authorizer = authorizer(AllowAll);
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/messages/events"); "edge module events")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/messages/c2d/post"); "edge module C2D messages")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/twin/desired"); "edge module update desired properties")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/twin/reported"); "edge module update reported properties")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/twin/get"); "edge module twin request")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/twin/res"); "edge module twin response")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/methods/post"); "module DM request")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/leaf-2/methods/res"); "module DM response")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/messages/events"); "iothub telemetry with moduleId")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/messages/c2d/post"); "iothub c2d messages with moduleId")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/twin/desired"); "iothub update desired properties with moduleId")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/twin/reported"); "iothub update reported properties with moduleId")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/twin/get"); "iothub module twin request")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/twin/res"); "iothub module twin response")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/methods/post"); "iothub module DM request")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/leaf-2/methods/res"); "iothub module DM response")]
+    fn it_allows_to_publish_for_on_behalf_of_leaf(activity: &Activity) {
+        let authorizer = authorizer(DenyAll);
 
         let auth = authorizer.authorize(&activity);
 
-        assert_matches!(auth, Ok(Authorization::Forbidden(_)));
+        assert_matches!(auth, Ok(Authorization::Allowed));
+    }
+
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/messages/events"); "edge module events")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/messages/c2d/post"); "edge module C2D messages")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/desired"); "edge module update desired properties")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/reported"); "edge module update reported properties")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/get"); "edge module twin request")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/res"); "edge module twin response")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/methods/post"); "module DM request")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/methods/res"); "module DM response")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/outputs/route1"); "edge module access M2M outputs")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/inputs/route1"); "edge module access M2M inputs")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/messages/events"); "iothub telemetry with moduleId")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/messages/c2d/post"); "iothub c2d messages with moduleId")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/desired"); "iothub update desired properties with moduleId")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/reported"); "iothub update reported properties with moduleId")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/get"); "iothub module twin request")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/res"); "iothub module twin response")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/methods/post"); "iothub module DM request")]
+    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/methods/res"); "iothub module DM response")]
+    fn it_allows_to_publish_for_on_behalf_of_module(activity: &Activity) {
+        let authorizer = authorizer(DenyAll);
+
+        let auth = authorizer.authorize(&activity);
+
+        assert_matches!(auth, Ok(Authorization::Allowed));
     }
 
     fn authorizer<Z>(inner: Z) -> EdgeHubAuthorizer<Z>
     where
         Z: Authorizer,
     {
-        let mut authorizer = EdgeHubAuthorizer::without_ready_handle(inner);
+        let mut authorizer = EdgeHubAuthorizer::without_ready_handle(inner, "this_edge".into());
 
-        let service_identity = IdentityUpdate {
-            identity: "device-1".to_string(),
-            auth_chain: Some("edgeB;device-1;".to_string()),
-        };
-        let service_identity2 = IdentityUpdate {
-            identity: "device-1/module-a".to_string(),
-            auth_chain: Some("edgeB;device-1/module-a;".to_string()),
-        };
-        let _ = authorizer.update(Box::new(AuthorizerUpdate(vec![
-            service_identity,
-            service_identity2,
-        ])));
+        let updates = vec![
+            // leaf
+            IdentityUpdate {
+                identity: "leaf-1".to_string(),
+                auth_chain: Some("leaf-1;this_edge".to_string()),
+            },
+            // child edgehub
+            IdentityUpdate {
+                identity: "edge-1/$edgeHub".to_string(),
+                auth_chain: Some("edge-1/$edgeHub;this_edge".to_string()),
+            },
+            // grandchild module
+            IdentityUpdate {
+                identity: "edge-1/module-a".to_string(),
+                auth_chain: Some("edge-1/module-a;edge-1;this_edge".to_string()),
+            },
+            // grandchild leaf
+            IdentityUpdate {
+                identity: "leaf-2".to_string(),
+                auth_chain: Some("leaf-2;edge-1;this_edge".to_string()),
+            },
+        ];
+
+        let _ = authorizer.update(Box::new(AuthorizerUpdate(updates)));
         authorizer
     }
 }

--- a/mqtt/mqtt-edgehub/tests/authorization.rs
+++ b/mqtt/mqtt-edgehub/tests/authorization.rs
@@ -38,6 +38,7 @@ async fn publish_not_allowed_identity_not_in_cache() {
                     Authorization::Forbidden("not allowed".to_string())
                 }
             }),
+            "this_edgehub_id".to_string(),
             BrokerReady::new().handle(),
         )))
         .build();
@@ -108,6 +109,7 @@ async fn auth_update_happy_case() {
                     Authorization::Forbidden("not allowed".to_string())
                 }
             }),
+            "this_edgehub_id".to_string(),
             BrokerReady::new().handle(),
         )))
         .build();
@@ -127,7 +129,7 @@ async fn auth_update_happy_case() {
         .build();
 
     let service_identity1 =
-        IdentityUpdate::new("device-1".into(), Some("device-1;$edgehub".into()));
+        IdentityUpdate::new("device-1".into(), Some("device-1;this_edgehub_id".into()));
     let identities = vec![service_identity1];
 
     // EdgeHub sends authorized identities + auth chains to broker
@@ -196,13 +198,16 @@ async fn disconnect_client_on_auth_update_reevaluates_subscriptions() {
     // but otherwise passes authorization along to EdgeHubAuthorizer
     let broker = BrokerBuilder::default()
         .with_authorizer(DummyAuthorizer::new(
-            EdgeHubAuthorizer::without_ready_handle(authorize_fn_ok(|activity| {
-                if matches!(activity.operation(), Operation::Connect) {
-                    Authorization::Allowed
-                } else {
-                    Authorization::Forbidden("not allowed".to_string())
-                }
-            })),
+            EdgeHubAuthorizer::without_ready_handle(
+                authorize_fn_ok(|activity| {
+                    if matches!(activity.operation(), Operation::Connect) {
+                        Authorization::Allowed
+                    } else {
+                        Authorization::Forbidden("not allowed".to_string())
+                    }
+                }),
+                "this_edgehub_id".to_string(),
+            ),
         ))
         .build();
     let broker_handle = broker.handle();
@@ -221,7 +226,7 @@ async fn disconnect_client_on_auth_update_reevaluates_subscriptions() {
         .build();
 
     let service_identity1 =
-        IdentityUpdate::new("device-1".into(), Some("device-1;$edgehub".into()));
+        IdentityUpdate::new("device-1".into(), Some("device-1;this_edgehub_id".into()));
     let identities = vec![service_identity1];
 
     // EdgeHub sends authorized identities + auth chains to broker

--- a/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
+++ b/mqtt/mqttd/src/broker/bootstrap/edgehub.rs
@@ -55,7 +55,8 @@ pub async fn broker(
     let device_id = env::var(DEVICE_ID_ENV).context(DEVICE_ID_ENV)?;
 
     let authorizer = LocalAuthorizer::new(EdgeHubAuthorizer::new(
-        PolicyAuthorizer::new(device_id, broker_ready.handle()),
+        PolicyAuthorizer::new(device_id.clone(), broker_ready.handle()),
+        device_id,
         broker_ready.handle(),
     ));
 


### PR DESCRIPTION
When we introduced on-behalf-of authorization logic, we had a wrong assumption about iothub topic structure.
- expected: `$iothub/clients/<device_id/modules/<module_id>/twin/get`
- actual: `$iothub/<device_id/<module_id>/twin/get`

Since the actual format does not contain useful "markers" (`clients`, `modules`), we can't simply split the string and extract device id and module id. We have to use regex now. As a result, the current logic for validation and caching of iothub topics is no longer needed, b/c Regex covers it.

Also, two more checks were added for the on-behalf-of scenario: 
 - check that actor_id is in the auth chain for current edgehub.
 - check that client_id is in the auth chain for current edgehub.