### PR TITLE
Fix getDeviceAndModuleOnBehalfOf to check if target device is in scope

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/NestedDeviceScopeApiClient.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/NestedDeviceScopeApiClient.cs
@@ -165,10 +165,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 Option<string> maybeAuthChain = await this.serviceIdentityHierarchy.GetAuthChain(onBehalfOfDevice);
                 string authChain = maybeAuthChain.Expect(() => new InvalidOperationException($"No valid authentication chain for {onBehalfOfDevice}"));
 
-                // We must pass the origin Edge ID along upstream, so the root
-                // can know which Edge to act OnBehalfOf when calling IoT Hub
-                msg.Headers.Add(Constants.OriginEdgeHeaderKey, onBehalfOfDevice);
-
                 var payload = new IdentityOnBehalfOfRequest(deviceId, moduleId.OrDefault(), authChain);
                 string token = await this.edgeHubTokenProvider.GetTokenAsync(Option.None<TimeSpan>());
                 msg.Headers.Add(HttpRequestHeader.Authorization.ToString(), token);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
@@ -26,7 +26,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const string SecurityMessageIoTHubInterfaceId = "urn:azureiot:Security:SecurityAgent:1";
 
         public const string ServiceApiIdHeaderKey = "x-ms-edge-moduleId";
-        public const string OriginEdgeHeaderKey = "x-ms-edge-origin";
         public const string ClientCertificateHeaderKey = "x-ms-edge-clientcert";
         public const string DefaultApiProxyId = "IoTEdgeAPIProxy";
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Primitives;
     using Newtonsoft.Json;
+    using Org.BouncyCastle.Asn1.Cmp;
 
     public class DeviceScopeController : Controller
     {
@@ -46,17 +47,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             }
 
             string authChain = request.AuthChain;
-            string[] ids = AuthChainHelpers.GetAuthChainIds(authChain);
-            if (ids.Length == 1)
-            {
-                // A child EdgeHub can use its module credentials to calls upstream
-                // OnBehalfOf its device identity, so the auth-chain would just have
-                // one element denoting the target device scope but no actor.
-                // However, the auth stack requires an actor to be specified for OnBehalfOf
-                // connections, so we manually add the actor to the auth-chain for this
-                // special case.
-                authChain = $"{ids[0]}/{Constants.EdgeHubModuleId};{ids[0]}";
-            }
+            //string[] ids = AuthChainHelpers.GetAuthChainIds(authChain);
+            //if (ids.Length == 1)
+            //{
+            //    // A child EdgeHub can use its module credentials to calls upstream
+            //    // OnBehalfOf its device identity, so the auth-chain would just have
+            //    // one element denoting the target device scope but no actor.
+            //    // However, the auth stack requires an actor to be specified for OnBehalfOf
+            //    // connections, so we manually add the actor to the auth-chain for this
+            //    // special case.
+            //    authChain = $"{ids[0]}/{Constants.EdgeHubModuleId};{ids[0]}";
+            //}
 
             IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
             HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), Option.Some(authChain), this.HttpContext);
@@ -115,6 +116,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             // Get the children of the target device and the target device itself;
             IEdgeHub edgeHub = await this.edgeHubGetter;
             IDeviceScopeIdentitiesCache identitiesCache = edgeHub.GetDeviceScopeIdentitiesCache();
+
+            Option<string> authChainToTarget = await identitiesCache.GetAuthChain(targetDeviceId);
+            (bool validationResult, string errorMsg) = ValidateAuthChainForRequestor(actorDeviceId, targetDeviceId, authChainToTarget);
+            if (!validationResult)
+            {
+                return new EdgeHubScopeResultError(HttpStatusCode.BadRequest, errorMsg);
+            }
+
             IList<ServiceIdentity> identities = await identitiesCache.GetDevicesAndModulesInTargetScopeAsync(targetDeviceId);
             Option<ServiceIdentity> targetDevice = await identitiesCache.GetServiceIdentity(targetDeviceId);
             targetDevice.ForEach(d => identities.Add(d));
@@ -123,6 +132,22 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             Events.SendingScopeResult(targetDeviceId, identities);
             return MakeResultFromIdentities(identities);
         }
