### PR TITLE
Fix RingBuffer initialization logic

### DIFF
--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -425,7 +425,8 @@ fn find_pointers_and_order_post_crash(file: &mut File, max_file_size: u64) -> Ri
                 },
                 order,
                 // Check to see if wrap around case.
-                can_read_from_wrap_around_when_write_full: (write == read && write_updates > read_updates),
+                can_read_from_wrap_around_when_write_full: (write == read
+                    && write_updates > read_updates),
             };
         }
 
@@ -464,7 +465,8 @@ fn find_pointers_and_order_post_crash(file: &mut File, max_file_size: u64) -> Ri
                 },
                 order,
                 // Check to see if wrap around case.
-                can_read_from_wrap_around_when_write_full: (write == read && write_updates > read_updates),
+                can_read_from_wrap_around_when_write_full: (write == read
+                    && write_updates > read_updates),
             };
         }
 
@@ -479,7 +481,8 @@ fn find_pointers_and_order_post_crash(file: &mut File, max_file_size: u64) -> Ri
                     },
                     order,
                     // Check to see if wrap around case.
-                    can_read_from_wrap_around_when_write_full: (write == read && write_updates > read_updates),
+                    can_read_from_wrap_around_when_write_full: (write == read
+                        && write_updates > read_updates),
                 };
             }
         };
@@ -860,7 +863,8 @@ mod tests {
 
             let loaded_read = rb.metadata.file_pointers.read_begin;
             let loaded_write = rb.metadata.file_pointers.write;
-            let loaded_can_read_from_wrap_around_when_write_full = rb.metadata.can_read_from_wrap_around_when_write_full;
+            let loaded_can_read_from_wrap_around_when_write_full =
+                rb.metadata.can_read_from_wrap_around_when_write_full;
             assert_eq!(read, loaded_read);
             assert_eq!(write, loaded_write);
             assert!(!loaded_can_read_from_wrap_around_when_write_full);
@@ -1367,7 +1371,7 @@ mod tests {
             assert_matches!(result, Ok(_));
             let mut batch = result.unwrap();
             while !batch.is_empty() {
-                for (key , publication) in entries.drain(..) {
+                for (key, publication) in entries.drain(..) {
                     let maybe_entry = batch.remove(0);
                     assert!(maybe_entry.is_some());
                     let entry = maybe_entry.unwrap();

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -834,7 +834,7 @@ mod tests {
             }
 
             // write till wrap around
-            // this will put write ahead of read
+            // this will put write before read
             loop {
                 let before_write_index = rb.metadata.file_pointers.write;
 

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -825,7 +825,7 @@ mod tests {
             let mut batch = result.unwrap();
             assert!(!batch.is_empty());
 
-             for (key, _) in batch.drain(..) {
+            for (key, _) in batch.drain(..) {
                 let result = rb.remove(key);
                 assert_matches!(result, Ok(_));
             }


### PR DESCRIPTION
The Ring buffer currently doesn't read the whole file for determining where write and read pointers should be. It actually short-circuits out when write pointer is determined. This can allow for a case where messages cannot be sent and are instead written over. 

The scenario is as follows:
- RingBuffer is filled and write pointer wraps around
- Data is being batched and read pointer progresses beyond initial point
- A restart occurs which means RingBuffer needs to re-initialize
- RingBuffer finds write pointer before read pointer and doesn't continue to find read pointer
- More writes come in and write over data that was not sent as read pointer is behind write pointer after re-init.