### PR TITLE
[mqtt] Make tracing looks like edgehub logs again

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -1158,6 +1158,7 @@ dependencies = [
 name = "mqttd"
 version = "0.1.0"
 dependencies = [
+ "ansi_term 0.12.1",
  "anyhow",
  "async-trait",
  "cfg-if",
@@ -1177,6 +1178,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-core",
  "tracing-log",
  "tracing-subscriber",
 ]

--- a/mqtt/mqttd/Cargo.toml
+++ b/mqtt/mqttd/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Azure IoT Edge Devs"]
 edition = "2018"
 
 [dependencies]
+ansi_term = { version = "0.12", optional = true }
 anyhow = "1.0"
 async-trait = "0.1"
 cfg-if = "1.0"
@@ -18,6 +19,7 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["net", "macros", "rt-multi-thread", "signal", "time"] }
 tokio-stream = { version = "0.1", features = ["signal"] }
 tracing = "0.1"
+tracing-core = "0.1"
 tracing-log = "0.1"
 tracing-subscriber = "0.2"
 
@@ -33,5 +35,6 @@ serde_json = "1.0"
 
 [features]
 default = ["edgehub"]
+ansi = ["ansi_term"]
 edgehub = ["mqtt-bridge", "mqtt-edgehub", "edgelet-client"]
 generic = ["mqtt-generic"]

--- a/mqtt/mqttd/src/tracing/edgehub.rs
+++ b/mqtt/mqttd/src/tracing/edgehub.rs
@@ -5,7 +5,7 @@ use tracing::Level;
 use tracing_log::LogTracer;
 use tracing_subscriber::{fmt, EnvFilter};
 
-// use super::Format;
+use super::Format;
 
 const EDGE_HUB_LOG_LEVEL_ENV: &str = "RuntimeLogLevel";
 
@@ -29,8 +29,7 @@ pub fn init() {
 
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::TRACE)
-        // TODO
-        // .on_event(Format::default())
+        .event_format(Format::edgehub())
         .with_env_filter(EnvFilter::new(log_level.clone()))
         .finish();
     let _ = tracing::subscriber::set_global_default(subscriber);

--- a/mqtt/mqttd/src/tracing/format.rs
+++ b/mqtt/mqttd/src/tracing/format.rs
@@ -1,4 +1,5 @@
 //! Code in this module is greatly inspired by `tracing-subscriber` internals.
