### PR TITLE
Add CredScan suppressions

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -28,6 +28,18 @@
     {
       "placeholder": "1234",
       "_justification": "This private key password (defined in /tools/CACertificates/ca-certs.ps1 and /tools/CACertificates/certGen.sh) is intended only to help demonstrate and prototype CA certs and warnings are provided to not use in production."
+    },
+    {
+      "placeholder": "pass",
+      "_justification": "This is a fake password used in the mqtt-bridge tests (mqtt/mqtt-bridge/tests/config.json)"
+    },
+    {
+      "file": "mqtt\\mqtt-broker\\test\\tls\\pkey.pem",
+      "_justification": "A synthetic key file used by the mqtt-broker tests"
+    },
+    {
+      "file": "http_proxy_io_requirements.md",
+      "_justification": "A file in a submodule repo, which we don't control, and which contains a fake password for illustration purposes"
     }
   ]
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/ModuleIdentityLifecycleManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/ModuleIdentityLifecycleManagerTest.cs
@@ -276,6 +276,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         {
             const string Name = "test-filters";
             // Use Json to create module because managedBy property can't has private set on Module object
+            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic symmetric keys used in tests")]
             const string ModuleJson = "{\"moduleId\":\"test-filters\",\"deviceId\":\"device1\",\"authentication\":{\"symmetricKey\":{\"primaryKey\":\"cHJpbWFyeVN5bW1ldHJpY0tleQ == \",\"secondaryKey\":\"c2Vjb25kYXJ5U3ltbWV0cmljS2V5\"},\"x509Thumbprint\":{\"primaryThumbprint\":null,\"secondaryThumbprint\":null},\"type\":\"sas\"},\"managedBy\":\"iotEdge\"}";
             var serviceModuleIdentity = JsonConvert.DeserializeObject<Module>(ModuleJson);
             var currentModule = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultStartupOrder, DefaultConfigurationInfo, EnvVars);
