### PR TITLE
Build Pipeline Optimization: Move only the rust executable into build context

### DIFF
--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -31,7 +31,7 @@ jobs:
           filePath: scripts/linux/cross-platform-rust-build.sh
           arguments: --os alpine --arch amd64 --build-path mqtt/mqttd --cargo-flags '--no-default-features --features="generic"'
 
-      - template: templates/move-rust-artifacts.yaml
+      - template: templates/copy-rust-binaries.yaml
         parameters:
           should.publish.amd64: "true"
           artifact.folder.path: "mqtt/target"
@@ -80,7 +80,7 @@ jobs:
           filePath: scripts/linux/cross-platform-rust-build.sh
           arguments: --os ubuntu18.04 --arch arm32v7 --build-path mqtt/mqttd --cargo-flags '--no-default-features --features="generic"'
 
-      - template: templates/move-rust-artifacts.yaml
+      - template: templates/copy-rust-binaries.yaml
         parameters:
           should.publish.arm32v7: "true"
           artifact.folder.path: "mqtt/target"

--- a/builds/misc/templates/consolidate-edgehub-artifacts.yaml
+++ b/builds/misc/templates/consolidate-edgehub-artifacts.yaml
@@ -9,20 +9,33 @@ parameters:
 
 steps:
   - bash: |
-      # Setup build context
       mkdir -p $(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}
       mkdir -p $(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}/mqtt
       mkdir -p $(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}/watchdog
-
-      # Copy watchdog artifacts
-      cp  -r ${{ parameters['watchdog.artifacts.path'] }} $(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}/watchdog
-
-      # Copy mqtt artifacts
-      cp  -r ${{ parameters['mqtt.artifacts.path'] }} $(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}/mqtt
       cp ${{ parameters['mqtt.config.path'] }} $(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}/mqtt
+    displayName: Setup build context
 
-      # Copy edgehub artifacts
+  - bash: |
       mv  $(Build.BinariesDirectory)/${{ parameters['dotnet.artifacts.path'] }}/docker $(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}
       mv $(Build.BinariesDirectory)/${{ parameters['dotnet.artifacts.path'] }} $(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}
+    displayName: Copy EdgeHub artifacts
 
-    displayName: Copy edgehub, watchdog, and broker artifacts to single folder
+  # Copy broker binaries
+  - template: copy-rust-binaries.yaml
+    parameters:
+      should.publish.amd64: "true"
+      should.publish.arm32v7: "true"
+      should.publish.arm64v8: "true"
+      artifact.folder.path: "${{ parameters['mqtt.artifacts.path'] }}"
+      destination.folder.path: "$(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}/mqtt"
+      artifact.name: "mqttd"
+
+  # Copy watchdog binaries
+  - template: copy-rust-binaries.yaml
+    parameters:
+      should.publish.amd64: "true"
+      should.publish.arm32v7: "true"
+      should.publish.arm64v8: "true"
+      artifact.folder.path: "${{ parameters['watchdog.artifacts.path'] }}"
+      destination.folder.path: "$(Build.BinariesDirectory)/${{ parameters['all.artifacts.path'] }}/watchdog"
+      artifact.name: "watchdog"

--- a/builds/misc/templates/copy-rust-binaries.yaml
+++ b/builds/misc/templates/copy-rust-binaries.yaml
@@ -26,16 +26,16 @@ steps:
       mkdir -p $DESTINATION_DIR
       cp  ${{ parameters['artifact.folder.path'] }}/${{ parameters['target.amd64'] }}/release/${{ parameters['artifact.name'] }} $DESTINATION_DIR/${{ parameters['artifact.name'] }}
     condition: and(eq('${{ parameters['should.publish.amd64'] }}', 'true'), succeeded())
-    displayName: Copy amd64 rust artifacts
+    displayName: Copy amd64 rust binary
   - bash: |
       DESTINATION_DIR=${{ parameters['destination.folder.path'] }}/${{ parameters['target.arm32v7'] }}/release
       mkdir -p $DESTINATION_DIR
       cp  ${{ parameters['artifact.folder.path'] }}/${{ parameters['target.arm32v7'] }}/release/${{ parameters['artifact.name'] }} $DESTINATION_DIR/${{ parameters['artifact.name'] }}
     condition: and(eq('${{ parameters['should.publish.arm32v7'] }}', 'true'), succeeded())
-    displayName: Copy arm32v7 rust artifacts
+    displayName: Copy arm32v7 rust binary
   - bash: |
       DESTINATION_DIR=${{ parameters['destination.folder.path'] }}/${{ parameters['target.arm64v8'] }}/release
       mkdir -p $DESTINATION_DIR
       cp  ${{ parameters['artifact.folder.path'] }}/${{ parameters['target.arm64v8'] }}/release/${{ parameters['artifact.name'] }} $DESTINATION_DIR/${{ parameters['artifact.name'] }}
     condition: and(eq('${{ parameters['should.publish.arm64v8'] }}', 'true'), succeeded())