+
+        (bool result, string errorMsg) ValidateAuthChainForRequestor(string actorDeviceId, string targetDeviceId, Option<string> authChain) =>
+            authChain.Match(
+                ac =>
+                {
+                    if (!AuthChainHelpers.ValidateAuthChain(actorDeviceId, targetDeviceId, ac))
+                    {
+                        return (false, $"Invalid request as auth chain ({ac}) to {targetDeviceId} does not contain {actorDeviceId}");
+                    }
+                    return (true, string.Empty);
+                },
+                () =>
+                {
+                    Events.AuthChainToTargetNotFound(actorDeviceId, targetDeviceId);
+                    return (false, $"Auth chain to target device {targetDeviceId} not found");
+                });
 
         async Task<EdgeHubScopeResult> HandleGetDeviceAndModuleOnBehalfOfAsync(string actorDeviceId, string actorModuleId, IdentityOnBehalfOfRequest request)
         {
@@ -168,29 +193,41 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             await targetIdentity.Match(
                 async ti =>
                 {
-                    var childrenOfTarget = await identitiesCache.GetDevicesAndModulesInTargetScopeAsync(originatingEdgeDevice);
-                    if(childrenOfTarget.Any(c => c.DeviceId == targetId))
+                    Option<string> authChainToTarget = await identitiesCache.GetAuthChain(targetId);
+                    if (!authChainToTarget.HasValue)
                     {
-                        identityList.Add(ti);
-                        // If the target is a module, we also need to
-                        // include the parent device as well to match
-                        // IoT Hub API behavior
-                        if (isModule)
-                        {
-                            Option<ServiceIdentity> device = await identitiesCache.GetServiceIdentity(request.TargetDeviceId);
-                            device.ForEach(i => identityList.Add(i));
-                        }
+                        Events.AuthChainToTargetNotFound(originatingEdgeDevice, targetId);
                     }
                     else
                     {
-                        Events.TargetNotChild(originatingEdgeDevice, targetId);
+                        await authChainToTarget.ForEachAsync(
+                            async ac =>
+                            {
+                                if (AuthChainHelpers.ValidateAuthChain(originatingEdgeDevice, targetId, ac))
+                                {
+                                    identityList.Add(ti);
+                                    // If the target is a module, we also need to
+                                    // include the parent device as well to match
+                                    // IoT Hub API behavior
+                                    if (isModule)
+                                    {
+                                        Option<ServiceIdentity> device = await identitiesCache.GetServiceIdentity(request.TargetDeviceId);
+                                        device.ForEach(i => identityList.Add(i));
+                                    }
+                                }
+                                else
+                                {
+                                    Events.TargetNotChild(originatingEdgeDevice, targetId);
+                                }
+                            });
                     }
                 },
                 () =>
                 {
+                    Events.TargetIdentityNotFound(originatingEdgeDevice, targetId);
                     return Task.CompletedTask;
                 });
-            
+
             Events.SendingScopeResult(targetId, identityList);
             return MakeResultFromIdentities(identityList);
         }
@@ -295,9 +332,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 Log.LogError((int)EventIds.AuthFail_InvalidAuthChain, $"Invalid auth chain, actor: {actorId}, target: {targetId}, auth chain: {authChain}");
             }
 
-            internal static void TargetNotChild(string originatorDeviceId, string targetId)
+            internal static void TargetNotChild(string originatingEdgeDevice, string targetId)
             {
-                Log.LogError((int)EventIds.AuthFail_InvalidRequest, $"Request to get device is invalid as {targetId} is not a child of {originatorDeviceId}.");
+                Log.LogError((int)EventIds.AuthFail_InvalidRequest, $"Request to get device is invalid as {targetId} is not a child of {originatingEdgeDevice}.");
+            }
+
+            internal static void AuthChainToTargetNotFound(string originatingEdgeDevice, string targetId)
+            {
+                Log.LogError((int)EventIds.AuthFail_InvalidRequest, $"Request to get device {targetId} by {originatingEdgeDevice} as auth chain to {targetId} was not found.");
+            }
+
+            internal static void TargetIdentityNotFound(string originatingEdgeDevice, string targetId)
+            {
+                Log.LogError((int)EventIds.AuthFail_InvalidRequest, $"Device {targetId} requested by {originatingEdgeDevice} was not found in the identities cache.");
             }
         }
     }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -14,9 +14,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity.Service;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Logging;
-    using Microsoft.Extensions.Primitives;
     using Newtonsoft.Json;
-    using Org.BouncyCastle.Asn1.Cmp;
 
     public class DeviceScopeController : Controller
     {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/DeviceScopeController.cs
@@ -88,21 +88,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 await this.SendResponse(result.Status, JsonConvert.SerializeObject(result));
             }
 
