### PR TITLE
Move NestedEdgeEnabled out of experimental features. (#4467)

### DIFF
--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -41,7 +41,7 @@
               "experimentalfeatures__enabled": {
                 "value": "true"
               },
-              "experimentalFeatures__nestedEdgeEnabled": {
+              "NestedEdgeEnabled": {
                 "value": "false"
               }
             },
@@ -413,7 +413,7 @@
                 "value": "<TestInfo>"
               },
               "testMode": {
-                "value":  "<TestMode>"
+                "value": "<TestMode>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
@@ -37,14 +37,6 @@
             "type": "docker",
             "status": "running",
             "restartPolicy": "always",
-            "env": {
-              "experimentalfeatures__enabled": {
-                "value": "true"
-              },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              }
-            },
             "settings": {
               "image": "<Container_Registry>/microsoft/azureiotedge-hub:<EdgeRuntime.BuildNumber>-linux-<Architecture>",
               "createOptions": "{\"ExposedPorts\": {\"9600/tcp\": {}}, \"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}, \"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}],\"9600/tcp\": [{\"HostPort\": \"9601\"}]}}}"
@@ -413,7 +405,7 @@
                 "value": "<TestInfo>"
               },
               "testMode": {
-                "value":  "<TestMode>"
+                "value": "<TestMode>"
               }
             },
             "settings": {

--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
@@ -41,9 +41,6 @@
               "experimentalFeatures__enabled": {
                 "value": "true"
               },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              },
               "experimentalFeatures__mqttBrokerEnabled": {
                 "value": "true"
               },

--- a/e2e_deployment_files/nestededge_isa95_smoke_test_BaseDeployment.json
+++ b/e2e_deployment_files/nestededge_isa95_smoke_test_BaseDeployment.json
@@ -17,7 +17,7 @@
               "image": "$upstream:443/microsoft/azureiotedge-agent:<Build.BuildNumber>-linux-<Architecture>",
               "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}}}"
             },
-            "https_proxy": {	
+            "https_proxy": {
               "value": "<proxyAddress>"
             }
           },
@@ -28,21 +28,15 @@
               "createOptions": "{\"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}, \"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "experimentalFeatures__enabled": {
-                "value": "true"
-              },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              },
               "DeviceScopeCacheRefreshDelaySecs": {
                 "value": 1
               },
               "RuntimeLogLevel": {
                 "value": "debug"
               },
-              "https_proxy": {	
+              "https_proxy": {
                 "value": "<proxyAddress>"
-              }                                 
+              }
             },
             "status": "running",
             "restartPolicy": "always"
@@ -64,7 +58,7 @@
                 "value": "-1"
               }
             }
-          }          
+          }
         }
       }
     },
@@ -79,18 +73,18 @@
         },
         "mqttBroker": {
           "authorizations": [
-              {
-                  "identities": [
-                      "{{iot:identity}}"
-                  ],
-                  "allow": [
-                      {
-                          "operations": [
-                              "mqtt:connect"
-                          ]
-                      }
+            {
+              "identities": [
+                "{{iot:identity}}"
+              ],
+              "allow": [
+                {
+                  "operations": [
+                    "mqtt:connect"
                   ]
-              }
+                }
+              ]
+            }
           ]
         }
       }

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
@@ -29,15 +29,12 @@
               "experimentalFeatures__enabled": {
                 "value": "true"
               },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              },
               "DeviceScopeCacheRefreshDelaySecs": {
                 "value": 1
               },
               "RuntimeLogLevel": {
                 "value": "debug"
-              }                   
+              }
             },
             "status": "running",
             "restartPolicy": "always"
@@ -74,18 +71,18 @@
         },
         "mqttBroker": {
           "authorizations": [
-              {
-                  "identities": [
-                      "{{iot:identity}}"
-                  ],
-                  "allow": [
-                      {
-                          "operations": [
-                              "mqtt:connect"
-                          ]
-                      }
+            {
+              "identities": [
+                "{{iot:identity}}"
+              ],
+              "allow": [
+                {
+                  "operations": [
+                    "mqtt:connect"
                   ]
-              }
+                }
+              ]
+            }
           ]
         }
       }

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_mqtt.json
@@ -36,9 +36,6 @@
               "experimentalFeatures__enabled": {
                 "value": "true"
               },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              },
               "experimentalFeatures__mqttBrokerEnabled": {
                 "value": "true"
               },
