### PR TITLE
[fix] check for empty string while processing manifest trust bundle

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -179,7 +179,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         IEnumerable<X509Certificate2> trustBundle =
                             await CertificateHelper.GetTrustBundleFromEdgelet(new Uri(workloadUri), apiVersion, Constants.WorkloadApiVersion, moduleId, moduleGenerationId);
                         CertificateHelper.InstallCertificates(trustBundle, logger);
-                        manifestTrustBundle = Option.Maybe(await CertificateHelper.GetManifestTrustBundleFromEdgelet(new Uri(workloadUri), apiVersion, Constants.WorkloadApiVersion, moduleId, moduleGenerationId));
+                        manifestTrustBundle = await CertificateHelper.GetManifestTrustBundleFromEdgelet(new Uri(workloadUri), apiVersion, Constants.WorkloadApiVersion, moduleId, moduleGenerationId);
 
                         break;
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
@@ -56,13 +56,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
                 certificates = await CertificateHelper.GetServerCertificatesFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId, edgeHubHostname, expiration);
                 IEnumerable<X509Certificate2> trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
-                X509Certificate2 manifestTrustBundle = await CertificateHelper.GetManifestTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
+                Option<X509Certificate2> manifestTrustBundle = await CertificateHelper.GetManifestTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
 
                 result = new EdgeHubCertificates(
                     certificates.ServerCertificate,
                     certificates.CertificateChain?.ToList(),
                     trustBundle?.ToList(),
-                    Option.Maybe(manifestTrustBundle));
+                    manifestTrustBundle);
             }
             else if (!string.IsNullOrEmpty(edgeHubDevCertPath) &&
                      !string.IsNullOrEmpty(edgeHubDevPrivateKeyPath) &&

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -266,10 +266,17 @@ namespace Microsoft.Azure.Devices.Edge.Util
             return ParseTrustedBundleCerts(response);
         }
 
-        public static async Task<X509Certificate2> GetManifestTrustBundleFromEdgelet(Uri workloadUri, string workloadApiVersion, string workloadClientApiVersion, string moduleId, string moduleGenerationId)
+        public static async Task<Option<X509Certificate2>> GetManifestTrustBundleFromEdgelet(Uri workloadUri, string workloadApiVersion, string workloadClientApiVersion, string moduleId, string moduleGenerationId)
         {
             string response = await new WorkloadClient(workloadUri, workloadApiVersion, workloadClientApiVersion, moduleId, moduleGenerationId).GetManifestTrustBundleAsync();
-            return ParseManifestTrustedBundleCerts(response);
+            if (string.IsNullOrEmpty(response))
+            {
+                return Option.None<X509Certificate2>();
+            }
+            else
+            {
+                return Option.Maybe(ParseManifestTrustedBundleCerts(response));
+            }
         }
 
         public static bool VerifyManifestTrustBunldeCertificateChaining(X509Certificate2 signerCertificate, X509Certificate2 intermediateCertificate, X509Certificate2 manifestTrustBundle)


### PR DESCRIPTION
While processing manifest trust bundle, check if its empty as its an optional field and configure accordingly. It avoids crashing of modules if its not set.