### PR TITLE
Update release artifact output format for RC releases

### DIFF
--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -89,5 +89,5 @@ jobs:
         displayName: Publish Artifacts
         inputs:
           PathtoPublish: '$(build.artifactstagingdirectory)'
-          ArtifactName: 'iotedged-$(os)-$(arch)'
+          ArtifactName: 'aziotedge-$(os)-$(arch)'
         condition: succeededOrFailed()

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -78,7 +78,7 @@ jobs:
       - script: edgelet/build/linux/package.sh
         displayName: Create aziotedge packages
       - task: CopyFiles@2
-        displayName: Copy aziot-edge Files to Artifact Staging
+        displayName: Copy aziotedge Files to Artifact Staging
         inputs:
           SourceFolder: $(target.aziotedge)
           Contents: |

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -15,57 +15,57 @@ jobs:
         Centos75-amd64:
           arch: amd64
           os: centos7
-          target.iotedged: edgelet/target/rpmbuild/RPMS/x86_64
+          target.aziotedge: edgelet/target/rpmbuild/RPMS/x86_64
         Debian9-amd64:
           os: debian9
           arch: amd64
-          target.iotedged: edgelet/target/release
+          target.aziotedge: edgelet/target/release
         Debian9-arm32v7:
           os: debian9
           arch: arm32v7
-          target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+          target.aziotedge: edgelet/target/armv7-unknown-linux-gnueabihf/release
         Debian9-aarch64:
           os: debian9
           arch: aarch64
-          target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+          target.aziotedge: edgelet/target/aarch64-unknown-linux-gnu/release
 
         Debian10-amd64:
           os: debian10
           arch: amd64
-          target.iotedged: edgelet/target/release
+          target.aziotedge: edgelet/target/release
         Debian10-arm32v7:
           os: debian10
           arch: arm32v7
-          target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+          target.aziotedge: edgelet/target/armv7-unknown-linux-gnueabihf/release
         Debian10-aarch64:
           os: debian10
           arch: aarch64
-          target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+          target.aziotedge: edgelet/target/aarch64-unknown-linux-gnu/release
           
         Ubuntu1804-amd64:
           os: ubuntu18.04
           arch: amd64
-          target.iotedged: edgelet/target/release
+          target.aziotedge: edgelet/target/release
         Ubuntu1804-arm32v7:
           os: ubuntu18.04
           arch: arm32v7
-          target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+          target.aziotedge: edgelet/target/armv7-unknown-linux-gnueabihf/release
         Ubuntu1804-aarch64:
           os: ubuntu18.04
           arch: aarch64
-          target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+          target.aziotedge: edgelet/target/aarch64-unknown-linux-gnu/release
         Ubuntu2004-amd64:
           arch: amd64
           os: ubuntu20.04
-          target.iotedged: edgelet/target/release
+          target.aziotedge: edgelet/target/release
         Ubuntu2004-arm32v7:
           arch: arm32v7
           os: ubuntu20.04
-          target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+          target.aziotedge: edgelet/target/armv7-unknown-linux-gnueabihf/release
         Ubuntu2004-aarch64:
           arch: aarch64
           os: ubuntu20.04
-          target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+          target.aziotedge: edgelet/target/aarch64-unknown-linux-gnu/release
     steps:
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
@@ -76,11 +76,11 @@ jobs:
           echo "##vso[task.setvariable variable=PACKAGE_OS;]$(os)"
         displayName: Set Version
       - script: edgelet/build/linux/package.sh
-        displayName: Create iotedged packages
+        displayName: Create aziotedge packages
       - task: CopyFiles@2
-        displayName: Copy iotedged Files to Artifact Staging
+        displayName: Copy aziot-edge Files to Artifact Staging
         inputs:
-          SourceFolder: $(target.iotedged)
+          SourceFolder: $(target.aziotedge)
           Contents: |
             *.deb
             *.rpm

--- a/edgelet/build/linux/package.sh
+++ b/edgelet/build/linux/package.sh
@@ -292,5 +292,9 @@ docker run --rm \
         $MAKE_COMMAND
     "
 
+# Rename the RC output artifacts from '*~rc' to be '*-rc'
+find "$PROJECT_ROOT" -name '*.deb' -execdir sh -c 'x="{}"; y=$(echo $x | sed -e "s/~/-/g"); mv "$x" "$y" 2>/dev/null' \;
+find "$PROJECT_ROOT" -name '*.rpm' -execdir sh -c 'x="{}"; y=$(echo $x | sed -e "s/~/-/g"); mv "$x" "$y" 2>/dev/null' \;
+
 find "$PROJECT_ROOT" -name '*.deb'
 find "$PROJECT_ROOT" -name '*.rpm'


### PR DESCRIPTION
Change an RC artifacts naming from `~rc` to be `-rc` according to [Debian standard](https://kerneltalks.com/tools/understanding-package-naming-convention-rpm-deb/#:~:text=1%20It%20starts%20with%20the%20package%20name%202,by%20a%20dot%20.%20...%20More%20items...) e.g. 

`aziot-edge_1.2.0~rc4-1_amd64.deb`  --> `aziot-edge_1.2.0-rc4-1_amd64.deb`