### PR TITLE
Fix for expired CA certificate not renewing (#4798)

### DIFF
--- a/edgelet/edgelet-http-workload/src/server/cert/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/mod.rs
@@ -284,10 +284,10 @@ pub(crate) fn prepare_edge_ca(
                     let cert = openssl::x509::X509::from_pem(cert.as_ref())
                         .map_err(|e| Error::from(e.context(context.clone())))?;
 
-                    let epoch =
-                        openssl::asn1::Asn1Time::from_unix(0).expect("unix epoch must be valid");
+                    let current_time = openssl::asn1::Asn1Time::days_from_now(0)
+                        .expect("current time must be valid");
 
-                    let diff = epoch
+                    let diff = current_time
                         .diff(&cert.not_after())
                         .map_err(|e| Error::from(e.context(context.clone())))?;
                     let diff = i64::from(diff.secs) + i64::from(diff.days) * 86400;


### PR DESCRIPTION
The logic for renewing the edge workload CA certificate was measuring expiration based on epoch instead of current time. Fixed the logic to look at current time instead.

Cherry-pick of 04e78bd850815303c613fd19292e6c1b231fec31