### PR TITLE
fix for iotedge check

### DIFF
--- a/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
@@ -74,8 +74,9 @@ namespace Diagnostics
         static async Task Upstream(string hostname, string port, string proxy)
         {
             var httpClientHandler = new HttpClientHandler();
-            httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => {
-                    return true;   //Is valid
+            httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) =>
+            {
+                    return true; // Is valid
             };
 
             if (proxy != null)
@@ -83,15 +84,15 @@ namespace Diagnostics
                 Environment.SetEnvironmentVariable("https_proxy", proxy);
             }
 
-                var httpClient = new HttpClient(httpClientHandler);
+            var httpClient = new HttpClient(httpClientHandler);
             var logsUrl = string.Format("https://{0}/devices/0000/modules", hostname);
             var httpRequest = new HttpRequestMessage(HttpMethod.Get, logsUrl);
             HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
 
             var keys = httpResponseMessage.Headers.GetValues("iothub-errorcode");
-            if (keys.Contains("InvalidProtocolVersion") == false)
+            if (!keys.Contains("InvalidProtocolVersion"))
             {
-                throw new Exception($"Got bad response");
+                throw new Exception($"Wrong value for iothub-errorcode header");
             }
         }
 

--- a/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
@@ -40,6 +40,7 @@ namespace Diagnostics
 
         static async Task MainAsync(string[] args)
         {
+            await Upstream("192.168.0.183", "443", "http://10.0.0.0");
             var config = new ConfigurationBuilder().AddCommandLine(args).Build();
             switch (args[0])
             {
@@ -85,52 +86,31 @@ namespace Diagnostics
 
         static async Task Upstream(string hostname, string port, string proxy)
         {
+            var httpClientHandler = new HttpClientHandler();
+            httpClientHandler.ServerCertificateCustomValidationCallback = (message, cert, chain, sslPolicyErrors) => {
+                    return true;   //Is valid
+            };
+
             if (proxy != null)
             {
-                Uri proxyUri = new Uri(proxy);
-                IProxyClient proxyClient = MakeProxy(proxyUri);
-
-                // Setup timeouts
-                proxyClient.ReceiveTimeout = (int)TimeSpan.FromSeconds(60).TotalMilliseconds;
-                proxyClient.SendTimeout = (int)TimeSpan.FromSeconds(60).TotalMilliseconds;
-
-                // Get TcpClient to futher work
-                var client = proxyClient.CreateConnection(hostname, int.Parse(port));
-                client.GetStream();
+                Environment.SetEnvironmentVariable("https_proxy", proxy);
             }
-            else
+
+                var httpClient = new HttpClient(httpClientHandler);
+            var logsUrl = string.Format("https://{0}/devices/0000/modules", hostname);
+            var httpRequest = new HttpRequestMessage(HttpMethod.Get, logsUrl);
+            HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead);
+
+            var keys = httpResponseMessage.Headers.GetValues("iothub-errorcode");
+            if (keys.Contains("InvalidProtocolVersion") == false)
             {
-                TcpClient client = new TcpClient();
-                await client.ConnectAsync(hostname, int.Parse(port));
-                client.GetStream();
+                throw new Exception($"Got bad response");
             }
         }
 
         static void ParentHostname(string parent_hostname)
         {
             _ = Dns.GetHostEntry(parent_hostname);
-        }
-
-        static IProxyClient MakeProxy(Uri proxyUri)
-        {
-            // Uses https://github.com/grinay/ProxyLib
-            ProxyClientFactory factory = new ProxyClientFactory();
-            if (proxyUri.UserInfo == string.Empty)
-            {
-                return factory.CreateProxyClient(ProxyType.Http, proxyUri.Host, proxyUri.Port);
-            }
-            else
-            {
-                if (proxyUri.UserInfo.Contains(':'))
-                {
-                    var userPass = proxyUri.UserInfo.Split(':');
-                    return factory.CreateProxyClient(ProxyType.Http, proxyUri.Host, proxyUri.Port, userPass[0], userPass[1]);
-                }
-                else
-                {
-                    throw new Exception($"Invalid user info: {proxyUri.UserInfo}");
-                }
-            }
         }
     }
 }

--- a/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
@@ -40,7 +40,6 @@ namespace Diagnostics
 
         static async Task MainAsync(string[] args)
         {
-            await Upstream("192.168.0.183", "443", "http://10.0.0.0");
             var config = new ConfigurationBuilder().AddCommandLine(args).Build();
             switch (args[0])
             {

--- a/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/Program.cs
@@ -2,24 +2,12 @@
 namespace Diagnostics
 {
     using System;
-    using System.IO;
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Net.Sockets;
-    using System.Text;
-    using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Client;
-    using Microsoft.Azure.Devices.Client.Transport.Mqtt;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Concurrency;
-    using Microsoft.Azure.Devices.Edge.Util.TransientFaultHandling;
-    using Microsoft.Azure.Devices.Shared;
     using Microsoft.Extensions.Configuration;
-    using Newtonsoft.Json;
-    using ProxyLib.Proxy;
-    using ProxyLib.Proxy.Exceptions;
 
     class Program
     {


### PR DESCRIPTION
fix for iotedge check.

Test performed:
With proxy nested
On golden path setup, lvl 3: Ran iotedge check with new diagnostic image:
× container on the default network can connect to upstream HTTPS / WebSockets port - Error
× container on the IoT Edge module network can connect to upstream HTTPS / WebSockets port - Error

Upgrade lvl 4 with new edgehub that returns new header:
√ host can connect to and perform TLS handshake with upstream HTTPS / WebSockets port - OK
√ container on the IoT Edge module network can connect to upstream HTTPS / WebSockets port - OK

Without proxy nested
On golden path setup, lvl 4: Ran iotedge check with new diagnostic image:
× container on the default network can connect to upstream HTTPS / WebSockets port - Error
× container on the IoT Edge module network can connect to upstream HTTPS / WebSockets port - Error

Upgrade lvl 5 with new edgehub that returns new header:
√ host can connect to and perform TLS handshake with upstream HTTPS / WebSockets port - OK
√ container on the IoT Edge module network can connect to upstream HTTPS / WebSockets port - OK

With proxy not nested (root)
 container on the default network can connect to upstream HTTPS / WebSockets port - OK
√ container on the IoT Edge module network can connect to upstream HTTPS / WebSockets port - OK