### PR TITLE
Fix check-agent-image-version check for nested Edge scenarios.

### DIFF
--- a/edgelet/edgelet-docker/src/config.rs
+++ b/edgelet/edgelet-docker/src/config.rs
@@ -95,12 +95,8 @@ pub const UPSTREAM_PARENT_KEYWORD: &str = "$upstream";
 
 impl NestedEdgeBodge for DockerConfig {
     fn parent_hostname_resolve_image(&mut self, parent_hostname: &str) {
-        if self.image.starts_with(UPSTREAM_PARENT_KEYWORD) {
-            self.image = format!(
-                "{}{}",
-                parent_hostname,
-                &self.image[UPSTREAM_PARENT_KEYWORD.len()..]
-            );
+        if let Some(rest) = self.image.strip_prefix(UPSTREAM_PARENT_KEYWORD) {
+            self.image = format!("{}{}", parent_hostname, rest);
         }
     }
 }


### PR DESCRIPTION
- Replace `$upstream` in the Edge Agent image spec and auth config
  with the parent hostname.

- Fix the version regex to use `'\.` instead of `.` to match `.`

- Fix the version check to not crash when the regex doesn't match the image,
  and when the captures can't be parsed as version components.