+#![allow(clippy::unused_self)]
 use std::{
     fmt::{self, Write},
     marker::PhantomData,
@@ -263,6 +264,7 @@ impl Style {
 }
 
 mod time {
+    #![allow(clippy::inline_always)]
     use std::fmt::{Result, Write};
 
     #[cfg(feature = "ansi")]

--- a/mqtt/mqttd/src/tracing/format.rs
+++ b/mqtt/mqttd/src/tracing/format.rs
@@ -1,63 +1,118 @@
-use std::marker::PhantomData;
+//! Code in this module is greatly inspired by `tracing-subscriber` internals.
+use std::{
+    fmt::{self, Write},
+    marker::PhantomData,
+};
 
-use tracing::{Event, Level};
+use tracing_core::{span, Event, Level, Subscriber};
+use tracing_subscriber::{
+    fmt::{
+        time::{ChronoLocal, FormatTime},
+        FmtContext, FormatEvent, FormatFields, FormattedFields,
+    },
+    registry::LookupSpan,
+};
+
+#[cfg(feature = "tracing-log")]
 use tracing_log::NormalizeEvent;
-use tracing_subscriber::fmt::{time::ChronoLocal, time::FormatTime, FormatEvent};
+
+#[cfg(feature = "ansi")]
+use ansi_term::{Colour, Style};
 
 /// Marker for `Format` that indicates that the syslog format should be used.
 pub(crate) struct EdgeHub;
 
-/// Custom event formatter.
 pub(crate) struct Format<F = EdgeHub, T = ChronoLocal> {
     format: PhantomData<F>,
     timer: T,
+
+    #[cfg(feature = "ansi")]
+    ansi: bool,
 }
 
-impl Default for Format<EdgeHub, ChronoLocal> {
-    fn default() -> Self {
+impl Format<EdgeHub, ChronoLocal> {
+    pub fn edgehub() -> Self {
         Format {
             format: PhantomData,
             timer: ChronoLocal::with_format("%F %T.%3f %:z".into()),
+
+            #[cfg(feature = "ansi")]
+            ansi: true,
         }
     }
 }
 
-impl<N, T> FormatEvent<N> for Format<EdgeHub, T>
+impl<S, N, T> FormatEvent<S, N> for Format<EdgeHub, T>
 where
-    N: for<'a> NewVisitor<'a>,
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
     T: FormatTime,
 {
     fn format_event(
         &self,
-        ctx: &Context<'_, N>,
-        writer: &mut dyn std::fmt::Write,
+        ctx: &FmtContext<'_, S, N>,
+        writer: &mut dyn fmt::Write,
         event: &Event<'_>,
-    ) -> std::fmt::Result {
+    ) -> fmt::Result {
+        #[cfg(feature = "tracing-log")]
         let normalized_meta = event.normalized_metadata();
+
+        #[cfg(feature = "tracing-log")]
         let meta = normalized_meta.as_ref().unwrap_or_else(|| event.metadata());
 
-        let (fmt_level, fmt_ctx) = (FmtLevel::new(meta.level()), FullCtx::new(&ctx));
+        #[cfg(not(feature = "tracing-log"))]
+        let meta = event.metadata();
+
+        let fmt_level = {
+            #[cfg(feature = "ansi")]
+            {
+                FmtLevel::new(meta.level(), self.ansi)
+            }
+            #[cfg(not(feature = "ansi"))]
+            {
+                FmtLevel::new(meta.level())
+            }
+        };
 
         write!(writer, "<{}> ", fmt_level.syslog_level())?;
-        self.timer.format_time(writer)?;
-        write!(writer, "[{}] [{}{}] - ", fmt_level, fmt_ctx, meta.target(),)?;
 
-        {
-            let mut recorder = ctx.new_visitor(writer, true);
-            event.record(&mut recorder);
-        }
+        #[cfg(feature = "ansi")]
+        time::write(&self.timer, writer, self.ansi)?;
 
+        #[cfg(not(feature = "ansi"))]
+        time::write(&self.timer, writer)?;
+
+        let full_ctx = {
+            #[cfg(feature = "ansi")]
+            {
+                FullCtx::new(ctx, event.parent(), self.ansi)
+            }
+            #[cfg(not(feature = "ansi"))]
+            {
+                FullCtx::new(ctx, event.parent())
+            }
+        };
+
+        write!(writer, "[{}] [{}{}] - ", fmt_level, full_ctx, meta.target(),)?;
+        ctx.format_fields(writer, event)?;
         writeln!(writer)
     }
 }
 
-/// Wrapper around `Level` to format it accordingly to `syslog` rules.
 struct FmtLevel<'a> {
     level: &'a Level,
+    #[cfg(feature = "ansi")]
+    ansi: bool,
 }
 
 impl<'a> FmtLevel<'a> {
-    fn new(level: &'a Level) -> Self {
+    #[cfg(feature = "ansi")]
+    pub(crate) fn new(level: &'a Level, ansi: bool) -> Self {
+        Self { level, ansi }
+    }
+
+    #[cfg(not(feature = "ansi"))]
+    pub(crate) fn new(level: &'a Level) -> Self {
         Self { level }
     }
 
@@ -71,45 +126,174 @@ impl<'a> FmtLevel<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for FmtLevel<'a> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+const TRACE_STR: &str = "TRC";
+const DEBUG_STR: &str = "DBG";
+const INFO_STR: &str = "INF";
+const WARN_STR: &str = "WRN";
+const ERROR_STR: &str = "ERR";
+
+#[cfg(not(feature = "ansi"))]
+impl<'a> fmt::Display for FmtLevel<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self.level {
-            Level::TRACE => f.pad("TRC"),
-            Level::DEBUG => f.pad("DBG"),
-            Level::INFO => f.pad("INF"),
-            Level::WARN => f.pad("WRN"),
-            Level::ERROR => f.pad("ERR"),
+            Level::TRACE => f.pad(TRACE_STR),
+            Level::DEBUG => f.pad(DEBUG_STR),
+            Level::INFO => f.pad(INFO_STR),
+            Level::WARN => f.pad(WARN_STR),
+            Level::ERROR => f.pad(ERROR_STR),
         }
     }
 }
 
-/// Wrapper around log entry context to format entry.
-struct FullCtx<'a, N> {
-    ctx: &'a Context<'a, N>,
-}
-
-impl<'a, N: 'a> FullCtx<'a, N> {
-    fn new(ctx: &'a Context<'a, N>) -> Self {
-        Self { ctx }
+#[cfg(feature = "ansi")]
+impl<'a> fmt::Display for FmtLevel<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.ansi {
+            match *self.level {
+                Level::TRACE => write!(f, "{}", Colour::Purple.paint(TRACE_STR)),
+                Level::DEBUG => write!(f, "{}", Colour::Blue.paint(DEBUG_STR)),
+                Level::INFO => write!(f, "{}", Colour::Green.paint(INFO_STR)),
+                Level::WARN => write!(f, "{}", Colour::Yellow.paint(WARN_STR)),
+                Level::ERROR => write!(f, "{}", Colour::Red.paint(ERROR_STR)),
+            }
+        } else {
+            match *self.level {
+                Level::TRACE => f.pad(TRACE_STR),
+                Level::DEBUG => f.pad(DEBUG_STR),
+                Level::INFO => f.pad(INFO_STR),
+                Level::WARN => f.pad(WARN_STR),
+                Level::ERROR => f.pad(ERROR_STR),
+            }
+        }
     }
 }
 
