### PR TITLE
Nested Pipelines: Fix wrong casing for upstream protocol

### DIFF
--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -27,6 +27,7 @@ stages:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       level: '5'
+      upstreamProtocol: 'amqp'
       deploymentFile: 'nestededge_topLayerBaseDeployment_amqp.json'
       parentName: ''
       parentDeviceId: ''
@@ -65,6 +66,7 @@ stages:
       parentDeviceId: $[ dependencies.SetupVM_level5.outputs['createIdentity.parentDeviceId'] ] 
       deploymentFile: 'nestededge_middleLayerBaseDeployment_amqp.json'
       level: '4'
+      upstreamProtocol: 'amqp'
     pool:
      name: $(pool.name)
      demands:
@@ -99,6 +101,7 @@ stages:
       parentDeviceId: $[ dependencies.SetupVM_level4.outputs['createIdentity.parentDeviceId'] ] 
       deploymentFile: 'nestededge_isa95_smoke_test_BaseDeployment.json'
       level: '3'
+      upstreamProtocol: 'amqp'
       proxyAddress: $(otProxy)    
     pool:
      name: $(pool.name)

--- a/builds/e2e/templates/nested-create-identity.yaml
+++ b/builds/e2e/templates/nested-create-identity.yaml
@@ -11,6 +11,8 @@ steps:
     inputs:
       targetType: inline
       script: |
+        set -e
+
         echo "Extracting hub name from connection string"
         #extract full hub name
         tmp=$(echo "$(IotHubStressConnString)" | sed -n 's/HostName=\(.*\);SharedAccessKeyName.*/\1/p')

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -13,7 +13,7 @@ jobs:
       deploymentFile: "nestededge_topLayerBaseDeployment_${{ parameters['upstream.protocol'] }}.json"
       parentName: ''
       parentDeviceId: ''
-      upstream.protocol: ${{ parameters['upstream.protocol'] }}
+      upstreamProtocol: ${{ parameters['upstream.protocol'] }}
     pool:
      name: $(pool.name)
      demands:


### PR DESCRIPTION
This PR fixes two things, but really they are the same issue:
- Existing bug in ISA95 smoke tests
- Bug I introduced yesterday in #4572 

The problem for both is that upstream protocol is not passed, or passed incorrectly.

This problem was masked by my testing, so I also made a change to fail the pipeline run if an error occurs making the identity. I do this with ```set -e```.
https://stackoverflow.com/questions/1378274/in-a-bash-script-how-can-i-exit-the-entire-script-if-a-certain-condition-occurs 