### PR TITLE
Nested E2E - Disable/Reenable parent Edge

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -125,7 +125,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         }
 
         public Task DeleteDeviceIdentityAsync(Device device, CancellationToken token) =>
-            this.RegistryManager.RemoveDeviceAsync(device);
+            this.RegistryManager.RemoveDeviceAsync(device.Id);
 
         public Task DeployDeviceConfigurationAsync(
             string deviceId,
@@ -227,6 +227,21 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             }
 
             await receiver.CloseAsync();
+        }
+
+        public async Task UpdateEdgeEnableStatus(string deviceId, bool enabled)
+        {
+            var edge = await this.RegistryManager.GetDeviceAsync(deviceId);
+
+            if (!edge.Capabilities.IotEdge)
+            {
+                throw new ArgumentException($"{deviceId} is not an Edge device!");
+            }
+
+            edge.Status = enabled ? DeviceStatus.Enabled : DeviceStatus.Disabled;
+            var updated = await this.RegistryManager.UpdateDeviceAsync(edge);
+            Log.Information($"Updated enabled status for {deviceId}, enabled: {enabled}");
+            Log.Information($"{updated.Id}, enabled: {updated.Status}");
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                 {
                                     new
                                     {
-                                        identities = new[] { $"{this.iotHub.Hostname}/{deviceId1}" },
+                                        identities = new[] { $"{this.IotHub.Hostname}/{deviceId1}" },
                                         deny = new[]
                                         {
                                             new
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     Option.Some(this.runtime.DeviceId),
                     false,
                     this.ca,
-                    this.iotHub,
+                    this.IotHub,
                     Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower()),
                     token,
                     Option.None<string>(),
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                 {
                                     new
                                     {
-                                        identities = new[] { $"{this.iotHub.Hostname}/{deviceId2}" },
+                                        identities = new[] { $"{this.IotHub.Hostname}/{deviceId2}" },
                                         allow = new[]
                                         {
                                             new
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             // Create device manually. We can't use LeafDevice.CreateAsync() since it is not
             // idempotent and cannot be retried reliably.
-            Devices.Device edge = await this.iotHub.GetDeviceIdentityAsync(this.runtime.DeviceId, token);
+            Devices.Device edge = await this.IotHub.GetDeviceIdentityAsync(this.runtime.DeviceId, token);
             Devices.Device leaf = new Devices.Device(deviceId2)
             {
                 Authentication = new AuthenticationMechanism
@@ -154,10 +154,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Scope = edge.Scope
             };
 
-            leaf = await this.iotHub.CreateDeviceIdentityAsync(leaf, token);
+            leaf = await this.IotHub.CreateDeviceIdentityAsync(leaf, token);
 
             string connectionString =
-                $"HostName={this.iotHub.Hostname};" +
+                $"HostName={this.IotHub.Hostname};" +
                 $"DeviceId={leaf.Id};" +
                 $"SharedAccessKey={leaf.Authentication.SymmetricKey.PrimaryKey};" +
                 $"GatewayHostName={Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower())}";
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 await client.OpenAsync();
             }, token);
 
-            await this.iotHub.DeleteDeviceIdentityAsync(leaf, token);
+            await this.IotHub.DeleteDeviceIdentityAsync(leaf, token);
         }
 
         /// <summary>
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                 {
                                     new
                                     {
-                                        identities = new[] { $"{this.iotHub.Hostname}/{deviceId1}" },
+                                        identities = new[] { $"{this.IotHub.Hostname}/{deviceId1}" },
                                         allow = new[]
                                         {
                                             new
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                     },
                                     new
                                     {
-                                        identities = new[] { $"{this.iotHub.Hostname}/{deviceId2}" },
+                                        identities = new[] { $"{this.IotHub.Hostname}/{deviceId2}" },
                                         deny = new[]
                                         {
                                             new
@@ -261,7 +261,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.Some(this.runtime.DeviceId),
                 false,
                 this.ca,
-                this.iotHub,
+                this.IotHub,
                 Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower()),
                 token,
                 Option.None<string>(),
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     Option.Some(this.runtime.DeviceId),
                     false,
                     this.ca,
-                    this.iotHub,
+                    this.IotHub,
                     Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower()),
                     token,
                     Option.None<string>(),

--- a/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     parentId,
                     testAuth.UseSecondaryCertificate(),
                     this.ca,
-                    this.iotHub,
+                    this.IotHub,
                     Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower()),
                     token,
                     Option.None<string>(),

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 await this.runtime.DeployConfigurationAsync(token, Context.Current.NestedEdge);
             }
 
-            var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("Ping", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)), token);
+            var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("Ping", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)), token);
 
             Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
             Assert.AreEqual("null", result.GetPayloadAsJson());
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             var request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.Some(10), Option.Some(since), Option.Some(until), Option.None<int>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
 