-    displayName: Copy arm64v8 rust artifacts
+    displayName: Copy arm64v8 rust binary

--- a/builds/misc/templates/copy-rust-binaries.yaml
+++ b/builds/misc/templates/copy-rust-binaries.yaml
@@ -26,16 +26,16 @@ steps:
       mkdir -p $DESTINATION_DIR
       cp  ${{ parameters['artifact.folder.path'] }}/${{ parameters['target.amd64'] }}/release/${{ parameters['artifact.name'] }} $DESTINATION_DIR/${{ parameters['artifact.name'] }}
     condition: and(eq('${{ parameters['should.publish.amd64'] }}', 'true'), succeeded())
-    displayName: Move amd64 rust artifacts
+    displayName: Copy amd64 rust artifacts
   - bash: |
       DESTINATION_DIR=${{ parameters['destination.folder.path'] }}/${{ parameters['target.arm32v7'] }}/release
       mkdir -p $DESTINATION_DIR
       cp  ${{ parameters['artifact.folder.path'] }}/${{ parameters['target.arm32v7'] }}/release/${{ parameters['artifact.name'] }} $DESTINATION_DIR/${{ parameters['artifact.name'] }}
     condition: and(eq('${{ parameters['should.publish.arm32v7'] }}', 'true'), succeeded())
-    displayName: Move arm32v7 rust artifacts
+    displayName: Copy arm32v7 rust artifacts
   - bash: |
       DESTINATION_DIR=${{ parameters['destination.folder.path'] }}/${{ parameters['target.arm64v8'] }}/release
       mkdir -p $DESTINATION_DIR
       cp  ${{ parameters['artifact.folder.path'] }}/${{ parameters['target.arm64v8'] }}/release/${{ parameters['artifact.name'] }} $DESTINATION_DIR/${{ parameters['artifact.name'] }}
     condition: and(eq('${{ parameters['should.publish.arm64v8'] }}', 'true'), succeeded())
-    displayName: Move arm64v8 rust artifacts
+    displayName: Copy arm64v8 rust artifacts

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -3,8 +3,8 @@ FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
-ADD ./watchdog/target/x86_64-unknown-linux-musl/release/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/x86_64-unknown-linux-musl/release/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 # RocksDB requires snappy	

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -3,8 +3,8 @@ FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
-ADD ./watchdog/target/x86_64-unknown-linux-musl/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/x86_64-unknown-linux-musl/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/target/x86_64-unknown-linux-musl/release/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/target/x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 # RocksDB requires snappy	

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -3,8 +3,8 @@ FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
-ADD ./watchdog/target/x86_64-unknown-linux-musl/release/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/target/x86_64-unknown-linux-musl/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/target/x86_64-unknown-linux-musl/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 # RocksDB requires snappy	

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,8 +1,8 @@
 ARG base_tag=1.0.6.4-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
-ADD ./watchdog/target/armv7-unknown-linux-gnueabihf/release/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/target/armv7-unknown-linux-gnueabihf/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/target/armv7-unknown-linux-gnueabihf/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 WORKDIR /app

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,8 +1,8 @@
 ARG base_tag=1.0.6.4-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
-ADD ./watchdog/target/armv7-unknown-linux-gnueabihf/release/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/armv7-unknown-linux-gnueabihf/release/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 WORKDIR /app

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,8 +1,8 @@
 ARG base_tag=1.0.6.4-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
-ADD ./watchdog/target/armv7-unknown-linux-gnueabihf/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/armv7-unknown-linux-gnueabihf/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/target/armv7-unknown-linux-gnueabihf/release/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/target/armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 WORKDIR /app

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,8 +1,8 @@
 ARG base_tag=1.0.6.4-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
-ADD ./watchdog/target/aarch64-unknown-linux-gnu/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/aarch64-unknown-linux-gnu/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/target/aarch64-unknown-linux-gnu/release/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/target/aarch64-unknown-linux-gnu/release/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 WORKDIR /app

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,8 +1,8 @@
 ARG base_tag=1.0.6.4-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
-ADD ./watchdog/target/aarch64-unknown-linux-gnu/release/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/aarch64-unknown-linux-gnu/release/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/aarch64-unknown-linux-gnu/release/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/aarch64-unknown-linux-gnu/release/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 WORKDIR /app

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,8 +1,8 @@
 ARG base_tag=1.0.6.4-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
-ADD ./watchdog/target/aarch64-unknown-linux-gnu/release/watchdog /usr/local/bin/watchdog
-ADD ./mqtt/target/aarch64-unknown-linux-gnu/release/mqttd /usr/local/bin/mqttd
+ADD ./watchdog/target/aarch64-unknown-linux-gnu/watchdog /usr/local/bin/watchdog
+ADD ./mqtt/target/aarch64-unknown-linux-gnu/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
 
 WORKDIR /app


### PR DESCRIPTION
I thought I made this optimization a while ago when I did it for the mqtt image build, but I forgot. This change will copy only the executable into the build context instead of the whole target folder. This reduces the build context size and will trim some time off the build pipeline.