### PR TITLE
Fix Linux Check

### DIFF
--- a/edge-modules/iotedge-diagnostics-dotnet/src/GetSocket.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/GetSocket.cs
@@ -13,20 +13,15 @@ namespace Diagnostics
     {
         public static string GetSocketResponse(string server, string endpoint)
         {
+            Uri uri = new Uri(server);
             string request = $"GET {endpoint} HTTP/1.1\r\nHost: {server}\r\nConnection: Close\r\n\r\n";
             byte[] bytesSent = Encoding.ASCII.GetBytes(request);
             byte[] bytesReceived = new byte[256];
-            server = server.Replace("unix://", string.Empty);
-
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                server = server.TrimStart('/');
-            }
 
             // Create a socket connection with the specified server and port.
             using (Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP))
             {
-                socket.Connect(new UnixDomainSocketEndPoint(server));
+                socket.Connect(new UnixDomainSocketEndPoint(uri.LocalPath));
 
                 // Send request to the server.
                 socket.Send(bytesSent, bytesSent.Length, 0);

--- a/edge-modules/iotedge-diagnostics-dotnet/src/GetSocket.cs
+++ b/edge-modules/iotedge-diagnostics-dotnet/src/GetSocket.cs
@@ -6,6 +6,7 @@ namespace Diagnostics
     using System.IO;
     using System.Net;
     using System.Net.Sockets;
+    using System.Runtime.InteropServices;
     using System.Text;
 
     public class GetSocket
@@ -15,7 +16,12 @@ namespace Diagnostics
             string request = $"GET {endpoint} HTTP/1.1\r\nHost: {server}\r\nConnection: Close\r\n\r\n";
             byte[] bytesSent = Encoding.ASCII.GetBytes(request);
             byte[] bytesReceived = new byte[256];
-            server = server.Replace("unix://", string.Empty).Trim('/');
+            server = server.Replace("unix://", string.Empty);
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                server = server.TrimStart('/');
+            }
 
             // Create a socket connection with the specified server and port.
             using (Socket socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.IP))


### PR DESCRIPTION
When checking the workload api from a container, Windows needs to remove a leading /. Linux doesn't, and removing the / caused it to incorrectly fail. 

To fix this, the Uri class is used to correctly localize the path.