-            string authChain = request.AuthChain;
-            string[] ids = AuthChainHelpers.GetAuthChainIds(authChain);
-            if (ids.Length == 1)
-            {
-                // A child EdgeHub can use its module credentials to calls upstream
-                // OnBehalfOf its device identity, so the auth-chain would just have
-                // one element denoting the target device scope but no actor.
-                // However, the auth stack requires an actor to be specified for OnBehalfOf
-                // connections, so we manually add the actor to the auth-chain for this
-                // special case.
-                authChain = $"{ids[0]}/{Constants.EdgeHubModuleId};{ids[0]}";
-            }
-
             IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-            HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), Option.Some(authChain), this.HttpContext);
+            HttpAuthResult authResult = await authenticator.AuthenticateAsync(actorDeviceId, Option.Some(actorModuleId), Option.Some(request.AuthChain), this.HttpContext);
 
             if (authResult.Authenticated)
             {
@@ -152,16 +139,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
 
             IEdgeHub edgeHub = await this.edgeHubGetter;
 
-            if (!AuthChainHelpers.TryGetTargetDeviceId(request.AuthChain, out string originatingEdge))
+            if (!AuthChainHelpers.TryGetTargetDeviceId(request.AuthChain, out string originatingEdgeDevice))
             {
-                originatingEdge = actorDeviceId;
+                originatingEdgeDevice = actorDeviceId;
             }
 
             // We must always forward the call further upstream first,
             // as this is invoked for refreshing an identity on-demand,
             // and we don't know whether our cache is out-of-date.
             IDeviceScopeIdentitiesCache identitiesCache = edgeHub.GetDeviceScopeIdentitiesCache();
-            await identitiesCache.RefreshServiceIdentityOnBehalfOf(targetId, originatingEdge);
+            await identitiesCache.RefreshServiceIdentityOnBehalfOf(targetId, originatingEdgeDevice);
             Option<ServiceIdentity> targetIdentity = await identitiesCache.GetServiceIdentity(targetId);
 
             if (!targetIdentity.HasValue)
@@ -181,8 +168,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             await targetIdentity.Match(
                 async ti =>
                 {
-                    var childrenOfTarget = await identitiesCache.GetDevicesAndModulesInTargetScopeAsync(originatingEdge);
-                    if(childrenOfTarget.Any(c => c.DeviceId == originatingEdge))
+                    var childrenOfTarget = await identitiesCache.GetDevicesAndModulesInTargetScopeAsync(originatingEdgeDevice);
+                    if(childrenOfTarget.Any(c => c.DeviceId == targetId))
                     {
                         identityList.Add(ti);
                         // If the target is a module, we also need to
@@ -196,7 +183,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                     }
                     else
                     {
-                        Events.TargetNotChild(originatingEdge, targetId);
+                        Events.TargetNotChild(originatingEdgeDevice, targetId);
                     }
                 },
                 () =>
@@ -204,8 +191,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                     return Task.CompletedTask;
                 });
             
-            targetIdentity.ForEach(i => identityList.Add(i));
-
             Events.SendingScopeResult(targetId, identityList);
             return MakeResultFromIdentities(identityList);
         }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -168,6 +168,75 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             Assert.False(AuthChainHelpers.ValidateAuthChain("edge1", "leaf1", ";"));
         }
 
