### PR TITLE
Align base images for mqtt perf tests with production images.

### DIFF
--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -11,7 +11,7 @@ jobs:
 ################################################################################
     displayName: Linux AMD64
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: "ubuntu-latest"
 
     variables:
       os: linux
@@ -33,10 +33,10 @@ jobs:
 
       - template: templates/move-rust-artifacts.yaml
         parameters:
-          should.publish.amd64: 'true'
-          artifact.folder.path: 'mqtt/target'
-          destination.folder.path: 'mqtt/build-context'
-          artifact.name: 'mqttd'
+          should.publish.amd64: "true"
+          artifact.folder.path: "mqtt/target"
+          destination.folder.path: "mqtt/build-context"
+          artifact.name: "mqttd"
 
       - task: Docker@2
         displayName: Build amd64 image
@@ -47,10 +47,10 @@ jobs:
           Dockerfile: mqtt/docker/$(os)/$(arch)/Dockerfile
           buildContext: mqtt/build-context
           tags: $(Build.BuildNumber)-$(os)-$(arch)
-      
+
       - script: echo $(registry.address)/$(imageName):$(Build.BuildNumber)-$(os)-$(arch) > artifactInfo.txt
         displayName: Create image name
-      
+
       - publish: artifactInfo.txt
         artifact: image-$(arch)
         displayName: Publish image name
@@ -60,7 +60,7 @@ jobs:
 ################################################################################
     displayName: Linux ARM32
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: "ubuntu-latest"
 
     variables:
       os: linux
@@ -78,14 +78,14 @@ jobs:
         displayName: Build MQTT Broker - arm32
         inputs:
           filePath: scripts/linux/cross-platform-rust-build.sh
-          arguments: --os ubuntu18.04 --arch arm32v7 --build-path mqtt/mqttd --cargo-flags '--no-default-features --features="generic"'
+          arguments: --os alpine --arch arm32v7 --build-path mqtt/mqttd --cargo-flags '--no-default-features --features="generic"'
 
       - template: templates/move-rust-artifacts.yaml
         parameters:
-          should.publish.arm32v7: 'true'
-          artifact.folder.path: 'mqtt/target'
-          destination.folder.path: 'mqtt/build-context'
-          artifact.name: 'mqttd'
+          should.publish.arm32v7: "true"
+          artifact.folder.path: "mqtt/target"
+          destination.folder.path: "mqtt/build-context"
+          artifact.name: "mqttd"
 
       - task: Docker@2
         displayName: Build arm32v7 image
@@ -99,7 +99,7 @@ jobs:
 
       - script: echo $(registry.address)/$(imageName):$(Build.BuildNumber)-$(os)-$(arch) > artifactInfo.txt
         displayName: Create image name
-      
+
       - publish: artifactInfo.txt
         artifact: image-$(arch)
         displayName: Publish image name

--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -78,7 +78,7 @@ jobs:
         displayName: Build MQTT Broker - arm32
         inputs:
           filePath: scripts/linux/cross-platform-rust-build.sh
-          arguments: --os alpine --arch arm32v7 --build-path mqtt/mqttd --cargo-flags '--no-default-features --features="generic"'
+          arguments: --os ubuntu18.04 --arch arm32v7 --build-path mqtt/mqttd --cargo-flags '--no-default-features --features="generic"'
 
       - template: templates/move-rust-artifacts.yaml
         parameters:

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -1,4 +1,5 @@
-FROM busybox
+ARG base_tag=3.1.4-alpine3.11
+FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 ADD ./x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd
 

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -1,3 +1,4 @@
+# Use the same base image as prod edgehub images
 ARG base_tag=3.1.4-alpine3.11
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -1,15 +1,15 @@
-FROM busybox
+ARG base_tag=3.1.10-bionic-arm32v7
+FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 ADD ./armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd
 
 # Add an unprivileged user account for running mqttd	
 ARG MQTTDUSER_ID=1000
 
-RUN adduser -Du ${MQTTDUSER_ID} mqttduser
+RUN useradd -ms /bin/bash -u ${MQTTDUSER_ID} mqttduser
 
 EXPOSE 1883/tcp
 EXPOSE 8883/tcp
-
 
 USER mqttduser
 

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -1,16 +1,13 @@
-ARG base_tag=3.1.10-bionic-arm32v7
-FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
+# Use the same base image as prod edgehub images
+ARG base_tag=1.0.6.4-linux-arm64v8
+FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd
-
-# Add an unprivileged user account for running mqttd	
-ARG MQTTDUSER_ID=1000
-
-RUN useradd -ms /bin/bash -u ${MQTTDUSER_ID} mqttduser
 
 EXPOSE 1883/tcp
 EXPOSE 8883/tcp
 
-USER mqttduser
+# Use an unprivileged user account from base image for running mqttd	
+USER edgehubuser
 
 ENTRYPOINT ["/usr/local/bin/mqttd"]

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 # Use the same base image as prod edgehub images
-ARG base_tag=1.0.6.4-linux-arm64v8
+ARG base_tag=1.0.6.4-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd


### PR DESCRIPTION
~~Since we use `busybox` as a base image for generic mqtt broker (used in perf tests), we need to use `alpine` and `armv7-unknown-linux-musleabihf` for building the image. If we try to build for `armv7-unknown-linux-gnueabihf`, it will fail to start on `busybox` since glibc is missing.~~

We need to align base images for mqtt perf tests with what we use in production.