### PR TITLE
E2E: Add regression test for custom mqtt topics

### DIFF
--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -165,6 +165,7 @@ steps:
       metricsValidatorImage = "$imagePrefix-metrics-validator:$imageTag";
       numberLoggerImage = "$imagePrefix-number-logger:$imageTag";
       edgeAgentBootstrapImage = "$imagePrefix-agent-bootstrap-e2e-$(os)-$(arch)";
+      genericMqttTesterImage = "$imagePrefix-generic-mqtt-tester:$imageTag"
       registries = @(
         @{
           address = '$(cr.address)';

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/EdgeConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/EdgeConfigBuilder.cs
@@ -45,9 +45,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
             return builder;
         }
 
-        public IModuleConfigBuilder AddModule(string name, string image)
+        public IModuleConfigBuilder AddModule(string name, string image, bool shouldRestart = true)
         {
-            var builder = new ModuleConfigBuilder(name, image);
+            var builder = new ModuleConfigBuilder(name, image, shouldRestart);
             this.moduleBuilders.Add(builder.Name, builder);
             return builder;
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/HubModuleConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/HubModuleConfigBuilder.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
         const string HubCreateOptions = "{\"HostConfig\":{\"PortBindings\":{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}],\"5671/tcp\":[{\"HostPort\":\"5671\"}]}}}";
 
         public HubModuleConfigBuilder(Option<string> image, bool optimizeForPerformance)
-            : base(ModuleName.EdgeHub, image.GetOrElse(DefaultImage), Option.Some(HubCreateOptions))
+            : base(ModuleName.EdgeHub, image.GetOrElse(DefaultImage), Option.Some(HubCreateOptions), true)
         {
             this.WithDesiredProperties(
                 new Dictionary<string, object>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/ModuleConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/ModuleConfigBuilder.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
             if (shouldRestart)
             {
                 restartPolicy = "always";
-
             }
             else
             {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/ModuleConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/ModuleConfigBuilder.cs
@@ -5,18 +5,29 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
 
     public class ModuleConfigBuilder : BaseModuleConfigBuilder
     {
-        public ModuleConfigBuilder(string name, string image)
-            : this(name, image, Option.None<string>())
+        public ModuleConfigBuilder(string name, string image, bool shouldRestart)
+            : this(name, image, Option.None<string>(), shouldRestart)
         {
         }
 
-        public ModuleConfigBuilder(string name, string image, Option<string> createOptions)
+        public ModuleConfigBuilder(string name, string image, Option<string> createOptions, bool shouldRestart)
             : base(name, image)
         {
+            string restartPolicy = string.Empty;
+            if (shouldRestart)
+            {
+                restartPolicy = "always";
+
+            }
+            else
+            {
+                restartPolicy = "never";
+            }
+
             this.WithDeployment(
                 new[]
                 {
-                    ("restartPolicy", "always"),
+                    ("restartPolicy", restartPolicy),
                     ("status", "running")
                 });
             createOptions.ForEach(s => this.WithSettings(new[] { ("createOptions", s) }));

--- a/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
@@ -20,6 +20,20 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string GenericMqttTesterTestStartDelay = "10s";
         const int SecondsBeforeVerification = 45;
 
+        /// <summary>
+        /// Scenario:
+        /// - Deploy Edge Hub with the broker enabled and two genericMqttTester
+        ///   modules.
+        /// - One genericMqttTester module will be in initiate mode and the other
+        ///   will be in relay mode.
+        /// - The initiate mode module will publish on an mqtt topic initiate/1
+        ///   which the relaying module will be subscribed to.
+        /// - When the relaying module receives a message, it will publish it
+        ///   back on relay/1.
+        /// - The initiating module will be subscribed on this relay/1 topic
+        ///   and will report to the TRC when it receives the message.
+        /// </summary>
+        /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
         public async Task GenericMqttTelemetry()
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Test
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Test.Common;
+    using Microsoft.Azure.Devices.Edge.Test.Common.Config;
+    using Microsoft.Azure.Devices.Edge.Test.Helpers;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
+    using NUnit.Framework;
+
+    [EndToEnd]
+    public class GenericMqtt : SasManualProvisioningFixture
+    {
+        const string NetworkControllerModuleName = "networkController";
+        const string GenericMqttInitiatorModuleName = "GenericMqttInitiator";
+        const string GenericMqttRelayerModuleName = "GenericMqttRelayer";
+        const string GenericMqttTesterMaxMessages = "5";
+        const string GenericMqttTesterTestStartDelay = "10s";
+        const int SecondsBeforeVerification = 45;
+
+        [Test]
+        public async Task GenericMqttTelemetry()
+        {
+            CancellationToken token = this.TestToken;
+            string networkControllerImage = Context.Current.NetworkControllerImage.Expect(() => new ArgumentException("networkControllerImage parameter is required for Generic Mqtt test"));
+            string trcImage = Context.Current.TestResultCoordinatorImage.Expect(() => new ArgumentException("testResultCoordinatorImage parameter is required for Generic Mqtt test"));
+            string genericMqttTesterImage = Context.Current.GenericMqttTesterImage.Expect(() => new ArgumentException("genericMqttTesterImage parameter is required for Generic Mqtt test"));
+            string trackingId = Guid.NewGuid().ToString();
+
+            Action<EdgeConfigBuilder> addMqttBrokerConfig = MqttBrokerUtil.BuildAddBrokerToDeployment(false);
+            Action<EdgeConfigBuilder> addNetworkControllerConfig = TestResultCoordinatorUtil.BuildAddNetworkControllerConfig(trackingId, networkControllerImage);
+            Action<EdgeConfigBuilder> addTestResultCoordinatorConfig = TestResultCoordinatorUtil.BuildAddTestResultCoordinatorConfig(trackingId, trcImage, GenericMqttInitiatorModuleName, GenericMqttInitiatorModuleName);
+            Action<EdgeConfigBuilder> addGenericMqttTesterConfig = this.BuildAddGenericMqttTesterConfig(trackingId, trcImage, genericMqttTesterImage);
+            Action<EdgeConfigBuilder> config = addMqttBrokerConfig + addNetworkControllerConfig + addTestResultCoordinatorConfig + addGenericMqttTesterConfig;
+            EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(config, token, Context.Current.NestedEdge);
+
+            await Task.Delay(TimeSpan.FromSeconds(SecondsBeforeVerification));
+
+            await TestResultCoordinatorUtil.ValidateResultsAsync();
+        }
+
+        private Action<EdgeConfigBuilder> BuildAddGenericMqttTesterConfig(string trackingId, string trcImage, string genericMqttTesterImage)
+        {
+            return new Action<EdgeConfigBuilder>(
+                builder =>
+                {
+                    builder.AddModule(GenericMqttInitiatorModuleName, genericMqttTesterImage, false)
+                        .WithEnvironment(new[]
+                        {
+                            ("TEST_SCENARIO", "Initiate"),
+                            ("TRACKING_ID", trackingId),
+                            ("TEST_START_DELAY", GenericMqttTesterTestStartDelay),
+                            ("MESSAGES_TO_SEND", GenericMqttTesterMaxMessages),
+                        });
+
+                    builder.AddModule(GenericMqttRelayerModuleName, genericMqttTesterImage, false)
+                        .WithEnvironment(new[]
+                        {
+                            ("TEST_SCENARIO", "Relay"),
+                            ("TRACKING_ID", trackingId),
+                            ("TEST_START_DELAY", GenericMqttTesterTestStartDelay),
+                        });
+                });
+        }
+    }
+}

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -85,9 +85,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 await testResultReportingClient.ReportResultAsync(messageTestResult.ToTestOperationResultDto());
             }
 
-            // TODO ANDREW: fix so that TRC isn't configured with delay where it doesn't look at recent results
-            //              prob isn't the problem tho or there wouldn't be any unmatched
-
             await TestResultCoordinatorUtil.ValidateResultsAsync();
         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Common;
@@ -17,7 +16,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
-    using Microsoft.Azure.EventHubs;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using NUnit.Framework;
@@ -45,13 +43,14 @@ namespace Microsoft.Azure.Devices.Edge.Test
             string trackingId = Guid.NewGuid().ToString();
             TestInfo testInfo = this.InitTestInfo(5, 1000, true);
 
-            Action<EdgeConfigBuilder> addInitialConfig = this.BuildAddInitialConfig(trackingId, RelayerModuleName, trcImage, loadGenImage, testInfo, false);
-            EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addInitialConfig, token, Context.Current.NestedEdge);
+            Action<EdgeConfigBuilder> addLoadGenConfig = this.BuildAddLoadGenConfig(trackingId, loadGenImage, testInfo, false);
+            Action<EdgeConfigBuilder> addTrcConfig = TestResultCoordinatorUtil.BuildAddTestResultCoordinatorConfig(trackingId, trcImage, LoadGenModuleName, RelayerModuleName);
+            EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig, token, Context.Current.NestedEdge);
             PriorityQueueTestStatus loadGenTestStatus = await this.PollUntilFinishedAsync(LoadGenModuleName, token);
             Action<EdgeConfigBuilder> addRelayerConfig = this.BuildAddRelayerConfig(relayerImage, loadGenTestStatus);
-            deployment = await this.runtime.DeployConfigurationAsync(addInitialConfig + addRelayerConfig, token, Context.Current.NestedEdge);
+            deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig + addRelayerConfig, token, Context.Current.NestedEdge);
             await this.PollUntilFinishedAsync(RelayerModuleName, token);
-            await this.ValidateResultsAsync();
+            await TestResultCoordinatorUtil.ValidateResultsAsync();
         }
 
         [Test]
@@ -68,9 +67,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             var testResultReportingClient = new TestResultReportingClient { BaseUrl = "http://localhost:5001" };
 
-            Action<EdgeConfigBuilder> addInitialConfig = this.BuildAddInitialConfig(trackingId, "hubtest", trcImage, loadGenImage, testInfo, true);
-            Action<EdgeConfigBuilder> addNetworkControllerConfig = this.BuildAddNetworkControllerConfig(trackingId, networkControllerImage);
-            EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addInitialConfig + addNetworkControllerConfig, token, Context.Current.NestedEdge);
+            Action<EdgeConfigBuilder> addLoadGenConfig = this.BuildAddLoadGenConfig(trackingId, loadGenImage, testInfo, false);
+            Action<EdgeConfigBuilder> addTrcConfig = TestResultCoordinatorUtil.BuildAddTestResultCoordinatorConfig(trackingId, trcImage, LoadGenModuleName, "hubtest");
+            Action<EdgeConfigBuilder> addNetworkControllerConfig = TestResultCoordinatorUtil.BuildAddNetworkControllerConfig(trackingId, networkControllerImage);
+            EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig + addNetworkControllerConfig, token, Context.Current.NestedEdge);
             bool networkOn = true;
             await this.ToggleConnectivity(!networkOn, NetworkControllerModuleName, token);
             await Task.Delay(TimeSpan.Parse(LoadGenTestDuration) + TimeSpan.Parse(testInfo.LoadGenStartDelay) + TimeSpan.FromSeconds(10));
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 await testResultReportingClient.ReportResultAsync(messageTestResult.ToTestOperationResultDto());
             }
 
