### PR TITLE
Re-enable E2E proxy test

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -92,29 +92,29 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: linux_amd64_proxy
-# ################################################################################
-#     displayName: Linux amd64 behind a proxy
+################################################################################
+  - job: linux_amd64_proxy
+################################################################################
+    displayName: Linux amd64 behind a proxy
 
-#     pool:
-#       name: $(pool.name)
-#       demands: new-e2e-proxy
+    pool:
+      name: $(pool.name)
+      demands: new-e2e-proxy
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu18.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-#       # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
-#       'agent.disablelogplugin.testfilepublisherplugin': true
-#       'agent.disablelogplugin.testresultlogplugin': true
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      identityServiceArtifactName: packages_ubuntu-18.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
+      'agent.disablelogplugin.testfilepublisherplugin': true
+      'agent.disablelogplugin.testresultlogplugin': true
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -118,3 +118,5 @@ jobs:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
+      parameters:
+        test_type: http_proxy

--- a/builds/e2e/proxy/configure_runner.sh
+++ b/builds/e2e/proxy/configure_runner.sh
@@ -39,9 +39,9 @@ cp ~/proxy-env.override.conf /etc/systemd/system/docker.service.d/
 systemctl daemon-reload
 systemctl restart docker
 
-# add iotedged's proxy settings (even though iotedged isn't installed--the tests do that later)
-mkdir -p /etc/systemd/system/iotedge.service.d
-cp ~/proxy-env.override.conf /etc/systemd/system/iotedge.service.d/
+# add aziot-identityd's proxy settings (even though aziot-identityd isn't installed--the tests do that later)
+mkdir -p /etc/systemd/system/aziot-identityd.service.d
+cp ~/proxy-env.override.conf /etc/systemd/system/aziot-identityd.service.d/
 
 echo 'Verifying VM behavior behind proxy server'
 

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -41,7 +41,12 @@ steps:
     elseif ($test_type -eq 'http_proxy')
     {
       #Disable tests that don't work in proxy environment. Renable post-investigation.
-      $filter += '&FullyQualifiedName!~PriorityQueue&FullyQualifiedName!~PlugAndPlay'
+      $filter += '&FullyQualifiedName!~PriorityQueue&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~ValidateMetrics'
+
+      #Disable tests that timeout in proxy self-host environment
+      $filter += '&FullyQualifiedName!~TestGetModuleLogs&FullyQualifiedName!~TestUploadSupportBundle'
+
+      #Disable nested edge tests
       $filter += '&Category!=NestedEdgeOnly'
     }
     else

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -38,9 +38,15 @@ steps:
     {
       $filter = 'Category=nestededge_isa95'
     }
+    elseif ($test_type -eq 'http_proxy')
+    {
+      #Disable tests that don't work in proxy environment. Renable post-investigation.
+      $filter += '&FullyQualifiedName!~PriorityQueue&FullyQualifiedName!~PlugAndPlay'
+      $filter += '&Category!=NestedEdgeOnly'
+    }
     else
     {
-      $filter += '&Category!=NestedEdgeOnly' 
+      $filter += '&Category!=NestedEdgeOnly'
     } 
 
     sudo --preserve-env dotnet test $testFile --logger:trx --testcasefilter:$filter

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2020_07_07/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2020_07_07/ModuleManagementHttpClient.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
             using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
