### PR TITLE
Update schemaVersion to 1.2 globally for e2e tests and fix bug in auth test

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/HubModuleConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/HubModuleConfigBuilder.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
             this.WithDesiredProperties(
                 new Dictionary<string, object>
                 {
-                    ["schemaVersion"] = "1.1",
+                    ["schemaVersion"] = "1.2",
                     ["routes"] = new { route1 = "from /* INTO $upstream" },
                     ["storeAndForwardConfiguration"] = new { timeToLiveSecs = 7200 }
                 });

--- a/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             await RetryPolicy.DefaultProgressive.ExecuteAsync(
                 async () =>
             {
-                using var client = DeviceClient.CreateFromConnectionString(connectionString);
+                using var client = DeviceClient.CreateFromConnectionString(connectionString, Client.TransportType.Mqtt);
                 await client.OpenAsync();
             }, token);
 


### PR DESCRIPTION
E2e tests broke after a recent commit that changed the way EdgeHub parses its config.
With the change, EdgeHub now needs the 1.2 schemaVersion set in order for the broker to be enabled.
This PR updates the schemaVersion for the e2e tests to 1.2, so that the broker can be enabled. It shouldn't have any negative effects, as 1.2 is backwards compatible.

During investigation we uncovered that the AuthorizationUpdatePolicy test has a bug where we don't set the second device to use MQTT, so it uses AMQP and bypasses the broker. This is fixed here too
