### PR TITLE
TestResultCoordinator: Explicitly fail for duplicate expected results (#4684)

### DIFF
--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportGeneratorTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportGeneratorTest.cs
@@ -19,23 +19,25 @@ namespace Modules.Test.TestResultCoordinator.Reports
         public static IEnumerable<object[]> GetCreateReportData =>
             new List<object[]>
             {
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 0, 0 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "3", "4", "5", "6" }, 10, 7, 6, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "6", "7" }, 10, 7, 6, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6", "7" }, 10, 7, 6, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "6", "7" }, 10, 7, 5, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6" }, 10, 7, 5, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7" }, 10, 7, 5, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "2", "3", "4", "4", "5", "6" }, 10, 7, 6, 2, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "2", "2", "3", "4", "4", "5", "6" }, 10, 7, 6, 3, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "1", "2", "3", "4", "5", "6", "6" }, 10, 7, 6, 2, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "3", "4", "5", "6" }, 4, 7, 6, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "6", "7" }, 4, 7, 6, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6", "7" }, 4, 7, 6, 0, 1 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "6", "7" }, 4, 7, 5, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6" }, 4, 7, 5, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7" }, 4, 7, 5, 0, 2 },
-                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7", "7" }, 4, 7, 5, 1, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 0, 0, 0 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "3", "4", "5", "6" }, 10, 7, 6, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "6", "7" }, 10, 7, 6, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6", "7" }, 10, 7, 6, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "6", "7" }, 10, 7, 5, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6" }, 10, 7, 5, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7" }, 10, 7, 5, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "2", "3", "4", "4", "5", "6" }, 10, 7, 6, 0, 2, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "2", "2", "3", "4", "4", "5", "6" }, 10, 7, 6, 0, 3, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "1", "2", "3", "4", "5", "6", "6" }, 10, 7, 6, 0, 2, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "2", "3", "4", "5", "6" }, 4, 7, 6, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "6", "7" }, 4, 7, 6, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6", "7" }, 4, 7, 6, 0, 0, 1 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "6", "7" }, 4, 7, 5, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "1", "3", "4", "5", "6" }, 4, 7, 5, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7" }, 4, 7, 5, 0, 0, 2 },
+                new object[] { Enumerable.Range(1, 7).Select(v => v.ToString()), new[] { "2", "3", "4", "5", "7", "7" }, 4, 7, 5, 0, 1, 2 },
+                new object[] { new[] { "1", "2", "3", "4", "5", "6", "7", "7" }, Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 1, 0, 0 },
+                new object[] { new[] { "1", "1", "2", "3", "4", "5", "6", "7", "7" }, Enumerable.Range(1, 7).Select(v => v.ToString()), 10, 7, 7, 2, 0, 0 },
             };
         static readonly string TestDescription = "dummy description";
         static readonly ushort UnmatchedResultsMaxSize = 10;
@@ -307,7 +309,8 @@ namespace Modules.Test.TestResultCoordinator.Reports
 
             Assert.Equal(0UL, report.TotalExpectCount);
             Assert.Equal(0UL, report.TotalMatchCount);
-            Assert.Equal(0UL, report.TotalDuplicateResultCount);
+            Assert.Equal(0UL, report.TotalDuplicateExpectedResultCount);
+            Assert.Equal(0UL, report.TotalDuplicateActualResultCount);
             Assert.Equal(0, report.UnmatchedResults.Count);
         }
 
@@ -319,7 +322,8 @@ namespace Modules.Test.TestResultCoordinator.Reports
             int batchSize,
             ulong expectedTotalExpectedCount,
             ulong expectedTotalMatchCount,
-            ulong expectedTotalDuplicateResultCount,
+            ulong expectedTotalDuplicateExpectedResultCount,
+            ulong expectedTotalDuplicateActualResultCount,
             int expectedMissingResultsCount)
         {
             string expectedSource = "expectedSource";
@@ -361,7 +365,8 @@ namespace Modules.Test.TestResultCoordinator.Reports
 
             Assert.Equal(expectedTotalExpectedCount, report.TotalExpectCount);
             Assert.Equal(expectedTotalMatchCount, report.TotalMatchCount);
-            Assert.Equal(expectedTotalDuplicateResultCount, report.TotalDuplicateResultCount);
+            Assert.Equal(expectedTotalDuplicateExpectedResultCount, report.TotalDuplicateExpectedResultCount);
+            Assert.Equal(expectedTotalDuplicateActualResultCount, report.TotalDuplicateActualResultCount);
             Assert.Equal(expectedMissingResultsCount, report.UnmatchedResults.Count);
         }
 

