### PR TITLE
Make E2E setup errors actionable for developers.

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
@@ -39,8 +39,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
         [Category("CentOsSafe")]
         public async Task DpsSymmetricKey()
         {
-            string idScope = Context.Current.DpsIdScope.Expect(() => new InvalidOperationException("Missing DPS ID scope"));
-            string groupKey = Context.Current.DpsGroupKey.Expect(() => new InvalidOperationException("Missing DPS enrollment group key"));
+            string idScope = Context.Current.DpsIdScope.Expect(() => new InvalidOperationException("Missing DPS ID scope (check dpsIdScope in context.json)"));
+            string groupKey = Context.Current.DpsGroupKey.Expect(() => new InvalidOperationException("Missing DPS enrollment group key (check DPS_GROUP_KEY env var)"));
             string registrationId = DeviceId.Current.Generate();
 
             string deviceKey = this.DeriveDeviceKey(Convert.FromBase64String(groupKey), registrationId);
@@ -84,10 +84,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
         public async Task DpsX509()
         {
             (string, string, string) rootCa =
-                        Context.Current.RootCaKeys.Expect(() => new InvalidOperationException("Missing root CA keys"));
+                        Context.Current.RootCaKeys.Expect(() => new InvalidOperationException("Missing DPS ID scope (check rootCaPrivateKeyPath in context.json)"));
             string caCertScriptPath =
-                        Context.Current.CaCertScriptPath.Expect(() => new InvalidOperationException("Missing CA cert script path"));
-            string idScope = Context.Current.DpsIdScope.Expect(() => new InvalidOperationException("Missing DPS ID scope"));
+                        Context.Current.CaCertScriptPath.Expect(() => new InvalidOperationException("Missing CA cert script path (check caCertScriptPath in context.json)"));
+            string idScope = Context.Current.DpsIdScope.Expect(() => new InvalidOperationException("Missing DPS ID scope (check dpsIdScope in context.json)"));
             string registrationId = DeviceId.Current.Generate();
 
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -132,7 +132,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     await this.daemon.UninstallAsync(token);
 
                     // Delete test certs, keys, etc.
-                    Directory.Delete(FixedPaths.E2E_TEST_DIR, true);
+                    if (Directory.Exists(FixedPaths.E2E_TEST_DIR))
+                    {
+                        Directory.Delete(FixedPaths.E2E_TEST_DIR, true);
+                    }
                 },
                 "Completed end-to-end test teardown"),
             () =>
@@ -179,7 +182,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         public static async Task<(TestCertificates, CertificateAuthority ca)> GenerateCertsAsync(string deviceId, CancellationToken token)
         {
             string scriptPath = Context.Current.CaCertScriptPath.Expect(
-                () => new System.InvalidOperationException("Missing CA cert script path"));
+                () => new System.InvalidOperationException("Missing CA cert script path (check caCertScriptPath in context.json)"));
             (string, string, string) rootCa = Context.Current.RootCaKeys.Expect(
                 () => new System.InvalidOperationException("Missing root CA"));
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
@@ -40,9 +40,12 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
                     // If any container registry arguments (server, username, password)
                     // are given, then they must *all* be given, otherwise throw an error.
-                    Preconditions.CheckNonWhiteSpace(address, nameof(address));
-                    Preconditions.CheckNonWhiteSpace(username, nameof(username));
-                    Preconditions.CheckNonWhiteSpace(password, nameof(password));
+                    Preconditions.CheckArgument(!string.IsNullOrWhiteSpace(address), $"Container registry address is missing from context.json.");
+                    Preconditions.CheckArgument(!string.IsNullOrWhiteSpace(username), $"Container registry username is missing from context.json.");
+                    Preconditions.CheckArgument(
+                        !string.IsNullOrWhiteSpace(password),
+                        $"Container registry password is missing. Please set E2E_REGISTRIES__0__PASSWORD " +
+                        "env var (preferable) or place it in context.json");
 
                     result.Add(new Registry(address, username, password));
                 }
