### PR TITLE
[mqtt] egress pump errors out when either persist or publish error occurred (#4790)

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.6"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a4d35f7401e948629c9c3d6638fb9bf94e0b2121e96c3b428cc4e631f3eb74"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -589,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.6"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d674eaa0056896d5ada519900dbf97ead2e46a7b6621e8160d79e2f2e1e2784b"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
@@ -606,15 +606,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.6"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc94b64bb39543b4e432f1790b6bf18e3ee3b74653c5449f63310e9a74b123c"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.6"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f57ed14da4603b2554682e9f2ff3c65d7567b53188db96cb71538217fc64581b"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -624,24 +624,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.6"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d8764258ed64ebc5d9ed185cf86a95db5cac810269c5d20ececb32e0088abbd"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.6"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd26820a9f3637f1302da8bceba3ff33adbe53464b54ca24d4e2d4f1db30f94"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-util"
-version = "0.3.6"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a894a0acddba51a2d49a6f4263b1e64b8c579ece8af50fa86503d52cd1eea34"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -650,7 +647,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project-lite 0.2.6",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1376,12 +1373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
-
-[[package]]
 name = "oorandom"
 version = "11.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1522,6 +1513,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,9 +1617,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2304,7 +2301,7 @@ dependencies = [
  "mio",
  "mio-uds",
  "num_cpus",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "signal-hook-registry",
  "slab",
  "tokio-macros",
@@ -2352,7 +2349,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -2366,7 +2363,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tokio",
 ]
 
@@ -2384,7 +2381,7 @@ checksum = "b0987850db3733619253fe60e17cb59b82d37c7e6c0236bb81e4d6b87c879f27"
 dependencies = [
  "cfg-if 0.1.10",
  "log",
- "pin-project-lite",
+ "pin-project-lite 0.1.11",
  "tracing-attributes",
  "tracing-core",
 ]

--- a/mqtt/mqtt-bridge/src/persist/loader.rs
+++ b/mqtt/mqtt-bridge/src/persist/loader.rs
@@ -10,7 +10,7 @@ use futures_util::stream::Stream;
 use mqtt3::proto::Publication;
 use parking_lot::Mutex;
 
-use crate::persist::{waking_state::StreamWakeableState, Key, PersistResult};
+use crate::persist::{waking_state::StreamWakeableState, Key, PersistError, PersistResult};
 
 /// Message loader used to extract elements from bridge persistence
 ///
@@ -41,7 +41,6 @@ where
 
     fn next_batch(&mut self) -> PersistResult<VecDeque<(Key, Publication)>> {
         let batch = self.state.lock().batch(self.batch_size)?;
-
         Ok(batch)
     }
 }
@@ -75,10 +74,13 @@ where
                         Some((new_key, _)) if new_key == key => {
                             new_batch.pop_front();
                         }
-                        _ => panic!(
-                            "Invalid MessageLoader state: new_batch is corrupted {:?} for a key {}",
-                            new_batch, key
-                        ),
+                        _ => {
+                            return Poll::Ready(Some(Err(PersistError::Loader {
+                                key: *key,
+                                loaded: self.loaded.iter().copied().collect(),
+                                new_batch: new_batch.iter().map(|(key, _)| *key).collect(),
+                            })));
+                        }
                     }
                 }
             }
@@ -88,11 +90,9 @@ where
             self.batch = new_batch;
 
             // get next element and return it
-            let maybe_extracted = self.batch.pop_front();
-            let mut state_lock = self.state.lock();
-            maybe_extracted.map_or_else(
+            self.batch.pop_front().map_or_else(
                 || {
-                    state_lock.set_waker(cx.waker());
+                    self.state.lock().set_waker(cx.waker());
                     Poll::Pending
                 },
                 |extracted| Poll::Ready(Some(Ok(extracted))),

--- a/mqtt/mqtt-bridge/src/persist/mod.rs
+++ b/mqtt/mqtt-bridge/src/persist/mod.rs
@@ -45,6 +45,13 @@ pub enum PersistError {
 
     #[error("Cannot remove key {current} that is not in order, but {expected} expected")]
     BadKeyOrdering { current: Key, expected: Key },
+
+    #[error("Unexpected loader state. key={key}, loaded={loaded:?}, new_batch={new_batch:?}")]
+    Loader {
+        key: Key,
+        loaded: Vec<Key>,
+        new_batch: Vec<Key>,
+    },
 }
 
 pub type PersistResult<T> = Result<T, PersistError>;


### PR DESCRIPTION
Previously egress part of the message pump was just logging an error and continue. 
These changes makes pump exit with corresponding error when persist or publish error occurred. That will lead to the whole chain to stop and restart `Egress -> Pump -> Bridge`.

Loader unexpected state error returned when loader has loaded keys off the new loaded batch instead of panic.

cherry-pick `08678d5`