### PR TITLE
EdgeHub: Add caching to TokenProvider

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
             try
             {
                 long curCtr = Interlocked.Increment(ref this.counter);
-                if(curCtr % 10 == 0)
+                if (curCtr % 10 == 0)
                 {
                     Console.WriteLine($"GetTokenAsync call count: {curCtr}");
                 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
     using System.Threading.Tasks;
 
     public class ClientTokenProvider : ITokenProvider
@@ -12,6 +13,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
         readonly Option<string> moduleId;
         readonly string iotHubHostName;
         readonly TimeSpan defaultTtl;
+        long counter = 0;
 
         public ClientTokenProvider(
             ISignatureProvider signatureProvider,
@@ -52,6 +54,12 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 });
             try
             {
+                long curCtr = Interlocked.Increment(ref this.counter);
+                if(curCtr % 10 == 0)
+                {
+                    Console.WriteLine($"GetTokenAsync call count: {curCtr}");
+                }
+
                 string signature = await this.signatureProvider.SignAsync(data);
                 return SasTokenHelper.BuildSasToken(audience, signature, expiresOn);
             }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.Devices.Edge.Util
         readonly TimeSpan defaultTtl;
         readonly TokenCache tokenCache;
         readonly AsyncLock cacheUpdateLock = new AsyncLock();
-        long counter = 0;
 
         public ClientTokenProvider(
             ISignatureProvider signatureProvider,
@@ -80,12 +79,6 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 });
             try
             {
-                long curCtr = Interlocked.Increment(ref this.counter);
-                if (curCtr % 10 == 0)
-                {
-                    Console.WriteLine($"GetTokenAsync call count: {curCtr}");
-                }
-
                 string signature = await this.signatureProvider.SignAsync(data);
                 return SasTokenHelper.BuildSasToken(audience, signature, expiresOn);
             }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/ClientTokenProvider.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Nito.AsyncEx;
 
     public class ClientTokenProvider : ITokenProvider
     {
@@ -13,6 +14,8 @@ namespace Microsoft.Azure.Devices.Edge.Util
         readonly Option<string> moduleId;
         readonly string iotHubHostName;
         readonly TimeSpan defaultTtl;
+        readonly TokenCache tokenCache;
+        readonly AsyncLock cacheUpdateLock = new AsyncLock();
         long counter = 0;
 
         public ClientTokenProvider(
@@ -27,6 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
             this.deviceId = deviceId;
             this.moduleId = Option.Maybe(moduleId);
             this.defaultTtl = defaultTtl;
+            this.tokenCache = new TokenCache(defaultTtl / 2);
         }
 
         public ClientTokenProvider(
@@ -40,11 +44,33 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
         public async Task<string> GetTokenAsync(Option<TimeSpan> ttl)
         {
-            DateTime startTime = DateTime.UtcNow;
+            return await this.tokenCache.GetToken().Match(
+                t => Task.FromResult(t),
+                async () =>
+                {
+                    using (await this.cacheUpdateLock.LockAsync())
+                    {
+                        return await this.tokenCache.GetToken().Match(
+                            t => Task.FromResult(t),
+                            async () =>
+                            {
+                                DateTime startTime = DateTime.UtcNow;
+                                TimeSpan ttlVal = ttl.GetOrElse(this.defaultTtl);
+                                DateTime expiryTime = startTime.Add(ttlVal);
+                                string tokenVal = await this.GetTokenAsyncInternal(startTime, ttlVal);
+                                this.tokenCache.UpdateToken(tokenVal, expiryTime);
+                                return tokenVal;
+                            });
+                    }
+                });
+        }
+
+        internal async Task<string> GetTokenAsyncInternal(DateTime startTime, TimeSpan ttl)
+        {
             string audience = this.moduleId
                 .Map(m => SasTokenHelper.BuildAudience(this.iotHubHostName, this.deviceId, m))
                 .GetOrElse(() => SasTokenHelper.BuildAudience(this.iotHubHostName, this.deviceId));
-            string expiresOn = SasTokenHelper.BuildExpiresOn(startTime, ttl.GetOrElse(this.defaultTtl));
+            string expiresOn = SasTokenHelper.BuildExpiresOn(startTime, ttl);
             string data = string.Join(
                 "\n",
                 new List<string>
@@ -66,6 +92,35 @@ namespace Microsoft.Azure.Devices.Edge.Util
             catch (SignatureProviderException e)
             {
                 throw new TokenProviderException(e);
+            }
+        }
+
+        class TokenCache
+        {
+            readonly TimeSpan expiryBuffer;
+
+            Option<string> token;
+            DateTime tokenExpiry;
+
+            public TokenCache(TimeSpan expiryBuffer)
+            {
+                this.expiryBuffer = expiryBuffer;
+            }
+
+            public void UpdateToken(string token, DateTime tokenExpiry)
+            {
+                this.token = Option.Maybe(token);
+                this.tokenExpiry = tokenExpiry;
+            }
+
+            public Option<string> GetToken()
+            {
+                if (this.tokenExpiry - DateTime.UtcNow > this.expiryBuffer)
+                {
+                    return this.token;
+                }
+
+                return Option.None<string>();
             }
         }
     }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
@@ -4,7 +4,6 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
     using System;
     using System.Net.Http;
     using System.Runtime.ExceptionServices;
-    using System.Runtime.InteropServices;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30.GeneratedCode;

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
     using System;
     using System.Net.Http;
     using System.Runtime.ExceptionServices;
+    using System.Runtime.InteropServices;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30.GeneratedCode;
@@ -93,7 +94,13 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
             using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
-                SignResponse response = await this.Execute(() => edgeletHttpClient.SignAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, signRequest), "SignAsync");
+                SignResponse response = await this.Execute(
+                    () =>
+                    {
+                        Console.WriteLine("Calling signAsync!");
+                        return edgeletHttpClient.SignAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, signRequest);
+                    },
+                    "SignAsync");
                 return Convert.ToBase64String(response.Digest);
             }
         }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
