### PR TITLE
Nested E2E - rotate SAS key of leaf device

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -21,11 +21,17 @@ steps:
     #filter out tests not usable on nested edge
     if ('$(nestededge)' -eq 'true')
     {
+      $filter += '&Category!=SingleNodeOnly'
+    
       #We are disabling some additional tests. See  PBI #9171870. Once this is fixed we should run what's directly below.
       #$filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope'
       $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
-    
+    else
+    {
+        $filter += '&Category!=NestedEdgeOnly'
+    }
+
     sudo --preserve-env dotnet test $testFile --logger:trx --testcasefilter:$filter  
   displayName: Run tests
   env:

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment.json
@@ -35,6 +35,9 @@
               "experimentalFeatures__mqttBrokerEnabled": {
                 "value": "true"
               },
+              "DeviceScopeCacheRefreshDelaySecs": {
+                "value": 1
+              },
               "RuntimeLogLevel": {
                 "value": "debug"
               }                   

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment.json
@@ -42,6 +42,9 @@
               "experimentalFeatures__mqttBrokerEnabled": {
                 "value": "true"
               },
+              "DeviceScopeCacheRefreshDelaySecs": {
+                "value": 1
+              },
               "RuntimeLogLevel": {
                 "value": "debug"
               }                   

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
             if (nestedEdge == true)
             {
-                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("experimentalFeatures__enabled", "true"), ("experimentalFeatures__nestedEdgeEnabled", "true") };
+                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("experimentalFeatures__enabled", "true"), ("experimentalFeatures__nestedEdgeEnabled", "true"), ("DeviceScopeCacheRefreshDelaySecs", "1") };
             }
             else
             {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
@@ -314,6 +314,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             return new LeafDevice(device, client, iotHub);
         }
 
+        public Task Close() => this.client.CloseAsync();
+
         public Task SendEventAsync(CancellationToken token)
         {
             var message = new Message(Encoding.ASCII.GetBytes(this.device.Id))

--- a/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
@@ -52,5 +52,74 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     await leaf.DeleteIdentityAsync(token);
                 });
         }
+
+        [Test]
+        [Category("CentOsSafe")]
+        [Category("NestedEdgeOnly")]
+        public async Task QuickstartChangeSasKey()
+        {
+            CancellationToken token = this.TestToken;
+
+            await this.runtime.DeployConfigurationAsync(token, Context.Current.NestedEdge);
+
+            string leafDeviceId = DeviceId.Current.Generate();
+
+            // Create leaf and send message
+            var leaf = await LeafDevice.CreateAsync(
+                leafDeviceId,
+                Protocol.Amqp,
+                AuthenticationType.Sas,
+                Option.Some(this.runtime.DeviceId),
+                false,
+                this.ca,
+                this.iotHub,
+                Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower()),
+                token,
+                Option.None<string>(),
+                Context.Current.NestedEdge);
+
+            await TryFinally.DoAsync(
+                async () =>
+                {
+                    DateTime seekTime = DateTime.Now;
+                    await leaf.SendEventAsync(token);
+                    await leaf.WaitForEventsReceivedAsync(seekTime, token);
+                    await leaf.InvokeDirectMethodAsync(token);
+                },
+                async () =>
+                {
+                    await leaf.Close();
+                    await leaf.DeleteIdentityAsync(token);
+                });
+
+            // Re-create the leaf with the same device ID, for our purposes this is
+            // the equivalent of updating the SAS keys
+            var leafUpdated = await LeafDevice.CreateAsync(
+                leafDeviceId,
+                Protocol.Amqp,
+                AuthenticationType.Sas,
+                Option.Some(this.runtime.DeviceId),
+                false,
+                this.ca,
+                this.iotHub,
+                Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower()),
+                token,
+                Option.None<string>(),
+                Context.Current.NestedEdge);
+
+            await TryFinally.DoAsync(
+                async () =>
+                {
+                    DateTime seekTime = DateTime.Now;
+                    await leafUpdated.SendEventAsync(token);
+                    await leafUpdated.WaitForEventsReceivedAsync(seekTime, token);
+                    await leafUpdated.InvokeDirectMethodAsync(token);
+                },
+                async () =>
+                {
+                    await leafUpdated.Close();
+                    await leafUpdated.DeleteIdentityAsync(token);
+                });
+        }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                             {
                                 Log.Information($"Found parent hostname {parentHostname}");
                                 config.SetParentHostname(parentHostname);
-                                msgBuilder.AppendLine(", parent hostname '{parentHostname}'");
+                                msgBuilder.AppendLine($", parent hostname '{parentHostname}'");
                                 props.Add(parentHostname);
 
                                 string edgeAgent = Regex.Replace(Context.Current.EdgeAgentImage.GetOrElse(string.Empty), @"\$upstream", parentHostname);


### PR DESCRIPTION
This change adds a testcase that rotates the SAS key of the leaf device at runtime, and verifies that the client can use the new credentials to connect through the hierarchy to IoT Hub.