### PR TITLE
Generic Mqtt Test Module: Clean up logging and fix report format

### DIFF
--- a/test/modules/generic-mqtt-tester/src/lib.rs
+++ b/test/modules/generic-mqtt-tester/src/lib.rs
@@ -16,6 +16,7 @@ use std::{
     io::{self},
 };
 
+use bytes::Buf;
 use mqtt3::{PublishError, ReceivedPublication, UpdateSubscriptionError};
 use tokio::{sync::mpsc::error::SendError, sync::mpsc::Sender, task::JoinError};
 use trc_client::ReportResultError;
@@ -90,4 +91,8 @@ pub enum MessageTesterError {
 
     #[error("received rejected subscription: {0}")]
     RejectedSubscription(String),
+}
+
+pub fn parse_sequence_number(publication: &ReceivedPublication) -> u32 {
+    publication.payload.slice(0..4).get_u32()
 }

--- a/test/modules/generic-mqtt-tester/src/message_channel.rs
+++ b/test/modules/generic-mqtt-tester/src/message_channel.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use bytes::Buf;
 use futures_util::{
     future::{self, Either},
     stream::StreamExt,
@@ -14,7 +13,7 @@ use mqtt3::{
 };
 use trc_client::{MessageTestResult, TrcClient};
 
-use crate::{MessageTesterError, ShutdownHandle, RECEIVE_SOURCE};
+use crate::{parse_sequence_number, MessageTesterError, ShutdownHandle, RECEIVE_SOURCE};
 
 /// Responsible for receiving publications and taking some action.
 #[async_trait]
@@ -46,7 +45,12 @@ impl MessageHandler for ReportResultMessageHandler {
         &mut self,
         received_publication: ReceivedPublication,
     ) -> Result<(), MessageTesterError> {
-        let sequence_number: u32 = received_publication.payload.slice(0..4).get_u32();
+        let sequence_number = parse_sequence_number(&received_publication);
+
+        info!(
+            "reporting result for publication with sequence number {}",
+            sequence_number,
+        );
         let result = MessageTestResult::new(
             self.tracking_id.clone(),
             self.batch_id.clone(),
@@ -85,8 +89,12 @@ impl MessageHandler for RelayingMessageHandler {
         &mut self,
         received_publication: ReceivedPublication,
     ) -> Result<(), MessageTesterError> {
-        info!("relaying publication {:?}", received_publication);
+        let sequence_number = parse_sequence_number(&received_publication);
 
+        info!(
+            "relaying publication with sequence number {}",
+            sequence_number,
+        );
         let new_publication = Publication {
             topic_name: self.topic.clone(),
             qos: QoS::ExactlyOnce,

--- a/test/modules/generic-mqtt-tester/src/message_channel.rs
+++ b/test/modules/generic-mqtt-tester/src/message_channel.rs
@@ -149,7 +149,6 @@ where
             match future::select(received_pub, shutdown_signal).await {
                 Either::Left((received_publication, _)) => {
                     if let Some(received_publication) = received_publication {
-                        info!("received publication {:?}", received_publication);
                         self.message_handler.handle(received_publication).await?;
                     } else {
                         error!("failed listening for incoming publication");

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -267,7 +267,7 @@ fn process_event(
             info!("received new connection");
         }
         Event::Publication(publication) => {
-            info!("received publication");
+            info!("received publication {:?}", publication);
             message_send_handle
                 .send(publication)
                 .map_err(MessageTesterError::SendPublicationInChannel)?;

--- a/test/rust-test-util/test-result-reporting-client/src/lib.rs
+++ b/test/rust-test-util/test-result-reporting-client/src/lib.rs
@@ -11,6 +11,8 @@
     clippy::missing_errors_doc
 )]
 
+use std::fmt;
+
 use enumset::EnumSetType;
 use hyper::http;
 
@@ -33,6 +35,12 @@ pub enum TestType {
     EdgeHubRestartDirectMethod,
     Error,
     TestInfo,
+}
+
+impl fmt::Display for TestType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self, f)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/test/rust-test-util/test-result-reporting-client/src/models/test_result_dto.rs
+++ b/test/rust-test-util/test-result-reporting-client/src/models/test_result_dto.rs
@@ -10,7 +10,7 @@ pub(crate) struct TestOperationResultDto {
     #[serde(rename = "result")]
     result: MessageTestResult,
     #[serde(rename = "type")]
-    test_type: u8,
+    test_type: String,
     #[serde(rename = "createdAt")]
     created_at: String,
 }
@@ -25,7 +25,7 @@ impl TestOperationResultDto {
         Self {
             source,
             result,
-            test_type: test_type as u8,
+            test_type: test_type.to_string(),
             created_at: created_at.to_rfc3339(),
         }
     }
@@ -51,7 +51,7 @@ mod tests {
         let test_result_dto =
             TestOperationResultDto::new(source, test_result, test_type, created_at);
 
-        let expected = format!("{{\"source\":\"source\",\"result\":\"tracking;batch;2\",\"type\":2,\"createdAt\":\"{}\"}}", created_at.to_rfc3339());
+        let expected = format!("{{\"source\":\"source\",\"result\":\"tracking;batch;2\",\"type\":\"Messages\",\"createdAt\":\"{}\"}}", created_at.to_rfc3339());
         let serialized = serde_json::to_string(&test_result_dto).unwrap();
 
         assert_eq!(expected, serialized);


### PR DESCRIPTION
Two changes:
- The logging can be improved by specifying the sequence number of the received message.
- Fixed the report format. The test type needs to be a string not an int, or report generation will fail.