### PR TITLE
Move NestedEdge/Broker out of experimental features

### DIFF
--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment.json
@@ -26,10 +26,7 @@
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "experimentalFeatures__enabled": {
-                "value": "true"
-              },
-              "experimentalFeatures__mqttBrokerEnabled": {
+              "MqttBrokerEnabled": {
                 "value": "true"
               },
               "DeviceScopeCacheRefreshDelaySecs": {

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment.json
@@ -29,9 +29,6 @@
               "experimentalFeatures__enabled": {
                 "value": "true"
               },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              },
               "experimentalFeatures__mqttBrokerEnabled": {
                 "value": "true"
               },
@@ -40,7 +37,7 @@
               },
               "RuntimeLogLevel": {
                 "value": "debug"
-              }                   
+              }
             },
             "status": "running",
             "restartPolicy": "always"
@@ -77,18 +74,18 @@
         },
         "mqttBroker": {
           "authorizations": [
-              {
-                  "identities": [
-                      "{{iot:identity}}"
-                  ],
-                  "allow": [
-                      {
-                          "operations": [
-                              "mqtt:connect"
-                          ]
-                      }
+            {
+              "identities": [
+                "{{iot:identity}}"
+              ],
+              "allow": [
+                {
+                  "operations": [
+                    "mqtt:connect"
                   ]
-              }
+                }
+              ]
+            }
           ]
         }
       }

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment.json
@@ -33,10 +33,7 @@
               "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "experimentalFeatures__enabled": {
-                "value": "true"
-              },
-              "experimentalFeatures__mqttBrokerEnabled": {
+              "MqttBrokerEnabled": {
                 "value": "true"
               },
               "DeviceScopeCacheRefreshDelaySecs": {

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment.json
@@ -36,9 +36,6 @@
               "experimentalFeatures__enabled": {
                 "value": "true"
               },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              },
               "experimentalFeatures__mqttBrokerEnabled": {
                 "value": "true"
               },
@@ -47,7 +44,7 @@
               },
               "RuntimeLogLevel": {
                 "value": "debug"
-              }                   
+              }
             },
             "status": "running",
             "restartPolicy": "always"
@@ -109,18 +106,18 @@
         },
         "mqttBroker": {
           "authorizations": [
-              {
-                  "identities": [
-                      "{{iot:identity}}"
-                  ],
-                  "allow": [
-                      {
-                          "operations": [
-                              "mqtt:connect"
-                          ]
-                      }
+            {
+              "identities": [
+                "{{iot:identity}}"
+              ],
+              "allow": [
+                {
+                  "operations": [
+                    "mqtt:connect"
                   ]
-              }
+                }
+              ]
+            }
           ]
         }
       }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             public const string StorageMaxOpenFiles = "RocksDB_MaxOpenFiles";
             public const string StorageLogLevel = "Storage_LogLevel";
             public const string ExperimentalFeatures = "experimentalFeatures";
-            public const string NestedEdgeEnabled = "nestedEdgeEnabled";
+            public const string NestedEdgeEnabled = "NestedEdgeEnabled";
             public const string MqttBrokerEnabled = "mqttBrokerEnabled";
         }
     }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             public const string StorageLogLevel = "Storage_LogLevel";
             public const string ExperimentalFeatures = "experimentalFeatures";
             public const string NestedEdgeEnabled = "NestedEdgeEnabled";
-            public const string MqttBrokerEnabled = "mqttBrokerEnabled";
+            public const string MqttBrokerEnabled = "MqttBrokerEnabled";
         }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -124,8 +124,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
             MetricsConfig metricsConfig = new MetricsConfig(this.configuration.GetSection("metrics:listener"));
 
-            this.RegisterCommonModule(builder, optimizeForPerformance, storeAndForward, metricsConfig, experimentalFeatures);
-            this.RegisterRoutingModule(builder, storeAndForward, experimentalFeatures);
+            bool nestedEdgeEnabled = this.configuration.GetValue<bool>(Constants.ConfigKey.NestedEdgeEnabled, true);
+
+            this.RegisterCommonModule(builder, optimizeForPerformance, storeAndForward, metricsConfig, nestedEdgeEnabled);
+            this.RegisterRoutingModule(builder, storeAndForward, experimentalFeatures, nestedEdgeEnabled);
             this.RegisterMqttModule(builder, storeAndForward, optimizeForPerformance, experimentalFeatures);
             this.RegisterAmqpModule(builder);
             builder.RegisterModule(new HttpModule(this.iotHubHostname));
@@ -176,7 +178,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         void RegisterRoutingModule(
             ContainerBuilder builder,
             StoreAndForward storeAndForward,
-            ExperimentalFeatures experimentalFeatures)
+            ExperimentalFeatures experimentalFeatures,
+            bool nestedEdgeEnabled)
         {
             var routes = this.configuration.GetSection("routes").Get<Dictionary<string, string>>();
             int connectionPoolSize = this.configuration.GetValue<int>("IotHubConnectionPoolSize");
@@ -246,7 +249,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     messageCleanupIntervalSecs,
                     experimentalFeatures,
                     closeCloudConnectionOnDeviceDisconnect,
-                    experimentalFeatures.EnableNestedEdge,
+                    nestedEdgeEnabled,
                     isLegacyUpstream));
         }
 
