### PR TITLE
Fix check-agent-image-version check for nested Edge scenarios. (#4742)

### DIFF
--- a/edgelet/edgelet-docker/src/config.rs
+++ b/edgelet/edgelet-docker/src/config.rs
@@ -95,12 +95,8 @@ pub const UPSTREAM_PARENT_KEYWORD: &str = "$upstream";
 
 impl NestedEdgeBodge for DockerConfig {
     fn parent_hostname_resolve_image(&mut self, parent_hostname: &str) {
-        if self.image.starts_with(UPSTREAM_PARENT_KEYWORD) {
-            self.image = format!(
-                "{}{}",
-                parent_hostname,
-                &self.image[UPSTREAM_PARENT_KEYWORD.len()..]
-            );
+        if let Some(rest) = self.image.strip_prefix(UPSTREAM_PARENT_KEYWORD) {
+            self.image = format!("{}{}", parent_hostname, rest);
         }
     }
 }

--- a/edgelet/iotedge/src/check/checks/check_agent_image.rs
+++ b/edgelet/iotedge/src/check/checks/check_agent_image.rs
@@ -1,14 +1,20 @@
-use crate::check::{checker::Checker, Check, CheckResult};
-use edgelet_core::RuntimeSettings;
+use std::borrow::Cow;
+
 use failure::{Context, ResultExt};
 use regex::Regex;
+
+use edgelet_core::module::NestedEdgeBodge;
+use edgelet_core::RuntimeSettings;
+use edgelet_docker::UPSTREAM_PARENT_KEYWORD;
+
+use crate::check::{checker::Checker, Check, CheckResult};
 
 #[derive(Default, serde_derive::Serialize)]
 pub(crate) struct CheckAgentImage {}
 
 impl Checker for CheckAgentImage {
     fn id(&self) -> &'static str {
-        "Check-Agent-image"
+        "check-agent-image"
     }
     fn description(&self) -> &'static str {
         "Agent image is valid and can be pulled from upstream"
@@ -37,14 +43,33 @@ impl CheckAgentImage {
             return Ok(CheckResult::Skipped);
         };
 
-        let agent_image = settings.agent().config().image();
+        let mut agent_config = settings.agent().config().clone();
+        if let Some(parent_hostname) = &check.parent_hostname {
+            agent_config.parent_hostname_resolve_image(parent_hostname);
+        }
+        let agent_image = agent_config.image();
 
         if check.parent_hostname.is_some() {
-            match check_agent_image_version(&agent_image) {
-                Ok(CheckResult::Ok) => (),
-                error => return error,
-            };
+            match check_agent_image_version_nested(&agent_image) {
+                CheckResult::Ok => (),
+                other => return Ok(other),
+            }
         }
+
+        let server_address = settings
+            .agent()
+            .config()
+            .auth()
+            .and_then(docker::models::AuthConfig::serveraddress);
+        let server_address = server_address.map(|server_address| {
+            if let Some(parent_hostname) = &check.parent_hostname {
+                if let Some(rest) = server_address.strip_prefix(UPSTREAM_PARENT_KEYWORD) {
+                    return Cow::Owned(format!("{}{}", parent_hostname, rest));
+                }
+            }
+
+            Cow::Borrowed(server_address)
+        });
 
         if let (Some(username), Some(password), Some(server_address)) = (
             &settings
@@ -57,11 +82,7 @@ impl CheckAgentImage {
                 .config()
                 .auth()
                 .and_then(docker::models::AuthConfig::password),
-            &settings
-                .agent()
-                .config()
-                .auth()
-                .and_then(docker::models::AuthConfig::serveraddress),
+            &server_address,
         ) {
             super::docker(
                 docker_host_arg,
@@ -86,48 +107,43 @@ impl CheckAgentImage {
     }
 }
 
-fn check_agent_image_version(agent_image: &str) -> Result<CheckResult, failure::Error> {
-    // We don't match the repo mcr.microsoft.com because in nested edge we expect the repo to be parent_hostname:443
-    let re = Regex::new(r".*?/azureiotedge-agent:(?P<Major>\d+).(?P<Minor>\d+).*")
-        .context("Failed to create regex")?;
+fn check_agent_image_version_nested(agent_image: &str) -> CheckResult {
+    // We don't match the repo mcr.microsoft.com because in nested edge we expect the repo to be $upstream:443
+    //
+    // If the image spec doesn't match what we expected, it's a custom image, and we can't make
+    // any determination of whether it's the right version or not. In that case we assume it is right.
+
+    let re = Regex::new(r".*?/azureiotedge-agent:(?P<Major>\d+)\.(?P<Minor>\d+).*")
+        .expect("hard-coded regex cannot fail to parse");
 
     if let Some(caps) = re.captures(&agent_image) {
-        let minor_version: i32 = caps
-            .name("Minor")
-            .expect("output does not match expected format")
-            .as_str()
-            .parse()
-            .expect("output does not match expected format");
-        let major_version: i32 = caps
+        let major = caps
             .name("Major")
-            .expect("output does not match expected format")
-            .as_str()
-            .parse()
-            .expect("output does not match expected format");
+            .and_then(|version| version.as_str().parse::<u32>().ok());
+        let minor = caps
+            .name("Minor")
+            .and_then(|version| version.as_str().parse::<u32>().ok());
 
-        if major_version < 1 {
-            return Ok(CheckResult::Failed(
-                Context::new("In nested edge, edgeAgent version need to be 1.2 or above").into(),
-            ));
-        }
-
-        if (major_version == 1) && (minor_version < 2) {
-            return Ok(CheckResult::Failed(
-                Context::new("In nested edge, edgeAgent version need to be 1.2 or above").into(),
-            ));
+        if let (Some(major), Some(minor)) = (major, minor) {
+            if major < 1 || (major == 1) && (minor < 2) {
+                return CheckResult::Failed(
+                    Context::new("In nested Edge, edgeAgent version need to be 1.2 or above")
+                        .into(),
+                );
+            }
         }
     }
 
-    Ok(CheckResult::Ok)
+    CheckResult::Ok
 }
 
 #[cfg(test)]
 mod tests {
-    use super::check_agent_image_version;
+    use super::check_agent_image_version_nested;
     use crate::check::CheckResult;
 
     #[test]
-    fn test_check_agent_image_version() {
+    fn test_check_agent_image_version_nested() {
         let test_cases = &[
             (
                 "mcr.microsoft.com/azureiotedge-agent:1.0.9.5-linux-amd64",
@@ -223,8 +239,10 @@ mod tests {
         ];
 
         for (agent_image, expected_is_valid) in test_cases {
-            let actual_is_valid =
-                matches!(check_agent_image_version(agent_image), Ok(CheckResult::Ok));
+            let actual_is_valid = matches!(
+                check_agent_image_version_nested(agent_image),
+                CheckResult::Ok
+            );
             assert_eq!(*expected_is_valid, actual_is_valid);
         }
     }


### PR DESCRIPTION
Cherry-pick from master of 146f530520eed20aae4103f4b168d1db0aff1b1b

- Replace `$upstream` in the Edge Agent image spec and auth config
  with the parent hostname.

- Fix the version regex to use `'\.` instead of `.` to match `.`

- Fix the version check to not crash when the regex doesn't match the image,
  and when the captures can't be parsed as version components.