### PR TITLE
Add optional proxy argument to iotedge (#4590)

### DIFF
--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -115,6 +115,13 @@ fn run() -> Result<(), Error> {
                         .takes_value(true),
                 )
                 .arg(
+                    Arg::with_name("proxy-uri")
+                        .long("proxy-uri")
+                        .value_name("PROXY_URI")
+                        .help("Sets the proxy URI that this device would use to connect to Azure DPS and IoTHub endpoints.")
+                        .takes_value(true),
+                )
+                .arg(
                     Arg::with_name("ntp-server")
                         .long("ntp-server")
                         .value_name("NTP_SERVER")
@@ -375,6 +382,7 @@ fn run() -> Result<(), Error> {
                 args.is_present("warnings-as-errors"),
                 aziot_bin.into(),
                 args.value_of("iothub-hostname").map(ToOwned::to_owned),
+                args.value_of("proxy-uri").map(ToOwned::to_owned),
             );
             check.execute(&mut tokio_runtime)
         }


### PR DESCRIPTION
The proxy-uri parameter can be passed in via command line argument. If that isn't specified, the settings (if valid) will be searched for Edge Agent's https_proxy environment variable.
Either way, the value will be passed along to aziotctl, where the connection check will occur using the proxy URI.

Note that this depends on https://github.com/Azure/iot-identity-service/pull/158

Cherry-pick of 6b0c6c5d8797462c7f6ca8c5c2d1cde4925c3279