### PR TITLE
Check fix 110

### DIFF
--- a/edge-modules/iotedge-diagnostics-dotnet/src/GetSocket.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/GetSocket.cs
@@ -15,7 +15,7 @@ namespace Diagnostics
             string request = $"GET {endpoint} HTTP/1.1\r\nHost: {server}\r\nConnection: Close\r\n\r\n";
             byte[] bytesSent = Encoding.ASCII.GetBytes(request);
             byte[] bytesReceived = new byte[256];
-            server = server.Replace("unix://", string.Empty);
+            server = server.Replace("unix://", string.Empty).Trim('/');
 
             // Create a socket connection with the specified server and port.
             using (Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP))

--- a/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
@@ -59,24 +59,22 @@ namespace Diagnostics
 
         static async Task EdgeAgent(string managementUri)
         {
-            string modules;
             if (managementUri.EndsWith(".sock"))
             {
-                modules = GetSocket.GetSocketResponse(managementUri, "/modules/?api-version=2018-06-28");
+                string response = GetSocket.GetSocketResponse(managementUri.TrimEnd('/'), "/modules/?api-version=2018-06-28");
+
+                if (!response.StartsWith("HTTP/1.1 200 OK"))
+                {
+                    throw new Exception($"Got bad response: {response}");
+                }
             }
             else
             {
                 using (var http = new HttpClient())
-                using (var response = await http.GetAsync(managementUri + "/modules/?api-version=2018-06-28"))
+                using (var response = await http.GetAsync(managementUri.TrimEnd('/') + "/modules/?api-version=2018-06-28"))
                 {
                     response.EnsureSuccessStatusCode();
-                    modules = await response.Content.ReadAsStringAsync();
                 }
-            }
-
-            if (!modules.StartsWith("HTTP/1.1 200 OK"))
-            {
-                throw new Exception($"Got bad response: {modules}");
             }
         }
 

--- a/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
@@ -59,7 +59,7 @@ namespace Diagnostics
 
         static async Task EdgeAgent(string managementUri)
         {
-            if (managementUri.EndsWith(".sock"))
+            if (managementUri.EndsWith("sock"))
             {
                 string response = GetSocket.GetSocketResponse(managementUri.TrimEnd('/'), "/modules/?api-version=2018-06-28");
 


### PR DESCRIPTION
Cherry-pick #3871 
> There were 2 problems: 
> * The diagnostics module was checking the body for the status code in addition to the headers. This is because in the socket case the entire response is read as a string, unlike the http case. This mistaken check was removed
> * The uri to check was sometimes passed in with a trailing `/`. This extra `/` is now trimmed.

There is an additional fix for windows. When adding proxy support, I didn't realize windows could use unix domain sockets, so the check didn't work correctly for those. Check would error and say `(Only 'http' and 'https' schemes are allowed. (Parameter 'requestUri'))`. It works correctly now. 