### PR TITLE
[mqtt] handle RPC sub requests (#4602)

### DIFF
--- a/mqtt/mqtt-bridge/src/upstream/events/remote.rs
+++ b/mqtt/mqtt-bridge/src/upstream/events/remote.rs
@@ -81,7 +81,10 @@ impl RemoteUpstreamPumpEventHandler {
         match self.remote_sub_handle.subscribe(subscribe_to).await {
             Ok(_) => {
                 if let Some(existing) = self.subscriptions.insert(&topic_filter, command_id) {
-                    warn!("duplicating sub request found for {}", existing);
+                    warn!(
+                        command_id = ?existing,
+                        "duplicating sub request found for topic {}", topic_filter
+                    );
                 }
             }
             Err(e) => {
@@ -105,7 +108,10 @@ impl RemoteUpstreamPumpEventHandler {
         {
             Ok(_) => {
                 if let Some(existing) = self.subscriptions.insert(&topic_filter, command_id) {
-                    warn!("duplicating unsub request found for {}", existing);
+                    warn!(
+                        commands = ?existing,
+                        "duplicating unsub request found for topic {}", topic_filter
+                    );
                 }
             }
             Err(e) => {

--- a/mqtt/mqtt-bridge/src/upstream/rpc/mod.rs
+++ b/mqtt/mqtt-bridge/src/upstream/rpc/mod.rs
@@ -16,7 +16,9 @@ use parking_lot::Mutex;
 pub use remote::{RemoteRpcMqttEventHandler, RpcPumpHandle};
 
 use std::{
-    collections::HashMap, fmt::Display, fmt::Formatter, fmt::Result as FmtResult, sync::Arc,
+    collections::{HashMap, VecDeque},
+    fmt::{Display, Formatter, Result as FmtResult},
+    sync::Arc,
 };
 
 use bson::doc;
@@ -110,17 +112,77 @@ impl Display for RpcCommand {
 /// response comes back as `mqtt3::Event` type which handled with the event
 /// handler.
 #[derive(Debug, Clone, Default)]
-pub struct RpcSubscriptions(Arc<Mutex<HashMap<String, CommandId>>>);
+pub struct RpcSubscriptions(Arc<Mutex<HashMap<String, VecDeque<CommandId>>>>);
 
 impl RpcSubscriptions {
     /// Stores topic filter to command identifier mapping.
-    pub fn insert(&self, topic_filter: &str, id: CommandId) -> Option<CommandId> {
-        self.0.lock().insert(topic_filter.into(), id)
+    pub fn insert(&self, topic_filter: &str, id: CommandId) -> Option<Vec<CommandId>> {
+        let mut inner = self.0.lock();
+
+        let existing = inner
+            .get(topic_filter)
+            .map(|ids| ids.iter().cloned().collect());
+
+        inner.entry(topic_filter.into()).or_default().push_back(id);
+
+        existing
     }
 
     /// Removes topic filter to command identifier mapping and returns
     /// `CommandId` if exists.
     pub fn remove(&self, topic_filter: &str) -> Option<CommandId> {
-        self.0.lock().remove(topic_filter)
+        let mut inner = self.0.lock();
+
+        inner
+            .remove_entry(topic_filter)
+            .and_then(|(topic, mut existing)| {
+                let id = existing.pop_front();
+
+                if !existing.is_empty() {
+                    inner.insert(topic, existing);
+                }
+
+                id
+            })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_handles_rpc_subscriptions() {
+        let subs = RpcSubscriptions::default();
+        assert!(subs.0.lock().is_empty());
+
+        assert_eq!(subs.insert("topic/1", "1".into()), None);
+        assert_eq!(commands(&subs, "topic/1"), Some(vec!["1".into()]));
+        assert_eq!(subs.insert("topic/2", "2".into()), None);
+        assert_eq!(commands(&subs, "topic/2"), Some(vec!["2".into()]));
+        assert_eq!(subs.insert("topic/1", "3".into()), Some(vec!["1".into()]));
+        assert_eq!(
+            commands(&subs, "topic/1"),
+            Some(vec!["1".into(), "3".into()])
+        );
+
+        assert_eq!(subs.remove("topic/1"), Some("1".into()));
+        assert_eq!(commands(&subs, "topic/1"), Some(vec!["3".into()]));
+        assert_eq!(subs.remove("topic/1"), Some("3".into()));
+        assert_eq!(commands(&subs, "topic/1"), None);
+        assert_eq!(subs.remove("topic/1"), None);
+        assert_eq!(commands(&subs, "topic/1"), None);
+        assert_eq!(subs.remove("topic/2"), Some("2".into()));
+        assert_eq!(commands(&subs, "topic/2"), None);
+
+        assert_eq!(subs.insert("topic/1", "4".into()), None);
+        assert_eq!(commands(&subs, "topic/1"), Some(vec!["4".into()]));
+    }
+
+    fn commands(subs: &RpcSubscriptions, topic_filter: &str) -> Option<Vec<CommandId>> {
+        subs.0
+            .lock()
+            .get(topic_filter)
+            .map(|ids| ids.iter().cloned().collect())
     }
 }

--- a/mqtt/mqtt-bridge/tests/common.rs
+++ b/mqtt/mqtt-bridge/tests/common.rs
@@ -72,15 +72,16 @@ where
 }
 
 pub async fn setup_bridge_controller(
+    device_id: &str,
     local_address: String,
     upstream_address: String,
     subs: Vec<Direction>,
     storage_dir_override: &PathBuf,
 ) -> (BridgeControllerHandle, JoinHandle<()>) {
     let credentials = Credentials::PlainText(AuthenticationSettings::new(
-        "bridge".into(),
+        device_id.into(),
+        format!("{}/edgehub", device_id),
         "pass".into(),
-        "bridge".into(),
         Some(CERTIFICATE.into()),
     ));
 
@@ -88,13 +89,13 @@ pub async fn setup_bridge_controller(
         upstream_address,
         credentials,
         subs,
-        true,
+        false,
         Duration::from_secs(5),
         storage_dir_override,
     )
     .unwrap();
 
-    let controller = BridgeController::new(local_address, "bridge".into(), settings);
+    let controller = BridgeController::new(local_address, device_id.into(), settings);
     let controller_handle = controller.handle();
     let controller: Box<dyn Sidecar + Send> = Box::new(controller);
 

--- a/mqtt/mqtt-bridge/tests/integration.rs
+++ b/mqtt/mqtt-bridge/tests/integration.rs
@@ -76,6 +76,7 @@ async fn send_message_upstream_downstream() {
     let storage_dir_override = dir.path().to_path_buf();
 
     let (controller_handle, controller_task) = common::setup_bridge_controller(
+        "edge-device-1",
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs,
@@ -168,6 +169,7 @@ async fn send_message_upstream_with_crash_is_lossless() {
     let storage_dir_override = dir.path().to_path_buf();
 
     let (controller_handle, controller_task) = common::setup_bridge_controller(
+        "edge-device-2",
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs.clone(),
@@ -218,6 +220,7 @@ async fn send_message_upstream_with_crash_is_lossless() {
         .build();
 
     let (controller_handle, controller_task) = common::setup_bridge_controller(
+        "edge-device-3",
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs.clone(),
@@ -263,6 +266,7 @@ async fn bridge_settings_update() {
     let storage_dir_override = dir.path().to_path_buf();
 
     let (mut controller_handle, controller_task) = common::setup_bridge_controller(
+        "edge-device-4",
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         vec![],
@@ -384,6 +388,7 @@ async fn subscribe_to_upstream_rejected_should_retry() {
     let storage_dir_override = dir.path().to_path_buf();
 
     let (controller_handle, controller_task) = common::setup_bridge_controller(
+        "edge-device-5",
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs,
@@ -474,6 +479,7 @@ async fn connect_to_upstream_failure_should_retry() {
     let storage_dir_override = dir.path().to_path_buf();
 
     let (controller_handle, controller_task) = common::setup_bridge_controller(
+        "edge-device-6",
         local_server_handle.address(),
         upstream_tls_address.clone(),
         subs,
@@ -560,6 +566,7 @@ async fn bridge_forwards_messages_after_restart() {
     let storage_dir_override = dir.path().to_path_buf();
 
     let (controller_handle, controller_task) = common::setup_bridge_controller(
+        "edge-device-7",
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs.clone(),
@@ -621,6 +628,7 @@ async fn bridge_forwards_messages_after_restart() {
 
     // restart bridge
     let (controller_handle, controller_task) = common::setup_bridge_controller(
+        "edge-device-8",
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs,
@@ -688,6 +696,7 @@ async fn recreate_upstream_bridge_when_fails() {
     let storage_dir_override = dir.path().to_path_buf();
 
     let (mut controller_handle, _) = common::setup_bridge_controller(
+        "edge-device-9",
         local_server_handle.address(),
         upstream_server_handle.tls_address().unwrap(),
         subs,


### PR DESCRIPTION
For some reasons when EdgeHub starts up it make several concurrent attempts to subscribe to $iothub topics. It causes first attempt to succeed and the second one to fail with a timeout.

The changes to treat RPC subsctioption commands as individual even for the same topic.

cherry-pick `491fd97`