### PR TITLE
Cherry-Pick to 1.2: Fix InMemoryDbStoreLimitsTest (#4048)

### DIFF
--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/StoreLimitsTestBase.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/StoreLimitsTestBase.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
         /// </summary>
         static readonly IDictionary<string, string> Routes = new Dictionary<string, string>()
         {
-            ["r1"] = "FROM /messages/modules/sender1 INTO BrokeredEndpoint(\"/modules/receiver1/inputs/input1\")",
+            ["r1"] = "FROM /messages/modules/sender1forstorelimits INTO BrokeredEndpoint(\"/modules/receiver1/inputs/input1\")",
         };
 
         protected async Task StoreLimitValidationTestAsync()
@@ -58,10 +58,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             string edgeDeviceConnectionString = await SecretsHelper.GetSecretFromConfigKey("edgeCapableDeviceConnStrKey");
             IotHubConnectionStringBuilder connectionStringBuilder = IotHubConnectionStringBuilder.Create(edgeDeviceConnectionString);
             RegistryManager rm = RegistryManager.CreateFromConnectionString(edgeDeviceConnectionString);
+            Guid guid = Guid.NewGuid();
             try
             {
                 await Task.Delay(TimeSpan.FromSeconds(10));
-                sender = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "sender1", StoreLimitTestTransportSettings, 0);
+                sender = await TestModule.CreateAndConnect(rm, connectionStringBuilder.HostName, connectionStringBuilder.DeviceId, "sender1forstorelimits", StoreLimitTestTransportSettings, 0);
 
                 // Send messages to ensure that the max storage size limit is reached.
                 int sentMessagesCount = 0;


### PR DESCRIPTION
Cherry-pick from main branch to 1.2
https://github.com/Azure/iotedge/pull/4048
InMemoryDbStoreLimitsTest is flaky in the CI pipeline. I believe it is because we overuse the "sender1" name. The test keeps failing on "Amqp resource is disconnected," which I think we get because we're trying to access an AMQP resource that has previously closed. This would make sense if we are using the "sender1" name somewhere else around the same time.

So this pr just changes the name to be more specific to the test. I've run it ~8 times in the pipeline and haven't seen the failure, so it looks like it solves the problem.