### PR TITLE
Revert to use only root CA as trust bundle

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 async () =>
                 {
                     ITransportSettings transport = protocol.ToTransportSettings();
-                    OsPlatform.Current.InstallCaCertificates(ca.EdgeCertificates.TrustedCertificates(), transport);
+                    OsPlatform.Current.InstallCaCertificates(ca.EdgeCertificates.TrustedCertificates, transport);
 
                     switch (auth)
                     {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/CaCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/CaCertificates.cs
@@ -10,21 +10,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
     {
         public string TrustedCertificatesPath { get; }
 
-        public IEnumerable<X509Certificate2> TrustedCertificates()
-        {
-            X509Chain chain = new X509Chain();
-            chain.Build(new X509Certificate2(this.TrustedCertificatesPath));
-            int chainLength = chain.ChainElements.Count;
-
-            X509Certificate2[] trustedCerts = new X509Certificate2[chainLength];
-
-            for (int i = 0; i < chainLength; i++)
+        public IEnumerable<X509Certificate2> TrustedCertificates =>
+            new[]
             {
-                trustedCerts[i] = chain.ChainElements[i].Certificate;
-            }
-
-            return trustedCerts;
-        }
+                new X509Certificate2(X509Certificate.CreateFromCertFile(this.TrustedCertificatesPath))
+            };
 
         string[] GetEdgeCertFileLocation(string deviceId)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/FixedPaths.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/FixedPaths.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
         {
             public static string Cert(string deviceId) => $"certs/iot-edge-device-{deviceId}-full-chain.cert.pem";
             public static string Key(string deviceId) => $"private/iot-edge-device-{deviceId}.key.pem";
-            public static string TrustCert = "certs/azure-iot-test-only.intermediate-full-chain.cert.pem";
+            public static string TrustCert = "certs/azure-iot-test-only.root.ca.cert.pem";
         }
 
         public sealed class RootCaCert


### PR DESCRIPTION
Reverts a previous change that added the intermediate certs to the trust bundle. Only put the root CA cert in the trust bundle. The E2E tests were failing when intermediate certs were in the trust bundle, possibly because it wasn't validating the full chain.