### PR TITLE
Fix: don't unsubscribe when there is no subscription registered (#4594)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ConnectionManager.cs
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             device.DeviceConnection.Filter(d => d.IsActive)
                 .ForEach(d =>
                 {
-                    hasChanged = true;
+                    hasChanged = true; // if there is no old value, that means no subscription, so this is a change
                     d.Subscriptions.AddOrUpdate(
                         deviceSubscription,
                         true,
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             device.DeviceConnection.Filter(d => d.IsActive)
                 .ForEach(d =>
                 {
-                    hasChanged = true;
+                    hasChanged = false; // if there is no old value, that means no subscription, so this is not a change
                     d.Subscriptions.AddOrUpdate(
                         deviceSubscription,
                         false,


### PR DESCRIPTION
There was an optimization on ConnectionManager so it did not do any action for subscription/unsubscription if the state did not change, to avoid excess communication to iothub. The status of a given subscription (e.g. for C2D messages) can be represented by three states: true, false or missing. Missing means that the subscription was never set, so the dictionary that stores the state has no information about it. When this happens that means that nothing has set the subscription yet, which means that no subscription exists to that topic. In this case when that subscription gets removed, that does not mean status change.

The original implementation handled this as a status change and executed a remove operation. This should not have caused any problems, however a bug in the C# SDK breaks something and it blocks subsequent subscriptions.

This fix makes the optimization work right, and it mitigates the occurrence of bug in the SDK till they fix it

(cherry picked from commit 53ff15b8ce1c619e2bf32da63ab9eba0c718d00f)