@@ -47,7 +44,7 @@
               },
               "RuntimeLogLevel": {
                 "value": "debug"
-              }                   
+              }
             },
             "status": "running",
             "restartPolicy": "always"

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
@@ -24,7 +24,7 @@
               "image": "<Container_Registry>/microsoft/azureiotedge-agent:<Build.BuildNumber>-linux-<Architecture>",
               "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}}}"
             },
-            "https_proxy": {	
+            "https_proxy": {
               "value": "<proxyAddress>"
             }
           },
@@ -35,21 +35,15 @@
               "createOptions": "{\"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}, \"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
             },
             "env": {
-              "experimentalFeatures__enabled": {
-                "value": "true"
-              },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              },
               "DeviceScopeCacheRefreshDelaySecs": {
                 "value": 1
               },
               "RuntimeLogLevel": {
                 "value": "debug"
               },
-              "https_proxy": {	
+              "https_proxy": {
                 "value": "<proxyAddress>"
-              }                                 
+              }
             },
             "status": "running",
             "restartPolicy": "always"
@@ -114,18 +108,18 @@
         },
         "mqttBroker": {
           "authorizations": [
-              {
-                  "identities": [
-                      "{{iot:identity}}"
-                  ],
-                  "allow": [
-                      {
-                          "operations": [
-                              "mqtt:connect"
-                          ]
-                      }
+            {
+              "identities": [
+                "{{iot:identity}}"
+              ],
+              "allow": [
+                {
+                  "operations": [
+                    "mqtt:connect"
                   ]
-              }
+                }
+              ]
+            }
           ]
         }
       }

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
@@ -24,7 +24,7 @@
               "image": "<Container_Registry>/microsoft/azureiotedge-agent:<Build.BuildNumber>-linux-<Architecture>",
               "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}}}"
             },
-            "https_proxy": {	
+            "https_proxy": {
               "value": "<proxyAddress>"
             }
           },
@@ -38,9 +38,6 @@
               "experimentalFeatures__enabled": {
                 "value": "true"
               },
-              "experimentalFeatures__nestedEdgeEnabled": {
-                "value": "true"
-              },
               "experimentalFeatures__mqttBrokerEnabled": {
                 "value": "true"
               },
@@ -50,9 +47,9 @@
               "RuntimeLogLevel": {
                 "value": "debug"
               },
-              "https_proxy": {	
+              "https_proxy": {
                 "value": "<proxyAddress>"
-              }                                 
+              }
             },
             "status": "running",
             "restartPolicy": "always"
@@ -117,18 +114,18 @@
         },
         "mqttBroker": {
           "authorizations": [
-              {
-                  "identities": [
-                      "{{iot:identity}}"
-                  ],
-                  "allow": [
-                      {
-                          "operations": [
-                              "mqtt:connect"
-                          ]
-                      }
+            {
+              "identities": [
+                "{{iot:identity}}"
+              ],
+              "allow": [
+                {
+                  "operations": [
+                    "mqtt:connect"
                   ]
-              }
+                }
+              ]
+            }
           ]
         }
       }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudConnectionProvider.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             bool useServerHeartbeat,
             Option<IWebProxy> proxy,
             IMetadataStore metadataStore,
