### PR TITLE
Remove transport type from agent groups

### DIFF
--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -49,7 +49,7 @@ stages:
     pool:
       name: $(pool.name)
       demands:
-        - agent-group -equals $(agent.group)-amqp
+        - agent-group -equals $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals X64
         - status -equals unlocked_$(Build.BuildId)  

--- a/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
@@ -9,8 +9,7 @@ jobs:
     pool:
       name: $(pool.name)
       demands:
-      # Currently, agent-group-amqp is in eastus in iotedge-deploy-vnet3, and agent-group-mqtt is in westus2 in iotedge-deploy-vnet
-        - agent-group -equals $(agent.group)-${{ parameters.transportType }}
+        - agent-group -equals $(agent.group)
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals X64
         - status -equals unlocked  

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -18,8 +18,7 @@ jobs:
     pool:
      name: $(pool.name)
      demands:
-     # Currently, agent-group-amqp is in eastus in iotedge-deploy-vnet3, and agent-group-mqtt is in westus2 in iotedge-deploy-vnet
-       - agent-group -equals $(agent.group)-${{ parameters.transportType }}
+       - agent-group -equals $(agent.group)
        - Agent.OS -equals Linux
        - Agent.OSArchitecture -equals X64
        - status -equals unlocked
@@ -49,8 +48,7 @@ jobs:
     pool:
      name: $(pool.name)
      demands:
-     # Currently, agent-group-amqp is in eastus in iotedge-deploy-vnet3, and agent-group-mqtt is in westus2 in iotedge-deploy-vnet
-       - agent-group -equals $(agent.group)-${{ parameters.transportType }}
+       - agent-group -equals $(agent.group)
        - Agent.OS -equals Linux
        - Agent.OSArchitecture -equals X64
        - status -equals unlocked    


### PR DESCRIPTION
Remove transport type from agent groups for NestedLongHaul (and soon to be NestedConnectivity since it uses a shared file, nested-parent-vm-setup.yaml) now that agent groups are in their respective subnets correctly.