### PR TITLE
Nested Longhaul: Fix upstream protocol and test name

### DIFF
--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -15,12 +15,10 @@ resources:
 
 stages:
 - stage: SetupVMs
-  variables:
-      upstream.protocol: 'mqtt'
   jobs:
   - template: templates/nested-parent-vm-setup.yaml
     parameters: 
-      upstreamProtocol: '$(upstream.protocol)'
+      upstreamProtocol: 'mqtt'
   - job:  Deploy_Connectivity_Linux_Amd64
     displayName: Set up and run connectivity tests on Linux Amd64
     dependsOn: SetupVM_level4_mqtt
@@ -84,6 +82,7 @@ stages:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb   
       artifactName: iotedged-ubuntu18.04-amd64
+      upstream.protocol: 'mqtt'
     steps:  
       - template: templates/set-run-flag.yaml
       - task: Bash@3

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -149,6 +149,7 @@ stages:
           aziotis.artifact.name: '$(aziotis.artifact.name)'
           aziotis.package.filter: '$(aziotis.package.filter)'
           connectivity.nested: 'true'
+          testInfo.testName: '$(testInfo.testName)'
   - job:  Clean_up      
     dependsOn:
       - SetupVM_level5_mqtt

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -15,10 +15,12 @@ resources:
 
 stages:
 - stage: SetupVMs
+  variables:
+      upstream.protocol: 'mqtt'
   jobs:
   - template: templates/nested-parent-vm-setup.yaml
     parameters: 
-      transportType: mqtt
+      upstreamProtocol: '$(upstream.protocol)'
   - job:  Deploy_Connectivity_Linux_Amd64
     displayName: Set up and run connectivity tests on Linux Amd64
     dependsOn: SetupVM_level4_mqtt

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -18,7 +18,7 @@ stages:
   jobs:
   - template: templates/nested-parent-vm-setup.yaml
     parameters: 
-      upstreamProtocol: 'mqtt'
+      upstream.protocol: 'mqtt'
   - job:  Deploy_Connectivity_Linux_Amd64
     displayName: Set up and run connectivity tests on Linux Amd64
     dependsOn: SetupVM_level4_mqtt

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -18,7 +18,7 @@ stages:
   jobs:
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      transportType: mqtt
+      upstream.protocol: mqtt
   - job:  SetupVM_and_RunTest_level3
     dependsOn:
       - SetupVM_level5_mqtt

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -18,17 +18,17 @@ stages:
   jobs:
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      upstreamProtocol: amqp
+      upstream.protocol: amqp
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
-      upstreamProtocol: amqp
+      upstream.protocol: amqp
       testInfo.testName: 'longhaul (nested-non-broker)'
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      upstreamProtocol: mqtt
+      upstream.protocol: mqtt
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
-      upstreamProtocol: mqtt
+      upstream.protocol: mqtt
       testInfo.testName: 'longhaul (nested-broker)'
 
   - job:  Clean_up      

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -22,12 +22,14 @@ stages:
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
       upstreamProtocol: amqp
+      testInfo.testName: 'longhaul (nested-non-broker)'
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
       upstreamProtocol: mqtt
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
       upstreamProtocol: mqtt
+      testInfo.testName: 'longhaul (nested-broker)'
 
   - job:  Clean_up      
     dependsOn:

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -18,16 +18,16 @@ stages:
   jobs:
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      transportType: amqp
+      upstreamProtocol: amqp
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
-      transportType: amqp
+      upstreamProtocol: amqp
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      transportType: mqtt
+      upstreamProtocol: mqtt
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
-      transportType: mqtt
+      upstreamProtocol: mqtt
 
   - job:  Clean_up      
     dependsOn:

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -18,17 +18,17 @@ stages:
   jobs:
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      upstream.protocol: 'amqp'
+      upstream.protocol: amqp
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
-      upstream.protocol: 'amqp'
+      upstream.protocol: amqp
       testInfo.testName: 'longhaul (nested-non-broker)'
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      upstream.protocol: 'mqtt'
+      upstream.protocol: mqtt
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
-      upstream.protocol: 'mqtt'
+      upstream.protocol: mqtt
       testInfo.testName: 'longhaul (nested-broker)'
 
   - job:  Clean_up      

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -18,17 +18,17 @@ stages:
   jobs:
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      upstream.protocol: amqp
+      upstream.protocol: 'amqp'
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
-      upstream.protocol: amqp
+      upstream.protocol: 'amqp'
       testInfo.testName: 'longhaul (nested-non-broker)'
   - template: templates/nested-parent-vm-setup.yaml
     parameters:
