### PR TITLE
[k8s] Allow alphanumerics to start K8s object names.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubeUtils.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubeUtils.cs
@@ -86,13 +86,20 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             return output.ToString();
         }
 
+        /// DNS label (as per RFC 1035
+        public static string SanitizeDNSValue(string name) => SanitizeDNSValue(name, IsAlpha);
+
         // DNS label (as per RFC 1035/1123)
-        public static string SanitizeDNSValue(string name)
+        public static string SanitizeDNSLabel(string name) => SanitizeDNSValue(name, IsAlphaNumeric);
+
+        private static string SanitizeDNSValue(string name, Func<char, bool> startCriteria)
         {
-            // The name returned from here must conform to following rules (as per RFC 1035):
+            // The name returned from here must conform to following rules (as per RFC 1035/1123):
             //  - length must be <= 63 characters
             //  - must be all lower case alphanumeric characters or '-'
-            //  - must start and end with an alphanumeric character
+            //  - (RFC 1123) must start and end with an alphanumeric character
+            //  - (RFC 1035) must start with an alphabet
+            //  - must end with an alphanumeric character
             if (string.IsNullOrEmpty(name))
             {
                 throw new InvalidKubernetesNameException($"DNS Name '{name}' is null or empty");
@@ -102,7 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
             // get index of first character from the left that is an alphanumeric
             int start = 0;
-            while (start < name.Length && !IsAlphaNumeric(name[start]))
+            while (start < name.Length && !startCriteria(name[start]))
             {
                 start++;
             }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubeUtils.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubeUtils.cs
@@ -86,14 +86,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             return output.ToString();
         }
 
-        // DNS label (as per RFC 1035)
+        // DNS label (as per RFC 1035/1123)
         public static string SanitizeDNSValue(string name)
         {
             // The name returned from here must conform to following rules (as per RFC 1035):
             //  - length must be <= 63 characters
             //  - must be all lower case alphanumeric characters or '-'
-            //  - must start with an alphabet
-            //  - must end with an alphanumeric character
+            //  - must start and end with an alphanumeric character
             if (string.IsNullOrEmpty(name))
             {
                 throw new InvalidKubernetesNameException($"DNS Name '{name}' is null or empty");
@@ -101,9 +100,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
             name = name.ToLower();
 
-            // get index of first character from the left that is an alphabet
+            // get index of first character from the left that is an alphanumeric
             int start = 0;
-            while (start < name.Length && !IsAlpha(name[start]))
+            while (start < name.Length && !IsAlphaNumeric(name[start]))
             {
                 start++;
             }
@@ -115,7 +114,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
             // get index of last character from right that's an alphanumeric
             int end = Math.Max(start, name.Length - 1);
-            while (end > start && !IsAlphaNumeric(name[end]))
+            while (end > start && !(name[end]))
             {
                 end--;
             }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubeUtils.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubeUtils.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
 
             // get index of last character from right that's an alphanumeric
             int end = Math.Max(start, name.Length - 1);
-            while (end > start && !(name[end]))
+            while (end > start && !IsAlphaNumeric(name[end]))
             {
                 end--;
             }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -324,7 +324,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
                     hostBinds => hostBinds
                         .Select(bind => bind.Split(':'))
                         .Where(bind => bind.Length >= 2)
-                        .Select(bind => new { Name = KubeUtils.SanitizeDNSValue(bind[0]), HostPath = bind[0], MountPath = bind[1], IsReadOnly = bind.Length > 2 && bind[2].Contains("ro") })
+                        .Select(bind => new { Name = KubeUtils.SanitizeDNSLabel(bind[0]), HostPath = bind[0], MountPath = bind[1], IsReadOnly = bind.Length > 2 && bind[2].Contains("ro") })
                         .ToList());
 
             binds.Map(hostBinds => hostBinds.Select(bind => new V1Volume(bind.Name, hostPath: new V1HostPathVolumeSource(bind.HostPath, "DirectoryOrCreate"))))
@@ -338,10 +338,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
                 .FlatMap(config => Option.Maybe(config.Mounts))
                 .Map(mounts => mounts.Where(mount => mount.Type.Equals("bind", StringComparison.InvariantCultureIgnoreCase)).ToList());
 
-            bindMounts.Map(mounts => mounts.Select(mount => new V1Volume(KubeUtils.SanitizeDNSValue(mount.Source), hostPath: new V1HostPathVolumeSource(mount.Source, "DirectoryOrCreate"))))
+            bindMounts.Map(mounts => mounts.Select(mount => new V1Volume(KubeUtils.SanitizeDNSLabel(mount.Source), hostPath: new V1HostPathVolumeSource(mount.Source, "DirectoryOrCreate"))))
                 .ForEach(volumes => volumeList.AddRange(volumes));
 
-            bindMounts.Map(mounts => mounts.Select(mount => new V1VolumeMount(mount.Target, KubeUtils.SanitizeDNSValue(mount.Source), readOnlyProperty: mount.ReadOnly)))
+            bindMounts.Map(mounts => mounts.Select(mount => new V1VolumeMount(mount.Target, KubeUtils.SanitizeDNSLabel(mount.Source), readOnlyProperty: mount.ReadOnly)))
                 .ForEach(mounts => volumeMountList.AddRange(mounts));
 
             // collect volumes and volume mounts from HostConfig.Mounts section for volumes
@@ -438,7 +438,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
         V1Volume GetVolume(KubernetesModule module, Mount mount)
         {
             // Volume name will be mount.Source
-            string volumeName = KubeUtils.SanitizeDNSValue(mount.Source);
+            string volumeName = KubeUtils.SanitizeDNSLabel(mount.Source);
             // PVC name will be volume name
             string pvcName = volumeName;
 
@@ -452,7 +452,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
         V1VolumeMount GetVolumeMount(Mount mount)
         {
             // Volume name will be mount.Source
-            string volumeName = KubeUtils.SanitizeDNSValue(mount.Source);
+            string volumeName = KubeUtils.SanitizeDNSLabel(mount.Source);
 
             return new V1VolumeMount(mount.Target, volumeName, readOnlyProperty: mount.ReadOnly);
         }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
 
         V1PersistentVolumeClaim ExtractPvc(KubernetesModule module, Mount mount, IDictionary<string, string> labels)
         {
-            string volumeName = KubeUtils.SanitizeK8sValue(mount.Source);
+            string volumeName = KubeUtils.SanitizeDNSLabel(mount.Source);
             string pvcName = volumeName;
             bool readOnly = mount.ReadOnly;
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/EdgeDeploymentControllerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/EdgeDeploymentControllerTest.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest
             var moduleName = "module-a";
             var deviceSelector = $"{Kubernetes.Constants.K8sEdgeDeviceLabel}=deviceid";
             var moduleLifeCycleManager = this.CreateModuleLifeCycleManager(moduleName);
-            var persistentVolumeName = "pvname";
+            var persistentVolumeName = "1pvname";
             var controller = this.CreateDeploymentController(deviceSelector, moduleLifeCycleManager, "storagename");
             KubernetesModule km1 = this.CreateKubernetesModuleWithHostConfig(moduleName, persistentVolumeName);
             var tokenSource = new CancellationTokenSource(DefaultTimeout * 3);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubeUtilsTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubeUtilsTest.cs
@@ -66,7 +66,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [InlineData("a-z", "---a-z---")]
         [InlineData("a-z---1", "---a-z-/--1")]
         [InlineData("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijab----------c", "ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJAB----------C")]
-        [InlineData("111111111", "111111111")]
         public void SanitizeDnsValueTest(string expected, string raw) => Assert.Equal(expected, KubeUtils.SanitizeDNSValue(raw));
 
         [Theory]
@@ -78,6 +77,34 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [InlineData(null)]
         [InlineData("$$$$$$")]
         public void SanitizeDnsValueFailTest(string raw) => Assert.Throws<InvalidKubernetesNameException>(() => KubeUtils.SanitizeDNSValue(raw));
+
+        [Theory]
+        [InlineData("edgeagent", "$edgeAgent")]
+        [InlineData("edgehub", "$edgeHub")]
+        // all characters are forced lowercase.
+        [InlineData("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabc", "ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABC")]
+        // Allow '-'
+        [InlineData("abcdefghi-abcdefghi-abcdefghi-abcdefghi-abcdefghi-abcdefghi-abc", "ABCDEFGHI-ABCDEFGHI-ABCDEFGHI-ABCDEFGHI-ABCDEFGHI-ABCDEFGHI-ABC")]
+        // Must start with alphabet and end with alphanumeric
+        [InlineData("a-0", "---a-0---")]
+        [InlineData("z-9", "---z-9---")]
+        [InlineData("a-0", "---A-0---")]
+        [InlineData("z-9", "---Z-9---")]
+        [InlineData("a-z", "---a-z---")]
+        [InlineData("a-z---1", "---a-z-/--1")]
+        [InlineData("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijab----------c", "ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJAB----------C")]
+        [InlineData("111111111", "111111111")]
+        public void SanitizeDnsLabelTest(string expected, string raw) => Assert.Equal(expected, KubeUtils.SanitizeDNSLabel(raw));
+
+        [Theory]
+        // length is <= 63 characters
+        [InlineData("ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJ")]
+        [InlineData("ABCDEFGHI-ABCDEFGHI-ABCDEFGHI-ABCDEFGHI-ABCDEFGHI-ABCDEFGHI-ABCDEFGHIJ")]
+        // Must start with alphabet and end with alphanumeric
+        [InlineData("ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJAB-------J")]
+        [InlineData(null)]
+        [InlineData("$$$$$$")]
+        public void SanitizeDnsLabelFailTest(string raw) => Assert.Throws<InvalidKubernetesNameException>(() => KubeUtils.SanitizeDNSLabel(raw));
 
         [Theory]
         // must be a one or more DNS labels separated by dots (.), not longer than 253 characters in total

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubeUtilsTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubeUtilsTest.cs
@@ -43,6 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [InlineData("edgeagent", "$edgeAgent")]
         [InlineData("edgehub", "$edgeHub")]
         [InlineData("---a-0---", "---a-0---")]
+        [InlineData("000", "000")]
         [InlineData(null, null)]
         public void SanitizeK8sValueTest(string expected, string raw) => Assert.Equal(expected, KubeUtils.SanitizeK8sValue(raw));
 
@@ -65,6 +66,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         [InlineData("a-z", "---a-z---")]
         [InlineData("a-z---1", "---a-z-/--1")]
         [InlineData("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijab----------c", "ABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJABCDEFGHIJAB----------C")]
+        [InlineData("111111111", "111111111")]
         public void SanitizeDnsValueTest(string expected, string raw) => Assert.Equal(expected, KubeUtils.SanitizeDNSValue(raw));
 
         [Theory]

--- a/edgelet/edgelet-kube/src/convert/mod.rs
+++ b/edgelet/edgelet-kube/src/convert/mod.rs
@@ -60,7 +60,7 @@ pub fn sanitize_label_value(name: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{sanitize_dns_value, sanitize_label_value, ErrorKind};
+    use super::{sanitize_dns_value, sanitize_dns_value_rfc1123, sanitize_label_value, ErrorKind};
 
     #[test]
     fn sanitize_dns_value_test_63chars() {

--- a/edgelet/edgelet-kube/src/convert/mod.rs
+++ b/edgelet/edgelet-kube/src/convert/mod.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
 
 use crate::error::{ErrorKind, Result};
-use edgelet_utils::sanitize_dns_label;
+use edgelet_utils::{sanitize_dns_label, sanitize_dns_label_rfc1123};
 
 mod named_secret;
 mod to_docker;

--- a/edgelet/edgelet-kube/src/convert/to_k8s.rs
+++ b/edgelet/edgelet-kube/src/convert/to_k8s.rs
@@ -25,7 +25,7 @@ use crate::constants::{
     PROXY_CONFIG_VOLUME_NAME, PROXY_CONTAINER_NAME, PROXY_TRUST_BUNDLE_FILENAME,
     PROXY_TRUST_BUNDLE_VOLUME_NAME,
 };
-use crate::convert::{sanitize_dns_value, sanitize_label_value};
+use crate::convert::{sanitize_dns_value, sanitize_dns_value_rfc1123, sanitize_label_value};
 use crate::error::{ErrorKind, Result};
 use crate::registry::ImagePullSecret;
 use crate::settings::Settings;

--- a/edgelet/edgelet-kube/src/convert/to_k8s.rs
+++ b/edgelet/edgelet-kube/src/convert/to_k8s.rs
@@ -200,7 +200,7 @@ fn spec_to_podspec(
             if element_count >= 2 {
                 // If we have a valid bind mount, create a Volume with the
                 // bind source as a host path.
-                let bind_name = sanitize_dns_value(bind_elements[0])?;
+                let bind_name = sanitize_dns_value_rfc1123(bind_elements[0])?;
                 let host_path_volume_source = api_core::HostPathVolumeSource {
                     path: bind_elements[0].to_string(),
                     type_: Some("DirectoryOrCreate".to_string()),
@@ -239,7 +239,7 @@ fn spec_to_podspec(
                 Some("bind") => {
                     // Treat bind options as above: Host Path Volume Source.
                     if let (Some(source), Some(target)) = (mount.source(), mount.target()) {
-                        let bind_name = sanitize_dns_value(source)?;
+                        let bind_name = sanitize_dns_value_rfc1123(source)?;
 
                         let host_path_volume_source = api_core::HostPathVolumeSource {
                             path: source.to_string(),
@@ -266,7 +266,7 @@ fn spec_to_podspec(
                 }
                 Some("volume") => {
                     if let (Some(source), Some(target)) = (mount.source(), mount.target()) {
-                        let volume_name = sanitize_dns_value(source)?;
+                        let volume_name = sanitize_dns_value_rfc1123(source)?;
 
                         let volume = api_core::Volume {
                             name: volume_name.clone(),


### PR DESCRIPTION
An automated system created a PVC with a GUID name,  It should be valid, but the GUID started with a number, and the number was stripped from the PVC name when doing a volume mount, leaving the pod pending.

This change allows DNS labels (object names) to start with alphanumerics.