### PR TITLE
Nested Longhaul: Add debug logging for non-broker case (#4607)

### DIFF
--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
@@ -37,6 +37,11 @@
             "type": "docker",
             "status": "running",
             "restartPolicy": "always",
+            "env": {
+              "RuntimeLogLevel": {
+                "value": "Debug"
+              }
+            },
             "settings": {
               "image": "<Container_Registry>/microsoft/azureiotedge-hub:<EdgeRuntime.BuildNumber>-linux-<Architecture>",
               "createOptions": "{\"ExposedPorts\": {\"9600/tcp\": {}}, \"HostConfig\": {\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\"}}, \"PortBindings\": {\"8883/tcp\": [{\"HostPort\": \"8883\"}],\"5671/tcp\": [{\"HostPort\": \"5671\"}],\"9600/tcp\": [{\"HostPort\": \"9601\"}]}}}"


### PR DESCRIPTION
Nested Longhaul: Add debug logging for non-broker case.

This was missed when the deployment was created. Adding it now.