### PR TITLE
Making NetworkStatusTimeline optional in TestResultCoordinator

### DIFF
--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/DirectMethodReportDataWithSenderAndReceiverSource.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/DirectMethodReportDataWithSenderAndReceiverSource.cs
@@ -218,6 +218,46 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     10, 6, 0, 0, 0, 0, 0, 1, 0, true,
                     NetworkControllerType.Satellite
                 },
+
+                new object[]
+                {
+                    // Online NetworkOnSuccess test
+                    Enumerable.Range(1, 7).Select(v => (ulong)v),
+                    Enumerable.Range(1, 7).Select(v => (ulong)v),
+                    new List<HttpStatusCode> { HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK },
+                    new DateTime[]
+                    {
+                        new DateTime(2020, 1, 1, 9, 10, 12, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 13, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 21, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 22, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 23, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 24, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 24, 15)
+                    },
+                    10, 7, 0, 0, 0, 0, 0, 0, 0, true,
+                    NetworkControllerType.Online
+                },
+
+                new object[]
+                {
+                    // Online NetworkOnFailure test
+                    Enumerable.Range(1, 7).Select(v => (ulong)v),
+                    Enumerable.Range(1, 7).Select(v => (ulong)v),
+                    new List<HttpStatusCode> { HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.NotFound, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK },
+                    new DateTime[]
+                    {
+                        new DateTime(2020, 1, 1, 9, 10, 12, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 13, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 21, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 22, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 23, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 24, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 24, 15)
+                    },
+                    10, 6, 0, 0, 0, 1, 0, 0, 0, false,
+                    NetworkControllerType.Online
+                },
             };
     }
 }

--- a/test/modules/TestResultCoordinator/Reports/TestReportGeneratorFactory.cs
+++ b/test/modules/TestResultCoordinator/Reports/TestReportGeneratorFactory.cs
@@ -2,6 +2,7 @@
 namespace TestResultCoordinator.Reports
 {
     using System;
+    using System.IO;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.ModuleUtil;
     using Microsoft.Azure.Devices.Edge.ModuleUtil.NetworkController;
@@ -183,11 +184,18 @@ namespace TestResultCoordinator.Reports
             }
         }
 
-        async Task<NetworkStatusTimeline> GetNetworkStatusTimelineAsync(TimeSpan tolerancePeriod)
+        async Task<Option<NetworkStatusTimeline>> GetNetworkStatusTimelineAsync(TimeSpan tolerancePeriod)
         {
-            return await NetworkStatusTimeline.CreateAsync(
-                new StoreTestResultCollection<TestOperationResult>(this.Storage.GetStoreFromSource("networkController"), BatchSize),
-                tolerancePeriod);
+            try
+            {
+                return Option.Some(await NetworkStatusTimeline.CreateAsync(
+                    new StoreTestResultCollection<TestOperationResult>(this.Storage.GetStoreFromSource("networkController"), BatchSize),
+                    tolerancePeriod));
+            }
+            catch (InvalidDataException)
+            {
+                return Option.None<NetworkStatusTimeline>();
+            }
         }
 
         ITestResultCollection<TestOperationResult> GetResults(string resultSource)


### PR DESCRIPTION
TestResultCoordinator uses NetworkStatusTimeline to generate DirectMethod reports. 
Now that we will be using TRC for longhaul, NetworkStatusTimeline should be optional, since there will be no networkController. This change makes NetworkStatusTimeline optional. It can only be absent if we're in an online scenario, though