### PR TITLE
[mqtt] Fix flaky tests for command handler

### DIFF
--- a/mqtt/mqtt-edgehub/tests/authorization.rs
+++ b/mqtt/mqtt-edgehub/tests/authorization.rs
@@ -49,7 +49,7 @@ async fn publish_not_allowed_identity_not_in_cache() {
     // start command handler with AuthorizedIdentitiesCommand
     let command = AuthorizedIdentitiesCommand::new(&broker_handle);
     let (command_handler_shutdown_handle, join_handle) =
-        common::start_command_handler(server_handle.address(), command)
+        common::start_command_handler_and_wait_ready(server_handle.address(), command)
             .await
             .expect("could not start command handler");
 
@@ -120,7 +120,7 @@ async fn auth_update_happy_case() {
     // start command handler with AuthorizedIdentitiesCommand
     let command = AuthorizedIdentitiesCommand::new(&broker_handle);
     let (command_handler_shutdown_handle, join_handle) =
-        common::start_command_handler(server_handle.address(), command)
+        common::start_command_handler_and_wait_ready(server_handle.address(), command)
             .await
             .expect("could not start command handler");
 
@@ -217,7 +217,7 @@ async fn disconnect_client_on_auth_update_reevaluates_subscriptions() {
     // start command handler with AuthorizedIdentitiesCommand
     let command = AuthorizedIdentitiesCommand::new(&broker_handle);
     let (command_handler_shutdown_handle, join_handle) =
-        common::start_command_handler(server_handle.address(), command)
+        common::start_command_handler_and_wait_ready(server_handle.address(), command)
             .await
             .expect("could not start command handler");
 

--- a/mqtt/mqtt-edgehub/tests/command.rs
+++ b/mqtt/mqtt-edgehub/tests/command.rs
@@ -26,7 +26,7 @@ async fn disconnect_client() {
 
     let command = DisconnectCommand::new(&broker_handle);
     let (command_handler_shutdown_handle, join_handle) =
-        common::start_command_handler(server_handle.address(), command)
+        common::start_command_handler_and_wait_ready(server_handle.address(), command)
             .await
             .expect("could not start command handler");
 

--- a/mqtt/mqttd/src/app/edgehub.rs
+++ b/mqtt/mqttd/src/app/edgehub.rs
@@ -38,7 +38,12 @@ use mqtt_edgehub::{
 use super::{shutdown, Bootstrap};
 
 const DEVICE_ID_ENV: &str = "IOTEDGE_DEVICEID";
+const WORKLOAD_URI: &str = "IOTEDGE_WORKLOADURI";
+const EDGE_DEVICE_HOST_NAME: &str = "EdgeDeviceHostName";
+const MODULE_ID: &str = "IOTEDGE_MODULEID";
+const MODULE_GENERATION_ID: &str = "IOTEDGE_MODULEGENERATIONID";
 
+pub const CERTIFICATE_VALIDITY_DAYS: i64 = 90;
 #[derive(Default)]
 pub struct EdgeHubBootstrap {
     broker_ready: BrokerReady,
@@ -228,13 +233,6 @@ fn make_sidecars(
 
     Ok(sidecars)
 }
-
-pub const WORKLOAD_URI: &str = "IOTEDGE_WORKLOADURI";
-pub const EDGE_DEVICE_HOST_NAME: &str = "EdgeDeviceHostName";
-pub const MODULE_ID: &str = "IOTEDGE_MODULEID";
-pub const MODULE_GENERATION_ID: &str = "IOTEDGE_MODULEGENERATIONID";
-
-pub const CERTIFICATE_VALIDITY_DAYS: i64 = 90;
 
 async fn download_server_certificate() -> Result<ServerCertificate> {
     let uri = env::var(WORKLOAD_URI).context(WORKLOAD_URI)?;


### PR DESCRIPTION
Fix to make CI build to succeed. 

`CommandHandler` tests used to rely on `init` method which subscribed to required topics and waited for responses.
Since the body of `init` moved to the `run` method instead, tests became flaky because they lost an ability to start verification only when `CommandHandler` initialized.

Changes were made to use another mqtt client to subscribe to the broker and wait for such an event emitted by broker.