-      upstream.protocol: mqtt
+      upstream.protocol: 'mqtt'
   - template: templates/nested-longhaul-deploy-amd64.yaml
     parameters:
-      upstream.protocol: mqtt
+      upstream.protocol: 'mqtt'
       testInfo.testName: 'longhaul (nested-broker)'
 
   - job:  Clean_up      

--- a/builds/e2e/templates/nested-create-identity.yaml
+++ b/builds/e2e/templates/nested-create-identity.yaml
@@ -19,7 +19,7 @@ steps:
         echo "Found Hub name: ${iotHubName}"
 
         az account set --subscription $(azure.subscription)
-        deviceId="level_$(level)_$(Build.BuildId)$(transportType)"
+        deviceId="level_$(level)_$(Build.BuildId)$(upstreamProtocol)"
 
         echo "Creating ${deviceId} iotedge in iothub: ${iotHubName}, in subscription $(azure.subscription)"
         if [ "$LEVEL" = "5" ]; then

--- a/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
@@ -33,7 +33,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json'
+          test.deploymentFileName: "nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json"
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'

--- a/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
@@ -1,10 +1,10 @@
 parameters:
-  transportType: ''
+  upstreamProtocol: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Amd64_${{ parameters.transportType }}
-    displayName: Set up and run longhaul tests on Linux Amd64 for ${{ parameters.transportType }}
-    dependsOn: SetupVM_level4_${{ parameters.transportType }}
+  - job:  Deploy_Longhaul_Linux_Amd64_${{ parameters.upstreamProtocol }}
+    displayName: Set up and run longhaul tests on Linux Amd64 for ${{ parameters.upstreamProtocol }}
+    dependsOn: SetupVM_level4_${{ parameters.upstreamProtocol }}
     condition: and(succeeded(), eq(variables['run.linux.amd64.moby'], 'true'))
     pool:
       name: $(pool.name)
@@ -14,8 +14,8 @@ jobs:
         - Agent.OSArchitecture -equals X64
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.transportType }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.transportType }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-ubuntu18.04-amd64'
       identityServiceArtifactName: 'packages_ubuntu-18.04_amd64'
       identityServicePackageFilter: 'aziot-identity-service_*_amd64.deb'
@@ -32,7 +32,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.transportType }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstreamProtocol }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'
@@ -65,3 +65,4 @@ jobs:
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
           testInfo.testName: '$(testInfo.testName)'
+          upstreamProtocol: ${{ parameters.upstreamProtocol }}

--- a/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
@@ -1,11 +1,11 @@
 parameters:
-  upstreamProtocol: ''
+  upstream.protocol: ''
   testInfo.testName: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Amd64_${{ parameters.upstreamProtocol }}
-    displayName: Set up and run longhaul tests on Linux Amd64 for ${{ parameters.upstreamProtocol }}
-    dependsOn: SetupVM_level4_${{ parameters.upstreamProtocol }}
+  - job:  Deploy_Longhaul_Linux_Amd64_${{ parameters.upstream.protocol }}
+    displayName: Set up and run longhaul tests on Linux Amd64 for ${{ parameters.upstream.protocol }}
+    dependsOn: SetupVM_level4_${{ parameters.upstream.protocol }}
     condition: and(succeeded(), eq(variables['run.linux.amd64.moby'], 'true'))
     pool:
       name: $(pool.name)
@@ -15,8 +15,8 @@ jobs:
         - Agent.OSArchitecture -equals X64
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-ubuntu18.04-amd64'
       identityServiceArtifactName: 'packages_ubuntu-18.04_amd64'
       identityServicePackageFilter: 'aziot-identity-service_*_amd64.deb'
@@ -33,7 +33,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstreamProtocol }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstream.protocol }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'
@@ -66,4 +66,4 @@ jobs:
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
           testInfo.testName: "${{ parameters['testInfo.testName'] }}"
-          upstreamProtocol: "${{ parameters['upstreamProtocol'] }}"
+          upstream.protocol: "${{ parameters['upstream.protocol'] }}"

