### PR TITLE
Ensure E2E tests start with clean config

### DIFF
--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -25,9 +25,11 @@ function setup_iotedge() {
     echo "" | sudo tee -a  /etc/aziot/certd/config.toml
     echo "[cert_issuance]" | sudo tee -a  /etc/aziot/certd/config.toml
     echo "" | sudo tee -a  /etc/aziot/certd/config.toml
-    echo "[preloaded_certs]" | sudo tee -a  /etc/aziot/certd/config.toml            
+    echo "[preloaded_certs]" | sudo tee -a  /etc/aziot/certd/config.toml
     echo "aziot-edged-ca = \"$device_ca_cert_path\"" | sudo tee -a  /etc/aziot/certd/config.toml
     echo "aziot-edged-trust-bundle = \"$trusted_ca_certs_path\"" | sudo tee -a  /etc/aziot/certd/config.toml
+    sudo chown aziotcs:aziotcs /etc/aziot/certd/config.toml
+    sudo chmod 644 /etc/aziot/certd/config.toml
     sudo cat /etc/aziot/certd/config.toml
 
     echo "Setup keyd"
@@ -35,10 +37,12 @@ function setup_iotedge() {
     echo "[aziot_keys]" | sudo tee  /etc/aziot/keyd/config.toml
     echo "homedir_path = \"/var/lib/aziot/keyd\"" | sudo tee -a  /etc/aziot/keyd/config.toml
     echo "" | sudo tee -a  /etc/aziot/keyd/config.toml
-    echo "[preloaded_keys]" | sudo tee -a  /etc/aziot/keyd/config.toml   
-    echo "device-id = \"file:///var/secrets/aziot/keyd/device-id\"" | sudo tee -a  /etc/aziot/keyd/config.toml       
+    echo "[preloaded_keys]" | sudo tee -a  /etc/aziot/keyd/config.toml
+    echo "device-id = \"file:///var/secrets/aziot/keyd/device-id\"" | sudo tee -a  /etc/aziot/keyd/config.toml
     device_ca_pk_path="file:///certs/private/iot-edge-device-${device_name}.key.pem"
     echo "aziot-edged-ca = \"$device_ca_pk_path\"" | sudo tee -a  /etc/aziot/keyd/config.toml
+    sudo chown aziotks:aziotks /etc/aziot/keyd/config.toml
+    sudo chmod 644 /etc/aziot/keyd/config.toml
     sudo cat /etc/aziot/keyd/config.toml
 
     echo "Setup edged"
@@ -61,9 +65,11 @@ function setup_iotedge() {
         echo "    Updating the device hostname"
         sudo sed -i "69s/.*/hostname: \"$device_name\"/" /etc/aziot/edged/config.yaml
     fi
+    sudo chown iotedge:iotedge /etc/aziot/edged/config.yaml
+    sudo chmod 644 /etc/aziot/edged/config.yaml
     sudo cat /etc/aziot/edged/config.yaml
 
-    echo "Setup identityd"   
+    echo "Setup identityd"
     sudo touch /etc/aziot/identityd/config.toml
     echo "hostname = \"$device_name\"" | sudo tee  /etc/aziot/identityd/config.toml
     echo "homedir = \"/var/lib/aziot/identityd\"" | sudo tee -a  /etc/aziot/identityd/config.toml
@@ -75,12 +81,14 @@ function setup_iotedge() {
         echo "iothub_hostname = \"$PARENT_NAME\"" | sudo tee -a  /etc/aziot/identityd/config.toml
     else
         echo "iothub_hostname = \"${IOT_HUB_NAME}.azure-devices.net\"" | sudo tee -a  /etc/aziot/identityd/config.toml
-    fi    
+    fi
     echo "device_id = \"${DEVICE_ID}\"" | sudo tee -a  /etc/aziot/identityd/config.toml
     echo "" | sudo tee -a  /etc/aziot/identityd/config.toml
     echo "[provisioning.authentication]" | sudo tee -a  /etc/aziot/identityd/config.toml
     echo "method = \"sas\"" | sudo tee -a  /etc/aziot/identityd/config.toml
     echo "device_id_pk = \"device-id\"" | sudo tee -a  /etc/aziot/identityd/config.toml
+    sudo chown aziotid:aziotid /etc/aziot/identityd/config.toml
+    sudo chmod 644 /etc/aziot/identityd/config.toml
     sudo cat /etc/aziot/identityd/config.toml
 
     echo "Setup aziot-edged-principal.toml"
@@ -96,7 +104,7 @@ function setup_iotedge() {
 
     echo "Setup /var/secrets/aziot/keyd/device-id"
     sudo touch /var/secrets/aziot/keyd/device-id
-    deviceSASKey=$(echo "${CONNECTION_STRING}" | sed -n 's/.*SharedAccessKey=\(.*\)/\1/p') 
+    deviceSASKey=$(echo "${CONNECTION_STRING}" | sed -n 's/.*SharedAccessKey=\(.*\)/\1/p')
     echo "SAS key: $deviceSASKey"
     echo $deviceSASKey | base64 -d > device-id
     sudo mv device-id  /var/secrets/aziot/keyd/device-id
@@ -213,7 +221,7 @@ function process_args() {
                 '-parentName' ) saveNextArg=15;;
                 '-connectionString' ) saveNextArg=16;;
                 '-deviceId' ) saveNextArg=17;;
-                '-iotHubName' ) saveNextArg=18;;             
+                '-iotHubName' ) saveNextArg=18;;
                 '-waitForTestComplete' ) WAIT_FOR_TEST_COMPLETE=1;;
                 '-cleanAll' ) CLEAN_ALL=1;;
 
