### PR TITLE
Fix clippy errors in mqtt-broker-tests-util (#4574)

### DIFF
--- a/builds/checkin/rust-test-modules.yaml
+++ b/builds/checkin/rust-test-modules.yaml
@@ -16,7 +16,7 @@ jobs:
         submodules: false
         fetchDepth: 3
       - bash: |
-          git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|test/modules/generic-mqtt-tester|test/rust-test-util)'
+          git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|test/modules/generic-mqtt-tester|test/rust-test-util|mqtt/mqtt-broker-tests-util)'
           if [[ $? == 0 ]]; then
             echo "Detected changes inside builds or rust test module folders"
             echo "##vso[task.setvariable variable=RUN_PIPELINE;isOutput=true]TRUE"

--- a/mqtt/mqtt-broker-tests-util/src/client.rs
+++ b/mqtt/mqtt-broker-tests-util/src/client.rs
@@ -263,7 +263,7 @@ where
                             Some(event) => {
                                 let event = event.expect("got error instead of event");
                                 match event {
-                                    Event::NewConnection { .. } => conn_sender
+                                    Event::NewConnection { .. } | Event::Disconnected(_) => conn_sender
                                         .send(event)
                                         .expect("can't send an event to a conn channel"),
                                     Event::Publication(publication) => pub_sender
@@ -272,9 +272,6 @@ where
                                     Event::SubscriptionUpdates(_) => sub_sender
                                         .send(event)
                                         .expect("can't send an event to a sub channel"),
-                                    Event::Disconnected(_) => conn_sender
-                                        .send(event)
-                                        .expect("can't send an event to a conn channel"),
                                 }
                             }
                             None => {


### PR DESCRIPTION
I am fixing it to unblock the rust-test-module-checkin.