### PR TITLE
Fix NugetSecurity warning for Long Haul pipeline

### DIFF
--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -2,6 +2,7 @@ trigger: none
 pr: none
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   images.artifact.name.linux: 'core-linux'
   images.artifact.name.windows: 'core-windows'
   vsts.project: $(System.TeamProjectId)


### PR DESCRIPTION
- Fix NugetSecurity warning for Long Haul pipeline