### PR TITLE
[k8s] Throw non-fatal exception if Mounts missing critical data.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/InvalidMountException.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/InvalidMountException.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
+{
+    using System;
+
+    [Serializable]
+    public class InvalidMountException : Exception
+    {
+        public InvalidMountException(string message)
+            : base(message)
+        {
+        }
+
+        public InvalidMountException(string message, Exception inner)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/deployment/KubernetesDeploymentMapper.cs
@@ -343,7 +343,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Deploymen
                     {
                         if (mount.Type is null || mount.Source is null || mount.Target is null)
                         {
-                            throw new InvalidMountException($"Type, Source, and Target required for all mounts ({mount.Type}, {mount.Source}, {mount.Target})");
+                            throw new InvalidMountException($"Type, Source, and Target required for all mounts [{identity.ModuleId}:{mount.Type}, {mount.Source}, {mount.Target}]");
                         }
                     }
                 });

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/edgedeployment/pvc/KubernetesPvcMapper.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.EdgeDeployment.Pvc
 
         bool ShouldCreatePvc(Mount mount)
         {
-            if (!mount.Type.Equals("volume", StringComparison.InvariantCultureIgnoreCase))
+            if (mount?.Type == null || !mount.Type.Equals("volume", StringComparison.InvariantCultureIgnoreCase))
             {
                 return false;
             }


### PR DESCRIPTION
Most data coming from createOptions is applied to the PodSpec if set, but Mounts are a slightly different story, it has three critical fields, and the Type and Source must be set, or else we don't know how to handle the mount.

Creating an invalid mount in the Mounts section of createOptions was throwing a Null Reference exception, which appears to be marked as a fatal exception, and it causes edgeAgent to crash.  A better experience is to check the fields we need and throw a non-fatal exception.  This also lets us report back to the user what went wrong more clearly, doesn't crash edgeAgent, and allows for a graceful recovery once the problem is fixed.

I did do a check of the other mappers, and I am reasonably certain the mappers changed in this PR are the ones which will most likely cause NullReference exception.

test:
Create an edge deployment with modules using HostConfig.Mounts, but drop critical fields ("Type", "Source", "Target")
- Hub will show a status of "500" and the reported properties will point out the failed module&Mount
Fix the Mount,
- Hub will show 200 OK.