### PR TITLE
MQTT: Use FQN for the authenticated identity (#3945)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/authentication/AuthAgentController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/authentication/AuthAgentController.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
         static object GetAuthResult(bool isAuthenticated, Option<IClientCredentials> credentials)
         {
             // note, that if authenticated, then these values are present, and defaults never apply
-            var id = credentials.Map(c => c.Identity.Id).GetOrElse("anonymous");
+            var id = credentials.Map(c => $"{c.Identity.IotHubHostname}/{c.Identity.Id}").GetOrElse("anonymous");
 
             if (isAuthenticated)
             {

--- a/mqtt/mqtt-broker/src/auth/mod.rs
+++ b/mqtt/mqtt-broker/src/auth/mod.rs
@@ -17,8 +17,6 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
-use crate::ClientId;
-
 /// Authenticated MQTT client identity.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum AuthId {
@@ -79,8 +77,8 @@ impl Display for Identity {
     }
 }
 
-impl PartialEq<ClientId> for Identity {
-    fn eq(&self, other: &ClientId) -> bool {
-        self.as_str() == other.as_str()
+impl<T: AsRef<str>> PartialEq<T> for Identity {
+    fn eq(&self, other: &T) -> bool {
+        self.as_str() == other.as_ref()
     }
 }

--- a/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
+++ b/mqtt/mqtt-edgehub/src/auth/authorization/edgehub.rs
@@ -21,6 +21,7 @@ pub struct EdgeHubAuthorizer<Z> {
     inner: Z,
     broker_ready: Option<BrokerReadyHandle>,
     device_id: String,
+    iothub_id: String,
 }
 
 impl<Z, E> EdgeHubAuthorizer<Z>
@@ -28,20 +29,35 @@ where
     Z: Authorizer<Error = E>,
     E: StdError,
 {
-    pub fn new(authorizer: Z, device_id: String, broker_ready: BrokerReadyHandle) -> Self {
-        Self::create(authorizer, device_id, Some(broker_ready))
+    pub fn new(
+        authorizer: Z,
+        device_id: impl Into<String>,
+        iothub_id: impl Into<String>,
+        broker_ready: BrokerReadyHandle,
+    ) -> Self {
+        Self::create(authorizer, device_id, iothub_id, Some(broker_ready))
     }
 
-    pub fn without_ready_handle(authorizer: Z, device_id: String) -> Self {
-        Self::create(authorizer, device_id, None)
+    pub fn without_ready_handle(
+        authorizer: Z,
+        device_id: impl Into<String>,
+        iothub_id: impl Into<String>,
+    ) -> Self {
+        Self::create(authorizer, device_id, iothub_id, None)
     }
 
-    fn create(authorizer: Z, device_id: String, broker_ready: Option<BrokerReadyHandle>) -> Self {
+    fn create(
+        authorizer: Z,
+        device_id: impl Into<String>,
+        iothub_id: impl Into<String>,
+        broker_ready: Option<BrokerReadyHandle>,
+    ) -> Self {
         Self {
             identities_cache: HashMap::default(),
             inner: authorizer,
             broker_ready,
-            device_id,
+            device_id: device_id.into(),
+            iothub_id: iothub_id.into(),
         }
     }
 
@@ -54,7 +70,8 @@ where
             )),
             // allow only those clients whose auth_id and client_id identical
             AuthId::Identity(identity) => {
-                if identity == activity.client_id() {
+                let actor_id = format!("{}/{}", self.iothub_id, activity.client_id());
+                if *identity == actor_id {
                     // delegate to inner authorizer.
                     self.inner.authorize(activity)
                 } else {
@@ -85,7 +102,7 @@ where
                 "Anonymous clients do not have access to IoTHub topics".to_string(),
             ),
             // allow authenticated clients with client_id == auth_id and accessing its own IoTHub topic
-            AuthId::Identity(identity) if identity == activity.client_id() => {
+            AuthId::Identity(_) => {
                 if self.is_iothub_operation_authorized(topic, activity.client_id()) {
                     Authorization::Allowed
                 } else {
@@ -99,11 +116,6 @@ where
                     }
                 }
             }
-            // forbid access otherwise
-            AuthId::Identity(_) => Authorization::Forbidden(format!(
-                "client_id {} must match registered iothub identity id to access IoTHub topic",
-                activity.client_id()
-            )),
         })
     }
 
@@ -445,15 +457,16 @@ mod tests {
         assert_matches!(auth, Ok(Authorization::Allowed));
     }
 
-    #[test_case(&tests::connect_activity("edge-1/$edgeHub", "edge-1/$edgeHub"); "module identical auth_id and client_id")]
-    #[test_case(&tests::connect_activity("edge-1", "edge-1"); "leaf identical auth_id and client_id")]
+    #[test_case(&tests::connect_activity("edge-1/$edgeHub", "myhub.azure-devices.net/edge-1/$edgeHub"); "module identical auth_id and client_id")]
+    #[test_case(&tests::connect_activity("edge-1", "myhub.azure-devices.net/edge-1"); "leaf identical auth_id and client_id")]
     #[test_case(&tests::publish_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "topic"); "module generic MQTT topic publish")]
     #[test_case(&tests::publish_activity("edge-1", "edge-1", "topic"); "leaf generic MQTT topic publish")]
     #[test_case(&tests::subscribe_activity("edge-1/$edgeHub", "edge-1/$edgeHub", "topic"); "module generic MQTT topic subscribe")]
     #[test_case(&tests::subscribe_activity("edge-1", "edge-1", "topic"); "leaf generic MQTT topic subscribe")]
     fn it_delegates_to_inner(activity: &Activity) {
         let inner = authorize_fn_ok(|_| Authorization::Forbidden("not allowed inner".to_string()));
-        let authorizer = EdgeHubAuthorizer::without_ready_handle(inner, "edgehub_id".into());
+        let authorizer =
+            EdgeHubAuthorizer::without_ready_handle(inner, "edgehub_id", "myhub.azure-devices.net");
 
         let auth = authorizer.authorize(&activity);
 
@@ -636,7 +649,8 @@ mod tests {
     where
         Z: Authorizer,
     {
-        let mut authorizer = EdgeHubAuthorizer::without_ready_handle(inner, "this_edge".into());
+        let mut authorizer =
+            EdgeHubAuthorizer::without_ready_handle(inner, "this_edge", "myhub.azure-devices.net");
 
         let _ = authorizer.update(Box::new(AuthorizerUpdate(identities)));
         authorizer

--- a/mqtt/mqtt-edgehub/tests/authorization.rs
+++ b/mqtt/mqtt-edgehub/tests/authorization.rs
@@ -40,12 +40,16 @@ async fn publish_not_allowed_identity_not_in_cache() {
                 }
             }),
             "this_edgehub_id".to_string(),
+            "myhub.azure-devices.net".to_string(),
             BrokerReady::new().handle(),
         )))
         .build();
     let broker_handle = broker.handle();
 
-    let server_handle = start_server(broker, DummyAuthenticator::with_id("device-1"));
+    let server_handle = start_server(
+        broker,
+        DummyAuthenticator::with_id("myhub.azure-devices.net/device-1"),
+    );
 
     // start command handler with AuthorizedIdentitiesCommand
     let command = AuthorizedIdentitiesCommand::new(&broker_handle);
@@ -111,12 +115,16 @@ async fn auth_update_happy_case() {
                 }
             }),
             "this_edgehub_id".to_string(),
+            "myhub.azure-devices.net".to_string(),
             BrokerReady::new().handle(),
         )))
         .build();
     let broker_handle = broker.handle();
 
