### PR TITLE
Fix SDL pipeline

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -40,6 +40,14 @@
     {
       "file": "http_proxy_io_requirements.md",
       "_justification": "A file in a submodule repo, which we don't control, and which contains a fake password for illustration purposes"
+    },
+    {
+      "placeholder": "YXppb3QtaWRlbnRpdHktc2VydmljZXxhemlvdC1pZGU=",
+      "_justification": "This is a fake key generated for testing purposes"
+    },
+    {
+      "placeholder": "YXppb3QtaWRlbnRpdHktc2VydmljZXxhemlvdC1pZGVudGl0eS1zZXJ2aWNlfGF6aW90LWlkZW50aXR5LXNlcg==",
+      "_justification": "This is a fake key generated for testing purposes"
     }
   ]
 }


### PR DESCRIPTION
Resolves SDL pipeline issues caused by recent changes to edgelet.
- Add CredScan suppressions for credentials used in new edgelet tests.
- Removed Windows build and artifact publish jobs in the SDL pipeline config