### PR TITLE
Update Base Images for Security Vulnerability (#4223)

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-bionic-arm32v7
+﻿ARG base_tag=3.1.11-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-bionic-arm64v8
+﻿ARG base_tag=3.1.11-bionic-arm64v8
 ARG num_procs=4
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/edge-agent/docker/windows/amd64/Dockerfile
+++ b/edge-agent/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # In order to set system PATH, ContainerAdministrator must be used

--- a/edge-agent/docker/windows/arm32v7/Dockerfile
+++ b/edge-agent/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/windows/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/windows/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-# Base image for arm32v7 dotnet-runtime container
+﻿# Base image for arm32v7 dotnet-runtime container
 FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
 ENV DOTNET_VERSION 3.1.4

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-bionic-arm32v7
+﻿ARG base_tag=3.1.11-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-bionic-arm64v8
+﻿ARG base_tag=3.1.11-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/windows/amd64/Dockerfile
+++ b/edge-hub/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/windows/arm32v7/Dockerfile
+++ b/edge-hub/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/windows/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/windows/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-# Base image for arm32v7 dotnet-runtime container
+﻿# Base image for arm32v7 dotnet-runtime container
 FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
 
 ENV DOTNET_VERSION 3.1.4

--- a/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/windows/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-bionic-arm32v7
+﻿ARG base_tag=3.1.11-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-bionic-arm64v8
+﻿ARG base_tag=3.1.11-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-# Base image for arm32v7 dotnet-runtime container
+﻿# Base image for arm32v7 dotnet-runtime container
 FROM mcr.microsoft.com/windows/nanoserver:1809-arm32v7
  
 ENV DOTNET_VERSION 3.1.4

--- a/edge-modules/edgehub-proxy/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/edgehub-proxy/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/haproxy:1.8.23
+﻿FROM arm32v7/haproxy:1.8.23
 
 RUN mkdir -p /run/haproxy
 

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/windows/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/windows/arm32v7/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 ARG base_registry
 FROM ${base_registry}/azureiotedge/azureiotedge-module-base:${base_tag}
 

--- a/edgelet/iotedge-proxy/docker/linux/arm32v7/base/Dockerfile
+++ b/edgelet/iotedge-proxy/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine:3.10
+﻿FROM arm32v6/alpine:3.10
 
 RUN addgroup -S proxy && adduser -S proxy -G proxy
 USER proxy

--- a/edgelet/iotedge-proxy/docker/linux/arm64v8/base/Dockerfile
+++ b/edgelet/iotedge-proxy/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.10
+﻿FROM arm64v8/alpine:3.10
 
 RUN addgroup -S proxy && adduser -S proxy -G proxy
 USER proxy

--- a/edgelet/iotedged/docker/linux/arm32v7/base/Dockerfile
+++ b/edgelet/iotedged/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:9-slim
+﻿FROM arm32v7/debian:9-slim
 
 # package installation needs to exec as root
 RUN apt-get update && apt-get install -y \

--- a/edgelet/iotedged/docker/linux/arm64v8/base/Dockerfile
+++ b/edgelet/iotedged/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:9-slim
+﻿FROM arm64v8/debian:9-slim
 
 # package installation needs to exec as root
 RUN apt-get update && apt-get install -y \

--- a/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 # Network controller arm32 and arm64 require different base images. This is because arm32 needs iproute tooling and thus needs module-base-full.
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
 # Network controller arm32 and arm64 require different base images. This is because arm32 needs iproute tooling and thus needs module-base-full.
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/windows/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/windows/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.10
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ENV MODULE_NAME "CloudToDeviceMessageTester.dll"

--- a/test/modules/CloudToDeviceMessageTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ENV MODULE_NAME "CloudToDeviceMessageTester.dll"

--- a/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/DeploymentTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ENV MODULE_NAME "DeploymentTester.dll"

--- a/test/modules/DeploymentTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ENV MODULE_NAME "DeploymentTester.dll"

--- a/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/windows/amd64/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/windows/amd64/Dockerfile
+++ b/test/modules/MetricsValidator/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/windows/amd64/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/windows/amd64/Dockerfile
+++ b/test/modules/NumberLogger/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/NumberLogger/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/amd64/Dockerfile
+++ b/test/modules/Relayer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/windows/amd64/Dockerfile
+++ b/test/modules/Relayer/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ENV MODULE_NAME "Relayer.dll"

--- a/test/modules/Relayer/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ENV MODULE_NAME "Relayer.dll"

--- a/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/windows/amd64/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-bionic-arm32v7
+﻿ARG base_tag=3.1.11-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-bionic-arm64v8
+﻿ARG base_tag=3.1.11-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/test/modules/TestAnalyzer/docker/windows/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/windows/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/amd64/Dockerfile
+++ b/test/modules/load-gen/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-alpine3.11
+ARG base_tag=3.1.11-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm32v7
+ARG base_tag=1.0.5.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.6-linux-arm64v8
+ARG base_tag=1.0.5.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/windows/amd64/Dockerfile
+++ b/test/modules/load-gen/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.10-nanoserver-1809
+ARG base_tag=3.1.11-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/windows/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/windows/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5-windows-arm32v7
+ARG base_tag=1.0.6-windows-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/tools/snitch/snitcher/docker/linux/arm32v7/base/Dockerfile
+++ b/tools/snitch/snitcher/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/ubuntu:18.04
+﻿FROM arm32v7/ubuntu:18.04
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y ca-certificates openssl

--- a/tools/snitch/snitcher/docker/linux/arm64v8/base/Dockerfile
+++ b/tools/snitch/snitcher/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/ubuntu:18.04
+﻿FROM arm64v8/ubuntu:18.04
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y ca-certificates openssl    


### PR DESCRIPTION
Updating Base Images for Security Vulnerability:
https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-1723

List of Update Base Images:
- Linux AMD64 :  3.1.4-alpine3.11 --> 3.1.11-alpine3.12
- Linux ARM32 & ARM64 : 3.1.10-bionic-arm* --> 3.1.11-bionic-arm*
- Windows AMD64 : 3.1.10-nanoserver-1809 --> 3.1.11-nanoserver-1809
- Windows ARM32 : nanoserver:1809-arm32v7 (latest)

Publishing ARM Base Images:
1.0.5.7-linux-arm*

Note to Reviewer: 
Please feel free to pull the branch down to your local machine and use your favorite editor's regex to make sure the base images are updated correctly. (I wish there is an easier way to do this).