-    let server_handle = start_server(broker, DummyAuthenticator::with_id("device-1"));
+    let server_handle = start_server(
+        broker,
+        DummyAuthenticator::with_id("myhub.azure-devices.net/device-1"),
+    );
 
     // start command handler with AuthorizedIdentitiesCommand
     let command = AuthorizedIdentitiesCommand::new(&broker_handle);
@@ -204,12 +212,16 @@ async fn disconnect_client_on_auth_update_reevaluates_subscriptions() {
                     }
                 }),
                 "this_edgehub_id".to_string(),
+                "myhub.azure-devices.net".to_string(),
             ),
         ))
         .build();
     let broker_handle = broker.handle();
 
-    let server_handle = start_server(broker, DummyAuthenticator::with_id("device-1"));
+    let server_handle = start_server(
+        broker,
+        DummyAuthenticator::with_id("myhub.azure-devices.net/device-1"),
+    );
 
     // start command handler with AuthorizedIdentitiesCommand
     let command = AuthorizedIdentitiesCommand::new(&broker_handle);

--- a/mqtt/mqttd/src/app/edgehub.rs
+++ b/mqtt/mqttd/src/app/edgehub.rs
@@ -37,6 +37,7 @@ use mqtt_edgehub::{
 use super::{shutdown, Bootstrap};
 
 const DEVICE_ID_ENV: &str = "IOTEDGE_DEVICEID";
+const IOTHUB_HOSTNAME_ENV: &str = "IOTEDGE_IOTHUBHOSTNAME";
 
 #[derive(Default)]
 pub struct EdgeHubBootstrap {
@@ -68,10 +69,12 @@ impl Bootstrap for EdgeHubBootstrap {
         info!("state loaded.");
 
         let device_id = env::var(DEVICE_ID_ENV).context(DEVICE_ID_ENV)?;
+        let iothub_id = env::var(IOTHUB_HOSTNAME_ENV).context(IOTHUB_HOSTNAME_ENV)?;
 
         let authorizer = LocalAuthorizer::new(EdgeHubAuthorizer::new(
             PolicyAuthorizer::new(device_id.clone(), self.broker_ready.handle()),
             device_id,
+            iothub_id,
             self.broker_ready.handle(),
         ));
 


### PR DESCRIPTION
When broker sends an authentication request to EH Core, it gets back the identity name without hub name prefix. As a result, customers have to use just device name in the policy engine, instead of FQN for device:

**Current:**
```
                        {
                            "identities": [
                                **"vakavali_leaf"**
                            ],
                            "allow": [
                                {
                                    "operations": [
                                        "mqtt:publish",
                                        "mqtt:subscribe"
                                    ],
                                    "resources": [
                                        "#"
                                    ]
                                }
                            ]
                        }
```

**Expected:**
```
                        {
                            "identities": [
                                **"mytesthub.azure-devices.net/vakavali_leaf"**
                            ],
                            "allow": [
                                {
                                    "operations": [
                                        "mqtt:publish",
                                        "mqtt:subscribe"
                                    ],
                                    "resources": [
                                        "#"
                                    ]
                                }
                            ]
                        }
```

**Notes:**
This is a quick fix solution. We may revisit it when we have story for local identities ready.