### PR TITLE
Fixing broken nested pipeline

### DIFF
--- a/builds/e2e/templates/nested-agent-deploy.yaml
+++ b/builds/e2e/templates/nested-agent-deploy.yaml
@@ -108,9 +108,9 @@ steps:
           iotedge_package="${pkg_list[*]}"
 
           echo "  Install library"
-          sudo dpkg -i --force-confnew ${iotedge_library}
+          sudo apt-get install ${iotedge_library}
           echo "  Install edgelet"
-          sudo dpkg -i --force-confnew ${iotedge_package}          
+          sudo apt-get install ${iotedge_package}          
   - ${{ if not(parameters.skipInstall) }}:
     - template: nested-deploy-config.yaml
       parameters:

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
@@ -41,7 +41,7 @@
           }
         },
         "modules": {
-          "iotedgeApiProxy": {
+          "IoTEdgeAPIProxy": {
             "version": "1.0",
             "type": "docker",
             "status": "running",

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
@@ -75,7 +75,7 @@
               }
             }
           },
-          "iotedgeApiProxy": {
+          "IoTEdgeAPIProxy": {
             "version": "1.0",
             "type": "docker",
             "status": "running",

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
@@ -81,7 +81,7 @@
               }
             }
           },
-          "iotedgeApiProxy": {
+          "IoTEdgeAPIProxy": {
             "version": "1.0",
             "type": "docker",
             "status": "running",

--- a/scripts/linux/nested-edge-deploy-agent.sh
+++ b/scripts/linux/nested-edge-deploy-agent.sh
@@ -14,133 +14,53 @@ function create_certificates() {
 }
 #@TODO this might not be compatible for CENTOS
 function setup_iotedge() {
-    echo "Setup certd"
+    sudo touch /etc/aziot/config.toml
 
-    echo "  Updating IoT Edge configuration file to use the newly installed certificcates"
     device_ca_cert_path="file:///certs/certs/iot-edge-device-${device_name}-full-chain.cert.pem"
     trusted_ca_certs_path="file:///certs/certs/azure-iot-test-only.root.ca.cert.pem"
+    device_key_cert_path="file:///certs/private/iot-edge-device-${device_name}.key.pem"
 
-    sudo touch /etc/aziot/certd/config.toml
-    echo "homedir_path = \"/var/lib/aziot/certd\"" | sudo tee  /etc/aziot/certd/config.toml
-    echo "" | sudo tee -a  /etc/aziot/certd/config.toml
-    echo "[cert_issuance]" | sudo tee -a  /etc/aziot/certd/config.toml
-    echo "" | sudo tee -a  /etc/aziot/certd/config.toml
-    echo "[preloaded_certs]" | sudo tee -a  /etc/aziot/certd/config.toml
-    echo "aziot-edged-ca = \"$device_ca_cert_path\"" | sudo tee -a  /etc/aziot/certd/config.toml
-    echo "aziot-edged-trust-bundle = \"$trusted_ca_certs_path\"" | sudo tee -a  /etc/aziot/certd/config.toml
-    sudo chown aziotcs:aziotcs /etc/aziot/certd/config.toml
-    sudo chmod 644 /etc/aziot/certd/config.toml
-    sudo cat /etc/aziot/certd/config.toml
-
-    # Grant aziot-edged access to edgeHub server certs.
-    >/tmp/principals.toml cat <<-EOF
-[[principal]]
-uid = $(id -u iotedge)
-certs = ["aziot-edged/module/*"]
-EOF
-    sudo mv /tmp/principals.toml /etc/aziot/certd/config.d/aziot-edged-principal.toml
-    sudo chown aziotcs:aziotcs /etc/aziot/certd/config.d/aziot-edged-principal.toml
-    sudo chmod 0600 /etc/aziot/certd/config.d/aziot-edged-principal.toml
-
-    echo "Setup keyd"
-    sudo touch /etc/aziot/keyd/config.toml
-    echo "[aziot_keys]" | sudo tee  /etc/aziot/keyd/config.toml
-    echo "homedir_path = \"/var/lib/aziot/keyd\"" | sudo tee -a  /etc/aziot/keyd/config.toml
-    echo "" | sudo tee -a  /etc/aziot/keyd/config.toml
-    echo "[preloaded_keys]" | sudo tee -a  /etc/aziot/keyd/config.toml
-    echo "device-id = \"file:///var/secrets/aziot/keyd/device-id\"" | sudo tee -a  /etc/aziot/keyd/config.toml
-    device_ca_pk_path="file:///certs/private/iot-edge-device-${device_name}.key.pem"
-    echo "aziot-edged-ca = \"$device_ca_pk_path\"" | sudo tee -a  /etc/aziot/keyd/config.toml
-    sudo chown aziotks:aziotks /etc/aziot/keyd/config.toml
-    sudo chmod 644 /etc/aziot/keyd/config.toml
-    sudo cat /etc/aziot/keyd/config.toml
-
-    # Grant aziot-identityd access to device ID and master encryption key.
-    >/tmp/principals.toml cat <<-EOF
-[[principal]]
-uid = $(id -u aziotid)
-keys = ["device-id", "aziot_identityd_master_id"]
-EOF
-    sudo mv /tmp/principals.toml /etc/aziot/keyd/config.d/aziot-identityd-principal.toml
-    sudo chown aziotks:aziotks /etc/aziot/keyd/config.d/aziot-identityd-principal.toml
-    sudo chmod 0600 /etc/aziot/keyd/config.d/aziot-identityd-principal.toml
-
-    # Grant aziot-edged access to device CA cert and master encryption key.
-    >/tmp/principals.toml cat <<-EOF
-[[principal]]
-uid = $(id -u iotedge)
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
-EOF
-    sudo mv /tmp/principals.toml /etc/aziot/keyd/config.d/aziot-edged-principal.toml
-    sudo chown aziotks:aziotks /etc/aziot/keyd/config.d/aziot-edged-principal.toml
-    sudo chmod 0600 /etc/aziot/keyd/config.d/aziot-edged-principal.toml
-
-    echo "Setup edged"
-    echo "    Updating edge Agent"
-    sudo cp /etc/aziot/edged/config.toml.default /etc/aziot/edged/config.toml
-    sudo sed -i "14s|.*|image = \"${CUSTOM_EDGE_AGENT_IMAGE}\"|" /etc/aziot/edged/config.toml
-    if [ -z $PARENT_NAME ]; then
-        sudo sed -i "15s|.*|auth = { serveraddress = \"${CONTAINER_REGISTRY}\", username = \"${CONTAINER_REGISTRY_USERNAME}\", password = \"${CONTAINER_REGISTRY_PASSWORD}\" }|" /etc/aziot/edged/config.toml
-    fi
-
+    echo "hostname = \"$device_name\"" | sudo tee -a /etc/aziot/config.toml
     if [ ! -z $PARENT_NAME ]; then
-        echo "    Updating the device and parent hostname"
-        sudo sed -i "1s/.*/hostname = \"$device_name\"/" /etc/aziot/edged/config.toml
-        echo "    Updating the parent hostname"
-        sudo sed -i "3s/.*/parent_hostname = \"$PARENT_NAME\"/" /etc/aziot/edged/config.toml
-    else
-        echo "    Updating the device hostname"
-        sudo sed -i "1s/.*/hostname = \"$device_name\"/" /etc/aziot/edged/config.toml
+         echo "parent_hostname = \"$PARENT_NAME\"" | sudo tee -a /etc/aziot/config.toml
     fi
-    sudo chown iotedge:iotedge /etc/aziot/edged/config.toml
-    sudo chmod 644 /etc/aziot/edged/config.toml
-    sudo cat /etc/aziot/edged/config.toml
+    echo "trust_bundle_cert = \"$trusted_ca_certs_path\"" | sudo tee -a  /etc/aziot/config.toml
+    echo "" | sudo tee -a  /etc/aziot/config.toml
 
-    echo "Setup identityd"
-    sudo touch /etc/aziot/identityd/config.toml
-    echo "hostname = \"$device_name\"" | sudo tee  /etc/aziot/identityd/config.toml
-    echo "homedir = \"/var/lib/aziot/identityd\"" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "[provisioning]" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "dynamic_reprovisioning = false" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "source = \"manual\"" | sudo tee -a  /etc/aziot/identityd/config.toml
+    echo "[provisioning]" | sudo tee -a  /etc/aziot/config.toml
+    echo "source = \"manual\"" | sudo tee -a /etc/aziot/config.toml
+    echo "connection_string = \"${CONNECTION_STRING}\"" | sudo tee -a /etc/aziot/config.toml
+    echo "" | sudo tee -a  /etc/aziot/config.toml
+
+    echo "[edge_ca]" | sudo tee -a  /etc/aziot/config.toml
+    echo "cert = \"$device_ca_cert_path\"" | sudo tee -a  /etc/aziot/config.toml
+    echo "pk = \"$device_key_cert_path\"" | sudo tee -a  /etc/aziot/config.toml
+    echo "" | sudo tee -a /etc/aziot/config.toml
+
+    echo "[agent]" | sudo tee -a  /etc/aziot/config.toml
+    echo "name = \"edgeAgent\"" | sudo tee -a  /etc/aziot/config.toml
+    echo "type = \"docker\"" | sudo tee -a /etc/aziot/config.toml
+
+    echo "[agent.config]" | sudo tee -a /etc/aziot/config.toml
     if [ ! -z $PARENT_NAME ]; then
-        echo "iothub_hostname = \"$PARENT_NAME\"" | sudo tee -a  /etc/aziot/identityd/config.toml
+        echo "image = \"\$upstream:443/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label\"" | sudo tee -a /etc/aziot/config.toml
     else
-        echo "iothub_hostname = \"${IOT_HUB_NAME}.azure-devices.net\"" | sudo tee -a  /etc/aziot/identityd/config.toml
-    fi
-    echo "device_id = \"${DEVICE_ID}\"" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "[provisioning.authentication]" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "method = \"sas\"" | sudo tee -a  /etc/aziot/identityd/config.toml
-    echo "device_id_pk = \"device-id\"" | sudo tee -a  /etc/aziot/identityd/config.toml
-    sudo chown aziotid:aziotid /etc/aziot/identityd/config.toml
-    sudo chmod 644 /etc/aziot/identityd/config.toml
-    sudo cat /etc/aziot/identityd/config.toml
-
-    echo "Setup aziot-edged-principal.toml"
-    id_aziot=$(id -u iotedge)
-    sudo touch /etc/aziot/identityd/config.d/aziot-edged-principal.toml
-    echo "[[principal]]" | sudo tee  /etc/aziot/identityd/config.d/aziot-edged-principal.toml
-    echo "uid = ${id_aziot}" | sudo tee -a  /etc/aziot/identityd/config.d/aziot-edged-principal.toml
-    echo "name = \"aziot-edge\"" | sudo tee -a  /etc/aziot/identityd/config.d/aziot-edged-principal.toml
-    sudo chown "$(id -u aziotid):$(id -g aziotid)" /etc/aziot/identityd/config.d/aziot-edged-principal.toml
-
-    echo "Setup /var/secrets/aziot/keyd/device-id"
-    sudo mkdir -p /var/secrets
-    sudo mkdir -p /var/secrets/aziot
-    sudo mkdir -p /var/secrets/aziot/keyd
-    sudo touch /var/secrets/aziot/keyd/device-id
-    deviceSASKey=$(echo "${CONNECTION_STRING}" | sed -n 's/.*SharedAccessKey=\(.*\)/\1/p')
-    echo "SAS key: $deviceSASKey"
-    echo $deviceSASKey | base64 -d > device-id
-    sudo mv device-id  /var/secrets/aziot/keyd/device-id
-    sudo chmod 600 /var/secrets/aziot/keyd/device-id
-    sudo chown aziotks:aziotks /var/secrets/aziot/keyd/device-id
-
+        echo "image = \"${CONTAINER_REGISTRY}:443/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label\"" | sudo tee -a /etc/aziot/config.toml
+    fi    
+    echo "createOptions = { }" | sudo tee -a /etc/aziot/config.toml
+    echo "" | sudo tee -a  /etc/aziot/config.toml
+    
+    echo "[agent.config.auth]" | sudo tee -a /etc/aziot/config.toml
+    echo "serveraddress = \"${CONTAINER_REGISTRY}\"" | sudo tee -a /etc/aziot/config.toml
+    echo "username = \"${CONTAINER_REGISTRY_USERNAME}\"" | sudo tee -a /etc/aziot/config.toml
+    echo "password = \"${CONTAINER_REGISTRY_PASSWORD}\"" | sudo tee -a /etc/aziot/config.toml
+    echo "" | sudo tee -a  /etc/aziot/config.toml
+    
     if [ ! -z $PROXY_ADDRESS ]; then
         echo "Configuring the bootstrapping edgeAgent to use http proxy"
-        sudo sed -i "12s|.*|env = { \"https_proxy\" = \"${PROXY_ADDRESS}\" }|" /etc/aziot/edged/config.toml
+        echo "[agent.env]" | sudo tee -a /etc/aziot/config.toml
+        echo "https_proxy = \"${PROXY_ADDRESS}\"" | sudo tee -a /etc/aziot/config.toml        
+        echo "" | sudo tee -a /etc/aziot/config.toml
 
         echo "Adding proxy configuration to docker"
         sudo mkdir -p /etc/systemd/system/docker.service.d/
@@ -163,12 +83,12 @@ EOF
         echo "Environment=HTTPS_PROXY=${PROXY_ADDRESS}";
         } | sudo tee /etc/systemd/system/aziot-edged.service.d/proxy.conf
         sudo systemctl daemon-reload
-
-     
     fi
 
+    sudo cat /etc/aziot/config.toml
+
     echo "Start IoT edge"
-    sudo systemctl start aziot-keyd aziot-certd aziot-identityd aziot-edged
+    sudo iotedge config apply
 }
 
 function prepare_test_from_artifacts() {
@@ -197,6 +117,8 @@ function prepare_test_from_artifacts() {
     if [[ ! -z "$CUSTOM_EDGE_HUB_IMAGE" ]]; then
         sed -i -e "s@\"image\":.*azureiotedge-hub:.*\"@\"image\": \"$CUSTOM_EDGE_HUB_IMAGE\"@g" "$deployment_working_file"
     fi
+
+    sudo cat ${deployment_working_file}
 
     #deploy the config in azure portal
     az iot edge set-modules --device-id ${DEVICE_ID} --hub-name ${IOT_HUB_NAME} --content ${deployment_working_file} --output none
@@ -331,20 +253,6 @@ process_args "$@"
 
 get_image_architecture_label
 
-if [ -z $CUSTOM_EDGE_AGENT_IMAGE ]; then
-    if [ ! -z $PARENT_NAME ]; then
-        CUSTOM_EDGE_AGENT_IMAGE="${PARENT_NAME}:443/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label"
-    else
-        CUSTOM_EDGE_AGENT_IMAGE="${CONTAINER_REGISTRY}/microsoft/azureiotedge-agent:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label"
-    fi
-fi
-if [ -z $CUSTOM_EDGE_HUB_IMAGE ]; then
-    if [ ! -z $PARENT_NAME ]; then
-        CUSTOM_EDGE_HUB_IMAGE="${PARENT_NAME}:443/microsoft/azureiotedge-hub:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label"
-    else
-        CUSTOM_EDGE_HUB_IMAGE="${CONTAINER_REGISTRY}/microsoft/azureiotedge-hub:$ARTIFACT_IMAGE_BUILD_NUMBER-linux-$image_architecture_label"
-    fi
-fi
 working_folder="$E2E_TEST_DIR/working"
 
 #@TODO remove hardcoding

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -295,6 +295,9 @@ namespace IotEdgeQuickstart.Details
             // Need to always reprovision so previous test runs don't affect this one.
             config[IDENTITYD].Document.RemoveIfExists("provisioning");
             config[IDENTITYD].Document.ReplaceOrAdd("provisioning.always_reprovision_on_startup", true);
+            parentHostname.ForEach(
+                parent_hostame =>
+                config[IDENTITYD].Document.ReplaceOrAdd("provisioning.local_gateway_hostname", parent_hostame));
 
             method.ManualConnectionString.Match(
                 cs =>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -105,12 +105,15 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 new string[] { "aziot-edged/module/*" });
         }
 
-        public void SetManualSasProvisioning(string hubHostname, string deviceId, string key)
+        public void SetManualSasProvisioning(string hubHostname, Option<string> parentHostname, string deviceId, string key)
         {
             string keyName = DaemonConfiguration.SanitizeName(deviceId);
             this.CreatePreloadedKey(keyName, key);
 
             this.config[Service.Identityd].Document.RemoveIfExists("provisioning");
+            parentHostname.ForEach(
+                parent_hostame =>
+                this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.local_gateway_hostname", parent_hostame));
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.always_reprovision_on_startup", true);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.source", "manual");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.iothub_hostname", hubHostname);
@@ -121,7 +124,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             this.SetAuth(keyName);
         }
 
-        public void SetDeviceManualX509(string hubhostname, string deviceId, string identityCertPath, string identityPkPath)
+        public void SetDeviceManualX509(string hubhostname, Option<string> parentHostname, string deviceId, string identityCertPath, string identityPkPath)
         {
             if (!File.Exists(identityCertPath))
             {
@@ -134,6 +137,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             }
 
             this.config[Service.Identityd].Document.RemoveIfExists("provisioning");
+            parentHostname.ForEach(
+                parent_hostame =>
+                this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.local_gateway_hostname", parent_hostame));
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.always_reprovision_on_startup", true);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.source", "manual");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.iothub_hostname", hubhostname);

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/SasManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/SasManualProvisioningFixture.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                         {
                             testCerts.AddCertsToConfig(config);
 
-                            config.SetManualSasProvisioning(Context.Current.ParentHostname.GetOrElse(this.device.HubHostname), this.device.Id, this.device.SharedAccessKey);
+                            config.SetManualSasProvisioning(this.IotHub.Hostname, Context.Current.ParentHostname, this.device.Id, this.device.SharedAccessKey);
 
                             config.Update();
                             return Task.FromResult((

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/X509ManualProvisioningFixture.cs
@@ -57,7 +57,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                             {
                                 testCerts.AddCertsToConfig(config);
                                 config.SetDeviceManualX509(
-                                    device.HubHostname,
+                                    this.IotHub.Hostname,
+                                    Context.Current.ParentHostname,
                                     device.Id,
                                     certPath,
                                     keyPath);


### PR DESCRIPTION
This PR is intended to bring back the nested pipeline to basic running state.
- Took the opportunity to use super config for the lvl 4 and lvl5 and use apt-get instead of dpckg
- The lvl4 and lvl5 was fixed the right way, however I was lacking the bandwidth to fix the quickstart + Microsoft.Azure.Devices.Edge.Test the right way. Just made a quick fix to get it to work

https://dev.azure.com/msazure/One/_build/results?buildId=40961617&view=logs&j=e8afecc0-c259-5cc1-62e0-5c5d1c2a3db4&t=f401ce77-605a-59dc-34fb-0bcc6cca03c5


