### PR TITLE
Fix ws auth with cert over ApiProxy 

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/AmqpWebSocketListener.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/AmqpWebSocketListener.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
 
         public string SubProtocol => Constants.WebSocketSubProtocol;
 
-        public async Task ProcessWebSocketRequestAsync(WebSocket webSocket, Option<EndPoint> localEndPoint, EndPoint remoteEndPoint, string correlationId, X509Certificate2 clientCert, IList<X509Certificate2> clientCertChain)
+        public async Task ProcessWebSocketRequestAsync(WebSocket webSocket, Option<EndPoint> localEndPoint, EndPoint remoteEndPoint, string correlationId, X509Certificate2 clientCert, IList<X509Certificate2> clientCertChain, IAuthenticator proxyAuthenticator = null)
         {
             try
             {
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                         correlationId,
                         clientCert,
                         clientCertChain,
-                        this.authenticator,
+                        proxyAuthenticator?? this.authenticator,
                         this.clientCredentialsFactory);
                 }
                 else

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/AmqpWebSocketListener.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/AmqpWebSocketListener.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                         correlationId,
                         clientCert,
                         clientCertChain,
-                        proxyAuthenticator?? this.authenticator,
+                        proxyAuthenticator ?? this.authenticator,
                         this.clientCredentialsFactory);
                 }
                 else

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IWebSocketListener.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/IWebSocketListener.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             EndPoint remoteEndPoint,
             string correlationId,
             X509Certificate2 clientCert,
-            IList<X509Certificate2> clientCertChain);
+            IList<X509Certificate2> clientCertChain,
+            IAuthenticator proxyAuthenticator = null);
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/HttpProxiedCertificateExtractor.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/HttpProxiedCertificateExtractor.cs
@@ -107,12 +107,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http
 
         public static void AuthenticationApiProxy(string remoteAddress)
         {
-            Log.LogInformation((int)EventIds.AuthenticationApiProxy, $"Received authentication attempt through ApiProxy for {remoteAddress}");
+            Log.LogDebug((int)EventIds.AuthenticationApiProxy, $"Received authentication attempt through ApiProxy for {remoteAddress}");
         }
 
         public static void AuthenticateApiProxySuccess()
         {
-            Log.LogInformation((int)EventIds.AuthenticationSuccess, $"Authentication attempt through ApiProxy success");
+            Log.LogDebug((int)EventIds.AuthenticationSuccess, $"Authentication attempt through ApiProxy success");
         }
 
         public static void AuthenticateApiProxyFailed(Exception ex)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/HttpRequestAuthenticator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/controllers/HttpRequestAuthenticator.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Controllers
 
             public static void AuthenticationApiProxy(string remoteAddress)
             {
-                Log.LogInformation((int)EventIds.AuthenticationApiProxy, $"Received authentication attempt through ApiProxy for {remoteAddress}");
+                Log.LogDebug((int)EventIds.AuthenticationApiProxy, $"Received authentication attempt through ApiProxy for {remoteAddress}");
             }
         }
     }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
@@ -86,6 +86,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
                 try
                 {
                     var certExtractor = await this.httpProxiedCertificateExtractorProvider;
+                    // if not certificate in header it returns null, no api proxy authentication needed in this case
+                    // if certificate was set in header it means it was forwarded by api proxy and authenticates api proxy by sas token
+                    // and throws AuthenticationException if api proxy was not authenticated or returns the certificate if api proxy authentication succeeded
                     cert = (await certExtractor.GetClientCertificate(context)).OrDefault();
                 }
                 catch (AuthenticationException ex)

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
                 Log.LogWarning((int)EventIds.InvalidCertificate, Invariant($"Invalid client certificate for incoming connection: {connectionIp}, Exception: {ex.Message}"));
 
             public static void AuthenticationApiProxy(string remoteAddress) =>
-                Log.LogInformation((int)EventIds.AuthenticationApiProxy, $"Received authentication attempt through ApiProxy for {remoteAddress}");
+                Log.LogDebug((int)EventIds.AuthenticationApiProxy, $"Received authentication attempt through ApiProxy for {remoteAddress}");
 
             public static void AuthenticationApiProxyFailed(string remoteAddress, Exception ex) =>
                 Log.LogError((int)EventIds.AuthenticationApiProxy, $"Failed authentication attempt through ApiProxy for {remoteAddress}", ex);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/WebSocketHandlingMiddleware.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
     using System.Linq;
     using System.Net;
     using System.Net.WebSockets;
+    using System.Security.Authentication;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
     using System.Threading.Tasks;
@@ -78,17 +79,28 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
             var remoteEndPoint = new IPEndPoint(context.Connection.RemoteIpAddress, context.Connection.RemotePort);
 
             X509Certificate2 cert = await context.Connection.GetClientCertificateAsync();
