### PR TITLE
remove early break from subscription processing

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/SubscriptionChangeHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/SubscriptionChangeHandler.cs
@@ -120,8 +120,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                         {
                             Events.CouldNotObtainListener(subscriptionPattern.Subscrition.ToString(), identity.Id);
                         }
-
-                        break;
                     }
                 }
             }


### PR DESCRIPTION
Left a 'break' in the code when changed handling client specific subscriptions to 'in the name of' subscriptions. In case of client specific subscription it did not happen that a subscription list contained subscription to an operation (e.g. direct method), so once a fit found, breaking the loop had performance benefits.
In case of 'in the name of' subscriptions in can happen that edgeHub subscribes to direct method in the name of client_a and client_b, having two subscriptions with the same nature. 
The forgotten break exited the loop and the second subscription was not processed.