### PR TITLE
Removing fix resolution for local hostnames

### DIFF
--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -49,7 +49,8 @@ http {
         location ~^/registry/(.*) {
             proxy_http_version 1.1;
             resolver 127.0.0.11;
-            proxy_pass          http://${DOCKER_REQUEST_ROUTE_ADDRESS}/$1$is_args$args;
+            set $upstream_endpoint http://${DOCKER_REQUEST_ROUTE_ADDRESS}/$1$is_args$args;
+            proxy_pass $upstream_endpoint;
         }
         #endif_tag ${DOCKER_REQUEST_ROUTE_ADDRESS}
 
@@ -57,7 +58,8 @@ http {
         location ~^/storage/(.*){
             resolver 127.0.0.11;
             proxy_http_version 1.1;
-            proxy_pass          http://${BLOB_UPLOAD_ROUTE_ADDRESS}/$1$is_args$args;
+            set $upstream_endpoint http://${BLOB_UPLOAD_ROUTE_ADDRESS}/$1$is_args$args;
+            proxy_pass $upstream_endpoint;
         }
         #endif_tag ${BLOB_UPLOAD_ROUTE_ADDRESS}        
 
@@ -77,10 +79,12 @@ http {
         #endif_tag ${IOTEDGE_PARENTHOSTNAME}
 
         location ~^/devices|twins/ {
+            resolver 127.0.0.11;
             proxy_http_version  1.1;
             proxy_ssl_verify    off;
-            proxy_set_header    x-ms-edge-clientcert    $ssl_client_escaped_cert;
-            proxy_pass          https://edgeHub;
+            proxy_set_header    x-ms-edge-clientcert    $ssl_client_escaped_cert;            
+            set $upstream_endpoint https://edgeHub;
+            proxy_pass $upstream_endpoint;
         }
     }
 }


### PR DESCRIPTION
nginx was resolving local hostname at startup. This would cause problem if the edgeHub or registry or blob storage was killed during run time.
If one of those container was killed and api proxy left running, then the container could come ack with a different IP and nginx would need to be restarted.
Fixing: https://msazure.visualstudio.com/One/_queries/edit/8682859/?triage=true