+        [Theory]
+        [InlineData("l4", "l3", "l3;l4;l5", true)]
+        [InlineData("l4", "l4", "l4;l5", true)]
+        [InlineData("l4", "l2", "l2;l3;l4;l5", true)]
+        [InlineData("l3", "l2", "l2;l3;l4;l5", true)]
+        [InlineData("l3-2", "l2", "l2;l3;l4;l5", false)]
+        [InlineData("l5", "l2", "l2;l3;l4;l5", true)]
+        public void ValidateAuthChainForRequestorTest(string actorDeviceId, string targetDeviceId, string authChain, bool expectedResult)
+        {
+            // Act
+            (bool result, string _) = DeviceScopeController.ValidateAuthChainForRequestor(actorDeviceId, targetDeviceId, Option.Maybe(authChain));
+
+            // Verify
+            Assert.Equal(expectedResult, result);
+
+        }
+
+        [Theory]
+        [InlineData("l4", "$edgeHub", "l3;l4", "l3", "l3;l4;l5", HttpStatusCode.OK)]
+        [InlineData("l4", "$edgeHub", "l2;l3;l4", "l2", "l2;l3;l4;l5", HttpStatusCode.OK)]
+        [InlineData("l3", "$edgeHub", "l2;l3", "l2", "l2;l3;l4;l5", HttpStatusCode.OK)]
+        [InlineData("l3", "$edgeHub", "l4", "l4", "l4;l5", HttpStatusCode.Unauthorized)]
+        [InlineData("l3", "$edgeHub", "l4", "l4", "l5", HttpStatusCode.Unauthorized)]
+        public async Task HandleDevicesAndModulesInTargetDeviceScopeAsyncTest(string actorDeviceId, string actorModuleId, string authChain,
+            string targetDeviceId, string authChainToTarget, HttpStatusCode expectedStatus)
+        {
+            // Setup
+            var request = new NestedScopeRequest(1, "", authChain);
+            var identitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
+            identitiesCache.Setup(i => i.GetAuthChain(targetDeviceId)).Returns(Task.FromResult(Option.Some(authChainToTarget)));
+            identitiesCache.Setup(i => i.GetServiceIdentity(targetDeviceId)).Returns(Task.FromResult(Option.None<ServiceIdentity>()));
+            identitiesCache.Setup(i => i.GetDevicesAndModulesInTargetScopeAsync(targetDeviceId)).Returns(Task.FromResult(new List<ServiceIdentity>() as IList<ServiceIdentity>));
+
+            // Act
+            EdgeHubScopeResult result = await DeviceScopeController.HandleDevicesAndModulesInTargetDeviceScopeAsync(actorDeviceId, actorModuleId, request, identitiesCache.Object);
+
+            // Verify
+            Assert.Equal(expectedStatus, result.Status);
+        }
+
+        [Theory]
+        [InlineData("l4", "$edgeHub", "leaf1", null, "l3;l4", "l3", "leaf1;l3;l4;l5", HttpStatusCode.OK)]
+        [InlineData("l4", "$edgeHub", "leaf1", "leafmod", "l3;l4", "l3", "leaf1/leafmod;leaf1;l3;l4;l5", HttpStatusCode.OK)]
+        [InlineData("l4", "$edgeHub", "leaf1", null, "l4", "l4", "leaf1;l3;l4;l5", HttpStatusCode.OK)]
+        [InlineData("l3", "$edgeHub", "leaf1", "leafmod", "l3;l4;l5", "l3", "leaf1/leafmod;leaf1;l3;l4;l5", HttpStatusCode.OK)]
+        [InlineData("l3", "$edgeHub", "l4", "mod1", "l3;l4;l5", "l3", "l4/mod1;l4;l5", HttpStatusCode.Unauthorized)]
+        [InlineData("l3", "$edgeHub", "l4child", null, "l3;l4", "l3", "l4child;l4", HttpStatusCode.Unauthorized)]
+        [InlineData("l3", "$edgeHub", "l4child", null, "l3;l4l;5", "l3", "l4child;l4;l5", HttpStatusCode.Unauthorized)]
+        [InlineData("l3", "$edgeHub", "l4", null, "l3;l4", "l3", "l4", HttpStatusCode.Unauthorized)]
+        public async Task HandleGetDeviceAndModuleOnBehalfOfAsync(string actorDeviceId, string actorModuleId,
+            string targetDeviceId, string targetModuleId, string authChain,
+            string originatorDeviceId, string authChainToTarget, HttpStatusCode expectedStatus)
+        {
+            // Setup
+            var request = new IdentityOnBehalfOfRequest(targetDeviceId, targetModuleId, authChain);
+            var identitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
+            string targetId = targetDeviceId + (string.IsNullOrWhiteSpace(targetModuleId) ? string.Empty : $"/{targetModuleId}");
+            identitiesCache.Setup(i => i.RefreshServiceIdentityOnBehalfOf(targetId, originatorDeviceId)).Returns(Task.CompletedTask);
+            var targetServiceIdentity = new ServiceIdentity(targetId, "dummy", Enumerable.Empty<string>(), new ServiceAuthentication(ServiceAuthenticationType.None), ServiceIdentityStatus.Enabled);
+            identitiesCache.Setup(i => i.GetServiceIdentity(targetId)).Returns(Task.FromResult(Option.Some(targetServiceIdentity)));
+            identitiesCache.Setup(i => i.GetAuthChain(targetId)).Returns(Task.FromResult(Option.Some(authChainToTarget)));
+
+            // Act
+            EdgeHubScopeResult edgeHubScopeResult = await DeviceScopeController.HandleGetDeviceAndModuleOnBehalfOfAsync(actorDeviceId, actorModuleId, request, identitiesCache.Object);
+
+            // Verity
+            Assert.Equal(expectedStatus, edgeHubScopeResult.Status);
+        }
+
         private static DeviceScopeController MakeController(string targetEdgeId, IList<ServiceIdentity> resultIdentities, IDictionary<string, string> authChains)
         {
             var identitiesCache = new Mock<IDeviceScopeIdentitiesCache>();

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -182,7 +182,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
 
             // Verify
             Assert.Equal(expectedResult, result);
-
         }
 
         [Theory]
