### PR TITLE
MQTT Perf Tests improvements.

### DIFF
--- a/builds/misc/mqtt-perf.yaml
+++ b/builds/misc/mqtt-perf.yaml
@@ -52,6 +52,7 @@ stages:
     clientDop: 4 # the number of max threads that can execute mqtt-benchmark tool code simultaneously
 
   pool: $(pool.name)
+  condition: always() # run stage even if previous failed
   jobs:
     - template: templates/mqtt-perf-setup.yaml
     - template: templates/mqtt-perf-run.yaml
@@ -67,6 +68,7 @@ stages:
     clientDop: 4 # the number of max threads that can execute mqtt-benchmark tool code simultaneously
 
   pool: $(pool.name)
+  condition: always() # run stage even if previous failed
   jobs:
     - template: templates/mqtt-perf-setup.yaml
     - template: templates/mqtt-perf-run.yaml
@@ -82,6 +84,7 @@ stages:
     clientDop: 4 # the number of max threads that can execute mqtt-benchmark tool code simultaneously
 
   pool: $(pool.name)
+  condition: always() # run stage even if previous failed
   jobs:
     - template: templates/mqtt-perf-setup.yaml
     - template: templates/mqtt-perf-run.yaml

--- a/builds/misc/templates/mqtt-perf-setup.yaml
+++ b/builds/misc/templates/mqtt-perf-setup.yaml
@@ -67,7 +67,7 @@ jobs:
         commands: |
           echo "$(registry.password)" | docker login $(registry.address) --username $(registry.user) --password-stdin 2>/dev/null
           docker pull $(cat brokerImageName.txt)
-          docker run -d --network=host --security-opt apparmor=docker-default --name=mqtt-broker $(cat brokerImageName.txt)
+          docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(cat brokerImageName.txt)
           docker logout
       condition: eq(variables['arch'], 'arm32v7')
       

--- a/builds/misc/templates/mqtt-perf-setup.yaml
+++ b/builds/misc/templates/mqtt-perf-setup.yaml
@@ -42,8 +42,8 @@ jobs:
         runOptions: commands
         commands: |
           echo "$(registry.password)" | docker login $(registry.address) --username $(registry.user) --password-stdin 2>/dev/null
-          docker pull $$(cat brokerImageName.txt)
-          docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(brokerImageName)
+          docker pull $(cat brokerImageName.txt)
+          docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(cat brokerImageName.txt)
           docker logout
       condition: eq(variables['arch'], 'amd64')
 
@@ -66,8 +66,8 @@ jobs:
         runOptions: commands
         commands: |
           echo "$(registry.password)" | docker login $(registry.address) --username $(registry.user) --password-stdin 2>/dev/null
-          docker pull $$(cat brokerImageName.txt)
-          docker run -d --network=host --security-opt apparmor=docker-default --name=mqtt-broker $(brokerImageName)
+          docker pull $(cat brokerImageName.txt)
+          docker run -d --network=host --security-opt apparmor=docker-default --name=mqtt-broker $(cat brokerImageName.txt)
           docker logout
       condition: eq(variables['arch'], 'arm32v7')
       

--- a/builds/misc/templates/mqtt-perf-setup.yaml
+++ b/builds/misc/templates/mqtt-perf-setup.yaml
@@ -30,7 +30,7 @@ jobs:
         sshEndpoint: iotedge-mqtt-perf-amd64-conn
         runOptions: commands        
         commands: |
-          docker stop mqtt-broker ; docker system prune -a -f
+          echo $(brokerImageName) > brokerImageName.txt ; docker stop mqtt-broker ; docker system prune -a -f
       # ignore cleanup errors if no containers running
       continueOnError: true 
       condition: eq(variables['arch'], 'amd64')
@@ -42,8 +42,8 @@ jobs:
         runOptions: commands
         commands: |
           echo "$(registry.password)" | docker login $(registry.address) --username $(registry.user) --password-stdin 2>/dev/null
-          docker pull $(brokerImageName)
-          docker run -d --network=host --name=mqtt-broker $(brokerImageName)
+          docker pull $$(cat brokerImageName.txt)
+          docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(brokerImageName)
           docker logout
       condition: eq(variables['arch'], 'amd64')
 
@@ -54,7 +54,7 @@ jobs:
         sshEndpoint: iotedge-mqtt-perf-arm32v7-conn
         runOptions: commands        
         commands: |
-          docker stop mqtt-broker ; docker system prune -a -f
+          echo $(brokerImageName) > brokerImageName.txt ; docker stop mqtt-broker ; docker system prune -a -f
       # ignore cleanup errors if no containers running
       continueOnError: true 
       condition: eq(variables['arch'], 'arm32v7')
