### PR TITLE
Bump aziot version

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -106,7 +106,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "serde",
 ]
@@ -225,7 +225,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "http-common",
  "libc",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "pkcs11",
  "serde",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "http-common",
  "serde",
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "serde",
  "toml",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "cc",
 ]
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1888,7 +1888,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#eb97a6b287e8bc1b5b39e2cf96b38bd7c394df94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
 
 [[package]]
 name = "pkg-config"


### PR DESCRIPTION
This aziot-identity-service version update is required due to the introduction of proxy-uri CLI argument within iotedge