-            bool nestedEdgeEnabled = false)
+            bool nestedEdgeEnabled = true)
         {
             this.messageConverterProvider = Preconditions.CheckNotNull(messageConverterProvider, nameof(messageConverterProvider));
             this.clientProvider = Preconditions.CheckNotNull(clientProvider, nameof(clientProvider));

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ServiceProxy.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
         readonly IDeviceScopeApiClientProvider securityScopesApiClientProvider;
         readonly bool nestedEdgeEnabled;
 
-        public ServiceProxy(IDeviceScopeApiClientProvider securityScopesApiClientProvider, bool nestedEdgeEnabled = false)
+        public ServiceProxy(IDeviceScopeApiClientProvider securityScopesApiClientProvider, bool nestedEdgeEnabled = true)
         {
             this.securityScopesApiClientProvider = Preconditions.CheckNotNull(securityScopesApiClientProvider, nameof(securityScopesApiClientProvider));
             this.nestedEdgeEnabled = nestedEdgeEnabled;

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeCertificateAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeCertificateAuthenticator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             IAuthenticator underlyingAuthenticator,
             IList<X509Certificate2> trustBundle,
             bool syncServiceIdentityOnFailure,
-            bool nestedEdgeEnabled = false)
+            bool nestedEdgeEnabled = true)
             : base(deviceScopeIdentitiesCache, underlyingAuthenticator, false, syncServiceIdentityOnFailure, nestedEdgeEnabled)
         {
             this.trustBundle = Preconditions.CheckNotNull(trustBundle, nameof(trustBundle));

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
             IAuthenticator underlyingAuthenticator,
             bool allowDeviceAuthForModule,
             bool syncServiceIdentityOnFailure,
-            bool nestedEdgeEnabled = false)
+            bool nestedEdgeEnabled = true)
             : base(deviceScopeIdentitiesCache, underlyingAuthenticator, allowDeviceAuthForModule, syncServiceIdentityOnFailure, nestedEdgeEnabled)
         {
             this.iothubHostName = Preconditions.CheckNonWhiteSpace(iothubHostName, nameof(iothubHostName));

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Constants.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             public const string StorageMaxOpenFiles = "RocksDB_MaxOpenFiles";
             public const string StorageLogLevel = "Storage_LogLevel";
             public const string ExperimentalFeatures = "experimentalFeatures";
-            public const string NestedEdgeEnabled = "nestedEdgeEnabled";
+            public const string NestedEdgeEnabled = "NestedEdgeEnabled";
             public const string MqttBrokerEnabled = "mqttBrokerEnabled";
         }
     }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/DependencyManager.cs
@@ -124,8 +124,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
             MetricsConfig metricsConfig = new MetricsConfig(this.configuration.GetSection("metrics:listener"));
 
-            this.RegisterCommonModule(builder, optimizeForPerformance, storeAndForward, metricsConfig, experimentalFeatures);
-            this.RegisterRoutingModule(builder, storeAndForward, experimentalFeatures);
+            bool nestedEdgeEnabled = this.configuration.GetValue<bool>(Constants.ConfigKey.NestedEdgeEnabled, true);
+
+            this.RegisterCommonModule(builder, optimizeForPerformance, storeAndForward, metricsConfig, nestedEdgeEnabled);
+            this.RegisterRoutingModule(builder, storeAndForward, experimentalFeatures, nestedEdgeEnabled);
             this.RegisterMqttModule(builder, storeAndForward, optimizeForPerformance, experimentalFeatures);
             this.RegisterAmqpModule(builder);
             builder.RegisterModule(new HttpModule(this.iotHubHostname));
@@ -176,7 +178,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         void RegisterRoutingModule(
             ContainerBuilder builder,
             StoreAndForward storeAndForward,
-            ExperimentalFeatures experimentalFeatures)
+            ExperimentalFeatures experimentalFeatures,
+            bool nestedEdgeEnabled)
         {
             var routes = this.configuration.GetSection("routes").Get<Dictionary<string, string>>();
             int connectionPoolSize = this.configuration.GetValue<int>("IotHubConnectionPoolSize");
@@ -212,6 +215,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool closeCloudConnectionOnDeviceDisconnect = this.configuration.GetValue("CloseCloudConnectionOnDeviceDisconnect", true);
             bool isLegacyUpstream = ExperimentalFeatures.IsViaBrokerUpstream(
                     experimentalFeatures,
+                    nestedEdgeEnabled,
                     this.GetConfigurationValueIfExists<string>(Constants.ConfigKey.GatewayHostname).HasValue);
 
             builder.RegisterModule(
@@ -246,7 +250,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     messageCleanupIntervalSecs,
                     experimentalFeatures,
                     closeCloudConnectionOnDeviceDisconnect,
-                    experimentalFeatures.EnableNestedEdge,
+                    nestedEdgeEnabled,
                     isLegacyUpstream));
         }
 
@@ -255,7 +259,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool optimizeForPerformance,
             StoreAndForward storeAndForward,
             MetricsConfig metricsConfig,
