### PR TITLE
support M2M subscription with both cases of /input/ included or not

### DIFF
--- a/mqtt/mqtt-edgehub/src/topic/translation.rs
+++ b/mqtt/mqtt-edgehub/src/topic/translation.rs
@@ -519,7 +519,7 @@ mod tests {
         assert_eq!(
             c2d.to_internal("devices/device_1/modules/module_a/foo/#", &client_id),
             None
-        );        
+        );
 
         // M2M incoming
         assert_eq!(

--- a/mqtt/mqtt-edgehub/src/topic/translation.rs
+++ b/mqtt/mqtt-edgehub/src/topic/translation.rs
@@ -262,7 +262,7 @@ translate_c2d! {
     // Module-to-Module inputs
     module_to_module_inputs {
         to_internal {
-            format!("devices/{}/modules/{}/(inputs/)?#", DEVICE_ID, MODULE_ID),
+            format!("devices/{}/modules/{}/(#|inputs/.*)", DEVICE_ID, MODULE_ID),
             {|captures: regex::Captures<'_>, _| format!("$edgehub/{}/{}/+/inputs/#", &captures["device_id"], &captures["module_id"])}
         },
         to_external {
@@ -513,6 +513,14 @@ mod tests {
 
         assert_eq!(
             c2d.to_internal("devices/device_1/modules/module_a/inputs/#", &client_id),
+            Some("$edgehub/device_1/module_a/+/inputs/#".to_owned())
+        );
+
+        assert_eq!(
+            c2d.to_internal(
+                "devices/device_1/modules/module_a/inputs/route_1/#",
+                &client_id
+            ),
             Some("$edgehub/device_1/module_a/+/inputs/#".to_owned())
         );
 

--- a/mqtt/mqtt-edgehub/src/topic/translation.rs
+++ b/mqtt/mqtt-edgehub/src/topic/translation.rs
@@ -262,7 +262,7 @@ translate_c2d! {
     // Module-to-Module inputs
     module_to_module_inputs {
         to_internal {
-            format!("devices/{}/modules/{}/#", DEVICE_ID, MODULE_ID),
+            format!("devices/{}/modules/{}/(inputs/)?#", DEVICE_ID, MODULE_ID),
             {|captures: regex::Captures<'_>, _| format!("$edgehub/{}/{}/+/inputs/#", &captures["device_id"], &captures["module_id"])}
         },
         to_external {
@@ -510,6 +510,16 @@ mod tests {
             c2d.to_internal("devices/device_1/modules/module_a/#", &client_id),
             Some("$edgehub/device_1/module_a/+/inputs/#".to_owned())
         );
+
+        assert_eq!(
+            c2d.to_internal("devices/device_1/modules/module_a/inputs/#", &client_id),
+            Some("$edgehub/device_1/module_a/+/inputs/#".to_owned())
+        );
+
+        assert_eq!(
+            c2d.to_internal("devices/device_1/modules/module_a/foo/#", &client_id),
+            None
+        );        
 
         // M2M incoming
         assert_eq!(


### PR DESCRIPTION
M2M messages are being sent in the form of:

 "devices/device_1/modules/module_a/inputs/some_parameters"

because of that structure, a client can subscribe either for

 "devices/device_1/modules/module_a/#" or
 "devices/device_1/modules/module_a/inputs/#"

the C# SDK choses the first form, and because of that the current implementation handles that. However, it turned out that there are clients using the second form, and that is ignored.

this PR makes handle both versions