### PR TITLE
GetModuleLogs works with http endpoints (#3908)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
         {
             using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
             {
-                string baseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri);
+                string baseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri).TrimEnd('/');
                 var logsUrl = new StringBuilder();
                 logsUrl.AppendFormat(CultureInfo.InvariantCulture, LogsUrlTemplate, baseUrl, module, this.Version.Name, follow.ToString().ToLowerInvariant());
                 tail.ForEach(t => logsUrl.AppendFormat($"&{LogsUrlTailParameter}={t}"));


### PR DESCRIPTION
This was a simple fix. 

~~The new e2e tests currently do not test the http configuration for mgmt and workload sockets, so there may be a follow up to add tests.~~
Since http is not officially supported for mgmt and workload sockets, no tests will be added.