--- a/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
@@ -3,9 +3,9 @@ parameters:
   testInfo.testName: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Amd64_${{ parameters.upstream.protocol }}
-    displayName: Set up and run longhaul tests on Linux Amd64 for ${{ parameters.upstream.protocol }}
-    dependsOn: SetupVM_level4_${{ parameters.upstream.protocol }}
+  - job:  Deploy_Longhaul_Linux_Amd64_${{ parameters['upstream.protocol'] }}
+    displayName: Set up and run longhaul tests on Linux Amd64 for ${{ parameters['upstream.protocol'] }}
+    dependsOn: SetupVM_level4_${{ parameters['upstream.protocol'] }}
     condition: and(succeeded(), eq(variables['run.linux.amd64.moby'], 'true'))
     pool:
       name: $(pool.name)
@@ -15,8 +15,8 @@ jobs:
         - Agent.OSArchitecture -equals X64
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters['upstream.protocol'] }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters['upstream.protocol'] }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-ubuntu18.04-amd64'
       identityServiceArtifactName: 'packages_ubuntu-18.04_amd64'
       identityServicePackageFilter: 'aziot-identity-service_*_amd64.deb'
@@ -33,7 +33,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstream.protocol }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'

--- a/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-amd64.yaml
@@ -1,5 +1,6 @@
 parameters:
   upstreamProtocol: ''
+  testInfo.testName: ''
 
 jobs:
   - job:  Deploy_Longhaul_Linux_Amd64_${{ parameters.upstreamProtocol }}
@@ -64,5 +65,5 @@ jobs:
           longHaul.parentEdgeDevice: '$(parentDeviceId)'
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
-          testInfo.testName: '$(testInfo.testName)'
-          upstreamProtocol: ${{ parameters.upstreamProtocol }}
+          testInfo.testName: "${{ parameters['testInfo.testName'] }}"
+          upstreamProtocol: "${{ parameters['upstreamProtocol'] }}"

--- a/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
@@ -1,22 +1,22 @@
 parameters:
-  transportType: ''
+  upstreamProtocol: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Arm32_${{ parameters.transportType }}
-    displayName: Set up and run longhaul tests on Linux Arm32 for ${{ parameters.transportType }}
-    dependsOn: SetupVM_level4_${{ parameters.transportType }}
+  - job:  Deploy_Longhaul_Linux_Arm32_${{ parameters.upstreamProtocol }}
+    displayName: Set up and run longhaul tests on Linux Arm32 for ${{ parameters.upstreamProtocol }}
+    dependsOn: SetupVM_level4_${{ parameters.upstreamProtocol }}
     condition: and(succeeded(), eq(variables['run.linux.arm32v7.moby'], 'true'))
     pool:
       name: $(pool.name)
       demands:
-        - agent-group -equals $(agent.group)-${{ parameters.transportType }}
+        - agent-group -equals $(agent.group)-${{ parameters.upstreamProtocol }}
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 32
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.transportType }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.transportType }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-debian9-arm32v7'
       identityServiceArtifactName: 'packages_debian-9-slim_arm32v7'
       identityServicePackageFilter: 'aziot-identity-service_*_armhf.deb'
@@ -33,7 +33,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.transportType }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstreamProtocol }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'
@@ -66,3 +66,4 @@ jobs:
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
           testInfo.testName: '$(testInfo.testName)'
+          upstreamProtocol: ${{ parameters.upstreamProtocol }} 

--- a/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
@@ -34,7 +34,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json'
+          test.deploymentFileName: "nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json"
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'

--- a/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
@@ -1,23 +1,23 @@
 parameters:
-  upstreamProtocol: ''
+  upstream.protocol: ''
   testInfo.testName: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Arm32_${{ parameters.upstreamProtocol }}
-    displayName: Set up and run longhaul tests on Linux Arm32 for ${{ parameters.upstreamProtocol }}
-    dependsOn: SetupVM_level4_${{ parameters.upstreamProtocol }}
+  - job:  Deploy_Longhaul_Linux_Arm32_${{ parameters.upstream.protocol }}
+    displayName: Set up and run longhaul tests on Linux Arm32 for ${{ parameters.upstream.protocol }}
+    dependsOn: SetupVM_level4_${{ parameters.upstream.protocol }}
     condition: and(succeeded(), eq(variables['run.linux.arm32v7.moby'], 'true'))
     pool:
       name: $(pool.name)
       demands:
