### PR TITLE
Add UpstreamProtocol to top level deployment file

### DIFF
--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
@@ -26,6 +26,11 @@
             },
             "https_proxy": {
               "value": "<proxyAddress>"
+            },
+            "env": {
+              "UpstreamProtocol": {
+                "value": "Mqtt"
+              }
             }
           },
           "edgeHub": {
@@ -49,6 +54,9 @@
               },
               "https_proxy": {
                 "value": "<proxyAddress>"
+              },
+              "UpstreamProtocol": {
+                "value": "Mqtt"
               }
             },
             "status": "running",


### PR DESCRIPTION
edgeHub and edgeAgent on the top level edge should have UpstreamProtocol set to Mqtt in the mqtt deployment file