### PR TITLE
[mqtt] Filter out publication duplicates in MessageLoader (#4745)

### DIFF
--- a/mqtt/mqtt-bridge/src/bridge.rs
+++ b/mqtt/mqtt-bridge/src/bridge.rs
@@ -1,5 +1,3 @@
-use std::num::NonZeroUsize;
-
 use futures_util::{
     future::{self, Either},
     pin_mut,
@@ -83,8 +81,6 @@ impl Bridge<WakingMemoryStore> {
         settings: &ConnectionSettings,
         memory_settings: MemorySettings,
     ) -> Result<Self, BridgeError> {
-        const BATCH_SIZE: usize = 10;
-
         debug!("creating bridge {}...", settings.name());
 
         let (local_pump, remote_pump) = Builder::<WakingMemoryStore>::default()
@@ -106,12 +102,7 @@ impl Bridge<WakingMemoryStore> {
                 ))
                 .with_rules(settings.subscriptions());
             })
-            .with_store(move |_| {
-                Ok(PublicationStore::new_memory(
-                    NonZeroUsize::new(BATCH_SIZE).unwrap(),
-                    &memory_settings,
-                ))
-            })
+            .with_store(move |_| Ok(PublicationStore::new_memory(&memory_settings)))
             .build()?;
 
         debug!("created bridge {}...", settings.name());
@@ -130,8 +121,6 @@ impl Bridge<RingBuffer> {
         settings: &ConnectionSettings,
         ring_buffer_settings: RingBufferSettings,
     ) -> Result<Self, BridgeError> {
-        const BATCH_SIZE: usize = 10;
-
         debug!("creating bridge {}...", settings.name());
         let bridge_name = String::from(settings.name());
 
@@ -155,12 +144,7 @@ impl Bridge<RingBuffer> {
                 .with_rules(settings.subscriptions());
             })
             .with_store(move |suffix| {
-                PublicationStore::new_ring_buffer(
-                    NonZeroUsize::new(BATCH_SIZE).unwrap(),
-                    &ring_buffer_settings,
-                    &bridge_name,
-                    suffix,
-                )
+                PublicationStore::new_ring_buffer(&ring_buffer_settings, &bridge_name, suffix)
             })
             .build()?;
 