@@ -66,8 +66,8 @@ jobs:
         runOptions: commands
         commands: |
           echo "$(registry.password)" | docker login $(registry.address) --username $(registry.user) --password-stdin 2>/dev/null
-          docker pull $(brokerImageName)
-          docker run -d --network=host --name=mqtt-broker $(brokerImageName)
+          docker pull $$(cat brokerImageName.txt)
+          docker run -d --network=host --security-opt apparmor=docker-default --name=mqtt-broker $(brokerImageName)
           docker logout
       condition: eq(variables['arch'], 'arm32v7')
       

--- a/builds/misc/templates/mqtt-perf-test-case.yaml
+++ b/builds/misc/templates/mqtt-perf-test-case.yaml
@@ -84,7 +84,7 @@ jobs:
       runOptions: commands
       commands: |
         docker rm -f mqtt-broker || true
-        docker run -d --network=host --security-opt apparmor=docker-default --name=mqtt-broker $(cat brokerImageName.txt)
+        docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(cat brokerImageName.txt)
     continueOnError: true 
     condition: eq(variables['arch'], 'amd64')
 
@@ -96,6 +96,6 @@ jobs:
       runOptions: commands
       commands: |
         docker rm -f mqtt-broker || true
-        docker run -d --network=host --security-opt apparmor=docker-default --name=mqtt-broker $(cat brokerImageName.txt)
+        docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(cat brokerImageName.txt)
     continueOnError: true 
     condition: eq(variables['arch'], 'arm32v7')

--- a/builds/misc/templates/mqtt-perf-test-case.yaml
+++ b/builds/misc/templates/mqtt-perf-test-case.yaml
@@ -78,24 +78,38 @@ jobs:
 
   # AMD64 Cleanup
   - task: SSH@0
-    displayName: Restart broker AMD64
+    displayName: Remove broker AMD64
     inputs:
       sshEndpoint: iotedge-mqtt-perf-amd64-conn
       runOptions: commands
       commands: |
         docker rm -f mqtt-broker || true
-        docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(cat brokerImageName.txt)
     continueOnError: true 
+    condition: eq(variables['arch'], 'amd64')
+  - task: SSH@0
+    displayName: Restart broker AMD64
+    inputs:
+      sshEndpoint: iotedge-mqtt-perf-amd64-conn
+      runOptions: commands
+      commands: |
+        docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(cat brokerImageName.txt)
     condition: eq(variables['arch'], 'amd64')
 
   # ARM32 Cleanup
+  - task: SSH@0
+    displayName: Remove broker ARM32
+    inputs:
+      sshEndpoint: iotedge-mqtt-perf-arm32v7-conn
+      runOptions: commands
+      commands: |
+        docker rm -f mqtt-broker || true
+    continueOnError: true 
+    condition: eq(variables['arch'], 'arm32v7')
   - task: SSH@0
     displayName: Restart broker ARM32
     inputs:
       sshEndpoint: iotedge-mqtt-perf-arm32v7-conn
       runOptions: commands
       commands: |
-        docker rm -f mqtt-broker || true
         docker run -d --network=host --security-opt apparmor=unconfined --name=mqtt-broker $(cat brokerImageName.txt)
-    continueOnError: true 
     condition: eq(variables['arch'], 'arm32v7')

--- a/builds/misc/templates/mqtt-perf-test-case.yaml
+++ b/builds/misc/templates/mqtt-perf-test-case.yaml
@@ -83,7 +83,8 @@ jobs:
       sshEndpoint: iotedge-mqtt-perf-amd64-conn
       runOptions: commands
       commands: |
-        docker restart mqtt-broker
+        docker rm -f mqtt-broker || true
+        docker run -d --network=host --security-opt apparmor=docker-default --name=mqtt-broker $(cat brokerImageName.txt)
     continueOnError: true 
     condition: eq(variables['arch'], 'amd64')
 
@@ -94,6 +95,7 @@ jobs:
       sshEndpoint: iotedge-mqtt-perf-arm32v7-conn
       runOptions: commands
       commands: |
-        docker restart mqtt-broker
+        docker rm -f mqtt-broker || true
+        docker run -d --network=host --security-opt apparmor=docker-default --name=mqtt-broker $(cat brokerImageName.txt)
     continueOnError: true 
     condition: eq(variables['arch'], 'arm32v7')


### PR DESCRIPTION
There are few small improvements I propose for MQTT perf tests:
- use `--security-opt apparmor=unconfined` flag to disable apparmor that sometimes causes problems restarting the containers
- use `docker rm -f` && `docker run` instead of `docker restart`
- save image name into local file, for ease of use in later steps.
- make all stages always run even if previous failed.