@@ -255,7 +258,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool optimizeForPerformance,
             StoreAndForward storeAndForward,
             MetricsConfig metricsConfig,
-            ExperimentalFeatures experimentalFeatures)
+            bool nestedEdgeEnabled)
         {
             bool cacheTokens = this.configuration.GetValue("CacheTokens", false);
             Option<string> workloadUri = this.GetConfigurationValueIfExists<string>(Constants.ConfigKey.WorkloadUri);
@@ -305,7 +308,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     storeAndForward.StorageMaxTotalWalSize,
                     storeAndForward.StorageMaxOpenFiles,
                     storeAndForward.StorageLogLevel,
-                    experimentalFeatures.EnableNestedEdge));
+                    nestedEdgeEnabled));
         }
 
         static string GetProductInfo()

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
@@ -7,12 +7,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class ExperimentalFeatures
     {
-        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck, bool enableMqttBroker)
+        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
             this.DisableConnectivityCheck = disableConnectivityCheck;
-            this.EnableMqttBroker = enableMqttBroker;
         }
 
         public static ExperimentalFeatures Create(IConfiguration experimentalFeaturesConfig, ILogger logger)
@@ -20,19 +19,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
             bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("disableConnectivityCheck", false);
-            bool enableMqttBroker = enabled && experimentalFeaturesConfig.GetValue(Constants.ConfigKey.MqttBrokerEnabled, false);
-            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableMqttBroker);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck);
             logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
             return experimentalFeatures;
-        }
-
-        public static bool IsViaBrokerUpstream(ExperimentalFeatures experimentalFeatures, bool hasGatewayHostname)
-        {
-            bool isLegacyUpstream = !experimentalFeatures.Enabled
-                || !experimentalFeatures.EnableMqttBroker
-                || !hasGatewayHostname;
-
-            return isLegacyUpstream;
         }
 
         public bool Enabled { get; }
@@ -40,7 +29,5 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         public bool DisableCloudSubscriptions { get; }
 
         public bool DisableConnectivityCheck { get; }
-
-        public bool EnableMqttBroker { get; }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
@@ -7,12 +7,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class ExperimentalFeatures
     {
-        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck, bool enableNestedEdge, bool enableMqttBroker)
+        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck, bool enableMqttBroker)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
             this.DisableConnectivityCheck = disableConnectivityCheck;
-            this.EnableNestedEdge = enableNestedEdge;
             this.EnableMqttBroker = enableMqttBroker;
         }
 
@@ -21,9 +20,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
             bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("disableConnectivityCheck", false);
-            bool enableNestedEdge = enabled && experimentalFeaturesConfig.GetValue(Constants.ConfigKey.NestedEdgeEnabled, false);
             bool enableMqttBroker = enabled && experimentalFeaturesConfig.GetValue(Constants.ConfigKey.MqttBrokerEnabled, false);
-            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableNestedEdge, enableMqttBroker);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableMqttBroker);
             logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
             return experimentalFeatures;
         }
@@ -32,7 +30,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         {
             bool isLegacyUpstream = !experimentalFeatures.Enabled
                 || !experimentalFeatures.EnableMqttBroker
-                || !experimentalFeatures.EnableNestedEdge
                 || !hasGatewayHostname;
 
             return isLegacyUpstream;
@@ -43,8 +40,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         public bool DisableCloudSubscriptions { get; }
 
         public bool DisableConnectivityCheck { get; }
-
-        public bool EnableNestedEdge { get; }
 
         public bool EnableMqttBroker { get; }
     }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             var mqttSettingsConfiguration = new Mock<IConfiguration>();
             mqttSettingsConfiguration.Setup(c => c.GetSection(It.IsAny<string>())).Returns(Mock.Of<IConfigurationSection>(s => s.Value == null));
 
