### PR TITLE
Fixed e2e tests after recent changes

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                 {
                                     new
                                     {
-                                        identities = new[] { deviceId1 },
+                                        identities = new[] { $"{this.iotHub.Hostname}/{deviceId1}" },
                                         allow = new[]
                                         {
                                             new
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                     },
                                     new
                                     {
-                                        identities = new[] { deviceId2 },
+                                        identities = new[] { $"{this.iotHub.Hostname}/{deviceId2}" },
                                         deny = new[]
                                         {
                                             new


### PR DESCRIPTION
A recent change in how we handle identities in the policy engine (#3945) broke the e2e tests. Needed to update the test.