### PR TITLE
Introduce the dedicated Packages Release Pipeline

### DIFF
--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1,0 +1,93 @@
+trigger: none
+pr: none
+jobs:
+
+################################################################################
+  - job: linux
+################################################################################
+    displayName: Linux
+    pool:
+      vmImage: 'ubuntu-18.04'
+    variables:
+      NugetSecurityAnalysisWarningLevel: warn
+    strategy:
+      matrix:
+        Centos75-amd64:
+          arch: amd64
+          os: centos7
+          target.iotedged: edgelet/target/rpmbuild/RPMS/x86_64
+        Debian9-amd64:
+          os: debian9
+          arch: amd64
+          target.iotedged: edgelet/target/release
+        Debian9-arm32v7:
+          os: debian9
+          arch: arm32v7
+          target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+        Debian9-aarch64:
+          os: debian9
+          arch: aarch64
+          target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+
+        Debian10-amd64:
+          os: debian10
+          arch: amd64
+          target.iotedged: edgelet/target/release
+        Debian10-arm32v7:
+          os: debian10
+          arch: arm32v7
+          target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+        Debian10-aarch64:
+          os: debian10
+          arch: aarch64
+          target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+          
+        Ubuntu1804-amd64:
+          os: ubuntu18.04
+          arch: amd64
+          target.iotedged: edgelet/target/release
+        Ubuntu1804-arm32v7:
+          os: ubuntu18.04
+          arch: arm32v7
+          target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+        Ubuntu1804-aarch64:
+          os: ubuntu18.04
+          arch: aarch64
+          target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+        Ubuntu2004-amd64:
+          arch: amd64
+          os: ubuntu20.04
+          target.iotedged: edgelet/target/release
+        Ubuntu2004-arm32v7:
+          arch: arm32v7
+          os: ubuntu20.04
+          target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+        Ubuntu2004-aarch64:
+          arch: aarch64
+          os: ubuntu20.04
+          target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+    steps:
+      - bash: |
+          BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+          VERSION="$BASE_VERSION"
+          echo "##vso[task.setvariable variable=VERSION;]$VERSION"
+
+          echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
+          echo "##vso[task.setvariable variable=PACKAGE_OS;]$(os)"
+        displayName: Set Version
+      - script: edgelet/build/linux/package.sh
+        displayName: Create iotedged packages
+      - task: CopyFiles@2
+        displayName: Copy iotedged Files to Artifact Staging
+        inputs:
+          SourceFolder: $(target.iotedged)
+          Contents: |
+            *.deb
+            *.rpm
+          TargetFolder: '$(build.artifactstagingdirectory)'
+      - task: PublishBuildArtifacts@1
+        displayName: Publish Artifacts
+        inputs:
+          PathtoPublish: '$(build.artifactstagingdirectory)'
+          ArtifactName: 'iotedged-$(os)-$(arch)'
+        condition: succeededOrFailed()


### PR DESCRIPTION
Introduce the dedicated Packages Release Pipeline

Currently our existing Azure-IoT-Edge-Core Edgelet Release pipeline is a GUI-based devops pipeline which has been working nicely for `iotedge` and `libiothsm` artifacts. Going forward starting with release/1.2-rc4, the `iotedge` and `libiothsm` are retired and replaced by the new Identity Service (IS). 

This pipeline is created to provide a support for the `aziot-edge` release artifact as a part of the new IS. We decided not the update the existing pipeline going forward because of its GUI-based property which is used across multiple branches (release1.1 & release1.2) in the release process. By updating the pipeline for release1.2 will inevitably break the release1.1 release.

Note: The RELEASE pipeline is almost identical to the BUILD pipeline in term of pipeline code base. We decide to be in favor of creating a new pipeline because
1. The version string different (we don't want the buildId in the final package)
2. We get to keep the Retention history in the pipeline itself.