-            await this.ValidateResultsAsync();
+            await TestResultCoordinatorUtil.ValidateResultsAsync();
         }
 
         [Test]
@@ -97,8 +97,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
             string trackingId = Guid.NewGuid().ToString();
             TestInfo testInfo = this.InitTestInfo(5, 20);
 
-            Action<EdgeConfigBuilder> addInitialConfig = this.BuildAddInitialConfig(trackingId, RelayerModuleName, trcImage, loadGenImage, testInfo, false);
-            EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addInitialConfig, token, Context.Current.NestedEdge);
+            Action<EdgeConfigBuilder> addLoadGenConfig = this.BuildAddLoadGenConfig(trackingId, loadGenImage, testInfo, false);
+            Action<EdgeConfigBuilder> addTrcConfig = TestResultCoordinatorUtil.BuildAddTestResultCoordinatorConfig(trackingId, trcImage, LoadGenModuleName, RelayerModuleName);
+            EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig, token, Context.Current.NestedEdge);
             PriorityQueueTestStatus loadGenTestStatus = await this.PollUntilFinishedAsync(LoadGenModuleName, token);
 
             // Wait long enough for TTL to expire for some of the messages
@@ -106,9 +107,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
             await Task.Delay(testInfo.TtlThreshold * 1000);
 
             Action<EdgeConfigBuilder> addRelayerConfig = this.BuildAddRelayerConfig(relayerImage, loadGenTestStatus);
