### PR TITLE
Fix server cert name in nested E2E

### DIFF
--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -36,7 +36,7 @@ function setup_iotedge() {
     >/tmp/principals.toml cat <<-EOF
 [[principal]]
 uid = $(id -u iotedge)
-certs = ["$edgeHub*server"]
+certs = ["aziot-edged/module/*"]
 EOF
     sudo mv /tmp/principals.toml /etc/aziot/certd/config.d/aziot-edged-principal.toml
     sudo chown aziotcs:aziotcs /etc/aziot/certd/config.d/aziot-edged-principal.toml


### PR DESCRIPTION
The name of edgeHub server certs was changed in d0978bf63bdd5624543680424452ee5c08fe285a. Updates nested E2E tests with the new name.