### PR TITLE
Remove files created by previous pipeline runs

### DIFF
--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -294,7 +294,6 @@ namespace IotEdgeQuickstart.Details
 
             // Need to always reprovision so previous test runs don't affect this one.
             config[IDENTITYD].Document.RemoveIfExists("provisioning");
-            config[IDENTITYD].Document.ReplaceOrAdd("provisioning.always_reprovision_on_startup", true);
             parentHostname.ForEach(
                 parent_hostame =>
                 config[IDENTITYD].Document.ReplaceOrAdd("provisioning.local_gateway_hostname", parent_hostame));

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -79,7 +79,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         void SetBasicDpsParam(string idScope)
         {
             this.config[Service.Identityd].Document.RemoveIfExists("provisioning");
-            this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.always_reprovision_on_startup", true);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.source", "dps");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.global_endpoint", GlobalEndPoint);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.scope_id", idScope);
@@ -114,7 +113,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             parentHostname.ForEach(
                 parent_hostame =>
                 this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.local_gateway_hostname", parent_hostame));
-            this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.always_reprovision_on_startup", true);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.source", "manual");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.iothub_hostname", hubHostname);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.device_id", deviceId);
@@ -140,7 +138,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             parentHostname.ForEach(
                 parent_hostame =>
                 this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.local_gateway_hostname", parent_hostame));
-            this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.always_reprovision_on_startup", true);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.source", "manual");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.iothub_hostname", hubhostname);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.device_id", deviceId);

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -99,6 +99,21 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 {
                     await this.InternalStopAsync(token);
 
+                    // Delete any existing Identity state.
+                    string device_info = "/var/lib/aziot/identityd/device_info";
+                    if (File.Exists(device_info))
+                    {
+                        File.Delete(device_info);
+                        Log.Information("Deleted old provisioning data.");
+                    }
+
+                    string prev_state = "/var/lib/aziot/identityd/prev_state";
+                    if (File.Exists(prev_state))
+                    {
+                        File.Delete(prev_state);
+                        Log.Information("Deleted previous Identity state.");
+                    }
+
                     ConfigFilePaths paths = new ConfigFilePaths
                     {
                         Keyd = "/etc/aziot/keyd/config.toml",

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -54,6 +54,19 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
                     // Install IoT Edge, and do some basic configuration
                     await this.daemon.UninstallAsync(token);
+
+                    // Delete directories used by previous installs.
+                    string[] directories = { "/run/aziot", "/var/lib/aziot" };
+
+                    foreach (string directory in directories)
+                    {
+                        if (Directory.Exists(directory))
+                        {
+                            Directory.Delete(directory, true);
+                            Log.Information($"Deleted {directory}");
+                        }
+                    }
+
                     await this.daemon.InstallAsync(Context.Current.PackagePath, Context.Current.EdgeProxy, token);
 
                     // Clean the directory for test certs, keys, etc.

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManualProvisioningFixture.cs
@@ -106,30 +106,5 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                 await NUnitLogs.CollectAsync(startTime, token);
             }
         }
-
-        [OneTimeTearDown]
-        public async Task RemoveCertificatesAsync()
-        {
-            // This is a temporary solution see ticket: 9288683
-            if (!Context.Current.ISA95Tag)
-            {
-                await Profiler.Run(
-                    async () =>
-                    {
-                        using (var cts = new CancellationTokenSource(Context.Current.TeardownTimeout))
-                        {
-                            await this.daemon.ConfigureAsync(
-                                config =>
-                                {
-                                    config.RemoveCertificates();
-                                    config.Update();
-                                    return Task.FromResult(("without edge certificates", Array.Empty<object>()));
-                                },
-                                cts.Token);
-                        }
-                    },
-                    "Completed custom certificate teardown");
-            }
-        }
     }
 }


### PR DESCRIPTION
Files left by previous runs would affect the current runs. Delete these files so that pipeline runs start fresh.