### PR TITLE
add bridge restart test

### DIFF
--- a/mqtt/mqtt-bridge/src/controller/bridges.rs
+++ b/mqtt/mqtt-bridge/src/controller/bridges.rs
@@ -57,6 +57,10 @@ impl Bridges {
         self.bridges.push(Box::pin(task));
     }
 
+    pub(crate) fn is_empty(&self) -> bool {
+        self.bridges.is_empty()
+    }
+
     pub(crate) async fn send_update(&mut self, update: BridgeUpdate) {
         if let Some(config) = self.config_updaters.get_mut(update.name()) {
             if let Err(e) = config.send_update(update).await {
@@ -64,6 +68,16 @@ impl Bridges {
             }
         } else {
             debug!("config for {} not found", update.name());
+        }
+    }
+
+    pub(crate) async fn shutdown_bridge(&mut self, name: &str) {
+        debug!("sending shutdown request to {} bridge...", name);
+
+        if let Some(bridge_handle) = self.bridge_handles.remove(name) {
+            bridge_handle.shutdown().await;
+        } else {
+            debug!("bridge {} not found", name);
         }
     }
 

--- a/mqtt/mqtt-bridge/src/controller/mod.rs
+++ b/mqtt/mqtt-bridge/src/controller/mod.rs
@@ -11,7 +11,7 @@ use futures_util::{
     StreamExt,
 };
 use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 use mqtt_broker::sidecar::{Sidecar, SidecarShutdownHandle, SidecarShutdownHandleError};
 
@@ -82,9 +82,13 @@ impl Sidecar for BridgeController {
         }
 
         loop {
-            let wait_bridge_or_pending = if bridges.is_terminated() {
-                // if no active bridges available, wait only for a new messages arrival
-                Either::Left(future::pending())
+            let wait_bridge_or_pending = if (bridges.is_terminated() || bridges.is_empty()) {
+                if (bridges.is_empty()) {
+                    // if no active bridges available, restart upstream bridge
+                    Either::Left(future::ready(Some((UPSTREAM.into(), Ok(Ok(()))))))
+                } else {
+                    Either::Left(future::ready(None))
+                }
             } else {
                 // otherwise try to await both a new message arrival or any bridge exit
                 Either::Right(bridges.next())
@@ -99,12 +103,16 @@ impl Sidecar for BridgeController {
                     bridges.shutdown_all().await;
                     break;
                 }
+                Either::Left((BridgeControllerMessage::ShutdownBridge(name), _)) => {
+                    info!("bridge {} shutdown requested", name);
+                    bridges.shutdown_bridge(name.as_ref()).await;
+                }
                 Either::Right((Some((name, bridge)), _)) => {
                     match bridge {
                         Ok(Ok(_)) => debug!("bridge {} exited", name),
-                        Ok(Err(e)) => warn!(error = %e, "bridge {} exited with error", name),
-                        Err(e) => warn!(error = %e, "bridge {} panicked ", name),
-                    }
+                        Ok(Err(e)) => error!(error = %e, "bridge {} exited with error", name),
+                        Err(e) => error!(error = %e, "bridge {} panicked ", name),
+                    };
 
                     // always restart upstream bridge
                     if name == UPSTREAM {
@@ -169,6 +177,12 @@ impl BridgeControllerHandle {
         }
     }
 
+    pub fn shutdown_bridge(&mut self, name: &str) {
+        if let Err(e) = self.send_message(BridgeControllerMessage::ShutdownBridge(name.into())) {
+            error!(error = %e, "unable to request shutdown for bridge {}", name);
+        }
+    }
+
     fn send_message(&mut self, message: BridgeControllerMessage) -> Result<(), Error> {
         self.sender
             .send(message)
@@ -181,6 +195,7 @@ impl BridgeControllerHandle {
 pub enum BridgeControllerMessage {
     BridgeControllerUpdate(BridgeControllerUpdate),
     Shutdown,
+    ShutdownBridge(String),
 }
 
 /// Error for `BridgeController`.

--- a/mqtt/mqtt-bridge/src/controller/mod.rs
+++ b/mqtt/mqtt-bridge/src/controller/mod.rs
@@ -194,7 +194,9 @@ impl BridgeControllerHandle {
 #[derive(Debug)]
 pub enum BridgeControllerMessage {
     BridgeControllerUpdate(BridgeControllerUpdate),
+    // Shutdown all bridges
     Shutdown,
+    // Shutdown a bridge by name. $upstream bridge will be recreated if it is shutdown
     ShutdownBridge(String),
 }
 

--- a/mqtt/mqtt-bridge/src/pump/messages.rs
+++ b/mqtt/mqtt-bridge/src/pump/messages.rs
@@ -98,7 +98,6 @@ where
 
                     for sub in added {
                         let subscribe_to = sub.subscribe_to();
-
                         match sub.try_into() {
                             Ok(mapper) => {
                                 self.topic_mappers_updates.insert(&subscribe_to, mapper);


### PR DESCRIPTION
- test for the case when upstream bridge is stopped and it should be recreated by controller
- return error in handle events if the client gets an error
- retry to create upstream bridge when new fails