@@ -307,6 +308,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         {
             const string Name = "test-filters";
             // Use Json to create module because managedBy property can't has private set on Module object
+            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic symmetric keys used in tests")]
             const string ModuleJson = "{\"moduleId\":\"test-filters\",\"deviceId\":\"device1\",\"authentication\":{\"symmetricKey\":{\"primaryKey\":\"cHJpbWFyeVN5bW1ldHJpY0tleQ == \",\"secondaryKey\":\"c2Vjb25kYXJ5U3ltbWV0cmljS2V5\"},\"x509Thumbprint\":{\"primaryThumbprint\":null,\"secondaryThumbprint\":null},\"type\":\"sas\"},\"managedBy\":null}";
             var serviceModuleIdentity = JsonConvert.DeserializeObject<Module>(ModuleJson);
             var currentModule = new TestModule(Name, "v1", "test", ModuleStatus.Running, new TestConfig("image"), RestartPolicy.OnUnhealthy, ImagePullPolicy.OnCreate, Constants.DefaultStartupOrder, DefaultConfigurationInfo, EnvVars);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/ImagePullSecretTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/ImagePullSecretTest.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
     {
         public static IEnumerable<object[]> GenerateAuthConfig()
         {
+            // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic user login information used in tests")]
             yield return new object[] { new AuthConfig { Username = "one", Password = "two", ServerAddress = "three" } };
         }
 

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -25,6 +25,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
     [Unit]
     public class DeviceScopeControllerTest
     {
+        // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic symmetric keys used in tests")]
+        readonly string primaryKey = "t3LtII3CppvtVqycKp9bo043vCEgWbGBJAzXZNmoBXo=";
+
+        // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic symmetric keys used in tests")]
+        readonly string secondaryKey = "kT4ac4PpH5UY0vA1JpLQWOu2yG6qKoqwvzee3j1Z3bA=";
+
         [Fact]
         public async Task GetDevicesAndModulesInTargetDeviceScope_RoundTripTest()
         {
@@ -36,9 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             string deviceScope = "deviceScope1";
             string parentScope = "parentScope1";
             string generationId = "generation1";
-            string primaryKey = "t3LtII3CppvtVqycKp9bo043vCEgWbGBJAzXZNmoBXo=";
-            string secondaryKey = "kT4ac4PpH5UY0vA1JpLQWOu2yG6qKoqwvzee3j1Z3bA=";
-            var authentication = new ServiceAuthentication(new SymmetricKeyAuthentication(primaryKey, secondaryKey));
+            var authentication = new ServiceAuthentication(new SymmetricKeyAuthentication(this.primaryKey, this.secondaryKey));
             var resultDeviceIdentity = new ServiceIdentity(deviceId, null, deviceScope, new List<string>() { parentScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultModuleIdentity = new ServiceIdentity(deviceId, moduleId, null, new List<string>() { deviceScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultIdentities = new List<ServiceIdentity>() { resultDeviceIdentity, resultModuleIdentity };
@@ -51,7 +55,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             await controller.GetDevicesAndModulesInTargetDeviceScopeAsync(parentEdgeId, "$edgeHub", request);
 
             // Verify EdgeHub result types
-            var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };
+            var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = this.primaryKey, SecondaryKey = this.secondaryKey } };
             var expectedDeviceIdentities = new List<EdgeHubScopeDevice>() { new EdgeHubScopeDevice(deviceId, generationId, DeviceStatus.Enabled, expectedAuth, new DeviceCapabilities(), deviceScope, new List<string> { parentScope }) };
             var expectedModuleIdentities = new List<EdgeHubScopeModule>() { new EdgeHubScopeModule(moduleId, deviceId, generationId, expectedAuth) };
             var responseExpected = new EdgeHubScopeResultSuccess(expectedDeviceIdentities, expectedModuleIdentities);
@@ -85,9 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             string deviceScope = "deviceScope1";
             string parentScope = "parentScope1";
             string generationId = "generation1";
-            string primaryKey = "t3LtII3CppvtVqycKp9bo043vCEgWbGBJAzXZNmoBXo=";
-            string secondaryKey = "kT4ac4PpH5UY0vA1JpLQWOu2yG6qKoqwvzee3j1Z3bA=";
-            var authentication = new ServiceAuthentication(new SymmetricKeyAuthentication(primaryKey, secondaryKey));
+            var authentication = new ServiceAuthentication(new SymmetricKeyAuthentication(this.primaryKey, this.secondaryKey));
             var resultDeviceIdentity = new ServiceIdentity(childEdgeId, null, deviceScope, new List<string>() { parentScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultModuleIdentity = new ServiceIdentity(childEdgeId, moduleId, null, new List<string>() { deviceScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultIdentities = new List<ServiceIdentity>() { resultDeviceIdentity, resultModuleIdentity };
@@ -102,7 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             await controller.GetDeviceAndModuleOnBehalfOfAsync(parentEdgeId, "$edgeHub", request);
 
             // Verify EdgeHub result types
-            var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };
+            var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = this.primaryKey, SecondaryKey = this.secondaryKey } };
             var expectedDeviceIdentities = new List<EdgeHubScopeDevice>() { new EdgeHubScopeDevice(childEdgeId, generationId, DeviceStatus.Enabled, expectedAuth, new DeviceCapabilities(), deviceScope, new List<string> { parentScope }) };
             var expectedModuleIdentities = new List<EdgeHubScopeModule>() { new EdgeHubScopeModule(moduleId, childEdgeId, generationId, expectedAuth) };
             var responseExpected = new EdgeHubScopeResultSuccess(expectedDeviceIdentities, expectedModuleIdentities);
@@ -126,9 +128,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             string deviceScope = "deviceScope1";
             string parentScope = "parentScope1";
             string generationId = "generation1";
-            string primaryKey = "t3LtII3CppvtVqycKp9bo043vCEgWbGBJAzXZNmoBXo=";
-            string secondaryKey = "kT4ac4PpH5UY0vA1JpLQWOu2yG6qKoqwvzee3j1Z3bA=";
-            var authentication = new ServiceAuthentication(new SymmetricKeyAuthentication(primaryKey, secondaryKey));
+            var authentication = new ServiceAuthentication(new SymmetricKeyAuthentication(this.primaryKey, this.secondaryKey));
             var resultDeviceIdentity = new ServiceIdentity(deviceId, null, deviceScope, new List<string>() { parentScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultModuleIdentity = new ServiceIdentity(deviceId, moduleId, null, new List<string>() { deviceScope }, generationId, Enumerable.Empty<string>(), authentication, ServiceIdentityStatus.Enabled);
             var resultIdentities = new List<ServiceIdentity>() { resultDeviceIdentity, resultModuleIdentity };
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             await controller.GetDeviceAndModuleOnBehalfOfAsync(parentEdgeId, "$edgeHub", request);
 
             // Verify EdgeHub result types
-            var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = primaryKey, SecondaryKey = secondaryKey } };
+            var expectedAuth = new AuthenticationMechanism() { SymmetricKey = new SymmetricKey() { PrimaryKey = this.primaryKey, SecondaryKey = this.secondaryKey } };
             var expectedDeviceIdentities = new List<EdgeHubScopeDevice>() { new EdgeHubScopeDevice(deviceId, generationId, DeviceStatus.Enabled, expectedAuth, new DeviceCapabilities(), deviceScope, new List<string> { parentScope }) };
             var responseExpected = new EdgeHubScopeResultSuccess(expectedDeviceIdentities, new List<EdgeHubScopeModule>());
             var responseExpectedJson = JsonConvert.SerializeObject(responseExpected);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/AuthAgentListenerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/AuthAgentListenerTest.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
                 dynamic content = new ExpandoObject();
                 content.version = "2020-04-20";
                 content.username = "testhub/device/api-version=2018-06-30";
+                // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic password used in tests")]
                 content.password = "somepassword";
 
                 dynamic response = await PostAsync(content, URL);
@@ -94,6 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
                 dynamic content = new ExpandoObject();
                 content.version = "2020-04-20";
                 content.username = "testhub/device/api-version=2018-06-30";
+                // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic password used in tests")]
                 content.password = "somepassword";
                 content.certificate = ThumbprintTestCert;
 
@@ -134,6 +136,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
 
                 dynamic content = new ExpandoObject();
                 content.username = "testhub/device/api-version=2018-06-30";
+                // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic password used in tests")]
                 content.password = "somepassword";
 
                 dynamic response = await PostAsync(content, URL);
@@ -154,6 +157,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
                 dynamic content = new ExpandoObject();
                 content.version = "2017-04-20";
                 content.username = "testhub/device/api-version=2018-06-30";
+                // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic password used in tests")]
                 content.password = "somepassword";
 
                 dynamic response = await PostAsync(content, URL);
@@ -175,6 +179,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
                 dynamic content = new ExpandoObject();
                 content.version = "2020-04-20";
                 content.username = "testhub/device/api-version=2018-06-30";
+                // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic password used in tests")]
                 content.password = "bad_token";
 
                 dynamic response = await PostAsync(content, URL);
@@ -254,6 +259,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
                 dynamic content = new ExpandoObject();
                 content.version = "2020-04-20";
                 content.username = "testhub/device/api-version=2018-06-30";
+                // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic password used in tests")]
                 content.password = "somepassword";
 
                 var response = await PostAsync(content, URL);
@@ -274,6 +280,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
                 dynamic content = new ExpandoObject();
                 content.version = "2020-04-20";
                 content.username = "testhub/device/module/api-version=2018-06-30";
+                // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic password used in tests")]
                 content.password = "somepassword";
 
                 var response = await PostAsync(content, URL);

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/CertificateHelper.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/CertificateHelper.cs
@@ -47,6 +47,7 @@ jakkDyV11Q==
 -----END CERTIFICATE-----
 ";
 
+        // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic key used in tests")]
         public const string PrivateKeyPem = @"-----BEGIN PRIVATE KEY-----
 MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQDaDQIZm/VDDbUf
 5/qmO6IQiKPteetPdonYo0hYOyfkK+9n99jQWO65ue5f2lU5RubjL8ewL8AtnHqQ
@@ -113,6 +114,7 @@ x0DnmhDakf0O/kICIQC0DzYCSXsk0Yce1+Bi7zmwjp320U7o0sCs7O8ZhUgy+g==
 -----END CERTIFICATE-----
 ";
 
+        // [SuppressMessage("Microsoft.Security", "CS002:SecretInNextLine", Justification="Synthetic key used in tests")]
         public const string ECCPrivateKeyPem = @"-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEIP+wX2mlEdZCqURmTFq05cV0XE6VefkqCshhc88q8mxMoAoGCCqGSM49
 AwEHoUQDQgAEvwMwWYNM6YWlwLMOpExYFobxVUQVdmgEXA7vnZEFdvzKvrNegc+H


### PR DESCRIPTION
Several synthetic secrets have been added over time to the tests. This change updates the suppressions list to silence the associated CredScan errors.

I used inline suppression where possible to co-locate the suppression with the corresponding code, except in a few cases where I added the suppression to `.config/CredScanSuppressions.json`:
- A synthetic password in a JSON file. Although CredScan supports comments in JSON, I'm not sure about our test pipeline.
- A PEM file checked into the repo and used by the mqtt-broker tests. Again, CredScan supports suppression comments in PEM files, but I don't understand the ramifications to the test pipeline.
- A synthetic password in some markdown files from our submodules. We can't control the submodules, so I suppressed the files. CredScan docs indicate that you can suppress folders, which would be a good strategy for submodules, but it's unclear whether that feature is officially supported in the lastest version and for the sake of time I didn't try it.