### PR TITLE
Registry API On-behalf-of calls auth check fix

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/RegistryController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/RegistryController.cs
@@ -430,6 +430,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                     return;
                 }
 
+                string targetAuthChainVal = targetAuthChain.OrDefault();
+                if(!AuthChainHelpers.ValidateAuthChain(actorDeviceId, targetDeviceId, targetAuthChainVal))
+                {
+                    Events.AuthorizationFail_NoAuthChain(targetDeviceId);
+                    await this.SendResponseAsync(HttpStatusCode.Unauthorized);
+                    return;
+                }
+
                 string edgeDeviceId = edgeHub.GetEdgeDeviceId();
                 RegistryApiHttpResult result = await this.apiClient.ListModulesAsync(
                     edgeDeviceId,

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/RegistryController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/RegistryController.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 actorDeviceId = WebUtility.UrlDecode(actorDeviceId);
                 IEdgeHub edgeHub = await this.edgeHubGetter;
                 IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(this.CreateOrUpdateModuleAsync), this.HttpContext, edgeHub, authenticator);
+                Try<string> targetAuthChainTry = await AuthorizeOnBehalfOf(actorDeviceId, requestData.AuthChain, nameof(this.CreateOrUpdateModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
                 if (targetAuthChainTry.Success)
                 {
                     string targetAuthChain = targetAuthChainTry.Value;
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 actorDeviceId = WebUtility.UrlDecode(actorDeviceId);
                 IEdgeHub edgeHub = await this.edgeHubGetter;
                 IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(this.GetModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
+                Try<string> targetAuthChainTry = await AuthorizeOnBehalfOf(actorDeviceId, requestData.AuthChain, nameof(this.GetModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
                 if (targetAuthChainTry.Success)
                 {
                     string targetAuthChain = targetAuthChainTry.Value;
@@ -381,7 +381,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 actorDeviceId = WebUtility.UrlDecode(actorDeviceId);
                 IEdgeHub edgeHub = await this.edgeHubGetter;
                 IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(this.ListModulesOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
+                Try<string> targetAuthChainTry = await AuthorizeOnBehalfOf(actorDeviceId, requestData.AuthChain, nameof(this.ListModulesOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
                 if (targetAuthChainTry.Success)
                 {
                     string targetAuthChain = targetAuthChainTry.Value;
@@ -432,7 +432,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 IEdgeHub edgeHub = await this.edgeHubGetter;
                 IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
 
-                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(this.DeleteModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
+                Try<string> targetAuthChainTry = await AuthorizeOnBehalfOf(actorDeviceId, requestData.AuthChain, nameof(this.DeleteModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
                 if (targetAuthChainTry.Success)
                 {
                     string targetAuthChain = targetAuthChainTry.Value;
@@ -455,7 +455,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             }
         }
 
-        internal static async Task<Try<string>> ValidateOnBehalfOfCall(
+        internal static async Task<Try<string>> AuthorizeOnBehalfOf(
             string actorDeviceId,
             string authChain,
             string source,

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/RegistryController.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/RegistryController.cs
@@ -281,7 +281,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 actorDeviceId = WebUtility.UrlDecode(actorDeviceId);
                 IEdgeHub edgeHub = await this.edgeHubGetter;
                 IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(CreateOrUpdateModuleAsync), this.HttpContext, edgeHub, authenticator);
+                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(this.CreateOrUpdateModuleAsync), this.HttpContext, edgeHub, authenticator);
                 if (targetAuthChainTry.Success)
                 {
                     string targetAuthChain = targetAuthChainTry.Value;
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 actorDeviceId = WebUtility.UrlDecode(actorDeviceId);
                 IEdgeHub edgeHub = await this.edgeHubGetter;
                 IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(GetModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
+                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(this.GetModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
                 if (targetAuthChainTry.Success)
                 {
                     string targetAuthChain = targetAuthChainTry.Value;
@@ -381,7 +381,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 actorDeviceId = WebUtility.UrlDecode(actorDeviceId);
                 IEdgeHub edgeHub = await this.edgeHubGetter;
                 IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
-                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(ListModulesOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
+                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(this.ListModulesOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
                 if (targetAuthChainTry.Success)
                 {
                     string targetAuthChain = targetAuthChainTry.Value;
@@ -432,7 +432,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 IEdgeHub edgeHub = await this.edgeHubGetter;
                 IHttpRequestAuthenticator authenticator = await this.authenticatorGetter;
 
-                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(DeleteModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
+                Try<string> targetAuthChainTry = await ValidateOnBehalfOfCall(actorDeviceId, requestData.AuthChain, nameof(this.DeleteModuleOnBehalfOfAsync), this.HttpContext, edgeHub, authenticator);
                 if (targetAuthChainTry.Success)
                 {
                     string targetAuthChain = targetAuthChainTry.Value;
@@ -455,7 +455,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             }
         }
 
-        static internal async Task<Try<string>> ValidateOnBehalfOfCall(
+        internal static async Task<Try<string>> ValidateOnBehalfOfCall(
             string actorDeviceId,
             string authChain,
             string source,
@@ -491,8 +491,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
                 {
                     Events.AuthorizationFail_NoAuthChain(targetDeviceId);
                     return Try<string>.Failure(new ValidationException(HttpStatusCode.Unauthorized));
-                }
-                );
+                });
         }
 
         static async Task<bool> AuthenticateAsync(
@@ -501,7 +500,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
             Option<string> authChain,
             HttpContext httpContext,
             IHttpRequestAuthenticator authenticator)
-        {            
+        {
             HttpAuthResult authResult = await authenticator.AuthenticateAsync(deviceId, moduleId, authChain, httpContext);
 
             if (authResult.Authenticated)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/RegistryControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/RegistryControllerTest.cs
@@ -305,6 +305,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         [InlineData("l3", "l4", "l4", "l4;l5", true, HttpStatusCode.Unauthorized)]
         [InlineData("l4", "l3;l4", "l3", null, true, HttpStatusCode.Unauthorized)]
         [InlineData("l4", "l3;l4", "l3", "l3;l4;l5", false, HttpStatusCode.Unauthorized)]
+        [InlineData("l4", "l3;l3", "l3", "l3;l4;l5", false, HttpStatusCode.Unauthorized)]
+        [InlineData("l4", "l5;l4;l3", "l3", "l3;l4;l5", false, HttpStatusCode.Unauthorized)]
         public async Task ValidateOnBehalfOfCallTest(string actorDeviceId, string authChain, string targetDeviceId, string targetAuthChain, bool authResult, HttpStatusCode expectedResult)
         {
             // Setup

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/RegistryControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/RegistryControllerTest.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
             var httpRequestAuthenticator = Mock.Of<IHttpRequestAuthenticator>(a => a.AuthenticateAsync(actorDeviceId, Option.Some(Constants.EdgeHubModuleId), Option.Some(authChain), httpContext) == Task.FromResult(new HttpAuthResult(authResult, string.Empty)));
 
             // Act
-            Try<string> authChainResult = await RegistryController.ValidateOnBehalfOfCall(actorDeviceId, authChain, "test", httpContext, edgeHub, httpRequestAuthenticator);
+            Try<string> authChainResult = await RegistryController.AuthorizeOnBehalfOf(actorDeviceId, authChain, "test", httpContext, edgeHub, httpRequestAuthenticator);
 
             // Verify
             if (expectedResult == HttpStatusCode.OK)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/RegistryControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/RegistryControllerTest.cs
@@ -306,7 +306,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         [InlineData("l4", "l3;l4", "l3", null, true, HttpStatusCode.Unauthorized)]
         [InlineData("l4", "l3;l4", "l3", "l3;l4;l5", false, HttpStatusCode.Unauthorized)]
         [InlineData("l4", "l3;l3", "l3", "l3;l4;l5", false, HttpStatusCode.Unauthorized)]
-        [InlineData("l4", "l5;l4;l3", "l3", "l3;l4;l5", false, HttpStatusCode.Unauthorized)]
         public async Task ValidateOnBehalfOfCallTest(string actorDeviceId, string authChain, string targetDeviceId, string targetAuthChain, bool authResult, HttpStatusCode expectedResult)
         {
             // Setup

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/RegistryControllerTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/RegistryControllerTest.cs
@@ -299,6 +299,38 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
         }
 
         [Theory]
+        [InlineData("l4", "l3;l4", "l3", "l3;l4;l5", true, HttpStatusCode.OK)]
+        [InlineData("l4", "l2;l3;l4", "l2", "l2;l3;l4;l5", true, HttpStatusCode.OK)]
+        [InlineData("l4", "l4", "l4", "l4;l5", true, HttpStatusCode.OK)]
+        [InlineData("l3", "l4", "l4", "l4;l5", true, HttpStatusCode.Unauthorized)]
+        [InlineData("l4", "l3;l4", "l3", null, true, HttpStatusCode.Unauthorized)]
+        [InlineData("l4", "l3;l4", "l3", "l3;l4;l5", false, HttpStatusCode.Unauthorized)]
+        public async Task ValidateOnBehalfOfCallTest(string actorDeviceId, string authChain, string targetDeviceId, string targetAuthChain, bool authResult, HttpStatusCode expectedResult)
+        {
+            // Setup
+            var identitiesCache = Mock.Of<IDeviceScopeIdentitiesCache>(c => c.GetAuthChain(targetDeviceId) == Task.FromResult(Option.Maybe(targetAuthChain)));
+            var edgeHub = Mock.Of<IEdgeHub>(e => e.GetDeviceScopeIdentitiesCache() == identitiesCache);
+            var httpContext = new DefaultHttpContext();
+            var httpRequestAuthenticator = Mock.Of<IHttpRequestAuthenticator>(a => a.AuthenticateAsync(actorDeviceId, Option.Some(Constants.EdgeHubModuleId), Option.Some(authChain), httpContext) == Task.FromResult(new HttpAuthResult(authResult, string.Empty)));
+
+            // Act
+            Try<string> authChainResult = await RegistryController.ValidateOnBehalfOfCall(actorDeviceId, authChain, "test", httpContext, edgeHub, httpRequestAuthenticator);
+
+            // Verify
+            if (expectedResult == HttpStatusCode.OK)
+            {
+                Assert.True(authChainResult.Success);
+                Assert.Equal(targetAuthChain, authChainResult.Value);
+            }
+            else
+            {
+                Assert.False(authChainResult.Success);
+                Assert.IsType<RegistryController.ValidationException>(authChainResult.Exception);
+                Assert.Equal(expectedResult, ((RegistryController.ValidationException)authChainResult.Exception).StatusCode);
+            }
+        }
+
+        [Theory]
         [MemberData(nameof(GetControllerMethodDelegates))]
         [System.Diagnostics.CodeAnalysis.SuppressMessage(
             "Usage",


### PR DESCRIPTION
Issue: The Registry APIs exposed by the EdgeHub are used to CRUD module identities. 
For nested scenarios, special on-behalf-of APIs are supported, which allows the parent EdgeHub to CRUD module identities on behalf of the child. 
Imagine a topology like l5->l4->l3. If a module is added to l3, then the EdgeHub on l4 and l5 need to make the call to create the module on l3. For this they use the "on-behalf-of" api. Same applies to list/delete as well. 
But currently the code does not check if the caller is making the call on behalf of a descendant. This allowed, for example, l4, to CRUD modules on behalf of l5!

Fix:
Get the auth chain from the current EdgeHub to the target, and make sure the caller is on that auth chain. For example, then l4 makes a call to l5, to create a module on l3, then the auth chain from l3 to l5 is "l3;l4;l5". So l5 can validate that l4 is in the auth chain. 
Now if l4 makes a call to create a module on l5, then the auth chain from l5 to l5 is  "l5". l4 is not in this auth chain, so validation fails. 