### PR TITLE
Fix API proxy race condition (#4768)

### DIFF
--- a/edge-modules/api-proxy-module/src/monitors/certs_monitor.rs
+++ b/edge-modules/api-proxy-module/src/monitors/certs_monitor.rs
@@ -20,7 +20,8 @@ const CERTIFICATE_POLL_INTERVAL: tokio::time::Duration = tokio::time::Duration::
 
 //Check for expiry of certificates. If certificates are expired: rotate.
 pub fn start(
-    notify_certs_rotated: Arc<Notify>,
+    notify_server_cert_reload_api_proxy: Arc<Notify>,
+    notify_trust_bundle_reload_api_proxy: Arc<Notify>,
 ) -> Result<(JoinHandle<Result<()>>, ShutdownHandle), Error> {
     info!("Initializing certs monitoring loop");
 
@@ -79,7 +80,7 @@ pub fn start(
         }
 
         //Trust bundle just received. Request for a reset of the API proxy.
-        notify_certs_rotated.notify();
+        notify_trust_bundle_reload_api_proxy.notify();
 
         info!("Starting certs monitoring loop");
 
@@ -120,7 +121,7 @@ pub fn start(
             };
 
             if new_server_cert {
-                notify_certs_rotated.notify();
+                notify_server_cert_reload_api_proxy.notify();
             }
         }
     });


### PR DESCRIPTION
Fixes issue 9653726
At start up API proxy waits for the trust bundle and server cert before starting. 
However if we get them too close together, it will receive only one event.
 
There is a "debouncing" of event made by the signaling system:
`Notify provides two APIs. The default API debounces events (if the backend reports two similar events in close succession, Notify will only report one).`

2 possible fixes:
1. Easy fix: remove debouncing. One liner. Though I am not sure of the impact. 
2. Change a bit the starting strategy, wait the have both cert before sending 1 signal.

This PR implements strategy 2, because the fix only impact start up. Once API proxy is running code path is same as before.

Test:
Stop and restarted API proxy 150 times.