### PR TITLE
Set default auth mode to Scope (#4095)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -265,18 +265,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
             if (!Enum.TryParse(this.configuration.GetValue("AuthenticationMode", string.Empty), true, out AuthenticationMode authenticationMode))
             {
-                if (!hasParentEdge)
-                {
-                    // Default setting should be local auth with fallback to cloud auth
-                    authenticationMode = AuthenticationMode.CloudAndScope;
-                }
-                else
-                {
-                    // If the Edge is nested and connects to a parent Edge, then we
-                    // should only allow local authentication as we don't expect to
-                    // have internet connectivity.
-                    authenticationMode = AuthenticationMode.Scope;
-                }
+                authenticationMode = AuthenticationMode.Scope;
             }
 
             int scopeCacheRefreshRateSecs = this.configuration.GetValue("DeviceScopeCacheRefreshRateSecs", 3600);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/appsettings_hub.json
@@ -74,7 +74,7 @@
   "ConnectivityCheckFrequencySecs": 300,
   "MaxConnectedClients": 100,
   "CacheTokens": false,
-  "AuthenticationMode": "CloudAndScope",
+  "AuthenticationMode": "Scope",
   "DeviceScopeCacheRefreshRateSecs": 3600,
   "DeviceScopeCacheRefreshDelaySecs": 120,
   "CloudConnectionIdleTimeoutSecs": 3600,

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                     iotHubConnectionStringBuilder.ModuleId,
                     string.Empty,
                     Option.None<string>(),
-                    AuthenticationMode.CloudAndScope,
+                    AuthenticationMode.Scope,
                     Option.Some(edgeHubConnectionString),
                     false,
                     usePersistentStorage,

--- a/scripts/linux/runE2ETest.sh
+++ b/scripts/linux/runE2ETest.sh
@@ -863,6 +863,7 @@ function run_quickstartcerts_test() {
         -d "$device_id-leaf" \
         -ct "${certs[0]}" \
         -ed "$(hostname)" && ret=$? || ret=$?
+        -ed-id "$device_id"
 
     local elapsed_seconds=$SECONDS
     test_end_time="$(date '+%Y-%m-%d %H:%M:%S')"

--- a/smoke/LeafDevice/details/Details.cs
+++ b/smoke/LeafDevice/details/Details.cs
@@ -175,9 +175,24 @@ namespace LeafDeviceTest
                         try
                         {
                             await deviceClient.SendEventAsync(message);
+                            if (string.IsNullOrWhiteSpace(this.context.Device.Scope))
+                            {
+                                throw new InvalidOperationException("Expected to throw exception");
+                            }
+
                             Console.WriteLine("Message Sent.");
                             await deviceClient.SetMethodHandlerAsync("DirectMethod", DirectMethod, null);
                             Console.WriteLine("Direct method callback is set.");
+                            break;
+                        }
+                        catch (InvalidOperationException) when (string.IsNullOrWhiteSpace(this.context.Device.Scope))
+                        {
+                            Console.WriteLine("Expected exception was not thrown");
+                            throw;
+                        }
+                        catch (UnauthorizedAccessException ex) when (!string.IsNullOrWhiteSpace(this.context.Device.Scope))
+                        {
+                            Console.WriteLine("Expected exception {0}", ex);
                             break;
                         }
                         catch (Exception e)
@@ -244,6 +259,10 @@ namespace LeafDeviceTest
 
         protected async Task VerifyDataOnIoTHubAsync()
         {
+            // Leaf device without parent not expected to send messages
+            if (!this.edgeDeviceId.HasValue)
+                return;
+
             var builder = new EventHubsConnectionStringBuilder(this.eventhubCompatibleEndpointWithEntityPath)
             {
                 TransportType = this.eventHubClientTransportType
@@ -294,6 +313,10 @@ namespace LeafDeviceTest
 
         protected async Task VerifyDirectMethodAsync()
         {
+            // Leaf device without parent not expected to succed dm
+            if (!this.edgeDeviceId.HasValue)
+                return;
+
             // User Service SDK to invoke Direct Method on the device.
             var settings = new ServiceClientTransportSettings();
             this.proxy.ForEach(p => settings.HttpProxy = p);

--- a/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 leafDeviceId,
                 Protocol.Amqp,
                 AuthenticationType.Sas,
-                Option.None<string>(),
+                Option.Some(this.runtime.DeviceId),
                 false,
                 CertificateAuthority.GetQuickstart(),
                 this.iotHub,


### PR DESCRIPTION
Cherry-pick #4095
Authentication mode is set as Scope by default. This is a breaking change for leaf devices which are not in scope of edge device. Customer can set the env variable to AuthenticationMode to CloudAndScope if they need to, going forward this option will be deprecated. Will follow up with Emmanuel to have this breaking change documented.