-            var experimentalFeatures = new ExperimentalFeatures(true, false, false, false, false);
+            var experimentalFeatures = new ExperimentalFeatures(true, false, false, false);
 
             builder.RegisterBuildCallback(
                 c =>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             var mqttSettingsConfiguration = new Mock<IConfiguration>();
             mqttSettingsConfiguration.Setup(c => c.GetSection(It.IsAny<string>())).Returns(Mock.Of<IConfigurationSection>(s => s.Value == null));
 
-            var experimentalFeatures = new ExperimentalFeatures(true, false, false, false);
+            var experimentalFeatures = new ExperimentalFeatures(true, false, false);
 
             builder.RegisterBuildCallback(
                 c =>

--- a/edge-hub/watchdog/src/main.rs
+++ b/edge-hub/watchdog/src/main.rs
@@ -30,12 +30,9 @@ fn main() -> Result<()> {
     init_logging();
     info!("Starting Watchdog");
 
-    let experimental_features_enabled = std::env::var("experimentalFeatures__enabled")
+    let mqtt_broker_enabled = std::env::var("MqttBrokerEnabled")
         .unwrap_or_else(|_| "false".to_string())
-        == "true";
-
-    let mqtt_broker_enabled = std::env::var("experimentalFeatures__mqttBrokerEnabled")
-        .unwrap_or_else(|_| "false".to_string())
+        .to_lowercase()
         == "true";
 
     let should_shutdown = register_shutdown_listener()
@@ -50,7 +47,7 @@ fn main() -> Result<()> {
 
     let mut broker_handle = None;
 
-    if experimental_features_enabled && mqtt_broker_enabled {
+    if mqtt_broker_enabled {
         broker_handle = match run(
             "MQTT Broker",
             "/usr/local/bin/mqttd",

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
@@ -44,11 +44,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
             if (nestedEdge == true)
             {
-                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("experimentalFeatures__enabled", "true"), ("experimentalFeatures__nestedEdgeEnabled", "true"), ("DeviceScopeCacheRefreshDelaySecs", "1") };
+                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("NestedEdgeEnabled", "true"), ("DeviceScopeCacheRefreshDelaySecs", "1") };
             }
             else
             {
-                hubEnvVar = new[] { ("RuntimeLogLevel", "debug") };
+                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("NestedEdgeEnabled", "false"), };
             }
 
             var builder = new EdgeConfigBuilder(this.DeviceId);

--- a/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     builder.GetModule(ModuleName.EdgeHub)
                         .WithEnvironment(new[]
                         {
-                            ("experimentalFeatures__enabled", "true"),
-                            ("experimentalFeatures__mqttBrokerEnabled", "true"),
+                            ("MqttBrokerEnabled", "true"),
                         })
                         // deploy with deny policy
                         .WithDesiredProperties(new Dictionary<string, object>
@@ -115,8 +114,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     builder.GetModule(ModuleName.EdgeHub)
                         .WithEnvironment(new[]
                         {
-                            ("experimentalFeatures__enabled", "true"),
-                            ("experimentalFeatures__mqttBrokerEnabled", "true"),
+                            ("MqttBrokerEnabled", "true"),
                         })
                         .WithDesiredProperties(new Dictionary<string, object>
                         {
@@ -197,8 +195,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     builder.GetModule(ModuleName.EdgeHub)
                         .WithEnvironment(new[]
                         {
-                            ("experimentalFeatures__enabled", "true"),
-                            ("experimentalFeatures__mqttBrokerEnabled", "true"),
+                            ("MqttBrokerEnabled", "true"),
                         })
                         .WithDesiredProperties(new Dictionary<string, object>
                         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -117,8 +117,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             builder.GetModule(ModuleName.EdgeHub)
                 .WithEnvironment(new[]
                 {
-                    ("experimentalFeatures__enabled", "true"),
-                    ("experimentalFeatures__mqttBrokerEnabled", "true"),
+                    ("MqttBrokerEnabled", "true"),
                 })
                 .WithDesiredProperties(new Dictionary<string, object>
                 {


### PR DESCRIPTION
### NOTE: After this PR is merged, Nested Edge would be enabled by default.
There are two main changes in this PR:
- Enable nested edge by default
- Move `NestedEdgeEnabled` and `MqttBrokerEnabled` settings out of `experimentalFeatures` sectiion.

### Before:
To enable nested edge/broker you would need to have the following env vars in your deployment manifest:
```json
                    "edgeHub": {
                        "type": "docker",
                        "status": "running",
                        "restartPolicy": "always",
                        "settings": {
                            "image": "edgerelease.azurecr.io/microsoft/azureiotedge-hub:1.2.0-rc3-linux-amd64",
                            "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"1883/tcp\": [{\"HostPort\": \"1883\"}], \"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
                        },
                        "env": {
                            "experimentalFeatures__nestedEdgeEnabled": {
                                "value": "true"
                            },
                            "experimentalFeatures__mqttBrokerEnabled": {
                                "value": "true"
                            },
                            "experimentalFeatures__enabled": {
                                "value": "true"
                            }
                        }
                    }
```

### After
With this change, the Nested Edge would be on by default, and `MqttBrokerEnabled` would be first class setting. So if you want to run nested + broker, here is how the deployment manifest would look like:
```json
                    "edgeHub": {
                        "type": "docker",
                        "status": "running",
                        "restartPolicy": "always",
                        "settings": {
                            "image": "edgerelease.azurecr.io/microsoft/azureiotedge-hub:1.2.0-rc3-linux-amd64",
                            "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"1883/tcp\": [{\"HostPort\": \"1883\"}], \"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
                        },
                        "env": {
                            "MqttBrokerEnabled": {
                                "value": "true"
                            }
                        }
                    }
```

if for some reason you want to disable nested edge, here's how to do that:
```json
                    "edgeHub": {
                        "type": "docker",
                        "status": "running",
                        "restartPolicy": "always",
                        "settings": {
                            "image": "edgerelease.azurecr.io/microsoft/azureiotedge-hub:1.2.0-rc3-linux-amd64",
                            "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"1883/tcp\": [{\"HostPort\": \"1883\"}], \"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
                        },
                        "env": {
                            "NestedEdgeEnabled": {
                                "value": "false"
                            }
                        }
                    }
```