+            IAuthenticator proxyAuthenticator = null;
 
             if (cert == null)
             {
-                var certExtractor = await this.httpProxiedCertificateExtractorProvider;
-                cert = (await certExtractor.GetClientCertificate(context)).OrDefault();
+                try
+                {
+                    var certExtractor = await this.httpProxiedCertificateExtractorProvider;
+                    cert = (await certExtractor.GetClientCertificate(context)).OrDefault();
+                }
+                catch (AuthenticationException ex)
+                {
+                    Events.AuthenticationApiProxyFailed(remoteEndPoint.ToString(), ex);
+                    // Set authenticator to unauthorize the call from subprotocol level (Mqtt or Amqp)
+                    proxyAuthenticator = new NullAuthenticator();
+                    cert = context.GetForwardedCertificate();
+                }
             }
 
             if (cert != null)
             {
                 IList<X509Certificate2> certChain = context.GetClientCertificateChain();
-                await listener.ProcessWebSocketRequestAsync(webSocket, localEndPoint, remoteEndPoint, correlationId, cert, certChain);
+                await listener.ProcessWebSocketRequestAsync(webSocket, localEndPoint, remoteEndPoint, correlationId, cert, certChain, proxyAuthenticator);
             }
             else
             {
@@ -130,6 +142,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
 
             public static void AuthenticationApiProxy(string remoteAddress) =>
                 Log.LogInformation((int)EventIds.AuthenticationApiProxy, $"Received authentication attempt through ApiProxy for {remoteAddress}");
+
+            public static void AuthenticationApiProxyFailed(string remoteAddress, Exception ex) =>
+                Log.LogError((int)EventIds.AuthenticationApiProxy, $"Failed authentication attempt through ApiProxy for {remoteAddress}", ex);
         }
     }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
@@ -75,9 +75,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             EndPoint remoteEndPoint,
             string correlationId,
             X509Certificate2 clientCert,
-            IList<X509Certificate2> clientCertChain)
+            IList<X509Certificate2> clientCertChain,
+            IAuthenticator proxyAuthenticator = null)
         {
-            var identityProvider = new DeviceIdentityProvider(this.authenticator, this.usernameParser, this.clientCredentialsFactory, this.metadataStore, this.clientCertAuthAllowed);
+            var identityProvider = new DeviceIdentityProvider(proxyAuthenticator?? this.authenticator, this.usernameParser, this.clientCredentialsFactory, this.metadataStore, this.clientCertAuthAllowed);
             identityProvider.RegisterConnectionCertificate(clientCert, clientCertChain);
             return this.ProcessWebSocketRequestAsyncInternal(identityProvider, webSocket, localEndPoint, remoteEndPoint, correlationId);
         }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttWebSocketListener.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
             IList<X509Certificate2> clientCertChain,
             IAuthenticator proxyAuthenticator = null)
         {
-            var identityProvider = new DeviceIdentityProvider(proxyAuthenticator?? this.authenticator, this.usernameParser, this.clientCredentialsFactory, this.metadataStore, this.clientCertAuthAllowed);
+            var identityProvider = new DeviceIdentityProvider(proxyAuthenticator ?? this.authenticator, this.usernameParser, this.clientCredentialsFactory, this.metadataStore, this.clientCertAuthAllowed);
             identityProvider.RegisterConnectionCertificate(clientCert, clientCertChain);
             return this.ProcessWebSocketRequestAsyncInternal(identityProvider, webSocket, localEndPoint, remoteEndPoint, correlationId);
         }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/WebSocketHandlingMiddlewareTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/WebSocketHandlingMiddlewareTest.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
                         It.IsAny<IList<X509Certificate2>>(),
                         It.Is<IAuthenticator>(auth => auth != null && auth.GetType() == typeof(NullAuthenticator))))
                 .Returns(Task.CompletedTask);
-            
+
             var registry = new WebSocketListenerRegistry();
             registry.TryRegister(listener.Object);
             var certContentBytes = Util.Test.Common.CertificateHelper.GenerateSelfSignedCert($"test_cert").Export(X509ContentType.Cert);
@@ -209,20 +209,19 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Test
 
             var registry = new WebSocketListenerRegistry();
             registry.TryRegister(listener.Object);
-            
+
             HttpContext httpContext = this.ContextWithRequestedSubprotocols("abc");
             var authenticator = new Mock<IAuthenticator>();
             authenticator.Setup(p => p.AuthenticateAsync(It.IsAny<IClientCredentials>())).ReturnsAsync(false);
 
             IHttpProxiedCertificateExtractor certExtractor = new HttpProxiedCertificateExtractor(authenticator.Object, Mock.Of<IClientCredentialsFactory>(), "hub", "edge", "proxy");
-            
+
             var middleware = new WebSocketHandlingMiddleware(next, registry, Task.FromResult(certExtractor));
             await middleware.Invoke(httpContext);
 
             authenticator.Verify(auth => auth.AuthenticateAsync(It.IsAny<IClientCredentials>()), Times.Never);
             listener.VerifyAll();
         }
-
 
         static IWebSocketListenerRegistry ObservingWebSocketListenerRegistry(List<string> correlationIds)
         {


### PR DESCRIPTION
For websockets connection the authentication needs to fail at subprotocol level to send the unauthorized to the client. 
It does the check in websockets middleware and if that fails it sets the Authenticator to NullAuthenticator. I think it is a little  weird, but otherwise would need to change the authenticator to receive the proxy token and do the proxy authentication there, better not to change it  now.  