-        - agent-group -equals $(agent.group)-${{ parameters.upstreamProtocol }}
+        - agent-group -equals $(agent.group)-${{ parameters.upstream.protocol }}
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 32
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-debian9-arm32v7'
       identityServiceArtifactName: 'packages_debian-9-slim_arm32v7'
       identityServicePackageFilter: 'aziot-identity-service_*_armhf.deb'
@@ -34,7 +34,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstreamProtocol }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstream.protocol }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'
@@ -67,4 +67,4 @@ jobs:
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
           testInfo.testName: "${{ parameters['testInfo.testName'] }}"
-          upstreamProtocol: "${{ parameters['upstreamProtocol'] }}"
+          upstream.protocol: "${{ parameters['upstream.protocol'] }}"

--- a/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
@@ -1,5 +1,6 @@
 parameters:
   upstreamProtocol: ''
+  testInfo.testName: ''
 
 jobs:
   - job:  Deploy_Longhaul_Linux_Arm32_${{ parameters.upstreamProtocol }}
@@ -65,5 +66,5 @@ jobs:
           longHaul.parentEdgeDevice: '$(parentDeviceId)'
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
-          testInfo.testName: '$(testInfo.testName)'
-          upstreamProtocol: ${{ parameters.upstreamProtocol }} 
+          testInfo.testName: "${{ parameters['testInfo.testName'] }}"
+          upstreamProtocol: "${{ parameters['upstreamProtocol'] }}"

--- a/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm32.yaml
@@ -3,21 +3,21 @@ parameters:
   testInfo.testName: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Arm32_${{ parameters.upstream.protocol }}
-    displayName: Set up and run longhaul tests on Linux Arm32 for ${{ parameters.upstream.protocol }}
-    dependsOn: SetupVM_level4_${{ parameters.upstream.protocol }}
+  - job:  Deploy_Longhaul_Linux_Arm32_${{ parameters['upstream.protocol'] }}
+    displayName: Set up and run longhaul tests on Linux Arm32 for ${{ parameters['upstream.protocol'] }}
+    dependsOn: SetupVM_level4_${{ parameters['upstream.protocol'] }}
     condition: and(succeeded(), eq(variables['run.linux.arm32v7.moby'], 'true'))
     pool:
       name: $(pool.name)
       demands:
-        - agent-group -equals $(agent.group)-${{ parameters.upstream.protocol }}
+        - agent-group -equals $(agent.group)-${{ parameters['upstream.protocol'] }}
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 32
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters['upstream.protocol'] }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters['upstream.protocol'] }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-debian9-arm32v7'
       identityServiceArtifactName: 'packages_debian-9-slim_arm32v7'
       identityServicePackageFilter: 'aziot-identity-service_*_armhf.deb'
@@ -34,7 +34,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstream.protocol }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'

--- a/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
@@ -3,21 +3,21 @@ parameters:
   testInfo.testName: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Arm64_${{ parameters.upstream.protocol }}
-    displayName: Set up and run longhaul tests on Linux Arm64 for ${{ parameters.upstream.protocol }}
-    dependsOn: SetupVM_level4_${{ parameters.upstream.protocol }}
+  - job:  Deploy_Longhaul_Linux_Arm64_${{ parameters['upstream.protocol'] }}
+    displayName: Set up and run longhaul tests on Linux Arm64 for ${{ parameters['upstream.protocol'] }}
+    dependsOn: SetupVM_level4_${{ parameters['upstream.protocol'] }}
     condition: and(succeeded(), eq(variables['run.linux.arm64v8.docker'], 'true'))
     pool:
       name: $(pool.name)
       demands:
-        - agent-group -equals $(agent.group)-${{ parameters.upstream.protocol }}
+        - agent-group -equals $(agent.group)-${{ parameters['upstream.protocol'] }}
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 64
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters['upstream.protocol'] }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters['upstream.protocol'] }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-ubuntu18.04-aarch64'
       identityServiceArtifactName: 'packages_ubuntu-18.04_aarch64'
       identityServicePackageFilter: 'aziot-identity-service_*_arm64.deb'
