### PR TITLE
MQTT Authz: Reduce test flakiness

### DIFF
--- a/mqtt/mqtt-broker-tests-util/src/server.rs
+++ b/mqtt/mqtt-broker-tests-util/src/server.rs
@@ -77,7 +77,7 @@ where
     P: MakePacketProcessor + Clone + Send + Sync + 'static,
 {
     lazy_static! {
-        static ref PORT: AtomicU32 = AtomicU32::new(5555);
+        static ref PORT: AtomicU32 = AtomicU32::new(8889);
     }
 
     let port = PORT.fetch_add(1, Ordering::SeqCst);

--- a/mqtt/mqtt-edgehub/tests/common/mod.rs
+++ b/mqtt/mqtt-edgehub/tests/common/mod.rs
@@ -1,6 +1,7 @@
+#![allow(dead_code)]
 use std::{any::Any, error::Error as StdError};
 
-use tokio::task::JoinHandle;
+use tokio::{sync::mpsc::UnboundedReceiver, sync::mpsc::UnboundedSender, task::JoinHandle};
 
 use mqtt3::ShutdownError;
 use mqtt_broker::{
@@ -11,18 +12,36 @@ use mqtt_edgehub::command::{Command, CommandHandler, ShutdownHandle};
 
 pub const LOCAL_BROKER_SUFFIX: &str = "$edgeHub/$broker";
 
-// We need a Dummy Authorizer to authorize the command handler and $edgehub
-// LocalAuthorizer currently wraps EdgeHubAuthorizer in production code,
+// We need a `DummyAuthorizer` to authorize the command handler and $edgehub.
+//
+// LocalAuthorizer currently wraps `EdgeHubAuthorizer` and `PolicyAuthorizer` in production code,
 // but LocalAuthorizer would authorize everything in the case of an integ test.
-pub struct DummyAuthorizer<Z>(Z);
+//
+// In addition, `DummyAuthorizer` provides a way to signal when authorizer receives updates.
+pub struct DummyAuthorizer<Z> {
+    inner: Z,
+    receiver: Option<UnboundedReceiver<()>>,
+    sender: UnboundedSender<()>,
+}
 
 impl<Z> DummyAuthorizer<Z>
 where
     Z: Authorizer,
 {
-    #![allow(dead_code)]
-    pub fn new(authorizer: Z) -> Self {
-        Self(authorizer)
+    pub fn new(inner: Z) -> Self {
+        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        Self {
+            inner,
+            receiver: Some(receiver),
+            sender,
+        }
+    }
+
+    /// A receiver that signals when authorizer update has happened.
+    pub fn update_signal(&mut self) -> UnboundedReceiver<()> {
+        self.receiver
+            .take()
+            .expect("You can get only one receiver instance")
     }
 }
 
@@ -42,12 +61,14 @@ where
         {
             Ok(Authorization::Allowed)
         } else {
-            self.0.authorize(activity)
+            self.inner.authorize(activity)
         }
     }
 
     fn update(&mut self, update: Box<dyn Any>) -> Result<(), Self::Error> {
-        self.0.update(update)
+        self.inner.update(update)?;
+        self.sender.send(()).expect("unable to send update signal");
+        Ok(())
     }
 }
 

--- a/mqtt/mqtt-edgehub/tests/common/mod.rs
+++ b/mqtt/mqtt-edgehub/tests/common/mod.rs
@@ -1,7 +1,10 @@
 #![allow(dead_code)]
 use std::{any::Any, error::Error as StdError};
 
-use tokio::{sync::mpsc::UnboundedReceiver, sync::mpsc::UnboundedSender, task::JoinHandle};
+use tokio::{
+    sync::mpsc::{self, UnboundedReceiver, UnboundedSender},
+    task::JoinHandle,
+};
 
 use mqtt3::ShutdownError;
 use mqtt_broker::{
@@ -29,7 +32,7 @@ where
     Z: Authorizer,
 {
     pub fn new(inner: Z) -> Self {
-        let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
+        let (sender, receiver) = mpsc::unbounded_channel();
         Self {
             inner,
             receiver: Some(receiver),

--- a/mqtt/mqtt-edgehub/tests/policy_authorizer.rs
+++ b/mqtt/mqtt-edgehub/tests/policy_authorizer.rs
@@ -67,7 +67,7 @@ async fn auth_policy_happy_case() {
     let mut authorizer = DummyAuthorizer::new(PolicyAuthorizer::without_ready_handle(
         "this_edgehub_id".to_string(),
     ));
-    let mut policy_update_signal = authorizer.update_signal();
+    let mut policy_ready = authorizer.update_signal();
     let broker = BrokerBuilder::default().with_authorizer(authorizer).build();
     let broker_handle = broker.handle();
 
@@ -118,7 +118,7 @@ async fn auth_policy_happy_case() {
         .await;
 
     // let policy update sink in...
-    policy_update_signal.recv().await;
+    policy_ready.recv().await;
 
     let mut device_client = PacketStream::connect(
         ClientId::IdWithCleanSession("device-1".into()),

--- a/mqtt/mqtt-edgehub/tests/policy_authorizer.rs
+++ b/mqtt/mqtt-edgehub/tests/policy_authorizer.rs
@@ -1,9 +1,6 @@
-use std::time::Duration;
-
 use assert_matches::assert_matches;
 use bytes::Bytes;
 use futures_util::StreamExt;
-use tokio::time;
 
 use mqtt3::proto::{
     ClientId, ConnectReturnCode, ConnectionRefusedReason, Packet, PacketIdentifier,
@@ -67,11 +64,11 @@ async fn connect_not_allowed_policy_not_set() {
 async fn auth_policy_happy_case() {
     // Start broker with DummyAuthorizer that allows everything from CommandHandler and $edgeHub,
     // but otherwise passes authorization along to PolicyAuthorizer
-    let broker = BrokerBuilder::default()
-        .with_authorizer(DummyAuthorizer::new(
-            PolicyAuthorizer::without_ready_handle("this_edgehub_id".to_string()),
-        ))
-        .build();
+    let mut authorizer = DummyAuthorizer::new(PolicyAuthorizer::without_ready_handle(
+        "this_edgehub_id".to_string(),
+    ));
+    let mut policy_update_signal = authorizer.update_signal();
+    let broker = BrokerBuilder::default().with_authorizer(authorizer).build();
     let broker_handle = broker.handle();
 
     let server_handle = start_server(
@@ -121,7 +118,7 @@ async fn auth_policy_happy_case() {
         .await;
 
     // let policy update sink in...
-    time::delay_for(Duration::from_secs(1)).await;
+    policy_update_signal.recv().await;
 
     let mut device_client = PacketStream::connect(
         ClientId::IdWithCleanSession("device-1".into()),
@@ -192,11 +189,11 @@ async fn policy_update_reevaluates_sessions() {
     mqtt_broker_tests_util::init_logging();
     // Start broker with DummyAuthorizer that allows everything from CommandHandler and $edgeHub,
     // but otherwise passes authorization along to PolicyAuthorizer
-    let broker = BrokerBuilder::default()
-        .with_authorizer(DummyAuthorizer::new(
-            PolicyAuthorizer::without_ready_handle("this_edgehub_id".to_string()),
-        ))
-        .build();
+    let mut authorizer = DummyAuthorizer::new(PolicyAuthorizer::without_ready_handle(
+        "this_edgehub_id".to_string(),
+    ));
+    let mut policy_update_signal = authorizer.update_signal();
+    let broker = BrokerBuilder::default().with_authorizer(authorizer).build();
     let broker_handle = broker.handle();
 
     let server_handle = start_server(
@@ -241,7 +238,7 @@ async fn policy_update_reevaluates_sessions() {
         .await;
 
     // let policy update sink in...
-    time::delay_for(Duration::from_secs(1)).await;
+    policy_update_signal.recv().await;
 
     let mut device_client = PacketStream::connect(
         ClientId::IdWithCleanSession("device-1".into()),
@@ -284,7 +281,7 @@ async fn policy_update_reevaluates_sessions() {
         .await;
 
     // let policy update sink in...
-    time::delay_for(Duration::from_secs(1)).await;
+    policy_update_signal.recv().await;
 
     // assert client disconnected
     assert_matches!(device_client.next().await, None);


### PR DESCRIPTION
Our authorizers (EdgeHub and Policy) integraiton tests are flacky, because there were no way to deterministically wait until authorizer processes the update.

As a fix, instead of using time delay to wait for authorizer update (which is not deterministic way) , I have introduced a channel in `DummyAuthorizer` that signals when an update happens.