### PR TITLE
Update Base Images for Security Vulnerability 3.1.12

### DIFF
--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -8,6 +8,7 @@ trigger:
       - preview/iiot
 pr: none
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   build.configuration: Release
   test.filter: Category=Integration&Category!=Stress
 jobs:

--- a/builds/ci/edgelet.yaml
+++ b/builds/ci/edgelet.yaml
@@ -7,6 +7,10 @@ trigger:
       - iiot
       - preview/iiot
 pr: none
+
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 jobs:
 
 ################################################################################

--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -7,6 +7,10 @@ trigger:
     include:
       - "mqtt/*"
       - "builds/*"
+
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 pr: none
 jobs:
 

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -2,6 +2,7 @@ trigger: none
 pr: none
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   images.artifact.name.linux: 'core-linux'
   vsts.project: $(System.TeamProjectId)
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -1,6 +1,9 @@
 trigger: none
 pr: none
 
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 resources:
   pipelines:
   - pipeline: images

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -2,6 +2,7 @@ trigger: none
 pr: none
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   images.artifact.name.linux: 'core-linux'
   vsts.project: $(System.TeamProjectId)
   # Variable defined in VSTS

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -10,6 +10,9 @@ resources:
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
     branch: master
 
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 jobs:
 
 ################################################################################		

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -2,6 +2,7 @@ trigger: none
 pr: none
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   images.artifact.name.linux: 'core-linux'
   vsts.project: $(System.TeamProjectId)
   # Variable defined in VSTS

--- a/builds/e2e/stresstest.yaml
+++ b/builds/e2e/stresstest.yaml
@@ -2,6 +2,7 @@ trigger: none
 pr: none
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   images.artifact.name.linux: 'core-linux'
   vsts.project: $(System.TeamProjectId)
   # Variable defined in VSTS

--- a/builds/misc/addons-publish.yaml
+++ b/builds/misc/addons-publish.yaml
@@ -2,6 +2,9 @@ name: $(version)
 trigger: none
 pr: none
 
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 jobs:
   - deployment: publishImages
     displayName: Publish Linux Images

--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -1,4 +1,8 @@
 name: $(version)
+
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 jobs: 
 ################################################################################
   - job: linux_API_proxy_module

--- a/builds/misc/base-images-publish.yaml
+++ b/builds/misc/base-images-publish.yaml
@@ -1,6 +1,9 @@
 trigger: none
 pr: none
 
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 jobs:
 ################################################################################
   - job: linux_arm32

--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -5,6 +5,9 @@ trigger:
       - master
 pr: none
 
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 jobs:
 ################################################################################
   - job: linux_amd64

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -7,6 +7,9 @@ trigger:
       - preview/iiot
 pr: none
 
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
 jobs:
 ################################################################################
   - job: linux_dotnet_projects

--- a/builds/misc/mqtt-perf.yaml
+++ b/builds/misc/mqtt-perf.yaml
@@ -36,6 +36,7 @@ resources:
     source: 'Azure-IoT-Edge-Core Build MQTT Images'
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   benchmarkToolPath: $(Agent.WorkFolder)/mqtt-benchmark
 
 stages:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -7,6 +7,7 @@ trigger:
       - preview/iiot
 pr: none
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   REVISION: '1'
   WINDOWS_CODESIGN_SERVICE_CONNECTION: 'Azure IoT Edge Code Sign 2'
 jobs:

--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.11-bionic-arm32v7
+﻿ARG base_tag=3.1.12-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.11-bionic-arm64v8
+﻿ARG base_tag=3.1.12-bionic-arm64v8
 ARG num_procs=4
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./watchdog/armv7-unknown-linux-gnueabihf/release/watchdog /usr/local/bin/watchdog

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.11-bionic-arm32v7
+﻿ARG base_tag=3.1.12-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./watchdog/aarch64-unknown-linux-gnu/release/watchdog /usr/local/bin/watchdog

--- a/edge-hub/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.11-bionic-arm64v8
+﻿ARG base_tag=3.1.12-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.11-bionic-arm32v7
+﻿ARG base_tag=3.1.12-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.11-bionic-arm64v8
+﻿ARG base_tag=3.1.12-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/windows/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-nanoserver-1809
+ARG base_tag=3.1.12-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edgelet/iotedge-proxy/docker/linux/arm32v7/base/Dockerfile
+++ b/edgelet/iotedge-proxy/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v6/alpine:3.10
+﻿FROM arm32v6/alpine:3.10
 
 RUN addgroup -S proxy && adduser -S proxy -G proxy
 USER proxy

--- a/edgelet/iotedge-proxy/docker/linux/arm64v8/base/Dockerfile
+++ b/edgelet/iotedge-proxy/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/alpine:3.10
+﻿FROM arm64v8/alpine:3.10
 
 RUN addgroup -S proxy && adduser -S proxy -G proxy
 USER proxy

--- a/edgelet/iotedged/docker/linux/arm32v7/base/Dockerfile
+++ b/edgelet/iotedged/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/debian:9-slim
+﻿FROM arm32v7/debian:9-slim
 
 # package installation needs to exec as root
 RUN apt-get update && apt-get install -y \

--- a/edgelet/iotedged/docker/linux/arm64v8/base/Dockerfile
+++ b/edgelet/iotedged/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM arm64v8/debian:9-slim
+﻿FROM arm64v8/debian:9-slim
 
 # package installation needs to exec as root
 RUN apt-get update && apt-get install -y \

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -1,5 +1,5 @@
 # Use the same base image as prod edgehub images
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 ADD ./x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 # Use the same base image as prod edgehub images
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd

--- a/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/windows/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.4-nanoserver-1809
+ARG base_tag=3.1.12-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/amd64/Dockerfile
+++ b/test/modules/Relayer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.11-bionic-arm32v7
+﻿ARG base_tag=3.1.12-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.11-bionic-arm64v8
+﻿ARG base_tag=3.1.12-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/aspnet:${base_tag}

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/amd64/Dockerfile
+++ b/test/modules/load-gen/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.11-alpine3.12
+ARG base_tag=3.1.12-alpine3.12
 FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm32v7
+ARG base_tag=1.0.6.7-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.6-linux-arm64v8
+ARG base_tag=1.0.6.7-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.


### PR DESCRIPTION
- Update ARM32/ARM64 Bionic base images to 3.1.12
- Update AMD64 (Linux) Alpine base images to 3.1.12
- Update AMD64 (Windows) Nanoserver base images to 3.1.12
- Update Nuget security injection failure