### PR TITLE
Longhaul: Filter duplicate results in relayer (#4682)

### DIFF
--- a/test/modules/Relayer/MessageHandlerContext.cs
+++ b/test/modules/Relayer/MessageHandlerContext.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Relayer
+{
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.ModuleUtil;
+    using Microsoft.Extensions.Logging;
+
+    class MessageHandlerContext
+    {
+        public ModuleClient ModuleClient;
+        public DuplicateMessageAuditor DuplicateMessageAuditor;
+
+        public MessageHandlerContext(ModuleClient moduleClient, DuplicateMessageAuditor duplicateMessageAuditor)
+        {
+            this.ModuleClient = moduleClient;
+            this.DuplicateMessageAuditor = duplicateMessageAuditor;
+        }
+    }
+
+    // Sometimes EdgeHub itself will duplicate a message when sending to this module.
+    // When this happens, we don't want to report two expected results to the TRC, as
+    // the TRC intentionally will fail duplicate expected results. Therefore we should
+    // filter duplicate messages from edgehub up to some tolerance period. If this
+    // tolerance for duplicates is exceeded, this module will not filter the proceeding
+    // duplicate messages and will report duplicate expected results to the TRC, which
+    // will fail the tests. That way we will know something is wrong.
+    //
+    // Below is how the duplicate filtering will work regarding different incoming messages.
+    //
+    // Case 1: New sequence number
+    //         This cannot be a duplicate, so we don't filter
+    // Case 2: Repeating sequence number under duplicate threshold
+    //         We expect edgehub to sometimes send duplicates, so it is ok.
+    // Case 1: Repeating sequence number over duplicate threshold
+    //         Something weird is likely going on, so we won't filter in order to fail the tests
+    class DuplicateMessageAuditor
+    {
+        int messageDuplicateTolerance;
+        int duplicateCounter;
+        string previousSequenceNumber;
+        static readonly ILogger Logger = ModuleUtil.CreateLogger("Relayer");
+
+        public DuplicateMessageAuditor(int messageDuplicateTolerance)
+        {
+            this.messageDuplicateTolerance = messageDuplicateTolerance;
+            this.previousSequenceNumber = string.Empty;
+            this.duplicateCounter = 0;
+        }
+
+        public bool ShouldFilterMessage(string sequenceNumber)
+        {
+            if (sequenceNumber.Equals(this.previousSequenceNumber))
+            {
+                this.duplicateCounter += 1;
+                if (this.duplicateCounter >= this.messageDuplicateTolerance)
+                {
+                    Logger.LogError($"Message with duplicate sequence number exceeded message duplicate tolerance: sequenceNumber={sequenceNumber}, duplicateThreshold={this.messageDuplicateTolerance}");
+                    return false;
+                }
+                else
+                {
+                    Logger.LogWarning($"Received message with duplicate sequence number within message duplicate tolerance: sequenceNumber={sequenceNumber}, duplicateThreshold={this.messageDuplicateTolerance}");
+                    return true;
+                }
+            }
+
+            this.previousSequenceNumber = sequenceNumber;
+            this.duplicateCounter = 0;
+            return false;
+        }
+    }
+}

--- a/test/modules/Relayer/Program.cs
+++ b/test/modules/Relayer/Program.cs
@@ -6,7 +6,6 @@ namespace Relayer
     using System.Collections.Generic;
     using System.Linq;
     using System.Net;
-    using System.Runtime.CompilerServices;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -39,13 +38,15 @@ namespace Relayer
                     ModuleUtil.DefaultTimeoutErrorDetectionStrategy,
                     ModuleUtil.DefaultTransientRetryStrategy,
                     Logger);