-            ExperimentalFeatures experimentalFeatures)
+            bool nestedEdgeEnabled)
         {
             bool cacheTokens = this.configuration.GetValue("CacheTokens", false);
             Option<string> workloadUri = this.GetConfigurationValueIfExists<string>(Constants.ConfigKey.WorkloadUri);
@@ -305,7 +309,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                     storeAndForward.StorageMaxTotalWalSize,
                     storeAndForward.StorageMaxOpenFiles,
                     storeAndForward.StorageLogLevel,
-                    experimentalFeatures.EnableNestedEdge));
+                    nestedEdgeEnabled));
         }
 
         static string GetProductInfo()

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/ExperimentalFeatures.cs
@@ -7,12 +7,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class ExperimentalFeatures
     {
-        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck, bool enableNestedEdge, bool enableMqttBroker)
+        public ExperimentalFeatures(bool enabled, bool disableCloudSubscriptions, bool disableConnectivityCheck, bool enableMqttBroker)
         {
             this.Enabled = enabled;
             this.DisableCloudSubscriptions = disableCloudSubscriptions;
             this.DisableConnectivityCheck = disableConnectivityCheck;
-            this.EnableNestedEdge = enableNestedEdge;
             this.EnableMqttBroker = enableMqttBroker;
         }
 
@@ -21,18 +20,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             bool enabled = experimentalFeaturesConfig.GetValue("enabled", false);
             bool disableCloudSubscriptions = enabled && experimentalFeaturesConfig.GetValue("disableCloudSubscriptions", false);
             bool disableConnectivityCheck = enabled && experimentalFeaturesConfig.GetValue("disableConnectivityCheck", false);
-            bool enableNestedEdge = enabled && experimentalFeaturesConfig.GetValue(Constants.ConfigKey.NestedEdgeEnabled, false);
             bool enableMqttBroker = enabled && experimentalFeaturesConfig.GetValue(Constants.ConfigKey.MqttBrokerEnabled, false);
-            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableNestedEdge, enableMqttBroker);
+            var experimentalFeatures = new ExperimentalFeatures(enabled, disableCloudSubscriptions, disableConnectivityCheck, enableMqttBroker);
             logger.LogInformation($"Experimental features configuration: {experimentalFeatures.ToJson()}");
             return experimentalFeatures;
         }
 
-        public static bool IsViaBrokerUpstream(ExperimentalFeatures experimentalFeatures, bool hasGatewayHostname)
+        public static bool IsViaBrokerUpstream(ExperimentalFeatures experimentalFeatures, bool nestedEdgeEnabled, bool hasGatewayHostname)
         {
             bool isLegacyUpstream = !experimentalFeatures.Enabled
                 || !experimentalFeatures.EnableMqttBroker
-                || !experimentalFeatures.EnableNestedEdge
+                || !nestedEdgeEnabled
                 || !hasGatewayHostname;
 
             return isLegacyUpstream;
@@ -43,8 +41,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         public bool DisableCloudSubscriptions { get; }
 
         public bool DisableConnectivityCheck { get; }
-
-        public bool EnableNestedEdge { get; }
 
         public bool EnableMqttBroker { get; }
     }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ServiceProxyTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/ServiceProxyTest.cs
@@ -47,7 +47,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act / Assert
             IServiceIdentitiesIterator iterator = serviceProxy.GetServiceIdentitiesIterator();
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "edgedevice");
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "edgedevice");
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "edgedevice");
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "edgedevice");
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiClient.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "edgedevice");
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiClient.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act / Assert
             await Assert.ThrowsAsync<InvalidOperationException>(() => serviceProxy.GetServiceIdentity("d1", "edgedevice"));
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiClient.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "m1", "edgedevice");
@@ -229,7 +229,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiClient.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act / Assert
             await Assert.ThrowsAsync<InvalidOperationException>(() => serviceProxy.GetServiceIdentity("d1", "m1", "edgedevice"));
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "m1", "edgedevice");
@@ -275,7 +275,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "m1", "edgedevice");
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "m1", "edgedevice");
@@ -319,7 +319,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             var deviceScopeApiClientProvider = new Mock<IDeviceScopeApiClientProvider>();
             deviceScopeApiClientProvider.Setup(p => p.CreateDeviceScopeClient()).Returns(deviceScopeApiResult.Object);
 
