### PR TITLE
Yophilav/fix pipeline err for1.1.1 release 1.1

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -2,6 +2,7 @@ trigger: none
 pr: none
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   images.artifact.name.linux: 'core-linux'
   images.artifact.name.windows: 'core-windows'
   vsts.project: $(System.TeamProjectId)

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -151,26 +151,9 @@ namespace IotEdgeQuickstart.Details
 
             Console.WriteLine($"Installing debian package '{PackageName}' from {this.archivePath ?? "apt"}");
 
-            string commandName;
-            string commandArgs;
-
-            // Use apt-get if a package name is given, or dpkg if a package file is given.
-            // We'd like to use apt-get for both cases, but older versions of apt-get (e.g.,
-            // in Raspbian) can't accept a package file.
-            if (string.IsNullOrEmpty(this.archivePath))
-            {
-                commandName = "apt-get";
-                commandArgs = $"--yes install {PackageName}";
-            }
-            else
-            {
-                commandName = "dpkg";
-                commandArgs = $"--force-confnew -i {this.archivePath}";
-            }
-
             return Process.RunAsync(
-                commandName,
-                commandArgs,
+                "apt-get",
+                $"--yes install {PackageName}",
                 300); // 5 min timeout because install can be slow on raspberry pi
         }
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -151,9 +151,34 @@ namespace IotEdgeQuickstart.Details
 
             Console.WriteLine($"Installing debian package '{PackageName}' from {this.archivePath ?? "apt"}");
 
+            string commandName;
+            string commandArgs;
+
+            // Use apt-get if a package name is given, or dpkg if a package file is given.
+            // We'd like to use apt-get for both cases, but older versions of apt-get (e.g.,
+            // in Raspbian) can't accept a package file.
+            if (System.Environment.Is64BitOperatingSystem)
+            {
+                commandName = "apt-get";
+                commandArgs = $"--yes install {PackageName}";
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(this.archivePath))
+                {
+                    commandName = "apt-get";
+                    commandArgs = $"--yes install {PackageName}";
+                }
+                else
+                {
+                    commandName = "dpkg";
+                    commandArgs = $"--force-confnew -i {this.archivePath}";
+                }
+            }
+
             return Process.RunAsync(
-                "apt-get",
-                $"--yes install {PackageName}",
+                commandName,
+                commandArgs,
                 300); // 5 min timeout because install can be slow on raspberry pi
         }
 

--- a/test/connectivity/scripts/testHelper.sh
+++ b/test/connectivity/scripts/testHelper.sh
@@ -10,6 +10,7 @@ function clean_up() {
     rm -rf /var/lib/iotedge/
     rm -rf /var/run/iotedge/
     rm -rf /etc/iotedge/config.yaml
+    rm -rf /etc/systemd/system/aziot-*.service.d/
 
     if [ "$CLEAN_ALL" = '1' ]; then
         echo 'Prune docker system'


### PR DESCRIPTION
- Fix Connectivity test pipeline's IS downgrade conflict.
Note: We don't need to implement this fix. Just have a test agent that strictly running 1.1 (agent-group=2). And a separate group running 1.2 (agent-group=1).