### PR TITLE
Updating base image (#4795)

### DIFF
--- a/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM arm32v7/nginx:1.19.7
+FROM arm32v7/nginx:1.19.9
 WORKDIR /app
 COPY ./docker/linux/arm32v7/api-proxy-module .
 COPY ./docker/linux/arm32v7/templates .

--- a/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-FROM arm64v8/nginx:1.19.7
+FROM arm64v8/nginx:1.19.9
 WORKDIR /app
 COPY ./docker/linux/arm64v8/api-proxy-module .
 COPY ./docker/linux/arm64v8/templates .


### PR DESCRIPTION
Updating base image for API proxy arm32 and aarch64.

Test:
https://dev.azure.com/msazure/One/_build/results?buildId=41155753&view=results
Deployed in nested hierarchy of PI with Tier1 OS (Raspbian stretch)
No anomaly observed.