### PR TITLE
Add edgeHub identity to the scopes cache at the startup. (#4760)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/modules/RoutingModule.cs
@@ -509,18 +509,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service.Modules
                     .SingleInstance();
             }
 
-            // IClientCredentials "EdgeHubCredentials"
-            builder.Register(
-                    c =>
-                    {
-                        var identityFactory = c.Resolve<IClientCredentialsFactory>();
-                        IClientCredentials edgeHubCredentials = this.connectionString.Map(cs => identityFactory.GetWithConnectionString(cs)).GetOrElse(
-                            () => identityFactory.GetWithIotEdged(this.edgeDeviceId, this.edgeModuleId));
-                        return edgeHubCredentials;
-                    })
-                .Named<IClientCredentials>("EdgeHubCredentials")
-                .SingleInstance();
-
             // Task<IInvokeMethodHandler>
             builder.Register(
                     async c =>


### PR DESCRIPTION
When we connect upstream, we verify that identity is in scope. This is done in order to avoid poisoning telemetry queue with the telemetry from disabled devices.

On a fresh start, we may not yet received the scopes from the upstream, so we need to force add edgeHub in the cache so it is able to connect upstream. Later in the startup process, once we get the scopes from the upstream, this record is replaced.