### PR TITLE
Test Dashboard: Allow longhaul / connectivity pipelines to show with new dashboard queries

### DIFF
--- a/builds/e2e/templates/connectivity-deploy.yaml
+++ b/builds/e2e/templates/connectivity-deploy.yaml
@@ -68,6 +68,7 @@ steps:
         testInfo="$testInfo,TestName=$testName"
         testInfo="$testInfo,CustomEdgeAgentImage=${{ parameters['customEdgeAgent.image'] }}"
         testInfo="$testInfo,CustomEdgeHubImage=${{ parameters['customEdgeHub.image'] }}"
+        testInfo="$testInfo,TestName=connectivity (single-node)"
         
         sudo $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/connectivityTest.sh \
           -testDir "$(Agent.HomeDirectory)/.." \

--- a/builds/e2e/templates/connectivity-deploy.yaml
+++ b/builds/e2e/templates/connectivity-deploy.yaml
@@ -56,7 +56,6 @@ steps:
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/testHelper.sh
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/connectivityTest.sh
-        testName="Connectivity"
 
         testInfo="TestBuildNumber=${{ parameters['test.buildNumber'] }}"
         testInfo="$testInfo,TestBuildId=${{ parameters['test.buildId'] }}"
@@ -65,7 +64,6 @@ steps:
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
         testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
         testInfo="$testInfo,NetworkDescription=${{ parameters['networkController.description'] }}"
-        testInfo="$testInfo,TestName=$testName"
         testInfo="$testInfo,CustomEdgeAgentImage=${{ parameters['customEdgeAgent.image'] }}"
         testInfo="$testInfo,CustomEdgeHubImage=${{ parameters['customEdgeHub.image'] }}"
         testInfo="$testInfo,TestName=connectivity (single-node)"

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -60,7 +60,6 @@ steps:
         testInfo="$testInfo,EdgeletSourceBranch=${{ parameters['edgelet.source.branch'] }}"
         testInfo="$testInfo,ImagesSourceBranch=${{ parameters['images.source.branch'] }}"
         testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
-        testInfo="$testInfo,TestName=$testName"
         testInfo="$testInfo,UpstreamProtocol=amqp"
         testInfo="$testInfo,TestName=longhaul (single-node)"
         

--- a/builds/e2e/templates/longhaul-deploy.yaml
+++ b/builds/e2e/templates/longhaul-deploy.yaml
@@ -62,6 +62,7 @@ steps:
         testInfo="$testInfo,HostPlatform=${{ parameters['metricsCollector.hostPlatform'] }}"
         testInfo="$testInfo,TestName=$testName"
         testInfo="$testInfo,UpstreamProtocol=amqp"
+        testInfo="$testInfo,TestName=longhaul (single-node)"
         
         . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/scripts/linux/runE2ETest.sh


### PR DESCRIPTION
We updated the dashboard queries to accommodate for nested test pipelines. Because of this, dashboard expects some more contextual information to be sent up to display properly.