### PR TITLE
fix: after disconnect/connect, client twins should be pulled (#4629)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/upstream/BrokeredCloudConnectionProvider.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/upstream/BrokeredCloudConnectionProvider.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             }
 
             var cloudProxy = new BrokeredCloudProxy(identity, this.cloudProxyDispatcher, connectionStatusChangedHandler);
+            await cloudProxy.OpenAsync();
             return new Try<ICloudConnection>(new BrokeredCloudConnection(identity, cloudProxy));
         }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/upstream/BrokeredCloudProxy.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter/upstream/BrokeredCloudProxy.cs
@@ -39,7 +39,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter
             return Task.FromResult(true);
         }
 
-        public Task<bool> OpenAsync() => Task.FromResult(true);
+        public Task<bool> OpenAsync()
+        {
+            this.connectionStatusChangedHandler?.Invoke(this.identity.Id, CloudConnectionStatus.ConnectionEstablished);
+            return Task.FromResult(true);
+        }
+
         public Task RemoveCallMethodAsync() => this.cloudProxyDispatcher.RemoveCallMethodAsync(this.identity);
         public Task RemoveDesiredPropertyUpdatesAsync() => this.cloudProxyDispatcher.RemoveDesiredPropertyUpdatesAsync(this.identity);
         public Task SendFeedbackMessageAsync(string messageId, FeedbackStatus feedbackStatus) => this.cloudProxyDispatcher.SendFeedbackMessageAsync(this.identity, messageId, feedbackStatus);


### PR DESCRIPTION
Using mqtt broker upstream, after a disconnection to the parent device and connecting back, edge should pull the twin of the connected clients. This used to work by accident: there was a bug, which did not close existing cloud proxy objects, so they remained subscribed to connection events and forwarder those, so eventually twin manager received a notification that device_x regained its connection, which in turn pulled the twin.
Fixing this bug removed the accidental event forwarding of the dead object, and because on losing the connection these objects are removed, nothing forwarded events to twin manager for the individual devices.
This fix copies the solution of the legacy CloudConnection (ConnectToIotHub), which during proxy creation calls an explicit Open() method, which sends the notification about the device connected.

(cherry picked from commit 794c32459051e1a9d4ea079e3a28484649081a4b)