### PR TITLE
Improving M2M feedback handling (#3960)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/ModuleToModuleResponseTimeout.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/ModuleToModuleResponseTimeout.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
+{
+    using System;
+
+    // The role of this class is to help injecting a timeout value without activators
+    public class ModuleToModuleResponseTimeout
+    {
+        TimeSpan timeout;
+
+        public ModuleToModuleResponseTimeout(TimeSpan timeout)
+        {
+            this.timeout = timeout;
+        }
+
+        public static implicit operator TimeSpan(ModuleToModuleResponseTimeout t) => t.timeout;
+    }
+}

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/MqttBrokerModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/MqttBrokerModule.cs
@@ -74,6 +74,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     .As<MqttBrokerProtocolHead>()
                     .SingleInstance();
 
+            // The purpose of this setting is to setup a cleanup timer throwing away unanswered message tokens to
+            // prevent memory leak. Giving a big enough multiplier to avoid deleting tokens in use, but also
+            // not to spin the clean cycle too much, even if the timeout value is short
+            var ackTimeout = Math.Max(this.config.GetValue("MessageAckTimeoutSecs", 30), 30);
+            builder.RegisterInstance(new ModuleToModuleResponseTimeout(TimeSpan.FromSeconds(ackTimeout * 10)))
+                   .SingleInstance();
+
             base.Load(builder);
         }
 

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -184,7 +184,7 @@ fn get_actor_id(topic: &str) -> Option<ClientId> {
             // - to extract device_id and module_id.
             //
             // format! is for ease of reading only.
-            &format!(r"^(\$edgehub|\$iothub)/(?P<device_id>[^/\+\#]+)(/(?P<module_id>[^/\+\#]+))?/({}|{}|{}|{}|{}|{}|{}|{}|{}|{})",
+            &format!(r"^(\$edgehub|\$iothub)/(?P<device_id>[^/\+\#]+)(/(?P<module_id>[^/\+\#]+))?/({}|{}|{}|{}|{}|{}|{}|{}|{})",
                 "messages/events",
                 "messages/c2d/post",
                 "twin/desired",
@@ -193,8 +193,7 @@ fn get_actor_id(topic: &str) -> Option<ClientId> {
                 "twin/res",
                 "methods/post",
                 "methods/res",
-                "inputs",
-                "outputs")
+                "\\+/inputs")
         ).expect("failed to create new Regex from pattern");
     }
 
