### PR TITLE
[mqtt] Implement shutdown/restart integration test

### DIFF
--- a/mqtt/mqtt-bridge/src/bridge.rs
+++ b/mqtt/mqtt-bridge/src/bridge.rs
@@ -6,7 +6,7 @@ use mqtt3::ShutdownError;
 use tracing::{debug, error, info, info_span};
 use tracing_futures::Instrument;
 
-use mqtt_util::client_io::Credentials;
+use mqtt_util::Credentials;
 
 use crate::{
     client::{ClientError, MqttClientConfig},

--- a/mqtt/mqtt-bridge/src/client.rs
+++ b/mqtt/mqtt-bridge/src/client.rs
@@ -11,10 +11,7 @@ use mqtt3::{
     proto::{self, Publication, SubscribeTo},
     Client, Event, ShutdownError, UpdateSubscriptionError,
 };
-
-use mqtt_util::client_io::{
-    ClientIoSource, Credentials, SasTokenSource, TcpConnection, TrustBundleSource,
-};
+use mqtt_util::{ClientIoSource, Credentials, SasTokenSource, TcpConnection, TrustBundleSource};
 
 const DEFAULT_MAX_RECONNECT: Duration = Duration::from_secs(60);
 // TODO: get QOS from topic settings
@@ -399,7 +396,7 @@ pub enum ClientError {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mqtt_util::client_io::AuthenticationSettings;
+    use mqtt_util::AuthenticationSettings;
 
     #[derive(Default)]
     struct EventHandler {}

--- a/mqtt/mqtt-bridge/src/settings.rs
+++ b/mqtt/mqtt-bridge/src/settings.rs
@@ -3,7 +3,7 @@ use std::{path::Path, time::Duration, vec::Vec};
 use config::{Config, ConfigError, Environment, File, FileFormat};
 use serde::Deserialize;
 
-use mqtt_util::client_io::{CredentialProviderSettings, Credentials};
+use mqtt_util::{CredentialProviderSettings, Credentials};
 
 pub const DEFAULTS: &str = include_str!("../config/default.json");
 const DEFAULT_UPSTREAM_PORT: &str = "8883";

--- a/mqtt/mqtt-bridge/tests/common.rs
+++ b/mqtt/mqtt-bridge/tests/common.rs
@@ -1,0 +1,102 @@
+use std::time::Duration;
+
+use tokio::task::JoinHandle;
+
+use mqtt_bridge::{
+    settings::{BridgeSettings, Direction},
+    BridgeController, BridgeControllerHandle,
+};
+use mqtt_broker::{
+    auth::Authorizer, sidecar::Sidecar, BrokerBuilder, BrokerHandle, ServerCertificate,
+};
+use mqtt_broker_tests_util::server::{
+    start_server, start_server_with_tls, DummyAuthenticator, ServerHandle,
+};
+use mqtt_util::{AuthenticationSettings, Credentials};
+
+const PRIVATE_KEY: &str = include_str!("../tests/tls/pkey.pem");
+const CERTIFICATE: &str = include_str!("../tests/tls/cert.pem");
+
+pub fn setup_brokers<Z, T>(
+    local_authorizer: Z,
+    upstream_authorizer: T,
+) -> (ServerHandle, BrokerHandle, ServerHandle, BrokerHandle)
+where
+    Z: Authorizer + Send + 'static,
+    T: Authorizer + Send + 'static,
+{
+    let (local_server_handle, local_broker_handle) = setup_local_broker(local_authorizer);
+    let (upstream_server_handle, upstream_broker_handle) =
+        setup_upstream_broker(upstream_authorizer, None, None);
+
+    (
+        local_server_handle,
+        local_broker_handle,
+        upstream_server_handle,
+        upstream_broker_handle,
+    )
+}
+
+pub fn setup_upstream_broker<Z>(
+    authorizer: Z,
+    tcp_addr: Option<String>,
+    tls_addr: Option<String>,
+) -> (ServerHandle, BrokerHandle)
+where
+    Z: Authorizer + Send + 'static,
+{
+    let upstream_broker = BrokerBuilder::default().with_authorizer(authorizer).build();
+    let upstream_broker_handle = upstream_broker.handle();
+    let identity = ServerCertificate::from_pem_pair(CERTIFICATE, PRIVATE_KEY).unwrap();
+
+    let upstream_server_handle = start_server_with_tls(
+        identity,
+        upstream_broker,
+        DummyAuthenticator::with_id("device_1"),
+        tcp_addr,
+        tls_addr,
+    );
+
+    (upstream_server_handle, upstream_broker_handle)
+}
+
+pub fn setup_local_broker<Z>(authorizer: Z) -> (ServerHandle, BrokerHandle)
+where
+    Z: Authorizer + Send + 'static,
+{
+    let local_broker = BrokerBuilder::default().with_authorizer(authorizer).build();
+    let local_broker_handle = local_broker.handle();
+    let local_server_handle = start_server(local_broker, DummyAuthenticator::with_id("local"));
+
+    (local_server_handle, local_broker_handle)
+}
+
+pub async fn setup_bridge_controller(
+    local_address: String,
+    upstream_address: String,
+    subs: Vec<Direction>,
+) -> (BridgeControllerHandle, JoinHandle<()>) {
+    let credentials = Credentials::PlainText(AuthenticationSettings::new(
+        "bridge".into(),
+        "pass".into(),
+        "bridge".into(),
+        Some(CERTIFICATE.into()),
+    ));
+
+    let settings = BridgeSettings::from_upstream_details(
+        upstream_address,
+        credentials,
+        subs,
+        true,
+        Duration::from_secs(5),
+    )
+    .unwrap();
+
+    let controller = BridgeController::new(local_address, "bridge".into(), settings);
+    let controller_handle = controller.handle();
+    let controller: Box<dyn Sidecar + Send> = Box::new(controller);
+
+    let join = tokio::spawn(controller.run());
+
+    (controller_handle, join)
+}

--- a/mqtt/mqtt-bridge/tests/integration.rs
+++ b/mqtt/mqtt-bridge/tests/integration.rs
@@ -185,7 +185,7 @@ async fn bridge_settings_update() {
         .unwrap();
 
     // delay to propagate the update
-    // tokio::time::delay_for(Duration::from_secs(2)).await;
+    tokio::time::delay_for(Duration::from_secs(2)).await;
 
     // send upstream
     local_client

--- a/mqtt/mqtt-bridge/tests/integration.rs
+++ b/mqtt/mqtt-bridge/tests/integration.rs
@@ -1,30 +1,24 @@
-use std::{any::Any, convert::Infallible, time::Duration, vec};
+mod common;
 
-use bson::{doc, spec::BinarySubtype};
+use std::{any::Any, convert::Infallible, time::Duration};
+
 use bytes::Bytes;
 use futures_util::StreamExt;
 use matches::assert_matches;
+
 use mqtt3::{
     proto::{ClientId, QoS},
     ReceivedPublication,
 };
 use mqtt_bridge::{
-    settings::{BridgeSettings, Direction, TopicRule},
-    BridgeController, BridgeControllerHandle, BridgeControllerUpdate,
+    settings::{Direction, TopicRule},
+    BridgeControllerUpdate,
 };
 use mqtt_broker::{
     auth::{Activity, AllowAll, Authorization, Authorizer, Operation},
-    sidecar::Sidecar,
-    BrokerBuilder, BrokerHandle, ServerCertificate, SystemEvent,
+    SystemEvent,
 };
-use mqtt_broker_tests_util::{
-    client::TestClientBuilder,
-    server::{start_server, start_server_with_tls, DummyAuthenticator, ServerHandle},
-};
-use mqtt_util::client_io::{AuthenticationSettings, Credentials};
-
-const PRIVATE_KEY: &str = include_str!("../tests/tls/pkey.pem");
-const CERTIFICATE: &str = include_str!("../tests/tls/cert.pem");
+use mqtt_broker_tests_util::client::TestClientBuilder;
 
 pub struct DummySubscribeAuthorizer(bool);
 
@@ -70,8 +64,8 @@ async fn send_message_upstream_downstream() {
     ];
 
     let (mut local_server_handle, _, mut upstream_server_handle, _) =
-        setup_brokers(AllowAll, AllowAll);
-    let controller_handle = setup_bridge_controller(
+        common::setup_brokers(AllowAll, AllowAll);
+    let (controller_handle, controller_task) = common::setup_bridge_controller(
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs,
@@ -111,15 +105,17 @@ async fn send_message_upstream_downstream() {
 
     assert_matches!(
         upstream_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("from local")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from local")
     );
 
     assert_matches!(
         local_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("from upstream")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from upstream")
     );
 
     controller_handle.shutdown();
+    controller_task.await.expect("controller task");
+
     local_server_handle.shutdown().await;
     upstream_server_handle.shutdown().await;
     upstream_client.shutdown().await;
@@ -129,8 +125,8 @@ async fn send_message_upstream_downstream() {
 #[tokio::test]
 async fn bridge_settings_update() {
     let (mut local_server_handle, _, mut upstream_server_handle, _) =
-        setup_brokers(AllowAll, AllowAll);
-    let mut controller_handle = setup_bridge_controller(
+        common::setup_brokers(AllowAll, AllowAll);
+    let (mut controller_handle, controller_task) = common::setup_bridge_controller(
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         vec![],
@@ -189,7 +185,7 @@ async fn bridge_settings_update() {
         .unwrap();
 
     // delay to propagate the update
-    tokio::time::delay_for(Duration::from_secs(2)).await;
+    // tokio::time::delay_for(Duration::from_secs(2)).await;
 
     // send upstream
     local_client
@@ -203,15 +199,17 @@ async fn bridge_settings_update() {
 
     assert_matches!(
         local_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("from upstream after update")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from upstream after update")
     );
 
     assert_matches!(
         upstream_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("from local after update")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from local after update")
     );
 
     controller_handle.shutdown();
+    controller_task.await.expect("controller task");
+
     local_server_handle.shutdown().await;
     upstream_server_handle.shutdown().await;
     upstream_client.shutdown().await;
@@ -221,7 +219,7 @@ async fn bridge_settings_update() {
 #[tokio::test]
 async fn subscribe_to_upstream_rejected_should_retry() {
     let (mut local_server_handle, _, mut upstream_server_handle, upstream_broker_handle) =
-        setup_brokers(AllowAll, DummySubscribeAuthorizer(false));
+        common::setup_brokers(AllowAll, DummySubscribeAuthorizer(false));
 
     let subs = vec![
         Direction::Out(TopicRule::new(
@@ -235,7 +233,7 @@ async fn subscribe_to_upstream_rejected_should_retry() {
             Some("downstream".into()),
         )),
     ];
-    let controller_handle = setup_bridge_controller(
+    let (controller_handle, controller_task) = common::setup_bridge_controller(
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs,
@@ -279,10 +277,12 @@ async fn subscribe_to_upstream_rejected_should_retry() {
 
     assert_matches!(
         local_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("from upstream after update")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from upstream after update")
     );
 
     controller_handle.shutdown();
+    controller_task.await.expect("controller task");
+
     local_server_handle.shutdown().await;
     upstream_server_handle.shutdown().await;
     upstream_client.shutdown().await;
@@ -291,7 +291,7 @@ async fn subscribe_to_upstream_rejected_should_retry() {
 
 #[tokio::test]
 async fn connect_to_upstream_failure_should_retry() {
-    let (mut local_server_handle, _) = setup_local_broker(AllowAll);
+    let (mut local_server_handle, _) = common::setup_local_broker(AllowAll);
 
     let subs = vec![
         Direction::Out(TopicRule::new(
@@ -307,7 +307,7 @@ async fn connect_to_upstream_failure_should_retry() {
     ];
     let upstream_tcp_address = "localhost:8801".to_string();
     let upstream_tls_address = "localhost:8802".to_string();
-    let controller_handle = setup_bridge_controller(
+    let (controller_handle, controller_task) = common::setup_bridge_controller(
         local_server_handle.address(),
         upstream_tls_address.clone(),
         subs,
@@ -326,10 +326,10 @@ async fn connect_to_upstream_failure_should_retry() {
 
     assert_matches!(
         local_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("{\"status\":\"Disconnected\"}")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("{\"status\":\"Disconnected\"}")
     );
 
-    let (mut upstream_server_handle, _) = setup_upstream_broker(
+    let (mut upstream_server_handle, _) = common::setup_upstream_broker(
         AllowAll,
         Some(upstream_tcp_address.clone()),
         Some(upstream_tls_address.clone()),
@@ -337,204 +337,145 @@ async fn connect_to_upstream_failure_should_retry() {
 
     assert_matches!(
         local_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("{\"status\":\"Connected\"}")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("{\"status\":\"Connected\"}")
     );
 
     upstream_server_handle.shutdown().await;
     assert_matches!(
         local_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("{\"status\":\"Disconnected\"}")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("{\"status\":\"Disconnected\"}")
     );
 
-    let (mut upstream_server_handle, _) = setup_upstream_broker(
+    let (mut upstream_server_handle, _) = common::setup_upstream_broker(
         AllowAll,
         Some(upstream_tcp_address),
         Some(upstream_tls_address),
     );
     assert_matches!(
         local_client.publications().next().await,
-        Some(ReceivedPublication{payload, .. }) if payload == Bytes::from("{\"status\":\"Connected\"}")
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("{\"status\":\"Connected\"}")
     );
 
     controller_handle.shutdown();
+    controller_task.await.expect("controller task");
+
     local_server_handle.shutdown().await;
     upstream_server_handle.shutdown().await;
     local_client.shutdown().await;
 }
 
 #[tokio::test]
-async fn get_twin_update_via_rpc() {
+async fn bridge_forwards_messages_after_restart() {
+    let subs = vec![
+        Direction::Out(TopicRule::new(
+            "temp/#".into(),
+            Some("to".into()),
+            Some("upstream".into()),
+        )),
+        Direction::In(TopicRule::new(
+            "filter/#".into(),
+            Some("to".into()),
+            Some("downstream".into()),
+        )),
+    ];
+
     let (mut local_server_handle, _, mut upstream_server_handle, _) =
-        setup_brokers(AllowAll, AllowAll);
-    let controller_handle = setup_bridge_controller(
+        common::setup_brokers(AllowAll, AllowAll);
+    let (controller_handle, controller_task) = common::setup_bridge_controller(
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
-        Vec::new(),
+        subs.clone(),
     )
     .await;
 
-    // connect to the remote broker to emulate upstream interaction
-    let mut upstream = TestClientBuilder::new(upstream_server_handle.address())
-        .with_client_id(ClientId::IdWithExistingSession("upstream".into()))
+    // connect to local server and subscribe for downstream topic
+    let mut local_client = TestClientBuilder::new(local_server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("local_client".into()))
         .build();
-    upstream
-        .subscribe("$iothub/+/twin/get/#", QoS::AtLeastOnce)
+    local_client
+        .subscribe("downstream/filter/#", QoS::AtLeastOnce)
         .await;
-    assert!(upstream.subscriptions().next().await.is_some());
+    local_client.subscriptions().next().await;
 
-    // connect to the local broker with eh-core client
-    let mut edgehub = TestClientBuilder::new(local_server_handle.address())
-        .with_client_id(ClientId::IdWithExistingSession("edgehub".into()))
+    // connect to upstream server and subscribe for upstream topic
+    let mut upstream_client = TestClientBuilder::new(upstream_server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("upstream_client".into()))
         .build();
-
-    // edgehub subscribes to any downstream topic command acknowledgement
-    edgehub.subscribe("$downstream/#", QoS::AtLeastOnce).await;
-    assert!(edgehub.subscriptions().next().await.is_some());
-
-    // edgehub subscribes to twin response
-    let payload = command("sub", "$iothub/device-1/twin/res/#", None);
-    edgehub
-        .publish_qos1("$upstream/rpc/1", payload, false)
+    upstream_client
+        .subscribe("upstream/temp/#", QoS::AtLeastOnce)
         .await;
-    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/rpc/ack/1");
+    upstream_client.subscriptions().next().await;
 
-    // edgehub makes a request to get a twin for the leaf device
-    let payload = command(
-        "pub",
-        "$iothub/device-1/twin/get/?rid=1",
-        Some(Vec::default()),
+    // send upstream
+    local_client
+        .publish_qos1("to/temp/1", "from local 1", false)
+        .await;
+
+    // send downstream
+    upstream_client
+        .publish_qos1("to/filter/1", "from upstream 1", false)
+        .await;
+
+    assert_matches!(
+        upstream_client.publications().next().await,
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from local 1")
     );
-    edgehub
-        .publish_qos1("$upstream/rpc/2", payload, false)
+
+    assert_matches!(
+        local_client.publications().next().await,
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from upstream 1")
+    );
+
+    // shutdown all bridges
+    controller_handle.shutdown();
+    controller_task.await.expect("controller task");
+
+    // send upstream
+    local_client
+        .publish_qos1("to/temp/1", "from local 2", false)
         .await;
-    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/rpc/ack/2");
 
-    // upstream client awaits on twin request and responds with twin message
-    assert_matches!(upstream.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$iothub/device-1/twin/get/?rid=1");
-
-    let twin = "device-1 twin";
-    upstream
-        .publish_qos1("$iothub/device-1/twin/res/200/?rid=1", twin, false)
+    // send downstream
+    upstream_client
+        .publish_qos1("to/filter/1", "from upstream 2", false)
         .await;
 
-    // edgehub verifies it received a twin response
-    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/device-1/twin/res/200/?rid=1");
+    // restart bridge
+    let (controller_handle, controller_task) = common::setup_bridge_controller(
+        local_server_handle.address(),
+        upstream_server_handle.tls_address().unwrap(),
+        subs,
+    )
+    .await;
 
-    // edgehub unsubscribes from twin response
-    let payload = command("unsub", "$iothub/device-1/twin/res/#", None);
-    edgehub
-        .publish_qos1("$upstream/rpc/3", payload, false)
+    // wait until the bridges up and running
+    tokio::time::delay_for(Duration::from_secs(1)).await;
+
+    // send upstream
+    local_client
+        .publish_qos1("to/temp/1", "from local 3", false)
         .await;
-    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/rpc/ack/3");
+
+    // send downstream
+    upstream_client
+        .publish_qos1("to/filter/1", "from upstream 3", false)
+        .await;
+
+    assert_matches!(
+        upstream_client.publications().next().await,
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from local 3")
+    );
+
+    assert_matches!(
+        local_client.publications().next().await,
+        Some(ReceivedPublication { payload, .. }) if payload == Bytes::from("from upstream 3")
+    );
 
     controller_handle.shutdown();
+    controller_task.await.expect("controller task");
+
     local_server_handle.shutdown().await;
     upstream_server_handle.shutdown().await;
-    edgehub.shutdown().await;
-    upstream.shutdown().await;
-}
-
-fn command(cmd: &str, topic: &str, payload: Option<Vec<u8>>) -> Bytes {
-    let mut command = doc! {
-        "version": "v1",
-        "cmd": cmd,
-        "topic": topic
-    };
-    if let Some(payload) = payload {
-        command.insert(
-            "payload",
-            bson::Binary {
-                subtype: BinarySubtype::Generic,
-                bytes: payload,
-            },
-        );
-    }
-
-    let mut payload = Vec::new();
-    command.to_writer(&mut payload).unwrap();
-    payload.into()
-}
-
-fn setup_brokers<Z, T>(
-    local_authorizer: Z,
-    upstream_authorizer: T,
-) -> (ServerHandle, BrokerHandle, ServerHandle, BrokerHandle)
-where
-    Z: Authorizer + Send + 'static,
-    T: Authorizer + Send + 'static,
-{
-    let (local_server_handle, local_broker_handle) = setup_local_broker(local_authorizer);
-    let (upstream_server_handle, upstream_broker_handle) =
-        setup_upstream_broker(upstream_authorizer, None, None);
-
-    (
-        local_server_handle,
-        local_broker_handle,
-        upstream_server_handle,
-        upstream_broker_handle,
-    )
-}
-
-fn setup_upstream_broker<Z>(
-    authorizer: Z,
-    tcp_addr: Option<String>,
-    tls_addr: Option<String>,
-) -> (ServerHandle, BrokerHandle)
-where
-    Z: Authorizer + Send + 'static,
-{
-    let upstream_broker = BrokerBuilder::default().with_authorizer(authorizer).build();
-    let upstream_broker_handle = upstream_broker.handle();
-    let identity = ServerCertificate::from_pem_pair(CERTIFICATE, PRIVATE_KEY).unwrap();
-
-    let upstream_server_handle = start_server_with_tls(
-        identity,
-        upstream_broker,
-        DummyAuthenticator::with_id("device_1"),
-        tcp_addr,
-        tls_addr,
-    );
-
-    (upstream_server_handle, upstream_broker_handle)
-}
-
-fn setup_local_broker<Z>(authorizer: Z) -> (ServerHandle, BrokerHandle)
-where
-    Z: Authorizer + Send + 'static,
-{
-    let local_broker = BrokerBuilder::default().with_authorizer(authorizer).build();
-    let local_broker_handle = local_broker.handle();
-    let local_server_handle = start_server(local_broker, DummyAuthenticator::with_id("local"));
-
-    (local_server_handle, local_broker_handle)
-}
-
-async fn setup_bridge_controller(
-    local_address: String,
-    upstream_address: String,
-    subs: Vec<Direction>,
-) -> BridgeControllerHandle {
-    let credentials = Credentials::PlainText(AuthenticationSettings::new(
-        "bridge".into(),
-        "pass".into(),
-        "bridge".into(),
-        Some(CERTIFICATE.into()),
-    ));
-
-    let settings = BridgeSettings::from_upstream_details(
-        upstream_address,
-        credentials,
-        subs,
-        true,
-        Duration::from_secs(5),
-    )
-    .unwrap();
-
-    let controller = BridgeController::new(local_address, "bridge".into(), settings);
-    let controller_handle = controller.handle();
-    let controller: Box<dyn Sidecar + Send> = Box::new(controller);
-
-    tokio::spawn(controller.run());
-
-    controller_handle
+    upstream_client.shutdown().await;
+    local_client.shutdown().await;
 }

--- a/mqtt/mqtt-bridge/tests/rpc.rs
+++ b/mqtt/mqtt-bridge/tests/rpc.rs
@@ -1,0 +1,108 @@
+mod common;
+
+use bson::{doc, spec::BinarySubtype};
+use bytes::Bytes;
+use futures_util::StreamExt;
+use matches::assert_matches;
+
+use mqtt3::{
+    proto::{ClientId, QoS},
+    ReceivedPublication,
+};
+use mqtt_broker::auth::AllowAll;
+use mqtt_broker_tests_util::client::TestClientBuilder;
+
+#[tokio::test]
+async fn get_twin_update_via_rpc() {
+    let (mut local_server_handle, _, mut upstream_server_handle, _) =
+        common::setup_brokers(AllowAll, AllowAll);
+    let (controller_handle, controller_task) = common::setup_bridge_controller(
+        local_server_handle.address(),
+        upstream_server_handle.tls_address().unwrap(),
+        Vec::new(),
+    )
+    .await;
+
+    // connect to the remote broker to emulate upstream interaction
+    let mut upstream = TestClientBuilder::new(upstream_server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("upstream".into()))
+        .build();
+    upstream
+        .subscribe("$iothub/+/twin/get/#", QoS::AtLeastOnce)
+        .await;
+    assert!(upstream.subscriptions().next().await.is_some());
+
+    // connect to the local broker with eh-core client
+    let mut edgehub = TestClientBuilder::new(local_server_handle.address())
+        .with_client_id(ClientId::IdWithExistingSession("edgehub".into()))
+        .build();
+
+    // edgehub subscribes to any downstream topic command acknowledgement
+    edgehub.subscribe("$downstream/#", QoS::AtLeastOnce).await;
+    assert!(edgehub.subscriptions().next().await.is_some());
+
+    // edgehub subscribes to twin response
+    let payload = command("sub", "$iothub/device-1/twin/res/#", None);
+    edgehub
+        .publish_qos1("$upstream/rpc/1", payload, false)
+        .await;
+    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/rpc/ack/1");
+
+    // edgehub makes a request to get a twin for the leaf device
+    let payload = command(
+        "pub",
+        "$iothub/device-1/twin/get/?rid=1",
+        Some(Vec::default()),
+    );
+    edgehub
+        .publish_qos1("$upstream/rpc/2", payload, false)
+        .await;
+    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/rpc/ack/2");
+
+    // upstream client awaits on twin request and responds with twin message
+    assert_matches!(upstream.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$iothub/device-1/twin/get/?rid=1");
+
+    let twin = "device-1 twin";
+    upstream
+        .publish_qos1("$iothub/device-1/twin/res/200/?rid=1", twin, false)
+        .await;
+
+    // edgehub verifies it received a twin response
+    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/device-1/twin/res/200/?rid=1");
+
+    // edgehub unsubscribes from twin response
+    let payload = command("unsub", "$iothub/device-1/twin/res/#", None);
+    edgehub
+        .publish_qos1("$upstream/rpc/3", payload, false)
+        .await;
+    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/rpc/ack/3");
+
+    controller_handle.shutdown();
+    controller_task.await.expect("controller task");
+
+    local_server_handle.shutdown().await;
+    upstream_server_handle.shutdown().await;
+    edgehub.shutdown().await;
+    upstream.shutdown().await;
+}
+
+fn command(cmd: &str, topic: &str, payload: Option<Vec<u8>>) -> Bytes {
+    let mut command = doc! {
+        "version": "v1",
+        "cmd": cmd,
+        "topic": topic
+    };
+    if let Some(payload) = payload {
+        command.insert(
+            "payload",
+            bson::Binary {
+                subtype: BinarySubtype::Generic,
+                bytes: payload,
+            },
+        );
+    }
+
+    let mut payload = Vec::new();
+    command.to_writer(&mut payload).unwrap();
+    payload.into()
+}

--- a/mqtt/mqtt-broker-tests-util/src/client.rs
+++ b/mqtt/mqtt-broker-tests-util/src/client.rs
@@ -19,7 +19,7 @@ use mqtt3::{
     Client, Event, PublishError, PublishHandle, ReceivedPublication, ShutdownHandle,
     UpdateSubscriptionHandle,
 };
-use mqtt_util::client_io::{
+use mqtt_util::{
     ClientIoSource, CredentialProviderSettings, Credentials, SasTokenSource, TcpConnection,
     TrustBundleSource,
 };

--- a/mqtt/mqtt-util/src/lib.rs
+++ b/mqtt/mqtt-util/src/lib.rs
@@ -1,1 +1,19 @@
-pub mod client_io;
+#![deny(rust_2018_idioms, warnings)]
+#![deny(clippy::all, clippy::pedantic)]
+#![allow(
+    clippy::cognitive_complexity,
+    clippy::large_enum_variant,
+    clippy::similar_names,
+    clippy::module_name_repetitions,
+    clippy::use_self,
+    clippy::match_same_arms,
+    clippy::must_use_candidate,
+    clippy::missing_errors_doc
+)]
+
+mod client_io;
+
+pub use client_io::{
+    AuthenticationSettings, ClientIoSource, CredentialProviderSettings, Credentials,
+    SasTokenSource, TcpConnection, TrustBundleSource,
+};

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -10,7 +10,7 @@ use mqtt3::{
     Client, Event, ReceivedPublication, SubscriptionUpdateEvent, UpdateSubscriptionHandle,
 };
 use mqtt_broker_tests_util::client;
-use mqtt_util::client_io::ClientIoSource;
+use mqtt_util::ClientIoSource;
 use trc_client::TrcClient;
 
 use crate::{


### PR DESCRIPTION
Adds an integration test that verifies the bridge can work properly after being restarted.
Moves RPC integration tests to appropriate module `rpc`.
Makes `mqtt_util` types exported as the high-level crate types.