### PR TITLE
Fixed quick start for nested device identity service

### DIFF
--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -272,7 +272,8 @@ namespace IotEdgeQuickstart.Details
                         switch (param[0])
                         {
                             case "HostName":
-                                config[IDENTITYD].document.ReplaceOrAdd("provisioning.iothub_hostname", param[1]);
+                                // replace IoTHub hostname with parent hostname for nested edge
+                                config[IDENTITYD].document.ReplaceOrAdd("provisioning.iothub_hostname", parentHostname.GetOrElse(param[1]));
                                 break;
                             case "SharedAccessKey":
                                 File.WriteAllBytes(keyPath, Convert.FromBase64String(param[1]));


### PR DESCRIPTION
This is a hack to make device identity service work for nested edge. Please refer to [9171870](https://msazure.visualstudio.com/One/_workitems/edit/9171870) for details.