### PR TITLE
Move 'Download aziot-identity-service' to separate file

### DIFF
--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -65,50 +65,16 @@ steps:
     downloadType: single
     artifactName: $(artifactName)
 
-- pwsh: |
-    $github_headers = '@{"Accept" = "application/vnd.github.v3+json"; "Authorization" = "token $(TestGitHubAccessToken)"}'
-    $aziot_commit = git submodule | awk '{print $1;}'
-
-    $proxy = ''
-    if($env:AGENT_PROXYURL)
-    {
-      $proxy = "-Proxy $env:AGENT_PROXYURL"
-    }
-
-    for($page = 1; ; $page++)
-    {
-      $url = "https://api.github.com/repos/azure/iot-identity-service/actions/runs?per_page=100&page=$page"
-      $actions_runs = Invoke-Expression "Invoke-WebRequest $proxy -Headers $github_headers -Uri '$url'" | ConvertFrom-JSON
-      $actions_size = $actions_runs.workflow_runs | Measure-Object
-
-      if($actions_size.Count -eq 0)
-      {
-        # Searched all pages and could not find artifact for submodule commit.
-        exit 1
-      }
-
-      $artifacts_link = $actions_runs.workflow_runs | `
-        where {($_.head_sha -eq $aziot_commit) -and ($_.name -eq 'packages')} | `
-        Select-Object -ExpandProperty artifacts_url
-
-      if([string]::IsNullOrEmpty($artifacts_link))
-      {
-        # Artifact not on this page.
-        continue
-      }
-
-      $artifacts = Invoke-Expression "Invoke-WebRequest $proxy -Headers $github_headers -Uri '$artifacts_link'" | ConvertFrom-JSON
-      $download_link = $artifacts.artifacts | where {$_.name -eq '$(identityServiceArtifactName)'} | `
-        Select-Object -ExpandProperty archive_download_url
-      Invoke-Expression "Invoke-WebRequest $proxy -Headers $github_headers -Uri '$download_link' -OutFile iot-identity-service.zip"
-      Expand-Archive -Path iot-identity-service.zip -DestinationPath iot-identity-service
-
-      $packages = Get-ChildItem -Recurse iot-identity-service -Filter $(identityServicePackageFilter)
-      $packagePath = Convert-Path '$(System.ArtifactsDirectory)/$(artifactName)'
-      Copy-Item $packages -Destination $packagePath
-      exit 0
-    }
-  displayName: Download iot-identity-service package
+- task: PowerShell@2
+  displayName: Download aziot-identity-service
+  inputs:
+    filePath: $(Build.SourcesDirectory)/scripts/local/test/DownloadIdentityService.ps1
+    workingDirectory: $(Build.SourcesDirectory)
+  env:
+    GITHUB_TOKEN: $(TestGitHubAccessToken)
+    ARTIFACT_NAME: $(identityServiceArtifactName)
+    PACKAGE_FILTER: $(identityServicePackageFilter)
+    DOWNLOAD_PATH: $(System.ArtifactsDirectory)/$(artifactName)
 
 - pwsh: |
     $certsDir = '$(System.ArtifactsDirectory)/certs'

--- a/scripts/local/test/DownloadIdentityService.ps1
+++ b/scripts/local/test/DownloadIdentityService.ps1
@@ -1,0 +1,71 @@
+# Downloads the aziot-identity-service package. Run this script from the iotedge repo's root directory.
+#
+# Set the following environment variables before running:
+# - GITHUB_TOKEN: GitHub personal access token. Must have public repo read permissions.
+# - ARTIFACT_NAME: Name of the GitHub artifact. Example: packages_ubuntu-20.04_amd64
+# - PACKAGE_FILTER: Filter for the package in the GitHub artifact. Example: aziot-identity-service_*_amd64.deb
+# - DOWNLOAD_PATH: Where to save the aziot-identity-service package.
+# - AGENT_PROXYURL: HTTP proxy and port, if needed.
+#
+# GitHub artifacts expire after 90 days. So if this script runs more than 90 days after the aziot submodule's
+# commit, it will fail.
+
+$proxy = ''
+if($env:AGENT_PROXYURL)
+{
+    Write-Output "Using proxy $env:AGENT_PROXYURL"
+    $proxy = "-Proxy $env:AGENT_PROXYURL"
+}
+else
+{
+    Write-Output "Downloading without proxy"
+}
+
+$github_headers = '@{"Accept" = "application/vnd.github.v3+json"; "Authorization" = "token ' + $env:GITHUB_TOKEN + '"}'
+$aziot_commit = git submodule | awk '{print $1;}'
+Write-Output "Downloading aziot-identity-service $aziot_commit"
+
+for($page = 1; ; $page++)
+{
+    $url = "https://api.github.com/repos/azure/iot-identity-service/actions/runs?per_page=100&page=$page"
+    Write-Output "GET $url"
+    $actions_runs = Invoke-Expression "Invoke-WebRequest $proxy -Headers $github_headers -Uri '$url'" | ConvertFrom-JSON
+    $actions_size = $actions_runs.workflow_runs | Measure-Object
+
+    if($actions_size.Count -eq 0)
+    {
+        # Searched all pages and could not find artifact for submodule commit.
+        Write-Output "Package for $aziot_commit not found"
+        exit 1
+    }
+
+    $artifacts_link = $actions_runs.workflow_runs | `
+    where {($_.head_sha -eq $aziot_commit) -and ($_.name -eq 'packages')} | `
+    Select-Object -ExpandProperty artifacts_url
+
+    if([string]::IsNullOrEmpty($artifacts_link))
+    {
+        # Artifact not on this page.
+        continue
+    }
+
+    Write-Output "GET $artifacts_link"
+    $artifacts = Invoke-Expression "Invoke-WebRequest $proxy -Headers $github_headers -Uri '$artifacts_link'" | ConvertFrom-JSON
+    $download_link = $artifacts.artifacts | where {$_.name -eq $env:ARTIFACT_NAME} | `
+    Select-Object -ExpandProperty archive_download_url
+
+    Write-Output "GET $download_link"
+    Invoke-Expression "Invoke-WebRequest $proxy -Headers $github_headers -Uri '$download_link' -OutFile aziot-identity-service.zip"
+
+    Write-Output "Extract aziot-identity-service.zip"
+    Expand-Archive -Path aziot-identity-service.zip -DestinationPath aziot-identity-service -Force
+
+    $packages = Get-ChildItem -Recurse aziot-identity-service -Filter $env:PACKAGE_FILTER
+    $packagePath = Convert-Path $env:DOWNLOAD_PATH
+
+    Write-Output "Copy $packages to $packagePath"
+    Copy-Item $packages -Destination $packagePath
+
+    Write-Output "Done"
+    exit 0
+}


### PR DESCRIPTION
Move the script that downloads aziot-identity-service from the E2E test YAML so it can be shared with the Connectivity test pipeline.