### PR TITLE
Fix package purge when aziot-edged is running

### DIFF
--- a/edgelet/contrib/debian/postrm
+++ b/edgelet/contrib/debian/postrm
@@ -4,6 +4,7 @@ set -e
 case "$1" in
     purge)
         systemctl daemon-reload
+        killall -SIGKILL -u iotedge || true
 
         if [ -d /etc/aziot ]; then
             rm -rf /etc/aziot/edged


### PR DESCRIPTION
Sometimes, `apt purge aziot-edge` fails because the `iotedge` user still has running processes during purge. Fix this by killing all processes running under the `iotedge` user before purging.