--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/CountingReportTest.cs
@@ -26,6 +26,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                 945,
                 923,
                 33,
+                34,
                 new List<TestOperationResult>
                 {
                     new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -41,7 +42,8 @@ namespace Modules.Test.TestResultCoordinator.Reports
             Assert.Equal("resultType1", report.ResultType);
             Assert.Equal(945UL, report.TotalExpectCount);
             Assert.Equal(923UL, report.TotalMatchCount);
-            Assert.Equal(33UL, report.TotalDuplicateResultCount);
+            Assert.Equal(33UL, report.TotalDuplicateExpectedResultCount);
+            Assert.Equal(34UL, report.TotalDuplicateActualResultCount);
 
             Assert.Equal("expectedSource", report.UnmatchedResults[0].Source);
             Assert.Equal("resultType1", report.UnmatchedResults[0].Type);
@@ -69,6 +71,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     945,
                     923,
                     33,
+                    34,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -95,6 +98,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     945,
                     923,
                     33,
+                    34,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -121,6 +125,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     945,
                     923,
                     33,
+                    34,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -147,6 +152,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     945,
                     923,
                     33,
+                    34,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),
@@ -173,6 +179,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
                     945,
                     923,
                     33,
+                    34,
                     new List<TestOperationResult>
                     {
                         new TestOperationResult("expectedSource", "resultType1", "332", new DateTime(2019, 12, 4, 10, 15, 15)),

--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/TwinCountingReportGeneratorTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/TwinCountingReportGeneratorTest.cs
@@ -266,7 +266,7 @@ namespace Modules.Test.TestResultCoordinator.Reports
 
             Assert.Equal(0UL, report.TotalExpectCount);
             Assert.Equal(0UL, report.TotalMatchCount);
-            Assert.Equal(0UL, report.TotalDuplicateResultCount);
+            Assert.Equal(0UL, report.TotalDuplicateActualResultCount);
             Assert.Equal(0, report.UnmatchedResults.Count);
         }
 

--- a/test/modules/Modules.Test/TestResultCoordinator/TestReportUtilTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/TestReportUtilTest.cs
@@ -6,7 +6,6 @@ namespace Modules.Test.TestResultCoordinator
     using System.Threading.Tasks;
     using global::TestResultCoordinator;
     using global::TestResultCoordinator.Reports;
-    using global::TestResultCoordinator.Reports.DirectMethod;
     using global::TestResultCoordinator.Reports.DirectMethod.Connectivity;
     using global::TestResultCoordinator.Reports.DirectMethod.LongHaul;
     using global::TestResultCoordinator.Reports.EdgeHubRestartTest;
@@ -541,7 +540,7 @@ namespace Modules.Test.TestResultCoordinator
         {
             if (!throwException)
             {
-                return Task.FromResult<ITestResultReport>(new CountingReport("mock", "mock", "mock", "mock", "mock", 23, 21, 12, new List<TestOperationResult>(), Option.None<EventHubSpecificReportComponents>(), Option.None<DateTime>()));
+                return Task.FromResult<ITestResultReport>(new CountingReport("mock", "mock", "mock", "mock", "mock", 23, 21, 12, 0, new List<TestOperationResult>(), Option.None<EventHubSpecificReportComponents>(), Option.None<DateTime>()));
             }
 
             return Task.FromException<ITestResultReport>(new ApplicationException("Inject exception for testing"));


### PR DESCRIPTION
… (#4684)

We need to account for duplicate expected results in our tests. The test report operates with an assumption that expected results are unique and actual results can be duplicated. When duplicate expected results happen (due to product issues), the test report makes it seem like we are missing some actual results. But we need to make it explicit that there are duplicate expected results, which should not be happening in our tests.

Here is what I mean. Imagine the following scenario:
```
Message 0 sent
Message 1 sent
Message 1 sent
Message 2 sent

~ time passes ~

Message 0 received
Message 1 received
Message 1 received
Message 2 received
``` 

In the TRC here are the expected / actual datastructures:
```
Expected: 0->1->1->2
Actual: 0->1->1->->2
```

When the TRC is processing the report it does not account for duplicate actual results. So it is the same scenario as this:
```
Expected: 0->1->1->2
Actual: 0->1->2

```

In processing the counting report, we match results 0 and 1. We see that there are duplicate actual results for 1 so we eliminate them. Then end up in this state which is the problem. Now the counting report will view the situation as we have an unmatched expected result with sequence number 1. This is not the case. 
```
Expected: 1->2
Actual: 2

```

The report looks indicates there is one unmatched result. But really all results are matched. It is just that there is a duplicate expected result. The test report will now reflect this by giving us the number of duplicate expected results that were seen.