@@ -34,7 +34,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstream.protocol }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'

--- a/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
@@ -1,5 +1,6 @@
 parameters:
   upstreamProtocol: ''
+  testInfo.testName: ''
 
 jobs:
   - job:  Deploy_Longhaul_Linux_Arm64_${{ parameters.upstreamProtocol }}
@@ -65,4 +66,5 @@ jobs:
           longHaul.parentEdgeDevice: '$(parentDeviceId)'
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
-          upstreamProtocol: ${{ parameters.upstreamProtocol }}
+          testInfo.testName: "${{ parameters['testInfo.testName'] }}"
+          upstreamProtocol: "${{ parameters['upstreamProtocol'] }}"

--- a/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
@@ -1,22 +1,22 @@
 parameters:
-  transportType: ''
+  upstreamProtocol: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Arm64_${{ parameters.transportType }}
-    displayName: Set up and run longhaul tests on Linux Arm64 for ${{ parameters.transportType }}
-    dependsOn: SetupVM_level4_${{ parameters.transportType }}
+  - job:  Deploy_Longhaul_Linux_Arm64_${{ parameters.upstreamProtocol }}
+    displayName: Set up and run longhaul tests on Linux Arm64 for ${{ parameters.upstreamProtocol }}
+    dependsOn: SetupVM_level4_${{ parameters.upstreamProtocol }}
     condition: and(succeeded(), eq(variables['run.linux.arm64v8.docker'], 'true'))
     pool:
       name: $(pool.name)
       demands:
-        - agent-group -equals $(agent.group)-${{ parameters.transportType }}
+        - agent-group -equals $(agent.group)-${{ parameters.upstreamProtocol }}
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 64
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.transportType }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.transportType }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-ubuntu18.04-aarch64'
       identityServiceArtifactName: 'packages_ubuntu-18.04_aarch64'
       identityServicePackageFilter: 'aziot-identity-service_*_arm64.deb'
@@ -33,7 +33,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.transportType }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstreamProtocol }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'
@@ -65,3 +65,4 @@ jobs:
           longHaul.parentEdgeDevice: '$(parentDeviceId)'
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
+          upstreamProtocol: ${{ parameters.upstreamProtocol }}

--- a/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
@@ -34,7 +34,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json'
+          test.deploymentFileName: "nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters['upstream.protocol'] }}.template.json"
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'

--- a/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy-arm64.yaml
@@ -1,23 +1,23 @@
 parameters:
-  upstreamProtocol: ''
+  upstream.protocol: ''
   testInfo.testName: ''
 
 jobs:
-  - job:  Deploy_Longhaul_Linux_Arm64_${{ parameters.upstreamProtocol }}
-    displayName: Set up and run longhaul tests on Linux Arm64 for ${{ parameters.upstreamProtocol }}
-    dependsOn: SetupVM_level4_${{ parameters.upstreamProtocol }}
+  - job:  Deploy_Longhaul_Linux_Arm64_${{ parameters.upstream.protocol }}
+    displayName: Set up and run longhaul tests on Linux Arm64 for ${{ parameters.upstream.protocol }}
+    dependsOn: SetupVM_level4_${{ parameters.upstream.protocol }}
     condition: and(succeeded(), eq(variables['run.linux.arm64v8.docker'], 'true'))
     pool:
       name: $(pool.name)
       demands:
-        - agent-group -equals $(agent.group)-${{ parameters.upstreamProtocol }}
+        - agent-group -equals $(agent.group)-${{ parameters.upstream.protocol }}
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals ARM
         - agent-osbits -equals 64
         - status -equals unlocked  
     variables:
-      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstreamProtocol }}.outputs['createIdentity.parentDeviceId'] ] 
+      parentName: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level4_${{ parameters.upstream.protocol }}.outputs['createIdentity.parentDeviceId'] ] 
       edgelet.artifact.name: 'iotedged-ubuntu18.04-aarch64'
       identityServiceArtifactName: 'packages_ubuntu-18.04_aarch64'
       identityServicePackageFilter: 'aziot-identity-service_*_arm64.deb'
@@ -34,7 +34,7 @@ jobs:
           test.buildNumber: '$(Build.BuildNumber)'
           test.buildId: '$(Build.BuildId)'
           test.startDelay: '$(test.startDelay)'
