### PR TITLE
Don't use http proxy for Amqp/Mqtt over TCP only

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClientProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/ModuleClientProvider.cs
@@ -100,7 +100,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                             settings.IdleTimeout = HeartbeatTimeout;
                         }
 
-                        proxy.ForEach(p => settings.Proxy = p);
                         return settings;
                     }
 
@@ -112,6 +111,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                             settings.IdleTimeout = HeartbeatTimeout;
                         }
 
+                        // Only WebSocket protocols can use an HTTP forward proxy
                         proxy.ForEach(p => settings.Proxy = p);
                         return settings;
                     }
@@ -119,13 +119,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 case UpstreamProtocol.Mqtt:
                     {
                         var settings = new MqttTransportSettings(TransportType.Mqtt_Tcp_Only);
-                        proxy.ForEach(p => settings.Proxy = p);
                         return settings;
                     }
 
                 case UpstreamProtocol.MqttWs:
                     {
                         var settings = new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only);
+
+                        // Only WebSocket protocols can use an HTTP forward proxy
                         proxy.ForEach(p => settings.Proxy = p);
                         return settings;
                     }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/ModuleClientProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/ModuleClientProviderTest.cs
@@ -64,14 +64,24 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 case UpstreamProtocol.AmqpWs:
                     var amqpTransportSettings = receivedTransportSettings as AmqpTransportSettings;
                     Assert.NotNull(amqpTransportSettings);
-                    webProxy.ForEach(w => Assert.Equal(w, amqpTransportSettings.Proxy));
+
+                    if (up == UpstreamProtocol.AmqpWs)
+                    {
+                        webProxy.ForEach(w => Assert.Equal(w, amqpTransportSettings.Proxy));
+                    }
+
                     break;
 
                 case UpstreamProtocol.Mqtt:
                 case UpstreamProtocol.MqttWs:
                     var mqttTransportSettings = receivedTransportSettings as MqttTransportSettings;
                     Assert.NotNull(mqttTransportSettings);
-                    webProxy.ForEach(w => Assert.Equal(w, mqttTransportSettings.Proxy));
+
+                    if (up == UpstreamProtocol.MqttWs)
+                    {
+                        webProxy.ForEach(w => Assert.Equal(w, mqttTransportSettings.Proxy));
+                    }
+
                     break;
             }
 
@@ -155,14 +165,24 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 case UpstreamProtocol.AmqpWs:
                     var amqpTransportSettings = receivedTransportSettings as AmqpTransportSettings;
                     Assert.NotNull(amqpTransportSettings);
-                    webProxy.ForEach(w => Assert.Equal(w, amqpTransportSettings.Proxy));
+
+                    if (up == UpstreamProtocol.AmqpWs)
+                    {
+                        webProxy.ForEach(w => Assert.Equal(w, amqpTransportSettings.Proxy));
+                    }
+
                     break;
 
                 case UpstreamProtocol.Mqtt:
                 case UpstreamProtocol.MqttWs:
                     var mqttTransportSettings = receivedTransportSettings as MqttTransportSettings;
                     Assert.NotNull(mqttTransportSettings);
-                    webProxy.ForEach(w => Assert.Equal(w, mqttTransportSettings.Proxy));
+
+                    if (up == UpstreamProtocol.MqttWs)
+                    {
+                        webProxy.ForEach(w => Assert.Equal(w, mqttTransportSettings.Proxy));
+                    }
+
                     break;
             }
 

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -213,15 +213,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                         switch (up)
                         {
                             case UpstreamProtocol.Amqp:
-                                return GetAmqpTransportSettings(TransportType.Amqp_Tcp_Only, connectionPoolSize, proxy, useServerHeartbeat);
+                                return GetAmqpTransportSettings(TransportType.Amqp_Tcp_Only, connectionPoolSize, Option.None<IWebProxy>(), useServerHeartbeat);
 
                             case UpstreamProtocol.AmqpWs:
+                                // Only WebSocket protocols can use an HTTP forward proxy
                                 return GetAmqpTransportSettings(TransportType.Amqp_WebSocket_Only, connectionPoolSize, proxy, useServerHeartbeat);
 
                             case UpstreamProtocol.Mqtt:
-                                return GetMqttTransportSettings(TransportType.Mqtt_Tcp_Only, proxy);
+                                return GetMqttTransportSettings(TransportType.Mqtt_Tcp_Only, Option.None<IWebProxy>());
 
                             case UpstreamProtocol.MqttWs:
+                                // Only WebSocket protocols can use an HTTP forward proxy
                                 return GetMqttTransportSettings(TransportType.Mqtt_WebSocket_Only, proxy);
 
                             default:
@@ -229,7 +231,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                         }
                     })
                 .GetOrElse(
-                    () => GetAmqpTransportSettings(TransportType.Amqp_Tcp_Only, connectionPoolSize, proxy, useServerHeartbeat));
+                    () => GetAmqpTransportSettings(TransportType.Amqp_Tcp_Only, connectionPoolSize, Option.None<IWebProxy>(), useServerHeartbeat));
         }
 
         static class Events

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
@@ -355,7 +355,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                             var actual = (AmqpTransportSettings)transportSettings;
                             Assert.True(expected.Equals(actual)); // AmqpTransportSettings impls Equals, but doesn't override Object.Equals
 
-                            if (proxy == Option.None<IWebProxy>())
+                            if (proxy == Option.None<IWebProxy>() || upstreamProtocol.Contains(UpstreamProtocol.Amqp))
                             {
                                 Assert.Null(actual.Proxy);
                             }
@@ -372,8 +372,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                         {
                             var expected = (MqttTransportSettings)expectedTransportSettings;
                             var actual = (MqttTransportSettings)transportSettings;
-                            Assert.True(actual.Proxy is WebProxy);
-                            Assert.Equal(((WebProxy)expected.Proxy).Address, ((WebProxy)actual.Proxy).Address);
+
+                            if (proxy == Option.None<IWebProxy>() || upstreamProtocol.Contains(UpstreamProtocol.Mqtt))
+                            {
+                                Assert.Null(actual.Proxy);
+                            }
+                            else
+                            {
+                                Assert.True(actual.Proxy is WebProxy);
+                                Assert.Equal(((WebProxy)expected.Proxy).Address, ((WebProxy)actual.Proxy).Address);
+                            }
+
                             break;
                         }
                 }


### PR DESCRIPTION
SDK is started throwing if the caller explicitly passes in a webproxy for TCP only protocols.  This change omits the proxy for Amqp/Mqtt over TCP so we get the old behavior back.