### PR TITLE
fix: don't delete indirect client connections on broker connected events

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ClientConnectionHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/ClientConnectionHandler.cs
@@ -158,6 +158,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
             public bool IsActive => this.isActive;
 
+            public bool IsDirectClient => true;
+
             public IIdentity Identity { get; }
 
             public Task CloseAsync(Exception ex)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/EdgeHubConnection.cs
@@ -299,6 +299,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public bool IsActive => true;
 
+            public bool IsDirectClient => true;
+
             public IIdentity Identity => this.edgeHubConnection.edgeHubIdentity;
 
             public Task CloseAsync(Exception ex) => Task.CompletedTask;

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
 
         public IIdentity Identity { get; }
 
+        public bool IsDirectClient => this.underlyingProxy.IsDirectClient;
+
         public Task ProcessMethodResponseAsync(IMessage message)
         {
             Preconditions.CheckNotNull(message, nameof(message));

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/IDeviceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/IDeviceProxy.cs
@@ -38,5 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
         void SetInactive();
 
         Task<Option<IClientCredentials>> GetUpdatedIdentity();
+
+        bool IsDirectClient { get; }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/DeviceProxy.cs
@@ -41,6 +41,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
 
         public bool IsActive => this.isActive.Get();
 
+        public bool IsDirectClient => true;
+
         public Task CloseAsync(Exception ex)
         {
             if (this.isActive.GetAndSet(false))

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/DeviceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/DeviceProxy.cs
@@ -18,9 +18,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
         readonly IModuleToModuleMessageHandler moduleToModuleMessageHandler;
         readonly ICloud2DeviceMessageHandler cloud2DeviceMessageHandler;
         readonly IDirectMethodHandler directMethodHandler;
-        readonly bool isDirectClient;
 
         public delegate DeviceProxy Factory(IIdentity identity, bool isDirectClient);
+
+        public bool IsDirectClient { get; }
 
         public DeviceProxy(
                     IIdentity identity,
@@ -38,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             this.cloud2DeviceMessageHandler = Preconditions.CheckNotNull(cloud2DeviceMessageHandler);
             this.directMethodHandler = Preconditions.CheckNotNull(directMethodHandler);
             this.isActive = new AtomicBoolean(true);
-            this.isDirectClient = isDirectClient;
+            this.IsDirectClient = isDirectClient;
 
             // when a child edge device connects, it uses $edgeHub identity.
             // Although it is a direct client, it uses the indirect topics
@@ -46,7 +47,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             {
                 if (string.Equals(moduleIdentity.ModuleId, Constants.EdgeHubModuleId))
                 {
-                    this.isDirectClient = false;
+                    this.IsDirectClient = false;
                 }
             }
 
@@ -76,31 +77,31 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
         public Task<DirectMethodResponse> InvokeMethodAsync(DirectMethodRequest request)
         {
             Events.SendingDirectMethod(this.Identity);
-            return this.directMethodHandler.CallDirectMethodAsync(request, this.Identity, this.isDirectClient);
+            return this.directMethodHandler.CallDirectMethodAsync(request, this.Identity, this.IsDirectClient);
         }
 
         public Task OnDesiredPropertyUpdates(IMessage desiredProperties)
         {
             Events.SendingDesiredPropertyUpdate(this.Identity);
-            return this.twinHandler.SendDesiredPropertiesUpdate(desiredProperties, this.Identity, this.isDirectClient);
+            return this.twinHandler.SendDesiredPropertiesUpdate(desiredProperties, this.Identity, this.IsDirectClient);
         }
 
         public Task SendC2DMessageAsync(IMessage message)
         {
             Events.SendingC2DMessage(this.Identity);
-            return this.cloud2DeviceMessageHandler.SendC2DMessageAsync(message, this.Identity, this.isDirectClient);
+            return this.cloud2DeviceMessageHandler.SendC2DMessageAsync(message, this.Identity, this.IsDirectClient);
         }
 
         public Task SendMessageAsync(IMessage message, string input)
         {
             Events.SendingModuleToModuleMessage(this.Identity);
-            return this.moduleToModuleMessageHandler.SendModuleToModuleMessageAsync(message, input, this.Identity, this.isDirectClient);
+            return this.moduleToModuleMessageHandler.SendModuleToModuleMessageAsync(message, input, this.Identity, this.IsDirectClient);
         }
 
         public Task SendTwinUpdate(IMessage twin)
         {
             Events.SendingTwinUpdate(this.Identity);
-            return this.twinHandler.SendTwinUpdate(twin, this.Identity, this.isDirectClient);
+            return this.twinHandler.SendTwinUpdate(twin, this.Identity, this.IsDirectClient);
         }
 
         public void SetInactive()

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/ConnectionHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/ConnectionHandler.cs
@@ -150,6 +150,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
         {
             foreach (var identity in identitiesRemoved)
             {
+                if (this.knownConnections.TryGetValue(identity, out IDeviceListener container))
+                {
+                    if (container is IDeviceProxy proxy)
+                    {
+                        // Clients connected indirectly (through a child edge device) will not be reported
+                        // by broker events and appear in the 'identitiesRemoved' list as missing identities.
+                        // Ignore those:
+                        if (!proxy.IsDirectClient)
+                        {
+                            continue;
+                        }
+                    }
+                }
+
                 if (this.knownConnections.TryRemove(identity, out var deviceListener))
                 {
                     await deviceListener.CloseAsync();


### PR DESCRIPTION
When a client connects/disconnects to the broker, the broker sends a connected client list. EdgeHub uses this list and compares with its state. When edgeHub has a connection in its registry, but the broker does not send that connection in its event, edgeHub removes the connection.
When a client connects through a child device, edgeHub creates a connection for that client when it first does something (e.g. sends a telemetry message or subscribes). That is because nothing else shows edgeHub that there was a connected client. A parent broker does not send connected events about devices from child edge devices.
It also means that when a broker sends the list of the connected devices, that list does not contain the indirectly connected devices. Because edgeHub reconciles this list with its own state, before the fix it removed all indirect clients.