### PR TITLE
Fix partially succeeding Build Images Pipeline

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
     <add key="MyGetDeviceSdk" value="https://www.myget.org/F/aziot-device-sdk/api/v3/index.json" />
     <add key="MyGetEdgeExtension" value="https://www.myget.org/F/aziot-edge-extension/api/v3/index.json" />


### PR DESCRIPTION
Here is the fix:

https://docs.microsoft.com/en-us/nuget/reference/nuget-config-file
> When <clear /> is present for a given node, NuGet ignores previously defined configuration values for that node. Read more about how settings are applied.