### PR TITLE
Remove conflicting packages left by iiot runs

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -100,11 +100,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
         {
             SupportedPackageExtension.Deb => new[]
             {
-                "apt-get purge --yes libiothsm-std iotedge"
+                "apt-get purge --yes aziot-edge aziot-identity-service libiothsm-std iotedge"
             },
             SupportedPackageExtension.Rpm => new[]
             {
-                "yum remove -y --remove-leaves libiothsm-std iotedge"
+                "yum remove -y --remove-leaves aziot-edge aziot-identity-service libiothsm-std iotedge"
             },
             _ => throw new NotImplementedException($"Don't know how to uninstall daemon on for '.{this.packageExtension}'")
         };


### PR DESCRIPTION
iiot usually cleans up its packages on completion, but won't be able to do this if it crashes, times out, or is canceled. Update tests to remove these packages if encountered.