### PR TITLE
Add test for rare RB init edge case

### DIFF
--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -908,7 +908,7 @@ mod tests {
 
             for (key, _) in batch.drain(..) {
                 rb.remove(key)
-                    .expect(&format!("unable to remove pub with key {:?}", key).to_owned());
+                    .unwrap_or_else(|_| panic!(format!("unable to remove pub with key {:?}", key)));
             }
 
             read = rb.metadata.file_pointers.read_begin;

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -872,9 +872,7 @@ mod tests {
 
     #[test]
     fn it_inits_ok_with_previous_data_and_write_pointer_is_reaches_read_pointer_after_read() {
-        let result = tempfile::NamedTempFile::new();
-        assert_matches!(result, Ok(_));
-        let file = result.unwrap();
+        let file = tempfile::NamedTempFile::new().unwrap();
 
         let publication = Publication {
             topic_name: "test".to_owned(),
@@ -885,8 +883,7 @@ mod tests {
 
         let block_size = *SERIALIZED_BLOCK_SIZE;
 
-        let result = bincode::serialize(&publication);
-        let data = result.unwrap();
+        let data = bincode::serialize(&publication).unwrap();
 
         let data_size = data.len() as u64;
 
@@ -897,9 +894,8 @@ mod tests {
         let read;
         let mut write;
         {
-            let result = RingBuffer::new(&file.path().to_path_buf(), max_file_size, FLUSH_OPTIONS);
-            assert!(result.is_ok());
-            let mut rb = result.unwrap();
+            let mut rb =
+                RingBuffer::new(&file.path().to_path_buf(), max_file_size, FLUSH_OPTIONS).unwrap();
 
             // write some
             for _ in 0..10 {
@@ -935,9 +931,8 @@ mod tests {
             // correct pointers and read again.
         }
         {
-            let result = RingBuffer::new(&file.path().to_path_buf(), max_file_size, FLUSH_OPTIONS);
-            assert!(result.is_ok());
-            let rb = result.unwrap();
+            let rb =
+                RingBuffer::new(&file.path().to_path_buf(), max_file_size, FLUSH_OPTIONS).unwrap();
 
             let loaded_read = rb.metadata.file_pointers.read_begin;
             let loaded_write = rb.metadata.file_pointers.write;

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -903,14 +903,12 @@ mod tests {
                 assert_matches!(result, Ok(_));
             }
 
-            let result = rb.batch(10);
-            assert_matches!(result, Ok(_));
-            let mut batch = result.unwrap();
+            let mut batch = rb.batch(10).unwrap();
             assert!(!batch.is_empty());
 
             for (key, _) in batch.drain(..) {
-                let result = rb.remove(key).expect(format!("unable to remove pub with key {}", key));
-                assert_matches!(result, Ok(_));
+                rb.remove(key)
+                    .expect(&format!("unable to remove pub with key {:?}", key).to_owned());
             }
 
             read = rb.metadata.file_pointers.read_begin;
@@ -941,6 +939,9 @@ mod tests {
             assert_eq!(write, loaded_write);
             assert_eq!(read, loaded_read);
             assert!(loaded_can_read_from_wrap_around_when_write_full);
+            // We would have written 10 + 20 entries, so the next one if there were a write
+            // should be 30. Order starts at 0.
+            assert_eq!(rb.metadata.order, 30);
         }
     }
 

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -909,7 +909,7 @@ mod tests {
             assert!(!batch.is_empty());
 
             for (key, _) in batch.drain(..) {
-                let result = rb.remove(key);
+                let result = rb.remove(key).expect(format!("unable to remove pub with key {}", key));
                 assert_matches!(result, Ok(_));
             }
 

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -435,19 +435,24 @@ fn find_pointers_and_order_post_crash(file: &mut File, max_file_size: u64) -> Ri
 
         // Check next block
         write_updates += 1;
-        order += 1; // We want to start with the next order number.
         start = end + data_size;
         end = start + block_size;
 
         // Found the last write, can stop updating write.
-        if inner.order() < order {
+        if should_update_write && inner.order() < order {
             should_update_write = false;
-            // Update write one last time to point at block
-            // where order is less.
-            write = start % max_file_size;
+
+            // If we haven't found any reads but we have found an order
+            // less than the last one, then we must have read and removed
+            // previous data. So, read should start at write and we
+            // are full.
+            if read_updates == 0 {
+                read = write;
+            }
         }
         if should_update_write {
             write = start % max_file_size;
+            order += 1; // We want to start with the next order number.
         }
 
         if start >= max_file_size {
@@ -862,6 +867,85 @@ mod tests {
             assert_eq!(read, loaded_read);
             assert_eq!(write, loaded_write);
             assert!(!loaded_can_read_from_wrap_around_when_write_full);
+        }
+    }
+
+    #[test]
+    fn it_inits_ok_with_previous_data_and_write_pointer_is_reaches_read_pointer_after_read() {
+        let result = tempfile::NamedTempFile::new();
+        assert_matches!(result, Ok(_));
+        let file = result.unwrap();
+
+        let publication = Publication {
+            topic_name: "test".to_owned(),
+            qos: QoS::AtMostOnce,
+            retain: true,
+            payload: Bytes::new(),
+        };
+
+        let block_size = *SERIALIZED_BLOCK_SIZE;
+
+        let result = bincode::serialize(&publication);
+        let data = result.unwrap();
+
+        let data_size = data.len() as u64;
+
+        let total_size = block_size + data_size;
+
+        let max_file_size = NonZeroU64::new(total_size * 20).unwrap();
+
+        let read;
+        let mut write;
+        {
+            let result = RingBuffer::new(&file.path().to_path_buf(), max_file_size, FLUSH_OPTIONS);
+            assert!(result.is_ok());
+            let mut rb = result.unwrap();
+
+            // write some
+            for _ in 0..10 {
+                let result = rb.insert(&publication);
+                assert_matches!(result, Ok(_));
+            }
+
+            let result = rb.batch(10);
+            assert_matches!(result, Ok(_));
+            let mut batch = result.unwrap();
+            assert!(!batch.is_empty());
+
+            for (key, _) in batch.drain(..) {
+                let result = rb.remove(key);
+                assert_matches!(result, Ok(_));
+            }
+
+            read = rb.metadata.file_pointers.read_begin;
+
+            // write till wrap around
+            // this will put write at read
+            loop {
+                // ignore err if any here, we just want to be full
+                let _result = rb.insert(&publication);
+
+                write = rb.metadata.file_pointers.write;
+                if write == read {
+                    break;
+                }
+            }
+
+            // Now we simulate a 'crash' and should be able to get
+            // correct pointers and read again.
+        }
+        {
+            let result = RingBuffer::new(&file.path().to_path_buf(), max_file_size, FLUSH_OPTIONS);
+            assert!(result.is_ok());
+            let rb = result.unwrap();
+
+            let loaded_read = rb.metadata.file_pointers.read_begin;
+            let loaded_write = rb.metadata.file_pointers.write;
+            let loaded_can_read_from_wrap_around_when_write_full =
+                rb.metadata.can_read_from_wrap_around_when_write_full;
+            assert_eq!(write, loaded_write);
+            assert_eq!(read, loaded_read);
+            assert!(loaded_can_read_from_wrap_around_when_write_full);
         }
     }
 


### PR DESCRIPTION
It is possible for a crash to occur where there are no deleted block but reads have occurred. In this case we would want to have read at write position on init as this should only happen if the buffer is full.