### PR TITLE
Fixing ValidateMetrics E2E (#3767)

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
@@ -25,6 +26,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
         {
             CancellationToken token = this.TestToken;
             await this.DeployAsync(token);
+
+            var agent = new EdgeAgent(this.runtime.DeviceId, this.iotHub);
+            await agent.PingAsync(token);
 
             var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ModuleName, new CloudToDeviceMethod("ValidateMetrics", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)), token);
             Assert.AreEqual(result.Status, (int)HttpStatusCode.OK);


### PR DESCRIPTION
Currently the `ValidateMetrics` parses [metric readme page](https://github.com/Azure/iotedge/blob/master/doc/BuiltInMetrics.md) to obtain all the metric keys. The test then deploy the system runtime modules and populate its metrics which then are compared against the parsed-document set.
There are a handful of not-so-positive metrics that are not being populated if the system modules operated on a happy path during the E2E test. These not-so-positive metrics are currently causing the `ValidateMetrics` to fail since they are not being populated.

Cherry-picked: https://github.com/Azure/iotedge/commit/f443dde70a7aea9ad6716cf61cc66f89b6642783