### PR TITLE
Persist in-flight queue on broker restart

### DIFF
--- a/mqtt/mqtt-broker/src/proptest.rs
+++ b/mqtt/mqtt-broker/src/proptest.rs
@@ -30,12 +30,14 @@ prop_compose! {
     pub fn arb_session_snapshot()(
         client_info in arb_client_info(),
         subscriptions in hash_map(arb_topic(), arb_subscription(), 0..5),
-        waiting_to_be_sent in vec_deque(arb_publication(), 0..5),
+        waiting_to_be_sent in vec_deque(arb_publication(), 0..3),
+        waiting_to_be_acked in vec_deque(arb_proto_publish(), 0..3),
     ) -> SessionSnapshot {
         SessionSnapshot::from_parts(
             client_info,
             subscriptions,
             waiting_to_be_sent,
+            waiting_to_be_acked,
             Utc::now()
         )
     }

--- a/mqtt/mqtt-broker/src/session/state/map.rs
+++ b/mqtt/mqtt-broker/src/session/state/map.rs
@@ -40,6 +40,15 @@ impl<K, V> SmallIndexMap<K, V> {
 
         Iter(ordered.into_iter())
     }
+
+    pub fn into_iter(self) -> IterOwned<K, V> {
+        let mut ordered = BTreeMap::new();
+        for (key, (order, value)) in self.items {
+            ordered.insert(order, (key, value));
+        }
+
+        IterOwned(ordered.into_iter())
+    }
 }
 
 impl<K, V> SmallIndexMap<K, V>
@@ -105,6 +114,15 @@ impl<'a, K, V> IntoIterator for &'a SmallIndexMap<K, V> {
     }
 }
 
+impl<K, V> IntoIterator for SmallIndexMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = IterOwned<K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_iter()
+    }
+}
+
 pub struct Iter<'a, K, V>(IntoIter<&'a u64, (&'a K, &'a V)>);
 
 impl<'a, K, V> Iterator for Iter<'a, K, V> {
@@ -112,6 +130,24 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(_, v)| v)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+pub struct IterOwned<K, V>(IntoIter<u64, (K, V)>);
+
+impl<K, V> Iterator for IterOwned<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(_, v)| v)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 

--- a/mqtt/mqtt-broker/src/session/state/queue.rs
+++ b/mqtt/mqtt-broker/src/session/state/queue.rs
@@ -129,8 +129,8 @@ impl LimitReached {
 impl Display for LimitReached {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::Memory(_) => write!(f, "out of memory limits"),
-            Self::QueueLength(_) => write!(f, "out of queue length limits"),
+            Self::Memory(_) => write!(f, "message queue reached configured size limits, check 'max_queued_size' settings"),
+            Self::QueueLength(_) => write!(f, "message queue reached configured length limits, check 'max_queued_messages' settings"),
         }
     }
 }

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tracing::{info, warn};
 
-use mqtt3::proto::{self, Publication};
+use mqtt3::proto::{Publication, Publish};
 
 use crate::{persist::Persist, ClientInfo, Error, Subscription};
 
@@ -31,6 +31,7 @@ pub struct SessionSnapshot {
     client_info: ClientInfo,
     subscriptions: HashMap<String, Subscription>,
     waiting_to_be_sent: VecDeque<Publication>,
+    waiting_to_be_acked: VecDeque<Publish>,
     last_active: DateTime<Utc>,
 }
 
@@ -39,28 +40,33 @@ impl SessionSnapshot {
         client_info: ClientInfo,
         subscriptions: HashMap<String, Subscription>,
         waiting_to_be_sent: VecDeque<Publication>,
+        waiting_to_be_acked: VecDeque<Publish>,
         last_active: DateTime<Utc>,
     ) -> Self {
         Self {
             client_info,
             subscriptions,
             waiting_to_be_sent,
+            waiting_to_be_acked,
             last_active,
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn into_parts(
         self,
     ) -> (
         ClientInfo,
         HashMap<String, Subscription>,
-        VecDeque<proto::Publication>,
+        VecDeque<Publication>,
+        VecDeque<Publish>,
         DateTime<Utc>,
     ) {
         (
             self.client_info,
             self.subscriptions,
             self.waiting_to_be_sent,
+            self.waiting_to_be_acked,
             self.last_active,
         )
     }

--- a/mqtt/mqtt-broker/tests/broker_model.rs
+++ b/mqtt/mqtt-broker/tests/broker_model.rs
@@ -56,7 +56,7 @@ async fn test_broker_manages_sessions(events: impl IntoIterator<Item = BrokerEve
 
     assert_eq!(sessions.len(), model.sessions.len());
 
-    for (client_info, subscriptions, _, _) in
+    for (client_info, subscriptions, _, _, _) in
         sessions.into_iter().map(|session| session.into_parts())
     {
         let model_session = model

--- a/mqtt/mqtt-broker/tests/integration.rs
+++ b/mqtt/mqtt-broker/tests/integration.rs
@@ -65,7 +65,7 @@ async fn drop_session_on_expiry() {
     let (_, mut sessions) = server_handle.shutdown().await.into_parts();
     assert_eq!(1, sessions.len());
 
-    let (client_info, _, _, _) = sessions.remove(0).into_parts();
+    let (client_info, _, _, _, _) = sessions.remove(0).into_parts();
     assert_eq!("online_client", client_info.client_id().as_str());
 
     // dispose a client.
@@ -149,7 +149,7 @@ async fn drop_session_on_expiry_after_restart() {
     let (_, mut sessions) = server_handle.shutdown().await.into_parts();
     assert_eq!(1, sessions.len());
 
-    let (client_info, _, _, _) = sessions.remove(0).into_parts();
+    let (client_info, _, _, _, _) = sessions.remove(0).into_parts();
     assert_eq!("online_client", client_info.client_id().as_str());
 
     // dispose a client.
@@ -208,7 +208,7 @@ async fn drop_sessions_on_reauthorize() {
     let (_, mut sessions) = server_handle.shutdown().await.into_parts();
     assert_eq!(1, sessions.len());
 
-    let (client_info, _, _, _) = sessions.remove(0).into_parts();
+    let (client_info, _, _, _, _) = sessions.remove(0).into_parts();
     assert_eq!("root", client_info.client_id().as_str());
 
     // dispose a client.


### PR DESCRIPTION
We have an issue where we are losing in-flight qos1 messages on restart. In this PR I have included `SessionState::waiting_to_be_acked` queue into `SessionSnapshot` and made sure it is being persisted on restart.

Main changes are in:
- mqtt/mqtt-broker/src/persist.rs
- mqtt/mqtt-broker/src/session/state/mod.rs
- tests

The rest is just plumbing.

You might ask that `SessionState::waiting_to_be_acked` covers only qos1, and qos2 is not covered completely and still prone to the same issue. But we are not going to support qos2 for GA and will fix it separately later.