### PR TITLE
Fixing arm64 image

### DIFF
--- a/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
@@ -2,8 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-
-FROM arm64v8/nginx:1.19.7-alpine
+FROM arm64v8/nginx:1.19.7
 WORKDIR /app
 COPY ./docker/linux/arm64v8/api-proxy-module .
 COPY ./docker/linux/arm64v8/templates .


### PR DESCRIPTION
It addresses the following bug: #9433402
[1.2-rc4BugBash] API proxy: arm64 images do not work
API does not work on arm64

Build:https://dev.azure.com/msazure/One/_build/results?buildId=39970527&view=logs&j=5e897c14-3122-5b03-9993-10a307d9da6f&t=be439baf-4cfc-5b62-e448-a0c93566f55e
Tested on arm64.