### PR TITLE
Fix policy test flakiness

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.IO;
     using System.Linq;
     using System.Net;
-    using System.Reflection.Metadata.Ecma335;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
     using System.Threading;

--- a/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
@@ -137,10 +137,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 },
                 token);
 
-
             // Create device manually. We can't use LeafDevice.CreateAsync() since it is not
             // idempotent and cannot be retried reliably.
-            Devices.Device edge = await iotHub.GetDeviceIdentityAsync(this.runtime.DeviceId, token);
+            Devices.Device edge = await this.iotHub.GetDeviceIdentityAsync(this.runtime.DeviceId, token);
             Devices.Device leaf = new Devices.Device(deviceId2)
             {
                 Authentication = new AuthenticationMechanism
@@ -150,9 +149,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Scope = edge.Scope
             };
 
-            leaf = await iotHub.CreateDeviceIdentityAsync(leaf, token);
+            leaf = await this.iotHub.CreateDeviceIdentityAsync(leaf, token);
             string connectionString =
-                $"HostName={iotHub.Hostname};" +
+                $"HostName={this.iotHub.Hostname};" +
                 $"DeviceId={leaf.Id};" +
                 $"SharedAccessKey={leaf.Authentication.SymmetricKey.PrimaryKey};" +
                 $"GatewayHostName={Dns.GetHostName().ToLower()}";
@@ -168,7 +167,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 await client.OpenAsync();
             }, token);
 
-            await iotHub.DeleteDeviceIdentityAsync(leaf, token);
+            await this.iotHub.DeleteDeviceIdentityAsync(leaf, token);
         }
 
         /// <summary>


### PR DESCRIPTION
There was another issue in Policy tests that make them flaky. `LeafDevice.CreateAsync` appears to be not idempotent, so there is a race condition, when LeafDevice tries to connect before the policy is updated, and in case of failed authorization, it tries to delete and re-create the device. That screws up cached symmetric keys in EH. And since EH does not refresh the device scopes (and keys) more often that 2min, the test fails after several retries.

The solution is to not to use `LeafDevice` - not to remove the device in case of authorization error, but just retry again.