### PR TITLE
Broker config must be sent as a retained message. (#3887)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/brokerConnection/IMqttBrokerConnector.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/brokerConnection/IMqttBrokerConnector.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
         Task ConnectAsync(string serverAddress, int port);
         Task DisconnectAsync();
 
-        Task<bool> SendAsync(string topic, byte[] payload);
+        Task<bool> SendAsync(string topic, byte[] payload, bool retain = false);
 
         Task EnsureConnected { get; }
     }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/brokerConnection/MqttBrokerConnector.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/brokerConnection/MqttBrokerConnector.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             }
         }
 
-        public async Task<bool> SendAsync(string topic, byte[] payload)
+        public async Task<bool> SendAsync(string topic, byte[] payload, bool retain = false)
         {
             var client = this.mqttClient.Expect(() => new Exception("No mqtt-bridge connector instance found to send messages."));
 
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             // put into the dictionary next line, causing the ACK being unknown.
             lock (this.guard)
             {
-                var messageId = client.Publish(topic, payload, 1, false);
+                var messageId = client.Publish(topic, payload, 1, retain);
                 added = this.pendingAcks.TryAdd(messageId, tcs);
             }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/BrokerConfigUpdateHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/BrokerConfigUpdateHandler.cs
@@ -61,10 +61,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
                 Events.PublishPolicyUpdate(policyUpdate);
 
                 var policyPayload = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(policyUpdate));
-                await this.connector.SendAsync(PolicyUpdateTopic, policyPayload);
+                await this.connector.SendAsync(PolicyUpdateTopic, policyPayload, retain: true);
 
                 var bridgePayload = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(bridgeUpdate));
-                await this.connector.SendAsync(BridgeUpdateTopic, bridgePayload);
+                await this.connector.SendAsync(BridgeUpdateTopic, bridgePayload, retain: true);
             }
             catch (Exception ex)
             {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/ScopeIdentitiesHandler.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/handlers/ScopeIdentitiesHandler.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             try
             {
                 var payload = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(brokerServiceIdentities));
-                await this.connector.SendAsync(Topic, payload);
+                await this.connector.SendAsync(Topic, payload, retain: true);
             }
             catch (Exception ex)
             {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/Cloud2DeviceMessageHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/Cloud2DeviceMessageHandlerTest.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
         public async Task EncodesDeviceNameInTopic()
         {
             var capture = new SendCapture();
-            var connector = GetConnector(capture);            
+            var connector = GetConnector(capture);
             var connectionRegistry = GetConnectionRegistry();
             var identity = new DeviceIdentity("hub", "device_id");
             var message = new EdgeMessage
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             await sut.SendC2DMessageAsync(message, identity, true);
 
             Mock.Get(connector)
-                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()), Times.Never());
+                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()), Times.Never());
         }
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ConnectionHandlerTests.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ConnectionHandlerTests.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             Mock.Get(authenticator)
                 .Setup(p => p.AuthenticateAsync(It.IsAny<IClientCredentials>()))
                 .Returns(Task.FromResult(true));
-            
+
             var connectionProviderGetter = Task.FromResult(connectionProvider);
             var authenticatorGetter = Task.FromResult(authenticator);
 
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
 
             var brokerConnector = Mock.Of<IMqttBrokerConnector>();
             Mock.Get(brokerConnector)
-                .Setup(p => p.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
+                .Setup(p => p.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()))
                 .Returns(() => Task.FromResult(true));
 
             var sut = default(ConnectionHandler);
@@ -58,7 +58,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             Mock.Get(brokerConnector).Verify(
                 c => c.SendAsync(
                             It.Is<string>(topic => topic.Equals("$edgehub/disconnect")),
-                            It.Is<byte[]>(payload => Encoding.UTF8.GetString(payload).Equals($"\"device_test\""))),
+                            It.Is<byte[]>(payload => Encoding.UTF8.GetString(payload).Equals($"\"device_test\"")),
+                            false),
                 Times.Once);
 
             DeviceProxy GetProxy(IIdentity identity, bool isDirectClient = true)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/DirectMethodHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/DirectMethodHandlerTest.cs
