### PR TITLE
Use parenthostname in network controller to set up rules

### DIFF
--- a/test/connectivity/modules/NetworkController/CellularController.cs
+++ b/test/connectivity/modules/NetworkController/CellularController.cs
@@ -13,7 +13,7 @@ namespace NetworkController
         static readonly ILogger Log = Logger.Factory.CreateLogger<CellularController>();
         readonly INetworkController underlyingController;
 
-        public CellularController(string networkInterfaceName, string iotHubHostname, NetworkProfileSetting settings)
+        public CellularController(string networkInterfaceName, string hubHostname, NetworkProfileSetting settings)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -21,7 +21,7 @@ namespace NetworkController
             }
             else
             {
-                this.underlyingController = new LinuxTrafficControlController(settings, networkInterfaceName, iotHubHostname);
+                this.underlyingController = new LinuxTrafficControlController(settings, networkInterfaceName, hubHostname);
             }
         }
 

--- a/test/connectivity/modules/NetworkController/LinuxTrafficControlController.cs
+++ b/test/connectivity/modules/NetworkController/LinuxTrafficControlController.cs
@@ -13,13 +13,13 @@ namespace NetworkController
     {
         static readonly ILogger Log = Logger.Factory.CreateLogger<LinuxTrafficControlController>();
         readonly string networkInterfaceName;
-        readonly string iotHubHostname;
+        readonly string hubHostname;
         readonly NetworkProfileSetting profileRuleSettings;
 
-        public LinuxTrafficControlController(NetworkProfileSetting settings, string networkInterfaceName, string iotHubHostname)
+        public LinuxTrafficControlController(NetworkProfileSetting settings, string networkInterfaceName, string hubHostname)
         {
             this.networkInterfaceName = networkInterfaceName;
-            this.iotHubHostname = iotHubHostname;
+            this.hubHostname = hubHostname;
             this.profileRuleSettings = settings;
         }
 
@@ -89,7 +89,7 @@ namespace NetworkController
         {
             try
             {
-                IPAddress[] iothubAddresses = await Dns.GetHostAddressesAsync(this.iotHubHostname);
+                IPAddress[] iothubAddresses = await Dns.GetHostAddressesAsync(this.hubHostname);
                 if (iothubAddresses.Length == 0)
                 {
                     throw new CommandExecutionException("No IP found for iothub hostname");

--- a/test/connectivity/modules/NetworkController/OfflineController.cs
+++ b/test/connectivity/modules/NetworkController/OfflineController.cs
@@ -13,7 +13,7 @@ namespace NetworkController
         static readonly ILogger Log = Logger.Factory.CreateLogger<OfflineController>();
         readonly INetworkController underlyingController;
 
-        public OfflineController(string networkInterfaceName, string iotHubHostname, NetworkProfileSetting settings)
+        public OfflineController(string networkInterfaceName, string hubHostname, NetworkProfileSetting settings)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -21,7 +21,7 @@ namespace NetworkController
             }
             else
             {
-                this.underlyingController = new LinuxTrafficControlController(settings, networkInterfaceName, iotHubHostname);
+                this.underlyingController = new LinuxTrafficControlController(settings, networkInterfaceName, hubHostname);
             }
         }
 

--- a/test/connectivity/modules/NetworkController/Program.cs
+++ b/test/connectivity/modules/NetworkController/Program.cs
@@ -36,9 +36,10 @@ namespace NetworkController
                 {
                     await networkInterfaceName.ForEachAsync(async name =>
                     {
-                        var offline = new OfflineController(name, Settings.Current.IotHubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
-                        var satellite = new SatelliteController(name, Settings.Current.IotHubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
-                        var cellular = new CellularController(name, Settings.Current.IotHubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
+                        string hubHostname = !string.IsNullOrEmpty(Settings.Current.ParentHostname) ? Settings.Current.ParentHostname : Settings.Current.IotHubHostname;
+                        var offline = new OfflineController(name, hubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
+                        var satellite = new SatelliteController(name, hubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
+                        var cellular = new CellularController(name, hubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
                         controllers.AddRange(new List<INetworkController> { offline, satellite, cellular });
 
                         // Reset network status before start delay to ensure network status is in designed state before test starts.
@@ -111,7 +112,8 @@ namespace NetworkController
             INetworkStatusReporter reporter = new NetworkStatusReporter(Settings.Current.TestResultCoordinatorEndpoint, Settings.Current.ModuleId, Settings.Current.TrackingId);
             NetworkProfileSetting customNetworkProfileSetting = Settings.Current.NetworkRunProfile.ProfileSetting;
             customNetworkProfileSetting.PackageLoss = 100;
-            var controller = new OfflineController(networkInterfaceName, Settings.Current.IotHubHostname, customNetworkProfileSetting);
+            string hubHostname = !string.IsNullOrEmpty(Settings.Current.ParentHostname) ? Settings.Current.ParentHostname : Settings.Current.IotHubHostname;
+            var controller = new OfflineController(networkInterfaceName, hubHostname, customNetworkProfileSetting);
             NetworkControllerStatus networkControllerStatus = networkOnValue ? NetworkControllerStatus.Disabled : NetworkControllerStatus.Enabled;
             await SetNetworkControllerStatus(controller, networkControllerStatus, reporter, token);
             return new MethodResponse((int)HttpStatusCode.OK);

--- a/test/connectivity/modules/NetworkController/SatelliteController.cs
+++ b/test/connectivity/modules/NetworkController/SatelliteController.cs
@@ -13,7 +13,7 @@ namespace NetworkController
         static readonly ILogger Log = Logger.Factory.CreateLogger<SatelliteController>();
         readonly INetworkController underlyingController;
 
-        public SatelliteController(string networkInterfaceName, string iotHubHostname, NetworkProfileSetting settings)
+        public SatelliteController(string networkInterfaceName, string hubHostname, NetworkProfileSetting settings)
         {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
@@ -21,7 +21,7 @@ namespace NetworkController
             }
             else
             {
-                this.underlyingController = new LinuxTrafficControlController(settings, networkInterfaceName, iotHubHostname);
+                this.underlyingController = new LinuxTrafficControlController(settings, networkInterfaceName, hubHostname);
             }
         }
 

--- a/test/connectivity/modules/NetworkController/Settings.cs
+++ b/test/connectivity/modules/NetworkController/Settings.cs
@@ -21,6 +21,7 @@ namespace NetworkController
         const string TrackingIdPropertyName = "TrackingId";
         const string ModuleIdPropertyName = "IOTEDGE_MODULEID";
         const string IotHubHostnamePropertyName = "IOTEDGE_IOTHUBHOSTNAME";
+        const string ParentHostnamePropertyName = "IOTEDGE_PARENTHOSTNAME";
         const string DefaultProfilesPropertyName = "DefaultProfiles";
         const string TransportTypePropertyName = "TransportType";
 
@@ -34,6 +35,7 @@ namespace NetworkController
             string trackingId,
             string moduleId,
             string iothubHostname,
+            string parentHostname,
             TransportType transportType)
         {
             this.StartAfter = startAfter;
@@ -46,6 +48,7 @@ namespace NetworkController
             this.TrackingId = Preconditions.CheckNonWhiteSpace(trackingId, nameof(trackingId));
             this.ModuleId = Preconditions.CheckNonWhiteSpace(moduleId, nameof(moduleId));
             this.IotHubHostname = Preconditions.CheckNonWhiteSpace(iothubHostname, nameof(iothubHostname));
+            this.ParentHostname = Preconditions.CheckNotNull(parentHostname, nameof(parentHostname));
             this.TransportType = transportType;
         }
 
@@ -66,6 +69,8 @@ namespace NetworkController
         public string ModuleId { get; }
 
         public string IotHubHostname { get; }
+
+        public string ParentHostname { get; }
 
         public TransportType TransportType { get; }
 
@@ -97,6 +102,7 @@ namespace NetworkController
                 configuration.GetValue<string>(TrackingIdPropertyName),
                 configuration.GetValue<string>(ModuleIdPropertyName),
                 configuration.GetValue<string>(IotHubHostnamePropertyName),
+                configuration.GetValue<string>(ParentHostnamePropertyName, string.Empty),
                 configuration.GetValue(TransportTypePropertyName, TransportType.Amqp_Tcp_Only));
         }
     }


### PR DESCRIPTION
Modified network controller to use IOTEDGE_PARENTHOSTNAME to set the network rules so that connectivity is set for connecting to parent device. If not in nested environment the parent env won't be set so it uses IOTEDGE_IOTHUBHOSTNAME.