### PR TITLE
TwinTester: Accommodate new exception indicating network failure (#4605)

### DIFF
--- a/test/modules/TwinTester/TwinAllOperationsInitializer.cs
+++ b/test/modules/TwinTester/TwinAllOperationsInitializer.cs
@@ -121,7 +121,7 @@ namespace TwinTester
                     cts.CancelAfter(stateUpdateTimeout);
                     await this.registryManager.GetTwinAsync(Settings.Current.DeviceId, Settings.Current.TargetModuleId, cts.Token);
                 }
-                catch (Exception e) when (e is IotHubCommunicationException || e is OperationCanceledException)
+                catch (Exception e) when (e is IotHubCommunicationException || e is OperationCanceledException || e.InnerException is TaskCanceledException)
                 {
                     this.twinTestState.LastNetworkOffline = DateTime.UtcNow;
                 }


### PR DESCRIPTION
There is a new exception I haven't seen indicating transient network outages. I believe this to be the cause of some TwinTest errors we are seeing in longhaul.

Here is an example:
```
[2021-03-15 21:59:05.024 WRN] Error in periodic operation TwinTestStateUpdate
Microsoft.Azure.Devices.Common.Exceptions.IotHubException: The operation was canceled.
 ---> System.Threading.Tasks.TaskCanceledException: The operation was canceled.
 ---> System.IO.IOException: Unable to read data from the transport connection: Operation canceled.
 ---> System.Net.Sockets.SocketException (125): Operation canceled
   --- End of inner exception stack trace ---
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.ThrowException(SocketError error, CancellationToken cancellationToken)
   at System.Net.Sockets.Socket.AwaitableSocketAsyncEventArgs.GetResult(Int16 token)
   at System.Net.Security.SslStream.<FillBufferAsync>g__InternalFillBufferAsync|215_0[TReadAdapter](TReadAdapter adap, ValueTask`1 task, Int32 min, Int32 initial)
   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.HttpConnection.SendAsyncCore(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithNtConnectionAuthAsync(HttpConnection connection, HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.RedirectHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.FinishSendAsyncBuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at Microsoft.Azure.Devices.HttpClientHelper.ExecuteAsync(HttpClient httpClient, HttpMethod httpMethod, Uri requestUri, Func`3 modifyRequestMessageAsync, Func`2 isMappedToException, Func`3 processResponseMessageAsync, IDictionary`2 errorMappingOverrides, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at Microsoft.Azure.Devices.HttpClientHelper.ExecuteAsync(HttpClient httpClient, HttpMethod httpMethod, Uri requestUri, Func`3 modifyRequestMessageAsync, Func`2 isMappedToException, Func`3 processResponseMessageAsync, IDictionary`2 errorMappingOverrides, CancellationToken cancellationToken)
   at Microsoft.Azure.Devices.HttpClientHelper.GetAsync[T](Uri requestUri, TimeSpan operationTimeout, IDictionary`2 errorMappingOverrides, IDictionary`2 customHeaders, Boolean throwIfNotFound, CancellationToken cancellationToken)
   at TwinTester.TwinAllOperationsInitializer.UpdateLastNetworkOfflineTimestampAsync(CancellationToken arg) in /home/vsts/work/1/s/test/modules/TwinTester/TwinAllOperationsInitializer.cs:line 129
   at Microsoft.Azure.Devices.Edge.Util.PeriodicTask.DoWork() in /home/vsts/work/1/s/edge-util/src/Microsoft.Azure.Devices.Edge.Util/PeriodicTask.cs:line 106
```