@@ -202,8 +202,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
         {
             var connector = Mock.Of<IMqttBrokerConnector>();
             Mock.Get(connector)
-                .Setup(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
-                .Returns((string topic, byte[] content) =>
+                .Setup(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()))
+                .Returns((string topic, byte[] content, bool retain) =>
                 {
                     sendCapture?.Caputre(topic, content);
                     return Task.FromResult(true);
@@ -243,14 +243,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             public Task AddDesiredPropertyUpdatesSubscription(string correlationId) => Task.CompletedTask;
             public Task AddSubscription(DeviceSubscription subscription) => Task.CompletedTask;
             public Task CloseAsync() => Task.CompletedTask;
-            public Task ProcessDeviceMessageBatchAsync(IEnumerable<IMessage> message) => Task.CompletedTask;            
+            public Task ProcessDeviceMessageBatchAsync(IEnumerable<IMessage> message) => Task.CompletedTask;
             public Task RemoveDesiredPropertyUpdatesSubscription(string correlationId) => Task.CompletedTask;
             public Task RemoveSubscription(DeviceSubscription subscription) => Task.CompletedTask;
             public Task SendGetTwinRequest(string correlationId) => Task.CompletedTask;
             public Task UpdateReportedPropertiesAsync(IMessage reportedPropertiesMessage, string correlationId) => Task.CompletedTask;
             public Task ProcessDeviceMessageAsync(IMessage message) => Task.CompletedTask;
             public Task ProcessMessageFeedbackAsync(string messageId, FeedbackStatus feedbackStatus) => Task.CompletedTask;
-           
+
             public Task ProcessMethodResponseAsync(IMessage message)
             {
                 this.CapturedMessage = message;

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/MessageConfirmingBase.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/MessageConfirmingBase.cs
@@ -32,8 +32,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
         {
             var connector = Mock.Of<IMqttBrokerConnector>();
             Mock.Get(connector)
-                .Setup(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
-                .Returns((string topic, byte[] content) =>
+                .Setup(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()))
+                .Returns((string topic, byte[] content, bool retain) =>
                 {
                     sendCapture?.Caputre(topic, content);
                     return Task.FromResult(true);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ModuleToModuleMessageHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ModuleToModuleMessageHandlerTest.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
 
         [Fact]
         public async Task ConfirmsMessageAfterSent()
-        {            
+        {
             var capturedLockId = default(string);
             var capturedStatus = (FeedbackStatus)(-1);
 
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             await sut.SendModuleToModuleMessageAsync(message, "some_input", identity, true);
 
             Mock.Get(connector)
-                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()), Times.Never());
+                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()), Times.Never());
         }
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ScopeIdentitiesHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ScopeIdentitiesHandlerTest.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
         {
             var connector = new Mock<IMqttBrokerConnector>();
             connector
-                .Setup(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
-                .Returns((string topic, byte[] content) =>
+                .Setup(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()))
+                .Returns((string topic, byte[] content, bool retain) =>
                 {
                     sendCapture?.Capture(topic, content);
                     return Task.FromResult(true);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/TwinHandlerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/TwinHandlerTest.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             _ = await sut.HandleAsync(publishInfo);
             await milestone.WaitAsync();
 
-            Assert.Equal(new byte [] { 1, 2, 3 }, listenerCapture.Captured.CapturedMessage.Body);
+            Assert.Equal(new byte[] { 1, 2, 3 }, listenerCapture.Captured.CapturedMessage.Body);
         }
 
         [Fact]
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             await sut.SendTwinUpdate(twin, identity, true);
 
             Mock.Get(connector)
-                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()), Times.Never());
+                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()), Times.Never());
         }
 
         [Fact]
@@ -177,7 +177,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             await sut.SendTwinUpdate(twin, identity, true);
 
             Mock.Get(connector)
-                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()), Times.Never());
+                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()), Times.Never());
         }
 
         [Fact]
@@ -243,7 +243,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             await sut.SendDesiredPropertiesUpdate(twin, identity, true);
 
             Mock.Get(connector)
-                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()), Times.Never());
+                .Verify(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()), Times.Never());
         }
 
         [Fact]
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             var twin = new EdgeMessage.Builder(new byte[] { 1, 2, 3 })
                                       .SetSystemProperties(new Dictionary<string, string>()
                                       {
-                                          [SystemProperties.Version] = "123"                                          
+                                          [SystemProperties.Version] = "123"
                                       })
                                       .Build();
 
