### PR TITLE
Cherry-pick Fix multiple TTL test to release/1.0.10 branch (#4037)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
@@ -204,13 +204,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
             public CleanupProcessor(MessageStore messageStore, bool checkEntireQueueOnCleanup)
             {
                 this.messageStore = messageStore;
-                this.ensureCleanupTaskTimer = new Timer(this.EnsureCleanupTask, null, TimeSpan.Zero, CleanupTaskFrequency);
                 this.cancellationTokenSource = new CancellationTokenSource();
                 this.checkEntireQueueOnCleanup = checkEntireQueueOnCleanup;
                 this.expiredCounter = Metrics.Instance.CreateCounter(
                    "messages_dropped",
                    "Messages cleaned up because of TTL expired",
                    new List<string> { "reason", "from", "from_route_output", MetricsConstants.MsTelemetry });
+                this.ensureCleanupTaskTimer = new Timer(this.EnsureCleanupTask, null, TimeSpan.Zero, CleanupTaskFrequency);
             }
 
             public void Dispose()

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
@@ -233,7 +233,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
         public async Task CleanupTestTimeoutMultipleTTLs(bool checkEntireQueueOnCleanup)
         {
             (IMessageStore messageStore, ICheckpointStore checkpointStore, InMemoryDbStore inMemoryDbStore) result = await this.GetMessageStore(checkEntireQueueOnCleanup, 10);
-            result.messageStore.SetTimeToLive(TimeSpan.FromSeconds(10));
             using (IMessageStore messageStore = result.messageStore)
             {
                 var messageIdsAlive = new List<string>();
@@ -257,7 +256,25 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
                     CompareUpdatedMessageWithOffset(input, i, updatedMessage);
                 }
 
-                await Task.Delay(TimeSpan.FromSeconds(70));
+                for (int i = 0; i < messageIdsExpired.Count; i++)
+                {
+                    if (checkEntireQueueOnCleanup || i == 0)
+                    {
+                        int retryAttempts = 0;
+                        while (await result.inMemoryDbStore.Contains(messageIdsExpired[i].ToBytes()))
+                        {
+                            Assert.True(retryAttempts < 10, "Test is taking too long and is considered a failure.");
+                            retryAttempts++;
+                            await Task.Delay(TimeSpan.FromSeconds(10));
+                        }
+
+                        Assert.False(await result.inMemoryDbStore.Contains(messageIdsExpired[i].ToBytes()));
+                    }
+                    else
+                    {
+                        Assert.True(await result.inMemoryDbStore.Contains(messageIdsExpired[i].ToBytes()));
+                    }
+                }
 
                 IMessageIterator module1Iterator = messageStore.GetMessageIterator("module1");
                 IEnumerable<IMessage> batch = await module1Iterator.GetNext(200);
@@ -265,18 +282,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
                 foreach (string edgeMessageId in messageIdsAlive)
                 {
                     Assert.True(await result.inMemoryDbStore.Contains(edgeMessageId.ToBytes()));
-                }
-
-                for (int i = 0; i < messageIdsExpired.Count; i++)
-                {
-                    if (checkEntireQueueOnCleanup || i == 0)
-                    {
-                        Assert.False(await result.inMemoryDbStore.Contains(messageIdsExpired[i].ToBytes()));
-                    }
-                    else
-                    {
-                        Assert.True(await result.inMemoryDbStore.Contains(messageIdsExpired[i].ToBytes()));
-                    }
                 }
             }
         }


### PR DESCRIPTION
Cherry-picking from main branch
This PR fixes a bug in product code where the cleanup task in MessageStore.cs can potentially start before all of its settings are set, resulting in it taking default values for its settings.
Also re-enables the MultipleTTL test in MessageStoreTest.cs and makes it run with polling vs a delay, which will speed up the test.