### PR TITLE
Handle thumbprint auth through API proxy for WebSocket

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
                     }
                     catch (Exception ex)
                     {
-                        Events.InvalidCertificate(ex);
+                        Events.InvalidCertificate(ex, remoteEndPoint.ToString());
                         throw;
                     }
                 }
@@ -136,8 +136,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
             public static void WebSocketRequestNoListener(string traceId, string correlationId) =>
                 Log.LogDebug((int)EventIds.BadRequest, Invariant($"No listener found for request {traceId}. CorrelationId {correlationId}"));
 
-            public static void InvalidCertificate(Exception ex) =>
-                Log.LogWarning((int)EventIds.InvalidCertificate, Invariant($"Invalid client certificate: {ex.Message}"));
+            public static void InvalidCertificate(Exception ex, string connectionIp) =>
+                Log.LogWarning((int)EventIds.InvalidCertificate, Invariant($"Invalid client certificate for incoming connection: {connectionIp}, Exception: {ex.Message}"));
         }
     }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
@@ -3,9 +3,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Net.WebSockets;
     using System.Security.Cryptography.X509Certificates;
+    using System.Text;
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Http;
@@ -13,6 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
     using Microsoft.Azure.Devices.Edge.Hub.Http.Extensions;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Primitives;
     using static System.FormattableString;
 
     class WebSocketHandlingMiddleware
@@ -72,6 +75,28 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
             var remoteEndPoint = new IPEndPoint(context.Connection.RemoteIpAddress, context.Connection.RemotePort);
 
             X509Certificate2 cert = await context.Connection.GetClientCertificateAsync();
+
+            if (cert == null)
+            {
+                // If the connection came through the API proxy, the client cert
+                // would have been forwarded in a custom header
+                if (context.Request.Headers.TryGetValue(Constants.ClientCertificateHeaderKey, out StringValues clientCertHeader) && clientCertHeader.Count > 0)
+                {
+                    string clientCertString = WebUtility.UrlDecode(clientCertHeader.First());
+
+                    try
+                    {
+                        var clientCertificateBytes = Encoding.UTF8.GetBytes(clientCertString);
+                        cert = new X509Certificate2(clientCertificateBytes);
+                    }
+                    catch (Exception ex)
+                    {
+                        Events.InvalidCertificate(ex);
+                        throw;
+                    }
+                }
+            }
+
             if (cert != null)
             {
                 IList<X509Certificate2> certChain = context.GetClientCertificateChain();
@@ -95,7 +120,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
                 RequestReceived = IdStart,
                 RequestCompleted,
                 BadRequest,
-                SubProtocolSelected
+                SubProtocolSelected,
+                InvalidCertificate,
             }
 
             public static void WebSocketRequestReceived(string traceId, string correlationId) =>
@@ -109,6 +135,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
 
             public static void WebSocketRequestNoListener(string traceId, string correlationId) =>
                 Log.LogDebug((int)EventIds.BadRequest, Invariant($"No listener found for request {traceId}. CorrelationId {correlationId}"));
+
+            public static void InvalidCertificate(Exception ex) =>
+                Log.LogWarning((int)EventIds.InvalidCertificate, Invariant($"Invalid client certificate: {ex.Message}"));
         }
     }
 

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/WebSocketHandlingMiddlewareTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/WebSocketHandlingMiddlewareTest.cs
@@ -138,6 +138,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             return Mock.Of<HttpContext>(
                 ctx =>
                     ctx.WebSockets == Mock.Of<WebSocketManager>(wsm => wsm.IsWebSocketRequest == true)
+                    && ctx.Request == Mock.Of<HttpRequest>(
+                        req =>
+                            req.Headers == Mock.Of<IHeaderDictionary>())
                     && ctx.Response == Mock.Of<HttpResponse>()
                     && ctx.Features == Mock.Of<IFeatureCollection>(
                         fc =>
@@ -169,6 +172,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
                             wsm.WebSocketRequestedProtocols == subprotocols
                             && wsm.IsWebSocketRequest
                             && wsm.AcceptWebSocketAsync(It.IsAny<string>()) == Task.FromResult(Mock.Of<WebSocket>()))
+                    && ctx.Request == Mock.Of<HttpRequest>(
+                        req =>
+                            req.Headers == Mock.Of<IHeaderDictionary>())
                     && ctx.Response == Mock.Of<HttpResponse>()
                     && ctx.Features == Mock.Of<IFeatureCollection>(
                         fc => fc.Get<ITlsConnectionFeatureExtended>() == Mock.Of<ITlsConnectionFeatureExtended>(f => f.ChainElements == new List<X509Certificate2>()))

--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -89,6 +89,8 @@ http {
 
         location ~^/.iothub/websocket {
             resolver 127.0.0.11;
+            proxy_ssl_verify off;
+            proxy_set_header x-ms-edge-clientcert $ssl_client_escaped_cert;            
             set $upstream_endpoint https://edgeHub;
             proxy_pass $upstream_endpoint;
             proxy_http_version 1.1;


### PR DESCRIPTION
Add logic in the websocket middleware to check for client cert in the custom header that API proxy uses to forward the payload.