### PR TITLE
Update base image update script to not include `generic-mqtt-tester`

### DIFF
--- a/tools/BaseImageUpdate/baseImage.ps1
+++ b/tools/BaseImageUpdate/baseImage.ps1
@@ -46,7 +46,7 @@ function Update-ARM-BaseImages
     Setup-BaseImage-Script
 
     # Get all the Dockerfile file location
-    $fileLocale = $(Get-ChildItem -Recurse -Filter "Dockerfile" )
+    $fileLocale = $(Get-ChildItem -Recurse -Filter "Dockerfile" | Where {$_.FullName -notlike "*generic-mqtt-tester*"})
 
     # Replace the underlying ASP .Net Core to the new version
     # Assuming the ARM64 & ARM32 both use the same *-bionic-arm* ASP .Net Core image tag


### PR DESCRIPTION
Update base image update script to not include `generic-mqtt-tester` base image.
Cherry-picked: https://github.com/Azure/iotedge/commit/0b6bace379d6a4241c6b44af1970d88cd5838b13