@@ -235,7 +243,7 @@ function process_args() {
     [[ -z "$CONTAINER_REGISTRY_PASSWORD" ]] && { print_error 'Container registry password is required'; exit 1; }
     [[ -z "$DEPLOYMENT_FILE_NAME" ]] && { print_error 'Deployment file name is required'; exit 1; }
     [[ -z "$IOT_HUB_CONNECTION_STRING" ]] && { print_error 'IoT hub connection string is required'; exit 1; }
-    [[ -z "$STORAGE_ACCOUNT_CONNECTION_STRING" ]] && { print_error 'Storage account connection string is required'; exit 1; }   
+    [[ -z "$STORAGE_ACCOUNT_CONNECTION_STRING" ]] && { print_error 'Storage account connection string is required'; exit 1; }
 
     echo 'Required parameters are provided'
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -289,13 +289,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             }
         }
 
-        public static void ResetConfigFile(string configFile, string defaultFile, string owner)
-        {
-            // Reset the config file to the default.
-            File.Copy(defaultFile, configFile, true);
-            OsPlatform.Current.SetOwner(configFile, owner, "644");
-        }
-
         private static string SanitizeName(string name)
         {
             // Due to '.' being used as a delimiter for config file tables, names cannot contain '.'

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -289,23 +289,10 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             }
         }
 
-        public static void CreateConfigFile(string configFile, string defaultFile, string owner)
+        public static void ResetConfigFile(string configFile, string defaultFile, string owner)
         {
-            // If the config file does not exist, create it from the default file.
-            // If the default file does not exist, create an empty config file.
-            if (!File.Exists(configFile))
-            {
-                if (File.Exists(defaultFile))
-                {
-                    File.Copy(defaultFile, configFile);
-                }
-                else
-                {
-                    File.Create(configFile).Dispose();
-                }
-            }
-
-            // Change owner of config file.
+            // Reset the config file to the default.
+            File.Copy(defaultFile, configFile, true);
             OsPlatform.Current.SetOwner(configFile, owner, "644");
         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -159,16 +159,16 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.attestation.symmetric_key", keyName);
         }
 