-            var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
+            var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
 
             Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
 
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             var request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
 
-            var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
+            var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
 
             Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
 
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             // restart module
             var restartRequest = new RestartRequest("1.0", moduleName);
-            var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("RestartModule", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(restartRequest)), token);
+            var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("RestartModule", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(restartRequest)), token);
 
             Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
             Assert.AreEqual("null", result.GetPayloadAsJson());
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             // check it restarted
             var logsRequest = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
-            result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(logsRequest)), token);
+            result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(logsRequest)), token);
 
             Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
 
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             var payload = JsonConvert.SerializeObject(request);
 
-            CloudToDeviceMethodResult result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("UploadModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(payload), token);
+            CloudToDeviceMethodResult result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("UploadModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(payload), token);
 
             var response = JsonConvert.DeserializeObject<TaskStatusResponse>(result.GetPayloadAsJson());
             await this.WaitForTaskCompletion(response.CorrelationId, token);
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             var payload = JsonConvert.SerializeObject(request);
 
-            CloudToDeviceMethodResult result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("UploadSupportBundle", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(payload), token);
+            CloudToDeviceMethodResult result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("UploadSupportBundle", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(payload), token);
 
             var response = JsonConvert.DeserializeObject<TaskStatusResponse>(result.GetPayloadAsJson());
             await this.WaitForTaskCompletion(response.CorrelationId, token);
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     correlationId
                 };
 
-                var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetTaskStatus", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
+                var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetTaskStatus", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
 
                 Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
                 var response = JsonConvert.DeserializeObject<TaskStatusResponse>(result.GetPayloadAsJson());

--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -27,10 +27,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
             CancellationToken token = this.TestToken;
             await this.DeployAsync(token);
 
-            var agent = new EdgeAgent(this.runtime.DeviceId, this.iotHub);
+            var agent = new EdgeAgent(this.runtime.DeviceId, this.IotHub);
             await agent.PingAsync(token);
 
-            var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, ModuleName, new CloudToDeviceMethod("ValidateMetrics", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)), token);
+            var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ModuleName, new CloudToDeviceMethod("ValidateMetrics", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)), token);
             Assert.AreEqual(result.Status, (int)HttpStatusCode.OK);
 
             string body = result.GetPayloadAsJson();

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             }
             else
             {
-                sensor = new EdgeModule(SensorName, this.runtime.DeviceId, this.iotHub);
+                sensor = new EdgeModule(SensorName, this.runtime.DeviceId, this.IotHub);
                 startTime = DateTime.Now;
             }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.Some(this.runtime.DeviceId),
                 false,
                 this.ca,
