### PR TITLE
message store cleanup catch exception when message is updated (#4271)

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/storage/MessageStoreTest.cs
@@ -79,6 +79,34 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Storage
         [Theory]
         [InlineData(false)]
         [InlineData(true)]
+        public async Task CleanupTestMessageStoreMissingValue(bool checkEntireQueueOnCleanup)
+        {
+            (IMessageStore messageStore, ICheckpointStore checkpointStore, InMemoryDbStore inMemoryDbStore) result = await this.GetMessageStore(checkEntireQueueOnCleanup, 5);
+
+            using (IMessageStore messageStore = result.messageStore)
+            {
+                for (int i = 0; i < 10; i++)
+                {
+                    IMessage input = this.GetMessage(i);
+                    await messageStore.Add("module1", input, 0);
+                    if (i == 1)
+                    {
+                        // remove a message to simulate messageStore not in sync with sequential store
+                        await result.inMemoryDbStore.Remove(input.SystemProperties[SystemProperties.EdgeMessageId].ToBytes());
+                    }
+                }
+
+                await Task.Delay(TimeSpan.FromSeconds(30));
+
+                IMessageIterator module1Iterator = messageStore.GetMessageIterator("module1");
+                IEnumerable<IMessage> batch = await module1Iterator.GetNext(100);
+                Assert.Empty(batch);
+            }
+        }
+
+        [Theory]
+        [InlineData(false)]
+        [InlineData(true)]
         public async Task CleanupTestTimeout(bool checkEntireQueueOnCleanup)
         {
             (IMessageStore messageStore, ICheckpointStore checkpointStore, InMemoryDbStore _) result = await this.GetMessageStore(checkEntireQueueOnCleanup, 20);


### PR DESCRIPTION
cherry-pick #4271
In some customer cases it happens that cleanup fails when it tries to update message store because value is not found in the db and throws InvalidOperationException. Catching the exception so it continues cleaning up otherwise it's not able to clean up messages for the endpoint.