### PR TITLE
Reduce NuGet dependency down to MyGet

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,8 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <clear/>
     <add key="MyGetDeviceSdk" value="https://www.myget.org/F/aziot-device-sdk/api/v3/index.json" />
-    <add key="MyGetEdgeExtension" value="https://www.myget.org/F/aziot-edge-extension/api/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
Reduce package dependencies down to a single MyGet stream by setting Nuget.org as the upstream