### PR TITLE
When common name is an ip address, add san entry as both iPAddress and dNSName

### DIFF
--- a/edgelet/edgelet-http-workload/src/server/cert/server.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/server.rs
@@ -94,9 +94,11 @@ where
 
                 if IpAddr::from_str(common_name).is_ok() {
                     ip.push(common_name.clone());
-                } else {
-                    dns.push(common_name.clone());
-                };
+                }
+
+                // add as dNSName even if it has been added as iPAddress. It is a workaround
+                // for OpenSSL, which does not check iPAddress entries when dNSName is present.
+                dns.push(common_name.clone());
 
                 #[allow(clippy::cast_sign_loss)]
                 let props = CertificateProperties::new(

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -18,7 +18,7 @@ pub mod macros;
 mod ser_de;
 mod yaml_file_source;
 
-use std::{collections::HashMap, net::IpAddr, str::FromStr};
+use std::collections::HashMap;
 
 pub use crate::error::{Error, ErrorKind};
 pub use crate::logging::log_failure;
@@ -79,23 +79,4 @@ pub fn prepare_dns_san_entries<'a>(
             Some(dns)
         }
     })
-}
-
-pub fn append_dns_san_entries(sans: &str, names: &[&str]) -> String {
-    let mut dns_ip_sans = names
-        .iter()
-        .filter_map(|name| {
-            if IpAddr::from_str(name).is_ok() {
-                Some(format!("IP:{}", name))
-            } else if name.trim().is_empty() {
-                None
-            } else {
-                Some(name.to_lowercase())
-            }
-        })
-        .collect::<Vec<String>>()
-        .join(", ");
-    dns_ip_sans.push_str(", ");
-    dns_ip_sans.push_str(sans);
-    dns_ip_sans
 }


### PR DESCRIPTION
This is a workaround of a problem happened with clients based on OpenSSL. When the host name is an ip address and the server certificate has a dNSAddres as a Subject Alternative Name entry, then OpenSSL ignores iPAddress entries.
Currently OpenSSL accepts only if
- there is not dNSName (like "edgehub" in our case), in this case it check iPAddress entries and the certificate validation passess
- there is a dNSName like "edgehub", but in this case also there is an extra dNSName for the ip address of the host

because we need "edgehub" alternative name for API Proxy, we need the second workaround to make it work