### PR TITLE
Enable topic translation tests (#3961)

### DIFF
--- a/mqtt/mqtt-edgehub/Cargo.toml
+++ b/mqtt/mqtt-edgehub/Cargo.toml
@@ -16,6 +16,7 @@ futures-util = "0.3"
 lazy_static = "1.4"
 openssl = "0.10"
 parking_lot = "0.11"
+proptest = { version = "0.9", optional = true }
 regex = "1"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
@@ -35,12 +36,12 @@ assert_matches = "1.3"
 lazy_static = "1.4"
 matches = "0.1"
 mockito = "0.25"
-proptest = "0.9"
 serial_test = "0.4"
 test-case = "1.0"
 tokio = { version = "0.2", features = ["macros"] }
 
 mqtt-broker-tests-util = { path = "../mqtt-broker-tests-util" }
+mqtt-broker = { path = "../mqtt-broker", features = ["proptest"] }
 
 [[test]]
 name = "translation"

--- a/mqtt/mqtt-edgehub/tests/translation.rs
+++ b/mqtt/mqtt-edgehub/tests/translation.rs
@@ -1,32 +1,26 @@
-use std::{
-    error::Error as StdError,
-    sync::atomic::{AtomicU32, Ordering},
-};
-
-use lazy_static::lazy_static;
 use matches::assert_matches;
+use mqtt_edgehub::connection::MakeEdgeHubPacketProcessor;
 use proptest::prelude::*;
-use tokio::{runtime::Runtime, sync::oneshot};
+use tokio::runtime::Runtime;
 
-use futures_util::FutureExt;
 use mqtt3::{
     proto::{ClientId, QoS},
     ReceivedPublication,
 };
 use mqtt_broker::{
-    auth::{AllowAll, Authenticator, Authorizer},
-    proptest::arb_clientid,
-    Broker, BrokerBuilder, Server,
+    auth::AllowAll, auth::Authorizer, Broker, BrokerBuilder, MakeMqttPacketProcessor, Server,
 };
-use mqtt_broker_tests_util::{DummyAuthenticator, ServerHandle, TestClient, TestClientBuilder};
-use mqtt_edgehub::connection::MakeEdgeHubPacketProcessor;
+use mqtt_broker_tests_util::{
+    client::{TestClient, TestClientBuilder},
+    server::{self, DummyAuthenticator, ServerHandle},
+};
 
 // https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-mqtt-support#retrieving-a-device-twins-properties
 #[tokio::test]
 async fn translation_twin_retrieve() {
     let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-    let server_handle = start_server(broker, DummyAuthenticator::anonymous());
+    let server_handle = start_server(broker);
 
     let mut edge_hub_core = TestClientBuilder::new(server_handle.address())
         .with_client_id(ClientId::IdWithCleanSession("edge_hub_core".into()))
@@ -71,7 +65,7 @@ async fn translation_twin_retrieve() {
 async fn translation_twin_update() {
     let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-    let server_handle = start_server(broker, DummyAuthenticator::anonymous());
+    let server_handle = start_server(broker);
 
     let mut edge_hub_core = TestClientBuilder::new(server_handle.address())
         .with_client_id(ClientId::IdWithCleanSession("edge_hub_core".into()))
@@ -120,7 +114,7 @@ async fn translation_twin_update() {
 async fn translation_twin_receive() {
     let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-    let server_handle = start_server(broker, DummyAuthenticator::anonymous());
+    let server_handle = start_server(broker);
 
     let mut edge_hub_core = TestClientBuilder::new(server_handle.address())
         .with_client_id(ClientId::IdWithCleanSession("edge_hub_core".into()))
@@ -160,7 +154,7 @@ async fn translation_twin_receive() {
 async fn translation_direct_method_response() {
     let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-    let server_handle = start_server(broker, DummyAuthenticator::anonymous());
+    let server_handle = start_server(broker);
 
     let mut edge_hub_core = TestClientBuilder::new(server_handle.address())
         .with_client_id(ClientId::IdWithCleanSession("edge_hub_core".into()))
@@ -225,7 +219,7 @@ async fn translation_twin_notify_with_wildcards() {
 
 proptest! {
     #[test]
-    fn translate_clientid_proptest(client_id in arb_clientid()) {
+    fn translate_clientid_proptest(client_id in mqtt_broker::proptest::arb_clientid()) {
         let mut rt = Runtime::new().unwrap();
         rt.block_on(test_twin_with_client_id(client_id.as_str()));
     }
@@ -234,7 +228,7 @@ proptest! {
 async fn test_twin_with_client_id(client_id: &str) {
     let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-    let server_handle = start_server(broker, DummyAuthenticator::anonymous());
+    let server_handle = start_server(broker);
 
     let mut edge_hub_core = TestClientBuilder::new(server_handle.address())
         .with_client_id(ClientId::IdWithCleanSession("edge_hub_core".into()))
@@ -331,28 +325,21 @@ async fn ensure_subscribed(client: &mut TestClient) {
     client.subscriptions().recv().await;
 }
 
-fn start_server<N, Z>(broker: Broker<Z>, authenticator: N) -> ServerHandle
+fn start_server<Z>(broker: Broker<Z>) -> ServerHandle
 where
-    N: Authenticator<Error = Box<dyn StdError>> + Send + Sync + 'static,
     Z: Authorizer + Send + Sync + 'static,
 {
-    lazy_static! {
-        static ref PORT: AtomicU32 = AtomicU32::new(5555);
-    }
+    let make_server = |addr| {
+        let broker_handle = broker.handle();
 
-    let port = PORT.fetch_add(1, Ordering::SeqCst);
-    let address = format!("localhost:{}", port);
+        let mut server = Server::from_broker(broker).with_packet_processor(
+            MakeEdgeHubPacketProcessor::new(broker_handle, MakeMqttPacketProcessor),
+        );
 
-    let mut server = Server::from_broker(broker)
-        .with_packet_processor(MakeEdgeHubPacketProcessor::default())
-        .with_tcp(&address, authenticator, None);
+        let authenticator = DummyAuthenticator::anonymous();
+        server.with_tcp(&addr, authenticator, None).unwrap();
 
-    let (shutdown, rx) = oneshot::channel::<()>();
-    let task = tokio::spawn(server.serve(rx.map(drop)));
-
-    ServerHandle {
-        address,
-        shutdown: Some(shutdown),
-        task: Some(task),
-    }
+        server
+    };
+    server::run(make_server)
 }


### PR DESCRIPTION
There was a bug in feature declaration and translation integration tests did not compile and run for a while. 

The fix is:
- Add optional `proptest` dependency to `mqtt-edgehub` package. That will enable `proptest` feature.
- Import  `mqtt-broker` with `features = ["proptest"]` as a dev-dependency in `mqtt-edgehub`.

The rest of the changes is just to make tests compile after all the recent changes.