### PR TITLE
Fix GetModules call error using RFC3339 DateTime format.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestHandlerBase.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/requests/RequestHandlerBase.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Storage;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Newtonsoft.Json;
     using Prometheus;
 
     public abstract class RequestHandlerBase<TU, TV> : IRequestHandler
@@ -35,7 +36,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Requests
         {
             try
             {
-                return payloadJson.Map(p => p.FromJson<TU>());
+                var jsonSerializerSettings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
+                return payloadJson.Map(p => p.FromJson<TU>(jsonSerializerSettings));
             }
             catch (Exception ex)
             {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestHandlerBaseTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestHandlerBaseTest.cs
@@ -17,6 +17,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         [InlineData("", typeof(ArgumentException))]
         [InlineData(null, typeof(ArgumentException))]
         [InlineData("{\"prop1\":\"foo\",\"prop2\":100}", null)]
+        [InlineData("{\"prop1\":\"1d\",\"prop2\":100}", null)]
+        [InlineData("{\"prop1\":\"yyyy-MM-ddTHH:mm:ssZ\",\"prop2\":100}", null)] // RFC3339 format
+        [InlineData("{\"prop1\":\"999999999\",\"prop2\":100}", null)] // Unix Timestamp
         public async Task GetResponseTest(string payloadJson, Type expectedException)
         {
             // Arrange

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestHandlerBaseTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/RequestHandlerBaseTest.cs
@@ -17,9 +17,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         [InlineData("", typeof(ArgumentException))]
         [InlineData(null, typeof(ArgumentException))]
         [InlineData("{\"prop1\":\"foo\",\"prop2\":100}", null)]
-        [InlineData("{\"prop1\":\"1d\",\"prop2\":100}", null)]
-        [InlineData("{\"prop1\":\"yyyy-MM-ddTHH:mm:ssZ\",\"prop2\":100}", null)] // RFC3339 format
-        [InlineData("{\"prop1\":\"999999999\",\"prop2\":100}", null)] // Unix Timestamp
         public async Task GetResponseTest(string payloadJson, Type expectedException)
         {
             // Arrange

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/SerDeExtensions.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/SerDeExtensions.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 
     public static class SerDeExtensions
     {
-        public static T FromJson<T>(this string json)
+        public static T FromJson<T>(this string json, JsonSerializerSettings jsonSerializerSettings = null)
         {
             if (string.IsNullOrWhiteSpace(json))
             {
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 
             return typeof(T) == typeof(string)
                 ? (T)(object)json
-                : JsonConvert.DeserializeObject<T>(json);
+                : JsonConvert.DeserializeObject<T>(json, jsonSerializerSettings);
         }
 
         public static string ToJson(this object value)

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -50,7 +50,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 }, token);
             await Task.Delay(30000);
 
-            var request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
+            string since = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd'T'HH:mm:sZ");
+            string until = DateTime.Now.AddDays(+1).ToString("yyyy-MM-dd'T'HH:mm:sZ");
+
+            var request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.Some(10), Option.Some(since), Option.Some(until), Option.None<int>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
 
             var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
 


### PR DESCRIPTION
Fix issue calling GetModuleLogs using DirectMethod with a payload that contains parameters using RF3339 DateTime format.