### PR TITLE
Fix Add-ons pipeline

### DIFF
--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -1,5 +1,5 @@
 name: $(version)
-jobs: 
+jobs:
 ################################################################################
   - job: linux_API_proxy_module
 ################################################################################
@@ -20,11 +20,11 @@ jobs:
           name: API Proxy
           imageName: azureiotedge-api-proxy
           project: api-proxy-module
-          version: $(version)
+          version: $(Build.BuildNumber)
       # Check API proxy
       - task: ComponentGovernanceComponentDetection@0
         inputs:
-          dockerImagesToScan: '$(registry.address)/microsoft/azureiotedge-api-proxy:$(version)-linux-amd64,$(registry.address)/microsoft/azureiotedge-api-proxy:$(version)-linux-arm32v7,$(registry.address)/microsoft/azureiotedge-api-proxy:$(version)-linux-arm64v8' 
+          dockerImagesToScan: '$(registry.address)/microsoft/azureiotedge-api-proxy:$(Build.BuildNumber)-linux-amd64,$(registry.address)/microsoft/azureiotedge-api-proxy:$(Build.BuildNumber)-linux-arm32v7,$(registry.address)/microsoft/azureiotedge-api-proxy:$(Build.BuildNumber)-linux-arm64v8'
 
 ################################################################################
   - job: manifest
@@ -35,5 +35,5 @@ jobs:
     dependsOn:
       - linux_API_proxy_module
     steps:
-    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-modules/api-proxy-module/docker/manifest.yaml.template -n microsoft --tags "$(tags)"
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(Build.BuildNumber) -t $(System.DefaultWorkingDirectory)/edge-modules/api-proxy-module/docker/manifest.yaml.template -n microsoft --tags "$(tags)"
       displayName: 'Publish azureiotedge-api-proxy Manifest'

--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -8,6 +8,13 @@ jobs:
       vmImage: 'ubuntu-18.04'
     steps:
       - bash: |
+            if [ -z '$(version)' ] then
+              echo '##vso[task.setvariable variable=buildVersion]$(Build.BuildNumber)'
+            else
+              echo '##vso[task.setvariable variable=buildVersion]$(version)'
+            fi
+        displayName: 'Set build version'
+      - bash: |
             # Need to login to EdgeBuilds Container Registry for base images.
             docker login '$(build.registry.address)' --username '$(build.registry.user)' --password '$(build.registry.password)'
             docker login '$(registry.address)' --username '$(registry.user)' --password '$(registry.password)'
@@ -20,11 +27,11 @@ jobs:
           name: API Proxy
           imageName: azureiotedge-api-proxy
           project: api-proxy-module
-          version: $(Build.BuildNumber)
+          version: $(buildVersion)
       # Check API proxy
       - task: ComponentGovernanceComponentDetection@0
         inputs:
-          dockerImagesToScan: '$(registry.address)/microsoft/azureiotedge-api-proxy:$(Build.BuildNumber)-linux-amd64,$(registry.address)/microsoft/azureiotedge-api-proxy:$(Build.BuildNumber)-linux-arm32v7,$(registry.address)/microsoft/azureiotedge-api-proxy:$(Build.BuildNumber)-linux-arm64v8'
+          dockerImagesToScan: '$(registry.address)/microsoft/azureiotedge-api-proxy:$(buildVersion)-linux-amd64,$(registry.address)/microsoft/azureiotedge-api-proxy:$(buildVersion)-linux-arm32v7,$(registry.address)/microsoft/azureiotedge-api-proxy:$(buildVersion)-linux-arm64v8'
 
 ################################################################################
   - job: manifest
@@ -35,5 +42,5 @@ jobs:
     dependsOn:
       - linux_API_proxy_module
     steps:
-    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(Build.BuildNumber) -t $(System.DefaultWorkingDirectory)/edge-modules/api-proxy-module/docker/manifest.yaml.template -n microsoft --tags "$(tags)"
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(buildVersion) -t $(System.DefaultWorkingDirectory)/edge-modules/api-proxy-module/docker/manifest.yaml.template -n microsoft --tags "$(tags)"
       displayName: 'Publish azureiotedge-api-proxy Manifest'

--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -42,5 +42,12 @@ jobs:
     dependsOn:
       - linux_API_proxy_module
     steps:
+    - bash: |
+          if [ -z '$(version)' ]; then
+            echo '##vso[task.setvariable variable=buildVersion]$(Build.BuildNumber)'
+          else
+            echo '##vso[task.setvariable variable=buildVersion]$(version)'
+          fi
+      displayName: 'Set build version'
     - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(buildVersion) -t $(System.DefaultWorkingDirectory)/edge-modules/api-proxy-module/docker/manifest.yaml.template -n microsoft --tags "$(tags)"
       displayName: 'Publish azureiotedge-api-proxy Manifest'

--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -8,7 +8,7 @@ jobs:
       vmImage: 'ubuntu-18.04'
     steps:
       - bash: |
-            if [ -z '$(version)' ] then
+            if [ -z '$(version)' ]; then
               echo '##vso[task.setvariable variable=buildVersion]$(Build.BuildNumber)'
             else
               echo '##vso[task.setvariable variable=buildVersion]$(version)'


### PR DESCRIPTION
Changes the use of $(version) to $(Build.BuildNumber) if $(version) is empty.