-impl<'a, N> std::fmt::Display for FullCtx<'a, N> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+struct FullCtx<'a, S, N>
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    ctx: &'a FmtContext<'a, S, N>,
+    span: Option<&'a span::Id>,
+    #[cfg(feature = "ansi")]
+    ansi: bool,
+}
+
+impl<'a, S, N: 'a> FullCtx<'a, S, N>
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    #[cfg(feature = "ansi")]
+    pub(crate) fn new(
+        ctx: &'a FmtContext<'a, S, N>,
+        span: Option<&'a span::Id>,
+        ansi: bool,
+    ) -> Self {
+        Self { ctx, span, ansi }
+    }
+
+    #[cfg(not(feature = "ansi"))]
+    pub(crate) fn new(ctx: &'a FmtContext<'a, S, N>, span: Option<&'a span::Id>) -> Self {
+        Self { ctx, span }
+    }
+
+    fn bold(&self) -> Style {
+        #[cfg(feature = "ansi")]
+        {
+            if self.ansi {
+                return Style::new().bold();
+            }
+        }
+
+        Style::new()
+    }
+}
+
+impl<'a, S, N> fmt::Display for FullCtx<'a, S, N>
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+    N: for<'writer> FormatFields<'writer> + 'static,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let bold = self.bold();
         let mut seen = false;
-        self.ctx.visit_spans(|_, span| {
-            write!(f, "{}", span.name())?;
+
+        let span = self
+            .span
+            .and_then(|id| self.ctx.span(&id))
+            .or_else(|| self.ctx.lookup_current());
+
+        let scope = span
+            .into_iter()
+            .flat_map(|span| span.from_root().chain(std::iter::once(span)));
+
+        for span in scope {
+            write!(f, "{}", bold.paint(span.metadata().name()))?;
             seen = true;
 
-            let fields = span.fields();
+            let ext = span.extensions();
+            let fields = &ext
+                .get::<FormattedFields<N>>()
+                .expect("Unable to find FormattedFields in extensions; this is a bug");
             if !fields.is_empty() {
-                write!(f, "{{{}}}", fields)?;
+                write!(f, "{}{}{}", bold.paint("{"), fields, bold.paint("}"))?;
             }
-            ":".fmt(f)
-        })?;
+            f.write_char(':')?;
+        }
+
         if seen {
-            f.pad(" ")?;
+            f.write_char(' ')?;
         }
         Ok(())
+    }
+}
+
+#[cfg(not(feature = "ansi"))]
+struct Style;
+
+#[cfg(not(feature = "ansi"))]
+impl Style {
+    fn new() -> Self {
+        Style
+    }
+    fn paint(&self, d: impl fmt::Display) -> impl fmt::Display {
+        d
+    }
+}
+
+mod time {
+    use std::fmt::{Result, Write};
+
+    #[cfg(feature = "ansi")]
+    use ansi_term::Style;
+    use tracing_subscriber::fmt::time::FormatTime;
+
+    #[inline(always)]
+    #[cfg(feature = "ansi")]
+    pub(crate) fn write<T>(timer: T, writer: &mut dyn Write, with_ansi: bool) -> Result
+    where
+        T: FormatTime,
+    {
+        if with_ansi {
+            let style = Style::new().dimmed();
+            write!(writer, "{}", style.prefix())?;
+            timer.format_time(writer)?;
+            write!(writer, "{}", style.suffix())?;
+        } else {
+            timer.format_time(writer)?;
+        }
+        writer.write_char(' ')?;
+        Ok(())
+    }
+
+    #[inline(always)]
+    #[cfg(not(feature = "ansi"))]
+    pub(crate) fn write<T>(timer: T, writer: &mut dyn Write) -> Result
+    where
+        T: FormatTime,
+    {
+        timer.format_time(writer)?;
+        write!(writer, " ")
     }
 }

--- a/mqtt/mqttd/src/tracing/mod.rs
+++ b/mqtt/mqttd/src/tracing/mod.rs
@@ -10,6 +10,8 @@ mod generic;
 #[cfg(all(not(feature = "edgehub"), feature = "generic"))]
 pub use generic::init;
 
-// TODO fix this
-// mod format;
-// use format::Format;
+#[cfg(feature = "edgehub")]
+mod format;
+
+#[cfg(feature = "edgehub")]
+use format::Format;


### PR DESCRIPTION
Bring back edgehub-like tracing logs after upgrade.

I added additional features which adds styling to log entries by it looks bag for logs inside container. It can be enabled with adding `ansi` feature when compiled