### PR TITLE
Adding checkout repo to longHaul instead of artifacts

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -52,7 +52,10 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu18.04-amd64'
     steps:
-      - checkout: none
+      - checkout: self
+        clean: true
+        fetchDepth: 100
+        submodules: recursive
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -143,7 +146,10 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-debian9-arm32v7'
     steps:
-      - checkout: none
+      - checkout: self
+        clean: true
+        fetchDepth: 100
+        submodules: recursive
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:
@@ -234,7 +240,10 @@ jobs:
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu18.04-aarch64'
     steps:
-      - checkout: none
+      - checkout: self
+        clean: true
+        fetchDepth: 100
+        submodules: recursive
       - task: AzureKeyVault@1
         displayName: 'Azure Key Vault'
         inputs:

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -70,9 +70,9 @@ steps:
         testInfo="$testInfo,TestName=$testName"
 
         if [ "${{ parameters['test.useTRC'] }}" == true ]; then
-          chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/trcE2ETest.sh
+          chmod +x $(Build.SourcesDirectory)/scripts/linux/trcE2ETest.sh
 
-          sudo $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/trcE2ETest.sh \
+          sudo $(Build.SourcesDirectory)/scripts/linux/trcE2ETest.sh \
             -testDir "$(Agent.HomeDirectory)/.." \
             -releaseLabel "${{ parameters['release.label'] }}" \
             -artifactImageBuildNumber "$BuildNumber" \


### PR DESCRIPTION
Adding checkout to azure pipelines for LongHaul. This should significantly speed up development, as we can now make changes to the script without having to build images (which takes 1.5 hours at the moment)

Only making this change for trc version since the other method (Analyzer) is going away