### PR TITLE
Config yaml 1.1

### DIFF
--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -223,7 +223,7 @@ agent:
   type: "docker"
   env: {}
   config:
-    image: "mcr.microsoft.com/azureiotedge-agent:1.0"
+    image: "mcr.microsoft.com/azureiotedge-agent:1.1"
     auth: {}
 
 ###############################################################################

--- a/edgelet/contrib/config/linux/debian/config.yaml
+++ b/edgelet/contrib/config/linux/debian/config.yaml
@@ -204,7 +204,7 @@ agent:
   type: "docker"
   env: {}
   config:
-    image: "mcr.microsoft.com/azureiotedge-agent:1.0"
+    image: "mcr.microsoft.com/azureiotedge-agent:1.1"
     auth: {}
 
 ###############################################################################

--- a/edgelet/contrib/config/windows/config.yaml
+++ b/edgelet/contrib/config/windows/config.yaml
@@ -223,7 +223,7 @@ agent:
   type: "docker"
   env: {}
   config:
-    image: "mcr.microsoft.com/azureiotedge-agent:1.0"
+    image: "mcr.microsoft.com/azureiotedge-agent:1.1"
     auth: {}
 
 ###############################################################################

--- a/edgelet/edgelet-docker/config/unix/default.yaml
+++ b/edgelet/edgelet-docker/config/unix/default.yaml
@@ -6,7 +6,7 @@ agent:
   type: "docker"
   env": {}
   config:
-    image: "mcr.microsoft.com/azureiotedge-agent:1.0"
+    image: "mcr.microsoft.com/azureiotedge-agent:1.1"
     auth: {}
 
 hostname: "localhost"

--- a/edgelet/edgelet-docker/config/windows/default.yaml
+++ b/edgelet/edgelet-docker/config/windows/default.yaml
@@ -6,7 +6,7 @@ agent:
   type: "docker"
   env": {}
   config:
-    image: "mcr.microsoft.com/azureiotedge-agent:1.0"
+    image: "mcr.microsoft.com/azureiotedge-agent:1.1"
     auth: {}
 
 hostname: "localhost"


### PR DESCRIPTION
This change updates the default agent tag in config.yaml to 1.1.

Cherry-pick a4faab5f62f96fa813d19a73bba0ddf92c72edf8 and update 1.1-specific Windows config.yaml.