### PR TITLE
Fix iotedge CLI in mariner build

### DIFF
--- a/builds/mariner/SPECS/azure-iotedge/azure-iotedge.spec
+++ b/builds/mariner/SPECS/azure-iotedge/azure-iotedge.spec
@@ -66,6 +66,8 @@ make %{?_smp_mflags} release
 
 %install
 export PATH=$PATH:/root/.cargo/bin/
+IOTEDGE_HOST=unix:///var/lib/iotedge/mgmt.sock
+export IOTEDGE_HOST
 make %{?_smp_mflags} install DESTDIR=$RPM_BUILD_ROOT unitdir=%{_unitdir} docdir=%{_docdir}/iotedge-%{version}
 
 %clean


### PR DESCRIPTION
After commit a34e0ed, the iotedge CLI fails in Mariner because IOTEDGE_HOST was not set during compilation, so the CLI has the wrong path to iotedged's management endpoint.

To fix this, we set IOTEDGE_HOST prior to running `make install`. It was already being set prior to `make release`.