### PR TITLE
EFLOW: Introduce environment variables for nuget operations

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -132,10 +132,6 @@ jobs:
   - job: EFLOW_amd64
 ################################################################################	
     displayName: EFLOW amd64
-    env:
-      NUGET_HTTP_CACHE_PATH: "/var/tmp/NuGet/v3-cache"
-      NUGET_PACKAGES: "/var/tmp/NuGet/packages"
-      NUGET_PLUGINS_CACHE_PATH: "/var/tmp/NuGet/plugins-cache"
 
     pool:
       name: $(pool.name)
@@ -149,9 +145,12 @@ jobs:
       os: linux
       arch: amd64
       artifactName: iotedged-mariner-amd64
+      NUGET_HTTP_CACHE_PATH: /var/tmp/NuGet/v3-cache
+      NUGET_PACKAGES: /var/tmp/NuGet/packages
+      NUGET_PLUGINS_CACHE_PATH: /var/tmp/NuGet/plugins-cache
 
     steps:
     - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml 
+    - template: templates/e2e-run.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -132,6 +132,10 @@ jobs:
   - job: EFLOW_amd64
 ################################################################################	
     displayName: EFLOW amd64
+    env:
+      NUGET_HTTP_CACHE_PATH: "/var/tmp/NuGet/v3-cache"
+      NUGET_PACKAGES: "/var/tmp/NuGet/packages"
+      NUGET_PLUGINS_CACHE_PATH: "/var/tmp/NuGet/plugins-cache"
 
     pool:
       name: $(pool.name)


### PR DESCRIPTION
Set env variables to direct nuget caches to the data partition instead of to the rootfs