+                DuplicateMessageAuditor duplicateMessageAuditor = new DuplicateMessageAuditor(Settings.Current.MessageDuplicateTolerance);
+                MessageHandlerContext messageHandlerContext = new MessageHandlerContext(moduleClient, duplicateMessageAuditor);
 
                 (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(TimeSpan.FromSeconds(5), Logger);
 
                 await SetIsFinishedDirectMethodAsync(moduleClient);
 
                 // Receive a message and call ProcessAndSendMessageAsync to send it on its way
-                await moduleClient.SetInputMessageHandlerAsync(Settings.Current.InputName, ProcessAndSendMessageAsync, moduleClient);
+                await moduleClient.SetInputMessageHandlerAsync(Settings.Current.InputName, ProcessAndSendMessageAsync, messageHandlerContext);
 
                 await cts.Token.WhenCanceled();
                 completed.Set();
@@ -78,10 +79,13 @@ namespace Relayer
 
             try
             {
-                if (!(userContext is ModuleClient moduleClient))
+                if (!(userContext is MessageHandlerContext messageHandlerContext))
                 {
                     throw new InvalidOperationException("UserContext doesn't contain expected value");
                 }
+
+                ModuleClient moduleClient = messageHandlerContext.ModuleClient;
+                DuplicateMessageAuditor duplicateMessageAuditor = messageHandlerContext.DuplicateMessageAuditor;
 
                 // Must make a new message instead of reusing the old message because of the way the SDK sends messages
                 string trackingId = string.Empty;
@@ -113,6 +117,11 @@ namespace Relayer
                     if (string.IsNullOrWhiteSpace(trackingId) || string.IsNullOrWhiteSpace(batchId) || string.IsNullOrWhiteSpace(sequenceNumber))
                     {
                         Logger.LogWarning($"Received message missing info: trackingid={trackingId}, batchId={batchId}, sequenceNumber={sequenceNumber}");
+                        return MessageResponse.Completed;
+                    }
+
+                    if (duplicateMessageAuditor.ShouldFilterMessage(sequenceNumber))
+                    {
                         return MessageResponse.Completed;
                     }
 

--- a/test/modules/Relayer/Settings.cs
+++ b/test/modules/Relayer/Settings.cs
@@ -20,6 +20,7 @@ namespace Relayer
             Uri testResultCoordinatorUrl,
             string moduleId,
             bool receiveOnly,
+            int messageDuplicateTolerance,
             bool enableTrcReporting,
             Option<int> uniqueResultsExpected)
         {
@@ -29,6 +30,7 @@ namespace Relayer
             this.TestResultCoordinatorUrl = Preconditions.CheckNotNull(testResultCoordinatorUrl, nameof(testResultCoordinatorUrl));
             this.ModuleId = Preconditions.CheckNonWhiteSpace(moduleId, nameof(moduleId));
             this.ReceiveOnly = receiveOnly;
+            this.MessageDuplicateTolerance = messageDuplicateTolerance;
             this.EnableTrcReporting = enableTrcReporting;
             this.UniqueResultsExpected = uniqueResultsExpected;
         }
@@ -51,6 +53,7 @@ namespace Relayer
                 configuration.GetValue<Uri>("testResultCoordinatorUrl", new Uri("http://testresultcoordinator:5001")),
                 configuration.GetValue<string>("IOTEDGE_MODULEID"),
                 configuration.GetValue<bool>("receiveOnly", false),
+                configuration.GetValue<int>("messageDuplicateTolerance", 2),
                 configuration.GetValue<bool>("enableTrcReporting", true),
                 uniqueResultsExpected);
         }
@@ -69,6 +72,8 @@ namespace Relayer
 
         public bool ReceiveOnly { get; }
 
+        public int MessageDuplicateTolerance { get; }
+
         public Option<int> UniqueResultsExpected { get; }
 
         public override string ToString()
@@ -82,6 +87,7 @@ namespace Relayer
                 { nameof(this.TransportType), Enum.GetName(typeof(TransportType), this.TransportType) },
                 { nameof(this.TestResultCoordinatorUrl), this.TestResultCoordinatorUrl.ToString() },
                 { nameof(this.ReceiveOnly), this.ReceiveOnly.ToString() },
+                { nameof(this.MessageDuplicateTolerance), this.MessageDuplicateTolerance.ToString() },
                 { nameof(this.EnableTrcReporting), this.EnableTrcReporting.ToString() },
             };
 


### PR DESCRIPTION
Currently there is a test bug where edgehub will duplicate a message from loadGen to relayer (acceptable behavior). This duplication causes the TRC to have duplicate expected results, which it is not configured to handle. The TRC will intentionally fail the tests for duplicate expected results, so this test bug results in a test failure for acceptable behavior.

The best fix I think is to filter the duplicates in the relayer test module up to some threshold. I have introduced ```DuplicateMessageAuditor``` in order to filter these duplicates.

Copied from DuplicateMessageAuditor abstraction:
```
    // Sometimes EdgeHub itself will duplicate a message when sending to this module.
    // When this happens, we don't want to report two expected results to the TRC, as
    // the TRC intentionally will fail duplicate expected results. Therefore we should
    // filter duplicate messages from edgehub up to some tolerance period. If this
    // tolerance for duplicates is exceeded, this module will not filter the proceeding
    // duplicate messages and will report duplicate expected results to the TRC, which
    // will fail the tests. That way we will know something is wrong.
    //
    // Below is how the duplicate filtering will work regarding different incoming messages.
    //
    // Case 1: New sequence number
    //         This cannot be a duplicate, so we don't filter
    // Case 2: Repeating sequence number under duplicate threshold
    //         We expect edgehub to sometimes send duplicates, so it is ok.
    // Case 1: Repeating sequence number over duplicate threshold
    //         Something weird is likely going on, so we won't filter in order to fail the tests
```

I also have a diff stacked and ready on this PR to make the TRC explicitly fail duplicate expected results so it is obvious in the test report. Another import thing to note is that this test module probably runs in our e2e test suites, but I don't expect it to cause issues.