-          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstreamProtocol }}.template.json'
+          test.deploymentFileName: 'nestededge_bottomLayerBaseDeployment_long_haul_${{ parameters.upstream.protocol }}.template.json'
           build.source.branch: '$(Build.SourceBranchName)'
           edgelet.source.branch: '$(edgelet.package.branchName)'
           images.source.branch: '$(images.branchName)'
@@ -67,4 +67,4 @@ jobs:
           testResultCoordinator.storageAccountConnectionString: '$(EdgeLonghaulStorageAccountConnString)'
           quickstart.package.name: '$(quickstart.package.name)'
           testInfo.testName: "${{ parameters['testInfo.testName'] }}"
-          upstreamProtocol: "${{ parameters['upstreamProtocol'] }}"
+          upstream.protocol: "${{ parameters['upstream.protocol'] }}"

--- a/builds/e2e/templates/nested-longhaul-deploy.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy.yaml
@@ -36,7 +36,7 @@ parameters:
   longHaul.parentEdgeDevice: ''
   testResultCoordinator.storageAccountConnectionString: ''
   quickstart.package.name: ''
-  upstreamProtocol: ''
+  upstream.protocol: ''
 
 steps:
   - checkout: self
@@ -187,7 +187,7 @@ steps:
             -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
             -desiredModulesToRestartCSV "${{ parameters['longHaul.desiredModulesToRestartCSV'] }}" \
             -sendReportFrequency "${{ parameters['longHaul.sendReportFrequency'] }}" \
-            -upstreamProtocol "${{ parameters['upstreamProtocol'] }}" \
+            -upstreamProtocol "${{ parameters['upstream.protocol'] }}" \
             -waitForTestComplete \
             -cleanAll
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/nested-longhaul-deploy.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy.yaml
@@ -3,6 +3,7 @@ parameters:
   test.buildNumber: ''
   test.buildId: ''
   test.startDelay: ''
+  test.deploymentFileName: ''
   build.source.branch: ''
   build.repo.path: ''
   edgelet.source.branch: ''
@@ -35,7 +36,8 @@ parameters:
   longHaul.parentEdgeDevice: ''
   testResultCoordinator.storageAccountConnectionString: ''
   quickstart.package.name: ''
-  test.deploymentFileName: ''
+  upstreamProtocol: ''
+
 steps:
   - checkout: self
     clean: true
@@ -185,6 +187,7 @@ steps:
             -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
             -desiredModulesToRestartCSV "${{ parameters['longHaul.desiredModulesToRestartCSV'] }}" \
             -sendReportFrequency "${{ parameters['longHaul.sendReportFrequency'] }}" \
+            -upstreamProtocol "${{ parameters['upstreamProtocol'] }}" \
             -waitForTestComplete \
             -cleanAll
       workingDirectory: "$(Agent.HomeDirectory)/.."

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -40,7 +40,7 @@ jobs:
       artifactName: iotedged-ubuntu18.04-amd64
       parentName: $[ dependencies.SetupVM_level5_${{ parameters['upstream.protocol'] }}.outputs['deployIoTEdge.deviceName'] ]
       parentDeviceId: $[ dependencies.SetupVM_level5_${{ parameters['upstream.protocol'] }}.outputs['createIdentity.parentDeviceId'] ]
-      deploymentFile: 'nestededge_middleLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json'
+      deploymentFile: "nestededge_middleLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json"
       level: 4
       upstreamProtocol: ${{ parameters['upstream.protocol'] }}
     pool:

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -1,19 +1,19 @@
 parameters:
-  upstreamProtocol: 'amqp'
+  upstream.protocol: 'amqp'
 
 jobs:
-  - job: SetupVM_level5_${{ parameters.upstreamProtocol }}
-    displayName: SettingUp level 5 for ${{ parameters.upstreamProtocol }}
+  - job: SetupVM_level5_${{ parameters.upstream.protocol }}
+    displayName: SettingUp level 5 for ${{ parameters.upstream.protocol }}
     timeoutInMinutes: 180
     variables:
       artifactName: iotedged-ubuntu18.04-amd64
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       level: 5
-      deploymentFile: 'nestededge_topLayerBaseDeployment_${{ parameters.upstreamProtocol }}.json'
+      deploymentFile: 'nestededge_topLayerBaseDeployment_${{ parameters.upstream.protocol }}.json'
       parentName: ''
       parentDeviceId: ''