-        public void SetDpsX509(string idScope, string registrationId, IdCertificates cert, string trustBundle)
+        public void SetDpsX509(string idScope, string registrationId, string identityCertPath, string identityPkPath, string trustBundle)
         {
-            if (!File.Exists(cert.CertificatePath))
+            if (!File.Exists(identityCertPath))
             {
-                throw new InvalidOperationException($"{cert.CertificatePath} does not exist");
+                throw new InvalidOperationException($"{identityCertPath} does not exist");
             }
 
-            if (!File.Exists(cert.KeyPath))
+            if (!File.Exists(identityPkPath))
             {
-                throw new InvalidOperationException($"{cert.KeyPath} does not exist");
+                throw new InvalidOperationException($"{identityPkPath} does not exist");
             }
 
             if (!File.Exists(trustBundle))
@@ -180,15 +180,15 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.attestation.method", "x509");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.attestation.registration_id", registrationId);
 
-            string certFileName = Path.GetFileName(cert.CertificatePath);
+            string certFileName = Path.GetFileName(identityCertPath);
             string certName = DaemonConfiguration.SanitizeName(certFileName);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.attestation.identity_cert", certName);
-            this.config[Service.Certd].Document.ReplaceOrAdd($"preloaded_certs.{certName}", "file://" + cert.CertificatePath);
+            this.config[Service.Certd].Document.ReplaceOrAdd($"preloaded_certs.{certName}", "file://" + identityCertPath);
 
-            string keyFileName = Path.GetFileName(cert.KeyPath);
+            string keyFileName = Path.GetFileName(identityPkPath);
             string keyName = DaemonConfiguration.SanitizeName(keyFileName);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.attestation.identity_pk", keyName);
