### PR TITLE
Add check up_to_date_config (#4596)

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -106,7 +106,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "serde",
 ]
@@ -225,7 +225,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "http-common",
  "libc",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "pkcs11",
  "serde",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "http-common",
  "serde",
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "serde",
  "toml",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "cc",
 ]
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1888,7 +1888,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#26c2922e12f806f9eb6a004d39945dc6bf4417c6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/edgelet-core/src/error.rs
+++ b/edgelet/edgelet-core/src/error.rs
@@ -72,18 +72,6 @@ pub enum ErrorKind {
     #[fail(display = "Invalid module type {:?}", _0)]
     InvalidModuleType(String),
 
-    #[fail(
-        display = "Error parsing URI {} specified for '{}'. Please check the config.yaml file.",
-        _0, _1
-    )]
-    InvalidSettingsUri(String, &'static str),
-
-    #[fail(
-        display = "Invalid file URI {} path specified for '{}'. Please check the config.yaml file.",
-        _0, _1
-    )]
-    InvalidSettingsUriFilePath(String, &'static str),
-
     #[fail(display = "Invalid URL {:?}", _0)]
     InvalidUrl(String),
 
@@ -110,18 +98,6 @@ pub enum ErrorKind {
 
     #[fail(display = "Signing error occurred. Invalid key length: {}", _0)]
     SignInvalidKeyLength(usize),
-
-    #[fail(
-        display = "URI {} is unsupported for '{}'. Please check the config.yaml file.",
-        _0, _1
-    )]
-    UnsupportedSettingsUri(String, &'static str),
-
-    #[fail(
-        display = "File URI {} is unsupported for '{}'. Please check the config.yaml file.",
-        _0, _1
-    )]
-    UnsupportedSettingsFileUri(String, &'static str),
 }
 
 impl Fail for Error {

--- a/edgelet/iotedge/src/check/checks/connect_management_uri.rs
+++ b/edgelet/iotedge/src/check/checks/connect_management_uri.rs
@@ -18,7 +18,7 @@ impl Checker for ConnectManagementUri {
         "connect-management-uri"
     }
     fn description(&self) -> &'static str {
-        "config.yaml has correct URIs for daemon mgmt endpoint"
+        "configuration has correct URIs for daemon mgmt endpoint"
     }
     fn execute(&mut self, check: &mut Check, _: &mut tokio::runtime::Runtime) -> CheckResult {
         self.inner_execute(check)
@@ -90,7 +90,7 @@ impl ConnectManagementUri {
 
         (scheme1, scheme2) if scheme1 != scheme2 => return Err(Context::new(
             format!(
-                "config.yaml has invalid combination of schemes for connect.management_uri ({:?}) and listen.management_uri ({:?})",
+                "configuration has invalid combination of schemes for connect.management_uri ({:?}) and listen.management_uri ({:?})",
                 scheme1, scheme2,
             ))
             .into()),

--- a/edgelet/iotedge/src/check/checks/container_resolve_parent_hostname.rs
+++ b/edgelet/iotedge/src/check/checks/container_resolve_parent_hostname.rs
@@ -12,7 +12,7 @@ impl Checker for ContainerResolveParentHostname {
         "container-resolve-parent-hostname"
     }
     fn description(&self) -> &'static str {
-        "config.yaml parent hostname is resolvable from inside container"
+        "parent hostname is resolvable from inside container"
     }
     fn execute(&mut self, check: &mut Check, _: &mut tokio::runtime::Runtime) -> CheckResult {
         self.inner_execute(check)

--- a/edgelet/iotedge/src/check/checks/hostname.rs
+++ b/edgelet/iotedge/src/check/checks/hostname.rs
@@ -19,7 +19,7 @@ impl Checker for Hostname {
         "hostname"
     }
     fn description(&self) -> &'static str {
-        "config.yaml has correct hostname"
+        "configuration has correct hostname"
     }
     fn execute(&mut self, check: &mut Check, _: &mut tokio::runtime::Runtime) -> CheckResult {
         self.inner_execute(check)
@@ -90,8 +90,8 @@ impl Hostname {
             && !config_hostname.starts_with(&format!("{}.", machine_hostname))
         {
             return Err(Context::new(format!(
-            "config.yaml has hostname {} but device reports hostname {}.\n\
-             Hostname in config.yaml must either be identical to the device hostname \
+            "configuration has hostname {} but device reports hostname {}.\n\
+             Hostname in configuration must either be identical to the device hostname \
              or be a fully-qualified domain name that has the device hostname as the first component.",
             config_hostname, machine_hostname,
         ))
@@ -102,7 +102,7 @@ impl Hostname {
         // For example, the IoT Hub C# SDK cannot connect to a hostname that contains an `_`.
         if !hostname_checks_common::is_rfc_1035_valid(config_hostname) {
             return Ok(CheckResult::Warning(Context::new(format!(
-            "config.yaml has hostname {} which does not comply with RFC 1035.\n\
+            "configuration has hostname {} which does not comply with RFC 1035.\n\
              \n\
              - Hostname must be between 1 and 255 octets inclusive.\n\
              - Each label in the hostname (component separated by \".\") must be between 1 and 63 octets inclusive.\n\
@@ -118,7 +118,7 @@ impl Hostname {
         if !hostname_checks_common::check_length_for_local_issuer(config_hostname) {
             return Ok(CheckResult::Warning(
                 Context::new(format!(
-                    "config.yaml hostname {} is too long to be used as a certificate issuer",
+                    "configuration hostname {} is too long to be used as a certificate issuer",
                     config_hostname,
                 ))
                 .into(),

--- a/edgelet/iotedge/src/check/checks/mod.rs
+++ b/edgelet/iotedge/src/check/checks/mod.rs
@@ -12,6 +12,7 @@ mod hostname;
 mod parent_hostname;
 mod pull_agent_from_upstream;
 mod storage_mounted_from_host;
+mod up_to_date_config;
 mod well_formed_config;
 
 pub(crate) use self::aziot_edged_version::AziotEdgedVersion;
@@ -28,6 +29,7 @@ pub(crate) use self::hostname::Hostname;
 pub(crate) use self::parent_hostname::ParentHostname;
 pub(crate) use self::pull_agent_from_upstream::PullAgentFromUpstream;
 pub(crate) use self::storage_mounted_from_host::{EdgeAgentStorageMounted, EdgeHubStorageMounted};
+pub(crate) use self::up_to_date_config::UpToDateConfig;
 pub(crate) use self::well_formed_config::WellFormedConfig;
 
 use std::ffi::OsStr;
@@ -79,6 +81,7 @@ pub(crate) fn built_in_checks() -> [(&'static str, Vec<Box<dyn Checker>>); 2] {
             "Configuration checks",
             vec![
                 Box::new(WellFormedConfig::default()),
+                Box::new(UpToDateConfig::default()),
                 Box::new(ContainerEngineInstalled::default()),
                 Box::new(Hostname::default()),
                 Box::new(ParentHostname::default()),

--- a/edgelet/iotedge/src/check/checks/parent_hostname.rs
+++ b/edgelet/iotedge/src/check/checks/parent_hostname.rs
@@ -16,7 +16,7 @@ impl Checker for ParentHostname {
         "parent_hostname"
     }
     fn description(&self) -> &'static str {
-        "config.yaml has correct parent_hostname"
+        "configuration has correct parent_hostname"
     }
     fn execute(&mut self, check: &mut Check, _: &mut tokio::runtime::Runtime) -> CheckResult {
         self.inner_execute(check)
@@ -54,7 +54,7 @@ impl ParentHostname {
         // For example, the IoT Hub C# SDK cannot connect to a hostname that contains an `_`.
         if !hostname_checks_common::is_rfc_1035_valid(config_parent_hostname) {
             return Ok(CheckResult::Warning(Context::new(format!(
-            "config.yaml has parent_hostname {} which does not comply with RFC 1035.\n\
+            "configuration has parent_hostname {} which does not comply with RFC 1035.\n\
              \n\
              - Hostname must be between 1 and 255 octets inclusive.\n\
              - Each label in the hostname (component separated by \".\") must be between 1 and 63 octets inclusive.\n\
@@ -70,7 +70,7 @@ impl ParentHostname {
         if !hostname_checks_common::check_length_for_local_issuer(config_parent_hostname) {
             return Ok(CheckResult::Failed(
                 Context::new(format!(
-                    "config.yaml parent_hostname {} is too long to be used as a certificate issuer",
+                    "configuration parent_hostname {} is too long to be used as a certificate issuer",
                     config_parent_hostname,
                 ))
                 .into(),

--- a/edgelet/iotedge/src/check/checks/up_to_date_config.rs
+++ b/edgelet/iotedge/src/check/checks/up_to_date_config.rs
@@ -1,0 +1,39 @@
+use failure::{self, Context};
+
+use aziotctl_common::check_last_modified::check_last_modified;
+use aziotctl_common::check_last_modified::CheckResult as InternalCheckResult;
+
+use crate::check::{checker::Checker, Check, CheckResult};
+
+#[derive(Default, serde_derive::Serialize)]
+pub(crate) struct UpToDateConfig {}
+
+impl Checker for UpToDateConfig {
+    fn id(&self) -> &'static str {
+        "config-up-to-date"
+    }
+    fn description(&self) -> &'static str {
+        "configuration up-to-date with config.toml"
+    }
+    fn execute(&mut self, check: &mut Check, _: &mut tokio::runtime::Runtime) -> CheckResult {
+        Self::inner_execute(check).unwrap_or_else(CheckResult::Failed)
+    }
+    fn get_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap()
+    }
+}
+
+impl UpToDateConfig {
+    fn inner_execute(_check: &mut Check) -> Result<CheckResult, failure::Error> {
+        let check_result = match check_last_modified(&["edged"]) {
+            InternalCheckResult::Ok => CheckResult::Ok,
+            InternalCheckResult::Ignored => CheckResult::Ignored,
+            InternalCheckResult::Warning(message) => {
+                CheckResult::Warning(Context::new(message).into())
+            }
+            InternalCheckResult::Failed(error) => CheckResult::Failed(error.into()),
+        };
+
+        Ok(check_result)
+    }
+}

--- a/edgelet/iotedge/src/config/apply.rs
+++ b/edgelet/iotedge/src/config/apply.rs
@@ -156,8 +156,8 @@ fn execute_inner(
     aziotid_uid: nix::unistd::Uid,
     iotedge_uid: nix::unistd::Uid,
 ) -> Result<RunOutput, std::borrow::Cow<'static, str>> {
-    let config =
-        std::fs::read(config).map_err(|err| format!("could not read config file: {}", err))?;
+    let config = std::fs::read(config)
+        .map_err(|err| format!("could not read config file {}: {}", config.display(), err))?;
 
     let super_config::Config {
         parent_hostname,

--- a/edgelet/iotedge/src/error.rs
+++ b/edgelet/iotedge/src/error.rs
@@ -57,7 +57,7 @@ pub enum ErrorKind {
     #[fail(display = "Unable to call docker inspect")]
     Docker,
 
-    #[fail(display = "Error communicating with 'aziot' binary")]
+    #[fail(display = "Error communicating with 'aziotctl' binary")]
     Aziot,
 
     #[fail(display = "Error running system command")]

--- a/edgelet/iotedge/src/main.rs
+++ b/edgelet/iotedge/src/main.rs
@@ -386,7 +386,7 @@ fn run() -> Result<(), Error> {
             );
             check.execute(&mut tokio_runtime)
         }
-        ("check-list", Some(_)) => Check::print_list(aziot_bin.into()),
+        ("check-list", Some(_)) => Check::print_list(aziot_bin),
         ("config", Some(args)) => match args.subcommand() {
             ("apply", Some(args)) => {
                 let config_file = args

--- a/edgelet/support-bundle/src/support_bundle.rs
+++ b/edgelet/support-bundle/src/support_bundle.rs
@@ -360,15 +360,6 @@ where
         self.print_verbose(&format!("Running docker inspect for {}", module_name));
         let mut inspect = ShellCommand::new("docker");
 
-        /***
-         * Note: this assumes using windows containers on a windows machine.
-         * This is the expected production scenario.
-         * Since the bundle command does not read the config.yaml, it cannot use the `moby.runtime_uri` from there.
-         * This will not fail the bundle, only note the failure to the user and in the bundle.
-         */
-        #[cfg(windows)]
-        inspect.args(&["-H", "npipe:////./pipe/iotedge_moby_engine"]);
-
         inspect.arg("inspect").arg(&module_name);
         let inspect = inspect.output();
 


### PR DESCRIPTION
This check verifies that the edged super config file (`/etc/aziot/edged/config.d/00-super.toml`) has a `last_modified` after `/etc/aziot/config.toml`. Prints a warning if `config.toml` was modified after `00-super.toml`, since that means the user probably forgot to run `iotedge config apply` after updating `config.toml`.

Example message:
```
‼ iotedge configuration up-to-date with config.toml - Warning
    /etc/aziot/config.toml was modified after edged's config
    You must run 'iotedge config apply' to update edged's config with the latest config.toml
```