### PR TITLE
Removing preview iothub and eventhub endpoint from PnP tests for 1.0.10

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -29,13 +29,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string TestModelId = "dtmi:edgeE2ETest:TestCapabilityModel;1";
         const string LoadGenModuleName = "loadGenModule";
 
-        public PlugAndPlay()
-            : base(
-            Context.Current.PreviewConnectionString.Expect<ArgumentException>(() => throw new ArgumentException("Must supply preview connection string for PlugAndPlay tests.")),
-            Context.Current.PreviewEventHubEndpoint.Expect<ArgumentException>(() => throw new ArgumentException("Must supply preview Event Hub endpoint for PlugAndPlay tests.")))
-        {
-        }
-
         [Test]
         public async Task DeviceClient()
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
@@ -78,13 +78,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
             this.CaCertScriptPath = Option.Maybe(Get("caCertScriptPath"));
             this.ConnectionString = Get("IOT_HUB_CONNECTION_STRING");
-            this.PreviewConnectionString = Option.Maybe(Get("PREVIEW_IOT_HUB_CONNECTION_STRING"));
             this.DpsIdScope = Option.Maybe(Get("dpsIdScope"));
             this.DpsGroupKey = Option.Maybe(Get("DPS_GROUP_KEY"));
             this.EdgeAgentImage = Option.Maybe(Get("edgeAgentImage"));
             this.EdgeHubImage = Option.Maybe(Get("edgeHubImage"));
             this.EventHubEndpoint = Get("EVENT_HUB_ENDPOINT");
-            this.PreviewEventHubEndpoint = Option.Maybe(Get("PREVIEW_EVENT_HUB_ENDPOINT"));
             this.InstallerPath = Option.Maybe(Get("installerPath"));
             this.LogFile = Option.Maybe(Get("logFile"));
             this.MethodReceiverImage = Option.Maybe(Get("methodReceiverImage"));
@@ -119,8 +117,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
         public string ConnectionString { get; }
 
-        public Option<string> PreviewConnectionString { get; }
-
         public Dictionary<string, EdgeDevice> DeleteList { get; } = new Dictionary<string, EdgeDevice>();
 
         public Option<string> DpsIdScope { get; }
@@ -132,8 +128,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         public Option<string> EdgeHubImage { get; }
 
         public string EventHubEndpoint { get; }
-
-        public Option<string> PreviewEventHubEndpoint { get; }
 
         public Option<string> InstallerPath { get; }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
@@ -19,14 +19,12 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         protected readonly IotHub iotHub;
         protected IEdgeDaemon daemon;
 
-        public ManualProvisioningFixture(string connectionString, string eventHubEndpoint)
-        {
-            this.iotHub = new IotHub(connectionString, eventHubEndpoint, Context.Current.Proxy);
-        }
-
         public ManualProvisioningFixture()
-            : this(Context.Current.ConnectionString, Context.Current.EventHubEndpoint)
         {
+            this.iotHub = new IotHub(
+                Context.Current.ConnectionString,
+                Context.Current.EventHubEndpoint,
+                Context.Current.Proxy);
         }
 
         [OneTimeSetUp]

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/SasManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/SasManualProvisioningFixture.cs
@@ -11,16 +11,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
     {
         protected EdgeRuntime runtime;
 
-        public SasManualProvisioningFixture()
-            : base()
-        {
-        }
-
-        public SasManualProvisioningFixture(string connectionString, string eventHubEndpoint)
-            : base(connectionString, eventHubEndpoint)
-        {
-        }
-
         protected override Task BeforeTestTimerStarts() => this.SasProvisionEdgeAsync();
 
         protected virtual async Task SasProvisionEdgeAsync()

--- a/test/README.md
+++ b/test/README.md
@@ -58,9 +58,7 @@ The tests also expect to find several _secret_ parameters. While these can techn
 |------|----------|-------------|
 | `[E2E_]DPS_GROUP_KEY` | * | The symmetric key of the DPS [enrollment group](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-service#enrollment-group) to use. Required when running any DPS tests, ignored otherwise. |
 | `[E2E_]IOT_HUB_CONNECTION_STRING` | ✔ | Hub-scoped IoT Hub connection string that can be used to get/add/remove devices, deploy edge configurations, and get/update module twins. |
-| `[E2E_]PREVIEW_IOT_HUB_CONNECTION_STRING` | * | Alternate Hub-scoped IoT Hub connection string in a region that has preview bits deployed for preview testing - required only for PlugAndPlay tests. |
 | `[E2E_]EVENT_HUB_ENDPOINT` | ✔ | Connection string used to connect to the Event Hub-compatible endpoint of your IoT Hub, to listen for D2C events sent by devices or modules. |
-| `[E2E_]PREVIEW_EVENT_HUB_ENDPOINT` | * | Alternate Event Hub that is in a region that has preview bits deployed for preview testing - required only for PlugAndPlay tests. |
 | `[E2E_]REGISTRIES__{n}__PASSWORD` || Password associated with a container registry entry in the `registries` array of `context.json`. `{n}` is the number corresponding to the (zero-based) array entry. For example, if you specified a single container registry in the `registries` array, the corresponding parameter would be `[E2E_]REGISTRIES__0__PASSWORD`. |
 | `[E2E_]ROOT_CA_PASSWORD` || The password associated with the root certificate specified in `rootCaCertificatePath`. |
 | `[E2E_]BLOB_STORE_SAS` || The sas token used to upload module logs and support bundle in the tests. |


### PR DESCRIPTION
Cherry-picking part of this commit from main branch to 1.0.10: https://github.com/Azure/iotedge/pull/4064

This PR cleans up workarounds that were put in when the PlugAndPlay tests were first made.

Previously, we needed to use a preview version of IoTHub that supported PnP. Since then, they've gone GA, and we can use our normal IoTHub and normal EventHub endpoint.