### PR TITLE
CentOS specific e2e iotedge check test

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
@@ -52,5 +52,23 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             Assert.AreEqual(string.Empty, errors_number);
         }
+
+        private async Task<bool> IsCentos(CancellationToken token)
+        {
+            string[] platformInfo = await Microsoft.Azure.Devices.Edge.Test.Common.Process.RunAsync("lsb_release", "-sir", token);
+            if (platformInfo.Length == 1)
+            {
+                platformInfo = platformInfo[0].Split(' ');
+            }
+
+            string os = platformInfo[0].Trim();
+            switch (os)
+            {
+                case "CentOS":
+                    return true;
+                default:
+                    return false;
+            }
+        }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
@@ -100,11 +100,19 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 }
             });
 
-            // TODO: iotedge check currently has 2 legitimate errors in it. When we update the aziot-submodule, the errors
-            // will go away, and we should change this assertion to empty string instead of passing on 2 errors.
+            // TODO: iotedge check currently has a legitimate error in it. When we update the aziot-submodule, the error
+            // will go away, and we should change this assertion to empty string instead of passing on an errors.
             // This is better than disabling the test, because it still tests iotedge check to some extent, and it will
             // remind us with a failed run to update this test.
-            Assert.AreEqual("1 check(s) raised errors.", errors_number);
+            if (await this.IsCentos(token))
+            {
+                // CentOS actually has 2 errors
+                Assert.AreEqual("2 check(s) raised errors.", errors_number);
+            }
+            else
+            {
+                Assert.AreEqual("1 check(s) raised errors.", errors_number);
+            }
         }
 
         private async Task<bool> IsCentos(CancellationToken token)


### PR DESCRIPTION
CentOS e2e iotedge check test has an additional error that the other platforms don't have. This will be fixed when the aziot submodule is updated. However, we should pass when CentOS raises 2 errors for now so that we don't have to disable the test.