### PR TITLE
Run MQTT images pipeline only when MQTT code changes.

### DIFF
--- a/builds/checkin/watchdog.yaml
+++ b/builds/checkin/watchdog.yaml
@@ -37,8 +37,6 @@ jobs:
         displayName: Install Rust
       - bash: scripts/linux/generic-rust/build.sh --project-root "edge-hub/watchdog" --packages "watchdog"
         displayName: Build
-      - bash: scripts/linux/generic-rust/install.sh --project-root "edge-hub/watchdog"
-        displayName: Install Rust
       - bash: scripts/linux/generic-rust/format.sh --project-root "edge-hub/watchdog"
         displayName: Format Code
       - bash: scripts/linux/generic-rust/clippy.sh --project-root "edge-hub/watchdog"

--- a/builds/misc/images-mqtt.yaml
+++ b/builds/misc/images-mqtt.yaml
@@ -3,6 +3,10 @@ trigger:
   branches:
     include:
       - master
+  paths:
+    include:
+      - "mqtt/*"
+      - "builds/*"
 pr: none
 
 variables:


### PR DESCRIPTION
We don't really need to run the MQTT images pipeline if nothing changed in MQTT code.