@@ -191,11 +190,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         [InlineData("l3", "$edgeHub", "l2;l3", "l2", "l2;l3;l4;l5", HttpStatusCode.OK)]
         [InlineData("l3", "$edgeHub", "l4", "l4", "l4;l5", HttpStatusCode.Unauthorized)]
         [InlineData("l3", "$edgeHub", "l4", "l4", "l5", HttpStatusCode.Unauthorized)]
-        public async Task HandleDevicesAndModulesInTargetDeviceScopeAsyncTest(string actorDeviceId, string actorModuleId, string authChain,
-            string targetDeviceId, string authChainToTarget, HttpStatusCode expectedStatus)
+        public async Task HandleDevicesAndModulesInTargetDeviceScopeAsyncTest(
+            string actorDeviceId,
+            string actorModuleId,
+            string authChain,
+            string targetDeviceId,
+            string authChainToTarget,
+            HttpStatusCode expectedStatus)
         {
             // Setup
-            var request = new NestedScopeRequest(1, "", authChain);
+            var request = new NestedScopeRequest(1, string.Empty, authChain);
             var identitiesCache = new Mock<IDeviceScopeIdentitiesCache>();
             identitiesCache.Setup(i => i.GetAuthChain(targetDeviceId)).Returns(Task.FromResult(Option.Some(authChainToTarget)));
             identitiesCache.Setup(i => i.GetServiceIdentity(targetDeviceId)).Returns(Task.FromResult(Option.None<ServiceIdentity>()));
@@ -217,9 +221,15 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         [InlineData("l3", "$edgeHub", "l4child", null, "l3;l4", "l3", "l4child;l4", HttpStatusCode.Unauthorized)]
         [InlineData("l3", "$edgeHub", "l4child", null, "l3;l4l;5", "l3", "l4child;l4;l5", HttpStatusCode.Unauthorized)]
         [InlineData("l3", "$edgeHub", "l4", null, "l3;l4", "l3", "l4", HttpStatusCode.Unauthorized)]
-        public async Task HandleGetDeviceAndModuleOnBehalfOfAsync(string actorDeviceId, string actorModuleId,
-            string targetDeviceId, string targetModuleId, string authChain,
-            string originatorDeviceId, string authChainToTarget, HttpStatusCode expectedStatus)
+        public async Task HandleGetDeviceAndModuleOnBehalfOfAsync(
+            string actorDeviceId,
+            string actorModuleId,
+            string targetDeviceId,
+            string targetModuleId,
+            string authChain,
+            string originatorDeviceId,
+            string authChainToTarget,
+            HttpStatusCode expectedStatus)
         {
             // Setup
             var request = new IdentityOnBehalfOfRequest(targetDeviceId, targetModuleId, authChain);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/DeviceScopeControllerTest.cs
@@ -99,7 +99,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
 
             // Act
-            controller.Request.Headers.Add(Constants.OriginEdgeHeaderKey, $"{childEdgeId}");
             var request = new IdentityOnBehalfOfRequest(childEdgeId, moduleId, $"{childEdgeId};{parentEdgeId}");
             await controller.GetDeviceAndModuleOnBehalfOfAsync(parentEdgeId, "$edgeHub", request);
 
@@ -137,7 +136,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var controller = MakeController(childEdgeId, resultIdentities, authChainMapping);
 
             // Act
-            controller.Request.Headers.Add(Constants.OriginEdgeHeaderKey, $"{childEdgeId}");
             var request = new IdentityOnBehalfOfRequest(deviceId, null, $"{deviceId};{childEdgeId};{parentEdgeId}");
             await controller.GetDeviceAndModuleOnBehalfOfAsync(parentEdgeId, "$edgeHub", request);
 


### PR DESCRIPTION
Issue: EdgeHub allows child EdgeHubs to get device/module information for the devices in their scope (l3/$edgeHub can ask for l3child information to l4/$edgeHub). But a child EdgeHub should not be able to ask for information on identities that are not its descendants. But the current code did not do this check. Consequently a child edgeHub (say l3/$edgeHub) can ask for information on an identity that is not its child (say l4child) and be able to receive it. 

Fix: Before returning the information to the requesting child, also check if the target device/module is one of its descendants. 