### PR TITLE
Reverting to nginx image (#4469)

### DIFF
--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -39,7 +39,7 @@ jobs:
           imageName: azureiotedge-api-proxy
           project: api-proxy-module
           version: $(buildVersion)
-          buildx_flag: true
+          buildx_flag: false
       # Check API proxy
       - task: ComponentGovernanceComponentDetection@0
         inputs:

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -221,7 +221,7 @@ jobs:
           name: API Proxy
           imageName: azureiotedge-api-proxy
           project: api-proxy-module
-          buildx_flag: true
+          buildx_flag: false
       # Check API proxy
       - task: ComponentGovernanceComponentDetection@0
         inputs:

--- a/edge-modules/api-proxy-module/docker/linux/amd64/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/amd64/Dockerfile
@@ -3,8 +3,6 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG DIR=.
-
 FROM alpine:3.13.1
 WORKDIR /app
 COPY ./docker/linux/amd64/api-proxy-module .

--- a/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
@@ -3,15 +3,11 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-ARG DIR=.
-
-FROM arm32v7/alpine:3.13.1
+FROM arm32v7/nginx:1.19.7-alpine
 WORKDIR /app
 COPY ./docker/linux/arm32v7/api-proxy-module .
 COPY ./docker/linux/arm32v7/templates .
-RUN	apk update && \
-    apk add nginx && \
-	mkdir /run/nginx
+
 #expose ports
 EXPOSE 443/tcp	
 EXPOSE 80/tcp

--- a/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
@@ -3,14 +3,11 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM arm64v8/alpine:3.13.1
+FROM arm64v8/nginx:1.19.7-alpine
 WORKDIR /app
-COPY ./docker/linux/arm64v8/lib/ /lib
 COPY ./docker/linux/arm64v8/api-proxy-module .
 COPY ./docker/linux/arm64v8/templates .
-RUN	apk update && \
-    apk add nginx && \
-	mkdir /run/nginx
+
 #expose ports
 EXPOSE 443/tcp	
 EXPOSE 80/tcp


### PR DESCRIPTION
Reverting to nginx since they updated their base image and because there has been a report of the arm32 image crashing and I was not able to reproduce it/fix it(9345043). So I am reverting for release rc4 until I can fix the issue.

https://dev.azure.com/msazure/One/_build/results?buildId=39734886&view=results
https://dev.azure.com/msazure/One/_build/results?buildId=39734935&view=results