@@ -394,8 +393,7 @@ mod tests {
     #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/get"); "edge module twin request")]
     #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/methods/post"); "module DM request")]
     #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/methods/res"); "module DM response")]
-    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/inputs/route1"); "edge module access M2M inputs")]
-    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/outputs/route1"); "edge module access M2M outputs")]
+    #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/+/inputs/route1"); "edge module access M2M inputs")]
     #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/messages/events"); "iothub telemetry with moduleId")]
     #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/messages/c2d/post"); "iothub c2d messages with moduleId")]
     #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/desired"); "iothub update desired properties with moduleId")]
@@ -595,8 +593,6 @@ mod tests {
     #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/twin/res"); "edge module twin response")]
     #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/methods/post"); "module DM request")]
     #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/methods/res"); "module DM response")]
-    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/outputs/route1"); "edge module access M2M outputs")]
-    #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$edgehub/edge-1/module-a/inputs/route1"); "edge module access M2M inputs")]
     #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/messages/events"); "iothub telemetry with moduleId")]
     #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/messages/c2d/post"); "iothub c2d messages with moduleId")]
     #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "$iothub/edge-1/module-a/twin/desired"); "iothub update desired properties with moduleId")]

--- a/mqtt/mqtt-edgehub/src/connection/delivery.rs
+++ b/mqtt/mqtt-edgehub/src/connection/delivery.rs
@@ -69,11 +69,11 @@ impl<P> PublicationDelivery<P> {
 }
 
 fn match_m2m_publish(packet: &Packet) -> Option<(proto::PacketIdentifier, String)> {
-    const ANYTHING_BUT_NOT_SLASH: &str = r"[^/]+";
+    const ANYTHING_BUT_SLASH: &str = r"[^/]+";
     lazy_static! {
         static ref M2M_PUBLISH_PATTERN: Regex = Regex::new(&format!(
-            "\\$edgehub/{}/{}/inputs/.+",
-            ANYTHING_BUT_NOT_SLASH, ANYTHING_BUT_NOT_SLASH
+            "\\$edgehub/{}/{}/{}/inputs/.+",
+            ANYTHING_BUT_SLASH, ANYTHING_BUT_SLASH, ANYTHING_BUT_SLASH
         ))
         .expect("failed to create new Regex from pattern");
     }

--- a/mqtt/mqtt-edgehub/src/topic/translation.rs
+++ b/mqtt/mqtt-edgehub/src/topic/translation.rs
@@ -262,11 +262,11 @@ translate_c2d! {
     // Module-to-Module inputs
     module_to_module_inputs {
         to_internal {
-            format!("devices/{}/modules/{}/(?P<path>.+)", DEVICE_ID, MODULE_ID),
-            {|captures: regex::Captures<'_>, _| format!("$edgehub/{}/{}/inputs/{}", &captures["device_id"], &captures["module_id"], &captures["path"])}
+            format!("devices/{}/modules/{}/#", DEVICE_ID, MODULE_ID),
+            {|captures: regex::Captures<'_>, _| format!("$edgehub/{}/{}/+/inputs/#", &captures["device_id"], &captures["module_id"])}
         },
         to_external {
-            format!("\\$edgehub/{}/{}/inputs/(?P<path>.+)", DEVICE_ID, MODULE_ID),
+            format!("\\$edgehub/{}/{}/[^/]+/inputs/(?P<path>.+)", DEVICE_ID, MODULE_ID),
             {|captures: regex::Captures<'_>| format!("devices/{}/modules/{}/inputs/{}", &captures["device_id"], &captures["module_id"], &captures["path"])}
         }
     }
@@ -508,20 +508,13 @@ mod tests {
         // M2M subscription
         assert_eq!(
             c2d.to_internal("devices/device_1/modules/module_a/#", &client_id),
-            Some("$edgehub/device_1/module_a/inputs/#".to_owned())
-        );
-        assert_eq!(
-            c2d.to_internal(
-                "devices/device_1/modules/module_a/telemetry/?rid=1",
-                &client_id
-            ),
-            Some("$edgehub/device_1/module_a/inputs/telemetry/?rid=1".to_owned())
+            Some("$edgehub/device_1/module_a/+/inputs/#".to_owned())
         );
 
         // M2M incoming
         assert_eq!(
             c2d.to_external(
-                "$edgehub/device_1/module_a/inputs/route_1/%24.cdid=device_1&%24.cmid=module_a"
+                "$edgehub/device_1/module_a/b9aa0940-dcf2-457f-83a4-45f4c7ceecf9/inputs/route_1/%24.cdid=device_1&%24.cmid=module_a"
             ),
             Some(
                 "devices/device_1/modules/module_a/inputs/route_1/%24.cdid=device_1&%24.cmid=module_a"

--- a/mqtt/mqtt-edgehub/tests/authorization.rs
+++ b/mqtt/mqtt-edgehub/tests/authorization.rs
@@ -251,7 +251,7 @@ async fn disconnect_client_on_auth_update_reevaluates_subscriptions() {
         packet_identifier: PacketIdentifier::new(1).unwrap(),
         subscribe_to: vec![SubscribeTo {
             // We need to use a post-translation topic here
-            topic_filter: "$edgehub/device-1/inputs/telemetry/#".into(),
+            topic_filter: "$edgehub/device-1/+/inputs/#".into(),
             qos: QoS::AtLeastOnce,
         }],
     };

--- a/mqtt/mqtt-edgehub/tests/delivery.rs
+++ b/mqtt/mqtt-edgehub/tests/delivery.rs
@@ -38,7 +38,7 @@ async fn it_sends_delivery_confirmation_for_m2m_messages() {
         .build();
 
     // subscribe to module inputs
-    let inputs = "devices/device-1/modules/module-1/telemetry/#";
+    let inputs = "devices/device-1/modules/module-1/#";
     module.subscribe(inputs, QoS::AtLeastOnce).await;
 
     let mut edgehub = TestClientBuilder::new(server_handle.address())
@@ -50,13 +50,14 @@ async fn it_sends_delivery_confirmation_for_m2m_messages() {
     edgehub.subscribe(confirmation, QoS::AtLeastOnce).await;
 
     // publish a message to module-1
-    let inputs = "$edgehub/device-1/module-1/inputs/telemetry/?rid=1";
+    let inputs = "$edgehub/device-1/module-1/c1906616-e64f-4cf0-96eb-33a40a2535c3/inputs/telemetry/%24.uid=something";
     edgehub.publish_qos1(inputs, "message", false).await;
 
     assert_eq!(
         module.publications().next().await,
         Some(ReceivedPublication {
-            topic_name: "devices/device-1/modules/module-1/inputs/telemetry/?rid=1".into(),
+            topic_name: "devices/device-1/modules/module-1/inputs/telemetry/%24.uid=something"
+                .into(),
             dup: false,
             qos: QoS::AtLeastOnce,
             retain: false,
@@ -71,7 +72,7 @@ async fn it_sends_delivery_confirmation_for_m2m_messages() {
             dup: false,
             qos: QoS::AtLeastOnce,
             retain: false,
-            payload: "\"$edgehub/device-1/module-1/inputs/telemetry/?rid=1\"".into()
+            payload: "\"$edgehub/device-1/module-1/c1906616-e64f-4cf0-96eb-33a40a2535c3/inputs/telemetry/%24.uid=something\"".into()
         })
     );
 


### PR DESCRIPTION
- m2m pending confirmations are stored by lockToken not by identity - allowing multiple pending messages by identity
- fixed race condition when confirmation message gets back sooner than lockToken gets stored

m2m pending messages were stored by identity - it worked most of the time because only one message is getting sent to a client. However when that message timeouts a new message will be sent, overwriting the previous pending message. This caused problems when the old message with the timeout got confirmed, because edgeHub believed that it was the recent message. With this change every messageId (lockToken) is saved, so feedbacks cannot be mismatched.

Also there was a race condition when the lock token of the sent out message was stored after the 'send' call. It could happened that the confirmation message get back earlier than the lock token got stored, and because of that the confirmation code could not find the related lock token. As a result the confirmed message was never been confirmed, causing resent messages.

(cherry picked from commit b1eceebc09ef0c696baee60926b31de3abc55f2f)