### PR TITLE
Fix CentOS package build.

### DIFF
--- a/edgelet/Makefile
+++ b/edgelet/Makefile
@@ -128,8 +128,9 @@ install: release
 	$(GZIP) $(DESTDIR)$(man8)/aziot-edged.8
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(localstatedir)/lib/aziot/edged
 	$(INSTALL) -d -m 0755 $(DESTDIR)$(localstatedir)/log/aziot/edged
-	$(INSTALL) -m 0660 /dev/null $(DESTDIR)$(localstatedir)/lib/aziot/edged/aziot-edged.mgmt.sock
-	$(INSTALL) -m 0666 /dev/null $(DESTDIR)$(localstatedir)/lib/aziot/edged/aziot-edged.workload.sock
+	$(INSTALL) -d -m 0755 $(DESTDIR)$(localstatedir)/lib/iotedge
+	$(INSTALL) -m 0660 /dev/null $(DESTDIR)$(localstatedir)/lib/iotedge/mgmt.sock
+	$(INSTALL) -m 0666 /dev/null $(DESTDIR)$(localstatedir)/lib/iotedge/workload.sock
 	$(INSTALL_DATA) -D $(srcdir)/contrib/docs/LICENSE $(DESTDIR)$(docdir)/LICENSE
 	$(INSTALL_DATA) -D $(srcdir)/contrib/docs/ThirdPartyNotices $(DESTDIR)$(docdir)/ThirdPartyNotices
 	$(INSTALL_DATA) -D $(srcdir)/contrib/docs/trademark $(DESTDIR)$(docdir)/trademark

--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -122,7 +122,7 @@ hostname: "<ADD HOSTNAME HERE>"
 # Note: When using the fd:// scheme for listen.management_uri or listen.workload_uri,
 # the path of connect.management_uri and connect.workload_uri must match
 # the path of the underlying socket in the systemd socket files
-# (aziot-edged.workload.sock and aziot-edged.mgmt.sock).
+# (mgmt.sock and workload.sock).
 #
 ###############################################################################
 
@@ -152,7 +152,7 @@ connect:
 # Note: When using the fd:// scheme for listen.management_uri or listen.workload_uri,
 # the path of connect.management_uri and connect.workload_uri must match
 # the path of the underlying socket in the systemd socket files
-# (aziot-edged.workload.sock and aziot-edged.mgmt.sock).
+# (mgmt.sock and workload.sock).
 #
 ###############################################################################
 

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -41,7 +41,7 @@ fn run() -> Result<(), Error> {
     let aziot_bin = option_env!("AZIOT_BIN").unwrap_or("aziot");
 
     let default_mgmt_uri =
-        option_env!("IOTEDGE_HOST").unwrap_or("unix:///var/lib/iotedge/mgmt.sock");
+        option_env!("IOTEDGE_HOST").unwrap_or("unix:///var/run/iotedge/mgmt.sock");
 
     let default_diagnostics_image_name = format!(
         "/azureiotedge-diagnostics:{}",


### PR DESCRIPTION
e4794aee0aa6c7d78bee83d62662d5935bf8f381 reverted the management and workload
sockets to be under `/var/lib/iotedge` on CentOS and
`/var/run/iotedge` everywhere else, but missed a few places.