### PR TITLE
Fix: don't unsubscribe when there is no subscription registered

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             device.DeviceConnection.Filter(d => d.IsActive)
                 .ForEach(d =>
                 {
-                    hasChanged = true;
+                    hasChanged = true; // if there is no old value, that means no subscription, so this is a change
                     d.Subscriptions.AddOrUpdate(
                         deviceSubscription,
                         true,
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             device.DeviceConnection.Filter(d => d.IsActive)
                 .ForEach(d =>
                 {
-                    hasChanged = true;
+                    hasChanged = false; // if there is no old value, that means no subscription, so this is not a change
                     d.Subscriptions.AddOrUpdate(
                         deviceSubscription,
                         false,

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/ConnectionManagerTest.cs
@@ -692,6 +692,73 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
 
         [Fact]
         [Unit]
+        public async Task SubscriptionChangeTest()
+        {
+            // Arrange
+            string deviceId = "d1";
+            var cloudConnectionProvider = Mock.Of<ICloudConnectionProvider>();
+            var credentialsCache = Mock.Of<ICredentialsCache>();
+            var deviceConnectivityManager = Mock.Of<IDeviceConnectivityManager>();
+
+            var connectionManager = new ConnectionManager(cloudConnectionProvider, credentialsCache, GetIdentityProvider(), deviceConnectivityManager);
+            var identity = Mock.Of<IIdentity>(i => i.Id == deviceId);
+
+            // Act
+            await connectionManager.AddDeviceConnection(identity, Mock.Of<IDeviceProxy>(d => d.IsActive));
+            Option<IReadOnlyDictionary<DeviceSubscription, bool>> subscriptionsOption = connectionManager.GetSubscriptions(deviceId);
+
+            // Assert
+            Assert.True(subscriptionsOption.HasValue);
+            IReadOnlyDictionary<DeviceSubscription, bool> subscriptions = subscriptionsOption.OrDefault();
+            Assert.Empty(subscriptions);
+
+            // Act (starting from empty subscription data)
+            var addMethodChange = connectionManager.AddSubscription(deviceId, DeviceSubscription.Methods);
+            var removeC2DChange = connectionManager.RemoveSubscription(deviceId, DeviceSubscription.C2D);
+            subscriptionsOption = connectionManager.GetSubscriptions(deviceId);
+
+            // Assert
+            Assert.True(subscriptionsOption.HasValue);
+            subscriptions = subscriptionsOption.OrDefault();
+            Assert.Equal(2, subscriptions.Count);
+            Assert.True(subscriptions[DeviceSubscription.Methods]);
+            Assert.False(subscriptions[DeviceSubscription.C2D]);
+            Assert.True(addMethodChange);
+            Assert.False(removeC2DChange);
+
+            // Act (flipping values)
+            var removeMethodChange = connectionManager.RemoveSubscription(deviceId, DeviceSubscription.Methods);
+            var addC2DChange = connectionManager.AddSubscription(deviceId, DeviceSubscription.C2D);
+            subscriptionsOption = connectionManager.GetSubscriptions(deviceId);
+
+            // Assert
+            Assert.True(subscriptionsOption.HasValue);
+            subscriptions = subscriptionsOption.OrDefault();
+            Assert.Equal(2, subscriptions.Count);
+            Assert.False(subscriptions[DeviceSubscription.Methods]);
+            Assert.True(subscriptions[DeviceSubscription.C2D]);
+            Assert.True(removeMethodChange);
+            Assert.True(addC2DChange);
+
+            // Act (not changing)
+            addMethodChange = connectionManager.AddSubscription(deviceId, DeviceSubscription.Methods);
+            var removeFirstC2DChange = connectionManager.RemoveSubscription(deviceId, DeviceSubscription.C2D);
+            var removeSecondC2DChange = connectionManager.RemoveSubscription(deviceId, DeviceSubscription.C2D);
+            subscriptionsOption = connectionManager.GetSubscriptions(deviceId);
+
+            // Assert
+            Assert.True(subscriptionsOption.HasValue);
+            subscriptions = subscriptionsOption.OrDefault();
+            Assert.Equal(2, subscriptions.Count);
+            Assert.True(subscriptions[DeviceSubscription.Methods]);
+            Assert.False(subscriptions[DeviceSubscription.C2D]);
+            Assert.True(addMethodChange);
+            Assert.True(removeFirstC2DChange);
+            Assert.False(removeSecondC2DChange);
+        }
+
+        [Fact]
+        [Unit]
         public async Task KeepSubscriptionsOnDeviceRemoveTest()
         {
             // Arrange


### PR DESCRIPTION
There was an optimization on ConnectionManager so it did not do any action for subscription/unsubscription if the state did not change, to avoid excess communication to iothub. The status of a given subscription (e.g. for C2D messages) can be represented by three states: true, false or missing. Missing means that the subscription was never set, so the dictionary that stores the state has no information about it. When this happens that means that nothing has set the subscription yet, which means that no subscription exists to that topic. In this case when that subscription gets removed, that does not mean status change.

The original implementation handled this as a status change and executed a remove operation. This should not have caused any problems, however a bug in the C# SDK breaks something and it blocks subsequent subscriptions.

This fix makes the optimization work right, and it mitigates the occurrence of bug in the SDK till they fix it