### PR TITLE
Fix license type in aziot-edge.spec

### DIFF
--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -10,7 +10,7 @@ Name:           aziot-edge
 Version:        @version@
 Release:        @release@%{?dist}
 
-License:        Proprietary
+License:        MIT
 Summary:        Azure IoT Edge Module Runtime
 URL:            https://github.com/azure/iotedge
 


### PR DESCRIPTION
Fix typo of license type in aziot-edge.spec.