### PR TITLE
Fix usage of edgeAgent from context.json

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Text.RegularExpressions;
     using Microsoft.Azure.Devices.Edge.Test.Common.Certs;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -212,9 +213,23 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             this.SetAuth(keyName);
         }
 
-        public void SetEdgeAgentImage(string value)
+        public void SetEdgeAgentImage(string value, IEnumerable<Registry> registries)
         {
             this.config[Service.Edged].Document.ReplaceOrAdd("agent.config.image", value);
+
+            // Currently, the only place for registries is [agent.config.auth]
+            // So only one registry is supported.
+            if (registries.Count() > 1)
+            {
+                throw new ArgumentException("Currently, up to a single registry is supported");
+            }
+
+            foreach (Registry registry in registries)
+            {
+                this.config[Service.Edged].Document.ReplaceOrAdd("agent.config.auth.serveraddress", registry.Address);
+                this.config[Service.Edged].Document.ReplaceOrAdd("agent.config.auth.username", registry.Username);
+                this.config[Service.Edged].Document.ReplaceOrAdd("agent.config.auth.password", registry.Password);
+            }
         }
 
         public void SetDeviceHostname(string value)

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                 edgeAgent = Regex.Replace(edgeAgent, @"\$upstream", parentHostname);
                             });
 
-                            config.SetEdgeAgentImage(edgeAgent);
+                            config.SetEdgeAgentImage(edgeAgent, Context.Current.Registries);
 
                             Context.Current.EdgeProxy.ForEach(proxy =>
                             {

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -99,6 +99,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
                             config.SetDeviceHostname(hostname);
                             msgBuilder.Append("with hostname '{hostname}'");
                             props.Add(hostname);
+
+                            string edgeAgent = Context.Current.EdgeAgentImage.GetOrElse("mcr.microsoft.com/azureiotedge-agent:1.2");
+
                             Log.Information("Search parents");
                             Context.Current.ParentHostname.ForEach(parentHostname =>
                             {
@@ -107,9 +110,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                 msgBuilder.AppendLine($", parent hostname '{parentHostname}'");
                                 props.Add(parentHostname);
 
-                                string edgeAgent = Regex.Replace(Context.Current.EdgeAgentImage.GetOrElse(string.Empty), @"\$upstream", parentHostname);
-                                config.SetEdgeAgentImage(edgeAgent);
+                                edgeAgent = Regex.Replace(edgeAgent, @"\$upstream", parentHostname);
                             });
+
+                            config.SetEdgeAgentImage(edgeAgent);
 
                             Context.Current.EdgeProxy.ForEach(proxy =>
                             {


### PR DESCRIPTION
Adds the Edge Agent image and container registry specified in context.json to aziot-edged's config.toml.