-            this.config[Service.Keyd].Document.ReplaceOrAdd($"preloaded_keys.{keyName}", "file://" + cert.KeyPath);
+            this.config[Service.Keyd].Document.ReplaceOrAdd($"preloaded_keys.{keyName}", "file://" + identityPkPath);
 
             this.config[Service.Certd].Document.ReplaceOrAdd("preloaded_certs.aziot-edged-trust-bundle", "file://" + trustBundle);
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         // All names passed to this function must be sanitized with DaemonConfiguration.SanitizeName
         private void CreatePreloadedKey(string name, string value)
         {
-            string filePath = $"/etc/aziot/e2e_tests/{name}.key";
+            string filePath = Path.Combine(FixedPaths.E2E_TEST_DIR, $"{name}.key");
 
             File.WriteAllBytes(filePath, Convert.FromBase64String(value));
             OsPlatform.Current.SetOwner(filePath, "aziotks", "600");

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IEdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IEdgeDaemon.cs
@@ -26,5 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         Task UninstallAsync(CancellationToken token);
 
         Task WaitForStatusAsync(EdgeDaemonStatus desired, CancellationToken token);
+
+        string GetDefaultEdgedConfig();
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 async () =>
                 {
                     ITransportSettings transport = protocol.ToTransportSettings();
-                    OsPlatform.Current.InstallCaCertificates(ca.EdgeCertificates.TrustedCertificates, transport);
+                    OsPlatform.Current.InstallCaCertificates(ca.EdgeCertificates.TrustedCertificates(), transport);
 
                     switch (auth)
                     {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/CaCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/CaCertificates.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
             {
                 FixedPaths.DeviceCaCert.Cert(deviceId),
                 FixedPaths.DeviceCaCert.Key(deviceId),
-                FixedPaths.DeviceCaCert.TrustCert(deviceId)
+                FixedPaths.DeviceCaCert.TrustCert
             };
         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/CaCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/CaCertificates.cs
@@ -10,11 +10,21 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
     {
         public string TrustedCertificatesPath { get; }
 
-        public IEnumerable<X509Certificate2> TrustedCertificates =>
-            new[]
+        public IEnumerable<X509Certificate2> TrustedCertificates()
+        {
+            X509Chain chain = new X509Chain();
+            chain.Build(new X509Certificate2(this.TrustedCertificatesPath));
+            int chainLength = chain.ChainElements.Count;
+
+            X509Certificate2[] trustedCerts = new X509Certificate2[chainLength];
+
+            for (int i = 0; i < chainLength; i++)
             {
-                new X509Certificate2(X509Certificate.CreateFromCertFile(this.TrustedCertificatesPath))
-            };
+                trustedCerts[i] = chain.ChainElements[i].Certificate;
+            }
+
+            return trustedCerts;
+        }
 
         string[] GetEdgeCertFileLocation(string deviceId)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/FixedPaths.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/FixedPaths.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
         {
             public static string Cert(string deviceId) => $"certs/iot-edge-device-{deviceId}-full-chain.cert.pem";
             public static string Key(string deviceId) => $"private/iot-edge-device-{deviceId}.key.pem";
-            public static string TrustCert(string deviceId) => "certs/azure-iot-test-only.intermediate-full-chain.cert.pem";
+            public static string TrustCert = "certs/azure-iot-test-only.intermediate-full-chain.cert.pem";
         }
 
         public sealed class RootCaCert

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/FixedPaths.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/FixedPaths.cs
@@ -2,8 +2,12 @@
 namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
 {
     using System.IO;
+
     public sealed class FixedPaths
     {
+        // Directory used by a test run to store temporary keys, certs, etc.
+        public const string E2E_TEST_DIR = "/etc/aziot/e2e_tests";
+
         public sealed class DeviceIdentityCert
         {
             public static string Cert(string deviceId) => $"certs/iot-device-{deviceId}-full-chain.cert.pem";
@@ -25,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
 
         public sealed class QuickStartCaCert
         {
-            private static string BasePath(string deviceId) => $"/etc/aziot/e2e_tests/{deviceId}";
+            private static string BasePath(string deviceId) => Path.Combine(E2E_TEST_DIR, deviceId);
 
             public static string Cert(string deviceId) => Path.Combine(BasePath(deviceId), "device_ca_cert.pem");
             public static string Key(string deviceId) => Path.Combine(BasePath(deviceId), "device_ca_cert_key.pem");

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -110,10 +110,10 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     // The name of the default aziot-edged config file differs based on OS.
                     string edgedDefault = this.packageManagement.GetDefaultEdgedConfig();
 
-                    DaemonConfiguration.CreateConfigFile(paths.Keyd, paths.Keyd + ".default", "aziotks");
-                    DaemonConfiguration.CreateConfigFile(paths.Certd, paths.Certd + ".default", "aziotcs");
-                    DaemonConfiguration.CreateConfigFile(paths.Identityd, paths.Identityd + ".default", "aziotid");
-                    DaemonConfiguration.CreateConfigFile(paths.Edged, edgedDefault, "iotedge");
+                    DaemonConfiguration.ResetConfigFile(paths.Keyd, paths.Keyd + ".default", "aziotks");
+                    DaemonConfiguration.ResetConfigFile(paths.Certd, paths.Certd + ".default", "aziotcs");
+                    DaemonConfiguration.ResetConfigFile(paths.Identityd, paths.Identityd + ".default", "aziotid");
+                    DaemonConfiguration.ResetConfigFile(paths.Edged, edgedDefault, "iotedge");
 
                     uint iotedgeUid = await EdgeDaemon.GetIotedgeUid(token);
                     DaemonConfiguration conf = new DaemonConfiguration(paths, iotedgeUid);

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -107,14 +107,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                         Edged = "/etc/aziot/edged/config.yaml"
                     };
 
-                    // The name of the default aziot-edged config file differs based on OS.
-                    string edgedDefault = this.packageManagement.GetDefaultEdgedConfig();
-
-                    DaemonConfiguration.ResetConfigFile(paths.Keyd, paths.Keyd + ".default", "aziotks");
-                    DaemonConfiguration.ResetConfigFile(paths.Certd, paths.Certd + ".default", "aziotcs");
-                    DaemonConfiguration.ResetConfigFile(paths.Identityd, paths.Identityd + ".default", "aziotid");
-                    DaemonConfiguration.ResetConfigFile(paths.Edged, edgedDefault, "iotedge");
-
                     uint iotedgeUid = await EdgeDaemon.GetIotedgeUid(token);
                     DaemonConfiguration conf = new DaemonConfiguration(paths, iotedgeUid);
                     (string msg, object[] props) = await config(conf);
@@ -253,6 +245,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     await Task.Delay(250, token).ConfigureAwait(false);
                 }
             }
+        }
+
+        public string GetDefaultEdgedConfig()
+        {
+            return this.packageManagement.GetDefaultEdgedConfig();
         }
 
         private static async Task<uint> GetIotedgeUid(CancellationToken token)

--- a/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
@@ -101,15 +101,27 @@ namespace Microsoft.Azure.Devices.Edge.Test
             IdCertificates idCert = await ca.GenerateIdentityCertificatesAsync(registrationId, token);
 
             // The trust bundle for this test isn't used. It can be any arbitrary existing certificate.
-            string trustBundle = Path.Combine(
-                caCertScriptPath,
-                "certs",
-                "azure-iot-test-only.intermediate-full-chain.cert.pem");
+            string trustBundle = Path.Combine(caCertScriptPath, FixedPaths.DeviceCaCert.TrustCert);
+
+            // Generated credentials need to be copied out of the script path because future runs
+            // of the script will overwrite them.
+            string path = Path.Combine(FixedPaths.E2E_TEST_DIR, registrationId);
+            string certPath = Path.Combine(path, "device_id_cert.pem");
+            string keyPath = Path.Combine(path, "device_id_cert_key.pem");
+            string trustBundlePath = Path.Combine(path, "trust_bundle.pem");
+
+            Directory.CreateDirectory(path);
+            File.Copy(idCert.CertificatePath, certPath);
+            OsPlatform.Current.SetOwner(certPath, "aziotcs", "644");
+            File.Copy(idCert.KeyPath, keyPath);
+            OsPlatform.Current.SetOwner(keyPath, "aziotks", "600");
+            File.Copy(trustBundle, trustBundlePath);
+            OsPlatform.Current.SetOwner(trustBundlePath, "aziotcs", "644");
 
             await this.daemon.ConfigureAsync(
                 config =>
                 {
-                    config.SetDpsX509(idScope, registrationId, idCert, trustBundle);
+                    config.SetDpsX509(idScope, registrationId, certPath, keyPath, trustBundlePath);
                     config.Update();
                     return Task.FromResult((
                         "with DPS X509 attestation for '{Identity}'",

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -62,6 +62,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     {
                         Directory.Delete(FixedPaths.E2E_TEST_DIR, true);
                     }
+
                     Directory.CreateDirectory(FixedPaths.E2E_TEST_DIR);
 
                     // Backup any existing service config files.

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -22,12 +22,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
     {
         IEdgeDaemon daemon;
 
-        private string[] configFiles =
+        private (string, string)[] configFiles =
         {
-            "/etc/aziot/keyd/config.toml",
-            "/etc/aziot/certd/config.toml",
-            "/etc/aziot/identityd/config.toml",
-            "/etc/aziot/edged/config.yaml"
+            ("/etc/aziot/keyd/config.toml", "aziotks"),
+            ("/etc/aziot/certd/config.toml", "aziotcs"),
+            ("/etc/aziot/identityd/config.toml", "aziotid"),
+            ("/etc/aziot/edged/config.yaml", "iotedge")
         };
 
         [OneTimeSetUp]
@@ -65,12 +65,18 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     Directory.CreateDirectory(FixedPaths.E2E_TEST_DIR);
 
                     // Backup any existing service config files.
-                    foreach (string file in this.configFiles)
+                    foreach ((string file, string owner) in this.configFiles)
                     {
                         if (File.Exists(file))
                         {
                             File.Move(file, file + ".backup", true);
                         }
+
+                        // The name of the default aziot-edged config file differs based on OS.
+                        string configDefault = file.Contains("edged") ? this.daemon.GetDefaultEdgedConfig() : file + ".default";
+
+                        // Reset all config files to the default file.
+                        ResetConfigFile(file, configDefault, owner);
                     }
 
                     await this.daemon.ConfigureAsync(
@@ -132,7 +138,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     Directory.Delete(FixedPaths.E2E_TEST_DIR, true);
 
                     // Restore backed up config files.
-                    foreach (string file in this.configFiles)
+                    foreach ((string file, string _) in this.configFiles)
                     {
                         string backupFile = file + ".backup";
 
@@ -151,6 +157,14 @@ namespace Microsoft.Azure.Devices.Edge.Test
             {
                 Log.CloseAndFlush();
             });
+
+        private static void ResetConfigFile(string configFile, string defaultFile, string owner)
+        {
+            // Reset the config file to the default.
+            Log.Information($"Resetting {configFile} to {defaultFile}");
+            File.Copy(defaultFile, configFile, true);
+            OsPlatform.Current.SetOwner(configFile, owner, "644");
+        }
     }
 
     // Generates a test CA cert, test CA key, and trust bundle.

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -57,8 +57,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     await this.daemon.UninstallAsync(token);
                     await this.daemon.InstallAsync(Context.Current.PackagePath, Context.Current.Proxy, token);
 
-                    // Create a directory for the tests to store certs, keys, etc.
-                    Directory.CreateDirectory("/etc/aziot/e2e_tests");
+                    // Clean the directory for test certs, keys, etc.
+                    if (Directory.Exists(FixedPaths.E2E_TEST_DIR))
+                    {
+                        Directory.Delete(FixedPaths.E2E_TEST_DIR, true);
+                    }
+                    Directory.CreateDirectory(FixedPaths.E2E_TEST_DIR);
 
                     // Backup any existing service config files.
                     foreach (string file in this.configFiles)
@@ -125,7 +129,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     await this.daemon.UninstallAsync(token);
 
                     // Delete test certs, keys, etc.
-                    Directory.Delete("/etc/aziot/e2e_tests", true);
+                    Directory.Delete(FixedPaths.E2E_TEST_DIR, true);
 
                     // Restore backed up config files.
                     foreach (string file in this.configFiles)
@@ -178,10 +182,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         public void AddCertsToConfig(DaemonConfiguration config)
         {
-            string path = $"/etc/aziot/e2e_tests/{this.deviceId}";
-            string certPath = $"{path}/device_ca_cert.pem";
-            string keyPath = $"{path}/device_ca_cert_key.pem";
-            string trustBundlePath = $"{path}/trust_bundle.pem";
+            string path = Path.Combine(FixedPaths.E2E_TEST_DIR, this.deviceId);
+            string certPath = Path.Combine(path, "device_ca_cert.pem");
+            string keyPath = Path.Combine(path, "device_ca_cert_key.pem");
+            string trustBundlePath = Path.Combine(path, "trust_bundle.pem");
 
             Directory.CreateDirectory(path);
             File.Copy(this.certs.TrustedCertificatesPath, trustBundlePath);

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
@@ -92,9 +92,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
             // Generated credentials need to be copied out of the script path because future runs
             // of the script will overwrite them.
-            string path = $"/etc/aziot/e2e_tests/{deviceId}";
-            string certPath = $"{path}/device_id_cert.pem";
-            string keyPath = $"{path}/device_id_cert_key.pem";
+            string path = Path.Combine(FixedPaths.E2E_TEST_DIR, deviceId);
+            string certPath = Path.Combine(path, "device_id_cert.pem");
+            string keyPath = Path.Combine(path, "device_id_cert_key.pem");
 
             Directory.CreateDirectory(path);
             File.Copy(identityCerts.CertificatePath, certPath);

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             File.Copy(identityCerts.KeyPath, keyPath);
             OsPlatform.Current.SetOwner(keyPath, "aziotks", "600");
 
-            X509Certificate2 deviceCert = new X509Certificate2(identityCerts.CertificatePath);
+            X509Certificate2 deviceCert = new X509Certificate2(certPath);
 
             return (new X509Thumbprint()
             {


### PR DESCRIPTION
Previous config files left by old tests would affect new test runs. Modifies the E2E tests to always start with the default config.

Also fixes a bug where only the first cert of a chain is parsed and added to the store.