### PR TITLE
Added Publish Test Results task to MQTT Pipelines + other pipeline improvements

### DIFF
--- a/builds/checkin/mqtt.yaml
+++ b/builds/checkin/mqtt.yaml
@@ -44,7 +44,7 @@ jobs:
         displayName: Build with no default features
       - bash: scripts/linux/generic-rust/build.sh --project-root "mqtt" --packages "mqttd/Cargo.toml" --manifest-path
         displayName: Build with default features
-      - bash: mqtt/build/linux/test.sh
+      - bash: mqtt/build/linux/test.sh --report test-results.xml
         displayName: Test
       - task: PublishTestResults@2
         displayName: Publish test results

--- a/builds/checkin/mqtt.yaml
+++ b/builds/checkin/mqtt.yaml
@@ -50,7 +50,7 @@ jobs:
         displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"
-          testResultsFiles: "test-results.xml"
+          testResultsFiles: "**/test-results.xml"
         condition: succeededOrFailed()
 
   ################################################################################

--- a/builds/checkin/mqtt.yaml
+++ b/builds/checkin/mqtt.yaml
@@ -7,14 +7,14 @@ pr:
 jobs:
   ################################################################################
   - job: check_run_pipeline
-    ################################################################################
+  ################################################################################
     displayName: Check pipeline preconditions (changes ARE in builds or mqtt)
     pool:
       vmImage: "ubuntu-16.04"
     steps:
       - checkout: self
         submodules: false
-        fetchDepth: 1
+        fetchDepth: 3
       - bash: |
           git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|mqtt)'
           if [[ $? == 0 ]]; then
@@ -26,13 +26,16 @@ jobs:
 
   ################################################################################
   - job: linux_amd64
-    ################################################################################
+  ################################################################################
     displayName: Linux amd64
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
       vmImage: "ubuntu-16.04"
     steps:
+      - checkout: self
+        submodules: false # mqtt broker does not use submodules
+        fetchDepth: 3
       - script: echo "##vso[task.setvariable variable=RUST_BACKTRACE;]1"
         displayName: Set env variables
       - bash: scripts/linux/generic-rust/install.sh --project-root "mqtt"
@@ -44,6 +47,7 @@ jobs:
       - bash: mqtt/build/linux/test.sh
         displayName: Test
       - task: PublishTestResults@2
+        displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"
           testResultsFiles: "test-results.xml"
@@ -51,13 +55,16 @@ jobs:
 
   ################################################################################
   - job: style_check
-    ################################################################################
+  ################################################################################
     displayName: Style Check
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
       vmImage: "ubuntu-16.04"
     steps:
+      - checkout: self
+        submodules: false # mqtt broker does not use submodules
+        fetchDepth: 3
       - bash: scripts/linux/generic-rust/install.sh --project-root "mqtt"
         displayName: Install Rust
       - bash: scripts/linux/generic-rust/format.sh --project-root "mqtt"

--- a/builds/checkin/mqtt.yaml
+++ b/builds/checkin/mqtt.yaml
@@ -51,6 +51,7 @@ jobs:
         inputs:
           testResultsFormat: "JUnit"
           testResultsFiles: "**/test-results.xml"
+          failTaskOnFailedTests: true
         condition: succeededOrFailed()
 
   ################################################################################

