### PR TITLE
Remove new package names from test agents

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -100,11 +100,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
         {
             SupportedPackageExtension.Deb => new[]
             {
-                "apt-get purge --yes libiothsm-std iotedge"
+                "dpkg --purge libiothsm-std aziot-edge aziot-identity-service iotedge"
             },
             SupportedPackageExtension.Rpm => new[]
             {
-                "yum remove -y --remove-leaves libiothsm-std iotedge"
+                "yum remove -y --remove-leaves libiothsm-std aziot-edge aziot-identity-service iotedge"
             },
             _ => throw new NotImplementedException($"Don't know how to uninstall daemon on for '.{this.packageExtension}'")
         };


### PR DESCRIPTION
On the iiot branch, the package names were renamed to aziot-*. Remove these packages (if installed) when running tests on the master branch.