### PR TITLE
Patch test to always install production iotedge

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -82,9 +82,13 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     properties = properties.Append(p).ToArray();
                 });
 
-            string[] commands = packagesPath.Match(
-                p => this.packageManagement.GetInstallCommandsFromLocal(p),
-                () => this.packageManagement.GetInstallCommandsFromMicrosoftProd(proxy));
+            //TODO: Temporarily disable installing newly built packages till e2e automation
+            //      is modified to handle Identity Service pre-test configuration.
+            // string[] commands = packagesPath.Match(
+            //     p => this.packageManagement.GetInstallCommandsFromLocal(p),
+            //     () => this.packageManagement.GetInstallCommandsFromMicrosoftProd(proxy));
+
+            string[] commands = this.packageManagement.GetInstallCommandsFromMicrosoftProd(proxy);
 
             await Profiler.Run(
                 async () =>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -82,12 +82,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     properties = properties.Append(p).ToArray();
                 });
 
-            //TODO: Temporarily disable installing newly built packages till e2e automation
+            // TODO: Temporarily disable installing newly built packages till e2e automation
             //      is modified to handle Identity Service pre-test configuration.
             // string[] commands = packagesPath.Match(
             //     p => this.packageManagement.GetInstallCommandsFromLocal(p),
             //     () => this.packageManagement.GetInstallCommandsFromMicrosoftProd(proxy));
-
             string[] commands = this.packageManagement.GetInstallCommandsFromMicrosoftProd(proxy);
 
             await Profiler.Run(


### PR DESCRIPTION
The tests are temporarily being changed to allow E2E regression testing for edgeAgent and edgeHub containers. Once the `iotedge` package has been renamed and all tests are configured to configure both new packages (`aziot-edge` and `aziot-identity-service`)