### PR TITLE
Longhaul: Track misordered actual results

### DIFF
--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportGeneratorTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportGeneratorTest.cs
@@ -19,26 +19,29 @@ namespace Modules.Test.TestResultCoordinator.Reports
         public static IEnumerable<object[]> GetCreateReportData =>
             new List<object[]>
             {
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 0, 0, 0 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "3", "4", "5", "6" }, 10, 7, 6, 0, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "6", "7" }, 10, 7, 6, 0, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6", "7" }, 10, 7, 6, 0, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "6", "7" }, 10, 7, 5, 0, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6" }, 10, 7, 5, 0, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7" }, 10, 7, 5, 0, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "2", "3", "4", "4", "5", "6" }, 10, 7, 6, 0, 2, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "2", "2", "3", "4", "4", "5", "6" }, 10, 7, 6, 0, 3, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "1", "2", "3", "4", "5", "6", "6" }, 10, 7, 6, 0, 2, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "3", "4", "5", "6" }, 4, 7, 6, 0, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "6", "7" }, 4, 7, 6, 0, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6", "7" }, 4, 7, 6, 0, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "6", "7" }, 4, 7, 5, 0, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6" }, 4, 7, 5, 0, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7" }, 4, 7, 5, 0, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7", "7" }, 4, 7, 5, 0, 1, 2 },
-                new object[] { new[] { "1", "2", "3", "4", "5", "6", "7", "7" }, Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 1, 0, 0 },
-                new object[] { new[] { "1", "1", "2", "3", "4", "5", "6", "7", "7" }, Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 2, 0, 0 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 0, 0, 0, 0 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "3", "4", "5", "6" }, 10, 7, 6, 0, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "6", "7" }, 10, 7, 6, 0, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6", "7" }, 10, 7, 6, 0, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "6", "7" }, 10, 7, 5, 0, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6" }, 10, 7, 5, 0, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7" }, 10, 7, 5, 0, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "2", "3", "4", "4", "5", "6" }, 10, 7, 6, 0, 2, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "2", "2", "3", "4", "4", "5", "6" }, 10, 7, 6, 0, 3, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "1", "2", "3", "4", "5", "6", "6" }, 10, 7, 6, 0, 2, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "3", "4", "5", "6" }, 4, 7, 6, 0, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "6", "7" }, 4, 7, 6, 0, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6", "7" }, 4, 7, 6, 0, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "6", "7" }, 4, 7, 5, 0, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6" }, 4, 7, 5, 0, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7" }, 4, 7, 5, 0, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7", "7" }, 4, 7, 5, 0, 1, 0, 2 },
+                new object[] { new[] { "1", "2", "3", "4", "5", "6", "7", "7" }, Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 1, 0, 0, 0 },
+                new object[] { new[] { "1", "1", "2", "3", "4", "5", "6", "7", "7" }, Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 2, 0, 0, 0 },
+                new object[] { new[] { "1", "2", "3", "4", "5", "6", "7" }, new[] { "1", "2", "1", "3", "4", "5", "6", "7" }, 10, 7, 7, 0, 0, 1, 0 },
+                new object[] { new[] { "1", "2", "3", "4", "5", "6", "7" }, new[] { "1", "2", "1", "3", "4", "5", "6", "7", "6" }, 10, 7, 7, 0, 0, 2, 0 },
             };
+
         static readonly string TestDescription = "dummy description";
         static readonly ushort UnmatchedResultsMaxSize = 10;
 
@@ -309,9 +312,10 @@ namespace Modules.Test.TestResultCoordinator.Reports
 
             Assert.Equal(0UL, report.TotalExpectCount);
             Assert.Equal(0UL, report.TotalMatchCount);
+            Assert.Equal(0UL, report.TotalUnmatchedCount);
             Assert.Equal(0UL, report.TotalDuplicateExpectedResultCount);
             Assert.Equal(0UL, report.TotalDuplicateActualResultCount);
-            Assert.Equal(0, report.UnmatchedResults.Count);
+            Assert.Equal(0UL, report.TotalMisorderedActualResultCount);
         }
 
         [Theory]
@@ -324,8 +328,13 @@ namespace Modules.Test.TestResultCoordinator.Reports
             ulong expectedTotalMatchCount,
             ulong expectedTotalDuplicateExpectedResultCount,
             ulong expectedTotalDuplicateActualResultCount,
-            int expectedMissingResultsCount)
+            ulong expectedTotalMisorderedActualResultCount,
+            ulong expectedMissingResultsCount)
         {
+            // give fake tracking id and batch id to mimic real scenario
+            expectedStoreValues = expectedStoreValues.Select(v => "xx;yy;" + v);
+            actualStoreValues = actualStoreValues.Select(v => "xx;yy;" + v);
+
             string expectedSource = "expectedSource";
             string actualSource = "actualSource";
             string resultType = TestOperationResultType.Messages.ToString();
@@ -365,9 +374,10 @@ namespace Modules.Test.TestResultCoordinator.Reports
 
             Assert.Equal(expectedTotalExpectedCount, report.TotalExpectCount);
             Assert.Equal(expectedTotalMatchCount, report.TotalMatchCount);
+            Assert.Equal(expectedMissingResultsCount, report.TotalUnmatchedCount);
             Assert.Equal(expectedTotalDuplicateExpectedResultCount, report.TotalDuplicateExpectedResultCount);
             Assert.Equal(expectedTotalDuplicateActualResultCount, report.TotalDuplicateActualResultCount);
-            Assert.Equal(expectedMissingResultsCount, report.UnmatchedResults.Count);
+            Assert.Equal(expectedTotalMisorderedActualResultCount, report.TotalMisorderedActualResultCount);
         }
 
         static List<(long, TestOperationResult)> GetStoreData(string source, string resultType, IEnumerable<string> resultValues, int start = 0)

