### PR TITLE
Update postrm to delete iotedge user on purge

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -106,7 +106,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "serde",
 ]
@@ -225,7 +225,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "http-common",
  "libc",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "pkcs11",
  "serde",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "http-common",
  "serde",
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "serde",
  "toml",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "cc",
 ]
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1888,7 +1888,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2120e3040acf5d5d405114a87cd56ebff6fa1fa8"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/contrib/debian/postrm
+++ b/edgelet/contrib/debian/postrm
@@ -21,6 +21,7 @@ case "$1" in
         done
 
         /usr/sbin/userdel iotedge
+        rm -rf /var/lib/aziot/edged
 
         if [ -d /var/lib/aziot ] && [ -z "$(ls -A /var/lib/aziot)" ]; then
             rm -rf /var/lib/aziot

--- a/edgelet/contrib/debian/postrm
+++ b/edgelet/contrib/debian/postrm
@@ -7,10 +7,7 @@ case "$1" in
 
         if [ -d /etc/aziot ]; then
             rm -rf /etc/aziot/edged
-
-            if [ -z "$(ls -A /etc/aziot)" ]; then
-                rm -rf /etc/aziot
-            fi
+            rm -f /etc/aziot/config.toml
         fi
 
         rm -rf /var/log/aziot

--- a/edgelet/contrib/debian/postrm
+++ b/edgelet/contrib/debian/postrm
@@ -6,18 +6,14 @@ case "$1" in
         systemctl daemon-reload
 
         if [ -d /etc/aziot ]; then
-            if [ -d /etc/aziot/edged ]; then
-                rm -rf /etc/aziot/edged
-            fi
+            rm -rf /etc/aziot/edged
 
             if [ -z "$(ls -A /etc/aziot)" ]; then
                 rm -rf /etc/aziot
             fi
         fi
 
-        if [ -d /var/log/aziot ]; then
-            rm -rf /var/log/aziot
-        fi
+        rm -rf /var/log/aziot
 
         /usr/sbin/userdel iotedge
 

--- a/edgelet/contrib/debian/postrm
+++ b/edgelet/contrib/debian/postrm
@@ -3,22 +3,30 @@ set -e
 
 case "$1" in
     purge)
-        if [ -f /etc/aziot/edged/config.toml ]; then
-            rm /etc/aziot/edged/config.toml
+        systemctl daemon-reload
+
+        if [ -d /etc/aziot ]; then
+            if [ -d /etc/aziot/edged ]; then
+                rm -rf /etc/aziot/edged
+            fi
+
+            if [ -z "$(ls -A /etc/aziot)" ]; then
+                rm -rf /etc/aziot
+            fi
         fi
-        if [ -d /etc/aziot/edged/config.d ]; then
-            rm -r /etc/aziot/edged/config.d
+
+        if [ -d /var/log/aziot ]; then
+            rm -rf /var/log/aziot
         fi
-        if [ -d /var/lib/aziot/edged ]; then
-            rm -rf /var/lib/aziot/edged
-        fi
-        if [ -d /var/log/aziot/edged ]; then
-            rm -rf /var/log/aziot/edged
+
+        /usr/sbin/userdel iotedge
+
+        if [ -d /var/lib/aziot ] && [ -z "$(ls -A /var/lib/aziot)" ]; then
+            rm -rf /var/lib/aziot
         fi
     ;;
     remove|upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
     ;;
-
     *)
         echo "postrm called with unknown argument \`$1'" >&2
         exit 1

--- a/edgelet/contrib/debian/postrm
+++ b/edgelet/contrib/debian/postrm
@@ -15,6 +15,11 @@ case "$1" in
 
         rm -rf /var/log/aziot
 
+        # Remove supplementary members from the iotedge group.
+        for u in $(getent group iotedge | sed -e "s/^.*://" -e "s/,/ /g"); do
+            gpasswd -d "$u" iotedge
+        done
+
         /usr/sbin/userdel iotedge
 
         if [ -d /var/lib/aziot ] && [ -z "$(ls -A /var/lib/aziot)" ]; then

--- a/edgelet/contrib/debian/preinst
+++ b/edgelet/contrib/debian/preinst
@@ -3,37 +3,38 @@ set -e
 
 add_groups()
 {
-    if ! getent passwd iotedge >/dev/null; then
-        adduser --system iotedge --home /var/lib/aziot/edged --shell /bin/false
+    if ! getent group iotedge >/dev/null; then
+        groupadd -r iotedge
     fi
 
-    if ! getent group iotedge >/dev/null; then
-        addgroup --system iotedge
+    if ! getent passwd iotedge >/dev/null; then
+        useradd -r -g iotedge -c 'iotedge user' -s /sbin/nologin -d /var/lib/aziot/edged iotedge
     fi
+    mkdir -p /var/lib/aziot/edged
 
     # add iotedge user to docker group so that it can talk to the docker socket
     if getent group docker >/dev/null; then
-        adduser iotedge docker
+        usermod -aG docker iotedge
     fi
 
     if getent group aziotcs >/dev/null; then
-        adduser iotedge aziotcs
+        usermod -aG aziotcs iotedge
     fi
     if getent group aziotks >/dev/null; then
-        adduser iotedge aziotks
+        usermod -aG aziotks iotedge
     fi
     if getent group aziotid >/dev/null; then
-        adduser iotedge aziotid
+        usermod -aG aziotid iotedge
     fi
 
     # Add each admin user to the iotedge group - for systems installed before precise
     for u in $(getent group admin | sed -e "s/^.*://" -e "s/,/ /g"); do
-        adduser "$u" iotedge >/dev/null || true
+        usermod -aG iotedge "$u" >/dev/null || true
     done
 
     # Add each sudo user to the iotedge group
     for u in $(getent group sudo | sed -e "s/^.*://" -e "s/,/ /g"); do
-        adduser "$u" iotedge >/dev/null || true
+        usermod -aG iotedge "$u" >/dev/null || true
     done
 }
 


### PR DESCRIPTION
Updates postrm so that apt purge fully removes all files used by aziot-edge and removes iotedge user.

This only applies to Debian, as CentOS (rpm) doesn't have a purge command.