### PR TITLE
Adds a ring buffer to MQTT bridge (#4304)

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -685,6 +685,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+]
+
+[[package]]
 name = "h2"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1004,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
+name = "memmap"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1115,6 +1136,7 @@ dependencies = [
  "humantime-serde",
  "lazy_static",
  "matches",
+ "memmap",
  "mockall",
  "mqtt-broker",
  "mqtt-broker-tests-util",
@@ -1122,6 +1144,7 @@ dependencies = [
  "openssl",
  "parking_lot 0.11.0",
  "percent-encoding 1.0.1",
+ "rand 0.8.3",
  "regex",
  "serde",
  "serde_bytes",
@@ -1697,11 +1720,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -1725,6 +1760,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1745,7 +1790,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.15",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -1764,6 +1818,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]

--- a/mqtt/mqtt-bridge/Cargo.toml
+++ b/mqtt/mqtt-bridge/Cargo.toml
@@ -16,6 +16,7 @@ futures-util = "0.3"
 humantime = "2.0"
 humantime-serde = "1.0"
 lazy_static = "1.4"
+memmap = "0.7"
 mockall = "0.8"
 openssl = "0.10"
 parking_lot = "0.11"
@@ -40,6 +41,7 @@ mqtt-broker = { path = "../mqtt-broker" }
 
 [dev-dependencies]
 matches = "0.1"
+rand = "0.8"
 serial_test = "0.4"
 tempfile = "3"
 test-case = "1.0"

--- a/mqtt/mqtt-bridge/src/persist/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/mod.rs
@@ -1,10 +1,13 @@
-use serde::{Deserialize, Serialize};
-
 mod loader;
 mod publication_store;
 mod waking_state;
+
+use bincode::Error as BincodeError;
+use serde::{Deserialize, Serialize};
+
 pub use loader::MessageLoader;
 pub use publication_store::PublicationStore;
+use waking_state::ring_buffer::error::RingBufferError;
 pub use waking_state::{memory::WakingMemoryStore, StreamWakeableState};
 
 /// Keys used in persistence.
@@ -18,4 +21,14 @@ pub struct Key {
 pub enum PersistError {
     #[error("Attempted to remove entry which does not exist")]
     RemovalForMissing,
+}
+
+// This might replace the PersistError or merge with it.
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("RingBuffer error occurred. Caused by: {0}")]
+    RingBuffer(#[from] RingBufferError),
+
+    #[error("Serialization error occurred. Caused by: {0}")]
+    Serialization(#[from] BincodeError),
 }

--- a/mqtt/mqtt-bridge/src/persist/waking_state/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/mod.rs
@@ -6,6 +6,7 @@ use mqtt3::proto::Publication;
 use crate::persist::{Key, PersistError};
 
 pub mod memory;
+pub mod ring_buffer;
 
 // TODO: Currently rocksdb does not compile on musl.
 //       Once we fix compilation we can add this module back.

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/block.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/block.rs
@@ -1,0 +1,311 @@
+use std::{
+    collections::hash_map::DefaultHasher,
+    fmt::Debug,
+    hash::{Hash, Hasher},
+};
+
+use lazy_static::lazy_static;
+use serde::{Deserialize, Serialize};
+
+use crate::persist::waking_state::ring_buffer::{
+    error::{BlockError, RingBufferError},
+    serialize::binary_serialize_size,
+    StorageResult,
+};
+
+lazy_static! {
+    pub(crate) static ref SERIALIZED_BLOCK_SIZE: usize =
+        binary_serialize_size(&BlockHeaderWithHash::new(0, 0, 0, 0)).unwrap();
+}
+
+/// A constant set bytes to help determine if a set of data comprises a block.
+pub const BLOCK_HINT: usize = 0xdead_beef;
+
+/// + --------------+------+---------+
+/// | `BlockHeader` | hash | data... |
+/// +---------------+------+---------+
+///
+/// The `BlockHeader` contains attributes meaningful for data storage and
+/// validation.
+#[derive(Copy, Clone, Debug, Deserialize, Hash, Serialize)]
+#[repr(C)]
+pub(crate) struct BlockHeader {
+    // The hint comes first so we can skip it when checking for empty block
+    // as the hint is always present.
+    hint: usize,
+    // variable fields
+    // A hash over the entire data that follows the header, this provides
+    // integrity check.
+    data_hash: u64,
+    // The size of the data after the header.
+    data_size: usize,
+    // The ordering of blocks, i.e. 1, 2, 3...
+    order: usize,
+    // A flag for determining if a block and data pair can be written over.
+    // Default state is the negative so to allow empty (all 0) data to
+    // deserialize in a way that makes sense (false).
+    should_not_overwrite: bool,
+    // The index of the write pointer when the block is created.
+    write_index: usize,
+}
+
+impl BlockHeader {
+    pub fn new(data_hash: u64, data_size: usize, order: usize, write_index: usize) -> Self {
+        Self {
+            data_hash,
+            data_size,
+            hint: BLOCK_HINT,
+            order,
+            should_not_overwrite: true,
+            write_index,
+        }
+    }
+
+    pub fn hint(&self) -> usize {
+        self.hint
+    }
+
+    pub fn data_size(&self) -> usize {
+        self.data_size
+    }
+
+    pub fn order(&self) -> usize {
+        self.order
+    }
+
+    pub fn write_index(&self) -> usize {
+        self.write_index
+    }
+
+    pub fn data_hash(&self) -> u64 {
+        self.data_hash
+    }
+
+    pub fn should_not_overwrite(&self) -> bool {
+        self.should_not_overwrite
+    }
+
+    pub fn set_should_not_overwrite(&mut self, value: bool) {
+        self.should_not_overwrite = value
+    }
+}
+
+/// + ----------------------+---------+
+/// | `BlockHeaderWithHash` | data... |
+/// +-----------------------+---------+
+///
+/// The `BlockHeaderWithHash` is a wrapper over the `BlockHeader` but also
+/// contains a hash over the header for validation.
+#[derive(Copy, Clone, Debug, Deserialize, Hash, Serialize)]
+#[repr(C)]
+pub(crate) struct BlockHeaderWithHash {
+    inner: BlockHeader,
+    // A hash over the entire block header to guarantee integrity.
+    block_hash: u64,
+}
+
+impl BlockHeaderWithHash {
+    pub fn new(data_hash: u64, data_size: usize, order: usize, write_index: usize) -> Self {
+        let header = BlockHeader::new(data_hash, data_size, order, write_index);
+        let header_hash = calculate_hash(&header);
+        Self {
+            inner: header,
+            block_hash: header_hash,
+        }
+    }
+
+    pub fn block_hash(&self) -> u64 {
+        self.block_hash
+    }
+
+    pub fn inner(&self) -> &BlockHeader {
+        &self.inner
+    }
+
+    pub fn inner_mut(&mut self) -> &mut BlockHeader {
+        &mut self.inner
+    }
+}
+
+/// A utility fn to calculate any entity that derives Hash.
+pub(crate) fn calculate_hash<T>(t: &T) -> u64
+where
+    T: Hash + ?Sized,
+{
+    let mut hasher = DefaultHasher::new();
+    t.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// A utility fn that validates the integrity of both the block and data.
+pub(crate) fn validate(block: &BlockHeaderWithHash, data: &[u8]) -> StorageResult<()> {
+    let actual_block_hash = block.block_hash();
+    let block_hash = calculate_hash(&block.inner);
+    if actual_block_hash != block_hash {
+        return Err(RingBufferError::Validate(BlockError::BlockHash {
+            found: actual_block_hash,
+            expected: block_hash,
+        })
+        .into());
+    }
+
+    let inner_block = block.inner;
+    let actual_data_size = inner_block.data_size();
+    let data_size = data.len();
+    if actual_data_size != data_size {
+        return Err(RingBufferError::Validate(BlockError::DataSize {
+            found: actual_data_size,
+            expected: data_size,
+        })
+        .into());
+    }
+
+    let data_hash = calculate_hash(data);
+    let actual_data_hash = inner_block.data_hash();
+    if actual_data_hash != data_hash {
+        return Err(RingBufferError::Validate(BlockError::DataHash {
+            found: actual_data_hash,
+            expected: data_hash,
+        })
+        .into());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::hash_map::DefaultHasher,
+        hash::{Hash, Hasher},
+        iter,
+    };
+
+    use matches::assert_matches;
+    use rand::{distributions::Alphanumeric, thread_rng, Rng};
+
+    use crate::persist::{
+        waking_state::ring_buffer::serialize::{binary_deserialize, binary_serialize},
+        StorageError,
+    };
+
+    use super::*;
+
+    fn random_string(data_length: usize) -> String {
+        let mut rng = thread_rng();
+        iter::repeat(())
+            .map(|()| rng.sample(Alphanumeric))
+            .map(char::from)
+            .take(data_length)
+            .collect()
+    }
+
+    fn test_serialize_helper(data: &str) {
+        let mut hasher = DefaultHasher::new();
+        data.hash(&mut hasher);
+        let data_hash = hasher.finish();
+
+        let result = binary_serialize_size(&data);
+        assert_matches!(result, Ok(_));
+        let data_size = result.unwrap();
+
+        let block_header_with_hash = BlockHeaderWithHash::new(data_hash, data_size, 0, 0);
+
+        let result = binary_serialize(&block_header_with_hash);
+        assert_matches!(result, Ok(_));
+        let serialized_block = result.unwrap();
+
+        let result = binary_deserialize::<BlockHeaderWithHash>(&serialized_block);
+        assert_matches!(result, Ok(_));
+        let deserialized_block = result.unwrap();
+
+        let result = binary_serialize(&data);
+        assert_matches!(result, Ok(_));
+        let serialized_data = result.unwrap();
+
+        let result = binary_deserialize::<String>(&serialized_data);
+        assert_matches!(result, Ok(_));
+        let deserialized_data = result.unwrap();
+
+        let block_hash = calculate_hash(&block_header_with_hash.inner);
+        assert_eq!(block_hash, deserialized_block.block_hash());
+
+        let deserialized_header = deserialized_block.inner;
+        assert_eq!(0, deserialized_header.write_index());
+        assert_eq!(data_hash, deserialized_header.data_hash());
+        assert_eq!(data_size, deserialized_header.data_size());
+
+        assert_eq!(data, deserialized_data);
+    }
+
+    #[test]
+    fn it_deserializes_serialized_empty_content() {
+        test_serialize_helper("");
+    }
+
+    #[test]
+    fn it_deserializes_serialized_content() {
+        test_serialize_helper("Hello World");
+    }
+
+    #[test]
+    fn it_deserializes_serialized_random_content() {
+        let random_str = random_string(100);
+        test_serialize_helper(&random_str);
+    }
+
+    #[test]
+    fn validate_errs_when_data_hash_do_not_match() {
+        let block = BlockHeaderWithHash::new(0x0000_0bad, 11, 0, 0);
+        let data = b"Hello World";
+        let result = validate(&block, data);
+        let _expected = calculate_hash(&data);
+        assert_matches!(
+            result,
+            Err(StorageError::RingBuffer(RingBufferError::Validate(
+                BlockError::DataHash {
+                    found: 0x0000_0bad,
+                    expected: _expected,
+                }
+            )))
+        );
+    }
+
+    #[test]
+    fn validate_errs_when_data_size_do_not_match() {
+        let data = b"Hello World";
+        let data_hash = calculate_hash(&data);
+        let block = BlockHeaderWithHash::new(data_hash, 0, 0, 0);
+        let result = validate(&block, data);
+        let expected_result = binary_serialize_size(&data);
+        assert_matches!(expected_result, Ok(_));
+        let _expected = expected_result.unwrap();
+        assert_matches!(
+            result,
+            Err(StorageError::RingBuffer(RingBufferError::Validate(
+                BlockError::DataSize {
+                    found: 0,
+                    expected: _expected,
+                }
+            )))
+        );
+    }
+
+    #[test]
+    fn validate_errs_when_block_hash_do_not_match() {
+        let data = b"Hello World";
+        let data_hash = calculate_hash(&data);
+        let mut block = BlockHeaderWithHash::new(data_hash, 19, 1, 0);
+        block.block_hash = 0x1;
+        let result = validate(&block, data);
+        assert_matches!(
+            result,
+            Err(StorageError::RingBuffer(RingBufferError::Validate(
+                BlockError::BlockHash {
+                    found: 0x1,
+                    expected: 0x5f41_0d03_497c_1cb0,
+                }
+            )))
+        );
+    }
+}

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/error.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/error.rs
@@ -1,0 +1,41 @@
+#[derive(Debug, thiserror::Error)]
+pub enum BlockError {
+    #[error("Unexpected block hash {found:?} expected {expected:?}")]
+    BlockHash { found: u64, expected: u64 },
+
+    #[error("Unexpected data hash {found:?} expected {expected:?}")]
+    DataHash { found: u64, expected: u64 },
+
+    #[error("Unexpected data size {found:?} expected {expected:?}")]
+    DataSize { found: usize, expected: usize },
+
+    #[error("Bad hint")]
+    Hint,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RingBufferError {
+    #[error("Flushing failed. Caused by {0}")]
+    Flush(std::io::Error),
+
+    #[error("Buffer is full and messages must be drained to continue")]
+    Full,
+
+    #[error("Mmap creation error occurred. Caused by {0}")]
+    MmapCreate(std::io::Error),
+
+    #[error("Key does not exist")]
+    NonExistantKey,
+
+    #[error("Key is at invalid index for removal")]
+    RemovalIndex,
+
+    #[error("Cannot remove before reading")]
+    RemoveBeforeRead,
+
+    #[error("Serialization error occurred. Caused by {0}")]
+    Serialization(#[from] bincode::Error),
+
+    #[error("Failed to validate internal details. Caused by {0}")]
+    Validate(#[from] BlockError),
+}

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/flush.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/flush.rs
@@ -1,0 +1,135 @@
+use std::time::Duration;
+
+use serde::Deserialize;
+
+/// `RingBuffer` can be configured to flush at certain intervals:
+///
+/// `AfterEachWrite` - Every write to buffer will cause a flush. This gives the
+///                    most durability but will cause decrease in performance.
+///
+/// `AfterXWrites` - Similar to `AfterEachWrite` but  will instead only flush
+///                  after 'X' writes to the `RingBuffer`. This allows
+///                  sacrificing durability for some performance. It is also
+///                  important to note that if 'X' is 0 or 1, it is same as
+///                  `AfterEachWrite`.
+///
+/// `AfterXBytes` - If 'X' bytes are written then a flush will happen.
+///
+/// `AfterXTime` - This allows for configuring around intervals of time
+///                for flushing. This does not mean that every 'X' a
+///                flush is called regardless of data incoming. This is
+///                for the difference between data is incoming. So, if
+///                5 inserts occur and after 3 the 'X' elapse a
+///                flush will happen. If only 2 inserts occur and 'X'
+///                ms is not reached then no flush occurs.
+///
+/// `Off` - No explicit flush will be called. This does not guarantee that no
+///         flush will occur or that data will not be pushed to 'disk'. This is
+///         the most performant option, but also the least durable.
+///
+/// It is important to note that after the threshold is reached for `AfterX`...
+/// a new window for tracking begins.
+#[derive(Clone, Copy, Debug, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FlushOptions {
+    AfterEachWrite,
+    AfterXWrites(usize),
+    AfterXBytes(usize),
+    AfterXTime(Duration),
+    Off,
+}
+
+/// A stateful object for tracking progress of any of the `AfterX`... options
+/// from `FlushOptions`.
+pub struct FlushState {
+    pub writes: usize,
+    pub bytes_written: usize,
+    pub elapsed: Duration,
+}
+
+impl FlushState {
+    pub(crate) fn new() -> Self {
+        Self {
+            writes: usize::default(),
+            bytes_written: usize::default(),
+            elapsed: Duration::default(),
+        }
+    }
+
+    pub(crate) fn reset(&mut self, flush_option: &FlushOptions) {
+        match flush_option {
+            FlushOptions::AfterEachWrite => {}
+            FlushOptions::AfterXWrites(_) => {
+                self.writes = usize::default();
+            }
+            FlushOptions::AfterXBytes(_) => {
+                self.bytes_written = usize::default();
+            }
+            FlushOptions::AfterXTime(_) => {
+                self.elapsed = Duration::default();
+            }
+            FlushOptions::Off => {}
+        }
+    }
+
+    pub(crate) fn update(&mut self, writes: usize, bytes_written: usize, elapsed: Duration) {
+        self.bytes_written += bytes_written;
+        self.elapsed += elapsed;
+        self.writes += writes;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_updates_flush_state_on_update() {
+        let mut fs = FlushState::new();
+        fs.update(1, 0, Duration::default());
+        assert_eq!(fs.writes, 1);
+        assert_eq!(fs.bytes_written, 0);
+        assert_eq!(fs.elapsed, Duration::default());
+        fs.update(0, 1, Duration::default());
+        assert_eq!(fs.writes, 1);
+        assert_eq!(fs.bytes_written, 1);
+        assert_eq!(fs.elapsed, Duration::default());
+        fs.update(0, 0, Duration::from_millis(1));
+        assert_eq!(fs.writes, 1);
+        assert_eq!(fs.bytes_written, 1);
+        assert_eq!(fs.elapsed, Duration::from_millis(1));
+        fs.update(1, 1, Duration::from_millis(1));
+        assert_eq!(fs.writes, 2);
+        assert_eq!(fs.bytes_written, 2);
+        assert_eq!(fs.elapsed, Duration::from_millis(2));
+    }
+
+    #[test]
+    fn it_resets_flush_state_on_reset() {
+        let mut fs = FlushState::new();
+        fs.update(1, 1, Duration::from_millis(1));
+        assert_eq!(fs.writes, 1);
+        assert_eq!(fs.bytes_written, 1);
+        assert_eq!(fs.elapsed, Duration::from_millis(1));
+        fs.reset(&FlushOptions::AfterEachWrite);
+        assert_eq!(fs.writes, 1);
+        assert_eq!(fs.bytes_written, 1);
+        assert_eq!(fs.elapsed, Duration::from_millis(1));
+        fs.reset(&FlushOptions::Off);
+        assert_eq!(fs.writes, 1);
+        assert_eq!(fs.bytes_written, 1);
+        assert_eq!(fs.elapsed, Duration::from_millis(1));
+        fs.reset(&FlushOptions::AfterXWrites(0));
+        assert_eq!(fs.writes, 0);
+        assert_eq!(fs.bytes_written, 1);
+        assert_eq!(fs.elapsed, Duration::from_millis(1));
+        fs.reset(&FlushOptions::AfterXBytes(0));
+        assert_eq!(fs.writes, 0);
+        assert_eq!(fs.bytes_written, 0);
+        assert_eq!(fs.elapsed, Duration::from_millis(1));
+        fs.reset(&FlushOptions::AfterXTime(Duration::default()));
+        assert_eq!(fs.writes, 0);
+        assert_eq!(fs.bytes_written, 0);
+        assert_eq!(fs.elapsed, Duration::default());
+    }
+}

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -1,0 +1,1129 @@
+#![allow(dead_code)]
+mod block;
+pub mod error;
+pub mod flush;
+mod serialize;
+
+use std::{
+    collections::VecDeque,
+    fmt::Debug,
+    fs::{File, OpenOptions},
+    io::Result as IOResult,
+    mem::size_of,
+    path::Path,
+    task::Waker,
+    time::{Duration, Instant},
+};
+
+use bincode::Result as BincodeResult;
+use error::BlockError;
+use memmap::MmapMut;
+use mqtt3::proto::Publication;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use tracing::error;
+
+use crate::persist::{
+    waking_state::ring_buffer::{
+        block::{calculate_hash, validate, BlockHeaderWithHash, BLOCK_HINT, SERIALIZED_BLOCK_SIZE},
+        error::RingBufferError,
+        flush::{FlushOptions, FlushState},
+        serialize::{binary_deserialize, binary_deserialize_owned, binary_serialize},
+    },
+    Key, StorageError,
+};
+
+pub type StorageResult<T> = Result<T, StorageError>;
+
+/// Convenience struct for tracking read and write pointers into the file.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub(crate) struct FilePointers {
+    write: usize,
+    read_begin: usize,
+    read_end: usize,
+}
+
+/// Imagine there are three pointers:
+/// W - A write pointer
+/// R - A read pointer
+/// D - A delete pointer
+///
+/// With a file buffer similar to below:
+/// +---+---+---+---+---+---+---+---+---+
+/// | A | B | C | D | E | F | G | H | I |
+/// +---+---+---+---+---+---+---+---+---+
+///
+/// It is possible that W could wrap around and cause us to lose data due to
+/// variable sized data being written. If W + data size > R and should write
+/// precede read, the data could become corrupted.
+///
+/// Either this is prevented by scanning the file for the next block and
+/// checking if the write will fit. Or, W + data must not pass both D and R.
+/// - Not passing D helps with guaranteeing all data read was handled.
+/// - Not passing R helps avoid corruption.
+pub(crate) struct RingBuffer {
+    // If write reaches read but we have data to read, this is set.
+    // It allows us handle the edge case of read == write, but data
+    // has not been read yet.
+    can_read_from_wrap_around: bool,
+    // The optional flush threshold to uphold.
+    flush_options: FlushOptions,
+    // For determining if a flush should occur.
+    flush_state: FlushState,
+    // If data has been read this is set, if data is removed to
+    // the point of reaching the read pointer this is unset.
+    // This prevents deletion of data without reading.
+    has_read: bool,
+    // Max size for the file that is required for mmap.
+    max_file_size: usize,
+    // A representation of Mmap with operations built-in.
+    mmap: MmapMut,
+    // A tracker for suppling an ordering to blocks being written.
+    order: usize,
+    // Pointers into the file (read/write).
+    pointers: FilePointers,
+    // A waker for updating any pending batch after an insert.
+    waker: Option<Waker>,
+}
+
+impl RingBuffer {
+    pub(crate) fn new(
+        file_path: &Path,
+        max_file_size: usize,
+        flush_options: &FlushOptions,
+    ) -> StorageResult<Self> {
+        let file = create_file(file_path).map_err(RingBufferError::MmapCreate)?;
+        file.set_len(max_file_size as u64)
+            .map_err(RingBufferError::MmapCreate)?;
+        let mmap = unsafe { MmapMut::map_mut(&file).map_err(RingBufferError::MmapCreate)? };
+        let (file_pointers, order) = find_pointers_and_order_post_crash(&mmap, max_file_size)?;
+
+        Ok(Self {
+            can_read_from_wrap_around: false,
+            flush_options: *flush_options,
+            flush_state: FlushState::new(),
+            has_read: false,
+            max_file_size,
+            mmap,
+            order,
+            pointers: file_pointers,
+            waker: None,
+        })
+    }
+
+    fn insert(&mut self, publication: &Publication) -> StorageResult<Key> {
+        let timer = Instant::now();
+        let data = binary_serialize(publication)?;
+        let data_size = data.len();
+        let data_hash = calculate_hash(&data);
+
+        let write_index = self.pointers.write;
+        let read_index = self.pointers.read_begin;
+        let order = self.order;
+        let key = write_index;
+
+        let block_header = BlockHeaderWithHash::new(data_hash, data_size, order, write_index);
+        let block_size = *SERIALIZED_BLOCK_SIZE;
+
+        let total_size = block_size + data_size;
+        // Check to see if we might corrupt data if we write, if so, return err of full.
+        // There are two cases for this:
+        // 1. write has wrapped around and is now behind read
+        if write_index < read_index && write_index + total_size > read_index {
+            return Err(StorageError::RingBuffer(RingBufferError::Full));
+        }
+        // 2. write has reached the end (or close enough) but read has not moved
+        if read_index == 0 && write_index + total_size > self.max_file_size {
+            return Err(StorageError::RingBuffer(RingBufferError::Full));
+        }
+        // 3. check if write would wrap around end and corrupt
+        if write_index > read_index
+            && write_index + total_size > self.max_file_size
+            && (write_index + total_size) % self.max_file_size > read_index
+        {
+            return Err(StorageError::RingBuffer(RingBufferError::Full));
+        }
+
+        let mut start = write_index;
+
+        // Check if an existing block header is present. If the block is there
+        // and if the overwrite flag is not set then we shouldn't write.
+        let result = load_block_header(&self.mmap, start, block_size, self.max_file_size);
+        if let Ok(block_header) = result {
+            let should_not_overwrite = block_header.inner().should_not_overwrite();
+            if should_not_overwrite {
+                return Err(StorageError::RingBuffer(RingBufferError::Full));
+            }
+        }
+
+        let should_flush = self.should_flush();
+
+        save_block_header(
+            &mut self.mmap,
+            &block_header,
+            start,
+            self.max_file_size,
+            should_flush,
+        )?;
+
+        let mut end = start + block_size;
+        start = end % self.max_file_size;
+
+        save_data(
+            &mut self.mmap,
+            &data,
+            start,
+            self.max_file_size,
+            should_flush,
+        )?;
+
+        end = start + data_size;
+        self.pointers.write = end % self.max_file_size;
+
+        // should only happen if we wrap around
+        if self.pointers.write == self.pointers.read_begin {
+            self.can_read_from_wrap_around = true;
+        }
+
+        self.wake_up_task();
+
+        self.order += 1;
+
+        self.flush_state_update(should_flush, 1, total_size, timer.elapsed());
+
+        Ok(Key { offset: key as u64 })
+    }
+
+    fn batch(&mut self, count: usize) -> StorageResult<VecDeque<(Key, Publication)>> {
+        let write_index = self.pointers.write;
+        let read_index = self.pointers.read_begin;
+        let block_size = *SERIALIZED_BLOCK_SIZE;
+
+        // If read would go into where writes are happening then we don't have data to read.
+        if self.pointers.read_end == write_index && !self.can_read_from_wrap_around {
+            return Ok(VecDeque::new());
+        }
+
+        // If we are reading then we can reset wrap around flag
+        self.can_read_from_wrap_around = false;
+
+        let mut start = read_index;
+        let mut vdata = VecDeque::new();
+        for _ in 0..count {
+            let end = start + block_size;
+            let bytes = &self.mmap[start..end];
+            // this is unused memory
+            if bytes.iter().map(|&x| x as usize).sum::<usize>() == 0 {
+                break;
+            }
+
+            let block = binary_deserialize::<BlockHeaderWithHash>(bytes)?;
+            // this means we read bytes that don't make a block, this is
+            // a really bad state to be in as somehow the pointers don't
+            // match to where data really is at.
+            if block.inner().hint() != BLOCK_HINT {
+                return Err(RingBufferError::Validate(BlockError::Hint).into());
+            }
+
+            let inner_block = block.inner();
+            let data_size = inner_block.data_size();
+            let index = inner_block.write_index();
+            start += block_size;
+            let end = start + data_size;
+            let data = load_data(&self.mmap, start, data_size, self.max_file_size)?;
+            start = end % self.max_file_size;
+            self.pointers.read_end = start;
+
+            validate(&block, &binary_serialize(&data)?)?;
+            let key = Key {
+                offset: index as u64,
+            };
+
+            vdata.push_back((key, data));
+
+            self.has_read = true;
+
+            // This case shouldn't be pending, as we must have gotten something we can process.
+            if start == write_index {
+                break;
+            }
+        }
+
+        Ok(vdata)
+    }
+
+    fn remove(&mut self, key: usize) -> StorageResult<()> {
+        if !self.has_read {
+            return Err(StorageError::RingBuffer(RingBufferError::RemoveBeforeRead));
+        }
+        let timer = Instant::now();
+        let read_index = self.pointers.read_begin;
+        if key != read_index {
+            return Err(StorageError::RingBuffer(RingBufferError::RemovalIndex));
+        }
+        let block_size = *SERIALIZED_BLOCK_SIZE;
+
+        let start = key;
+        let mut block = load_block_header(&self.mmap, start, block_size, self.max_file_size)
+            .map_err(StorageError::Serialization)?;
+
+        if block.inner().hint() != BLOCK_HINT {
+            return Err(StorageError::RingBuffer(RingBufferError::NonExistantKey));
+        }
+
+        let data_size = {
+            let inner_block = block.inner_mut();
+            inner_block.set_should_not_overwrite(false);
+            inner_block.data_size()
+        };
+
+        let should_flush = self.should_flush();
+        save_block_header(
+            &mut self.mmap,
+            &block,
+            start,
+            self.max_file_size,
+            should_flush,
+        )?;
+
+        let end = start + block_size + data_size;
+        self.pointers.read_begin = end % self.max_file_size;
+
+        self.flush_state_update(should_flush, 0, 0, timer.elapsed());
+
+        if self.pointers.read_end == self.pointers.read_begin {
+            self.has_read = false;
+        }
+
+        Ok(())
+    }
+
+    fn set_waker(&mut self, waker: &Waker) {
+        self.waker = Some(waker.clone());
+    }
+
+    fn should_flush(&self) -> bool {
+        match self.flush_options {
+            FlushOptions::AfterEachWrite => true,
+            FlushOptions::AfterXWrites(xwrites) => self.flush_state.writes >= xwrites,
+            FlushOptions::AfterXBytes(xbytes) => self.flush_state.bytes_written >= xbytes,
+            FlushOptions::AfterXTime(xelapsed) => self.flush_state.elapsed >= xelapsed,
+            FlushOptions::Off => false,
+        }
+    }
+
+    fn wake_up_task(&mut self) {
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+
+    fn flush_state_update(
+        &mut self,
+        should_flush: bool,
+        writes: usize,
+        bytes_written: usize,
+        millis: Duration,
+    ) {
+        if should_flush {
+            self.flush_state.reset(&self.flush_options);
+        } else {
+            self.flush_state.update(writes, bytes_written, millis);
+        }
+    }
+}
+
+impl Drop for RingBuffer {
+    fn drop(&mut self) {
+        let result = self.mmap.flush();
+        if let Some(err) = result.err() {
+            error!("Failed to flush {:?}", err);
+        }
+    }
+}
+
+fn create_file(file_path: &Path) -> IOResult<File> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(file_path)
+}
+
+fn find_pointers_and_order_post_crash(
+    mmap: &MmapMut,
+    max_file_size: usize,
+) -> StorageResult<(FilePointers, usize)> {
+    let mut block: BlockHeaderWithHash;
+    let block_size = *SERIALIZED_BLOCK_SIZE;
+
+    let mut start = 0;
+    let mut end = start + block_size;
+    let mut read = 0;
+    let mut write = 0;
+    let mut order = 0;
+
+    // First we need to find *a* block header to work with.
+    // Once we find one, if any, then we can skip more efficiently
+    // to others.
+    loop {
+        if end > max_file_size {
+            return Ok((
+                FilePointers {
+                    write,
+                    read_begin: read,
+                    read_end: read,
+                },
+                order,
+            ));
+        }
+
+        let hint_result = binary_deserialize::<usize>(&mmap[start..(start + size_of::<usize>())]);
+
+        if let Ok(hint) = hint_result {
+            if hint == BLOCK_HINT {
+                block = load_block_header(mmap, start, block_size, max_file_size)?;
+                order = block.inner().order();
+            } else {
+                start += 1;
+                end += 1;
+                continue;
+            }
+        } else {
+            start += 1;
+            end += 1;
+            continue;
+        }
+
+        // We have found a block and can break the loop.
+        break;
+    }
+
+    // Now that a block has been found, we can find the last write.
+    // Note read pointer is found a different way.
+    // Read is found by scanning blocks marked for overwrite
+    // and taking the value of the first non-overwrite block.
+    loop {
+        let inner = block.inner();
+        let found_overwrite_block = !inner.should_not_overwrite();
+        let data_size = inner.data_size();
+
+        // Found a block that was removed, so update the read pointer.
+        if found_overwrite_block && inner.hint() == BLOCK_HINT {
+            read = end + data_size;
+        }
+        // Found the last write, take whatever we got for read and write
+        // and return the pointers.
+        if inner.order() < order {
+            write = start;
+
+            return Ok((
+                FilePointers {
+                    write,
+                    read_begin: read,
+                    read_end: read,
+                },
+                order,
+            ));
+        }
+
+        // Check next block
+        order = inner.order();
+        start = (end + data_size) % max_file_size;
+        end = (start + block_size) % max_file_size;
+
+        let bytes = &mmap[start..end];
+        // this is unused memory
+        if bytes.iter().map(|&x| x as usize).sum::<usize>() == 0 {
+            write = start;
+
+            return Ok((
+                FilePointers {
+                    write,
+                    read_begin: read,
+                    read_end: read,
+                },
+                order,
+            ));
+        }
+
+        block = match load_block_header(mmap, start, block_size, max_file_size) {
+            Ok(block) => block,
+            Err(_) => {
+                return Ok((
+                    FilePointers {
+                        write,
+                        read_begin: read,
+                        read_end: read,
+                    },
+                    order,
+                ));
+            }
+        };
+    }
+}
+
+fn load_block_header(
+    mmap: &MmapMut,
+    mut start: usize,
+    size: usize,
+    file_size: usize,
+) -> BincodeResult<BlockHeaderWithHash> {
+    if start > file_size {
+        start %= file_size;
+    }
+    let end = start + size;
+
+    if end > file_size {
+        mmap_read_wrap_around(mmap, start, size, file_size)
+    } else {
+        mmap_read(mmap, start, size)
+    }
+}
+
+fn save_block_header(
+    mmap: &mut MmapMut,
+    block: &BlockHeaderWithHash,
+    start: usize,
+    file_size: usize,
+    should_flush: bool,
+) -> StorageResult<()> {
+    let bytes = binary_serialize(block)?;
+    mmap_write(mmap, start, &bytes, file_size, should_flush)
+}
+
+fn save_data(
+    mmap: &mut MmapMut,
+    serialized_data: &[u8],
+    start: usize,
+    file_size: usize,
+    should_flush: bool,
+) -> StorageResult<()> {
+    mmap_write(mmap, start, &serialized_data, file_size, should_flush)
+}
+
+fn load_data(
+    mmap: &MmapMut,
+    mut start: usize,
+    size: usize,
+    file_size: usize,
+) -> BincodeResult<Publication> {
+    if start > file_size {
+        start %= file_size;
+    }
+    let end = start + size;
+
+    if end > file_size {
+        mmap_read_wrap_around(mmap, start, size, file_size)
+    } else {
+        mmap_read(mmap, start, size)
+    }
+}
+
+fn mmap_read<'a, T>(mmap: &'a MmapMut, start: usize, size: usize) -> BincodeResult<T>
+where
+    T: Deserialize<'a>,
+{
+    let end = start + size;
+    binary_deserialize::<T>(&mmap[start..end])
+}
+
+fn mmap_read_wrap_around<T>(
+    mmap: &MmapMut,
+    start: usize,
+    size: usize,
+    file_size: usize,
+) -> BincodeResult<T>
+where
+    T: DeserializeOwned,
+{
+    let end = start + size;
+    let file_split = end - file_size;
+    let mut wrap = vec![];
+    wrap.extend_from_slice(&mmap[start..file_size]);
+    wrap.extend_from_slice(&mmap[0..file_split]);
+    binary_deserialize_owned::<T>(&wrap)
+}
+
+fn mmap_write(
+    mmap: &mut MmapMut,
+    start: usize,
+    bytes: &[u8],
+    file_size: usize,
+    should_flush: bool,
+) -> StorageResult<()> {
+    let end = start + bytes.len();
+    if end > file_size {
+        let file_split = end - file_size;
+        let bytes_split = bytes.len() - file_split;
+        mmap[start..file_size].copy_from_slice(&bytes[..bytes_split]);
+        mmap[0..file_split].copy_from_slice(&bytes[bytes_split..]);
+    } else {
+        mmap[start..end].copy_from_slice(&bytes);
+    }
+    if should_flush {
+        mmap.flush_async_range(start, end - start)
+            .map_err(RingBufferError::Flush)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::write, panic};
+
+    use bytes::Bytes;
+    use matches::assert_matches;
+    use mqtt3::proto::QoS;
+
+    use crate::persist::waking_state::ring_buffer::serialize::binary_serialize_size;
+
+    use super::*;
+
+    const FLUSH_OPTIONS: FlushOptions = FlushOptions::Off;
+    const MAX_FILE_SIZE: usize = 1024;
+
+    struct TestRingBuffer(RingBuffer);
+
+    impl Default for TestRingBuffer {
+        fn default() -> Self {
+            let result = tempfile::NamedTempFile::new();
+            assert_matches!(result, Ok(_));
+            let file = result.unwrap();
+            let file_path = file.path();
+            let result = RingBuffer::new(file_path, MAX_FILE_SIZE, &FLUSH_OPTIONS);
+            assert!(result.is_ok());
+            Self(result.unwrap())
+        }
+    }
+
+    #[test]
+    fn it_inits_ok_with_no_previous_data() {
+        let result = panic::catch_unwind(|| {
+            TestRingBuffer::default();
+        });
+        assert_matches!(result, Ok(_));
+    }
+
+    #[test]
+    fn it_inits_ok_with_previous_data() {
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+        let result = panic::catch_unwind(|| {
+            let read;
+            let write;
+            let result = tempfile::NamedTempFile::new();
+            assert_matches!(result, Ok(_));
+            let file = result.unwrap();
+            let mut keys = vec![];
+            // Create ring buffer and perform some operations and then destruct.
+            {
+                let result = RingBuffer::new(file.path(), MAX_FILE_SIZE, &FLUSH_OPTIONS);
+                assert!(result.is_ok());
+                let mut rb = result.unwrap();
+                for _ in 0..10 {
+                    let result = rb.insert(&publication);
+                    assert_matches!(result, Ok(_));
+                    keys.push(result.unwrap());
+                }
+
+                let result = rb.batch(4);
+                assert_matches!(result, Ok(_));
+                let mut batch = result.unwrap();
+                assert_eq!(batch.len(), 4);
+                for key in &keys[..4] {
+                    assert_eq!(batch.pop_front().unwrap().0, *key);
+                }
+
+                {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let key = keys[0].offset as usize;
+                    assert_matches!(rb.remove(key), Ok(_));
+                }
+
+                {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let key = keys[1].offset as usize;
+                    assert_matches!(rb.remove(key), Ok(_));
+                }
+
+                {
+                    #[allow(clippy::cast_possible_truncation)]
+                    let key = keys[2].offset as usize;
+                    assert_matches!(rb.remove(key), Ok(_));
+                }
+
+                read = rb.pointers.read_begin;
+                write = rb.pointers.write;
+            }
+            // Create ring buffer again and validate pointers match where they left off.
+            {
+                let result = RingBuffer::new(file.path(), MAX_FILE_SIZE, &FLUSH_OPTIONS);
+                assert!(result.is_ok());
+                let mut rb = result.unwrap();
+                let loaded_read = rb.pointers.read_begin;
+                let loaded_write = rb.pointers.write;
+                assert_eq!(read, loaded_read);
+                assert_eq!(write, loaded_write);
+                let result = rb.batch(2);
+                assert_matches!(result, Ok(_));
+                let mut batch = result.unwrap();
+                assert_eq!(batch.len(), 2);
+                for key in &keys[3..5] {
+                    assert_eq!(batch.pop_front().unwrap().0, *key);
+                }
+            }
+        });
+        assert_matches!(result, Ok(_));
+    }
+
+    #[test]
+    fn it_inserts_ok_when_not_full() {
+        let mut rb = TestRingBuffer::default();
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+        let result = rb.0.insert(&publication);
+        assert_matches!(result, Ok(_));
+    }
+
+    #[test]
+    fn it_inserts_ok_after_leftover() {
+        let result = tempfile::NamedTempFile::new();
+        assert_matches!(result, Ok(_));
+        let file = result.unwrap();
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+        let mut keys = vec![];
+        {
+            let result = RingBuffer::new(file.path(), MAX_FILE_SIZE, &FLUSH_OPTIONS);
+            assert!(result.is_ok());
+            let mut rb = result.unwrap();
+            // write some
+            for _ in 0..5 {
+                let result = rb.insert(&publication);
+                assert_matches!(result, Ok(_));
+                let key = result.unwrap();
+                keys.push(key);
+            }
+
+            let result = rb.batch(5);
+            assert_matches!(result, Ok(_));
+            let mut batch = result.unwrap();
+            assert!(!batch.is_empty());
+
+            for key in &keys[..5] {
+                let maybe_entry = batch.remove(0);
+                assert!(maybe_entry.is_some());
+                let entry = maybe_entry.unwrap();
+                assert_eq!(*key, entry.0);
+                assert_eq!(publication, entry.1);
+                #[allow(clippy::cast_possible_truncation)]
+                let result = rb.remove(key.offset as usize);
+                assert_matches!(result, Ok(_));
+            }
+        }
+        {
+            let result = RingBuffer::new(file.path(), MAX_FILE_SIZE, &FLUSH_OPTIONS);
+            assert!(result.is_ok());
+            let mut rb = result.unwrap();
+
+            // write some more
+            for _ in 0..5 {
+                let result = rb.insert(&publication);
+                assert_matches!(result, Ok(_));
+                let key = result.unwrap();
+                keys.push(key);
+            }
+
+            let result = rb.batch(5);
+            assert_matches!(result, Ok(_));
+            let mut batch = result.unwrap();
+            assert!(!batch.is_empty());
+
+            for key in &keys[5..] {
+                let maybe_entry = batch.remove(0);
+                assert!(maybe_entry.is_some());
+                let entry = maybe_entry.unwrap();
+                assert_eq!(*key, entry.0);
+                assert_eq!(publication, entry.1);
+            }
+        }
+    }
+
+    #[test]
+    fn it_errs_on_insert_when_full() {
+        let mut rb = TestRingBuffer::default();
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        let block_size = *SERIALIZED_BLOCK_SIZE;
+
+        let result = binary_serialize(&publication);
+        assert_matches!(result, Ok(_));
+        let data = result.unwrap();
+        let data_size = data.len();
+
+        let total_size = block_size + data_size;
+
+        let inserts = MAX_FILE_SIZE / total_size;
+        for _ in 0..inserts {
+            let result = rb.0.insert(&publication);
+            assert_matches!(result, Ok(_));
+        }
+        let result = rb.0.insert(&publication);
+        assert_matches!(result, Err(StorageError::RingBuffer(RingBufferError::Full)));
+    }
+
+    #[test]
+    fn it_errs_on_insert_when_full_and_had_batched_and_removed() {
+        let mut rb = TestRingBuffer::default();
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        let block_size = *SERIALIZED_BLOCK_SIZE;
+
+        let result = binary_serialize(&publication);
+        assert_matches!(result, Ok(_));
+        let data = result.unwrap();
+        let data_size = data.len();
+
+        let total_size = block_size + data_size;
+
+        let inserts = MAX_FILE_SIZE / total_size;
+        for _ in 0..inserts {
+            let result = rb.0.insert(&publication);
+            assert_matches!(result, Ok(_));
+        }
+
+        let result = rb.0.batch(1);
+        assert_matches!(result, Ok(_));
+        let batch = result.unwrap();
+
+        #[allow(clippy::cast_possible_truncation)]
+        let result = rb.0.remove(batch[0].0.offset as usize);
+        assert_matches!(result, Ok(_));
+
+        // need bigger pub
+        let big_publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::from(
+                "It was the best of times, it was the worst of times, 
+                it was the age of wisdom, it was the age of foolishness, 
+                it was the epoch of belief, it was the epoch of incredulity, 
+                it was the season of light, it was the season of darkness, 
+                it was the spring of hope, it was the winter of despair.",
+            ),
+        };
+
+        let result = rb.0.insert(&big_publication);
+        assert_matches!(result, Err(StorageError::RingBuffer(RingBufferError::Full)));
+    }
+
+    #[test]
+    fn it_batches_correctly_after_insert() {
+        let mut rb = TestRingBuffer::default();
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        // first with 1
+        let result = rb.0.insert(&publication);
+        assert_matches!(result, Ok(_));
+        let key = result.unwrap();
+        let result = rb.0.batch(1);
+        assert_matches!(result, Ok(_));
+        let batch = result.unwrap();
+        assert!(!batch.is_empty());
+        assert_eq!(key, batch[0].0);
+
+        // now with 9 more
+        let mut keys = vec![];
+        keys.push(key);
+        for _ in 0..9 {
+            let result = rb.0.insert(&publication);
+            assert_matches!(result, Ok(_));
+            let key = result.unwrap();
+            keys.push(key)
+        }
+
+        let result = rb.0.batch(10);
+        assert_matches!(result, Ok(_));
+        let batch = result.unwrap();
+        assert_eq!(10, batch.len());
+        for i in 0..10 {
+            assert_eq!(keys[i], batch[i].0);
+        }
+    }
+
+    #[test]
+    fn it_batches_ok_when_no_insert() {
+        let mut rb = TestRingBuffer::default();
+        let result = rb.0.batch(1);
+        assert_matches!(result, Ok(_));
+    }
+
+    #[test]
+    fn it_batches_ok_when_leftover_from_file() {
+        let result = tempfile::NamedTempFile::new();
+        assert_matches!(result, Ok(_));
+        let file = result.unwrap();
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+        let mut keys = vec![];
+        {
+            let result = RingBuffer::new(file.path(), MAX_FILE_SIZE, &FLUSH_OPTIONS);
+            assert!(result.is_ok());
+            let mut rb = result.unwrap();
+
+            // write some
+            for _ in 0..10 {
+                let result = rb.insert(&publication);
+                assert_matches!(result, Ok(_));
+                let key = result.unwrap();
+                keys.push(key);
+            }
+
+            let result = rb.batch(5);
+            assert_matches!(result, Ok(_));
+            let mut batch = result.unwrap();
+            assert!(!batch.is_empty());
+
+            for key in &keys[..5] {
+                let maybe_entry = batch.remove(0);
+                assert!(maybe_entry.is_some());
+                let entry = maybe_entry.unwrap();
+                assert_eq!(*key, entry.0);
+                assert_eq!(publication, entry.1);
+                #[allow(clippy::cast_possible_truncation)]
+                let result = rb.remove(key.offset as usize);
+                assert_matches!(result, Ok(_));
+            }
+        }
+        {
+            let result = RingBuffer::new(file.path(), MAX_FILE_SIZE, &FLUSH_OPTIONS);
+            assert!(result.is_ok());
+            let mut rb = result.unwrap();
+
+            let result = rb.batch(5);
+            assert_matches!(result, Ok(_));
+            let mut batch = result.unwrap();
+            assert!(!batch.is_empty());
+
+            for key in &keys[5..] {
+                let maybe_entry = batch.remove(0);
+                assert!(maybe_entry.is_some());
+                let entry = maybe_entry.unwrap();
+                assert_eq!(*key, entry.0);
+                assert_eq!(publication, entry.1);
+            }
+        }
+    }
+
+    #[test]
+    fn it_batches_err_when_bad_block_from_file() {
+        let result = tempfile::NamedTempFile::new();
+        assert_matches!(result, Ok(_));
+        let file = result.unwrap();
+
+        let result = RingBuffer::new(file.path(), MAX_FILE_SIZE, &FLUSH_OPTIONS);
+        assert!(result.is_ok());
+        let mut rb = result.unwrap();
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        let result = rb.insert(&publication);
+        assert_matches!(result, Ok(_));
+
+        let result = write(file.path(), "garbage");
+        assert_matches!(result, Ok(_));
+
+        let result = rb.batch(1);
+        assert_matches!(
+            result,
+            Err(StorageError::RingBuffer(RingBufferError::Validate(
+                BlockError::Hint
+            )))
+        );
+    }
+
+    #[test]
+    fn it_batches_ok_when_write_reaches_begin_again() {
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+        let result = binary_serialize(&publication);
+        assert_matches!(result, Ok(_));
+
+        let data = result.unwrap();
+
+        let block_size = *SERIALIZED_BLOCK_SIZE;
+
+        let result = binary_serialize_size(&data);
+        assert_matches!(result, Ok(_));
+        let data_size = result.unwrap();
+
+        let file_size = 10 * (block_size + data_size);
+
+        let result = tempfile::NamedTempFile::new();
+        assert_matches!(result, Ok(_));
+        let file = result.unwrap();
+
+        let result = RingBuffer::new(file.path(), file_size, &FLUSH_OPTIONS);
+        assert!(result.is_ok());
+        let mut rb = result.unwrap();
+
+        let mut keys = vec![];
+        for _ in 0..10 {
+            let result = rb.insert(&publication);
+            assert_matches!(result, Ok(_));
+            keys.push(result.unwrap());
+        }
+
+        let result = rb.batch(10);
+        assert_matches!(result, Ok(_));
+        let batch = result.unwrap();
+        assert!(!batch.is_empty());
+
+        assert_eq!(
+            batch.iter().map(|(k, _)| k.offset).collect::<Vec<_>>(),
+            keys.iter().map(|k| k.offset).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn it_errs_on_remove_when_no_read() {
+        let mut rb = TestRingBuffer::default();
+        let result = rb.0.remove(1);
+        assert_matches!(result, Err(_));
+        assert_matches!(
+            result.unwrap_err(),
+            StorageError::RingBuffer(RingBufferError::RemoveBeforeRead)
+        );
+    }
+
+    #[test]
+    fn it_errs_on_remove_with_key_not_equal_to_read() {
+        let mut rb = TestRingBuffer::default();
+
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        let result = rb.0.insert(&publication);
+        assert_matches!(result, Ok(_));
+
+        let result = rb.0.batch(1);
+        assert_matches!(result, Ok(_));
+
+        let result = rb.0.remove(1);
+        assert_matches!(result, Err(_));
+        assert_matches!(
+            result.unwrap_err(),
+            StorageError::RingBuffer(RingBufferError::RemovalIndex)
+        );
+    }
+
+    #[test]
+    fn it_errs_on_remove_with_key_that_does_not_exist() {
+        let result = tempfile::NamedTempFile::new();
+        assert_matches!(result, Ok(_));
+        let file = result.unwrap();
+
+        let result = RingBuffer::new(file.path(), MAX_FILE_SIZE, &FLUSH_OPTIONS);
+        assert!(result.is_ok());
+        let mut rb = result.unwrap();
+
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        let result = rb.insert(&publication);
+        assert_matches!(result, Ok(_));
+
+        let result = rb.batch(1);
+        assert_matches!(result, Ok(_));
+
+        let result = write(file.path(), "garbage");
+        assert_matches!(result, Ok(_));
+
+        let result = rb.remove(0);
+        assert_matches!(result, Err(_));
+        assert_matches!(
+            result.unwrap_err(),
+            StorageError::RingBuffer(RingBufferError::NonExistantKey)
+        );
+    }
+
+    #[test]
+    fn it_removes_in_order_of_batch() {
+        let mut rb = TestRingBuffer::default();
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        let mut keys = vec![];
+        for _ in 0..10_usize {
+            let result = rb.0.insert(&publication);
+            assert_matches!(result, Ok(_));
+            let key = result.unwrap();
+            keys.push(key)
+        }
+
+        let result = rb.0.batch(10);
+        assert_matches!(result, Ok(_));
+        let mut batch = result.unwrap();
+
+        for key in keys {
+            let entry = batch.pop_front().unwrap();
+            assert_eq!(key, entry.0);
+
+            #[allow(clippy::cast_possible_truncation)]
+            let result = rb.0.remove(key.offset as usize);
+            assert_matches!(result, Ok(_));
+        }
+    }
+}

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/serialize.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/serialize.rs
@@ -1,0 +1,31 @@
+use bincode::Result as BincodeResult;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+pub(crate) fn binary_serialize<T>(something: &T) -> BincodeResult<Vec<u8>>
+where
+    T: Serialize,
+{
+    bincode::serialize(something)
+}
+
+pub(crate) fn binary_serialize_size<T>(something: &T) -> BincodeResult<usize>
+where
+    T: Serialize,
+{
+    #[allow(clippy::cast_possible_truncation)]
+    bincode::serialized_size(something).map(|x| x as usize)
+}
+
+pub(crate) fn binary_deserialize<'de, T>(bytes: &'de [u8]) -> BincodeResult<T>
+where
+    T: Deserialize<'de>,
+{
+    bincode::deserialize::<T>(bytes)
+}
+
+pub(crate) fn binary_deserialize_owned<T>(bytes: &[u8]) -> BincodeResult<T>
+where
+    T: DeserializeOwned,
+{
+    bincode::deserialize::<T>(bytes)
+}


### PR DESCRIPTION
* Adds ring buffer

* Fix dep ordering in Cargo.toml

* Restructure layout

* Add flush tests

* Fix clippy warn

* Fmt change only

* Add block validation tests

* Fix style for block

* Add Hint error

* Fix style in ring_buffer

* Move should_flush to impl

* Fix clippy errors

* Update crate versions

* Fix usings style

* Add deserialize owned

* Make flush use duration

* Update block and data

* Reorganize errors

* Clean up RingBuffer

* millis_elapsed to elapsed

* Fix fmt error

* Update storage error to have 'Caused by'

Co-authored-by: Denis Molokanov <dmolokanov@users.noreply.github.com>

* Adds caused by to error msgs

Co-authored-by: Denis Molokanov <dmolokanov@users.noreply.github.com>