-            deployment = await this.runtime.DeployConfigurationAsync(addInitialConfig + addRelayerConfig, token, Context.Current.NestedEdge);
+            deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig + addRelayerConfig, token, Context.Current.NestedEdge);
             await this.PollUntilFinishedAsync(RelayerModuleName, token);
-            await this.ValidateResultsAsync();
+            await TestResultCoordinatorUtil.ValidateResultsAsync();
         }
 
         async Task ReceiveEventsFromIotHub(DateTime startTime, ConcurrentQueue<MessageTestResult> messages, PriorityQueueTestStatus loadGenTestStatus, string trackingId, CancellationToken token)
@@ -159,20 +160,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 loadGenTestStatus.ResultCount);
         }
 
-        private async Task ValidateResultsAsync()
-        {
-            HttpClient client = new HttpClient();
-            HttpResponseMessage response = await client.GetAsync("http://localhost:5001/api/report");
-            var jsonstring = await response.Content.ReadAsStringAsync();
-            bool isPassed = (bool)JArray.Parse(jsonstring)[0]["IsPassed"];
-            if (!isPassed)
-            {
-                Log.Information("Test Result Coordinator response: {Response}", jsonstring);
-            }
-
-            Assert.IsTrue(isPassed);
-        }
-
         private Action<EdgeConfigBuilder> BuildAddRelayerConfig(string relayerImage, PriorityQueueTestStatus loadGenTestStatus)
         {
             return new Action<EdgeConfigBuilder>(
@@ -208,50 +195,11 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 });
         }
 
