### PR TITLE
Remove extraneous "await" on task.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEnvironmentOperator.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesEnvironmentOperator.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             // The cts object is coming from an external source, check it and put it into an Option for safe handling.
             Option<CancellationTokenSource> shutdownCts = Option.Maybe(shutdownCtsObject as CancellationTokenSource);
 
-            HttpOperationResponse<V1PodList> podListResp = await task;
+            HttpOperationResponse<V1PodList> podListResp;
             try
             {
                 podListResp = await task;


### PR DESCRIPTION
In what looks like a merge error, "task" is awaited twice in KubernetesEnvironmentOperator. This may have the effect of silently shutting down the Environment operator when the "ListPods" fails in specific ways.