--- a/mqtt/mqtt-bridge/src/messages.rs
+++ b/mqtt/mqtt-bridge/src/messages.rs
@@ -278,7 +278,7 @@ mod tests {
 
     impl Default for MemoryPublicationStore {
         fn default() -> Self {
-            PublicationStore::new_memory(BATCH_SIZE, &MemorySettings::new(MAX_SIZE))
+            PublicationStore::new_memory(&MemorySettings::new(MAX_SIZE))
         }
     }
 
@@ -292,7 +292,6 @@ mod tests {
             let dir_path = dir.path().to_path_buf();
 
             let result = PublicationStore::new_ring_buffer(
-                BATCH_SIZE,
                 &RingBufferSettings::new(MAX_FILE_SIZE, dir_path, FLUSH_OPTIONS),
                 "test",
                 "local",
@@ -467,7 +466,7 @@ mod tests {
             .unwrap();
         handler.handle(Event::Publication(pub1)).await.unwrap();
 
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
 
         let extracted1 = loader.try_next().await.unwrap().unwrap();
         assert_eq!(extracted1.1, expected);
@@ -537,7 +536,7 @@ mod tests {
         handler.handle(Event::Publication(pub1)).await.unwrap();
         handler.handle(Event::Publication(pub2)).await.unwrap();
 
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
         let extracted1 = loader.try_next().await.unwrap().unwrap();
         let extracted2 = loader.try_next().await.unwrap().unwrap();
         assert_eq!(extracted1.1, expected1);
@@ -582,7 +581,7 @@ mod tests {
             .unwrap();
 
         handler.handle(Event::Publication(pub1)).await.unwrap();
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
         let extracted = loader.try_next().await.unwrap().unwrap();
         assert_eq!(extracted.1, expected);
     }
@@ -624,7 +623,7 @@ mod tests {
             .unwrap();
 
         handler.handle(Event::Publication(pub1)).await.unwrap();
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
         let extracted = loader.try_next().await.unwrap().unwrap();
         assert_eq!(extracted.1, expected);
     }
@@ -666,7 +665,7 @@ mod tests {
             .unwrap();
 
         handler.handle(Event::Publication(pub1)).await.unwrap();
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
         let extracted = loader.try_next().await.unwrap().unwrap();
         assert_eq!(extracted.1, expected);
     }
@@ -739,7 +738,7 @@ mod tests {
         handler.handle(Event::Publication(pub1)).await.unwrap();
         handler.handle(Event::Publication(pub2)).await.unwrap();
 
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
 
         let extracted1 = loader.try_next().await.unwrap().unwrap();
         assert_eq!(extracted1.1, expected1);
@@ -787,7 +786,7 @@ mod tests {
             .unwrap();
         handler.handle(Event::Publication(pub1)).await.unwrap();
 
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
 
         let extracted1 = loader.try_next().await.unwrap().unwrap();
         assert_eq!(extracted1.1, expected);
@@ -834,7 +833,7 @@ mod tests {
 
         handler.handle(Event::Publication(pub1)).await.unwrap();
 
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
 
         let extracted1 = loader.try_next().await.unwrap().unwrap();
         assert_eq!(extracted1.1, expected);
@@ -891,7 +890,7 @@ mod tests {
         handler.handle(Event::Publication(pub1)).await.unwrap();
         handler.handle(Event::Publication(pub2)).await.unwrap();
 
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
 
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
         if let Either::Right(_) = future::select(interval.next(), loader.next()).await {
@@ -923,7 +922,7 @@ mod tests {
 
         handler.handle(Event::Publication(pub1)).await.unwrap();
 
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
 
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
 
@@ -974,7 +973,7 @@ mod tests {
 
         handler.handle(Event::Publication(pub1)).await.unwrap();
 
-        let mut loader = handler.store.loader();
+        let mut loader = handler.store.loader(BATCH_SIZE);
 
         let mut interval = tokio::time::interval(std::time::Duration::from_secs(1));
 

--- a/mqtt/mqtt-bridge/src/persist/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/mod.rs
@@ -2,6 +2,8 @@ mod loader;
 mod publication_store;
 mod waking_state;
 
+use std::fmt::{Display, Formatter, Result as FmtResult};
+
 use bincode::Error as BincodeError;
 use serde::{Deserialize, Serialize};
 
@@ -21,6 +23,12 @@ pub struct Key {
     offset: u64,
 }
 
+impl Display for Key {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        write!(f, "{}", self.offset)
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum PersistError {
     #[error("RingBuffer error occurred. Caused by: {0}")]
@@ -34,6 +42,9 @@ pub enum PersistError {
 
     #[error("Serialization error occurred. Caused by: {0}")]
     Serialization(#[from] BincodeError),
+
+    #[error("Cannot remove key {current} that is not in order, but {expected} expected")]
+    BadKeyOrdering { current: Key, expected: Key },
 }
 
 pub type PersistResult<T> = Result<T, PersistError>;

--- a/mqtt/mqtt-bridge/src/persist/publication_store.rs
+++ b/mqtt/mqtt-bridge/src/persist/publication_store.rs
@@ -8,27 +8,20 @@ use crate::{
     persist::{
         loader::MessageLoader,
         waking_state::{memory::WakingMemoryStore, ring_buffer::RingBuffer, StreamWakeableState},
-        Key, PersistResult,
+        Key, PersistError, PersistResult,
     },
     settings::{MemorySettings, RingBufferSettings},
 };
 
-/// Pattern allows for the wrapping `PublicationStore` to be cloned and have non mutable methods
-/// This facilitates sharing between multiple futures in a single threaded environment
-struct PublicationStoreInner<S> {
-    state: Arc<Mutex<S>>,
-    loader: MessageLoader<S>,
-}
 /// Persistence implementation used for the bridge
-pub struct PublicationStore<S>(Arc<Mutex<PublicationStoreInner<S>>>);
+pub struct PublicationStore<S> {
+    state: Arc<Mutex<S>>,
+}
 
 impl PublicationStore<WakingMemoryStore> {
-    pub fn new_memory(
-        batch_size: NonZeroUsize,
-        memory_settings: &MemorySettings,
-    ) -> PublicationStore<WakingMemoryStore> {
+    pub fn new_memory(memory_settings: &MemorySettings) -> PublicationStore<WakingMemoryStore> {
         let max_size = memory_settings.max_size();
-        Self::new(WakingMemoryStore::new(max_size), batch_size)
+        Self::new(WakingMemoryStore::new(max_size))
     }
 }
 
@@ -40,7 +33,6 @@ impl PublicationStore<RingBuffer> {
     /// It also allows for a device to have clear isolated dir for
     /// storage files.
     pub fn new_ring_buffer(
-        batch_size: NonZeroUsize,
         ring_buffer_settings: &RingBufferSettings,
         bridge_name: &str,
         suffix: &str,
@@ -51,7 +43,7 @@ impl PublicationStore<RingBuffer> {
         let max_file_size = ring_buffer_settings.max_file_size();
         let flush_options = ring_buffer_settings.flush_options();
         let rb = RingBuffer::new(&file_path, max_file_size, *flush_options)?;
-        Ok(Self::new(rb, batch_size))
+        Ok(Self::new(rb))
     }
 }
 
@@ -59,24 +51,17 @@ impl<S> PublicationStore<S>
 where
     S: StreamWakeableState,
 {
-    pub fn new(state: S, batch_size: NonZeroUsize) -> Self {
-        let state = Arc::new(Mutex::new(state));
-        let loader = MessageLoader::new(state.clone(), batch_size);
-
-        let inner = PublicationStoreInner { state, loader };
-        let inner = Arc::new(Mutex::new(inner));
-
-        Self(inner)
+    pub fn new(state: S) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(state)),
+        }
     }
 
     pub fn push(&self, message: &Publication) -> PersistResult<Key> {
-        let inner_borrow = self.0.lock();
-
-        let mut borrowed_store = inner_borrow.state.lock();
-        let key = borrowed_store.insert(message)?;
+        let key = self.state.lock().insert(message)?;
 
         debug!(
-            "persisted publication on topic {} with key {:?}",
+            "persisted publication on topic {} with key {}",
             message.topic_name, key
         );
 
@@ -84,21 +69,29 @@ where
     }
 
     pub fn remove(&self, key: Key) -> PersistResult<()> {
-        debug!("removing publication with key {:?}", key);
-        let lock = self.0.lock();
-        let mut state = lock.state.lock();
-        state.remove(key)
+        debug!("removing publication with key {}", key);
+        let removed = self.state.lock().pop()?;
+
+        if removed != key {
+            return Err(PersistError::BadKeyOrdering {
+                current: key,
+                expected: removed,
+            });
+        }
+
+        Ok(())
     }
 
-    pub fn loader(&self) -> MessageLoader<S> {
-        let inner = self.0.lock();
-        inner.loader.clone()
+    pub fn loader(&self, batch_size: NonZeroUsize) -> MessageLoader<S> {
+        MessageLoader::new(self.state.clone(), batch_size)
     }
 }
 
 impl<S: StreamWakeableState> Clone for PublicationStore<S> {
     fn clone(&self) -> Self {
-        Self(self.0.clone())
+        Self {
+            state: self.state.clone(),
+        }
     }
 }
 
@@ -127,8 +120,7 @@ mod tests {
     #[tokio::test]
     async fn insert(state: impl StreamWakeableState) {
         // setup state
-        let batch_size = NonZeroUsize::new(5).unwrap();
-        let persistence = PublicationStore::new(state, batch_size);
+        let persistence = PublicationStore::new(state);
 
         // setup data
         let pub1 = Publication {
@@ -149,7 +141,8 @@ mod tests {
         let key2 = persistence.push(&pub2).unwrap();
 
         // get loader
-        let mut loader = persistence.loader();
+        let batch_size = NonZeroUsize::new(5).unwrap();
+        let mut loader = persistence.loader(batch_size);
 
         // make sure same publications come out in correct order
         let extracted1 = loader.try_next().await.unwrap().unwrap();
@@ -165,8 +158,7 @@ mod tests {
     #[tokio::test]
     async fn remove(state: impl StreamWakeableState) {
         // setup state
-        let batch_size = NonZeroUsize::new(1).unwrap();
-        let persistence = PublicationStore::new(state, batch_size);
+        let persistence = PublicationStore::new(state);
 
         // setup data
         let pub1 = Publication {
@@ -186,7 +178,8 @@ mod tests {
         persistence.push(&pub1).unwrap();
 
         // get loader
-        let mut loader = persistence.loader();
+        let batch_size = NonZeroUsize::new(1).unwrap();
+        let mut loader = persistence.loader(batch_size);
 
         // process first message, forcing loader to get new batch on the next read
         let (key1, _) = loader.try_next().await.unwrap().unwrap();
@@ -202,8 +195,7 @@ mod tests {
     #[test_case(TestWakingMemoryStore::default())]
     fn remove_key_inserted_but_not_retrieved(state: impl StreamWakeableState) {
         // setup state
-        let batch_size = NonZeroUsize::new(1).unwrap();
-        let persistence = PublicationStore::new(state, batch_size);
+        let persistence = PublicationStore::new(state);
 
         // setup data
         let pub1 = Publication {
@@ -223,8 +215,7 @@ mod tests {
     #[test_case(TestWakingMemoryStore::default())]
     fn remove_key_dne(state: impl StreamWakeableState) {
         // setup state
-        let batch_size = NonZeroUsize::new(1).unwrap();
-        let persistence = PublicationStore::new(state, batch_size);
+        let persistence = PublicationStore::new(state);
 
         // setup data
         let key1 = Key { offset: 0 };
@@ -239,8 +230,7 @@ mod tests {
     #[tokio::test]
     async fn get_loader(state: impl StreamWakeableState) {
         // setup state
-        let batch_size = NonZeroUsize::new(2).unwrap();
-        let persistence = PublicationStore::new(state, batch_size);
+        let persistence = PublicationStore::new(state);
 
         // setup data
         let pub1 = Publication {
@@ -261,7 +251,8 @@ mod tests {
         let key2 = persistence.push(&pub2).unwrap();
 
         // get loader with batch size
-        let mut loader = persistence.loader();
+        let batch_size = NonZeroUsize::new(2).unwrap();
+        let mut loader = persistence.loader(batch_size);
 
         // verify the loader returns both elements
         let extracted1 = loader.try_next().await.unwrap().unwrap();

--- a/mqtt/mqtt-bridge/src/persist/waking_state/memory/error.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/memory/error.rs
@@ -1,13 +1,15 @@
 use thiserror::Error;
 
+use crate::persist::Key;
+
 #[derive(Debug, Error)]
 pub enum MemoryError {
-    #[error("Cannot remove key that is not in order")]
-    BadKeyOrdering,
-
     #[error("In memory buffer is full")]
     Full,
 
     #[error("Cannot remove when no keys are present")]
     RemoveOnEmpty,
+
+    #[error("Cannot remove before reading a publication with key {0}")]
+    RemoveBeforeRead(Key),
 }

--- a/mqtt/mqtt-bridge/src/persist/waking_state/memory/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/memory/mod.rs
@@ -1,4 +1,4 @@
-use std::{cmp::min, collections::VecDeque, num::NonZeroUsize, task::Waker};
+use std::{collections::VecDeque, num::NonZeroUsize, task::Waker};
 
 use mqtt3::proto::Publication;
 use tracing::debug;
@@ -12,19 +12,19 @@ pub mod test;
 /// When elements are retrieved they are moved to the loaded collection.
 /// This loaded collection is necessary so it behaves the same as other `StreamWakeableState` implementations
 pub struct WakingMemoryStore {
-    queue: VecDeque<(Key, Publication)>,
-    loaded: VecDeque<Key>,
+    queue: VecDeque<Item>,
     waker: Option<Waker>,
     max_size: usize,
+    offset: u64,
 }
 
 impl WakingMemoryStore {
     pub fn new(max_size: NonZeroUsize) -> Self {
         Self {
             queue: VecDeque::new(),
-            loaded: VecDeque::new(),
             waker: None,
             max_size: max_size.get(),
+            offset: 0,
         }
     }
 }
@@ -32,52 +32,67 @@ impl WakingMemoryStore {
 impl StreamWakeableState for WakingMemoryStore {
     fn insert(&mut self, value: &Publication) -> PersistResult<Key> {
         let key = Key {
-            offset: self.queue.len() as u64,
+            offset: self.offset,
         };
-
-        debug!("inserting publication with key {:?}", key);
+        debug!("inserting publication with key {}", key);
 
         if self.max_size <= self.queue.len() {
             return Err(MemoryError::Full.into());
         }
 
-        self.queue.push_back((key, value.clone()));
+        let item = Item {
+            key,
+            publication: value.clone(),
+            has_read: false,
+        };
+
+        self.queue.push_back(item);
 
         if let Some(waker) = self.waker.take() {
             waker.wake();
         }
 
+        self.offset += 1;
+
         Ok(key)
     }
 
-    fn batch(&mut self, count: usize) -> PersistResult<VecDeque<(Key, Publication)>> {
-        let count = min(count, self.queue.len());
-        let output: VecDeque<_> = self.queue.drain(..count).collect();
-
-        for (key, _) in &output {
-            self.loaded.push_back(*key);
+    fn batch(&mut self, size: usize) -> PersistResult<VecDeque<(Key, Publication)>> {
+        let mut batch = VecDeque::with_capacity(size);
+        for item in self.queue.iter_mut().take(size) {
+            batch.push_back((item.key, item.publication.clone()));
+            item.has_read = true;
         }
 
-        Ok(output)
+        Ok(batch)
     }
 
-    fn remove(&mut self, key: Key) -> PersistResult<()> {
-        debug!(
-            "Removing publication with key {:?}. Current state of loaded messages: {:?}",
-            key, self.loaded
-        );
+    fn pop(&mut self) -> PersistResult<Key> {
+        match self.queue.pop_front() {
+            Some(item) if !item.has_read => {
+                let key = item.key;
+                self.queue.push_front(item);
+                Err(MemoryError::RemoveBeforeRead(key).into())
+            }
+            Some(item) => {
+                debug!("removing publication with key {} ", item.key);
 
-        if self.loaded.is_empty() {
-            Err(MemoryError::RemoveOnEmpty.into())
-        } else if self.loaded[0] == key {
-            self.loaded.pop_front();
-            Ok(())
-        } else {
-            Err(MemoryError::BadKeyOrdering.into())
+                if let Some(waker) = self.waker.take() {
+                    waker.wake();
+                }
+                Ok(item.key)
+            }
+            None => Err(MemoryError::RemoveOnEmpty.into()),
         }
     }
 
     fn set_waker(&mut self, waker: &Waker) {
         self.waker = Some(waker.clone());
     }
+}
+
+struct Item {
+    key: Key,
+    publication: Publication,
+    has_read: bool,
 }

--- a/mqtt/mqtt-bridge/src/persist/waking_state/memory/test.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/memory/test.rs
@@ -21,12 +21,12 @@ impl StreamWakeableState for TestWakingMemoryStore {
         self.0.insert(value)
     }
 
-    fn batch(&mut self, count: usize) -> PersistResult<VecDeque<(Key, Publication)>> {
-        self.0.batch(count)
+    fn batch(&mut self, size: usize) -> PersistResult<VecDeque<(Key, Publication)>> {
+        self.0.batch(size)
     }
 
-    fn remove(&mut self, key: Key) -> PersistResult<()> {
-        self.0.remove(key)
+    fn pop(&mut self) -> PersistResult<Key> {
+        self.0.pop()
     }
 
     fn set_waker(&mut self, waker: &Waker) {

--- a/mqtt/mqtt-bridge/src/persist/waking_state/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/mod.rs
@@ -15,13 +15,16 @@ pub mod ring_buffer;
 /// All implementations of this trait should have the same behavior with respect to errors.
 /// Thus all implementations will share the below test suite.
 pub trait StreamWakeableState {
+    /// Inserts a publication to the queue.
+    /// Returns the key of the inserted publication.
     fn insert(&mut self, value: &Publication) -> PersistResult<Key>;
 
-    /// Get count elements of store, excluding those that have already been loaded
-    fn batch(&mut self, count: usize) -> PersistResult<VecDeque<(Key, Publication)>>;
+    /// Returns a batch of elements in order of insertion.
+    fn batch(&mut self, size: usize) -> PersistResult<VecDeque<(Key, Publication)>>;
 
-    // This remove should error if the given element has not yet been returned by batch.
-    fn remove(&mut self, key: Key) -> PersistResult<()>;
+    /// Removes the oldest publication from the queue.
+    /// This remove should error if the given element has not yet been returned by batch.
+    fn pop(&mut self) -> PersistResult<Key>;
 
     fn set_waker(&mut self, waker: &Waker);
 }
@@ -47,7 +50,6 @@ mod tests {
             memory::test::TestWakingMemoryStore, ring_buffer::test::TestRingBuffer,
             StreamWakeableState,
         },
-        Key,
     };
 
     #[test_case(TestRingBuffer::default())]
@@ -122,11 +124,12 @@ mod tests {
         assert_eq!(key2, keys[1]);
 
         // remove some
-        {
-            let mut borrowed_state = state.lock();
-            borrowed_state.remove(key1).unwrap();
-            borrowed_state.remove(key2).unwrap();
-        }
+        let key = state.lock().pop().unwrap();
+        assert_eq!(key, key1);
+
+        let key = state.lock().pop().unwrap();
+        assert_eq!(key, key2);
+
         // check that the ordering is maintained
         for key in &keys[2..] {
             let extracted_offset = loader.try_next().await.unwrap().unwrap().0.offset;
@@ -194,7 +197,7 @@ mod tests {
 
         let key1 = state.insert(&pub1).unwrap();
         state.batch(1).unwrap();
-        assert_matches!(state.remove(key1), Ok(_));
+        assert_matches!(state.pop(), Ok(key) if key == key1);
 
         let result = state.batch(1);
         assert_matches!(result, Ok(_));
@@ -203,8 +206,7 @@ mod tests {
     #[test_case(TestRingBuffer::default())]
     #[test_case(TestWakingMemoryStore::default())]
     fn remove_loaded_dne(mut state: impl StreamWakeableState) {
-        let key1 = Key { offset: 0 };
-        let bad_removal = state.remove(key1);
+        let bad_removal = state.pop();
         assert_matches!(bad_removal, Err(_));
     }
 
@@ -218,35 +220,9 @@ mod tests {
             payload: Bytes::new(),
         };
 
-        let key1 = state.insert(&pub1).unwrap();
-        let bad_removal = state.remove(key1);
+        let _ = state.insert(&pub1).unwrap();
+        let bad_removal = state.pop();
         assert_matches!(bad_removal, Err(_));
-    }
-
-    #[test_case(TestRingBuffer::default())]
-    #[test_case(TestWakingMemoryStore::default())]
-    fn remove_loaded_out_of_order(mut state: impl StreamWakeableState) {
-        // setup data
-        let pub1 = Publication {
-            topic_name: "1".to_string(),
-            qos: QoS::ExactlyOnce,
-            retain: true,
-            payload: Bytes::new(),
-        };
-        let pub2 = Publication {
-            topic_name: "2".to_string(),
-            qos: QoS::ExactlyOnce,
-            retain: true,
-            payload: Bytes::new(),
-        };
-
-        // insert elements and extract
-        let _key1 = state.insert(&pub1).unwrap();
-        let key2 = state.insert(&pub2).unwrap();
-        state.batch(2).unwrap();
-
-        // remove out of order and verify
-        assert_matches!(state.remove(key2), Err(_))
     }
 
     #[test_case(TestRingBuffer::default())]

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/error.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/error.rs
@@ -1,15 +1,17 @@
+use crate::persist::Key;
+
 #[derive(Debug, thiserror::Error)]
 pub enum BlockError {
-    #[error("Unexpected block crc {found:?} expected {expected:?}")]
+    #[error("Unexpected block crc {found} expected {expected}")]
     BlockCrc { found: u32, expected: u32 },
 
     #[error("Failed to create block. Caused by {0}")]
     BlockCreation(#[from] bincode::Error),
 
-    #[error("Unexpected data crc {found:?} expected {expected:?}")]
+    #[error("Unexpected data crc {found} expected {expected}")]
     DataCrc { found: u32, expected: u32 },
 
-    #[error("Unexpected data size {found:?} expected {expected:?}")]
+    #[error("Unexpected data size {found} expected {expected}")]
     DataSize { found: u64, expected: u64 },
 
     #[error("Bad hint")]
@@ -41,14 +43,11 @@ pub enum RingBufferError {
     )]
     FileTruncation { current: u64, new: u64 },
 
-    #[error("Key does not exist")]
-    NonExistantKey,
+    #[error("Read unknown block with {current} but {expected} hint expected")]
+    UnknownBlock { current: u32, expected: u32 },
 
-    #[error("Key is at invalid index for removal")]
-    RemovalIndex,
-
-    #[error("Cannot remove before reading")]
-    RemoveBeforeRead,
+    #[error("Cannot remove before reading a publication with key {0}")]
+    RemoveBeforeRead(Key),
 
     #[error("Serialization error occurred. Caused by {0}")]
     Serialization(#[from] bincode::Error),

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/mod.rs
@@ -249,7 +249,7 @@ impl StreamWakeableState for RingBuffer {
         Ok(Key { offset: key })
     }
 
-    fn batch(&mut self, count: usize) -> PersistResult<VecDeque<(Key, Publication)>> {
+    fn batch(&mut self, size: usize) -> PersistResult<VecDeque<(Key, Publication)>> {
         let write_index = self.metadata.file_pointers.write;
         let read_index = self.metadata.file_pointers.read_begin;
 
@@ -268,7 +268,7 @@ impl StreamWakeableState for RingBuffer {
         let mut start = read_index;
         let mut vdata = VecDeque::new();
         let mut reader = BufReader::with_capacity(page_size::get(), &mut self.file);
-        for _ in 0..count {
+        for _ in 0..size {
             let block = load_block_header(&mut reader, start, block_size, self.max_file_size)?;
 
             // this means we read bytes that don't make a block, this is
@@ -308,26 +308,30 @@ impl StreamWakeableState for RingBuffer {
         Ok(vdata)
     }
 
-    fn remove(&mut self, key: Key) -> PersistResult<()> {
-        if !self.has_read {
-            return Err(PersistError::RingBuffer(RingBufferError::RemoveBeforeRead));
-        }
-        let timer = Instant::now();
+    fn pop(&mut self) -> PersistResult<Key> {
         let read_index = self.metadata.file_pointers.read_begin;
-        let key = key.offset;
-        if key != read_index {
-            return Err(PersistError::RingBuffer(RingBufferError::RemovalIndex));
+        let key = Key { offset: read_index };
+
+        if !self.has_read {
+            return Err(PersistError::RingBuffer(RingBufferError::RemoveBeforeRead(
+                key,
+            )));
         }
+
+        let timer = Instant::now();
 
         let block_size = *SERIALIZED_BLOCK_SIZE;
 
-        let start = key;
+        let start = key.offset;
         let mut block = load_block_header(&mut self.file, start, block_size, self.max_file_size)
             .map_err(PersistError::Serialization)?;
 
         let BlockVersion::Version1(inner_block) = block.inner_mut();
         if inner_block.hint() != BLOCK_HINT {
-            return Err(PersistError::RingBuffer(RingBufferError::NonExistantKey));
+            return Err(PersistError::RingBuffer(RingBufferError::UnknownBlock {
+                current: inner_block.hint(),
+                expected: BLOCK_HINT,
+            }));
         }
 
         inner_block.set_should_not_overwrite(false);
@@ -352,7 +356,9 @@ impl StreamWakeableState for RingBuffer {
             self.has_read = false;
         }
 
-        Ok(())
+        self.wake_up_task();
+
+        Ok(key)
     }
 
     fn set_waker(&mut self, waker: &Waker) {
@@ -758,7 +764,7 @@ mod tests {
                 }
 
                 for key in &keys[..39] {
-                    assert_matches!(rb.remove(*key), Ok(_));
+                    assert_matches!(rb.pop(), Ok(removed) if &removed == key);
                 }
 
                 read = rb.metadata.file_pointers.read_begin;
@@ -784,7 +790,7 @@ mod tests {
                 assert_eq!(batch.len(), 61);
                 for key in &keys[39..] {
                     assert_eq!(batch.pop_front().unwrap().0, *key);
-                    assert_matches!(rb.remove(*key), Ok(_));
+                    assert_matches!(rb.pop(), Ok(removed) if &removed == key);
                 }
                 assert_eq!(rb.metadata.order, 100);
             }
@@ -828,8 +834,8 @@ mod tests {
             assert!(!batch.is_empty());
 
             for (key, _) in batch.drain(..) {
-                let result = rb.remove(key);
-                assert_matches!(result, Ok(_));
+                let result = rb.pop();
+                assert_matches!(result, Ok(removed) if removed == key);
             }
 
             // write till wrap around
@@ -907,8 +913,13 @@ mod tests {
             assert!(!batch.is_empty());
 
             for (key, _) in batch.drain(..) {
-                rb.remove(key)
-                    .unwrap_or_else(|_| panic!(format!("unable to remove pub with key {:?}", key)));
+                let removed = rb.pop().expect("unable to pop publication");
+                if removed != key {
+                    panic!(
+                        "invalid publication removed {} but expected {}",
+                        removed, key
+                    );
+                }
             }
 
             read = rb.metadata.file_pointers.read_begin;
@@ -981,20 +992,9 @@ mod tests {
                 assert_eq!(batch.pop_front().unwrap().0, *key);
             }
 
-            {
-                let key = keys[0];
-                assert_matches!(rb.remove(key), Ok(_));
-            }
-
-            {
-                let key = keys[1];
-                assert_matches!(rb.remove(key), Ok(_));
-            }
-
-            {
-                let key = keys[2];
-                assert_matches!(rb.remove(key), Ok(_));
-            }
+            assert_matches!(rb.pop(), Ok(removed) if removed == keys[0]);
+            assert_matches!(rb.pop(), Ok(removed) if removed == keys[1]);
+            assert_matches!(rb.pop(), Ok(removed) if removed == keys[2]);
 
             assert_eq!(rb.metadata.order, 10);
         }
@@ -1068,8 +1068,8 @@ mod tests {
                 let entry = maybe_entry.unwrap();
                 assert_eq!(*key, entry.0);
                 assert_eq!(publication, entry.1);
-                let result = rb.remove(*key);
-                assert_matches!(result, Ok(_));
+                let result = rb.pop();
+                assert_matches!(result, Ok(removed) if &removed == key);
             }
             assert_eq!(rb.metadata.order, 5);
         }
@@ -1134,9 +1134,9 @@ mod tests {
 
         let result = rb.0.batch(2);
         let batch = result.unwrap();
-        for entry in batch {
-            rb.0.remove(entry.0)
-                .expect("Failed to remove from RingBuffer");
+        for (key, _) in batch {
+            let removed = rb.0.pop().expect("Failed to remove from RingBuffer");
+            assert_eq!(removed, key);
         }
 
         let smaller_publication = Publication {
@@ -1220,8 +1220,8 @@ mod tests {
         assert_matches!(result, Ok(_));
         let batch = result.unwrap();
 
-        let result = rb.0.remove(batch[0].0);
-        assert_matches!(result, Ok(_));
+        let result = rb.0.pop();
+        assert_matches!(result, Ok(removed) if removed == batch[0].0);
 
         // need bigger pub
         let big_publication = Publication {
@@ -1329,8 +1329,8 @@ mod tests {
                 let entry = maybe_entry.unwrap();
                 assert_eq!(*key, entry.0);
                 assert_eq!(publication, entry.1);
-                let result = rb.remove(*key);
-                assert_matches!(result, Ok(_));
+                let result = rb.pop();
+                assert_matches!(result, Ok(removed) if &removed == key);
             }
         }
         {
@@ -1401,8 +1401,8 @@ mod tests {
                 let entry = maybe_entry.unwrap();
                 assert_eq!(key, entry.0);
                 assert_eq!(publication, entry.1);
-                let result = rb.remove(key);
-                assert_matches!(result, Ok(_));
+                let result = rb.pop();
+                assert_matches!(result, Ok(removed) if removed == key);
             }
 
             // write till wrap around
@@ -1596,71 +1596,12 @@ mod tests {
     #[test]
     fn it_errs_on_remove_when_no_read() {
         let mut rb = TestRingBuffer::default();
-        let result = rb.0.remove(Key { offset: 1 });
+        let result = rb.0.pop();
         assert_matches!(result, Err(_));
         assert_matches!(
             result.unwrap_err(),
-            PersistError::RingBuffer(RingBufferError::RemoveBeforeRead)
+            PersistError::RingBuffer(RingBufferError::RemoveBeforeRead(_))
         );
-    }
-
-    #[test]
-    fn it_errs_on_remove_with_key_not_equal_to_read() {
-        let mut rb = TestRingBuffer::default();
-
-        let publication = Publication {
-            topic_name: "test".to_owned(),
-            qos: QoS::AtMostOnce,
-            retain: true,
-            payload: Bytes::new(),
-        };
-
-        let result = rb.0.insert(&publication);
-        assert_matches!(result, Ok(_));
-
-        let result = rb.0.batch(1);
-        assert_matches!(result, Ok(_));
-
-        let result = rb.0.remove(Key { offset: 1 });
-        assert_matches!(result, Err(_));
-        assert_matches!(
-            result.unwrap_err(),
-            PersistError::RingBuffer(RingBufferError::RemovalIndex)
-        );
-    }
-
-    #[test]
-    fn it_errs_on_remove_with_key_that_does_not_exist() {
-        let result = tempfile::NamedTempFile::new();
-        assert_matches!(result, Ok(_));
-        let file = result.unwrap();
-
-        let result = RingBuffer::new(
-            &file.path().to_path_buf(),
-            MAX_FILE_SIZE_NON_ZERO,
-            FLUSH_OPTIONS,
-        );
-        assert!(result.is_ok());
-        let mut rb = result.unwrap();
-
-        let publication = Publication {
-            topic_name: "test".to_owned(),
-            qos: QoS::AtMostOnce,
-            retain: true,
-            payload: Bytes::new(),
-        };
-
-        let result = rb.insert(&publication);
-        assert_matches!(result, Ok(_));
-
-        let result = rb.batch(1);
-        assert_matches!(result, Ok(_));
-
-        let result = write(file.path(), "garbage");
-        assert_matches!(result, Ok(_));
-
-        let result = rb.remove(Key { offset: 0 });
-        assert_matches!(result, Err(_));
     }
 
     #[test]
@@ -1689,8 +1630,8 @@ mod tests {
             let entry = batch.pop_front().unwrap();
             assert_eq!(key, entry.0);
 
-            let result = rb.0.remove(key);
-            assert_matches!(result, Ok(_));
+            let result = rb.0.pop();
+            assert_matches!(result, Ok(removed) if removed == key);
         }
     }
 }

--- a/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/test.rs
+++ b/mqtt/mqtt-bridge/src/persist/waking_state/ring_buffer/test.rs
@@ -20,12 +20,12 @@ impl StreamWakeableState for TestRingBuffer {
         self.0.insert(value)
     }
 
-    fn batch(&mut self, count: usize) -> PersistResult<VecDeque<(Key, Publication)>> {
-        self.0.batch(count)
+    fn batch(&mut self, size: usize) -> PersistResult<VecDeque<(Key, Publication)>> {
+        self.0.batch(size)
     }
 
-    fn remove(&mut self, key: Key) -> PersistResult<()> {
-        self.0.remove(key)
+    fn pop(&mut self) -> PersistResult<Key> {
+        self.0.pop()
     }
 
     fn set_waker(&mut self, waker: &Waker) {


### PR DESCRIPTION
There is a bug in the MessageLoader which does not filter out publications after they've loaded from storage. It caused message duplicates to be sent to the $upstream sometimes out of order.

Adds a filtering step to prevent duplicates to be sent when a new batch is loaded.

Changes `fn remove(key)` -> `fn pop()` to reflect the fact we cannot remove publication by any key.

cherry-pick `0c0536a`