-                FileResponse response = await this.Execute(() => edgeletHttpClient.GetSupportBundleAsync(this.Version.Name, since.OrDefault(), until.OrDefault(), null, iothubHostname.OrDefault(), edgeRuntimeOnly.Map<bool?>(e => e).OrDefault()), "reprovision the device");
+                FileResponse response = await this.Execute(() => edgeletHttpClient.GetSupportBundleAsync(this.Version.Name, since.OrDefault(), until.OrDefault(), null, iothubHostname.OrDefault(), edgeRuntimeOnly.Map<bool?>(e => e).OrDefault()), "getting the support bundle");
 
                 return response.Stream;
             }

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -198,6 +198,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
             var request = new
             {
                 schemaVersion = "1.0",
+                since = "2d",
+                edgeRuntimeOnly = false,
                 sasUrl,
             };
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
@@ -90,10 +90,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
             {
                 // When test runs behind proxy, skip MQTT and AMQP checks which legitimately fail
                 new List<string>
-                {   "--dont-run", 
-                    "container-connect-upstream-mqtt", "container-connect-upstream-amqp", 
+                {   "--dont-run",
+                    "container-connect-upstream-mqtt", "container-connect-upstream-amqp",
                     "container-default-connect-upstream-mqtt", "container-default-connect-upstream-amqp",
-                    "host-connect-iothub-mqtt", "host-connect-iothub-amqp" 
+                    "host-connect-iothub-mqtt", "host-connect-iothub-amqp"
                 }.ForEach(arg => iotedgeCheckProcess.StartInfo.ArgumentList.Add(arg));
             }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
@@ -105,8 +105,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
             {
                 Assert.AreEqual("6 check(s) raised errors.", errors_number);
             }
-
-            Assert.AreEqual(string.Empty, errors_number);
+            else
+            {
+                Assert.AreEqual(string.Empty, errors_number);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
@@ -100,10 +100,12 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 }
             });
 
-            // TODO: iotedge check currently has 2 legitimate errors in it. When we update the aziot-submodule, the errors
-            // will go away, and we should change this assertion to empty string instead of passing on 2 errors.
-            // This is better than disabling the test, because it still tests iotedge check to some extent, and it will
-            // remind us with a failed run to update this test.
+            // When test runs behind proxy, MQTT and AMQP checks legitimately fail in three different connectivity checks
+            if (Context.Current.EdgeProxy.HasValue)
+            {
+                Assert.AreEqual("6 check(s) raised errors.", errors_number);
+            }
+
             Assert.AreEqual(string.Empty, errors_number);
         }
     }

--- a/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
@@ -90,7 +90,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
             {
                 // When test runs behind proxy, skip MQTT and AMQP checks which legitimately fail
                 new List<string>
-                {   "--dont-run",
+                {
+                    "--dont-run",
                     "container-connect-upstream-mqtt", "container-connect-upstream-amqp",
                     "container-default-connect-upstream-mqtt", "container-default-connect-upstream-amqp",
                     "host-connect-iothub-mqtt", "host-connect-iothub-amqp"

--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -29,10 +29,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string TestModelId = "dtmi:edgeE2ETest:TestCapabilityModel;1";
         const string LoadGenModuleName = "loadGenModule";
 
-        [TestCase(Protocol.Mqtt, false)]
-        [TestCase(Protocol.Amqp, false)]
-        [TestCase(Protocol.Mqtt, true)]
-        [TestCase(Protocol.Amqp, true)]
+        [TestCase(Protocol.MqttWs, false)]
+        [TestCase(Protocol.AmqpWs, false)]
+        [TestCase(Protocol.MqttWs, true)]
+        [TestCase(Protocol.AmqpWs, true)]
         public async Task PlugAndPlayDeviceClient(Protocol protocol, bool brokerOn)
         {
             CancellationToken token = this.TestToken;
@@ -84,10 +84,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 });
         }
 
-        [TestCase(Protocol.Mqtt, false)]
-        [TestCase(Protocol.Amqp, false)]
-        [TestCase(Protocol.Mqtt, true)]
-        [TestCase(Protocol.Amqp, true)]
+        [TestCase(Protocol.MqttWs, false)]
+        [TestCase(Protocol.AmqpWs, false)]
+        [TestCase(Protocol.MqttWs, true)]
+        [TestCase(Protocol.AmqpWs, true)]
         [Test]
         public async Task PlugAndPlayModuleClient(Protocol protocol, bool brokerOn)
         {


### PR DESCRIPTION
- Re-enable E2E pipeline job to run tests in proxy environment
- Fixed some tests to run using Websockets transport (which is generally the case for E2E tests)
- Improve UploadSupportBundle test reliability in self-host environment by reducing requested log time range
- Fixed typo in traces within UploadSupportBundle product code
- Filtered out Nested Edge tests and temporarily filtered out tests that timeout in proxy environment