--- a/builds/checkin/mqtt.yaml
+++ b/builds/checkin/mqtt.yaml
@@ -5,7 +5,6 @@ pr:
       - master
       - release/*
 jobs:
-
   ################################################################################
   - job: check_run_pipeline
     ################################################################################
@@ -13,6 +12,9 @@ jobs:
     pool:
       vmImage: "ubuntu-16.04"
     steps:
+      - checkout: self
+        submodules: false
+        fetchDepth: 1
       - bash: |
           git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|mqtt)'
           if [[ $? == 0 ]]; then
@@ -41,6 +43,11 @@ jobs:
         displayName: Build with default features
       - bash: mqtt/build/linux/test.sh
         displayName: Test
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: "JUnit"
+          testResultsFiles: "test-results.xml"
+        condition: succeededOrFailed()
 
   ################################################################################
   - job: style_check

--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -55,7 +55,7 @@ jobs:
       - task: Bash@3
         displayName: Test
         inputs:
-          filePath: mqtt/build/linux/test.sh
+          filePath: mqtt/build/linux/test.sh --report test-results.xml
       - task: PublishTestResults@2
         displayName: Publish test results
         inputs:
@@ -102,7 +102,7 @@ jobs:
         displayName: Test
         inputs:
           filePath: mqtt/build/linux/test.sh
-          arguments: --target armv7-unknown-linux-gnueabihf --cargo cross
+          arguments: --target armv7-unknown-linux-gnueabihf --cargo cross --report test-results.xml
       - task: PublishTestResults@2
         displayName: Publish test results
         inputs:

--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -55,7 +55,8 @@ jobs:
       - task: Bash@3
         displayName: Test
         inputs:
-          filePath: mqtt/build/linux/test.sh --report test-results.xml
+          filePath: mqtt/build/linux/test.sh
+          arguments: --report test-results.xml
       - task: PublishTestResults@2
         displayName: Publish test results
         inputs:

--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - checkout: self
         submodules: false
-        fetchDepth: 1
+        fetchDepth: 3
       - bash: |
           git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|mqtt)'
           if [[ $? == 0 ]]; then
@@ -34,6 +34,9 @@ jobs:
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
+      - checkout: self
+        submodules: false # mqtt broker does not use submodules
+        fetchDepth: 3
       - task: Bash@3
         displayName: Install Rust
         inputs:
@@ -58,7 +61,7 @@ jobs:
           testResultsFormat: "JUnit"
           testResultsFiles: "test-results.xml"
         condition: succeededOrFailed()
-        
+
 ################################################################################
   - job: linux_arm32v7
 ################################################################################
@@ -68,6 +71,9 @@ jobs:
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
+      - checkout: self
+        submodules: false # mqtt broker does not use submodules
+        fetchDepth: 3
       - script: |
           echo "##vso[task.setvariable variable=RUSTUP_HOME;]$(Agent.WorkFolder)/rustup"
           echo "##vso[task.setvariable variable=CARGO_HOME;]$(Agent.WorkFolder)/cargo"
@@ -96,6 +102,7 @@ jobs:
           filePath: mqtt/build/linux/test.sh
           arguments: --target armv7-unknown-linux-gnueabihf --cargo cross
       - task: PublishTestResults@2
+        displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"
           testResultsFiles: "test-results.xml"

--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -59,7 +59,7 @@ jobs:
       - task: PublishTestResults@2
         inputs:
           testResultsFormat: "JUnit"
-          testResultsFiles: "test-results.xml"
+          testResultsFiles: "**/test-results.xml"
         condition: succeededOrFailed()
 
 ################################################################################
@@ -105,5 +105,5 @@ jobs:
         displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"
-          testResultsFiles: "test-results.xml"
+          testResultsFiles: "**/test-results.xml"
         condition: succeededOrFailed()

--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -13,6 +13,9 @@ jobs:
     pool:
       vmImage: "ubuntu-16.04"
     steps:
+      - checkout: self
+        submodules: false
+        fetchDepth: 1
       - bash: |
           git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|mqtt)'
           if [[ $? == 0 ]]; then
@@ -50,7 +53,12 @@ jobs:
         displayName: Test
         inputs:
           filePath: mqtt/build/linux/test.sh
-
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: "JUnit"
+          testResultsFiles: "test-results.xml"
+        condition: succeededOrFailed()
+        
 ################################################################################
   - job: linux_arm32v7
 ################################################################################
@@ -73,12 +81,12 @@ jobs:
       - script: cargo install cross --version 0.1.16
         displayName: Install cross
       - task: Bash@3
-        displayName: Build
+        displayName: Build with no default features
         inputs:
           filePath: scripts/linux/generic-rust/build.sh
           arguments: --project-root "mqtt" --packages "mqttd/Cargo.toml" --manifest-path --no-default-features --features "generic" --target armv7-unknown-linux-gnueabihf --cargo cross
       - task: Bash@3
-        displayName: Build
+        displayName: Build with default features
         inputs:
           filePath: scripts/linux/generic-rust/build.sh
           arguments: --project-root "mqtt" --packages "mqttd/Cargo.toml" --manifest-path --target armv7-unknown-linux-gnueabihf --cargo cross
@@ -87,27 +95,8 @@ jobs:
         inputs:
           filePath: mqtt/build/linux/test.sh
           arguments: --target armv7-unknown-linux-gnueabihf --cargo cross
-
-################################################################################
-  - job: style_check
-################################################################################
-    displayName: Style Check
-    dependsOn: check_run_pipeline
-    condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
-    pool:
-      vmImage: 'ubuntu-16.04'
-    steps:
-      - task: Bash@3
-        displayName: Install Rust
+      - task: PublishTestResults@2
         inputs:
