### PR TITLE
Cherry-pick policy engine changes from master to release/1.2 (Part 2)

### DIFF
--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -11,7 +11,7 @@ jobs:
 ################################################################################
     displayName: Linux AMD64
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: "ubuntu-latest"
 
     variables:
       os: linux
@@ -33,10 +33,10 @@ jobs:
 
       - template: templates/move-rust-artifacts.yaml
         parameters:
-          should.publish.amd64: 'true'
-          artifact.folder.path: 'mqtt/target'
-          destination.folder.path: 'mqtt/build-context'
-          artifact.name: 'mqttd'
+          should.publish.amd64: "true"
+          artifact.folder.path: "mqtt/target"
+          destination.folder.path: "mqtt/build-context"
+          artifact.name: "mqttd"
 
       - task: Docker@2
         displayName: Build amd64 image
@@ -47,10 +47,10 @@ jobs:
           Dockerfile: mqtt/docker/$(os)/$(arch)/Dockerfile
           buildContext: mqtt/build-context
           tags: $(Build.BuildNumber)-$(os)-$(arch)
-      
+
       - script: echo $(registry.address)/$(imageName):$(Build.BuildNumber)-$(os)-$(arch) > artifactInfo.txt
         displayName: Create image name
-      
+
       - publish: artifactInfo.txt
         artifact: image-$(arch)
         displayName: Publish image name
@@ -60,7 +60,7 @@ jobs:
 ################################################################################
     displayName: Linux ARM32
     pool:
-      vmImage: 'ubuntu-latest'
+      vmImage: "ubuntu-latest"
 
     variables:
       os: linux
@@ -82,10 +82,10 @@ jobs:
 
       - template: templates/move-rust-artifacts.yaml
         parameters:
-          should.publish.arm32v7: 'true'
-          artifact.folder.path: 'mqtt/target'
-          destination.folder.path: 'mqtt/build-context'
-          artifact.name: 'mqttd'
+          should.publish.arm32v7: "true"
+          artifact.folder.path: "mqtt/target"
+          destination.folder.path: "mqtt/build-context"
+          artifact.name: "mqttd"
 
       - task: Docker@2
         displayName: Build arm32v7 image
@@ -99,7 +99,7 @@ jobs:
 
       - script: echo $(registry.address)/$(imageName):$(Build.BuildNumber)-$(os)-$(arch) > artifactInfo.txt
         displayName: Create image name
-      
+
       - publish: artifactInfo.txt
         artifact: image-$(arch)
         displayName: Publish image name

--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -225,6 +225,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "winapi 0.3.9",
 ]

--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -1546,8 +1546,10 @@ dependencies = [
 name = "policy"
 version = "0.1.0"
 dependencies = [
+ "itertools",
  "lazy_static",
  "matches",
+ "proptest",
  "regex",
  "serde",
  "serde_json",

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -1,4 +1,6 @@
-FROM busybox
+# Use the same base image as prod edgehub images
+ARG base_tag=3.1.4-alpine3.11
+FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 ADD ./x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd
 

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -1,16 +1,13 @@
-FROM busybox
+# Use the same base image as prod edgehub images
+ARG base_tag=1.0.6.4-linux-arm32v7
+FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd
-
-# Add an unprivileged user account for running mqttd	
-ARG MQTTDUSER_ID=1000
-
-RUN adduser -Du ${MQTTDUSER_ID} mqttduser
 
 EXPOSE 1883/tcp
 EXPOSE 8883/tcp
 
-
-USER mqttduser
+# Use an unprivileged user account from base image for running mqttd	
+USER edgehubuser
 
 ENTRYPOINT ["/usr/local/bin/mqttd"]

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 async-trait = "0.1"
 bincode = "1.2"
 bytes = "0.5"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 criterion = { version = "0.3", optional = true }
 fail = "0.3"
 flate2 = "1.0"

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, convert::TryInto, panic};
 
+use chrono::{DateTime, Utc};
 use futures_util::StreamExt;
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
 use tracing::{debug, error, info, info_span, warn};
@@ -97,13 +98,17 @@ where
                                 debug!("successfully send publication");
                             }
                         }
+                        SystemEvent::SessionCleanup(expiration) => {
+                            self.cleanup_sessions(expiration);
+                            debug!("session cleanup completed");
+                        }
                     }
                 }
             }
         }
 
         info!("broker is shutdown.");
-        Ok(self.snapshot())
+        Ok(self.into_snapshot())
     }
 
     fn prepare_activities(session: &Session) -> Vec<Activity> {
@@ -156,6 +161,29 @@ where
         }
     }
 
