### PR TITLE
[mqtt] Retry non-iothub subscription when rejected by server (#4249)

### DIFF
--- a/mqtt/mqtt-bridge/src/pump/messages.rs
+++ b/mqtt/mqtt-bridge/src/pump/messages.rs
@@ -99,7 +99,7 @@ where
                     for sub in added {
                         let subscribe_to = sub.subscribe_to();
 
-                        match sub.to_owned().try_into() {
+                        match sub.try_into() {
                             Ok(mapper) => {
                                 self.topic_mappers_updates.insert(&subscribe_to, mapper);
 

--- a/mqtt/mqtt-bridge/src/pump/mod.rs
+++ b/mqtt/mqtt-bridge/src/pump/mod.rs
@@ -16,7 +16,7 @@ use futures_util::{
     join, pin_mut,
 };
 use mockall::automock;
-use parking_lot::Mutex;
+use parking_lot::RwLock;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
@@ -253,32 +253,32 @@ impl<M: Debug + Send + 'static> PumpHandle<M> {
 
 /// Topic settings received as updates from twin or from initial configuration in the default config file
 #[derive(Clone)]
-pub struct TopicMapperUpdates(Arc<Mutex<HashMap<String, TopicMapper>>>);
+pub struct TopicMapperUpdates(Arc<RwLock<HashMap<String, TopicMapper>>>);
 
 impl TopicMapperUpdates {
     pub fn new(mappings: HashMap<String, TopicMapper>) -> Self {
-        Self(Arc::new(Mutex::new(mappings)))
+        Self(Arc::new(RwLock::new(mappings)))
     }
 
     pub fn insert(&self, topic_filter: &str, mapper: TopicMapper) -> Option<TopicMapper> {
-        self.0.lock().insert(topic_filter.into(), mapper)
+        self.0.write().insert(topic_filter.into(), mapper)
     }
 
     pub fn remove(&self, topic_filter: &str) -> Option<TopicMapper> {
-        self.0.lock().remove(topic_filter)
+        self.0.write().remove(topic_filter)
     }
 
     pub fn get(&self, topic_filter: &str) -> Option<TopicMapper> {
-        self.0.lock().get(topic_filter).cloned()
+        self.0.read().get(topic_filter).cloned()
     }
 
     pub fn contains_key(&self, topic_filter: &str) -> bool {
-        self.0.lock().contains_key(topic_filter)
+        self.0.read().contains_key(topic_filter)
     }
 
     pub fn subscriptions(&self) -> Vec<String> {
         self.0
-            .lock()
+            .read()
             .values()
             .map(TopicMapper::subscribe_to)
             .collect()

--- a/mqtt/mqtt-bridge/src/upstream/rpc/local.rs
+++ b/mqtt/mqtt-bridge/src/upstream/rpc/local.rs
@@ -75,7 +75,7 @@ impl LocalRpcMqttEventHandler {
     fn handle_subscription_update(&mut self, subscription: &SubscriptionUpdateEvent) -> bool {
         let topic_filter = match subscription {
             SubscriptionUpdateEvent::Subscribe(sub) => &sub.topic_filter,
-            SubscriptionUpdateEvent::RejectedByServer(topic_filter) => topic_filter,
+            SubscriptionUpdateEvent::RejectedByServer(sub) => &sub.topic_filter,
             SubscriptionUpdateEvent::Unsubscribe(topic_filter) => topic_filter,
         };
 
@@ -249,7 +249,10 @@ mod tests {
                 qos: QoS::AtLeastOnce,
                 topic_filter: "/foo".into(),
             }),
-            SubscriptionUpdateEvent::RejectedByServer("/foo".into()),
+            SubscriptionUpdateEvent::RejectedByServer(SubscribeTo {
+                qos: QoS::AtLeastOnce,
+                topic_filter: "/foo".into(),
+            }),
             SubscriptionUpdateEvent::Unsubscribe("/foo".into()),
         ];
 
@@ -270,7 +273,10 @@ mod tests {
                 qos: QoS::AtLeastOnce,
                 topic_filter: "$upstream/rpc/+".into(),
             }),
-            SubscriptionUpdateEvent::RejectedByServer("$upstream/rpc/+".into()),
+            SubscriptionUpdateEvent::RejectedByServer(SubscribeTo {
+                qos: QoS::AtLeastOnce,
+                topic_filter: "$upstream/rpc/+".into(),
+            }),
             SubscriptionUpdateEvent::Unsubscribe("$upstream/rpc/+".into()),
         ];
 
@@ -291,7 +297,10 @@ mod tests {
                 qos: QoS::AtLeastOnce,
                 topic_filter: "/foo/bar".into(),
             }),
-            SubscriptionUpdateEvent::RejectedByServer("/foo".into()),
+            SubscriptionUpdateEvent::RejectedByServer(SubscribeTo {
+                qos: QoS::AtLeastOnce,
+                topic_filter: "/foo/bar".into(),
+            }),
             SubscriptionUpdateEvent::Unsubscribe("/bar".into()),
         ];
 
@@ -300,7 +309,10 @@ mod tests {
                 qos: QoS::AtLeastOnce,
                 topic_filter: "$upstream/rpc/+".into(),
             }),
-            SubscriptionUpdateEvent::RejectedByServer("$upstream/rpc/+".into()),
+            SubscriptionUpdateEvent::RejectedByServer(SubscribeTo {
+                qos: QoS::AtLeastOnce,
+                topic_filter: "$upstream/rpc/+".into(),
+            }),
             SubscriptionUpdateEvent::Unsubscribe("$upstream/rpc/+".into()),
         ];
 

--- a/mqtt/mqtt-edgehub/src/command/handler.rs
+++ b/mqtt/mqtt-edgehub/src/command/handler.rs
@@ -182,7 +182,9 @@ async fn subscribe(
                         subacks.remove(&sub.topic_filter);
                     }
                     SubscriptionUpdateEvent::RejectedByServer(sub) => {
-                        return Err(CommandHandlerError::SubscriptionRejectedByServer(sub));
+                        return Err(CommandHandlerError::SubscriptionRejectedByServer(
+                            sub.topic_filter,
+                        ));
                     }
                     SubscriptionUpdateEvent::Unsubscribe(_) => {}
                 }

