### PR TITLE
Set auto_reprovisioning_mode to AlwaysOnStartup in tests

### DIFF
--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -293,6 +293,7 @@ namespace IotEdgeQuickstart.Details
             SetOwner(keyDir, config[KEYD].Owner, "700");
 
             // Need to always reprovision so previous test runs don't affect this one.
+            config[EDGED].Document.ReplaceOrAdd("auto_reprovisioning_mode", "AlwaysOnStartup");
             config[IDENTITYD].Document.RemoveIfExists("provisioning");
             parentHostname.ForEach(
                 parent_hostame =>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -78,6 +78,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
         void SetBasicDpsParam(string idScope)
         {
+            this.config[Service.Edged].Document.ReplaceOrAdd("auto_reprovisioning_mode", "AlwaysOnStartup");
+
             this.config[Service.Identityd].Document.RemoveIfExists("provisioning");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.source", "dps");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.global_endpoint", GlobalEndPoint);
@@ -119,6 +121,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.authentication.method", "sas");
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.authentication.device_id_pk", keyName);
 
+            this.config[Service.Edged].Document.ReplaceOrAdd("auto_reprovisioning_mode", "AlwaysOnStartup");
+
             this.SetAuth(keyName);
         }
 
@@ -153,6 +157,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             string keyName = DaemonConfiguration.SanitizeName(keyFileName);
             this.config[Service.Identityd].Document.ReplaceOrAdd("provisioning.authentication.identity_pk", keyName);
             this.config[Service.Keyd].Document.ReplaceOrAdd($"preloaded_keys.{keyName}", "file://" + identityPkPath);
+
+            this.config[Service.Edged].Document.ReplaceOrAdd("auto_reprovisioning_mode", "AlwaysOnStartup");
 
             this.SetAuth(keyName);
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -99,21 +99,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 {
                     await this.InternalStopAsync(token);
 
-                    // Delete any existing Identity state.
-                    string device_info = "/var/lib/aziot/identityd/device_info";
-                    if (File.Exists(device_info))
-                    {
-                        File.Delete(device_info);
-                        Log.Information("Deleted old provisioning data.");
-                    }
-
-                    string prev_state = "/var/lib/aziot/identityd/prev_state";
-                    if (File.Exists(prev_state))
-                    {
-                        File.Delete(prev_state);
-                        Log.Information("Deleted previous Identity state.");
-                    }
-
                     ConfigFilePaths paths = new ConfigFilePaths
                     {
                         Keyd = "/etc/aziot/keyd/config.toml",


### PR DESCRIPTION
This is needed to remove old provisioning data that might affect the current test run.