### PR TITLE
Persist in-flight queue on broker restart (#4356)

### DIFF
--- a/mqtt/mqtt-broker/src/persist.rs
+++ b/mqtt/mqtt-broker/src/persist.rs
@@ -4,7 +4,7 @@ use std::os::unix::fs::symlink;
 use std::os::windows::fs::symlink_file;
 use std::{
     cmp,
-    collections::HashMap,
+    collections::{HashMap, VecDeque},
     error::Error as StdError,
     fs::{self, OpenOptions},
     io::{Read, Write},
@@ -20,9 +20,13 @@ use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use serde::{ser::SerializeMap, Deserialize, Deserializer, Serialize, Serializer};
 use tracing::{debug, info, info_span};
 
-use mqtt3::proto::Publication;
+use mqtt3::proto::{Publication, Publish};
 
-use crate::{subscription::Subscription, BrokerSnapshot, ClientInfo, SessionSnapshot};
+use crate::{
+    proto::{PacketIdentifierDupQoS, QoS},
+    subscription::Subscription,
+    BrokerSnapshot, ClientInfo, SessionSnapshot,
+};
 
 /// sets the number of past states to save - 2 means we save the current and the pervious
 const STATE_DEFAULT_PREVIOUS_COUNT: usize = 2;
@@ -159,15 +163,20 @@ impl FileFormat for VersionedFileFormat {
     }
 }
 
+/// Actual representation of broker state data that is saved to disk.
 #[derive(Deserialize, Serialize)]
 struct ConsolidatedState {
     #[serde(serialize_with = "serialize_payloads")]
     #[serde(deserialize_with = "deserialize_payloads")]
     payloads: HashMap<u64, Bytes>,
-    retained: HashMap<String, SimplifiedPublication>,
+    retained: HashMap<String, PublicationRef>,
     sessions: Vec<ConsolidatedSession>,
 }
 
+/// In case a single message being delivered to multiple subscribers,
+/// we don't want to duplicate the payload for every session.
+/// So, when we convert from `BrokerSnapshot` to `ConsolidatedState` we
+/// store all the payloads separate, and reference them in `PublicationRef`
 impl From<BrokerSnapshot> for ConsolidatedState {
     fn from(state: BrokerSnapshot) -> Self {
         let (retained, sessions) = state.into_parts();
@@ -175,40 +184,37 @@ impl From<BrokerSnapshot> for ConsolidatedState {
         #[allow(clippy::mutable_key_type)]
         let mut payloads = HashMap::new();
 
-        let mut shrink_payload = |publication: Publication| {
-            let next_id = payloads.len() as u64;
-
-            let id = *payloads.entry(publication.payload).or_insert(next_id);
-
-            SimplifiedPublication {
-                topic_name: publication.topic_name,
-                qos: publication.qos,
-                retain: publication.retain,
-                payload: id,
-            }
-        };
-
         let retained = retained
             .into_iter()
-            .map(|(topic, publication)| (topic, shrink_payload(publication)))
+            .map(|(topic, publication)| (topic, shrink_payload(publication, &mut payloads)))
             .collect();
 
         let sessions = sessions
             .into_iter()
             .map(|session| {
-                let (client_info, subscriptions, waiting_to_be_sent, last_active) =
-                    session.into_parts();
+                let (
+                    client_info,
+                    subscriptions,
+                    waiting_to_be_sent,
+                    waiting_to_be_acked,
+                    last_active,
+                ) = session.into_parts();
 
-                #[allow(clippy::redundant_closure)] // removing closure leads to borrow error
                 let waiting_to_be_sent = waiting_to_be_sent
                     .into_iter()
-                    .map(|publication| shrink_payload(publication))
+                    .map(|publication| shrink_payload(publication, &mut payloads))
+                    .collect();
+
+                let waiting_to_be_acked = waiting_to_be_acked
+                    .into_iter()
+                    .map(|publication| shrink_in_flight(publication, &mut payloads))
                     .collect();
 
                 ConsolidatedSession {
                     client_info,
                     subscriptions,
                     waiting_to_be_sent,
+                    waiting_to_be_acked,
                     last_active,
                 }
             })
@@ -237,9 +243,19 @@ impl From<ConsolidatedState> for BrokerSnapshot {
             sessions,
         } = state;
 
-        let expand_payload = |publication: SimplifiedPublication| Publication {
+        let expand_payload = |publication: PublicationRef| Publication {
             topic_name: publication.topic_name,
             qos: publication.qos,
+            retain: publication.retain,
+            payload: payloads
+                .get(&publication.payload)
+                .expect("corrupted data")
+                .clone(),
+        };
+
+        let expand_in_flight = |publication: InFlightPublicationRef| Publish {
+            topic_name: publication.topic_name,
+            packet_identifier_dup_qos: publication.packet_identifier_dup_qos,
             retain: publication.retain,
             payload: payloads
                 .get(&publication.payload)
@@ -260,10 +276,16 @@ impl From<ConsolidatedState> for BrokerSnapshot {
                     .into_iter()
                     .map(expand_payload)
                     .collect();
+                let waiting_to_be_acked = session
+                    .waiting_to_be_acked
+                    .into_iter()
+                    .map(expand_in_flight)
+                    .collect();
                 SessionSnapshot::from_parts(
                     session.client_info,
                     session.subscriptions,
                     waiting_to_be_sent,
+                    waiting_to_be_acked,
                     session.last_active,
                 )
             })
@@ -273,20 +295,66 @@ impl From<ConsolidatedState> for BrokerSnapshot {
     }
 }
 
+/// Actual representation of session state data that is saved to disk.
 #[derive(Deserialize, Serialize)]
 struct ConsolidatedSession {
     client_info: ClientInfo,
     subscriptions: HashMap<String, Subscription>,
-    waiting_to_be_sent: Vec<SimplifiedPublication>,
+    waiting_to_be_sent: VecDeque<PublicationRef>,
+    waiting_to_be_acked: VecDeque<InFlightPublicationRef>,
     last_active: DateTime<Utc>,
 }
 
+/// Represents a queued publication
+/// that has a reference to a payload in `ConsolidatedState`
+/// but not yet in-flight.
 #[derive(Deserialize, Serialize)]
-struct SimplifiedPublication {
+struct PublicationRef {
     topic_name: String,
-    qos: crate::proto::QoS,
+    qos: QoS,
     retain: bool,
     payload: u64,
+}
+
+/// Represents an in-flight publication (has packet id)
+/// and a reference to a payload in `ConsolidatedState`.
+#[derive(Deserialize, Serialize)]
+struct InFlightPublicationRef {
+    topic_name: String,
+    packet_identifier_dup_qos: PacketIdentifierDupQoS,
+    retain: bool,
+    payload: u64,
+}
+
+#[allow(clippy::mutable_key_type)]
+fn shrink_payload(publication: Publication, payloads: &mut HashMap<Bytes, u64>) -> PublicationRef {
+    let next_id = payloads.len() as u64;
+
+    let id = payloads.entry(publication.payload).or_insert(next_id);
+
+    PublicationRef {
+        topic_name: publication.topic_name,
+        qos: publication.qos,
+        retain: publication.retain,
+        payload: *id,
+    }
+}
+
+#[allow(clippy::mutable_key_type)]
+fn shrink_in_flight(
+    publication: Publish,
+    payloads: &mut HashMap<Bytes, u64>,
+) -> InFlightPublicationRef {
+    let next_id = payloads.len() as u64;
+
+    let id = payloads.entry(publication.payload).or_insert(next_id);
+
+    InFlightPublicationRef {
+        topic_name: publication.topic_name,
+        packet_identifier_dup_qos: publication.packet_identifier_dup_qos,
+        retain: publication.retain,
+        payload: *id,
+    }
 }
 
 fn serialize_payloads<S>(payloads: &HashMap<u64, Bytes>, serializer: S) -> Result<S::Ok, S::Error>

--- a/mqtt/mqtt-broker/src/proptest.rs
+++ b/mqtt/mqtt-broker/src/proptest.rs
@@ -30,12 +30,14 @@ prop_compose! {
     pub fn arb_session_snapshot()(
         client_info in arb_client_info(),
         subscriptions in hash_map(arb_topic(), arb_subscription(), 0..5),
-        waiting_to_be_sent in vec_deque(arb_publication(), 0..5),
+        waiting_to_be_sent in vec_deque(arb_publication(), 0..3),
+        waiting_to_be_acked in vec_deque(arb_proto_publish(), 0..3),
     ) -> SessionSnapshot {
         SessionSnapshot::from_parts(
             client_info,
             subscriptions,
             waiting_to_be_sent,
+            waiting_to_be_acked,
             Utc::now()
         )
     }

--- a/mqtt/mqtt-broker/src/session/state/map.rs
+++ b/mqtt/mqtt-broker/src/session/state/map.rs
@@ -40,6 +40,15 @@ impl<K, V> SmallIndexMap<K, V> {
 
         Iter(ordered.into_iter())
     }
+
+    pub fn into_iter(self) -> IterOwned<K, V> {
+        let mut ordered = BTreeMap::new();
+        for (key, (order, value)) in self.items {
+            ordered.insert(order, (key, value));
+        }
+
+        IterOwned(ordered.into_iter())
+    }
 }
 
 impl<K, V> SmallIndexMap<K, V>
@@ -105,6 +114,15 @@ impl<'a, K, V> IntoIterator for &'a SmallIndexMap<K, V> {
     }
 }
 
+impl<K, V> IntoIterator for SmallIndexMap<K, V> {
+    type Item = (K, V);
+    type IntoIter = IterOwned<K, V>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_iter()
+    }
+}
+
 pub struct Iter<'a, K, V>(IntoIter<&'a u64, (&'a K, &'a V)>);
 
 impl<'a, K, V> Iterator for Iter<'a, K, V> {
@@ -112,6 +130,24 @@ impl<'a, K, V> Iterator for Iter<'a, K, V> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(_, v)| v)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+pub struct IterOwned<K, V>(IntoIter<u64, (K, V)>);
+
+impl<K, V> Iterator for IterOwned<K, V> {
+    type Item = (K, V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|(_, v)| v)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
     }
 }
 

--- a/mqtt/mqtt-broker/src/session/state/queue.rs
+++ b/mqtt/mqtt-broker/src/session/state/queue.rs
@@ -58,7 +58,7 @@ impl BoundedQueue {
             if self.inner.len() >= max_len.get() {
                 return self
                     .handle_queue_limit(publication)
-                    .map(LimitReached::QueueLength);
+                    .map(|publication| LimitReached::QueueLength(max_len.get(), publication));
             }
         }
 
@@ -67,7 +67,7 @@ impl BoundedQueue {
             if self.current_size + pub_len > max_size.get() {
                 return self
                     .handle_queue_limit(publication)
-                    .map(LimitReached::Memory);
+                    .map(|publication| LimitReached::QueueSize(max_size.get(), publication));
             }
         }
 
@@ -113,15 +113,15 @@ impl Extend<proto::Publication> for BoundedQueue {
 
 #[derive(Debug)]
 pub enum LimitReached {
-    Memory(proto::Publication),
-    QueueLength(proto::Publication),
+    QueueSize(usize, proto::Publication),
+    QueueLength(usize, proto::Publication),
 }
 
 impl LimitReached {
     pub fn publication(&self) -> &proto::Publication {
         match self {
-            Self::Memory(publication) => publication,
-            Self::QueueLength(publication) => publication,
+            Self::QueueSize(_, publication) => publication,
+            Self::QueueLength(_, publication) => publication,
         }
     }
 }
@@ -129,8 +129,8 @@ impl LimitReached {
 impl Display for LimitReached {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
-            Self::Memory(_) => write!(f, "out of memory limits"),
-            Self::QueueLength(_) => write!(f, "out of queue length limits"),
+            Self::QueueSize(limit, _) => write!(f, "message queue reached configured size limits of {}, check 'max_queued_size' settings", limit),
+            Self::QueueLength(limit, _) => write!(f, "message queue reached configured length limits of {}, check 'max_queued_messages' settings", limit),
         }
     }
 }

--- a/mqtt/mqtt-broker/src/snapshot.rs
+++ b/mqtt/mqtt-broker/src/snapshot.rs
@@ -4,7 +4,7 @@ use chrono::{DateTime, Utc};
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tracing::{info, warn};
 
-use mqtt3::proto::{self, Publication};
+use mqtt3::proto::{Publication, Publish};
 
 use crate::{persist::Persist, ClientInfo, Error, Subscription};
 
@@ -31,6 +31,7 @@ pub struct SessionSnapshot {
     client_info: ClientInfo,
     subscriptions: HashMap<String, Subscription>,
     waiting_to_be_sent: VecDeque<Publication>,
+    waiting_to_be_acked: VecDeque<Publish>,
     last_active: DateTime<Utc>,
 }
 
@@ -39,28 +40,33 @@ impl SessionSnapshot {
         client_info: ClientInfo,
         subscriptions: HashMap<String, Subscription>,
         waiting_to_be_sent: VecDeque<Publication>,
+        waiting_to_be_acked: VecDeque<Publish>,
         last_active: DateTime<Utc>,
     ) -> Self {
         Self {
             client_info,
             subscriptions,
             waiting_to_be_sent,
+            waiting_to_be_acked,
             last_active,
         }
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn into_parts(
         self,
     ) -> (
         ClientInfo,
         HashMap<String, Subscription>,
-        VecDeque<proto::Publication>,
+        VecDeque<Publication>,
+        VecDeque<Publish>,
         DateTime<Utc>,
     ) {
         (
             self.client_info,
             self.subscriptions,
             self.waiting_to_be_sent,
+            self.waiting_to_be_acked,
             self.last_active,
         )
     }

--- a/mqtt/mqtt-broker/tests/broker_model.rs
+++ b/mqtt/mqtt-broker/tests/broker_model.rs
@@ -56,7 +56,7 @@ async fn test_broker_manages_sessions(events: impl IntoIterator<Item = BrokerEve
 
     assert_eq!(sessions.len(), model.sessions.len());
 
-    for (client_info, subscriptions, _, _) in
+    for (client_info, subscriptions, _, _, _) in
         sessions.into_iter().map(|session| session.into_parts())
     {
         let model_session = model

--- a/mqtt/mqtt-broker/tests/compliance.rs
+++ b/mqtt/mqtt-broker/tests/compliance.rs
@@ -743,6 +743,152 @@ async fn inflight_qos1_messages_redelivered_on_reconnect() {
 }
 
 /// Scenario:
+/// - Client A connects with clean session
+/// - Client B connects with existing session
+/// - Client B subscribes to a topic
+/// - Client A sends QoS0 and several QoS1 packets
+/// - Client B receives packets and don't send PUBACKs
+/// - Broker restarts
+/// - Client B connects and expects to receive only QoS1 packets with dup=true in correct order.
+#[tokio::test]
+async fn inflight_qos1_messages_redelivered_on_server_restart() {
+    let topic_a = "topic/A";
+
+    let broker = BrokerBuilder::default().with_authorizer(AllowAll).build();
+
+    let mut server_handle = start_server(broker, DummyAuthenticator::anonymous());
+
+    let mut client_a = PacketStream::connect(
+        ClientId::IdWithCleanSession("test-client-a".into()),
+        server_handle.address(),
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    client_a.next().await; // skip connack
+
+    let mut client_b = PacketStream::connect(
+        ClientId::IdWithExistingSession("test-client-b".into()),
+        server_handle.address(),
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    client_b.next().await; // skip connack
+
+    // connect client B with persisted session.
+    client_b
+        .send_packet(Packet::Subscribe(Subscribe {
+            packet_identifier: PacketIdentifier::new(1).unwrap(),
+            subscribe_to: vec![SubscribeTo {
+                topic_filter: topic_a.into(),
+                qos: QoS::AtLeastOnce,
+            }],
+        }))
+        .await;
+
+    assert_eq!(
+        client_b.next().await,
+        Some(Packet::SubAck(SubAck {
+            packet_identifier: PacketIdentifier::new(1).unwrap(),
+            qos: vec![SubAckQos::Success(QoS::AtLeastOnce)]
+        }))
+    );
+
+    client_a
+        .send_publish(Publish {
+            packet_identifier_dup_qos: PacketIdentifierDupQoS::AtMostOnce,
+            retain: false,
+            topic_name: topic_a.into(),
+            payload: Bytes::from("qos 0"),
+        })
+        .await;
+
+    const QOS1_MESSAGES: u16 = 3;
+
+    for i in 1..=QOS1_MESSAGES {
+        client_a
+            .send_publish(Publish {
+                packet_identifier_dup_qos: PacketIdentifierDupQoS::AtLeastOnce(
+                    PacketIdentifier::new(i).unwrap(),
+                    false,
+                ),
+                retain: false,
+                topic_name: topic_a.into(),
+                payload: Bytes::from(format!("qos 1-{}", i)),
+            })
+            .await;
+    }
+
+    // receive all messages but don't send puback for QoS1/2.
+    assert_matches!(
+        client_b.next().await,
+        Some(Packet::Publish(Publish {
+            payload,
+            ..
+        })) if payload == Bytes::from("qos 0")
+    );
+
+    for i in 1..=QOS1_MESSAGES {
+        let publish = match client_b.next().await {
+            Some(Packet::Publish(publish)) => publish,
+            x => panic!("Expected publish but {:?} found", x),
+        };
+
+        assert_matches!(
+            publish.packet_identifier_dup_qos,
+            PacketIdentifierDupQoS::AtLeastOnce(_, false)
+        );
+        assert_eq!(publish.payload, Bytes::from(format!("qos 1-{0}", i)));
+    }
+
+    // restart broker.
+    let state = server_handle.shutdown().await;
+    let broker = BrokerBuilder::default()
+        .with_state(state)
+        .with_authorizer(AllowAll)
+        .build();
+
+    let server_handle = start_server(broker, DummyAuthenticator::anonymous());
+
+    // reconnect client_b
+    let mut client_b = PacketStream::connect(
+        ClientId::IdWithExistingSession("test-client-b".into()),
+        server_handle.address(),
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert_eq!(
+        client_b.next().await,
+        Some(Packet::ConnAck(ConnAck {
+            session_present: true,
+            return_code: ConnectReturnCode::Accepted
+        }))
+    );
+
+    // expect messages to be redelivered in order (QoS 1).
+    for i in 1..=QOS1_MESSAGES {
+        let publish = match client_b.next().await {
+            Some(Packet::Publish(publish)) => publish,
+            x => panic!("Expected publish but {:?} found", x),
+        };
+
+        assert_matches!(
+            publish.packet_identifier_dup_qos,
+            PacketIdentifierDupQoS::AtLeastOnce(id, true) if id == PacketIdentifier::new(i).unwrap()
+        );
+        assert_eq!(publish.payload, Bytes::from(format!("qos 1-{0}", i)));
+    }
+}
+
+/// Scenario:
 /// - Client A connects with clean session.
 /// - Client A subscribes to Topic/A
 /// - Client A subscribes to Topic/+

--- a/mqtt/mqtt-broker/tests/integration.rs
+++ b/mqtt/mqtt-broker/tests/integration.rs
@@ -65,7 +65,7 @@ async fn drop_session_on_expiry() {
     let (_, mut sessions) = server_handle.shutdown().await.into_parts();
     assert_eq!(1, sessions.len());
 
-    let (client_info, _, _, _) = sessions.remove(0).into_parts();
+    let (client_info, _, _, _, _) = sessions.remove(0).into_parts();
     assert_eq!("online_client", client_info.client_id().as_str());
 
     // dispose a client.
@@ -149,7 +149,7 @@ async fn drop_session_on_expiry_after_restart() {
     let (_, mut sessions) = server_handle.shutdown().await.into_parts();
     assert_eq!(1, sessions.len());
 
-    let (client_info, _, _, _) = sessions.remove(0).into_parts();
+    let (client_info, _, _, _, _) = sessions.remove(0).into_parts();
     assert_eq!("online_client", client_info.client_id().as_str());
 
     // dispose a client.
@@ -208,7 +208,7 @@ async fn drop_sessions_on_reauthorize() {
     let (_, mut sessions) = server_handle.shutdown().await.into_parts();
     assert_eq!(1, sessions.len());
 
-    let (client_info, _, _, _) = sessions.remove(0).into_parts();
+    let (client_info, _, _, _, _) = sessions.remove(0).into_parts();
     assert_eq!("root", client_info.client_id().as_str());
 
     // dispose a client.


### PR DESCRIPTION
We have an issue where we are losing in-flight qos1 messages on restart. In this PR I have included `SessionState::waiting_to_be_acked` queue into `SessionSnapshot` and made sure it is being persisted on restart.

Main changes are in:
- mqtt/mqtt-broker/src/persist.rs
- mqtt/mqtt-broker/src/session/state/mod.rs
- tests

The rest is just plumbing.

You might ask that `SessionState::waiting_to_be_acked` covers only qos1, and qos2 is not covered completely and still prone to the same issue. But we are not going to support qos2 for GA and will fix it separately later.