-          filePath: scripts/linux/generic-rust/install.sh
-          arguments: --project-root "mqtt"
-      - task: Bash@3
-        displayName: Format Code
-        inputs:
-          filePath: scripts/linux/generic-rust/format.sh
-          arguments: --project-root "mqtt"
-      - task: Bash@3
-        displayName: Clippy
-        inputs:
-          filePath: mqtt/build/linux/clippy.sh
+          testResultsFormat: "JUnit"
+          testResultsFiles: "test-results.xml"
+        condition: succeededOrFailed()

--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -57,9 +57,11 @@ jobs:
         inputs:
           filePath: mqtt/build/linux/test.sh
       - task: PublishTestResults@2
+        displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"
           testResultsFiles: "**/test-results.xml"
+          failTaskOnFailedTests: true
         condition: succeededOrFailed()
 
 ################################################################################
@@ -106,4 +108,5 @@ jobs:
         inputs:
           testResultsFormat: "JUnit"
           testResultsFiles: "**/test-results.xml"
+          failTaskOnFailedTests: true
         condition: succeededOrFailed()

--- a/mqtt/build/linux/test.sh
+++ b/mqtt/build/linux/test.sh
@@ -28,6 +28,7 @@ usage()
     echo ""
     echo "options"
     echo " -h, --help          Print this help and exit."
+    echo " -t, --target        Target architecture."
     echo " -r, --release       Release build? (flag, default: false)"
     echo " --report            Optional. Generates the xml test report with specified name."
     exit 1;
@@ -57,6 +58,7 @@ process_args()
                 "-r" | "--release" ) RELEASE="--release";;
                 "-c" | "--cargo" ) save_next_arg=2;;
                 "--report" ) save_next_arg=3;;
+                * ) usage;;
             esac
         fi
     done

--- a/mqtt/build/linux/test.sh
+++ b/mqtt/build/linux/test.sh
@@ -30,6 +30,7 @@ usage()
     echo " -h, --help          Print this help and exit."
     echo " -t, --target        Target architecture."
     echo " -r, --release       Release build? (flag, default: false)"
+    echo " -c, --cargo         Path of cargo installation."
     echo " --report            Optional. Generates the xml test report with specified name."
     exit 1;
 }

--- a/mqtt/build/linux/test.sh
+++ b/mqtt/build/linux/test.sh
@@ -73,4 +73,4 @@ else
 fi
 
 # Convert test results to junit format.
-cat test-result.json | cargo2junit > test-result.xml
+cat test-result.json | cargo2junit > test-results.xml

--- a/mqtt/build/linux/test.sh
+++ b/mqtt/build/linux/test.sh
@@ -63,8 +63,14 @@ process_args()
 
 process_args "$@"
 
+# Get cargo2junit to report test results to Azure Pipelines
+$CARGO install cargo2junit
+
 if [[ -z ${RELEASE} ]]; then
-    cd "$PROJECT_ROOT" && $CARGO test --workspace --all-features --target "$TARGET"
+    cd "$PROJECT_ROOT" && $CARGO test --no-fail-fast --workspace --all-features --target "$TARGET" -- -Z unstable-options --format json | tee test-result.json
 else
-    cd "$PROJECT_ROOT" && $CARGO test --workspace --all-features --release --target "$TARGET"
+    cd "$PROJECT_ROOT" && $CARGO test --no-fail-fast --workspace --all-features --release --target "$TARGET" -- -Z unstable-options --format json | tee test-result.json
 fi
+
+# Convert test results to junit format.
+cat test-result.json | cargo2junit > test-result.xml


### PR DESCRIPTION
Rust tests don't have native test results support in Azure Pipelines. In this PR I want to add [a 3rd party tool](https://github.com/johnterickson/cargo2junit) that converts cargo test output into junit format (Azure Pipelines compatible). As a result, we can enjoy test stats, can see flaky tests, trends.

![image](https://user-images.githubusercontent.com/546843/99211035-35faf800-277c-11eb-8e44-28a4e8e75a79.png)


Drawbacks:
- We have to use unstable cargo feature to generate json output. I believe this should not be a problem, since it does not affect production bits, but only tests.
- Console output in the pipeline becomes less readable, but not that bad, and still searchable. Can use "Tests" tab instead!

Another minor improvements in this PR:
- Don't checkout submodules for MQTT Broker. It doesn't use any.
- Shallow clone (speeds up checkout x4)
- Removed Style Check task from MQTT CI. I can argue that it was redundant.