### PR TITLE
Fix DownloadIdentityService for iot-identity-service branches

### DIFF
--- a/scripts/local/test/DownloadIdentityService.ps1
+++ b/scripts/local/test/DownloadIdentityService.ps1
@@ -66,7 +66,7 @@ for($page = 1; ; $page++)
 
     $artifacts_link = $actions_runs.workflow_runs | `
     where {($_.head_sha -eq $aziot_commit) -and ($_.name -eq 'packages')} | `
-    Select-Object -ExpandProperty artifacts_url
+    Select-Object -First 1 -ExpandProperty artifacts_url
 
     if([string]::IsNullOrEmpty($artifacts_link))
     {


### PR DESCRIPTION
If iot-identity-service has the same commit in multiple branches, duplicate artifacts will be found. Fix DownloadIdentityService to only consider the first artifact.