### PR TITLE
[unit test] Long container registry names fails on kubernetes deployments

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/ImagePullSecretNameTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/ImagePullSecretNameTest.cs
@@ -75,6 +75,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
                     "dockeruser-any-acr-server.azurecr.io-3030",
                     new AuthConfig { Username = "dockeruser", Password = "password", ServerAddress = "any-acr-server.azurecr.io:3030" }
                 ),
+                (
+                    "thisisavalidusername-thisisavalidcontainerregistrynamewith50characters",
+                    new AuthConfig { Username = "thisisavalidusername", Password = "password", ServerAddress = "thisisavalidcontainerregistrynamewith50characters.azurecr.io" }
+                ),
             };
             return data.Select(
                 d => new object[]


### PR DESCRIPTION
This is more a query than a pull request. I saw this failing on Azure stackedge when the Azure container registry name was long. Then the 63 character DNS sanitisation in `KubeUtils::SanitizeDNSDomain` failed and we had to migrate edge modules to an ACR with shorter name.

The below addition causes the unit tests to fail. I like to confirm if that is intentional or otherwise.