### PR TITLE
Temporarily raise quickstart EdgeCA cert's expiry to 30 days.

### DIFF
--- a/edgelet/iotedge/src/config/apply.rs
+++ b/edgelet/iotedge/src/config/apply.rs
@@ -228,7 +228,7 @@ fn execute_inner(
             aziot_certd_config::CertIssuanceOptions {
                 method: aziot_certd_config::CertIssuanceMethod::SelfSigned,
                 common_name: Some(IOTEDGED_COMMONNAME.to_owned()),
-                expiry_days: Some(1),
+                expiry_days: Some(30),
             },
         );
 

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/certd.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-tpm/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-x509/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manual-x509/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/moby-runtime-content-trust/certd.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-content-trust/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/certd.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 common_name = "iotedged workload ca"
-expiry_days = 1
+expiry_days = 30
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]


### PR DESCRIPTION
Temporarily raise quickstart EdgeCA cert's expiry to 30 days.

Currently certd does not cap an issued cert's not-after to the issuer's.
This means a situation can happen where Edge Hub requests a module server cert
for 30 days and is granted one, but the Edge CA cert is valid for less than
30 more days. EH won't renew its cert until it's 5 minutes to expiry,
but for most of that time the full cert chain will be invalid because of
the expired issuer and modules would refuse to connect to it.

In fact, this is what happens with self-signed Edge CA as configured by
`iotedge config apply` in quickstart mode before this change, because
the expiry defaults to 1 day.

Until certd is fixed, for RC4 we decided to do the simpler workaround of
just raising the quickstart Edge CA's expiry to 30 days.