@@ -94,13 +94,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
             using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
-                SignResponse response = await this.Execute(
-                    () =>
-                    {
-                        Console.WriteLine("Calling signAsync!");
-                        return edgeletHttpClient.SignAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, signRequest);
-                    },
-                    "SignAsync");
+                SignResponse response = await this.Execute(() => edgeletHttpClient.SignAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, signRequest), "SignAsync");
                 return Convert.ToBase64String(response.Digest);
             }
         }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/ClientTokenProviderTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/ClientTokenProviderTest.cs
@@ -6,7 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
-    using Moq;    
+    using Moq;
     using Xunit;
 
     public class ClientTokenProviderTest
@@ -79,6 +79,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             {
                 Assert.Equal(token, tokens[i]);
             }
+
             signatureProvider.Verify(s => s.SignAsync(It.IsAny<string>()), Times.Once);
 
             await Task.Delay(TimeSpan.FromSeconds(15));

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/ClientTokenProviderTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/ClientTokenProviderTest.cs
@@ -2,10 +2,11 @@
 namespace Microsoft.Azure.Devices.Edge.Util.Test
 {
     using System;
-    using System.Linq;
+    using System.Collections.Generic;
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Moq;    
     using Xunit;
 
     public class ClientTokenProviderTest
@@ -40,6 +41,55 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
                 Assert.Contains(kvp[0], keys);
                 Assert.NotNull(kvp[1]);
             }
+        }
+
+        [Fact]
+        [Unit]
+        public async Task GetModuleTokenTestCacheTest()
+        {
+            // Arrange
+            var signatureProvider = new Mock<ISignatureProvider>();
+            signatureProvider.Setup(s => s.SignAsync(It.IsAny<string>())).Returns(Task.FromResult(Guid.NewGuid().ToString()));
+
+            string iotHubHostName = "testIoThub";
+            string deviceId = "testDeviceId";
+            string moduleId = "$edgeHub";
+            ITokenProvider tokenProvider = new ClientTokenProvider(signatureProvider.Object, iotHubHostName, deviceId, moduleId, TimeSpan.FromSeconds(30));
+
+            // Act
+            string token = await tokenProvider.GetTokenAsync(Option.None<TimeSpan>());
+
+            // Assert
+            Assert.NotNull(token);
+            signatureProvider.Verify(s => s.SignAsync(It.IsAny<string>()), Times.Once);
+
+            // Act
+            var tasks = new List<Task<string>>();
+            for (int i = 0; i < 5; i++)
+            {
+                tasks.Add(tokenProvider.GetTokenAsync(Option.None<TimeSpan>()));
+            }
+
+            string[] tokens = await Task.WhenAll(tasks);
+
+            // Assert
+            Assert.NotNull(tokens);
+            Assert.Equal(5, tokens.Length);
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.Equal(token, tokens[i]);
+            }
+            signatureProvider.Verify(s => s.SignAsync(It.IsAny<string>()), Times.Once);
+
+            await Task.Delay(TimeSpan.FromSeconds(15));
+
+            // Act
+            string newToken = await tokenProvider.GetTokenAsync(Option.None<TimeSpan>());
+
+            // Assert
+            Assert.NotNull(newToken);
+            Assert.NotEqual(token, newToken);
+            signatureProvider.Verify(s => s.SignAsync(It.IsAny<string>()), Times.AtMost(2));
         }
 
         [Fact]


### PR DESCRIPTION
EdgeHub makes a call to the Workload API SignAsync to get a token every time it needs one. If too many such calls are made, some of them could fail. 
This code adds logic to cache a previously obtained token, and reuse it. The cache duration is half of the token expiry duration, after which it should get a fresh token. 