--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportTest.cs
@@ -27,6 +27,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                 923,
                 33,
                 34,
+                0,
                 new List<TestOperationResult>
                 {
                     new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -44,6 +45,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
             Assert.Equal(923UL, report.TotalMatchCount);
             Assert.Equal(33UL, report.TotalDuplicateExpectedResultCount);
             Assert.Equal(34UL, report.TotalDuplicateActualResultCount);
+            Assert.Equal(0UL, report.TotalMisorderedActualResultCount);
 
             Assert.Equal("expectedSource", report.UnmatchedResults[0].Source);
             Assert.Equal("resultType1", report.UnmatchedResults[0].Type);
@@ -72,6 +74,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     923,
                     33,
                     34,
+                    0,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -99,6 +102,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     923,
                     33,
                     34,
+                    0,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -126,6 +130,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     923,
                     33,
                     34,
+                    0,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -153,6 +158,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     923,
                     33,
                     34,
+                    0,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -180,6 +186,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     923,
                     33,
                     34,
+                    0,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),

--- a/test/modules/Modules.Test/TestResultCoordinator/TestReportUtilTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/TestReportUtilTest.cs
@@ -540,7 +540,7 @@ namespace Modules.Test.TestResultCoordinator
         {
             if (!throwException)
             {
-                return Task.FromResult<ITestResultReport>(new CountingReport("mock", "mock", "mock", "mock", "mock", 23, 21, 12, 0, new List<TestOperationResult>(), Option.None<EventHubSpecificReportComponents>(), Option.None<DateTime>()));
+                return Task.FromResult<ITestResultReport>(new CountingReport("mock", "mock", "mock", "mock", "mock", 23, 21, 12, 0, 0, new List<TestOperationResult>(), Option.None<EventHubSpecificReportComponents>(), Option.None<DateTime>()));
             }
 
             return Task.FromException<ITestResultReport>(new ApplicationException("Inject exception for testing"));

--- a/test/modules/TestResultCoordinator/Reports/CountingReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/CountingReport.cs
@@ -37,6 +37,7 @@ namespace TestResultCoordinator.Reports
             ulong totalMatchCount,
             ulong totalDuplicateExpectedResultCount,
             ulong totalDuplicateActualResultCount,
+            ulong totalMisorderedActualResultCount,
             IReadOnlyList<TestOperationResult> unmatchedResults,
             Option<EventHubSpecificReportComponents> eventHubSpecificReportComponents,
             Option<DateTime> lastActualResultTimestamp)
@@ -46,9 +47,11 @@ namespace TestResultCoordinator.Reports
             this.ActualSource = Preconditions.CheckNonWhiteSpace(actualSource, nameof(actualSource));
             this.TotalExpectCount = totalExpectCount;
             this.TotalMatchCount = totalMatchCount;
+            this.TotalUnmatchedCount = Convert.ToUInt64(unmatchedResults.Count);
             this.TotalDuplicateExpectedResultCount = totalDuplicateExpectedResultCount;
             this.TotalDuplicateActualResultCount = totalDuplicateActualResultCount;
-            this.UnmatchedResults = unmatchedResults ?? new List<TestOperationResult>();
+            this.TotalMisorderedActualResultCount = totalMisorderedActualResultCount;
+            this.UnmatchedResults = unmatchedResults;
             this.EventHubSpecificReportComponents = eventHubSpecificReportComponents;
             this.LastActualResultTimestamp = lastActualResultTimestamp;
         }
@@ -61,9 +64,13 @@ namespace TestResultCoordinator.Reports
 
         public ulong TotalMatchCount { get; }
 
+        public ulong TotalUnmatchedCount { get; }
+
         public ulong TotalDuplicateExpectedResultCount { get; }
 
         public ulong TotalDuplicateActualResultCount { get; }
+
+        public ulong TotalMisorderedActualResultCount { get; }
 
         public IReadOnlyList<TestOperationResult> UnmatchedResults { get; }
 

--- a/test/modules/TestResultCoordinator/Reports/CountingReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/Reports/CountingReportGenerator.cs
@@ -76,6 +76,7 @@ namespace TestResultCoordinator.Reports
             ulong totalMatchCount = 0;
             ulong totalDuplicateExpectedResultCount = 0;
             ulong totalDuplicateActualResultCount = 0;