@@ -352,8 +352,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
         {
             var connector = Mock.Of<IMqttBrokerConnector>();
             Mock.Get(connector)
-                .Setup(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>()))
-                .Returns((string topic, byte[] content) =>
+                .Setup(c => c.SendAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<bool>()))
+                .Returns((string topic, byte[] content, bool retain) =>
                 {
                     sendCapture?.Caputre(topic, content);
                     return Task.FromResult(true);
@@ -377,13 +377,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
             }
 
             public IIdentity Identity { get; }
-            
+
             public Task AddDesiredPropertyUpdatesSubscription(string correlationId) => Task.CompletedTask;
             public Task AddSubscription(DeviceSubscription subscription) => Task.CompletedTask;
             public Task CloseAsync() => Task.CompletedTask;
             public Task ProcessDeviceMessageBatchAsync(IEnumerable<IMessage> message) => Task.CompletedTask;
             public Task RemoveDesiredPropertyUpdatesSubscription(string correlationId) => Task.CompletedTask;
-            public Task RemoveSubscription(DeviceSubscription subscription) => Task.CompletedTask;                        
+            public Task RemoveSubscription(DeviceSubscription subscription) => Task.CompletedTask;
             public Task ProcessDeviceMessageAsync(IMessage message) => Task.CompletedTask;
             public Task ProcessMessageFeedbackAsync(string messageId, FeedbackStatus feedbackStatus) => Task.CompletedTask;
             public Task ProcessMethodResponseAsync(IMessage message) => Task.CompletedTask;

--- a/mqtt/mqtt-edgehub/tests/authorization.rs
+++ b/mqtt/mqtt-edgehub/tests/authorization.rs
@@ -1,4 +1,5 @@
 use assert_matches::assert_matches;
+use bytes::Bytes;
 use futures_util::StreamExt;
 use mqtt_broker::{auth::authorize_fn_ok, BrokerReady};
 
@@ -68,7 +69,7 @@ async fn publish_not_allowed_identity_not_in_cache() {
         packet_identifier: PacketIdentifier::new(1).unwrap(),
         subscribe_to: vec![SubscribeTo {
             // We need to use a post-translation topic here
-            topic_filter: "$edgehub/device-1/inputs/telemetry/#".into(),
+            topic_filter: "$edgehub/device-1/twin/res/#".into(),
             qos: QoS::AtLeastOnce,
         }],
     };
@@ -137,7 +138,7 @@ async fn auth_update_happy_case() {
         .publish_qos1(
             AUTHORIZED_IDENTITIES_TOPIC,
             serde_json::to_string(&identities).expect("unable to serialize identities"),
-            false,
+            true,
         )
         .await;
 
@@ -145,7 +146,7 @@ async fn auth_update_happy_case() {
         packet_identifier: PacketIdentifier::new(1).unwrap(),
         subscribe_to: vec![SubscribeTo {
             // We need to use a post-translation topic here
-            topic_filter: "$edgehub/device-1/inputs/telemetry/#".into(),
+            topic_filter: "$edgehub/device-1/twin/res/#".into(),
             qos: QoS::AtLeastOnce,
         }],
     };
@@ -166,14 +167,10 @@ async fn auth_update_happy_case() {
     assert_matches!(device_client.next().await, Some(Packet::SubAck(_)));
 
     edgehub_client
-        .publish_qos1(
-            "$edgehub/device-1/inputs/telemetry/#",
-            "test_payload",
-            false,
-        )
+        .publish_qos1("$edgehub/device-1/twin/res/#", "test_payload", true)
         .await;
 
-    assert_matches!(device_client.next().await, Some(Packet::Publish(_)));
+    assert_matches!(device_client.next().await, Some(Packet::Publish(p)) if p.payload == Bytes::from("test_payload"));
 
     command_handler_shutdown_handle
         .shutdown()
@@ -234,7 +231,7 @@ async fn disconnect_client_on_auth_update_reevaluates_subscriptions() {
         .publish_qos1(
             AUTHORIZED_IDENTITIES_TOPIC,
             serde_json::to_string(&identities).expect("unable to serialize identities"),
-            false,
+            true,
         )
         .await;
 
@@ -269,7 +266,7 @@ async fn disconnect_client_on_auth_update_reevaluates_subscriptions() {
         .publish_qos1(
             AUTHORIZED_IDENTITIES_TOPIC,
             serde_json::to_string(&identities).expect("unable to serialize identities"),
-            false,
+            true,
         )
         .await;
 


### PR DESCRIPTION
Bridge, policy and identities must be sent as retained messages to the broker.