-      transportType: ${{ parameters.upstreamProtocol }}
+      upstream.protocol: ${{ parameters.upstream.protocol }}
     pool:
      name: $(pool.name)
      demands:
@@ -29,20 +29,20 @@ jobs:
      - template: nested-create-identity.yaml   
      - template: nested-agent-deploy.yaml
 
-  - job: SetupVM_level4_${{ parameters.upstreamProtocol }}
-    dependsOn: SetupVM_level5_${{ parameters.upstreamProtocol }}
-    displayName: SettingUp level 4 for ${{ parameters.upstreamProtocol }}
+  - job: SetupVM_level4_${{ parameters.upstream.protocol }}
+    dependsOn: SetupVM_level5_${{ parameters.upstream.protocol }}
+    displayName: SettingUp level 4 for ${{ parameters.upstream.protocol }}
     condition: succeeded()
     timeoutInMinutes: 180
     variables:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb   
       artifactName: iotedged-ubuntu18.04-amd64
-      parentName: $[ dependencies.SetupVM_level5_${{ parameters.upstreamProtocol }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level5_${{ parameters.upstreamProtocol }}.outputs['createIdentity.parentDeviceId'] ]
-      deploymentFile: 'nestededge_middleLayerBaseDeployment_${{ parameters.upstreamProtocol }}.json'
+      parentName: $[ dependencies.SetupVM_level5_${{ parameters.upstream.protocol }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level5_${{ parameters.upstream.protocol }}.outputs['createIdentity.parentDeviceId'] ]
+      deploymentFile: 'nestededge_middleLayerBaseDeployment_${{ parameters.upstream.protocol }}.json'
       level: 4
-      transportType: ${{ parameters.upstreamProtocol }}
+      upstreamProtocol: ${{ parameters.upstream.protocol }}
     pool:
      name: $(pool.name)
      demands:

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -10,7 +10,7 @@ jobs:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       level: 5
-      deploymentFile: nestededge_topLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json
+      deploymentFile: "nestededge_topLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json"
       parentName: ''
       parentDeviceId: ''
       upstream.protocol: ${{ parameters['upstream.protocol'] }}

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -2,18 +2,18 @@ parameters:
   upstream.protocol: 'amqp'
 
 jobs:
-  - job: SetupVM_level5_${{ parameters.upstream.protocol }}
-    displayName: SettingUp level 5 for ${{ parameters.upstream.protocol }}
+  - job: SetupVM_level5_${{ parameters['upstream.protocol'] }}
+    displayName: SettingUp level 5 for ${{ parameters['upstream.protocol'] }}
     timeoutInMinutes: 180
     variables:
       artifactName: iotedged-ubuntu18.04-amd64
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       level: 5
-      deploymentFile: 'nestededge_topLayerBaseDeployment_${{ parameters.upstream.protocol }}.json'
+      deploymentFile: 'nestededge_topLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json'
       parentName: ''
       parentDeviceId: ''
-      upstream.protocol: ${{ parameters.upstream.protocol }}
+      upstream.protocol: ${{ parameters['upstream.protocol'] }}
     pool:
      name: $(pool.name)
      demands:
@@ -29,20 +29,20 @@ jobs:
      - template: nested-create-identity.yaml   
      - template: nested-agent-deploy.yaml
 
-  - job: SetupVM_level4_${{ parameters.upstream.protocol }}
-    dependsOn: SetupVM_level5_${{ parameters.upstream.protocol }}
-    displayName: SettingUp level 4 for ${{ parameters.upstream.protocol }}
+  - job: SetupVM_level4_${{ parameters['upstream.protocol'] }}
+    dependsOn: SetupVM_level5_${{ parameters['upstream.protocol'] }}
+    displayName: SettingUp level 4 for ${{ parameters['upstream.protocol'] }}
     condition: succeeded()
     timeoutInMinutes: 180
     variables:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb   
       artifactName: iotedged-ubuntu18.04-amd64
-      parentName: $[ dependencies.SetupVM_level5_${{ parameters.upstream.protocol }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level5_${{ parameters.upstream.protocol }}.outputs['createIdentity.parentDeviceId'] ]
-      deploymentFile: 'nestededge_middleLayerBaseDeployment_${{ parameters.upstream.protocol }}.json'
+      parentName: $[ dependencies.SetupVM_level5_${{ parameters['upstream.protocol'] }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level5_${{ parameters['upstream.protocol'] }}.outputs['createIdentity.parentDeviceId'] ]
+      deploymentFile: 'nestededge_middleLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json'
       level: 4
-      upstreamProtocol: ${{ parameters.upstream.protocol }}
+      upstreamProtocol: ${{ parameters['upstream.protocol'] }}
     pool:
      name: $(pool.name)
      demands:

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -1,19 +1,19 @@
 parameters:
-  transportType: 'amqp'
+  upstreamProtocol: 'amqp'
 
 jobs:
-  - job: SetupVM_level5_${{ parameters.transportType }}
-    displayName: SettingUp level 5 for ${{ parameters.transportType }} 
+  - job: SetupVM_level5_${{ parameters.upstreamProtocol }}
+    displayName: SettingUp level 5 for ${{ parameters.upstreamProtocol }}
     timeoutInMinutes: 180
     variables:
       artifactName: iotedged-ubuntu18.04-amd64
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       level: 5
-      deploymentFile: 'nestededge_topLayerBaseDeployment_${{ parameters.transportType }}.json'
+      deploymentFile: 'nestededge_topLayerBaseDeployment_${{ parameters.upstreamProtocol }}.json'
       parentName: ''
       parentDeviceId: ''
-      transportType: ${{ parameters.transportType }}
+      transportType: ${{ parameters.upstreamProtocol }}
     pool:
      name: $(pool.name)
      demands:
@@ -29,20 +29,20 @@ jobs:
      - template: nested-create-identity.yaml   
      - template: nested-agent-deploy.yaml
 
-  - job: SetupVM_level4_${{ parameters.transportType }}
-    dependsOn: SetupVM_level5_${{ parameters.transportType }}
-    displayName: SettingUp level 4 for ${{ parameters.transportType }}
+  - job: SetupVM_level4_${{ parameters.upstreamProtocol }}
+    dependsOn: SetupVM_level5_${{ parameters.upstreamProtocol }}
+    displayName: SettingUp level 4 for ${{ parameters.upstreamProtocol }}
     condition: succeeded()
     timeoutInMinutes: 180
     variables:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb   
       artifactName: iotedged-ubuntu18.04-amd64
-      parentName: $[ dependencies.SetupVM_level5_${{ parameters.transportType }}.outputs['deployIoTEdge.deviceName'] ]
-      parentDeviceId: $[ dependencies.SetupVM_level5_${{ parameters.transportType }}.outputs['createIdentity.parentDeviceId'] ] 
-      deploymentFile: 'nestededge_middleLayerBaseDeployment_${{ parameters.transportType }}.json'
+      parentName: $[ dependencies.SetupVM_level5_${{ parameters.upstreamProtocol }}.outputs['deployIoTEdge.deviceName'] ]
+      parentDeviceId: $[ dependencies.SetupVM_level5_${{ parameters.upstreamProtocol }}.outputs['createIdentity.parentDeviceId'] ]
+      deploymentFile: 'nestededge_middleLayerBaseDeployment_${{ parameters.upstreamProtocol }}.json'
       level: 4
-      transportType: ${{ parameters.transportType }}
+      transportType: ${{ parameters.upstreamProtocol }}
     pool:
      name: $(pool.name)
      demands:

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -10,7 +10,7 @@ jobs:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       level: 5
-      deploymentFile: 'nestededge_topLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json'
+      deploymentFile: nestededge_topLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json
       parentName: ''
       parentDeviceId: ''
       upstream.protocol: ${{ parameters['upstream.protocol'] }}


### PR DESCRIPTION
Fixes:
- Upstream protocol is incorrectly configured. It assigns the correct upstream protocol, but always reports amqp to log analytics. I fixed this and standardized the naming for upstream protocol across our yamls as ```upstream.protocol```.
- The addition of test name I made has a problem, as I thought we had two nested longhaul pipelines. Turns out these are duplicates and we have one nested longhaul pipeline that runs two longhaul tests. One for amqp upstream and one for mqtt upstream with broker. Therefore we need to plumb this information down not through pipeline vars, but hardcoded values in the nested longhaul yaml similar to upstream protocol.