### PR TITLE
Use native precondition for MQTT CI (#4179)

### DIFF
--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -3,34 +3,17 @@ trigger:
     include:
       - master
       - release/*
+  paths:
+    include:
+      - "mqtt/*"
+      - "builds/*"
 pr: none
 jobs:
-
-################################################################################
-  - job: check_run_pipeline
-################################################################################
-    displayName: Check pipeline preconditions (changes ARE in builds or mqtt)
-    pool:
-      vmImage: "ubuntu-16.04"
-    steps:
-      - checkout: self
-        submodules: false
-        fetchDepth: 3
-      - bash: |
-          git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|mqtt)'
-          if [[ $? == 0 ]]; then
-            echo "Detected changes inside builds or mqtt folders"
-            echo "##vso[task.setvariable variable=RUN_PIPELINE;isOutput=true]TRUE"
-          fi
-        displayName: Check changes in sources
-        name: check_files
 
 ################################################################################
   - job: linux_amd64
 ################################################################################
     displayName: Linux amd64
-    dependsOn: check_run_pipeline
-    condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
       vmImage: 'ubuntu-16.04'
     steps:
@@ -69,8 +52,6 @@ jobs:
   - job: linux_arm32v7
 ################################################################################
     displayName: Linux arm32v7
-    dependsOn: check_run_pipeline
-    condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
       vmImage: 'ubuntu-16.04'
     steps:


### PR DESCRIPTION
## Problem:
Right now if someone wants to run MQTT CI on an arbitrary commit - they can't. The commit must contain changes in mqtt or builds folder.

## Solution:
Out other CI pipelines don't use "precondition task" to check if they need to run or not. I'm removing the precondition check from MQTT CI as well, but instead I'm adding "native" precondition check for `builds` and `mqtt` folders. This way it will be possible to start the pipeline manually, but it won't be auto-triggered unnecessarily.