+            ulong totalMisorderedActualResultCount = 0;
             var unmatchedResults = new Queue<TestOperationResult>();
             bool allActualResultsMatch = false;
             Option<EventHubSpecificReportComponents> eventHubSpecificReportComponents = Option.None<EventHubSpecificReportComponents>();
@@ -89,6 +90,17 @@ namespace TestResultCoordinator.Reports
                 this.ValidateResult(this.ExpectedTestResults.Current, this.ExpectedSource);
                 this.ValidateResult(this.ActualTestResults.Current, this.ActualSource);
 
+                // If we see an actual result with an older sequence number
+                // then we know that it came in out of order. So we should
+                // record it and skip it.
+                if (this.IsActualResultSequenceNumberOlder(this.ActualTestResults.Current, this.ExpectedTestResults.Current))
+                {
+                    totalMisorderedActualResultCount++;
+
+                    hasActualResult = await this.ActualTestResults.MoveNextAsync();
+                    continue;
+                }
+
                 if (this.TestResultComparer.Matches(lastLoadedExpectedResult, this.ExpectedTestResults.Current))
                 {
                     totalDuplicateExpectedResultCount++;
@@ -101,14 +113,6 @@ namespace TestResultCoordinator.Reports
 
                 lastLoadedExpectedResult = this.ExpectedTestResults.Current;
 
-                // Skip any duplicate actual value
-                while (hasActualResult && this.TestResultComparer.Matches(lastLoadedActualResult, this.ActualTestResults.Current))
-                {
-                    totalDuplicateActualResultCount++;
-                    lastLoadedActualResult = this.ActualTestResults.Current;
-                    hasActualResult = await this.ActualTestResults.MoveNextAsync();
-                }
-
                 totalExpectCount++;
 
                 if (this.TestResultComparer.Matches(this.ExpectedTestResults.Current, this.ActualTestResults.Current))
@@ -117,6 +121,15 @@ namespace TestResultCoordinator.Reports
                     hasActualResult = await this.ActualTestResults.MoveNextAsync();
                     hasExpectedResult = await this.ExpectedTestResults.MoveNextAsync();
                     totalMatchCount++;
+
+                    // Skip any duplicate actual value
+                    while (hasActualResult && this.TestResultComparer.Matches(lastLoadedActualResult, this.ActualTestResults.Current))
+                    {
+                        totalDuplicateActualResultCount++;
+                        lastLoadedActualResult = this.ActualTestResults.Current;
+                        hasActualResult = await this.ActualTestResults.MoveNextAsync();
+                        continue;
+                    }
                 }
                 else
                 {
@@ -189,6 +202,11 @@ namespace TestResultCoordinator.Reports
                 // Log actual queue items
                 Logger.LogError($"Unexpected actual test result: {this.ActualTestResults.Current.Source}, {this.ActualTestResults.Current.Type}, {this.ActualTestResults.Current.Result} at {this.ActualTestResults.Current.CreatedAt}");
 
+                if (this.IsActualResultSequenceNumberOlder(this.ActualTestResults.Current, lastLoadedExpectedResult))
+                {
+                    totalMisorderedActualResultCount++;
+                }
+
                 hasActualResult = await this.ActualTestResults.MoveNextAsync();
             }
 
@@ -207,9 +225,24 @@ namespace TestResultCoordinator.Reports
                 totalMatchCount,
                 totalDuplicateExpectedResultCount,
                 totalDuplicateActualResultCount,
+                totalMisorderedActualResultCount,
                 new List<TestOperationResult>(unmatchedResults).AsReadOnly(),
                 eventHubSpecificReportComponents,
                 lastLoadedResultCreatedAt);
+        }
+
+        bool IsActualResultSequenceNumberOlder(TestOperationResult actualResult, TestOperationResult expectedResult)
+        {
+            // TODO: The controller for TestResultCoordinator takes in a custom type
+            // not derived from the original types the test modules send. This
+            // means we have to rely on string magic like this to get the sequence
+            // numbers. In order to clean this up we should allow the controller to
+            // ingest the original type the test modules are sending. Then we
+            // can cast to MessageTestResult and grab the sequence number attribute.
+            int actualSequenceNumber = int.Parse(actualResult.Result.Split(";")[2]);
+            int expectedSequenceNumber = int.Parse(expectedResult.Result.Split(";")[2]);
+
+            return actualSequenceNumber < expectedSequenceNumber;
         }
 
         void ValidateResult(TestOperationResult current, string expectedSource)


### PR DESCRIPTION
In longhaul sometimes product bugs happen where actual results get misordered such that the following case happens:
```
Expected: 1 -> 2 -> 3 -> 4 -> 5-> 6 -> 7
Actual: 1 -> 2 -> 3 -> 4 -> 2 -> 5 -> 6 -> 7
```

The current test logic assumes that misordered actual results are not possible, and will fail to match results 5, 6, and 7 treating them as unmatched. This renders the TRC report useless for any result after the first misordered actual result. 

Instead of this behavior we want it to match all these results, but report that there was one misordered actual result. I have added logic to detect these misordered actual results to the counting report. If this situation occurs it will fail the tests. 