### PR TITLE
Update current config when plan is empty

### DIFF
--- a/doc/BuiltInMetrics.md
+++ b/doc/BuiltInMetrics.md
@@ -54,7 +54,7 @@ instance_number | A Guid representing the current runtime. On restart, all metri
 | `edgeAgent_command_latency_seconds` | `command` | How long it took docker to execute the given command. Possible commands are: create, update,  remove, start, stop, restart | Gauge |
 | `edgeAgent_iothub_syncs_total` |  | The amount of times edgeAgent attempted to sync its twin with iotHub, both successful and unsuccessful. This incudes both agent requesting a twin and hub notifying of a twin update | Counter |
 | `edgeAgent_unsuccessful_iothub_syncs_total` |  | The amount of times edgeAgent failed to sync its twin with iotHub. | Counter |
-| `edgeAgent_deployment_time_seconds` |  | The amount of time it took to complete a new deployment after recieving a change. | Counter |
+| `edgeAgent_deployment_time_seconds` |  | The amount of time it took to complete a new deployment after receiving a change. | Counter |
 | `edgeagent_direct_method_invocations_count` | `method_name` | Number of times a built-in edgeAgent direct method is called, such as Ping or Restart. | Counter |
 |||
 | `edgeAgent_host_uptime_seconds` || How long the host has been on | Gauge |
@@ -65,7 +65,7 @@ instance_number | A Guid representing the current runtime. On restart, all metri
 | `edgeAgent_total_memory_bytes` | `module_name` | RAM available | Gauge |
 | `edgeAgent_used_cpu_percent` | `module_name` | Percent of cpu used by all processes | Histogram |
 | `edgeAgent_created_pids_total` | `module_name` | The number of processes or threads the container has created | Gauge |
-| `edgeAgent_total_network_in_bytes` | `module_name` | The amount of bytes recieved from the network | Gauge |
+| `edgeAgent_total_network_in_bytes` | `module_name` | The amount of bytes received from the network | Gauge |
 | `edgeAgent_total_network_out_bytes` | `module_name` | The amount of bytes sent to network | Gauge |
 | `edgeAgent_total_disk_read_bytes` | `module_name` | The amount of bytes read from the disk | Gauge |
 | `edgeAgent_total_disk_write_bytes` | `module_name` | The amount of bytes written to disk | Gauge |

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
@@ -146,7 +146,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
                         if (plan.IsEmpty)
                         {
-                            await this.UpdateCurrentConfig(deploymentConfigInfo);
+                            if (this.currentConfig.Version != deploymentConfigInfo.Version)
+                            {
+                                await this.UpdateCurrentConfig(deploymentConfigInfo);
+                            }
+
                             this.status = DeploymentStatus.Success;
                         }
                         else

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Agent.cs
@@ -146,6 +146,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
                         if (plan.IsEmpty)
                         {
+                            await this.UpdateCurrentConfig(deploymentConfigInfo);
                             this.status = DeploymentStatus.Success;
                         }
                         else

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/AgentTests.cs
@@ -129,6 +129,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 .ReturnsAsync(ImmutableDictionary<string, IModuleIdentity>.Empty);
             mockPlanner.Setup(pl => pl.PlanAsync(It.Is<ModuleSet>(ms => ms.Equals(desiredModuleSet)), currentModuleSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty))
                 .Returns(Task.FromResult(Plan.Empty));
+            mockReporter.Setup(r => r.ReportAsync(token, It.IsAny<ModuleSet>(), It.IsAny<IRuntimeInfo>(), It.IsAny<long>(), DeploymentStatus.Success))
+                .Returns(Task.CompletedTask);
 
             var agent = new Agent(mockConfigSource.Object, mockEnvironmentProvider.Object, mockPlanner.Object, mockPlanRunner.Object, mockReporter.Object, mockModuleIdentityLifecycleManager.Object, configStore, DeploymentConfigInfo.Empty, serde, encryptionDecryptionProvider, availabilityMetric);
 
@@ -136,7 +138,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
 
             mockEnvironment.Verify(env => env.GetModulesAsync(token), Times.Once);
             mockPlanner.Verify(pl => pl.PlanAsync(It.Is<ModuleSet>(ms => ms.Equals(desiredModuleSet)), currentModuleSet, runtimeInfo, ImmutableDictionary<string, IModuleIdentity>.Empty), Times.Once);
-            mockReporter.Verify(r => r.ReportAsync(token, currentModuleSet, runtimeInfo, DeploymentConfigInfo.Empty.Version, DeploymentStatus.Success), Times.Once);
+            mockReporter.Verify(r => r.ReportAsync(token, currentModuleSet, runtimeInfo, deploymentConfigInfo.Version, DeploymentStatus.Success), Times.Once);
             mockPlanRunner.Verify(r => r.ExecuteAsync(1, Plan.Empty, token), Times.Never);
         }
 


### PR DESCRIPTION
edgeAgent should save the current config with the corresponding version even when there is no update in the deployment but just the version update and report back to iothub.