-                this.iotHub,
+                this.IotHub,
                 Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower()),
                 token,
                 Option.Some(TestModelId),
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         async Task ValidateIdentity(string deviceId, Option<string> moduleId, string expectedModelId, CancellationToken token)
         {
-            Twin twin = await this.iotHub.GetTwinAsync(deviceId, moduleId, token);
+            Twin twin = await this.IotHub.GetTwinAsync(deviceId, moduleId, token);
             string actualModelId = twin.ModelId;
             Assert.AreEqual(expectedModelId, actualModelId);
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 async () =>
                 {
                     HashSet<int> results = new HashSet<int>();
-                    await this.iotHub.ReceiveEventsAsync(
+                    await this.IotHub.ReceiveEventsAsync(
                         this.runtime.DeviceId,
                         startTime,
                         data =>
@@ -345,7 +345,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         private async Task ToggleConnectivity(bool connectivityOn, string moduleName, CancellationToken token) =>
             await Profiler.Run(
                 async () =>
-                    await this.iotHub.InvokeMethodAsync(
+                    await this.IotHub.InvokeMethodAsync(
                         this.runtime.DeviceId,
                         moduleName,
                         new CloudToDeviceMethod("toggleConnectivity", TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(20)).SetPayloadJson($"{{\"networkOnValue\": \"{connectivityOn}\"}}"),
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             do
             {
                 await Task.Delay(TimeSpan.FromSeconds(5));
-                var result = await this.iotHub.InvokeMethodAsync(this.runtime.DeviceId, moduleName, new CloudToDeviceMethod("IsFinished", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)), token);
+                var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, moduleName, new CloudToDeviceMethod("IsFinished", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)), token);
                 Assert.AreEqual(result.Status, (int)HttpStatusCode.OK);
                 testStatus = JsonConvert.DeserializeObject<PriorityQueueTestStatus>(result.GetPayloadAsJson());
             }

--- a/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Option.Some(this.runtime.DeviceId),
                 false,
                 this.ca,
-                this.iotHub,
+                this.IotHub,
                 Context.Current.Hostname.GetOrElse(Dns.GetHostName().ToLower()),
                 token,
                 Option.None<string>(),

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
@@ -17,13 +17,14 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
     // we have our own timeout mechanism.
     public class ManualProvisioningFixture : BaseFixture
     {
-        protected readonly IotHub iotHub;
+        public IotHub IotHub { get; }
+
         protected IEdgeDaemon daemon;
         protected CertificateAuthority ca;
 
         public ManualProvisioningFixture()
         {
-            this.iotHub = new IotHub(
+            this.IotHub = new IotHub(
                 Context.Current.ConnectionString,
                 Context.Current.EventHubEndpoint,
                 Context.Current.TestRunnerProxy);
@@ -50,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             {
                 await this.daemon.WaitForStatusAsync(EdgeDaemonStatus.Running, token);
 
-                var agent = new EdgeAgent(device.Id, this.iotHub);
+                var agent = new EdgeAgent(device.Id, this.IotHub);
                 await agent.WaitForStatusAsync(EdgeModuleStatus.Running, token);
                 await agent.PingAsync(token);
             }

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/SasManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/SasManualProvisioningFixture.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                 EdgeDevice device = await EdgeDevice.GetOrCreateIdentityAsync(
                     Context.Current.DeviceId.GetOrElse(DeviceId.Current.Generate()),
                     Context.Current.ParentDeviceId,
-                    this.iotHub,
+                    this.IotHub,
                     AuthenticationType.Sas,
                     null,
                     token);
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                     Context.Current.EdgeProxy,
                     Context.Current.Registries,
                     Context.Current.OptimizeForPerformance,
-                    this.iotHub);
+                    this.IotHub);
 
                 // This is a temporary solution see ticket: 9288683
                 if (!Context.Current.ISA95Tag)

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                         EdgeDevice device = await EdgeDevice.GetOrCreateIdentityAsync(
                             deviceId,
                             Context.Current.ParentDeviceId,
-                            this.iotHub,
+                            this.IotHub,
                             AuthenticationType.SelfSigned,
                             thumbprint,
                             token);
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                             Context.Current.EdgeProxy,
                             Context.Current.Registries,
                             Context.Current.OptimizeForPerformance,
-                            this.iotHub);
+                            this.IotHub);
 
                         TestCertificates testCerts;
                         (testCerts, this.ca) = await TestCertificates.GenerateCertsAsync(device.Id, token);


### PR DESCRIPTION
New E2E testcase that disables and re-enables the Edge device first before trying to connect a leaf device.  This can be run in both single node and nested mode.

Nested E2E run:
https://msazure.visualstudio.com/One/_build/results?buildId=39737520&view=results