### PR TITLE
Remove case sensitivity in hostname check

### DIFF
--- a/edgelet/iotedge/src/check/checks/hostname.rs
+++ b/edgelet/iotedge/src/check/checks/hostname.rs
@@ -86,8 +86,12 @@ impl Hostname {
         //
         // Instead, we punt on this check and assume that everything's fine if config_hostname is identical to the device hostname,
         // or starts with it.
-        if config_hostname != machine_hostname
-            && !config_hostname.starts_with(&format!("{}.", machine_hostname))
+        //
+        // Azure FQDN don't support capital letter so we lower case the hostname before doing the check.
+        if config_hostname.to_lowercase() != machine_hostname.to_lowercase()
+            && !config_hostname
+                .to_lowercase()
+                .starts_with(&format!("{}.", machine_hostname.to_lowercase()))
         {
             return Err(Context::new(format!(
             "config.yaml has hostname {} but device reports hostname {}.\n\


### PR DESCRIPTION
Series of fix + improvement on iotedge check.
PR following: https://github.com/Azure/iotedge/pull/4608

Removing case sensitivity when checking hostname.
It created issue, like being unable to use fqdn if your hostname has a capital letter (if you use azure VMs).