-        private Action<EdgeConfigBuilder> BuildAddInitialConfig(string trackingId, string actualSource, string trcImage, string loadGenImage, TestInfo testInfo, bool cloudUpstream)
+        private Action<EdgeConfigBuilder> BuildAddLoadGenConfig(string trackingId, string loadGenImage, TestInfo testInfo, bool cloudUpstream)
         {
             return new Action<EdgeConfigBuilder>(
                 builder =>
                 {
-                    // This test uses the TestResultCoordinator. It was originally designed for connectivity tests, so many of the parameters
-                    // are unnecessary for the e2e tests.
-                    // TODO: Make TestResultCoordinator more generic, so we don't have to fill out garbage values in the e2e tests.
-                    builder.AddModule(TrcModuleName, trcImage)
-                       .WithEnvironment(new[]
-                       {
-                           ("trackingId", trackingId),
-                           ("useTestResultReportingService", "false"),
-                           ("useResultEventReceivingService", "false"),
-                           ("IOT_HUB_CONNECTION_STRING", Context.Current.ConnectionString),
-                           ("testStartDelay", "00:00:00"),
-                           ("testDuration", "00:20:00"),
-                           ("verificationDelay", "00:00:00"),
-                           ("NetworkControllerRunProfile", "Online"),
-                           ("TEST_INFO", "key=unnecessary")
-                       })
-                       .WithSettings(new[] { ("createOptions", "{\"HostConfig\": {\"PortBindings\": {\"5001/tcp\": [{\"HostPort\": \"5001\"}]}}}") })
-
-                       .WithDesiredProperties(new Dictionary<string, object>
-                       {
-                           ["reportMetadataList"] = new Dictionary<string, object>
-                           {
-                               ["reportMetadata1"] = new Dictionary<string, object>
-                               {
-                                   ["TestReportType"] = "CountingReport",
-                                   ["TestOperationResultType"] = "Messages",
-                                   ["ExpectedSource"] = $"{LoadGenModuleName}.send",
-                                   ["ActualSource"] = $"{actualSource}.receive",
-                                   ["TestDescription"] = "unnecessary"
-                               },
-                               ["reportMetadata2"] = new Dictionary<string, object>
-                               {
-                                   ["TestReportType"] = "NetworkControllerReport",
-                                   ["Source"] = $"{NetworkControllerModuleName}",
-                                   ["TestDescription"] = "network controller"
-                               }
-                           }
-                       });
-
                     builder.AddModule(LoadGenModuleName, loadGenImage)
                         .WithEnvironment(new[]
                         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             Action<EdgeConfigBuilder> addLoadGenConfig = this.BuildAddLoadGenConfig(trackingId, loadGenImage, testInfo, false);
             Action<EdgeConfigBuilder> addTrcConfig = TestResultCoordinatorUtil.BuildAddTestResultCoordinatorConfig(trackingId, trcImage, LoadGenModuleName, RelayerModuleName);
+
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig, token, Context.Current.NestedEdge);
             PriorityQueueTestStatus loadGenTestStatus = await this.PollUntilFinishedAsync(LoadGenModuleName, token);
             Action<EdgeConfigBuilder> addRelayerConfig = this.BuildAddRelayerConfig(relayerImage, loadGenTestStatus);

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -68,9 +68,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             var testResultReportingClient = new TestResultReportingClient { BaseUrl = "http://localhost:5001" };
 
-            Action<EdgeConfigBuilder> addLoadGenConfig = this.BuildAddLoadGenConfig(trackingId, loadGenImage, testInfo, false);
+            Action<EdgeConfigBuilder> addLoadGenConfig = this.BuildAddLoadGenConfig(trackingId, loadGenImage, testInfo, true);
             Action<EdgeConfigBuilder> addTrcConfig = TestResultCoordinatorUtil.BuildAddTestResultCoordinatorConfig(trackingId, trcImage, LoadGenModuleName, "hubtest");
             Action<EdgeConfigBuilder> addNetworkControllerConfig = TestResultCoordinatorUtil.BuildAddNetworkControllerConfig(trackingId, networkControllerImage);
+
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig + addNetworkControllerConfig, token, Context.Current.NestedEdge);
             bool networkOn = true;
             await this.ToggleConnectivity(!networkOn, NetworkControllerModuleName, token);
@@ -83,6 +84,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
             {
                 await testResultReportingClient.ReportResultAsync(messageTestResult.ToTestOperationResultDto());
             }
+
+            // TODO ANDREW: fix so that TRC isn't configured with delay where it doesn't look at recent results
+            //              prob isn't the problem tho or there wouldn't be any unmatched
 
             await TestResultCoordinatorUtil.ValidateResultsAsync();
         }
@@ -100,6 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             Action<EdgeConfigBuilder> addLoadGenConfig = this.BuildAddLoadGenConfig(trackingId, loadGenImage, testInfo, false);
             Action<EdgeConfigBuilder> addTrcConfig = TestResultCoordinatorUtil.BuildAddTestResultCoordinatorConfig(trackingId, trcImage, LoadGenModuleName, RelayerModuleName);
+
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig, token, Context.Current.NestedEdge);
             PriorityQueueTestStatus loadGenTestStatus = await this.PollUntilFinishedAsync(LoadGenModuleName, token);
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             this.TestResultCoordinatorImage = Option.Maybe(Get("testResultCoordinatorImage"));
             this.LoadGenImage = Option.Maybe(Get("loadGenImage"));
             this.RelayerImage = Option.Maybe(Get("relayerImage"));