-            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object);
+            IServiceProxy serviceProxy = new ServiceProxy(deviceScopeApiClientProvider.Object, false);
 
             // Act
             Option<ServiceIdentity> serviceIdentity = await serviceProxy.GetServiceIdentity("d1", "m1", "edgedevice");
@@ -391,7 +391,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
 
         static Module GetModule(string deviceId, string moduleId)
         {
-            string moduleJson = @"{                        
+            string moduleJson = @"{
                       ""deviceId"": """ + deviceId + @""",
                       ""moduleId"": """ + moduleId + @""",
                       ""managedBy"": ""iotEdge"",

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -725,7 +725,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
                 TimeSpan.FromSeconds(20),
                 false,
                 Option.None<IWebProxy>(),
-                metadataStore.Object);
+                metadataStore.Object,
+                false);
             cloudConnectionProvider.BindEdgeHub(Mock.Of<IEdgeHub>());
             var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
             var connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/DependencyManager.cs
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             var mqttSettingsConfiguration = new Mock<IConfiguration>();
             mqttSettingsConfiguration.Setup(c => c.GetSection(It.IsAny<string>())).Returns(Mock.Of<IConfigurationSection>(s => s.Value == null));
 
-            var experimentalFeatures = new ExperimentalFeatures(true, false, false, false, false);
+            var experimentalFeatures = new ExperimentalFeatures(true, false, false, false);
 
             builder.RegisterBuildCallback(
                 c =>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
@@ -44,11 +44,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
             if (nestedEdge == true)
             {
-                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("experimentalFeatures__enabled", "true"), ("experimentalFeatures__nestedEdgeEnabled", "true"), ("DeviceScopeCacheRefreshDelaySecs", "1") };
+                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("DeviceScopeCacheRefreshDelaySecs", "0") };
             }
             else
             {
-                hubEnvVar = new[] { ("RuntimeLogLevel", "debug") };
+                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("NestedEdgeEnabled", "false"), };
             }
 
             var builder = new EdgeConfigBuilder(this.DeviceId);


### PR DESCRIPTION
There are two main changes in this PR:
- Enable nested edge by default
- Move `NestedEdgeEnabled` settings out of `experimentalFeatures` section.

To enable nested edge/broker you would need to have the following env vars in your deployment manifest:
```json
                    "edgeHub": {
                        "type": "docker",
                        "status": "running",
                        "restartPolicy": "always",
                        "settings": {
                            "image": "edgerelease.azurecr.io/microsoft/azureiotedge-hub:1.2.0-rc3-linux-amd64",
                            "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"1883/tcp\": [{\"HostPort\": \"1883\"}], \"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
                        },
                        "env": {
                            "experimentalFeatures__nestedEdgeEnabled": {
                                "value": "true"
                            },
                            "experimentalFeatures__mqttBrokerEnabled": {
                                "value": "true"
                            },
                            "experimentalFeatures__enabled": {
                                "value": "true"
                            }
                        }
                    }
```

With this change, the Nested Edge would be on by default. So if you want to run nested + broker, here is how the deployment manifest would look like:
```json
                    "edgeHub": {
                        "type": "docker",
                        "status": "running",
                        "restartPolicy": "always",
                        "settings": {
                            "image": "edgerelease.azurecr.io/microsoft/azureiotedge-hub:1.2.0-rc3-linux-amd64",
                            "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"1883/tcp\": [{\"HostPort\": \"1883\"}], \"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
                        },
                        "env": {
                            "experimentalFeatures__mqttBrokerEnabled": {
                                "value": "true"
                            },
                            "experimentalFeatures__enabled": {
                                "value": "true"
                            }
                        }
                    }
```

if for some reason you want to disable nested edge, here's how to do that:
```json
                    "edgeHub": {
                        "type": "docker",
                        "status": "running",
                        "restartPolicy": "always",
                        "settings": {
                            "image": "edgerelease.azurecr.io/microsoft/azureiotedge-hub:1.2.0-rc3-linux-amd64",
                            "createOptions": "{\"HostConfig\": {\"PortBindings\": {\"1883/tcp\": [{\"HostPort\": \"1883\"}], \"8883/tcp\": [{\"HostPort\": \"8883\"}],\"443/tcp\": [{\"HostPort\": \"443\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}]}}}"
                        },
                        "env": {
                            "NestedEdgeEnabled": {
                                "value": "false"
                            }
                        }
                    }
```