### PR TITLE
EdgeHub: Log error when failure updating edgehub config

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/TwinConfigSource.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/TwinConfigSource.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
 
             internal static void ErrorGettingEdgeHubConfig(Exception ex)
             {
-                Log.LogWarning(
+                Log.LogError(
                     (int)EventIds.ErrorPatchingDesiredProperties,
                     ex,
                     Invariant($"Error getting edge hub config from twin desired properties"));


### PR DESCRIPTION
Faulty bridge settings makes edgehub complain and we never get the policy ready signal. I think we just need to log an error instead of a warning, which will indicate that the state isn't valid.