+            this.GenericMqttTesterImage = Option.Maybe(Get("genericMqttTesterImage"));
             this.NetworkControllerImage = Option.Maybe(Get("networkControllerImage"));
             this.TestTimeout = TimeSpan.FromMinutes(context.GetValue("testTimeoutMinutes", 5));
             this.Verbose = context.GetValue<bool>("verbose");
@@ -184,6 +185,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         public Option<string> LoadGenImage { get; }
 
         public Option<string> RelayerImage { get; }
+
+        public Option<string> GenericMqttTesterImage { get; }
 
         public Option<string> NetworkControllerImage { get; }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/MqttBrokerUtil.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/MqttBrokerUtil.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Test.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Devices.Edge.Test.Common.Config;
+
+    public class MqttBrokerUtil
+    {
+        static readonly List<Dictionary<string, object>> OnlyIotHubOperationAuthorizations = new List<Dictionary<string, object>>
+        {
+            new Dictionary<string, object>
+            {
+                ["identities"] = new[] { "{{iot:identity}}" },
+                ["allow"] = new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["operations"] = new[] { "mqtt:connect" }
+                    }
+                }
+            }
+        };
+
+        static readonly List<Dictionary<string, object>> AllOperationAuthorizations = new List<Dictionary<string, object>>
+        {
+            new Dictionary<string, object>
+            {
+                ["identities"] = new[] { "{{iot:identity}}" },
+                ["allow"] = new[]
+                {
+                    new Dictionary<string, object>
+                    {
+                        ["operations"] = new[] { "mqtt:connect", "mqtt:publish", "mqtt:subscribe" },
+                        ["resources"] = new[] { "#" }
+                    }
+                }
+            }
+        };
+
+        public static Action<EdgeConfigBuilder> BuildAddBrokerToDeployment(bool onlyIotHubTopics)
+        {
+            var authorizations = new List<Dictionary<string, object>> { };
+            if (onlyIotHubTopics)
+            {
+                authorizations = OnlyIotHubOperationAuthorizations;
+            }
+            else
+            {
+                authorizations = AllOperationAuthorizations;
+            }
+
+            return new Action<EdgeConfigBuilder>(
+                builder =>
+                {
+                    builder.GetModule(ModuleName.EdgeHub)
+                        .WithEnvironment(new[]
+                        {
+                    ("experimentalFeatures__enabled", "true"),
+                    ("experimentalFeatures__mqttBrokerEnabled", "true"),
+                        })
+                        .WithDesiredProperties(new Dictionary<string, object>
+                        {
+                            ["mqttBroker"] = new Dictionary<string, object>
+                            {
+                                ["authorizations"] = authorizations
+                            }
+                        });
+                });
+        }
+    }
+}

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
@@ -41,10 +41,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             return new Action<EdgeConfigBuilder>(
                 builder =>
                 {
-                    // This test uses the TestResultCoordinator. It was originally designed for connectivity tests, so many of the parameters
+                    // This test uses the TestResultCoordinator. It was originally designed for connectivity tests, so some of the parameters
                     // are unnecessary for the e2e tests.
-                    // TODO: Make TestResultCoordinator more generic, so we don't have to fill out garbage values in the e2e tests.
-                    // TODO ANDREW: Can we safely remove test duration?
                     builder.AddModule(TrcModuleName, trcImage)
                        .WithEnvironment(new[]
                        {

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Test.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Test.Common.Config;
+    using Newtonsoft.Json.Linq;
+    using NUnit.Framework;
+    using Serilog;
+
+    public class TestResultCoordinatorUtil
+    {
+        const string TestResultCoordinatorUrl = "http://testResultCoordinator:5001";
+        const string TrcModuleName = "testResultCoordinator";
+        const string NetworkControllerModuleName = "networkController";
+
+        public static Action<EdgeConfigBuilder> BuildAddNetworkControllerConfig(string trackingId, string networkControllerImage)
+        {
+            return new Action<EdgeConfigBuilder>(
+                builder =>
+                {
+                    builder.AddModule(NetworkControllerModuleName, networkControllerImage)
+                        .WithEnvironment(new[]
+                        {
+                            ("trackingId", trackingId),
+                            ("testResultCoordinatorUrl", TestResultCoordinatorUrl),
+                            ("RunFrequencies__0__OfflineFrequency", "00:00:00"),
+                            ("RunFrequencies__0__OnlineFrequency", "00:00:00"),
+                            ("RunFrequencies__0__RunsCount", "0"),
+                            ("NetworkControllerRunProfile", "Online"),
+                            ("StartAfter", "00:00:00")
+                        })
+                        .WithSettings(new[] { ("createOptions", "{\"HostConfig\":{\"Binds\":[\"/var/run/docker.sock:/var/run/docker.sock\"], \"NetworkMode\":\"host\", \"Privileged\":true},\"NetworkingConfig\":{\"EndpointsConfig\":{\"host\":{}}}}") });
+                });
+        }
+
+        public static Action<EdgeConfigBuilder> BuildAddTestResultCoordinatorConfig(string trackingId, string trcImage, string expectedSourceModuleName, string actualSourceModuleName)
+        {
+            return new Action<EdgeConfigBuilder>(
+                builder =>
+                {
+                    // This test uses the TestResultCoordinator. It was originally designed for connectivity tests, so many of the parameters
+                    // are unnecessary for the e2e tests.
+                    // TODO: Make TestResultCoordinator more generic, so we don't have to fill out garbage values in the e2e tests.
+                    // TODO ANDREW: Can we safely remove test duration?
+                    builder.AddModule(TrcModuleName, trcImage)
+                       .WithEnvironment(new[]
+                       {
+                           ("trackingId", trackingId),
+                           ("useTestResultReportingService", "false"),
+                           ("useResultEventReceivingService", "false"),
+                           ("IOT_HUB_CONNECTION_STRING", Context.Current.ConnectionString),
+                           ("testStartDelay", "00:00:00"),
+                           ("verificationDelay", "00:00:00"),
+                           ("NetworkControllerRunProfile", "Online"),
+                           ("TEST_INFO", "key=unnecessary")
+                       })
+                       .WithSettings(new[] { ("createOptions", "{\"HostConfig\": {\"PortBindings\": {\"5001/tcp\": [{\"HostPort\": \"5001\"}]}}}") })
+
+                       .WithDesiredProperties(new Dictionary<string, object>
+                       {
+                           ["reportMetadataList"] = new Dictionary<string, object>
+                           {
+                               ["reportMetadata1"] = new Dictionary<string, object>
+                               {
+                                   ["TestReportType"] = "CountingReport",
+                                   ["TestOperationResultType"] = "Messages",
+                                   ["ExpectedSource"] = $"{expectedSourceModuleName}.send",
+                                   ["ActualSource"] = $"{actualSourceModuleName}.receive",
+                                   ["TestDescription"] = "unnecessary"
+                               },
+                               ["reportMetadata2"] = new Dictionary<string, object>
+                               {
+                                   ["TestReportType"] = "NetworkControllerReport",
+                                   ["Source"] = $"{NetworkControllerModuleName}",
+                                   ["TestDescription"] = "network controller"
+                               }
+                           }
+                       });
+                });
+        }
+
+        public static async Task ValidateResultsAsync()
+        {
+            HttpClient client = new HttpClient();
+            HttpResponseMessage response = await client.GetAsync("http://localhost:5001/api/report");
+            var jsonstring = await response.Content.ReadAsStringAsync();
+            bool isPassed = (bool)JArray.Parse(jsonstring)[0]["IsPassed"];
+            if (!isPassed)
+            {
+                Log.Information("Test Result Coordinator response: {Response}", jsonstring);
+            }
+
+            Assert.IsTrue(isPassed);
+        }
+    }
+}

--- a/test/README.md
+++ b/test/README.md
@@ -46,7 +46,8 @@ The end-to-end tests take several parameters, which they expect to find in a fil
 | `tempFilterImage` | * | Docker image to pull/use for the temperature filter module. Required when running the test 'TempFilter', ignored otherwise.|
 | `tempSensorImage` || Docker image to pull/use for the temperature sensor module (see the test 'TempSensor'). If not given, `mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0` is used.|
 | `numberLoggerImage` || Docker image to pull/use for the Edge agent direct method tests. Used to generate predictable logs. |
-| `testResultCoordinatorImage` | * | TestResultCoordinator image to be used. Required when running PriorityQueue tests, ignored otherwise.|
+| `testResultCoordinatorImage` | * | TestResultCoordinator image to be used. Required when running PriorityQueue or GenericMqtt tests, ignored otherwise.|
+| `genericMqttTesterImage` | * | GenericMqttTester image to be used. Required when running GenericMqtt tests, ignored otherwise.
 | `testTimeoutMinutes` || The maximum amount of time, in minutes, a single test should take. If this time is exceeded, the associated test will fail with a timeout error. If not given, the default value is `5`. |
 | `verbose` || Boolean value indicating whether to output more verbose logging information to standard output during a test run. If not given, the default is `false`. |
 

--- a/test/modules/generic-mqtt-tester/src/lib.rs
+++ b/test/modules/generic-mqtt-tester/src/lib.rs
@@ -28,9 +28,6 @@ pub mod message_initiator;
 pub mod settings;
 pub mod tester;
 
-const SEND_SOURCE: &str = "genericMqttTester.send";
-const RECEIVE_SOURCE: &str = "genericMqttTester.receive";
-
 #[derive(Debug, Clone)]
 pub struct ShutdownHandle(Sender<()>);
 

--- a/test/modules/generic-mqtt-tester/src/settings.rs
+++ b/test/modules/generic-mqtt-tester/src/settings.rs
@@ -29,6 +29,8 @@ pub struct Settings {
     relay_topic: String,
 
     messages_to_send: Option<u32>,
+
+    iotedge_moduleid: String,
 }
 
 impl Settings {
@@ -103,6 +105,10 @@ impl Settings {
 
     pub fn messages_to_send(&self) -> Option<u32> {
         self.messages_to_send
+    }
+
+    pub fn module_name(&self) -> String {
+        self.iotedge_moduleid.clone()
     }
 }
 

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -123,6 +123,7 @@ impl MessageTester {
 
         let tracking_id = settings.tracking_id();
         let relay_topic = settings.relay_topic();
+        let module_name = settings.module_name();
         let test_result_coordinator_url = settings.trc_url();
         let reporting_client = TrcClient::new(test_result_coordinator_url);
 
@@ -135,6 +136,7 @@ impl MessageTester {
                     reporting_client.clone(),
                     tracking_id,
                     batch_id,
+                    &module_name,
                 ))
             }
             TestScenario::Relay => Box::new(RelayingMessageHandler::new(
@@ -147,11 +149,7 @@ impl MessageTester {
         let mut message_initiator = None;
         let mut message_initiator_shutdown = None;
         if let TestScenario::Initiate = settings.test_scenario() {
-            let batch_id = settings
-                .batch_id()
-                .ok_or(MessageTesterError::MissingBatchId)?;
-            let initiator =
-                MessageInitiator::new(publish_handle, reporting_client, settings.clone(), batch_id);
+            let initiator = MessageInitiator::new(publish_handle, reporting_client, &settings)?;
 
             message_initiator_shutdown = Some(initiator.shutdown_handle());
             message_initiator = Some(initiator);


### PR DESCRIPTION
This PR is adding an E2E test for custom mqtt topics using the existing ```genericMqttTester``` image we run in longhaul. 

This test will deploy edgehub with the broker enabled and two genericMqttTester modules. One genericMqttTester module will be in initiate mode and the other will be in relay mode. The initiate mode module will publish on an mqtt topic ```initiate/1``` and the relaying module will subscribe to this topic. When the relaying module receives a message, it will publish it back on ```relay/1```. The initiating module will be subscribed on this ```relay/1``` topic and will report to the TRC when it receives the message.

In addition to adding the test it:
1. Refactors shared logic into util abstractions for cleaner code. Specifically adding the broker/TRC to the deployment.
2. Introduces a configuration for defining the restartPolicy for test module deployed in the test. This is done so that the genericMqttTester module will no start back up after it sends its defined amount of messages.
3. Improves the genericMqttTester module to use the module name when reporting to the trc rather than some hardcoded string "genericMqttTester". This allows the dotnet test code we right here to be more understandable.
3. Updates the documentation to include new parameters required for this test