+    fn cleanup_sessions(&mut self, expiration: DateTime<Utc>) {
+        let sessions = self
+            .sessions
+            .values()
+            .filter_map(|session| match session {
+                Session::Offline(session) if session.last_active() < expiration => {
+                    Some(session.client_id())
+                }
+                _ => None,
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for client_id in sessions {
+            if let Err(reason) = self.drop_session(&client_id) {
+                warn!(
+                    "error dropping session for client {}; reason: {}",
+                    client_id, reason
+                );
+            }
+        }
+    }
+
     fn snapshot(&self) -> BrokerSnapshot {
         let retained = self.retained.clone();
         let sessions = self
@@ -169,6 +197,20 @@ where
             .collect();
 
         BrokerSnapshot::new(retained, sessions)
+    }
+
+    fn into_snapshot(self) -> BrokerSnapshot {
+        let sessions = self
+            .sessions
+            .into_iter()
+            .filter_map(|(_, session)| match session {
+                Session::Persistent(c) => Some(c.into_snapshot()),
+                Session::Offline(o) => Some(o.into_snapshot()),
+                _ => None,
+            })
+            .collect();
+
+        BrokerSnapshot::new(self.retained, sessions)
     }
 
     #[cfg(any(test, feature = "proptest"))]
@@ -741,16 +783,17 @@ where
             }
             None => {
                 // No session present - create a new one.
-                let new_session = if let proto::ClientId::IdWithExistingSession(_) =
-                    connreq.connect().client_id
-                {
-                    info!("creating new persistent session for {}", client_id);
-                    let state = SessionState::new(client_info, self.config.session().clone());
-                    Session::new_persistent(connreq, state)
-                } else {
-                    info!("creating new transient session for {}", client_id);
-                    let state = SessionState::new(client_info, self.config.session().clone());
-                    Session::new_transient(connreq, state)
+                let state = SessionState::new(client_info, self.config.session().clone());
+
+                let new_session = match connreq.connect().client_id {
+                    proto::ClientId::IdWithExistingSession(_) => {
+                        info!("creating new persistent session for {}", client_id);
+                        Session::new_persistent(connreq, state)
+                    }
+                    proto::ClientId::ServerGenerated | proto::ClientId::IdWithCleanSession(_) => {
+                        info!("creating new transient session for {}", client_id);
+                        Session::new_transient(connreq, state)
+                    }
                 };
 
                 let subscription_change =
@@ -806,21 +849,21 @@ where
         let (mut state, _will, handle) = current_connected.into_parts();
         let old_session = Session::new_disconnecting(state.client_info().clone(), None, handle);
         let client_id = connreq.client_id().clone();
-        let new_client_info = ClientInfo::new(client_id.clone(), connreq.peer_addr(), auth_id);
+        let client_info = ClientInfo::new(client_id.clone(), connreq.peer_addr(), auth_id);
         let (new_session, session_present) =
             if let proto::ClientId::IdWithExistingSession(_) = connreq.connect().client_id {
                 debug!(
                     "moving persistent session to this connection for {}",
                     client_id
                 );
-                state.set_client_info(new_client_info);
+                state.set_client_info(client_info);
                 let new_session = Session::new_persistent(connreq, state);
                 (new_session, true)
             } else {
                 info!("cleaning session for {}", client_id);
                 let new_session = Session::new_transient(
                     connreq,
-                    SessionState::new(new_client_info, self.config.session().clone()),
+                    SessionState::new(client_info, self.config.session().clone()),
                 );
                 (new_session, false)
             };
@@ -862,7 +905,7 @@ where
 
                 let (state, will, handle) = connected.into_parts();
                 let client_info = state.client_info().clone();
-                let new_session = Session::new_offline(state);
+                let new_session = Session::new_offline(state, Utc::now());
                 self.sessions.insert(client_id.clone(), new_session);
                 Some(Session::new_disconnecting(client_info, will, handle))
             }
@@ -1053,7 +1096,12 @@ where
                 let sessions = sessions
                     .into_iter()
                     .map(|snapshot| SessionState::from_snapshot(snapshot, config.session().clone()))
-                    .map(|state| (state.client_id().clone(), Session::new_offline(state)))
+                    .map(|(state, last_active)| {
+                        (
+                            state.client_id().clone(),
+                            Session::new_offline(state, last_active),
+                        )
+                    })
                     .collect::<HashMap<ClientId, Session>>();
                 (retained, sessions)
             }

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -146,9 +146,9 @@ where
             .collect::<Vec<_>>();
 
         for activity in disconnecting {
-            if let Err(reason) = self.process_drop_connection(activity.client_id()) {
+            if let Err(reason) = self.drop_session(activity.client_id()) {
                 warn!(
-                    "error dropping connection for client {}. Reason {}",
+                    "error dropping session for client {}; reason: {}",
                     activity.client_id(),
                     reason
                 );
@@ -414,10 +414,6 @@ where
     }
 
     fn process_drop_connection(&mut self, client_id: &ClientId) -> Result<(), Error> {
-        self.drop_connection(client_id)
-    }
-
-    fn drop_connection(&mut self, client_id: &ClientId) -> Result<(), Error> {
         debug!("handling drop connection...");
         if let Some(session) = self.close_session(client_id)? {
             session.send(ClientEvent::DropConnection)?;
@@ -577,11 +573,11 @@ where
                 }
                 Ok(Authorization::Forbidden(reason)) => {
                     warn!("not authorized: {}; reason: {}", &activity, reason);
-                    self.drop_connection(&client_id)?;
+                    self.process_drop_connection(&client_id)?;
                 }
                 Err(e) => {
                     warn!(message="error authorizing client: {}", error = %e);
-                    self.drop_connection(&client_id)?;
+                    self.process_drop_connection(&client_id)?;
                 }
             }
         } else {
@@ -838,6 +834,7 @@ where
         OpenSession::DuplicateSession(old_session, ack)
     }
 
+    /// Transition session to a closed state. Persist the session if needed.
     fn close_session(&mut self, client_id: &ClientId) -> Result<Option<Session>, Error> {
         let new_session = match self.sessions.remove(client_id) {
             Some(Session::Transient(connected)) => {
@@ -864,13 +861,10 @@ where
                 self.publish_all(StateChange::new_connection_change(&self.sessions).try_into()?)?;
 
                 let (state, will, handle) = connected.into_parts();
-                let new_session = Session::new_offline(state.clone());
+                let client_info = state.client_info().clone();
+                let new_session = Session::new_offline(state);
                 self.sessions.insert(client_id.clone(), new_session);
-                Some(Session::new_disconnecting(
-                    state.client_info().clone(),
-                    will,
-                    handle,
-                ))
+                Some(Session::new_disconnecting(client_info, will, handle))
             }
             Some(Session::Offline(offline)) => {
                 debug!("closing already offline session for {}", client_id);
@@ -882,6 +876,23 @@ where
         };
 
         Ok(new_session)
+    }
+
+    /// Hard drop the session, even if it is persistent. Usually due to authorization violations.
+    fn drop_session(&mut self, client_id: &ClientId) -> Result<(), Error> {
+        if let Some(session) = self.sessions.remove(client_id) {
+            info!("dropping session for {}", client_id);
+            self.publish_all(StateChange::new_connection_change(&self.sessions).try_into()?)?;
+            self.publish_all(StateChange::new_session_change(&self.sessions).try_into()?)?;
+            self.publish_all(StateChange::new_subscription_change(client_id, None).try_into()?)?;
+
+            // Ungraceful drop session - send the will
+            if let Some(will) = session.into_will() {
+                self.publish_all(will)?;
+            }
+        };
+
+        Ok(())
     }
 
     fn publish_all(&mut self, mut publication: proto::Publication) -> Result<(), Error> {

--- a/mqtt/mqtt-broker/src/broker.rs
+++ b/mqtt/mqtt-broker/src/broker.rs
@@ -249,7 +249,7 @@ where
             }
         }
 
-        for mut session in sessions {
+        for session in sessions {
             if let Err(e) = session.send(ClientEvent::DropConnection) {
                 warn!(error = %e, message = "an error occurred closing the session", client_id = %session.client_id());
             }
@@ -378,7 +378,7 @@ where
                 self.publish_all(StateChange::new_connection_change(&self.sessions).try_into()?)?;
                 self.publish_all(subscriptions)?;
             }
-            OpenSession::DuplicateSession(mut old_session, ack) => {
+            OpenSession::DuplicateSession(old_session, ack) => {
                 // Drop the old connection
                 old_session.send(ClientEvent::DropConnection)?;
 
@@ -393,7 +393,7 @@ where
                     session.send(ClientEvent::DropConnection)?;
                 }
             }
-            OpenSession::ProtocolViolation(mut old_session) => {
+            OpenSession::ProtocolViolation(old_session) => {
                 old_session.send(ClientEvent::DropConnection)?
             }
         }
@@ -404,7 +404,7 @@ where
 
     fn process_disconnect(&mut self, client_id: &ClientId) -> Result<(), Error> {
         debug!("handling disconnect...");
-        if let Some(mut session) = self.close_session(client_id)? {
+        if let Some(session) = self.close_session(client_id)? {
             session.send(ClientEvent::Disconnect(proto::Disconnect))?;
         } else {
             debug!("no session for {}", client_id);
@@ -419,7 +419,7 @@ where
 
     fn drop_connection(&mut self, client_id: &ClientId) -> Result<(), Error> {
         debug!("handling drop connection...");
-        if let Some(mut session) = self.close_session(client_id)? {
+        if let Some(session) = self.close_session(client_id)? {
             session.send(ClientEvent::DropConnection)?;
 
             // Ungraceful disconnect - send the will
@@ -1079,7 +1079,7 @@ pub struct BrokerHandle {
 }
 
 impl BrokerHandle {
-    pub fn send(&mut self, message: Message) -> Result<(), Error> {
+    pub fn send(&self, message: Message) -> Result<(), Error> {
         let sender = match &message {
             Message::Client(_, ClientEvent::PubAck0(_))
             | Message::Client(_, ClientEvent::PubAck(_))
@@ -1161,7 +1161,7 @@ pub(crate) mod tests {
     async fn test_double_connect_protocol_violation() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -1231,7 +1231,7 @@ pub(crate) mod tests {
     async fn test_double_connect_drop_first_transient() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -1306,7 +1306,7 @@ pub(crate) mod tests {
     async fn test_invalid_protocol_name() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -1347,7 +1347,7 @@ pub(crate) mod tests {
     async fn test_invalid_protocol_level() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -1398,7 +1398,7 @@ pub(crate) mod tests {
     async fn test_connect_auth_succeeded() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -1443,7 +1443,7 @@ pub(crate) mod tests {
     async fn test_connect_unknown_client() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -1495,7 +1495,7 @@ pub(crate) mod tests {
     async fn test_connect_authentication_failed() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -1551,7 +1551,7 @@ pub(crate) mod tests {
             }))
             .build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -1605,7 +1605,7 @@ pub(crate) mod tests {
             .with_authorizer(|_: &Activity| Err(AuthorizeError))
             .build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
         let connect1 = proto::Connect {
@@ -2071,10 +2071,10 @@ pub(crate) mod tests {
             }))
             .build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
-        let (client_id, mut rx) = connect_client("pub", &mut broker_handle).await.unwrap();
+        let (client_id, mut rx) = connect_client("pub", &broker_handle).await.unwrap();
 
         let publish = proto::Publish {
             packet_identifier_dup_qos: proto::PacketIdentifierDupQoS::AtLeastOnce(
@@ -2109,10 +2109,10 @@ pub(crate) mod tests {
             }))
             .build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
-        let (client_id, mut rx1) = connect_client("sub", &mut broker_handle).await.unwrap();
+        let (client_id, mut rx1) = connect_client("sub", &broker_handle).await.unwrap();
 
         let subscribe = proto::Subscribe {
             packet_identifier: proto::PacketIdentifier::new(1).unwrap(),
@@ -2150,15 +2150,13 @@ pub(crate) mod tests {
     async fn test_notify_state_change_single_connection() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
-        let (a_id, mut a_rx) = connect_client("client_a", &mut broker_handle)
-            .await
-            .unwrap();
+        let (a_id, mut a_rx) = connect_client("client_a", &broker_handle).await.unwrap();
 
         send_subscribe(
-            &mut broker_handle,
+            &broker_handle,
             &mut a_rx,
             a_id.clone(),
             &["$edgehub/connected"],
@@ -2189,22 +2187,16 @@ pub(crate) mod tests {
     async fn test_notify_state_change_multiple_connection() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
-        let (a_id, mut a_rx) = connect_client("client_a", &mut broker_handle)
-            .await
-            .unwrap();
+        let (a_id, mut a_rx) = connect_client("client_a", &broker_handle).await.unwrap();
 
-        connect_client("client_b", &mut broker_handle)
-            .await
-            .unwrap();
-        connect_client("client_c", &mut broker_handle)
-            .await
-            .unwrap();
+        connect_client("client_b", &broker_handle).await.unwrap();
+        connect_client("client_c", &broker_handle).await.unwrap();
 
         send_subscribe(
-            &mut broker_handle,
+            &broker_handle,
             &mut a_rx,
             a_id.clone(),
             &["$edgehub/connected"],
@@ -2218,22 +2210,16 @@ pub(crate) mod tests {
     async fn test_notify_state_change_add_remove_connection() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
-        let (a_id, mut a_rx) = connect_client("client_a", &mut broker_handle)
-            .await
-            .unwrap();
+        let (a_id, mut a_rx) = connect_client("client_a", &broker_handle).await.unwrap();
 
-        connect_client("client_b", &mut broker_handle)
-            .await
-            .unwrap();
-        connect_client("client_c", &mut broker_handle)
-            .await
-            .unwrap();
+        connect_client("client_b", &broker_handle).await.unwrap();
+        connect_client("client_c", &broker_handle).await.unwrap();
 
         send_subscribe(
-            &mut broker_handle,
+            &broker_handle,
             &mut a_rx,
             a_id.clone(),
             &["$edgehub/connected"],
@@ -2241,12 +2227,10 @@ pub(crate) mod tests {
         .await;
         check_notify_received(&mut a_rx, &["client_a", "client_b", "client_c"]).await;
 
-        connect_client("client_d", &mut broker_handle)
-            .await
-            .unwrap();
+        connect_client("client_d", &broker_handle).await.unwrap();
         check_notify_received(&mut a_rx, &["client_a", "client_b", "client_c", "client_d"]).await;
 
-        disconnect_client("client_c", &mut broker_handle).await;
+        disconnect_client("client_c", &broker_handle).await;
         check_notify_received(&mut a_rx, &["client_a", "client_b", "client_d"]).await;
     }
 
@@ -2254,19 +2238,15 @@ pub(crate) mod tests {
     async fn test_notify_state_change_add_remove_subscription() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
-        let (a_id, mut a_rx) = connect_client("client_a", &mut broker_handle)
-            .await
-            .unwrap();
+        let (a_id, mut a_rx) = connect_client("client_a", &broker_handle).await.unwrap();
 
-        let (b_id, mut b_rx) = connect_client("client_b", &mut broker_handle)
-            .await
-            .unwrap();
+        let (b_id, mut b_rx) = connect_client("client_b", &broker_handle).await.unwrap();
 
         send_subscribe(
-            &mut broker_handle,
+            &broker_handle,
             &mut a_rx,
             a_id.clone(),
             &["$edgehub/client_b/subscriptions"],
@@ -2274,13 +2254,13 @@ pub(crate) mod tests {
         .await;
         check_notify_received(&mut a_rx, &[]).await;
 
-        send_subscribe(&mut broker_handle, &mut b_rx, b_id.clone(), &["foo"]).await;
+        send_subscribe(&broker_handle, &mut b_rx, b_id.clone(), &["foo"]).await;
         check_notify_received(&mut a_rx, &["foo"]).await;
 
-        send_subscribe(&mut broker_handle, &mut b_rx, b_id.clone(), &["bar"]).await;
+        send_subscribe(&broker_handle, &mut b_rx, b_id.clone(), &["bar"]).await;
         check_notify_received(&mut a_rx, &["foo", "bar"]).await;
 
-        send_unsubscribe(&mut broker_handle, &mut b_rx, b_id.clone(), &["foo"]).await;
+        send_unsubscribe(&broker_handle, &mut b_rx, b_id.clone(), &["foo"]).await;
         check_notify_received(&mut a_rx, &["bar"]).await;
     }
 
@@ -2288,19 +2268,15 @@ pub(crate) mod tests {
     async fn test_notify_state_change_add_remove_multiple_subscriptions() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
-        let (a_id, mut a_rx) = connect_client("client_a", &mut broker_handle)
-            .await
-            .unwrap();
+        let (a_id, mut a_rx) = connect_client("client_a", &broker_handle).await.unwrap();
 
-        let (b_id, mut b_rx) = connect_client("client_b", &mut broker_handle)
-            .await
-            .unwrap();
+        let (b_id, mut b_rx) = connect_client("client_b", &broker_handle).await.unwrap();
 
         send_subscribe(
-            &mut broker_handle,
+            &broker_handle,
             &mut a_rx,
             a_id.clone(),
             &["$edgehub/client_b/subscriptions"],
@@ -2309,7 +2285,7 @@ pub(crate) mod tests {
         check_notify_received(&mut a_rx, &[]).await;
 
         send_subscribe(
-            &mut broker_handle,
+            &broker_handle,
             &mut b_rx,
             b_id.clone(),
             &["foo", "bar", "baz"],
@@ -2317,7 +2293,7 @@ pub(crate) mod tests {
         .await;
         check_notify_received(&mut a_rx, &["foo", "bar", "baz"]).await;
 
-        send_unsubscribe(&mut broker_handle, &mut b_rx, b_id.clone(), &["foo", "baz"]).await;
+        send_unsubscribe(&broker_handle, &mut b_rx, b_id.clone(), &["foo", "baz"]).await;
         check_notify_received(&mut a_rx, &["bar"]).await;
     }
 
@@ -2325,21 +2301,17 @@ pub(crate) mod tests {
     async fn test_notify_state_change_existing_subscriptions() {
         let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
 
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         tokio::spawn(broker.run().map(drop));
 
-        let (a_id, mut a_rx) = connect_client("client_a", &mut broker_handle)
-            .await
-            .unwrap();
+        let (a_id, mut a_rx) = connect_client("client_a", &broker_handle).await.unwrap();
 
-        let (b_id, mut b_rx) = connect_client("client_b", &mut broker_handle)
-            .await
-            .unwrap();
+        let (b_id, mut b_rx) = connect_client("client_b", &broker_handle).await.unwrap();
 
-        send_subscribe(&mut broker_handle, &mut b_rx, b_id.clone(), &["foo", "bar"]).await;
-        send_subscribe(&mut broker_handle, &mut b_rx, b_id.clone(), &["baz"]).await;
+        send_subscribe(&broker_handle, &mut b_rx, b_id.clone(), &["foo", "bar"]).await;
+        send_subscribe(&broker_handle, &mut b_rx, b_id.clone(), &["baz"]).await;
         send_subscribe(
-            &mut broker_handle,
+            &broker_handle,
             &mut a_rx,
             a_id.clone(),
             &["$edgehub/client_b/subscriptions"],
@@ -2355,7 +2327,7 @@ pub(crate) mod tests {
 
     async fn connect_client(
         client_id: &str,
-        broker_handle: &mut BrokerHandle,
+        broker_handle: &BrokerHandle,
     ) -> Result<(ClientId, UnboundedReceiver<Message>), Error> {
         let connect = persistent_connect(client_id.into());
 
@@ -2386,7 +2358,7 @@ pub(crate) mod tests {
         Ok((client_id, rx))
     }
 
-    async fn disconnect_client(client_id: &str, broker_handle: &mut BrokerHandle) {
+    async fn disconnect_client(client_id: &str, broker_handle: &BrokerHandle) {
         let event = ClientEvent::Disconnect(proto::Disconnect {});
 
         broker_handle
@@ -2395,7 +2367,7 @@ pub(crate) mod tests {
     }
 
     async fn send_subscribe(
-        handle: &mut BrokerHandle,
+        handle: &BrokerHandle,
         rx: &mut UnboundedReceiver<Message>,
         client_id: ClientId,
         topics: &[&str],
@@ -2421,7 +2393,7 @@ pub(crate) mod tests {
     }
 
     async fn send_unsubscribe(
-        handle: &mut BrokerHandle,
+        handle: &BrokerHandle,
         rx: &mut UnboundedReceiver<Message>,
         client_id: ClientId,
         topics: &[&str],

--- a/mqtt/mqtt-broker/src/connection/mod.rs
+++ b/mqtt/mqtt-broker/src/connection/mod.rs
@@ -59,7 +59,7 @@ impl ConnectionHandle {
         Self::new(Uuid::new_v4(), sender)
     }
 
-    pub fn send(&mut self, message: Message) -> Result<(), Error> {
+    pub fn send(&self, message: Message) -> Result<(), Error> {
         self.sender
             .send(message)
             .map_err(Error::SendConnectionMessage)
@@ -86,7 +86,7 @@ impl PartialEq for ConnectionHandle {
 pub async fn process<I, N, P>(
     io: I,
     remote_addr: SocketAddr,
-    mut broker_handle: BrokerHandle,
+    broker_handle: BrokerHandle,
     authenticator: &N,
     make_processor: P,
 ) -> Result<(), Error>
@@ -250,7 +250,7 @@ where
 async fn incoming_task<S, P>(
     client_id: ClientId,
     mut incoming: S,
-    mut broker: BrokerHandle,
+    broker: BrokerHandle,
     mut processor: P,
 ) -> Result<(), Error>
 where
@@ -286,7 +286,7 @@ where
 async fn outgoing_task<S, P>(
     mut messages: UnboundedReceiver<Message>,
     mut outgoing: S,
-    mut broker: BrokerHandle,
+    broker: BrokerHandle,
     mut processor: P,
 ) -> Result<(), (UnboundedReceiver<Message>, Error)>
 where

--- a/mqtt/mqtt-broker/src/lib.rs
+++ b/mqtt/mqtt-broker/src/lib.rs
@@ -38,6 +38,7 @@ use std::{
     sync::Arc,
 };
 
+use chrono::{DateTime, Utc};
 use proto::Publication;
 use serde::{Deserialize, Serialize};
 use tokio::sync::OwnedSemaphorePermit;
@@ -385,6 +386,10 @@ pub enum SystemEvent {
     /// The main difference is `ClientEvent::Publish` it doesn't require
     /// ClientId of sender to be passed along with the event.
     Publish(Publication),
+
+    /// An event for a broker to go through offline sessions
+    /// and clean up ones that past provided expiration time.
+    SessionCleanup(DateTime<Utc>),
 }
 
 impl Debug for SystemEvent {
@@ -397,6 +402,9 @@ impl Debug for SystemEvent {
             }
             SystemEvent::Publish(publication) => {
                 f.debug_tuple("Publish").field(&publication).finish()
+            }
+            SystemEvent::SessionCleanup(instant) => {
+                f.debug_tuple("SessionCleanup").field(&instant).finish()
             }
         }
     }

--- a/mqtt/mqtt-broker/src/proptest.rs
+++ b/mqtt/mqtt-broker/src/proptest.rs
@@ -2,13 +2,15 @@
 use std::{net::IpAddr, net::SocketAddr, time::Duration};
 
 use bytes::Bytes;
-use mqtt3::proto;
+use chrono::Utc;
 use proptest::{
     bool,
     collection::{hash_map, vec, vec_deque},
     num,
     prelude::*,
 };
+
+use mqtt3::proto;
 
 use crate::{
     AuthId, BrokerSnapshot, ClientId, ClientInfo, Publish, Segment, SessionSnapshot, Subscription,
@@ -34,6 +36,7 @@ prop_compose! {
             client_info,
             subscriptions,
             waiting_to_be_sent,
+            Utc::now()
         )
     }
 }

--- a/mqtt/mqtt-broker/src/server.rs
+++ b/mqtt/mqtt-broker/src/server.rs
@@ -110,7 +110,7 @@ where
             listeners,
             make_processor,
         } = self;
-        let mut handle = broker.handle();
+        let handle = broker.handle();
 
         // prepare dispatcher in a separate task
         let broker_task = tokio::spawn(broker.run());

--- a/mqtt/mqtt-broker/src/session/connected.rs
+++ b/mqtt/mqtt-broker/src/session/connected.rs
@@ -130,7 +130,7 @@ impl ConnectedSession {
         Ok(unsuback)
     }
 
-    pub fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
+    pub fn send(&self, event: ClientEvent) -> Result<(), Error> {
         let message = Message::Client(self.state.client_id().clone(), event);
         self.handle.send(message)
     }

--- a/mqtt/mqtt-broker/src/session/connected.rs
+++ b/mqtt/mqtt-broker/src/session/connected.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use chrono::Utc;
 use tracing::warn;
 
 use mqtt3::proto;
@@ -34,7 +35,11 @@ impl ConnectedSession {
     }
 
     pub fn snapshot(&self) -> SessionSnapshot {
-        self.state.clone().into()
+        self.state.clone().into_snapshot(Utc::now())
+    }
+
+    pub fn into_snapshot(self) -> SessionSnapshot {
+        self.state.into_snapshot(Utc::now())
     }
 
     pub fn state(&self) -> &SessionState {

--- a/mqtt/mqtt-broker/src/session/disconnecting.rs
+++ b/mqtt/mqtt-broker/src/session/disconnecting.rs
@@ -30,7 +30,7 @@ impl DisconnectingSession {
         self.will
     }
 
-    pub fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
+    pub fn send(&self, event: ClientEvent) -> Result<(), Error> {
         let message = Message::Client(self.client_info().client_id().clone(), event);
         self.handle.send(message)
     }

--- a/mqtt/mqtt-broker/src/session/mod.rs
+++ b/mqtt/mqtt-broker/src/session/mod.rs
@@ -190,11 +190,11 @@ impl Session {
         }
     }
 
-    pub fn send(&mut self, event: ClientEvent) -> Result<(), Error> {
+    pub fn send(&self, event: ClientEvent) -> Result<(), Error> {
         match self {
-            Self::Transient(ref mut connected) => connected.send(event),
-            Self::Persistent(ref mut connected) => connected.send(event),
-            Self::Disconnecting(ref mut disconnecting) => disconnecting.send(event),
+            Self::Transient(connected) => connected.send(event),
+            Self::Persistent(connected) => connected.send(event),
+            Self::Disconnecting(disconnecting) => disconnecting.send(event),
             _ => Err(Error::SessionOffline),
         }
     }

--- a/mqtt/mqtt-broker/src/settings/mod.rs
+++ b/mqtt/mqtt-broker/src/settings/mod.rs
@@ -46,6 +46,8 @@ impl BrokerConfig {
 pub struct SessionConfig {
     #[serde(with = "humantime_serde")]
     expiration: Duration,
+    #[serde(with = "humantime_serde")]
+    cleanup_interval: Duration,
     max_message_size: Option<HumanSize>,
     max_inflight_messages: usize,
     max_queued_messages: usize,
@@ -56,6 +58,7 @@ pub struct SessionConfig {
 impl SessionConfig {
     pub fn new(
         expiration: Duration,
+        cleanup_interval: Duration,
         max_message_size: Option<HumanSize>,
         max_inflight_messages: usize,
         max_queued_messages: usize,
@@ -64,6 +67,7 @@ impl SessionConfig {
     ) -> Self {
         Self {
             expiration,
+            cleanup_interval,
             max_message_size,
             max_inflight_messages,
             max_queued_messages,
@@ -93,12 +97,21 @@ impl SessionConfig {
     pub fn when_full(&self) -> QueueFullAction {
         self.when_full
     }
+
+    pub fn expiration(&self) -> Duration {
+        self.expiration
+    }
+
+    pub fn cleanup_interval(&self) -> Duration {
+        self.cleanup_interval
+    }
 }
 
 impl Default for SessionConfig {
     fn default() -> Self {
         SessionConfig::new(
             Duration::from_secs(60 * DAYS),
+            Duration::from_secs(DAYS), // 1d
             Some(HumanSize::new_kilobytes(256).expect("256kb")),
             16,
             1000,

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 
+use chrono::{DateTime, Utc};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tracing::{info, warn};
 
@@ -30,6 +31,7 @@ pub struct SessionSnapshot {
     client_info: ClientInfo,
     subscriptions: HashMap<String, Subscription>,
     waiting_to_be_sent: VecDeque<Publication>,
+    last_active: DateTime<Utc>,
 }
 
 impl SessionSnapshot {
@@ -37,11 +39,13 @@ impl SessionSnapshot {
         client_info: ClientInfo,
         subscriptions: HashMap<String, Subscription>,
         waiting_to_be_sent: VecDeque<Publication>,
+        last_active: DateTime<Utc>,
     ) -> Self {
         Self {
             client_info,
             subscriptions,
             waiting_to_be_sent,
+            last_active,
         }
     }
 
@@ -51,11 +55,13 @@ impl SessionSnapshot {
         ClientInfo,
         HashMap<String, Subscription>,
         VecDeque<proto::Publication>,
+        DateTime<Utc>,
     ) {
         (
             self.client_info,
             self.subscriptions,
             self.waiting_to_be_sent,
+            self.last_active,
         )
     }
 }

--- a/mqtt/mqtt-broker/src/state_change.rs
+++ b/mqtt/mqtt-broker/src/state_change.rs
@@ -95,6 +95,8 @@ mod tests {
         str::FromStr,
     };
 
+    use chrono::Utc;
+
     use mqtt3::proto;
 
     use crate::{
@@ -423,7 +425,7 @@ mod tests {
                 state,
             )
         } else {
-            Session::new_offline(state)
+            Session::new_offline(state, Utc::now())
         }
     }
 

--- a/mqtt/mqtt-broker/tests/broker_model.rs
+++ b/mqtt/mqtt-broker/tests/broker_model.rs
@@ -56,7 +56,8 @@ async fn test_broker_manages_sessions(events: impl IntoIterator<Item = BrokerEve
 
     assert_eq!(sessions.len(), model.sessions.len());
 
-    for (client_info, subscriptions, _) in sessions.into_iter().map(|session| session.into_parts())
+    for (client_info, subscriptions, _, _) in
+        sessions.into_iter().map(|session| session.into_parts())
     {
         let model_session = model
             .sessions

--- a/mqtt/mqtt-broker/tests/compliance.rs
+++ b/mqtt/mqtt-broker/tests/compliance.rs
@@ -1,3 +1,9 @@
+///! This module contains tests that verify MQTT protocol compliance.
+///! (qos, ordering, re-delivery, retained messages, will, etc...)
+///! Only MQTT-protocol related tests should be added here.
+///!
+///! For other tests not related to MQTT protocol (like broker config, storage, cleanup)
+///! please use `integration.rs`.
 use std::time::Duration;
 
 use bytes::Bytes;

--- a/mqtt/mqtt-broker/tests/integration.rs
+++ b/mqtt/mqtt-broker/tests/integration.rs
@@ -2,17 +2,159 @@
 ///! of the broker (like config, storage, cleanup, etc...).
 ///!
 ///! For tests related to MQTT protocol please use `compliance.rs`.
-use std::{any::Any, convert::Infallible};
+use std::{any::Any, convert::Infallible, time::Duration};
 
+use chrono::Utc;
 use mqtt3::{proto::ClientId, ConnectionError, Event};
 use mqtt_broker::{
+    auth::AllowAll,
     auth::{Activity, Authorization, Authorizer},
-    BrokerBuilder, Message, SystemEvent,
+    BrokerBuilder, BrokerSnapshot, Message, SystemEvent,
 };
 use mqtt_broker_tests_util::{
     client::TestClientBuilder,
     server::{start_server, DummyAuthenticator},
 };
+
+/// Validates the case when offline session is dropped if expired.
+#[tokio::test]
+async fn drop_session_on_expiry() {
+    let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
+
+    let broker_handle = broker.handle();
+    let mut server_handle = start_server(broker, DummyAuthenticator::with_id("device_1"));
+
+    // connect a client with persistent session.
+    let mut offline_client = TestClientBuilder::new(server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("offline_client".into()))
+        .build();
+
+    // connect another client with persistent session that is always connected.
+    let mut online_client = TestClientBuilder::new(server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("online_client".into()))
+        .build();
+
+    // assert clients connected
+    assert_eq!(
+        offline_client.connections().recv().await,
+        Some(Event::NewConnection {
+            reset_session: true
+        })
+    );
+    assert_eq!(
+        online_client.connections().recv().await,
+        Some(Event::NewConnection {
+            reset_session: true
+        })
+    );
+
+    // disconnect client and bring its session to offline state.
+    offline_client.shutdown().await;
+
+    // let broker process disconnect.
+    tokio::time::delay_for(Duration::from_secs(1)).await;
+
+    // send cleanup signal that should remove the offline session.
+    let expiration = Utc::now();
+    broker_handle
+        .send(Message::System(SystemEvent::SessionCleanup(expiration)))
+        .expect("unable to send cleanup signal");
+
+    // assert that offline session is removed.
+    // and only "online" client's session remains.
+    let (_, mut sessions) = server_handle.shutdown().await.into_parts();
+    assert_eq!(1, sessions.len());
+
+    let (client_info, _, _, _) = sessions.remove(0).into_parts();
+    assert_eq!("online_client", client_info.client_id().as_str());
+
+    // dispose a client.
+    online_client.shutdown().await;
+}
+
+/// Validates the case when offline session is dropped if expired
+/// even if broker restarted.
+#[tokio::test]
+async fn drop_session_on_expiry_after_restart() {
+    let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
+
+    let mut server_handle = start_server(broker, DummyAuthenticator::with_id("device_1"));
+
+    // connect a client with persistent session.
+    let mut offline_client = TestClientBuilder::new(server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("offline_client".into()))
+        .build();
+
+    // connect another client with persistent session that is always connected.
+    let mut online_client = TestClientBuilder::new(server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("online_client".into()))
+        .build();
+
+    // assert clients connected
+    assert_eq!(
+        offline_client.connections().recv().await,
+        Some(Event::NewConnection {
+            reset_session: true
+        })
+    );
+    assert_eq!(
+        online_client.connections().recv().await,
+        Some(Event::NewConnection {
+            reset_session: true
+        })
+    );
+
+    // disconnect client and bring its session to offline state.
+    offline_client.shutdown().await;
+
+    // let broker process disconnect.
+    tokio::time::delay_for(Duration::from_secs(1)).await;
+
+    // take a expiration date now, so sessions created above would be
+    // considered expired.
+    let expiration = Utc::now();
+
+    // restart the broker.
+    let (retained, sessions) = server_handle.shutdown().await.into_parts();
+    assert_eq!(2, sessions.len());
+
+    let broker = BrokerBuilder::default()
+        .with_authorizer(AllowAll)
+        .with_state(BrokerSnapshot::new(retained, sessions))
+        .build();
+
+    let broker_handle = broker.handle();
+    let mut server_handle = start_server(broker, DummyAuthenticator::with_id("device_1"));
+
+    // connect client with the same id and persistent session.
+    let mut online_client = TestClientBuilder::new(server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("online_client".into()))
+        .build();
+
+    // assert client reconnected with persistent session.
+    assert_eq!(
+        online_client.connections().recv().await,
+        Some(Event::NewConnection {
+            reset_session: false
+        })
+    );
+
+    // send cleanup signal that should remove the offline session.
+    broker_handle
+        .send(Message::System(SystemEvent::SessionCleanup(expiration)))
+        .expect("unable to send cleanup signal");
+
+    // assert that offline session is removed.
+    // and only "online" client's session remains.
+    let (_, mut sessions) = server_handle.shutdown().await.into_parts();
+    assert_eq!(1, sessions.len());
+
+    let (client_info, _, _, _) = sessions.remove(0).into_parts();
+    assert_eq!("online_client", client_info.client_id().as_str());
+
+    // dispose a client.
+    online_client.shutdown().await;
+}
 
 /// Validates the case when authorization rules change leads to some
 /// existing sessions (connected or offline) being unauthorized and dropped.
@@ -31,13 +173,19 @@ async fn drop_sessions_on_reauthorize() {
         .build();
 
     // connect another client with persistent session that is always authorized.
-    let root = TestClientBuilder::new(server_handle.address())
+    let mut root_client = TestClientBuilder::new(server_handle.address())
         .with_client_id(ClientId::IdWithExistingSession("root".into()))
         .build();
 
-    // assert client connected
+    // assert clients connected
     assert_eq!(
         client.connections().recv().await,
+        Some(Event::NewConnection {
+            reset_session: true
+        })
+    );
+    assert_eq!(
+        root_client.connections().recv().await,
         Some(Event::NewConnection {
             reset_session: true
         })
@@ -60,12 +208,12 @@ async fn drop_sessions_on_reauthorize() {
     let (_, mut sessions) = server_handle.shutdown().await.into_parts();
     assert_eq!(1, sessions.len());
 
-    let (client_info, _, _) = sessions.remove(0).into_parts();
+    let (client_info, _, _, _) = sessions.remove(0).into_parts();
     assert_eq!("root", client_info.client_id().as_str());
 
     // dispose a client.
     client.shutdown().await;
-    root.shutdown().await;
+    root_client.shutdown().await;
 }
 
 struct BooleanAuthorizer(bool);

--- a/mqtt/mqtt-broker/tests/integration.rs
+++ b/mqtt/mqtt-broker/tests/integration.rs
@@ -1,0 +1,87 @@
+///! This module contains tests that verify non-MQTT related functionality
+///! of the broker (like config, storage, cleanup, etc...).
+///!
+///! For tests related to MQTT protocol please use `compliance.rs`.
+use std::{any::Any, convert::Infallible};
+
+use mqtt3::{proto::ClientId, ConnectionError, Event};
+use mqtt_broker::{
+    auth::{Activity, Authorization, Authorizer},
+    BrokerBuilder, Message, SystemEvent,
+};
+use mqtt_broker_tests_util::{
+    client::TestClientBuilder,
+    server::{start_server, DummyAuthenticator},
+};
+
+/// Validates the case when authorization rules change leads to some
+/// existing sessions (connected or offline) being unauthorized and dropped.
+#[tokio::test]
+async fn drop_sessions_on_reauthorize() {
+    let broker = BrokerBuilder::default()
+        .with_authorizer(BooleanAuthorizer(true))
+        .build();
+
+    let broker_handle = broker.handle();
+    let mut server_handle = start_server(broker, DummyAuthenticator::with_id("device_1"));
+
+    // connect a client with persistent session.
+    let mut client = TestClientBuilder::new(server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("device_1".into()))
+        .build();
+
+    // connect another client with persistent session that is always authorized.
+    let root = TestClientBuilder::new(server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("root".into()))
+        .build();
+
+    // assert client connected
+    assert_eq!(
+        client.connections().recv().await,
+        Some(Event::NewConnection {
+            reset_session: true
+        })
+    );
+
+    broker_handle
+        .send(Message::System(SystemEvent::AuthorizationUpdate(Box::new(
+            false,
+        ))))
+        .expect("unable to send authorization update");
+
+    // assert client disconnected.
+    assert_eq!(
+        client.connections().recv().await,
+        Some(Event::Disconnected(ConnectionError::ServerClosedConnection))
+    );
+
+    // assert that unauthorized persisted session is removed.
+    // and only "root" client's session remains.
+    let (_, mut sessions) = server_handle.shutdown().await.into_parts();
+    assert_eq!(1, sessions.len());
+
+    let (client_info, _, _) = sessions.remove(0).into_parts();
+    assert_eq!("root", client_info.client_id().as_str());
+
+    // dispose a client.
+    client.shutdown().await;
+    root.shutdown().await;
+}
+
+struct BooleanAuthorizer(bool);
+
+impl Authorizer for BooleanAuthorizer {
+    type Error = Infallible;
+
+    fn authorize(&self, activity: &Activity) -> Result<Authorization, Self::Error> {
+        Ok(if self.0 || activity.client_id().as_str() == "root" {
+            Authorization::Allowed
+        } else {
+            Authorization::Forbidden("not authorized".into())
+        })
+    }
+    fn update(&mut self, update: Box<dyn Any>) -> Result<(), Self::Error> {
+        self.0 = *update.downcast_ref::<bool>().expect("expected bool");
+        Ok(())
+    }
+}

--- a/mqtt/mqtt-edgehub/config/default.json
+++ b/mqtt/mqtt-edgehub/config/default.json
@@ -21,6 +21,7 @@
         },
         "session": {
             "expiration": "60d",
+            "cleanup_interval": "1d",
             "max_message_size": "256kb",
             "max_inflight_messages": 16,
             "max_queued_messages": 1000,

--- a/mqtt/mqtt-edgehub/src/settings.rs
+++ b/mqtt/mqtt-edgehub/src/settings.rs
@@ -255,6 +255,7 @@ mod tests {
             settings.broker().session(),
             &SessionConfig::new(
                 Duration::from_secs(60 * DAYS),
+                Duration::from_secs(DAYS), // 1d
                 Some(HumanSize::new_kilobytes(256).expect("256kb")),
                 17,
                 1001,
@@ -281,6 +282,7 @@ mod tests {
                     RetainedMessagesConfig::new(1000, Duration::from_secs(60 * DAYS)),
                     SessionConfig::new(
                         Duration::from_secs(60 * DAYS),
+                        Duration::from_secs(DAYS), // 1d
                         Some(HumanSize::new_kilobytes(256).expect("256kb")),
                         16,
                         1000,

--- a/mqtt/mqtt-generic/config/default.json
+++ b/mqtt/mqtt-generic/config/default.json
@@ -11,6 +11,7 @@
         },
         "session": {
             "expiration": "60d",
+            "cleanup_interval": "1d",
             "max_message_size": "256kb",
             "max_inflight_messages": 16,
             "max_queued_messages": 1000,

--- a/mqtt/mqtt-generic/src/settings.rs
+++ b/mqtt/mqtt-generic/src/settings.rs
@@ -176,6 +176,7 @@ mod tests {
                     RetainedMessagesConfig::new(1000, Duration::from_secs(60 * DAYS)),
                     SessionConfig::new(
                         Duration::from_secs(60 * DAYS),
+                        Duration::from_secs(DAYS), // 1d
                         Some(HumanSize::new_kilobytes(256).expect("256kb")),
                         16,
                         1000,

--- a/mqtt/mqttd/src/app/cleanup.rs
+++ b/mqtt/mqttd/src/app/cleanup.rs
@@ -1,0 +1,36 @@
+use std::time::Duration as StdDuration;
+
+use anyhow::Result;
+use chrono::{Duration, Utc};
+use tokio::time::{self, Instant};
+use tracing::{info, warn};
+
+use mqtt_broker::{BrokerHandle, Message, SystemEvent};
+
+pub async fn start_cleanup(
+    broker_handle: BrokerHandle,
+    cleanup_interval: StdDuration,
+    expiration: StdDuration,
+) -> Result<()> {
+    info!("starting cleanup job...");
+
+    let expiration = Duration::from_std(expiration)?;
+    let tick = tick_cleanup(cleanup_interval, expiration, broker_handle);
+    tokio::spawn(tick);
+
+    Ok(())
+}
+
+async fn tick_cleanup(period: StdDuration, expiration: Duration, broker_handle: BrokerHandle) {
+    info!("cleaning up expired sessions every {:?}", period);
+    let start = Instant::now() + period;
+    let mut interval = time::interval_at(start, period);
+    loop {
+        interval.tick().await;
+        if let Err(e) = broker_handle.send(Message::System(SystemEvent::SessionCleanup(
+            Utc::now() - expiration,
+        ))) {
+            warn!(message = "failed to tick the cleanup job", error = %e);
+        }
+    }
+}

--- a/mqtt/mqttd/src/app/edgehub.rs
+++ b/mqtt/mqttd/src/app/edgehub.rs
@@ -96,7 +96,7 @@ impl Bootstrap for EdgeHubBootstrap {
         config: Self::Settings,
         broker: Broker<Self::Authorizer>,
     ) -> Result<BrokerSnapshot> {
-        let mut broker_handle = broker.handle();
+        let broker_handle = broker.handle();
         let sidecars = make_sidecars(&broker_handle, &config)?;
 
         info!("starting server...");

--- a/mqtt/mqttd/src/app/edgehub.rs
+++ b/mqtt/mqttd/src/app/edgehub.rs
@@ -2,6 +2,7 @@ use std::{
     env, fs,
     future::Future,
     path::{Path, PathBuf},
+    time::Duration as StdDuration,
 };
 
 use anyhow::{bail, Context, Result};
@@ -87,8 +88,16 @@ impl Bootstrap for EdgeHubBootstrap {
         Ok((broker, persistor))
     }
 
-    fn snapshot_interval(&self, settings: &Self::Settings) -> std::time::Duration {
+    fn snapshot_interval(&self, settings: &Self::Settings) -> StdDuration {
         settings.broker().persistence().time_interval()
+    }
+
+    fn session_expiration(&self, settings: &Self::Settings) -> StdDuration {
+        settings.broker().session().expiration()
+    }
+
+    fn session_cleanup_interval(&self, settings: &Self::Settings) -> StdDuration {
+        settings.broker().session().cleanup_interval()
     }
 
     async fn run(

--- a/mqtt/mqttd/src/app/generic.rs
+++ b/mqtt/mqttd/src/app/generic.rs
@@ -1,7 +1,4 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{time::Duration, fs, path::{Path, PathBuf}};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
@@ -53,8 +50,16 @@ impl Bootstrap for GenericBootstrap {
         Ok((broker, persistor))
     }
 
-    fn snapshot_interval(&self, settings: &Self::Settings) -> std::time::Duration {
+    fn snapshot_interval(&self, settings: &Self::Settings) -> Duration {
         settings.broker().persistence().time_interval()
+    }
+
+    fn session_expiration(&self, settings: &Self::Settings) -> Duration {
+        settings.broker().session().expiration()
+    }
+
+    fn session_cleanup_interval(&self, settings: &Self::Settings) -> Duration {
+        settings.broker().session().cleanup_interval()
     }
 
     async fn run(

--- a/mqtt/mqttd/src/app/snapshot.rs
+++ b/mqtt/mqttd/src/app/snapshot.rs
@@ -41,7 +41,7 @@ pub async fn start_snapshotter(
 
 async fn tick_snapshot(
     period: Duration,
-    mut broker_handle: BrokerHandle,
+    broker_handle: BrokerHandle,
     snapshot_handle: StateSnapshotHandle,
 ) {
     info!("persisting state every {:?}", period);
@@ -66,7 +66,7 @@ mod imp {
 
     #[cfg(unix)]
     pub(super) async fn snapshot(
-        mut broker_handle: BrokerHandle,
+        broker_handle: BrokerHandle,
         snapshot_handle: StateSnapshotHandle,
     ) {
         let mut stream = match signal(SignalKind::user_defined1()) {

--- a/mqtt/mqttd/src/app/snapshot.rs
+++ b/mqtt/mqttd/src/app/snapshot.rs
@@ -1,6 +1,6 @@
 use tokio::{
     task::JoinHandle,
-    time::{Duration, Instant},
+    time::{self, Duration, Instant},
 };
 use tracing::{info, warn};
 
@@ -46,7 +46,7 @@ async fn tick_snapshot(
 ) {
     info!("persisting state every {:?}", period);
     let start = Instant::now() + period;
-    let mut interval = tokio::time::interval_at(start, period);
+    let mut interval = time::interval_at(start, period);
     loop {
         interval.tick().await;
         if let Err(e) = broker_handle.send(Message::System(SystemEvent::StateSnapshot(

--- a/mqtt/policy/Cargo.toml
+++ b/mqtt/policy/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 
 [dependencies]
 lazy_static = "1"
+proptest = { version = "0.9", optional = true }
 regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
@@ -14,3 +15,4 @@ thiserror = "1.0"
 
 [dev-dependencies]
 matches = "0.1"
+itertools = "0.9"

--- a/mqtt/policy/src/core/builder.rs
+++ b/mqtt/policy/src/core/builder.rs
@@ -306,7 +306,7 @@ impl Statement {
 }
 
 /// Represents an effect on a statement.
-#[derive(Debug, Deserialize, Copy, Clone)]
+#[derive(Debug, Deserialize, Copy, Clone, PartialOrd, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum Effect {
     Allow,
@@ -320,7 +320,7 @@ mod tests {
     use matches::assert_matches;
 
     use crate::{
-        core::{tests::build_policy, EffectImpl, EffectOrd},
+        core::{tests::build_policy, Effect, EffectOrd},
         validator::ValidatorError,
     };
 
@@ -573,7 +573,7 @@ mod tests {
         assert_eq!(
             EffectOrd {
                 order: 0,
-                effect: EffectImpl::Allow
+                effect: Effect::Allow
             },
             policy.static_rules["actor_a"].0["write"].0["events/telemetry"]
         );
@@ -582,7 +582,7 @@ mod tests {
         assert_eq!(
             EffectOrd {
                 order: 2,
-                effect: EffectImpl::Allow
+                effect: Effect::Allow
             },
             policy.variable_rules["actor_a"].0["read"].0["{{variable}}/#"]
         );
@@ -620,28 +620,28 @@ mod tests {
         assert_eq!(
             policy.static_rules["actor_a"].0["write"].0["events/telemetry"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.static_rules["actor_a"].0["read"].0["events/telemetry"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.static_rules["actor_b"].0["write"].0["events/telemetry"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.static_rules["actor_b"].0["read"].0["events/telemetry"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
@@ -651,42 +651,42 @@ mod tests {
         assert_eq!(
             policy.variable_rules["actor_a"].0["write"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["actor_a"].0["read"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["actor_b"].0["write"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["actor_b"].0["read"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["{{var_actor}}"].0["write"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["{{var_actor}}"].0["read"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: EffectImpl::Allow,
+                effect: Effect::Allow,
                 order: 0
             }
         );
@@ -712,7 +712,7 @@ mod tests {
                 {
                     "effect": "allow",
                     "identities": [
-                        "contoso.azure-devices.net/monitor"
+                        "monitor"
                     ],
                     "operations": [
                         "read"

--- a/mqtt/policy/src/core/builder.rs
+++ b/mqtt/policy/src/core/builder.rs
@@ -19,12 +19,12 @@ pub struct PolicyBuilder<V, M, S> {
     validator: V,
     matcher: M,
     substituter: S,
-    json: String,
+    source: Source,
     default_decision: Decision,
 }
 
 impl PolicyBuilder<DefaultValidator, DefaultResourceMatcher, DefaultSubstituter> {
-    /// Constructs a `PolicyBuilder` from provided json policy definition and
+    /// Constructs a `PolicyBuilder` from provided json policy definition, with
     /// default configuration.
     ///
     /// Call to this method does not parse or validate the json, all heavy work
@@ -33,7 +33,24 @@ impl PolicyBuilder<DefaultValidator, DefaultResourceMatcher, DefaultSubstituter>
         json: impl Into<String>,
     ) -> PolicyBuilder<DefaultValidator, DefaultResourceMatcher, DefaultSubstituter> {
         PolicyBuilder {
-            json: json.into(),
+            source: Source::Json(json.into()),
+            validator: DefaultValidator,
+            matcher: DefaultResourceMatcher,
+            substituter: DefaultSubstituter,
+            default_decision: Decision::Denied,
+        }
+    }
+
+    /// Constructs a `PolicyBuilder` from provided policy definition struct, with
+    /// default configuration.
+    ///
+    /// Call to this method does not validate the definition, all heavy work
+    /// is done in `build` method.
+    pub fn from_definition(
+        definition: PolicyDefinition,
+    ) -> PolicyBuilder<DefaultValidator, DefaultResourceMatcher, DefaultSubstituter> {
+        PolicyBuilder {
+            source: Source::Definition(definition),
             validator: DefaultValidator,
             matcher: DefaultResourceMatcher,
             substituter: DefaultSubstituter,
@@ -52,7 +69,7 @@ where
     /// Specifies the `PolicyValidator` to validate the policy definition.
     pub fn with_validator<V1>(self, validator: V1) -> PolicyBuilder<V1, M, S> {
         PolicyBuilder {
-            json: self.json,
+            source: self.source,
             validator,
             matcher: self.matcher,
             substituter: self.substituter,
@@ -63,7 +80,7 @@ where
     /// Specifies the `ResourceMatcher` to use with `Policy`.
     pub fn with_matcher<M1>(self, matcher: M1) -> PolicyBuilder<V, M1, S> {
         PolicyBuilder {
-            json: self.json,
+            source: self.source,
             validator: self.validator,
             matcher,
             substituter: self.substituter,
@@ -74,7 +91,7 @@ where
     /// Specifies the `Substituter` to use with `Policy`.
     pub fn with_substituter<S1>(self, substituter: S1) -> PolicyBuilder<V, M, S1> {
         PolicyBuilder {
-            json: self.json,
+            source: self.source,
             validator: self.validator,
             matcher: self.matcher,
             substituter,
@@ -96,13 +113,26 @@ where
     ///
     /// Any validation errors are collected and returned as `Error::ValidationSummary`.
     pub fn build(self) -> Result<Policy<M, S>> {
-        let mut definition: PolicyDefinition = PolicyDefinition::from_json(&self.json)?;
+        let PolicyBuilder {
+            validator,
+            matcher,
+            substituter,
+            source,
+            default_decision,
+        } = self;
+
+        let mut definition: PolicyDefinition = match source {
+            Source::Json(json) => PolicyDefinition::from_json(&json)?,
+            Source::Definition(definition) => definition,
+        };
 
         for (order, mut statement) in definition.statements.iter_mut().enumerate() {
             statement.order = order;
         }
 
-        self.validate(&definition)?;
+        validator
+            .validate(&definition)
+            .map_err(|e| Error::Validation(e.into()))?;
 
         let mut static_rules = Identities::new();
         let mut variable_rules = Identities::new();
@@ -112,18 +142,12 @@ where
         }
 
         Ok(Policy {
-            default_decision: self.default_decision,
-            resource_matcher: self.matcher,
-            substituter: self.substituter,
+            default_decision,
+            resource_matcher: matcher,
+            substituter,
             static_rules: static_rules.0,
             variable_rules: variable_rules.0,
         })
-    }
-
-    fn validate(&self, definition: &PolicyDefinition) -> Result<()> {
-        self.validator
-            .validate(definition)
-            .map_err(|e| Error::Validation(e.into()))
     }
 }
 
@@ -215,11 +239,16 @@ fn is_variable_rule(value: &str) -> bool {
     VAR_PATTERN.is_match(value)
 }
 
+enum Source {
+    Json(String),
+    Definition(PolicyDefinition),
+}
+
 /// Represents a deserialized policy definition.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PolicyDefinition {
-    statements: Vec<Statement>,
+    pub(super) statements: Vec<Statement>,
 }
 
 impl PolicyDefinition {
@@ -236,18 +265,18 @@ impl PolicyDefinition {
 }
 
 /// Represents a statement in a policy definition.
-#[derive(Deserialize)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Statement {
     #[serde(default)]
-    order: usize,
+    pub(super) order: usize,
     #[serde(default)]
-    description: String,
-    effect: Effect,
-    identities: Vec<String>,
-    operations: Vec<String>,
+    pub(super) description: String,
+    pub(super) effect: Effect,
+    pub(super) identities: Vec<String>,
+    pub(super) operations: Vec<String>,
     #[serde(default)]
-    resources: Vec<String>,
+    pub(super) resources: Vec<String>,
 }
 
 impl Statement {
@@ -277,7 +306,7 @@ impl Statement {
 }
 
 /// Represents an effect on a statement.
-#[derive(Deserialize, Copy, Clone)]
+#[derive(Debug, Deserialize, Copy, Clone)]
 #[serde(rename_all = "camelCase")]
 pub enum Effect {
     Allow,
@@ -291,7 +320,7 @@ mod tests {
     use matches::assert_matches;
 
     use crate::{
-        core::{tests::build_policy, Effect as CoreEffect, EffectOrd},
+        core::{tests::build_policy, EffectImpl, EffectOrd},
         validator::ValidatorError,
     };
 
@@ -544,7 +573,7 @@ mod tests {
         assert_eq!(
             EffectOrd {
                 order: 0,
-                effect: CoreEffect::Allow
+                effect: EffectImpl::Allow
             },
             policy.static_rules["actor_a"].0["write"].0["events/telemetry"]
         );
@@ -553,7 +582,7 @@ mod tests {
         assert_eq!(
             EffectOrd {
                 order: 2,
-                effect: CoreEffect::Allow
+                effect: EffectImpl::Allow
             },
             policy.variable_rules["actor_a"].0["read"].0["{{variable}}/#"]
         );
@@ -591,28 +620,28 @@ mod tests {
         assert_eq!(
             policy.static_rules["actor_a"].0["write"].0["events/telemetry"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.static_rules["actor_a"].0["read"].0["events/telemetry"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.static_rules["actor_b"].0["write"].0["events/telemetry"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.static_rules["actor_b"].0["read"].0["events/telemetry"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
@@ -622,42 +651,42 @@ mod tests {
         assert_eq!(
             policy.variable_rules["actor_a"].0["write"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["actor_a"].0["read"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["actor_b"].0["write"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["actor_b"].0["read"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["{{var_actor}}"].0["write"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );
         assert_eq!(
             policy.variable_rules["{{var_actor}}"].0["read"].0["devices/{{variable}}/#"],
             EffectOrd {
-                effect: CoreEffect::Allow,
+                effect: EffectImpl::Allow,
                 order: 0
             }
         );

--- a/mqtt/policy/src/core/mod.rs
+++ b/mqtt/policy/src/core/mod.rs
@@ -36,30 +36,21 @@ where
     /// If no rules match the `&Request` - the default `Decision` is returned.
     pub fn evaluate(&self, request: &Request<RC>) -> Result<Decision> {
         match self.eval_static_rules(request) {
-            // static rules not defined. Need to check variable rules.
-            Ok(EffectOrd {
-                effect: EffectImpl::Undefined,
-                ..
-            }) => match self.eval_variable_rules(request) {
+            // static rules undefined. Need to check variable rules.
+            Ok(None) => match self.eval_variable_rules(request) {
                 // variable rules undefined as well. Return default decision.
-                Ok(EffectOrd {
-                    effect: EffectImpl::Undefined,
-                    ..
-                }) => Ok(self.default_decision),
+                Ok(None) => Ok(self.default_decision),
                 // variable rules defined. Return the decision.
-                Ok(effect) => Ok(effect.into()),
+                Ok(Some(effect)) => Ok(effect.into()),
                 Err(e) => Err(e),
             },
             // static rules are defined. Evaluate variable rules and compare priority.
-            Ok(static_effect) => {
+            Ok(Some(static_effect)) => {
                 match self.eval_variable_rules(request) {
                     // variable rules undefined. Proceed with static rule decision.
-                    Ok(EffectOrd {
-                        effect: EffectImpl::Undefined,
-                        ..
-                    }) => Ok(static_effect.into()),
+                    Ok(None) => Ok(static_effect.into()),
                     // variable rules defined. Compare priority and return.
-                    Ok(variable_effect) => {
+                    Ok(Some(variable_effect)) => {
                         // compare order.
                         Ok(if variable_effect > static_effect {
                             static_effect
@@ -76,7 +67,7 @@ where
         }
     }
 
-    fn eval_static_rules(&self, request: &Request<RC>) -> Result<EffectOrd> {
+    fn eval_static_rules(&self, request: &Request<RC>) -> Result<Option<EffectOrd>> {
         // lookup an identity
         match self.static_rules.get(&request.identity) {
             // identity exists. Look up operations.
@@ -85,27 +76,29 @@ where
                 Some(resources) => {
                     // iterate over and match resources.
                     // we need to go through all resources and find one with highest priority (smallest order).
-                    let mut result = &EffectOrd::undefined();
+                    let mut result: Option<EffectOrd> = None;
                     for (resource, effect) in &resources.0 {
-                        if effect.order < result.order // check the order
+                        // check the order first
+                        if effect.order < result.map_or(usize::MAX, |e| e.order)
+                             // only then check that matches
                             && self.resource_matcher.do_match( // only then check that matches
                                 request,
                                 &request.resource,
                                 &resource,
                             )
                         {
-                            result = effect;
+                            result = Some(*effect);
                         }
                     }
-                    Ok(*result)
+                    Ok(result)
                 }
-                None => Ok(EffectOrd::undefined()),
+                None => Ok(None),
             },
-            None => Ok(EffectOrd::undefined()),
+            None => Ok(None),
         }
     }
 
-    fn eval_variable_rules(&self, request: &Request<RC>) -> Result<EffectOrd> {
+    fn eval_variable_rules(&self, request: &Request<RC>) -> Result<Option<EffectOrd>> {
         for (identity, operations) in &self.variable_rules {
             // process identity variables.
             let identity = self.substituter.visit_identity(identity, request)?;
@@ -117,25 +110,27 @@ where
                     Some(resources) => {
                         // iterate over and match resources.
                         // we need to go through all resources and find one with highest priority (smallest order).
-                        let mut result = &EffectOrd::undefined();
+                        let mut result: Option<EffectOrd> = None;
                         for (resource, effect) in &resources.0 {
                             let resource = self.substituter.visit_resource(resource, request)?;
-                            if effect.order < result.order // check the order
-                                && self.resource_matcher.do_match( // only then check that matches
+                            // check the order first
+                            if effect.order < result.map_or(usize::MAX, |e| e.order)
+                                // only then check that matches
+                                && self.resource_matcher.do_match(
                                     request,
                                     &request.resource,
                                     &resource,
                                 )
                             {
-                                result = effect;
+                                result = Some(*effect);
                             }
                         }
                         // continue to look for other identity variable rules
                         // if no resources matched the current one.
-                        if result == &EffectOrd::undefined() {
+                        if result == None {
                             continue;
                         }
-                        Ok(*result)
+                        Ok(result)
                     }
                     // continue to look for other identity variable rules
                     // if no operation found for the current one.
@@ -143,7 +138,7 @@ where
                 };
             }
         }
-        Ok(EffectOrd::undefined())
+        Ok(None)
     }
 }
 
@@ -304,29 +299,15 @@ pub enum Decision {
     Denied,
 }
 
-#[derive(Debug, Copy, Clone, PartialOrd, PartialEq)]
-enum EffectImpl {
-    Allow,
-    Deny,
-    Undefined,
-}
-
 #[derive(Debug, Copy, Clone, PartialEq)]
 struct EffectOrd {
     order: usize,
-    effect: EffectImpl,
+    effect: Effect,
 }
 
 impl EffectOrd {
-    pub fn new(effect: EffectImpl, order: usize) -> Self {
+    pub fn new(effect: Effect, order: usize) -> Self {
         Self { order, effect }
-    }
-
-    pub fn undefined() -> Self {
-        Self {
-            order: usize::MAX,
-            effect: EffectImpl::Undefined,
-        }
     }
 
     /// Merges two `EffectOrd` by replacing with the one with higher priority.
@@ -348,9 +329,8 @@ impl PartialOrd for EffectOrd {
 impl From<EffectOrd> for Decision {
     fn from(effect: EffectOrd) -> Self {
         match effect.effect {
-            EffectImpl::Allow => Decision::Allowed,
-            EffectImpl::Deny => Decision::Denied,
-            EffectImpl::Undefined => Decision::Denied,
+            Effect::Allow => Decision::Allowed,
+            Effect::Deny => Decision::Denied,
         }
     }
 }
@@ -358,8 +338,8 @@ impl From<EffectOrd> for Decision {
 impl From<&Statement> for EffectOrd {
     fn from(statement: &Statement) -> Self {
         match statement.effect() {
-            builder::Effect::Allow => EffectOrd::new(EffectImpl::Allow, statement.order()),
-            builder::Effect::Deny => EffectOrd::new(EffectImpl::Deny, statement.order()),
+            builder::Effect::Allow => EffectOrd::new(Effect::Allow, statement.order()),
+            builder::Effect::Deny => EffectOrd::new(Effect::Deny, statement.order()),
         }
     }
 }
@@ -600,6 +580,21 @@ pub(crate) mod tests {
         let request = Request::new("other_actor", "connect", "").unwrap();
 
         assert_matches!(policy.evaluate(&request), Ok(Decision::Allowed));
+    }
+
+    #[test]
+    fn evaluate_definition_no_statements() {
+        let json = r#"{
+            "schemaVersion": "2020-10-30",
+            "statements": [ ]
+        }"#;
+
+        let policy = build_policy(json);
+
+        let request = Request::new("actor_a", "connect", "").unwrap();
+
+        // default decision expected.
+        assert_matches!(policy.evaluate(&request), Ok(Decision::Denied));
     }
 
     /// Scenario:

--- a/mqtt/policy/src/lib.rs
+++ b/mqtt/policy/src/lib.rs
@@ -17,7 +17,7 @@ mod matcher;
 mod substituter;
 mod validator;
 
-pub use crate::core::{Decision, Policy, Request};
+pub use crate::core::{Decision, Effect, Policy, Request};
 pub use crate::core::{PolicyBuilder, PolicyDefinition, Statement};
 pub use crate::errors::{Error, Result};
 pub use crate::matcher::{DefaultResourceMatcher, ResourceMatcher};


### PR DESCRIPTION
This PR is a set of pending cherry-picks for release/1.2. It contains mostly changes to policy engine and broker authorization.

- Policy engine improvements
- Drop session on re-authorize
- Session cleanup job.
- Fix for MQTT Build images pipeline.

See the list of the commits included.