### PR TITLE
Change i-i-s cargo dependency to release/1.2 branch

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -106,7 +106,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -177,7 +177,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -202,7 +202,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "serde",
 ]
@@ -225,7 +225,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -235,7 +235,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -253,7 +253,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "http-common",
  "libc",
@@ -263,7 +263,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "pkcs11",
  "serde",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "http-common",
  "serde",
@@ -282,7 +282,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -507,7 +507,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "serde",
  "toml",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1748,7 +1748,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "cc",
 ]
@@ -1785,7 +1785,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1888,7 +1888,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1905,7 +1905,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18f5e5c92a68d08f37ddafeceb16075f1260bcb7"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/aziot-edged/Cargo.toml
+++ b/edgelet/aziot-edged/Cargo.toml
@@ -26,16 +26,16 @@ native-tls = "0.2"
 url = "2"
 url_serde = "0.2"
 
-aziot-cert-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-client = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-openssl-engine = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-openssl2 = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-openssl-sys2 = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-cert-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-key-client = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-key-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-key-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-key-openssl-engine = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+openssl2 = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+openssl-sys2 = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
 
 docker = { path = "../docker-rs" }
 edgelet-core = { path = "../edgelet-core" }

--- a/edgelet/cert-client/Cargo.toml
+++ b/edgelet/cert-client/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = "1.0"
 typed-headers = "0.1"
 url = "2"
 
-aziot-cert-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-cert-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-key-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-http = { path = "../edgelet-http" }

--- a/edgelet/edgelet-docker/Cargo.toml
+++ b/edgelet/edgelet-docker/Cargo.toml
@@ -22,9 +22,9 @@ tokio-process = "0.2"
 url = { version = "2", features = ["serde"] }
 url_serde = "0.2"
 
-aziot-cert-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-cert-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
 cert-client = { path = "../cert-client" }
-config-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+config-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
 docker = { path = "../docker-rs" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-http = { path = "../edgelet-http" }

--- a/edgelet/edgelet-http-mgmt/Cargo.toml
+++ b/edgelet/edgelet-http-mgmt/Cargo.toml
@@ -15,7 +15,7 @@ serde = "1.0"
 serde_json = "1.0"
 url = "2"
 
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-docker = { path = "../edgelet-docker" }
 edgelet-http = { path = "../edgelet-http" }

--- a/edgelet/edgelet-http-workload/Cargo.toml
+++ b/edgelet/edgelet-http-workload/Cargo.toml
@@ -16,14 +16,14 @@ openssl = "0.10"
 serde = "1.0"
 serde_json = "1.0"
 
-aziot-key-openssl-engine = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-client = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-openssl2 = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-openssl-sys2 = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-key-openssl-engine = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-key-client = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-key-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-key-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+openssl2 = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+openssl-sys2 = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
 
 cert-client = { path = "../cert-client" }
 edgelet-core = { path = "../edgelet-core" }

--- a/edgelet/identity-client/Cargo.toml
+++ b/edgelet/identity-client/Cargo.toml
@@ -18,7 +18,7 @@ serde_json = "1.0"
 typed-headers = "0.1"
 url = "2"
 
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-http = { path = "../edgelet-http" }

--- a/edgelet/iotedge/Cargo.toml
+++ b/edgelet/iotedge/Cargo.toml
@@ -37,14 +37,14 @@ typed-headers = "0.1.1"
 url = "2"
 zip = "0.5.3"
 
-aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identityd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-keyd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-keys-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-tpmd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziotctl-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-config-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-identityd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-keyd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-keys-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziot-tpmd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+aziotctl-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
+config-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.2" }
 docker = { path = "../docker-rs" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-docker = { path = "../edgelet-docker" }


### PR DESCRIPTION
Switches the cargo dependency from `main` to `release/1.2` of the iot-identity-service repo.