### PR TITLE
Update v1.1 YAML pipelines to 1ES-hosted agents

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -44,14 +44,14 @@ jobs:
 #     - template: templates/e2e-run.yaml
 
 ################################################################################
-  - job: linux_amd64
+  - job: ubuntu_1804_msmoby
 ################################################################################
-    displayName: Linux amd64
+    displayName: Ubuntu 18.04 with iotedge-moby
 
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
 
     variables:
       os: linux
@@ -63,9 +63,68 @@ jobs:
     - template: templates/e2e-run.yaml
 
 ################################################################################
+  - job: ubuntu_1804_docker
+################################################################################
+    displayName: Ubuntu 18.04 with Docker (minimal)
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      minimal: true
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_2004_msmoby
+################################################################################
+    displayName: Ubuntu 20.04 with iotedge-moby
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_2004_docker
+################################################################################
+    displayName: Ubuntu 20.04 with Docker (minimal)
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      minimal: true
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
   - job: windows_server
 ################################################################################
-    displayName: Windows Server 2019 (full)
+    displayName: Windows Server 2019
 
     pool:
       name: $(pool.windows.name)

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -16,6 +16,9 @@ resources:
       - master
       - release/*
 
+variables:
+  minimal: false
+
 jobs:
 
 # ################################################################################

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -60,9 +60,9 @@ jobs:
     - template: templates/e2e-run.yaml
 
 ################################################################################
-  - job: windows_amd64
+  - job: windows_server
 ################################################################################
-    displayName: Windows amd64
+    displayName: Windows Server 2019 (full)
 
     pool:
       name: $(pool.windows.name)
@@ -73,6 +73,47 @@ jobs:
       os: windows
       arch: amd64
       artifactName: iotedged-windows
+
+    steps:
+    - template: templates/e2e-setup.yaml
+
+    - pwsh: |
+        $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
+        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
+        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
+          -ArgumentList 'Root', 'LocalMachine'
+        $store.Open('ReadWrite')
+        $store.Add($cert)
+      displayName: Install CAB signing root cert
+      env:
+        PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
+
+    - pwsh: |
+        Write-Output '>>> BEFORE:'
+        netsh interface ipv6 show prefixpolicies
+        netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
+        Write-Output '>>> AFTER:'
+        netsh interface ipv6 show prefixpolicies
+      displayName: Prefer IPv4
+
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: windows_10ent
+################################################################################
+    displayName: Windows 10 Enterprise (minimal)
+
+    pool:
+      name: $(pool.windows.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-win10-entn2019-test
+
+    variables:
+      os: windows
+      arch: amd64
+      artifactName: iotedged-windows
+      minimal: true
 
     steps:
     - template: templates/e2e-setup.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -17,6 +17,14 @@ resources:
       - release/*
 
 variables:
+  # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
+  # environments that are very similar to other platforms/environments in our matrix, e.g. Windows
+  # Server 2019 vs. Windows 10 Enterprise, or Ubuntu 18.04 with the 'docker-ce' package vs. Ubuntu
+  # 18.04 with the 'iotedge-moby' package vs. the same variations in Ubuntu 20.04. In these
+  # instances the platforms/environments are so similar that we don't reasonably expect to encounter
+  # differences--if we do, it would likely manifest during installation, or in running a very basic
+  # test. We don't need to repeat the entire test suite.
+  # The 'minimal' variable defaults to 'false'; we override it in specific jobs as needed.
   minimal: false
 
 jobs:

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -24,7 +24,7 @@ jobs:
 #     displayName: Linux arm32v7
 
 #     pool:
-#       name: $(pool.name)
+#       name: $(pool.custom.name)
 #       demands: rpi3-e2e-tests
 
 #     variables:
@@ -110,7 +110,7 @@ jobs:
     displayName: CentOs7 amd64
 
     pool:
-      name: $(pool.name)
+      name: $(pool.custom.name)
       demands:
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals X64
@@ -134,7 +134,7 @@ jobs:
 #     displayName: EFLOW amd64
 
 #     pool:
-#       name: $(pool.name)
+#       name: $(pool.custom.name)
 #       demands:
 #         - Agent.OS -equals Linux
 #         - Agent.OSArchitecture -equals X64

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -75,11 +75,6 @@ jobs:
       artifactName: iotedged-windows
 
     steps:
-    - pwsh: |
-        Remove-Item –path C:\ProgramData\iotedge\hsm\cert_keys\* –recurse -ErrorAction SilentlyContinue
-        Remove-Item –path C:\ProgramData\iotedge\hsm\certs\* –recurse -ErrorAction SilentlyContinue
-      displayName: Clean up HSM previous run artifacts
-
     - template: templates/e2e-setup.yaml
 
     - pwsh: |

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -29,27 +29,27 @@ variables:
 
 jobs:
 
-# ################################################################################
-#   - job: linux_arm32v7
-# ################################################################################
-#     displayName: Linux arm32v7
+################################################################################
+  - job: linux_arm32v7
+################################################################################
+    displayName: Linux arm32v7
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands: rpi3-e2e-tests
+    pool:
+      name: $(pool.custom.name)
+      demands: rpi3-e2e-tests
 
-#     variables:
-#       os: linux
-#       arch: arm32v7
-#       artifactName: iotedged-debian9-arm32v7
+    variables:
+      os: linux
+      arch: arm32v7
+      artifactName: iotedged-debian9-arm32v7
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_1804_msmoby
@@ -234,29 +234,29 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml 
 
-# ################################################################################
-#   - job: EFLOW_amd64
-# ################################################################################
-#     displayName: EFLOW amd64
+################################################################################
+  - job: EFLOW_amd64
+################################################################################
+    displayName: EFLOW amd64
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands:
-#         - Agent.OS -equals Linux
-#         - Agent.OSArchitecture -equals X64
-#         - run-new-e2e-tests -equals true
-#         - eflow -equals true
+    pool:
+      name: $(pool.custom.name)
+      demands:
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - run-new-e2e-tests -equals true
+        - eflow -equals true
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-mariner-amd64
-#       NUGET_HTTP_CACHE_PATH: /var/tmp/NuGet/v3-cache
-#       NUGET_PACKAGES: /var/tmp/NuGet/packages
-#       NUGET_PLUGINS_CACHE_PATH: /var/tmp/NuGet/plugins-cache
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-mariner-amd64
+      NUGET_HTTP_CACHE_PATH: /var/tmp/NuGet/v3-cache
+      NUGET_PACKAGES: /var/tmp/NuGet/packages
+      NUGET_PLUGINS_CACHE_PATH: /var/tmp/NuGet/plugins-cache
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -46,12 +46,9 @@ jobs:
     displayName: Linux amd64
 
     pool:
-      name: $(pool.name2)
+      name: $(pool.linux.name)
       demands:
-        - Agent.OS -equals Linux
-        - Agent.OSArchitecture -equals X64
-        - ImageOverride -equals azure-iot-edge-ubuntu-18.04-test-image
-        # - run-new-e2e-tests -equals true
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
 
     variables:
       os: linux
@@ -68,13 +65,9 @@ jobs:
     displayName: Windows amd64
 
     pool:
-      name: $(pool.name2)
+      name: $(pool.windows.name)
       demands:
-        - Agent.OS -equals Windows_NT
-        - Agent.OSArchitecture -equals X64
-        - ImageOverride -equals aziotedge-winserver-2019-agent
-        # - ImageOverride -equals aziotedge-win10-entn2019-agent
-        # - run-new-e2e-tests -equals true
+        - ImageOverride -equals agent-aziotedge-winserver-2019-test
 
     variables:
       os: windows
@@ -117,13 +110,12 @@ jobs:
     displayName: CentOs7 amd64
 
     pool:
-      name: $(pool.name2)
+      name: $(pool.name)
       demands:
         - Agent.OS -equals Linux
         - Agent.OSArchitecture -equals X64
-        - ImageOverride -equals aziotedge-agent-centos-7
-        # - run-new-e2e-tests -equals true
-        # - centos -equals 7
+        - run-new-e2e-tests -equals true
+        - centos -equals 7
 
     variables:
       os: linux

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -67,7 +67,7 @@ jobs:
     pool:
       name: $(pool.windows.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-winserver-2019-test
+        - ImageOverride -equals agent-aziotedge-winserver-2019dc-test
 
     variables:
       os: windows

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -11,7 +11,7 @@ steps:
         $(Join-Path $env:ProgramFiles 'iotedge'),
         $(Join-Path $env:ProgramFiles 'iotedge-moby') -join ';'
 
-      if ($(variables.minimal))
+      if ($(minimal))
       {
         dotnet vstest $testFile --logger:trx --testcasefilter 'TempSensor'
       }

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -13,11 +13,11 @@ steps:
 
       if ('$(minimal)' -eq 'true')
       {
-        dotnet vstest $testFile --logger:trx --testcasefilter 'Name~TempSensor'
+        dotnet test $testFile --no-build --logger 'trx' --filter 'Name~TempSensor'
       }
       else
       {
-        dotnet vstest $testFile --logger:trx
+        dotnet test $testFile --no-build --logger 'trx'
       }
     }
     else
@@ -25,11 +25,15 @@ steps:
       # Unfortunately CentOs has some failing test that need to be worked on.
       if ('$(Agent.Name)'.Contains('centos'))
       {
-        sudo --preserve-env dotnet test $testFile --logger:trx --filter 'TestCategory=CentOsSafe'
+        sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter 'TestCategory=CentOsSafe'
+      }
+      else if ('$(minimal)' -eq 'true')
+      {
+        sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter 'Name~TempSensor'
       }
       else
       {
-        sudo --preserve-env dotnet vstest $testFile --logger:trx
+        sudo --preserve-env dotnet test $testFile --no-build --logger 'trx'
       }
     }
   displayName: Run tests

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -11,14 +11,21 @@ steps:
         $(Join-Path $env:ProgramFiles 'iotedge'),
         $(Join-Path $env:ProgramFiles 'iotedge-moby') -join ';'
 
-      dotnet vstest $testFile --logger:trx
+      if ($(variables.minimal))
+      {
+        dotnet vstest $testFile --logger:trx --testcasefilter 'TempSensor'
+      }
+      else
+      {
+        dotnet vstest $testFile --logger:trx
+      }
     }
     else
     {
       # Unfortunately CentOs has some failing test that need to be worked on.
       if ('$(Agent.Name)'.Contains('centos'))
       {
-        sudo --preserve-env dotnet test $testFile --logger:trx --filter "TestCategory=CentOsSafe"
+        sudo --preserve-env dotnet test $testFile --logger:trx --filter 'TestCategory=CentOsSafe'
       }
       else
       {

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -11,7 +11,7 @@ steps:
         $(Join-Path $env:ProgramFiles 'iotedge'),
         $(Join-Path $env:ProgramFiles 'iotedge-moby') -join ';'
 
-      if ('$(minimal)' == 'true')
+      if ('$(minimal)' -eq 'true')
       {
         dotnet vstest $testFile --logger:trx --testcasefilter 'TempSensor'
       }

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -13,7 +13,7 @@ steps:
 
       if ('$(minimal)' -eq 'true')
       {
-        dotnet vstest $testFile --logger:trx --testcasefilter 'TempSensor'
+        dotnet vstest $testFile --logger:trx --testcasefilter 'Name~TempSensor'
       }
       else
       {

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -27,7 +27,7 @@ steps:
       {
         sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter 'TestCategory=CentOsSafe'
       }
-      else if ('$(minimal)' -eq 'true')
+      elseif ('$(minimal)' -eq 'true')
       {
         sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter 'Name~TempSensor'
       }

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -11,7 +11,7 @@ steps:
         $(Join-Path $env:ProgramFiles 'iotedge'),
         $(Join-Path $env:ProgramFiles 'iotedge-moby') -join ';'
 
-      if ($(minimal))
+      if ('$(minimal)' == 'true')
       {
         dotnet vstest $testFile --logger:trx --testcasefilter 'TempSensor'
       }

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -22,26 +22,6 @@ steps:
       TestRootCaPassword,
       TestBlobStoreSas
 
-- pwsh: |
-    $imageBuildId = $(resources.pipeline.images.runID)
-    $packageBuildId = $(resources.pipeline.packages.runID)
-
-    if ('$(az.pipeline.images.buildId)')
-    {
-      Write-Output '>> User supplied az.pipeline.images.buildId=$(az.pipeline.images.buildId)'
-      $imageBuildId = '$(az.pipeline.images.buildId)'
-    }
-
-    if ('$(az.pipeline.packages.buildId)')
-    {
-      Write-Output '>> User supplied az.pipeline.packages.buildId=$(az.pipeline.packages.buildId)'
-      $packageBuildId = '$(az.pipeline.packages.buildId)'
-    }
-
-    Write-Output "##vso[task.setvariable variable=imageBuildId]$imageBuildId"
-    Write-Output "##vso[task.setvariable variable=packageBuildId]$packageBuildId"
-  displayName: Override artifacts with user-supplied args
-
 - task: DownloadBuildArtifacts@0
   displayName: Get Docker image info
   inputs:
@@ -49,7 +29,7 @@ steps:
     project: $(resources.pipeline.images.projectID)
     pipeline: $(resources.pipeline.images.pipelineName)
     buildVersionToDownload: specific
-    buildId: $(imageBuildId)
+    buildId: $(resources.pipeline.images.runID)
     downloadType: single
     artifactName: $(az.pipeline.images.artifacts)
     itemPattern: $(az.pipeline.images.artifacts)/artifactInfo.txt
@@ -61,7 +41,7 @@ steps:
     project: $(resources.pipeline.packages.projectID)
     pipeline: $(resources.pipeline.packages.pipelineName)
     buildVersionToDownload: specific
-    buildId: $(packageBuildId)
+    buildId: $(resources.pipeline.packages.runID)
     downloadType: single
     artifactName: $(artifactName)
 

--- a/builds/mariner/SPECS/rust/rust.spec
+++ b/builds/mariner/SPECS/rust/rust.spec
@@ -45,7 +45,6 @@ chmod 755 %{buildroot}%{_libdir}/lib*.so
 %doc %{_docdir}/rls/*
 %doc %{_docdir}/rust-analyzer/*
 %doc %{_docdir}/rustfmt/*
-# %{_datadir}/zsh/*
 %{_prefix}%{_sysconfdir}/bash_completion.d/cargo
 
 %changelog

--- a/builds/mariner/SPECS/rust/rust.spec
+++ b/builds/mariner/SPECS/rust/rust.spec
@@ -45,7 +45,7 @@ chmod 755 %{buildroot}%{_libdir}/lib*.so
 %doc %{_docdir}/rls/*
 %doc %{_docdir}/rust-analyzer/*
 %doc %{_docdir}/rustfmt/*
-%{_datadir}/zsh/*
+# %{_datadir}/zsh/*
 %{_prefix}%{_sysconfdir}/bash_completion.d/cargo
 
 %changelog

--- a/builds/mariner/SPECS/rust/rust.spec
+++ b/builds/mariner/SPECS/rust/rust.spec
@@ -45,7 +45,7 @@ chmod 755 %{buildroot}%{_libdir}/lib*.so
 %doc %{_docdir}/rls/*
 %doc %{_docdir}/rust-analyzer/*
 %doc %{_docdir}/rustfmt/*
-# %{_datadir}/zsh/*
+%{_datadir}/zsh/*
 %{_prefix}%{_sysconfdir}/bash_completion.d/cargo
 
 %changelog

--- a/builds/mariner/SPECS/rust/rust.spec
+++ b/builds/mariner/SPECS/rust/rust.spec
@@ -45,6 +45,7 @@ chmod 755 %{buildroot}%{_libdir}/lib*.so
 %doc %{_docdir}/rls/*
 %doc %{_docdir}/rust-analyzer/*
 %doc %{_docdir}/rustfmt/*
+# %{_datadir}/zsh/*
 %{_prefix}%{_sysconfdir}/bash_completion.d/cargo
 
 %changelog

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -12,10 +12,9 @@ jobs:
 ################################################################################
     displayName: LinuxDotnet
     pool:
-      name: $(pool.name)
+      name: $(pool.linux.name)
       demands:
-        - agent.os -equals Linux
-        - agent.osarchitecture -equals X64
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     steps:
       - bash: 'docker login $(registry.address) --username $(registry.user) --password $(registry.password)'
         displayName: 'Docker Login'
@@ -217,10 +216,8 @@ jobs:
     displayName: Windows
     timeoutInMinutes: 90
     pool:
-      name: $(pool.name)
+      name: $(pool.windows.name)
       demands:
-        - Agent.OS -equals Windows_NT
-        - Agent.OSArchitecture -equals X64
         - ImageOverride -equals agent-aziotedge-winserver-2019-build
     workspace:
       clean: all
@@ -393,10 +390,9 @@ jobs:
 ################################################################################
     displayName: Manifest
     pool:
-      name: $(pool.name)
+      name: $(pool.linux.name)
       demands:
-        - agent.os -equals Linux
-        - agent.osarchitecture -equals X64
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     dependsOn:
       - linux_dotnet_projects
       - linux_rust_amd64

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -218,7 +218,7 @@ jobs:
     pool:
       name: $(pool.windows.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-winserver-2019-build
+        - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
     workspace:
       clean: all
     steps:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -127,8 +127,6 @@ jobs:
           echo '=========='
           env
           echo '=========='
-          curl -L 'https://packages.microsoft.com/cbl-mariner/1.0/prod/'
-          echo '=========='
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -107,10 +107,11 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      name: $(pool.name)
-      demands:
-        - agent.os -equals Linux
-        - agent.osarchitecture -equals X64
+      vmImage: 'ubuntu-18.04'
+      # name: $(pool.name)
+      # demands:
+      #   - agent.os -equals Linux
+      #   - agent.osarchitecture -equals X64
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -191,11 +191,12 @@ jobs:
     displayName: Windows amd64
     timeoutInMinutes: 90
     pool:
-      name: $(pool.name)
-      demands:
-        - Agent.OS -equals Windows_NT
-        - Agent.OSArchitecture -equals X64
-        - ImageOverride -equals agent-aziotedge-winserver-2019-build
+      vmImage: 'windows-2019'
+      # name: $(pool.name)
+      # demands:
+      #   - Agent.OS -equals Windows_NT
+      #   - Agent.OSArchitecture -equals X64
+      #   - ImageOverride -equals agent-aziotedge-winserver-2019-build
     steps:
       - powershell: ls env:/
         displayName: Dump environment

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -127,6 +127,8 @@ jobs:
           echo '=========='
           env
           echo '=========='
+          curl -L 'https://packages.microsoft.com/cbl-mariner/1.0/prod/'
+          echo '=========='
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -241,7 +241,7 @@ jobs:
           CertificateId: 302
           OpusName: 'Azure IoT Edge'
           OpusInfo: 'https://azure.microsoft.com/en-us/services/iot-edge/'
-          SessionTimeout: 20
+          SessionTimeout: 120
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact: iotedged-windows'
         inputs:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -19,7 +19,6 @@ jobs:
       demands:
         - agent.os -equals Linux
         - agent.osarchitecture -equals X64
-        - ImageOverride -equals temp-ubuntu-18.04
     strategy:
       matrix:
         Centos75-amd64:
@@ -108,12 +107,10 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      vmImage: ubuntu-18.04
-      # name: $(pool.name)
-      # demands:
-      #   - agent.os -equals Linux
-      #   - agent.osarchitecture -equals X64
-      #   - ImageOverride -equals azure-iot-edge-ubuntu-20.04-test-image
+      name: $(pool.name)
+      demands:
+        - agent.os -equals Linux
+        - agent.osarchitecture -equals X64
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -110,6 +110,7 @@ jobs:
       demands:
         - agent.os -equals Linux
         - agent.osarchitecture -equals X64
+        - ImageOverride -equals azure-iot-edge-ubuntu-20.04-test-image
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -106,11 +106,12 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      name: $(pool.name)
-      demands:
-        - agent.os -equals Linux
-        - agent.osarchitecture -equals X64
-        - ImageOverride -equals azure-iot-edge-ubuntu-20.04-test-image
+      vmImage: ubuntu-18.04
+      # name: $(pool.name)
+      # demands:
+      #   - agent.os -equals Linux
+      #   - agent.osarchitecture -equals X64
+      #   - ImageOverride -equals azure-iot-edge-ubuntu-20.04-test-image
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -107,10 +107,7 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      name: $(pool.name)
-      demands:
-        - agent.os -equals Linux
-        - agent.osarchitecture -equals X64
+      vmImage: 'ubuntu-18.04'
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -111,7 +111,6 @@ jobs:
       demands:
         - agent.os -equals Linux
         - agent.osarchitecture -equals X64
-        - ImageOverride -equals MMSUbuntu18.04
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -191,12 +191,11 @@ jobs:
     displayName: Windows amd64
     timeoutInMinutes: 90
     pool:
-      vmImage: 'windows-2019'
-      # name: $(pool.name)
-      # demands:
-      #   - Agent.OS -equals Windows_NT
-      #   - Agent.OSArchitecture -equals X64
-      #   - ImageOverride -equals agent-aziotedge-winserver-2019-build
+      name: $(pool.name)
+      demands:
+        - Agent.OS -equals Windows_NT
+        - Agent.OSArchitecture -equals X64
+        - ImageOverride -equals agent-aziotedge-winserver-2019-build
     steps:
       - powershell: ls env:/
         displayName: Dump environment

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -127,6 +127,8 @@ jobs:
           echo '=========='
           env
           echo '=========='
+          docker run --rm curlimages/curl -fsSL https://packages.microsoft.com/cbl-mariner/1.0/prod/
+          echo '=========='
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -107,7 +107,10 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      vmImage: 'ubuntu-18.04'
+      name: $(pool.name)
+      demands:
+        - agent.os -equals Linux
+        - agent.osarchitecture -equals X64
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -241,7 +241,7 @@ jobs:
           CertificateId: 302
           OpusName: 'Azure IoT Edge'
           OpusInfo: 'https://azure.microsoft.com/en-us/services/iot-edge/'
-          SessionTimeout: 120
+          SessionTimeout: 20
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact: iotedged-windows'
         inputs:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -19,6 +19,7 @@ jobs:
       demands:
         - agent.os -equals Linux
         - agent.osarchitecture -equals X64
+        - ImageOverride -equals temp-ubuntu-18.04
     strategy:
       matrix:
         Centos75-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -111,6 +111,7 @@ jobs:
       demands:
         - agent.os -equals Linux
         - agent.osarchitecture -equals X64
+        - ImageOverride -equals MMSUbuntu18.04
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -120,13 +120,18 @@ jobs:
           target.iotedged: builds/mariner/out/RPMS/x86_64/
     steps:
       - bash: |
-          echo '=========='
-          sudo ls -al /usr/local/go/bin
-          echo '=========='
-          command -v go
-          echo '=========='
-          env
-          echo '=========='
+          sudo apt-get update
+          sudo apt-get install -y binutils bison brotli build-essential bzip2 \
+            coreutils curl dbus dnsutils dpkg fakeroot file flex ftp gnupg2   \
+            haveged imagemagick iproute2 iputils-ping jq lib32z1 libc++-dev   \
+            libc++abi-dev libcurl3 libgbm-dev libgconf-2-4 libgsl-dev         \
+            libgtk-3-0 libmagic-dev libmagickcore-dev libmagickwand-dev       \
+            libsecret-1-dev libsqlite3-dev libunwind8 libxkbfile-dev libxss1  \
+            locales m4 mediainfo net-tools netcat openssh-client p7zip-full   \
+            p7zip-rar parallel pass patchelf pkg-config pollinate             \
+            python-setuptools rpm rsync shellcheck sphinxsearch sqlite3 ssh   \
+            sshpass subversion sudo swig telnet texinfo time tk tzdata unzip  \
+            upx wget xorriso xvfb xz-utils zip zsync
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -192,19 +192,6 @@ jobs:
         - Agent.OSArchitecture -equals X64
         - ImageOverride -equals agent-aziotedge-winserver-2019-build
     steps:
-      - powershell: |
-          $VsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools'
-          Import-Module "$VsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
-          Enter-VsDevShell -VsInstallPath $VsPath
-          Get-Command cmake
-          cmake --version
-        displayName: Is CMake available inside developer command prompt environment?
-
-      - powershell: |
-          Get-Command cmake
-          cmake --version
-        displayName: Is CMake available outside of developer command prompt environment?
-
       - powershell: ls env:/
         displayName: Dump environment
 

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -67,6 +67,7 @@ jobs:
           target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
     steps:
       # Ensure any changes here are replicated in packages.slow.yaml
+      - bash: env
 
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -15,10 +15,9 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      name: $(pool.name)
+      name: $(pool.linux.name)
       demands:
-        - agent.os -equals Linux
-        - agent.osarchitecture -equals X64
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     strategy:
       matrix:
         Centos75-amd64:
@@ -107,10 +106,9 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      name: $(pool.name)
+      name: $(pool.linux.name)
       demands:
-        - agent.os -equals Linux
-        - agent.osarchitecture -equals X64
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:
@@ -191,10 +189,8 @@ jobs:
     displayName: Windows amd64
     timeoutInMinutes: 90
     pool:
-      name: $(pool.name)
+      name: $(pool.windows.name)
       demands:
-        - Agent.OS -equals Windows_NT
-        - Agent.OSArchitecture -equals X64
         - ImageOverride -equals agent-aziotedge-winserver-2019-build
     steps:
       - powershell: ls env:/

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -124,7 +124,7 @@ jobs:
           sudo apt-get install -y binutils bison brotli build-essential bzip2 \
             coreutils curl dbus dnsutils dpkg fakeroot file flex ftp gnupg2   \
             haveged imagemagick iproute2 iputils-ping jq lib32z1 libc++-dev   \
-            libc++abi-dev libcurl3 libgbm-dev libgconf-2-4 libgsl-dev         \
+            libc++abi-dev libgbm-dev libgconf-2-4 libgsl-dev                  \
             libgtk-3-0 libmagic-dev libmagickcore-dev libmagickwand-dev       \
             libsecret-1-dev libsqlite3-dev libunwind8 libxkbfile-dev libxss1  \
             locales m4 mediainfo net-tools netcat openssh-client p7zip-full   \
@@ -132,6 +132,7 @@ jobs:
             python-setuptools rpm rsync shellcheck sphinxsearch sqlite3 ssh   \
             sshpass subversion sudo swig telnet texinfo time tk tzdata unzip  \
             upx wget xorriso xvfb xz-utils zip zsync
+          # libcurl3
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -106,9 +106,7 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      name: $(pool.linux.name)
-      demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+      vmImage: 'ubuntu-18.04'
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -190,6 +190,19 @@ jobs:
         - Agent.OSArchitecture -equals X64
         - ImageOverride -equals agent-aziotedge-winserver-2019-build
     steps:
+      - powershell: |
+          $VsPath = 'C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools'
+          Import-Module "$VsPath\Common7\Tools\Microsoft.VisualStudio.DevShell.dll"
+          Enter-VsDevShell -VsInstallPath $VsPath
+          Get-Command cmake
+          cmake --version
+        displayName: Is CMake available inside developer command prompt environment?
+
+      - powershell: |
+          Get-Command cmake
+          cmake --version
+        displayName: Is CMake available outside of developer command prompt environment?
+
       - powershell: ls env:/
         displayName: Dump environment
 

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -189,7 +189,7 @@ jobs:
     pool:
       name: $(pool.windows.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-winserver-2019-build
+        - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
     steps:
       - powershell: ls env:/
         displayName: Dump environment

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -107,11 +107,10 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      vmImage: 'ubuntu-18.04'
-      # name: $(pool.name)
-      # demands:
-      #   - agent.os -equals Linux
-      #   - agent.osarchitecture -equals X64
+      name: $(pool.name)
+      demands:
+        - agent.os -equals Linux
+        - agent.osarchitecture -equals X64
     strategy:
       matrix:
         CBL-Mariner1.0-amd64:

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -66,8 +66,6 @@ jobs:
           target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
     steps:
       # Ensure any changes here are replicated in packages.slow.yaml
-      - bash: env
-
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
@@ -115,20 +113,6 @@ jobs:
           release: tags/1.0-stable
           target.iotedged: builds/mariner/out/RPMS/x86_64/
     steps:
-      - bash: |
-          sudo apt-get update
-          sudo apt-get install -y binutils bison brotli build-essential bzip2 \
-            coreutils curl dbus dnsutils dpkg fakeroot file flex ftp gnupg2   \
-            haveged imagemagick iproute2 iputils-ping jq lib32z1 libc++-dev   \
-            libc++abi-dev libgbm-dev libgconf-2-4 libgsl-dev                  \
-            libgtk-3-0 libmagic-dev libmagickcore-dev libmagickwand-dev       \
-            libsecret-1-dev libsqlite3-dev libunwind8 libxkbfile-dev libxss1  \
-            locales m4 mediainfo net-tools netcat openssh-client p7zip-full   \
-            p7zip-rar parallel pass patchelf pkg-config pollinate             \
-            python-setuptools rpm rsync shellcheck sphinxsearch sqlite3 ssh   \
-            sshpass subversion sudo swig telnet texinfo time tk tzdata unzip  \
-            upx wget xorriso xvfb xz-utils zip zsync
-          # libcurl3
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
@@ -191,9 +175,6 @@ jobs:
       demands:
         - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
     steps:
-      - powershell: ls env:/
-        displayName: Dump environment
-
       - powershell: |
           $base_version = Get-Content -Path "$(Build.SourcesDirectory)\edgelet\version.txt"
           if ($base_version -like '*~*') {

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -127,8 +127,6 @@ jobs:
           echo '=========='
           env
           echo '=========='
-          docker run --rm curlimages/curl -fsSL https://packages.microsoft.com/cbl-mariner/1.0/prod/
-          echo '=========='
       - bash: |
           BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
           VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"

--- a/builds/misc/templates/image-linux-rust-jobs.yaml
+++ b/builds/misc/templates/image-linux-rust-jobs.yaml
@@ -10,10 +10,9 @@ jobs:
 ################################################################################
     displayName: Linux Rust ${{ parameters.archName }}
     pool:
-      name: $(pool.name)
+      name: $(pool.linux.name)
       demands:
-        - agent.os -equals Linux
-        - agent.osarchitecture -equals X64
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     steps:
       - bash: 'docker login $(registry.address) --username $(registry.user) --password $(registry.password)'
         displayName: 'Docker Login'

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -94,6 +94,6 @@ sudo tar xzf toolkit.tar.gz
 pushd toolkit
 
 # Build Mariner RPM packages
-sudo make build-packages PACKAGE_BUILD_LIST="azure-iotedge libiothsm-std" CONFIG_FILE= -j$(nproc) LOG_LEVEL=debug
+sudo make build-packages PACKAGE_BUILD_LIST="azure-iotedge libiothsm-std" CONFIG_FILE= -j$(nproc)
 popd
 popd

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -94,6 +94,6 @@ sudo tar xzf toolkit.tar.gz
 pushd toolkit
 
 # Build Mariner RPM packages
-sudo make build-packages PACKAGE_BUILD_LIST="azure-iotedge libiothsm-std" CONFIG_FILE= -j$(nproc)
+sudo make build-packages PACKAGE_BUILD_LIST="azure-iotedge libiothsm-std" CONFIG_FILE= -j$(nproc) LOG_LEVEL=debug
 popd
 popd

--- a/edgelet/build/windows/install.ps1
+++ b/edgelet/build/windows/install.ps1
@@ -10,8 +10,8 @@ $util = Join-Path -Path $PSScriptRoot -ChildPath "util.ps1"
 
 Assert-Rust -Arm:$Arm
 
-# # Bring in openssl install function
-# $openssl = Join-Path -Path $PSScriptRoot -ChildPath "openssl.ps1"
-# . $openssl
+# Bring in openssl install function
+$openssl = Join-Path -Path $PSScriptRoot -ChildPath "openssl.ps1"
+. $openssl
 
-# Get-OpenSSL -Arm:$Arm
+Get-OpenSSL -Arm:$Arm

--- a/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
@@ -70,9 +70,6 @@ if(MSVC)
         add_definitions(/W4)
     endif(run_unittests)
 
-    # Turn off compiler warning C5105 in VS2019+
-    add_definitions(/wd5105)
-
     # export functions in DLL
     set(source_c_files ${source_c_files}
         ./src/hsm_client_data.def

--- a/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
@@ -70,6 +70,9 @@ if(MSVC)
         add_definitions(/W4)
     endif(run_unittests)
 
+    # Turn off compiler warning C5105 in VS2019+
+    add_definitions(/wd5105)
+
     # export functions in DLL
     set(source_c_files ${source_c_files}
         ./src/hsm_client_data.def

--- a/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
@@ -62,6 +62,9 @@ if(MSVC)
     #windows needs this define
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
+    # Turn off compiler warning C5105 in VS2019+
+    add_compile_options(/wd5105)
+
     # Make warning as error
     add_definitions(/WX)
     if (run_unittests)
@@ -69,9 +72,6 @@ if(MSVC)
     else()
         add_definitions(/W4)
     endif(run_unittests)
-
-    # Turn off compiler warning C5105 in VS2019+
-    add_definitions(/wd5105)
 
     # export functions in DLL
     set(source_c_files ${source_c_files}

--- a/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/CMakeLists.txt
@@ -62,9 +62,6 @@ if(MSVC)
     #windows needs this define
     add_definitions(-D_CRT_SECURE_NO_WARNINGS)
 
-    # Turn off compiler warning C5105 in VS2019+
-    add_compile_options(/wd5105)
-
     # Make warning as error
     add_definitions(/WX)
     if (run_unittests)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/CMakeLists.txt
@@ -4,6 +4,11 @@
 include(../deps/c-shared/configs/azure_iot_build_rules.cmake)
 usePermissiveRulesForSamplesAndTests()
 
+if(MSVC)
+    # Turn off compiler warning C5105 in VS2019+
+    add_definitions(/wd5105)
+endif(MSVC)
+
 set(save_ut ${run_unittests})
 set(run_unittests OFF CACHE BOOL "unittests" FORCE)
 add_subdirectory(../deps/c-shared/testtools/ctest c-shared/testtools/ctest)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/CMakeLists.txt
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/CMakeLists.txt
@@ -4,11 +4,6 @@
 include(../deps/c-shared/configs/azure_iot_build_rules.cmake)
 usePermissiveRulesForSamplesAndTests()
 
-if(MSVC)
-    # Turn off compiler warning C5105 in VS2019+
-    add_definitions(/wd5105)
-endif(MSVC)
-
 set(save_ut ${run_unittests})
 set(run_unittests OFF CACHE BOOL "unittests" FORCE)
 add_subdirectory(../deps/c-shared/testtools/ctest c-shared/testtools/ctest)

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeLogs.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeLogs.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             foreach (string name in modules)
             {
                 string moduleLog = $"{filePrefix}-{name}.log";
-                output = await Process.RunAsync("iotedge", $"logs {name}", token, false);
+                output = await Process.RunAsync("iotedge", $"logs {name}", token, logVerbose: false);
                 await File.WriteAllLinesAsync(moduleLog, output, token);
                 paths.Add(moduleLog);
             }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                         static bool DaemonNotReady(string details) =>
                             details.Contains("Incorrect function", StringComparison.OrdinalIgnoreCase) ||
                             details.Contains("Could not list modules", StringComparison.OrdinalIgnoreCase) ||
+                            details.Contains("Operation not permitted", StringComparison.OrdinalIgnoreCase) ||
                             details.Contains("Socket file could not be found", StringComparison.OrdinalIgnoreCase);
 
                         return DaemonNotReady(e.ToString());

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.28.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <!-- <PackageReference Include="RunProcessAsTask" Version="1.2.4" /> -->
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />
   </ItemGroup>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/ProcessEx.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/ProcessEx.cs
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
+// Adapted from https://github.com/jamesmanning/RunProcessAsTask
 
 // Copyright (c) 2013 James Manning
 namespace RunProcessAsTask

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/ProcessEx.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/ProcessEx.cs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft. All rights reserved.
-// Adapted from https://github.com/jamesmanning/RunProcessAsTask
 
 // Copyright (c) 2013 James Manning
+// Adapted from https://github.com/jamesmanning/RunProcessAsTask
 namespace RunProcessAsTask
 {
     using System;

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/OsPlatform.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
         public async Task<string> CollectDaemonLogsAsync(DateTime testStartTime, string filePrefix, CancellationToken token)
         {
             string args = $"-u iotedge -u docker --since \"{testStartTime:yyyy-MM-dd HH:mm:ss}\" --no-pager";
-            string[] output = await Process.RunAsync("journalctl", args, token, false);
+            string[] output = await Process.RunAsync("journalctl", args, token, logVerbose: false);
 
             string daemonLog = $"{filePrefix}-iotedged.log";
             await File.WriteAllLinesAsync(daemonLog, output, token);

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
@@ -104,20 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
             var sc = new ServiceController("iotedge");
             if (sc.Status != ServiceControllerStatus.Stopped)
             {
-                static bool DaemonAlreadyStopped(string details) =>
-                    details.Contains("The service has not been started", StringComparison.OrdinalIgnoreCase) ||
-                    details.Contains("The requested control is not valid for this service", StringComparison.OrdinalIgnoreCase) ||
-                    new Regex(@"Cannot stop .+ service on computer '\.'").IsMatch(details);
-
-                try
-                {
-                    sc.Stop();
-                }
-                catch (InvalidOperationException e) when (DaemonAlreadyStopped(e.InnerException.Message))
-                {
-                    Log.Verbose(e, "Did not stop edge daemon because it is already stopped");
-                }
-
+                sc.Stop();
                 await WaitForStatusAsync(sc, ServiceControllerStatus.Stopped, token);
             }
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
     using System.Linq;
     using System.Net;
     using System.ServiceProcess;
+    using System.Text.RegularExpressions;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -105,7 +106,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
             {
                 static bool DaemonAlreadyStopped(string details) =>
                     details.Contains("The service has not been started", StringComparison.OrdinalIgnoreCase) ||
-                    details.Contains("The requested control is not valid for this service", StringComparison.OrdinalIgnoreCase);
+                    details.Contains("The requested control is not valid for this service", StringComparison.OrdinalIgnoreCase) ||
+                    new Regex(@"Cannot stop .+ service on computer '\.'").IsMatch(details);
 
                 try
                 {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/OsPlatform.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
                 "| Sort-Object @{Expression=\'TimeCreated\';Descending=$false} " +
                 "| Format-Table -AutoSize -HideTableHeaders " +
                 "| Out-String -Width 512";
-            string[] output = await Process.RunAsync("powershell", command, token, false);
+            string[] output = await Process.RunAsync("powershell", command, token, logVerbose: false);
 
             string daemonLog = $"{filePrefix}-iotedged.log";
             await File.WriteAllLinesAsync(daemonLog, output, token);


### PR DESCRIPTION
Prior to this change, the Azure DevOps pipelines described by YAML files in this repo ran on either (1) Microsoft-hosted Linux and Windows agents or (2) custom-built agents hosted and maintained by the product team. The Microsoft-hosted agents are great because someone else manages their maintenance, but they're also shared among many teams so availability can be a problem. The custom-built agents have better availability but require more care and attention.

To get better availability and control with a reduced maintenance burden, this change converts the YAML pipelines to refer to 1ES-hosted agents (1ES is Microsoft's internal engineering system). These agents are defined by the product team but are maintained by 1ES.

This change only impacts three pipelines: Build Images (images.yaml), Edgelet Packages (packages.yaml), and End-to-end tests (e2e.yaml). And there are a few exceptions: Raspberry Pi OS, CentOS-7, Windows EFLOW, and proxy jobs have not been converted to 1ES either because they're not yet supported by 1ES or they simply require more work. Other pipelines will be converted in future PRs.

Other details:
- This change expands the platforms and environments that run the end-to-end tests. Ubuntu 20.04 is now covered, and both Ubuntu versions run against Docker (supported only for development scenarios) and a Microsoft-built fork of the Moby project (officially supported for production scenarios). Also, the tests run against Windows 10 Enterprise and Windows Server 2019.
- The artifact overrides task was removed from e2e-run.yaml because specifying artifact builds via the `az.pipeline.images.buildId` and `az.pipeline.packages.buildId` variables is obsolete. You can now use the Azure Pipelines "resources" feature to accomplish the same thing.
- The .NET Core 2.1 & 3.1 install tasks were removed from images.yaml because they're installed when the 1ES-hosted image is built; they don't need to be installed at runtime.
- A `docker system prune` task was removed from images.yaml because the new 1ES-hosted images are stateless, and therefore don't require cleanup between runs.
- A bug was fixed in the cargo install script wherein it didn't set up the user's PATH. This was likely hidden by the fact that the pipeline ran on stateful agents, where cargo had already been installed. Cargo install will likely become a build-time action in the future, so this task will be removed altogether.
- A bug was fixed in the openssl library build task, which again probably went undetected because it only ran on stateful agents.
- The end-to-end tests now detect a couple more cases where `iotedge list` fails because the daemon is still starting up. In such cases the tests will retry the commands rather than failing.
- Process.RunAsync was updated to stream stdout in real time rather than waiting until the call ends to return output (and potentially discarding output in some failure cases). This improves logging, but required forking the open source RunProcessAsTask project into the source code rather than taking a NuGet dependency. The changes could potentially be contributed back instead, but the project seems not to have been updated for some time. Note that a few calls to Process.RunAsync still request the old behavior (via `logVerbose: false`) because they're logging the output to file and therefore don't want to repeat it to stdout.