### PR TITLE
[mqtt] upgrade percent-encoding to v2

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -385,7 +385,7 @@ dependencies = [
  "matches",
  "mockito",
  "openssl",
- "percent-encoding 1.0.1",
+ "percent-encoding",
  "serde",
  "serde_json",
  "test-case",
@@ -474,7 +474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]
@@ -1128,7 +1128,7 @@ dependencies = [
  "futures-util",
  "mqtt3",
  "openssl",
- "percent-encoding 1.0.1",
+ "percent-encoding",
  "serde",
  "thiserror",
  "tokio",
@@ -1309,12 +1309,6 @@ dependencies = [
  "smallvec",
  "winapi",
 ]
-
-[[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
@@ -2257,7 +2251,7 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "matches",
- "percent-encoding 2.1.0",
+ "percent-encoding",
 ]
 
 [[package]]

--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -63,9 +63,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.48"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea56748e10732c49404c153638a15ec3d6211ec5ff35d9bb20e13b93576adf"
+checksum = "589652ce7ccb335d1e7ecb3be145425702b290dbcb7029bbeaae263fc1d87b48"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -174,9 +174,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cast"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f566d1fbeb40ec78c78344e9983f46ff9eb4e944fa930ed01b7d72b72a37c11"
+checksum = "cc38c385bfd7e444464011bb24820f40dd1c76bcdfa1b78611cb7c2e5cafab75"
 dependencies = [
  "rustc_version",
 ]
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8270314b5ccceb518e7e578952f0b72b88222d02e8f77f5ecf7abbb673539041"
 dependencies = [
  "bitflags",
 ]

--- a/mqtt/edgelet-client/Cargo.toml
+++ b/mqtt/edgelet-client/Cargo.toml
@@ -15,7 +15,7 @@ futures-util = "0.3"
 openssl = "0.10"
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
-percent-encoding = "1.0"
+percent-encoding = "2"
 thiserror = "1.0"
 tokio = { version = "1", features = ["net"] }
 tower-service = "0.3"

--- a/mqtt/edgelet-client/src/lib.rs
+++ b/mqtt/edgelet-client/src/lib.rs
@@ -13,6 +13,7 @@ mod connect;
 mod workload;
 
 pub use connect::Connector;
+use percent_encoding::{AsciiSet, CONTROLS};
 pub use workload::{
     CertificateResponse, IdentityCertificateRequest, ServerCertificateRequest, SignRequest,
     SignResponse, TrustBundleResponse, WorkloadClient, WorkloadError,
@@ -25,6 +26,20 @@ use hyper::{client::HttpConnector, Client};
 #[cfg(unix)]
 use hyperlocal::UnixConnector;
 use url::{ParseError, Url};
+
+/// Ref <https://url.spec.whatwg.org/#path-percent-encode-set>
+pub const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &CONTROLS
+    .add(b' ')
+    .add(b'"')
+    .add(b'<')
+    .add(b'>')
+    .add(b'`') // fragment percent-encode set
+    .add(b'#')
+    .add(b'?')
+    .add(b'{')
+    .add(b'}'); // path percent-encode set
+
+pub const IOTHUB_ENCODE_SET: &AsciiSet = &PATH_SEGMENT_ENCODE_SET.add(b'$');
 
 pub fn workload(url: &str) -> Result<WorkloadClient, Error> {
     let url = Url::parse(url).map_err(|e| Error::ParseUrl(url.to_string(), e))?;

--- a/mqtt/edgelet-client/src/workload/client.rs
+++ b/mqtt/edgelet-client/src/workload/client.rs
@@ -4,17 +4,14 @@ use bytes::buf::Buf;
 use chrono::{DateTime, Utc};
 use http::{Request, StatusCode, Uri};
 use hyper::{body, Body, Client};
-use percent_encoding::{define_encode_set, percent_encode, PATH_SEGMENT_ENCODE_SET};
+use percent_encoding::percent_encode;
 use serde::{de::DeserializeOwned, Serialize};
 
 use crate::{
     make_hyper_uri, ApiError, CertificateResponse, Connector, IdentityCertificateRequest, Scheme,
-    ServerCertificateRequest, SignRequest, SignResponse, TrustBundleResponse,
+    ServerCertificateRequest, SignRequest, SignResponse, TrustBundleResponse, IOTHUB_ENCODE_SET,
+    PATH_SEGMENT_ENCODE_SET,
 };
-
-define_encode_set! {
-    pub IOTHUB_ENCODE_SET = [PATH_SEGMENT_ENCODE_SET] | { '$' }
-}
 
 #[derive(Debug)]
 pub struct WorkloadClient {

--- a/mqtt/mqtt-util/Cargo.toml
+++ b/mqtt/mqtt-util/Cargo.toml
@@ -9,7 +9,7 @@ async-trait = "0.1"
 chrono = "0.4"
 futures-util = "0.3"
 openssl = "0.10"
-percent-encoding = "1.0"
+percent-encoding = "2"
 serde = { version = "1.0", features = ["derive", "rc"] }
 thiserror = "1.0"
 tracing = "0.1"


### PR DESCRIPTION
Long waited upgrade to a new major version (v2) of `percent-encoding` crate