@@ -62,11 +65,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                     !string.IsNullOrWhiteSpace(key) ||
                     !string.IsNullOrWhiteSpace(password))
                 {
-                    Preconditions.CheckNonWhiteSpace(certificate, nameof(certificate));
-                    Preconditions.CheckNonWhiteSpace(key, nameof(key));
-                    Preconditions.CheckNonWhiteSpace(password, nameof(password));
-                    Preconditions.CheckArgument(File.Exists(certificate));
-                    Preconditions.CheckArgument(File.Exists(key));
+                    Preconditions.CheckArgument(!string.IsNullOrWhiteSpace(certificate), $"rootCaCertificatePath is missing from context.json.");
+                    Preconditions.CheckArgument(!string.IsNullOrWhiteSpace(key), $"rootCaPrivateKeyPath is missing from context.json.");
+                    Preconditions.CheckArgument(!string.IsNullOrWhiteSpace(password), $"ROOT_CA_PASSWORD is missing from environment or context.json.");
+                    Preconditions.CheckArgument(File.Exists(certificate), "rootCaCertificatePath file does not exist");
+                    Preconditions.CheckArgument(File.Exists(key), "rootCaPrivateKeyPath file does not exist");
                     return Option.Some((certificate, key, password));
                 }
 
@@ -78,6 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
             this.CaCertScriptPath = Option.Maybe(Get("caCertScriptPath"));
             this.ConnectionString = Get("IOT_HUB_CONNECTION_STRING");
+            Preconditions.CheckArgument(!string.IsNullOrWhiteSpace(this.ConnectionString), $"IOT_HUB_CONNECTION_STRING is missing from environment or context.json.");
             this.ParentDeviceId = Option.Maybe(Get("parentDeviceId"));
             this.DpsIdScope = Option.Maybe(Get("dpsIdScope"));
             this.DpsGroupKey = Option.Maybe(Get("DPS_GROUP_KEY"));
@@ -85,6 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             this.EdgeHubImage = Option.Maybe(Get("edgeHubImage"));
             this.DiagnosticsImage = Option.Maybe(Get("diagnosticsImage"));
             this.EventHubEndpoint = Get("EVENT_HUB_ENDPOINT");
+            Preconditions.CheckArgument(!string.IsNullOrWhiteSpace(this.EventHubEndpoint), $"EVENT_HUB_ENDPOINT is missing from environment or context.json.");
             this.InstallerPath = Option.Maybe(Get("installerPath"));
             this.LogFile = Option.Maybe(Get("logFile"));
             this.MethodReceiverImage = Option.Maybe(Get("methodReceiverImage"));

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
@@ -70,9 +70,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         public async Task SetUpCertificatesAsync(CancellationToken token, DateTime startTime, string deviceId)
         {
             (string, string, string) rootCa =
-                Context.Current.RootCaKeys.Expect(() => new InvalidOperationException("Missing root CA keys"));
+                Context.Current.RootCaKeys.Expect(() => new InvalidOperationException("Missing DPS ID scope (check rootCaPrivateKeyPath in context.json)"));
             string caCertScriptPath =
-                Context.Current.CaCertScriptPath.Expect(() => new InvalidOperationException("Missing CA cert script path"));
+                Context.Current.CaCertScriptPath.Expect(() => new InvalidOperationException("Missing CA cert script path (check caCertScriptPath in context.json)"));
             string certId = Context.Current.Hostname.GetOrElse(deviceId);
 
             try

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
@@ -76,11 +76,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         async Task<(X509Thumbprint, string, string)> CreateIdentityCertAsync(string deviceId, CancellationToken token)
         {
             (string, string, string) rootCa =
-            Context.Current.RootCaKeys.Expect(() => new InvalidOperationException("Missing root CA keys"));
+            Context.Current.RootCaKeys.Expect(() => new InvalidOperationException("Missing DPS ID scope (check rootCaPrivateKeyPath in context.json)"));
             string caCertScriptPath = Context.Current.CaCertScriptPath.Expect(
-                () => new InvalidOperationException("Missing CA cert script path"));
+                () => new InvalidOperationException("Missing CA cert script path (check caCertScriptPath in context.json)"));
             string idScope = Context.Current.DpsIdScope.Expect(
-                () => new InvalidOperationException("Missing DPS ID scope"));
+                () => new InvalidOperationException("Missing DPS ID scope(check dpsIdScope in context.json)"));
 
             CertificateAuthority ca = await CertificateAuthority.CreateAsync(
                 deviceId,


### PR DESCRIPTION
Right now it is very hard to setup E2E test on a local box. Docs need updates and not all error messages are useful.

In this PR I'm trying to improve most of the cases where we can encounter E2E setup error.