### PR TITLE
Nested Tests: Default dynamic reprovisioning to false

### DIFF
--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -102,7 +102,7 @@ EOF
     echo "homedir = \"/var/lib/aziot/identityd\"" | sudo tee -a  /etc/aziot/identityd/config.toml
     echo "" | sudo tee -a  /etc/aziot/identityd/config.toml
     echo "[provisioning]" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "dynamic_reprovisioning = true" | sudo tee -a  /etc/aziot/identityd/config.toml
+    echo "dynamic_reprovisioning = false" | sudo tee -a  /etc/aziot/identityd/config.toml
     echo "source = \"manual\"" | sudo tee -a  /etc/aziot/identityd/config.toml
     if [ ! -z $PARENT_NAME ]; then
         echo "iothub_hostname = \"$PARENT_NAME\"" | sudo tee -a  /etc/aziot/identityd/config.toml


### PR DESCRIPTION
For our nested longhaul tests, dynamic provisioning is set to true when it is not using dps. I don't think this config is used with any dps tests as the same config sets up manual provisioning. So it should be safe to update.