--- a/mqtt/mqtt3/src/client/mod.rs
+++ b/mqtt/mqtt3/src/client/mod.rs
@@ -528,7 +528,7 @@ pub enum Event {
 pub enum SubscriptionUpdateEvent {
     Subscribe(crate::proto::SubscribeTo),
     Unsubscribe(String),
-    RejectedByServer(String),
+    RejectedByServer(crate::proto::SubscribeTo),
 }
 
 /// A message that was received from the server
@@ -783,7 +783,6 @@ pub enum Error {
     ServerClosedConnection,
     SubAckDoesNotContainEnoughQoS(crate::proto::PacketIdentifier, usize, usize),
     SubscriptionDowngraded(String, crate::proto::QoS, crate::proto::QoS),
-    SubscriptionRejectedByServer,
     UnexpectedSubAck(crate::proto::PacketIdentifier, UnexpectedSubUnsubAckReason),
     UnexpectedUnsubAck(crate::proto::PacketIdentifier, UnexpectedSubUnsubAckReason),
 }
@@ -854,9 +853,6 @@ impl std::fmt::Display for Error {
 			Error::SubscriptionDowngraded(topic_name, expected, actual) =>
 				write!(f, "Server downgraded subscription for topic filter {:?} with QoS {:?} to {:?}", topic_name, expected, actual),
 
-			Error::SubscriptionRejectedByServer =>
-				write!(f, "Server rejected one or more subscriptions"),
-
 			Error::UnexpectedSubAck(packet_identifier, reason) =>
 				write!(f, "received SUBACK {} but {}", packet_identifier, reason),
 
@@ -878,7 +874,6 @@ impl std::error::Error for Error {
             Error::ServerClosedConnection => None,
             Error::SubAckDoesNotContainEnoughQoS(_, _, _) => None,
             Error::SubscriptionDowngraded(_, _, _) => None,
-            Error::SubscriptionRejectedByServer => None,
             Error::UnexpectedSubAck(_, _) => None,
             Error::UnexpectedUnsubAck(_, _) => None,
         }

--- a/mqtt/mqtt3/src/client/subscriptions.rs
+++ b/mqtt/mqtt3/src/client/subscriptions.rs
@@ -114,7 +114,10 @@ impl State {
                                     // Return an event for rejected subscription instead of retrying to send the subscription
                                     subscription_updates.push(
                                         super::SubscriptionUpdateEvent::RejectedByServer(
-                                            topic_filter,
+                                            crate::proto::SubscribeTo {
+                                                topic_filter,
+                                                qos: expected_qos,
+                                            },
                                         ),
                                     );
                                 }

--- a/mqtt/mqtt3/tests/subscriptions.rs
+++ b/mqtt/mqtt3/tests/subscriptions.rs
@@ -661,7 +661,10 @@ fn should_send_reject_event() {
                     topic_filter: "topic1".to_string(),
                     qos: mqtt3::proto::QoS::AtLeastOnce,
                 }),
-                mqtt3::SubscriptionUpdateEvent::RejectedByServer("topic2".to_owned()),
+                mqtt3::SubscriptionUpdateEvent::RejectedByServer(mqtt3::proto::SubscribeTo {
+                    topic_filter: "topic2".to_string(),
+                    qos: mqtt3::proto::QoS::AtLeastOnce,
+                }),
             ]),
         ],
     );


### PR DESCRIPTION
When edge deployed on several levels in nested scenarios there can be a lag between all rules are applied. In this case, lower level subscriptions can be rejected by the upper level. The lower level should keep retrying until it is subscribed.

cherry-pick `be3d482`