### PR TITLE
Cherry-pick check proxy fixes

### DIFF
--- a/edgelet/iotedge/src/check/checks/container_connect_iothub.rs
+++ b/edgelet/iotedge/src/check/checks/container_connect_iothub.rs
@@ -122,14 +122,16 @@ impl ContainerConnectIotHub {
             &port,
         ]);
 
-        let proxy = settings
-            .agent()
-            .env()
-            .get("https_proxy")
-            .map(std::string::String::as_str);
-        self.proxy = proxy.map(ToOwned::to_owned);
-        if let Some(proxy) = proxy {
-            args.extend(&["--proxy", proxy]);
+        if &port == "443" {
+            let proxy = settings
+                .agent()
+                .env()
+                .get("https_proxy")
+                .map(std::string::String::as_str);
+            self.proxy = proxy.map(ToOwned::to_owned);
+            if let Some(proxy) = proxy {
+                args.extend(&["--proxy", proxy]);
+            }
         }
 
         if let Err((_, err)) = super::docker(docker_host_arg, args) {

--- a/edgelet/iotedge/src/check/checks/host_connect_iothub.rs
+++ b/edgelet/iotedge/src/check/checks/host_connect_iothub.rs
@@ -64,10 +64,14 @@ impl HostConnectIotHub {
         };
         self.iothub_hostname = Some(iothub_hostname.clone());
 
-        self.proxy = check
-            .settings
-            .as_ref()
-            .and_then(|settings| settings.agent().env().get("https_proxy").cloned());
+        self.proxy = if self.port_number == 443 {
+            check
+                .settings
+                .as_ref()
+                .and_then(|settings| settings.agent().env().get("https_proxy").cloned())
+        } else {
+            None
+        };
 
         if let Some(proxy) = &self.proxy {
             runtime.block_on(


### PR DESCRIPTION
Only proxy the https check through a proxy. This is b/c customers are expected to use AMQP and MQTT over Websockets when using a proxy. 

Co-authored-by: Ubuntu <iotedgeuser@hug3l3edge.0x1kslxyg1putjewhwmoznt1le.yx.internal.cloudapp.net>