### PR TITLE
Set default agent version to 1.2.0-rc4

### DIFF
--- a/edgelet/contrib/config/linux/default.toml
+++ b/edgelet/contrib/config/linux/default.toml
@@ -11,7 +11,7 @@ name = "edgeAgent"
 type = "docker"
 
 [agent.config]
-image = "mcr.microsoft.com/azureiotedge-agent:1.2"
+image = "mcr.microsoft.com/azureiotedge-agent:1.2.0-rc4"
 
 [connect]
 workload_uri = "@connect_workload_uri@"

--- a/edgelet/contrib/config/linux/template.toml
+++ b/edgelet/contrib/config/linux/template.toml
@@ -211,7 +211,7 @@
 # imagePullPolicy = "..."   # "on-create" or "never". Defaults to "on-create"
 
 # [agent.config]
-# image = "mcr.microsoft.com/azureiotedge-agent:1.2"
+# image = "mcr.microsoft.com/azureiotedge-agent:1.2.0-rc4"
 # createOptions = { }       # Docker container create options, in TOML format.
 
 # [agent.config.auth]

--- a/edgelet/iotedge/src/config/super_config.rs
+++ b/edgelet/iotedge/src/config/super_config.rs
@@ -39,7 +39,7 @@ pub(super) fn default_agent() -> edgelet_core::ModuleSpec<edgelet_docker::Docker
         type_: "docker".to_owned(),
         image_pull_policy: Default::default(),
         config: edgelet_docker::DockerConfig {
-            image: "mcr.microsoft.com/azureiotedge-agent:1.2".to_owned(),
+            image: "mcr.microsoft.com/azureiotedge-agent:1.2.0-rc4".to_owned(),
             image_id: None,
             create_options: docker::models::ContainerCreateBody::new(),
             digest: None,


### PR DESCRIPTION
The official 1.2 agent image will be tagged upon release. For now, set the latest official agent image (1.2.0-rc4)