### PR TITLE
Improve error message of `iotedge logs` if module doesn't exist

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -781,6 +781,7 @@ version = "0.1.0"
 dependencies = [
  "aziot-identity-common",
  "chrono",
+ "docker",
  "edgelet-core",
  "edgelet-docker",
  "edgelet-http",

--- a/edgelet/edgelet-http-mgmt/Cargo.toml
+++ b/edgelet/edgelet-http-mgmt/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = "1.0"
 url = "2"
 
 aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+docker = { path = "../docker-rs" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-docker = { path = "../edgelet-docker" }
 edgelet-http = { path = "../edgelet-http" }

--- a/edgelet/edgelet-http-mgmt/src/error.rs
+++ b/edgelet/edgelet-http-mgmt/src/error.rs
@@ -133,6 +133,9 @@ impl IntoResponse for Error {
         let status_code =
             if let Some(cause) = Fail::find_root_cause(&self).downcast_ref::<DockerErrorKind>() {
                 match cause {
+                    DockerErrorKind::DockerRuntime(docker::apis::Error::Api(api_error)) => {
+                        api_error.code
+                    }
                     DockerErrorKind::NotFound(_) => StatusCode::NOT_FOUND,
                     DockerErrorKind::Conflict => StatusCode::CONFLICT,
                     DockerErrorKind::NotModified => StatusCode::NOT_MODIFIED,

--- a/edgelet/iotedge/src/error.rs
+++ b/edgelet/iotedge/src/error.rs
@@ -62,6 +62,9 @@ pub enum ErrorKind {
 
     #[fail(display = "Error running system command")]
     System,
+
+    #[fail(display = "Error fetching module logs")]
+    Logs,
 }
 
 impl Fail for Error {

--- a/edgelet/iotedge/src/logs.rs
+++ b/edgelet/iotedge/src/logs.rs
@@ -5,6 +5,7 @@ use std::io::stdout;
 use futures::prelude::*;
 
 use edgelet_core::{LogOptions, ModuleRuntime};
+use failure::Fail;
 use support_bundle::pull_logs;
 
 use crate::error::{Error, ErrorKind};
@@ -35,7 +36,7 @@ where
     fn execute(self) -> Self::Future {
         let id = self.id.clone();
         let result = pull_logs(&self.runtime, &id, &self.options, stdout())
-            .map_err(|_| Error::from(ErrorKind::ModuleRuntime))
+            .map_err(|err| err.context(ErrorKind::Logs).into())
             .map(drop);
         Box::new(result)
     }


### PR DESCRIPTION
Updated `iotedge logs` to check if the module exists prior to fetching its logs.

The old behavior was to simply emit "A module runtime error occured", when in reality it was just docker returning an error code that the specified container didn't exist.