### PR TITLE
[iotedge check] bugbash fixes

### DIFF
--- a/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
+++ b/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
@@ -24,11 +24,16 @@ impl Checker for AziotEdgedVersion {
     fn description(&self) -> &'static str {
         "latest security daemon"
     }
+    #[allow(unreachable_code)] // TODO: remove once check is re-enabled
     fn execute(
         &mut self,
         check: &mut Check,
         tokio_runtime: &mut tokio::runtime::Runtime,
     ) -> CheckResult {
+        // TODO: re-enable after sorting out which URL 1.2 version info will be pulled from
+        let _ = (check, tokio_runtime);
+        return CheckResult::Ignored;
+
         let latest_versions = if let Some(expected_aziot_edged_version) =
             &check.expected_aziot_edged_version
         {

--- a/edgelet/iotedge/src/check/checks/mod.rs
+++ b/edgelet/iotedge/src/check/checks/mod.rs
@@ -1,4 +1,4 @@
-// mod aziot_edged_version;
+mod aziot_edged_version;
 mod connect_management_uri;
 mod container_connect_upstream;
 mod container_engine_dns;
@@ -14,7 +14,7 @@ mod pull_agent_from_upstream;
 mod storage_mounted_from_host;
 mod well_formed_config;
 
-// pub(crate) use self::aziot_edged_version::AziotEdgedVersion;
+pub(crate) use self::aziot_edged_version::AziotEdgedVersion;
 pub(crate) use self::connect_management_uri::ConnectManagementUri;
 pub(crate) use self::container_connect_upstream::get_host_container_upstream_tests;
 pub(crate) use self::container_engine_dns::ContainerEngineDns;
@@ -84,8 +84,7 @@ pub(crate) fn built_in_checks() -> [(&'static str, Vec<Box<dyn Checker>>); 2] {
                 Box::new(ParentHostname::default()),
                 Box::new(ContainerResolveParentHostname::default()),
                 Box::new(ConnectManagementUri::default()),
-                // TODO: re-enable after sorting out which URL 1.2 version info will be pulled from
-                // Box::new(AziotEdgedVersion::default()),
+                Box::new(AziotEdgedVersion::default()),
                 Box::new(ContainerLocalTime::default()),
                 Box::new(ContainerEngineDns::default()),
                 Box::new(ContainerEngineIPv6::default()),

--- a/edgelet/iotedge/src/check/checks/mod.rs
+++ b/edgelet/iotedge/src/check/checks/mod.rs
@@ -1,4 +1,4 @@
-mod aziot_edged_version;
+// mod aziot_edged_version;
 mod connect_management_uri;
 mod container_connect_upstream;
 mod container_engine_dns;
@@ -14,7 +14,7 @@ mod pull_agent_from_upstream;
 mod storage_mounted_from_host;
 mod well_formed_config;
 
-pub(crate) use self::aziot_edged_version::AziotEdgedVersion;
+// pub(crate) use self::aziot_edged_version::AziotEdgedVersion;
 pub(crate) use self::connect_management_uri::ConnectManagementUri;
 pub(crate) use self::container_connect_upstream::get_host_container_upstream_tests;
 pub(crate) use self::container_engine_dns::ContainerEngineDns;
@@ -84,7 +84,8 @@ pub(crate) fn built_in_checks() -> [(&'static str, Vec<Box<dyn Checker>>); 2] {
                 Box::new(ParentHostname::default()),
                 Box::new(ContainerResolveParentHostname::default()),
                 Box::new(ConnectManagementUri::default()),
-                Box::new(AziotEdgedVersion::default()),
+                // TODO: re-enable after sorting out which URL 1.2 version info will be pulled from
+                // Box::new(AziotEdgedVersion::default()),
                 Box::new(ContainerLocalTime::default()),
                 Box::new(ContainerEngineDns::default()),
                 Box::new(ContainerEngineIPv6::default()),

--- a/edgelet/iotedge/src/check/checks/well_formed_config.rs
+++ b/edgelet/iotedge/src/check/checks/well_formed_config.rs
@@ -12,10 +12,10 @@ pub(crate) struct WellFormedConfig {}
 
 impl Checker for WellFormedConfig {
     fn id(&self) -> &'static str {
-        "config-yaml-well-formed"
+        "config-toml-well-formed"
     }
     fn description(&self) -> &'static str {
-        "config.yaml is well-formed"
+        "config.toml is well-formed"
     }
     fn execute(&mut self, check: &mut Check, _: &mut tokio::runtime::Runtime) -> CheckResult {
         Self::inner_execute(check).unwrap_or_else(CheckResult::Failed)

--- a/edgelet/iotedge/src/check/checks/well_formed_config.rs
+++ b/edgelet/iotedge/src/check/checks/well_formed_config.rs
@@ -12,10 +12,10 @@ pub(crate) struct WellFormedConfig {}
 
 impl Checker for WellFormedConfig {
     fn id(&self) -> &'static str {
-        "config-toml-well-formed"
+        "aziot-edged-config-well-formed"
     }
     fn description(&self) -> &'static str {
-        "config.toml is well-formed"
+        "aziot-edged configuration is well-formed"
     }
     fn execute(&mut self, check: &mut Check, _: &mut tokio::runtime::Runtime) -> CheckResult {
         Self::inner_execute(check).unwrap_or_else(CheckResult::Failed)


### PR DESCRIPTION
- Temporarily remove aziot-edged version check until we sort out where the version info for 1.2 will live
- Remove references to config.yaml, replace with broader "configuration" terminology