### PR TITLE
Update base image update script to not include `generic-mqtt-tester` base image.

### DIFF
--- a/tools/BaseImageUpdate/baseImage.ps1
+++ b/tools/BaseImageUpdate/baseImage.ps1
@@ -46,7 +46,7 @@ function Update-ARM-BaseImages
     Setup-BaseImage-Script
 
     # Get all the Dockerfile file location
-    $fileLocale1 = $(Get-ChildItem -Recurse -Filter "Dockerfile" | Where {$_.FullName -notlike "*generic-mqtt-tester*"})
+    $fileLocale = $(Get-ChildItem -Recurse -Filter "Dockerfile" | Where {$_.FullName -notlike "*generic-mqtt-tester*"})
 
     # Replace the underlying ASP .Net Core to the new version
     # Assuming the ARM64 & ARM32 both use the same *-bionic-arm* ASP .Net Core image tag

--- a/tools/BaseImageUpdate/baseImage.ps1
+++ b/tools/BaseImageUpdate/baseImage.ps1
@@ -46,7 +46,7 @@ function Update-ARM-BaseImages
     Setup-BaseImage-Script
 
     # Get all the Dockerfile file location
-    $fileLocale = $(Get-ChildItem -Recurse -Filter "Dockerfile" )
+    $fileLocale1 = $(Get-ChildItem -Recurse -Filter "Dockerfile" | Where {$_.FullName -notlike "*generic-mqtt-tester*"})
 
     # Replace the underlying ASP .Net Core to the new version
     # Assuming the ARM64 & ARM32 both use the same *-bionic-arm* ASP .Net Core image tag


### PR DESCRIPTION
Update base image update script to not include `generic-mqtt-tester` base image.