### PR TITLE
bridge topics fix when inPrefix or outPrefix are empty (#3893)

### DIFF
--- a/mqtt/mqtt-bridge/src/messages.rs
+++ b/mqtt/mqtt-bridge/src/messages.rs
@@ -65,17 +65,23 @@ impl<S> StoreMqttEventHandler<S> {
                 // maps if local does not have a value it uses the topic that was received,
                 // else it checks that the received topic starts with local prefix and removes the local prefix
                 .map_or(Some(topic_name), |local_prefix| {
-                    let prefix = format!("{}/", local_prefix);
-                    topic_name.strip_prefix(&prefix)
+                    if local_prefix.is_empty() {
+                        topic_name.strip_prefix(local_prefix)
+                    } else {
+                        topic_name.strip_prefix(format!("{}/", local_prefix).as_str())
+                    }
                 })
                 // match topic without local prefix with the topic filter pattern
                 .filter(|stripped_topic| mapper.topic_filter.matches(stripped_topic))
-                .map(|stripped_topic| {
-                    if let Some(remote_prefix) = mapper.topic_settings.out_prefix() {
-                        format!("{}/{}", remote_prefix, stripped_topic)
-                    } else {
-                        stripped_topic.to_string()
+                .map(|stripped_topic| match mapper.topic_settings.out_prefix() {
+                    Some(remote_prefix) => {
+                        if remote_prefix.is_empty() {
+                            stripped_topic.to_string()
+                        } else {
+                            format!("{}/{}", remote_prefix, stripped_topic)
+                        }
                     }
+                    None => stripped_topic.to_string(),
                 })
         })
     }
@@ -282,6 +288,62 @@ mod tests {
             ]))
             .await
             .unwrap();
+        handler.handle(Event::Publication(pub1)).await.unwrap();
+
+        let mut loader = handler.store.loader();
+
+        let extracted1 = loader.try_next().await.unwrap().unwrap();
+        assert_eq!(extracted1.1, expected);
+    }
+
+    #[tokio::test]
+    async fn message_handler_saves_message_with_empty_local_and_forward_topic() {
+        let batch_size: usize = 5;
+        let settings = BridgeSettings::from_file("tests/config.json").unwrap();
+        let connection_settings = settings.upstream().unwrap();
+
+        let topics = connection_settings
+            .forwards()
+            .iter()
+            .map(|sub| {
+                (
+                    sub.subscribe_to(),
+                    TopicMapper {
+                        topic_settings: sub.clone(),
+                        topic_filter: TopicFilter::from_str(sub.topic()).unwrap(),
+                    },
+                )
+            })
+            .collect();
+
+        let store = PublicationStore::new_memory(batch_size);
+        let mut handler = StoreMqttEventHandler::new(store, TopicMapperUpdates::new(topics));
+
+        let pub1 = ReceivedPublication {
+            topic_name: "floor2/1".to_string(),
+            qos: QoS::AtLeastOnce,
+            retain: true,
+            payload: Bytes::new(),
+            dup: false,
+        };
+
+        let expected = Publication {
+            topic_name: "floor2/1".to_string(),
+            qos: QoS::AtLeastOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        handler
+            .handle(Event::SubscriptionUpdates(vec![
+                SubscriptionUpdateEvent::Subscribe(SubscribeTo {
+                    topic_filter: "floor2/#".to_string(),
+                    qos: QoS::AtLeastOnce,
+                }),
+            ]))
+            .await
+            .unwrap();
+
         handler.handle(Event::Publication(pub1)).await.unwrap();
 
         let mut loader = handler.store.loader();

--- a/mqtt/mqtt-bridge/src/settings.rs
+++ b/mqtt/mqtt-bridge/src/settings.rs
@@ -267,10 +267,15 @@ impl TopicRule {
     }
 
     pub fn subscribe_to(&self) -> String {
-        if let Some(local) = &self.in_prefix {
-            format!("{}/{}", local, self.topic)
-        } else {
-            self.topic.clone()
+        match &self.in_prefix {
+            Some(local) => {
+                if local.is_empty() {
+                    self.topic.clone()
+                } else {
+                    format!("{}/{}", local, self.topic)
+                }
+            }
+            None => self.topic.clone(),
         }
     }
 }

--- a/mqtt/mqtt-bridge/tests/config.json
+++ b/mqtt/mqtt-bridge/tests/config.json
@@ -21,6 +21,12 @@
             {
                 "direction": "out",
                 "topic": "pattern/#"
+            },
+            {
+                "direction": "out",
+                "topic": "floor2/#",
+                "inPrefix": "",
+                "outPrefix": ""
             }
         ]
     },


### PR DESCRIPTION
cherry-pick from release/1.2

when inPrefix or outPrefix are empty string it should work as None.

Note: I think would be nicer just to deserialize "" as None, but couldn't make it work with custom deserialization when field was missing. For now will go with this fix and will try in the meantime with custom deserialization