### PR TITLE
Update C SDK submodules to 2020-12-09.

### DIFF
--- a/edgelet/edgelet-kube/src/module/authentication.rs
+++ b/edgelet/edgelet-kube/src/module/authentication.rs
@@ -125,7 +125,7 @@ mod tests {
     use hyper::{header, Body, Method, Request, Response, StatusCode};
     use maplit::btreemap;
     use serde_json::json;
-    use tokio::runtime::Runtime;
+    use tokio::runtime::current_thread::Runtime;
     use typed_headers::{mime, ContentLength, ContentType, HeaderMapExt};
 
     use edgelet_core::{AuthId, Authenticator};

--- a/edgelet/edgelet-kube/src/module/create.rs
+++ b/edgelet/edgelet-kube/src/module/create.rs
@@ -315,7 +315,7 @@ mod tests {
     use hyper::{Body, Method, Request, StatusCode};
     use maplit::btreemap;
     use serde_json::json;
-    use tokio::runtime::Runtime;
+    use tokio::runtime::current_thread::Runtime;
 
     use docker::models::{AuthConfig, ContainerCreateBody, HostConfig, Mount};
     use edgelet_core::{ImagePullPolicy, ModuleSpec, RuntimeOperation};

--- a/edgelet/edgelet-kube/src/module/trust_bundle.rs
+++ b/edgelet/edgelet-kube/src/module/trust_bundle.rs
@@ -102,7 +102,7 @@ mod tests {
     use hyper::{Body, Error as HyperError, Method, Request, Response, StatusCode};
     use maplit::btreemap;
     use serde_json::json;
-    use tokio::runtime::Runtime;
+    use tokio::runtime::current_thread::Runtime;
 
     use edgelet_test_utils::cert::TestCert;
     use edgelet_test_utils::crypto::TestHsm;

--- a/edgelet/edgelet-kube/src/registry/pull.rs
+++ b/edgelet/edgelet-kube/src/registry/pull.rs
@@ -122,7 +122,7 @@ mod tests {
     use hyper::{Body, Method, Request, StatusCode};
     use maplit::btreemap;
     use serde_json::json;
-    use tokio::runtime::Runtime;
+    use tokio::runtime::current_thread::Runtime;
 
     use docker::models::{AuthConfig, ContainerCreateBody};
     use edgelet_docker::DockerConfig;

--- a/edgelet/edgelet-kube/src/runtime.rs
+++ b/edgelet/edgelet-kube/src/runtime.rs
@@ -410,7 +410,7 @@ mod tests {
     use hyper::{Body, Method, Request, StatusCode};
     use maplit::btreemap;
     use serde_json::json;
-    use tokio::runtime::Runtime;
+    use tokio::runtime::current_thread::Runtime;
 
     use edgelet_core::ModuleRuntime;
     use edgelet_test_utils::routes;

--- a/edgelet/edgelet-utils/src/ser_de.rs
+++ b/edgelet/edgelet-utils/src/ser_de.rs
@@ -84,7 +84,7 @@ where
     // parameters.
     struct OptionalValueVisitor<K, V> {
         marker: PhantomData<fn() -> (K, V)>,
-    };
+    }
 
     impl<K, V> OptionalValueVisitor<K, V> {
         fn new() -> Self {

--- a/edgelet/hsm-sys/azure-iot-hsm-c/src/edge_hsm_client_x509.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/src/edge_hsm_client_x509.c
@@ -87,15 +87,15 @@ HSM_CLIENT_HANDLE edge_x598_hsm_create()
     }
     else
     {
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-        if (interface == NULL)
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+        if (iface == NULL)
         {
             LOG_ERROR("hsm_client_crypto_interface returned NULL");
             result = NULL;
         }
         else
         {
-            result = interface->hsm_client_crypto_create();
+            result = iface->hsm_client_crypto_create();
             if (result != NULL)
             {
                 g_ref_cnt++;
@@ -124,14 +124,14 @@ void edge_x509_hsm_destroy(HSM_CLIENT_HANDLE hsm_handle)
         }
         else
         {
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            if (interface == NULL)
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            if (iface == NULL)
             {
                 LOG_ERROR("hsm_client_crypto_interface returned NULL");
             }
             else
             {
-                interface->hsm_client_crypto_destroy(hsm_handle);
+                iface->hsm_client_crypto_destroy(hsm_handle);
             }
             g_ref_cnt--;
         }
@@ -173,9 +173,9 @@ static int get_device_id_cert_env_vars(char **device_cert_file_path, char **devi
 
 static CERT_INFO_HANDLE get_device_id_cert_if_exists(HSM_CLIENT_HANDLE hsm_handle)
 {
-    const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+    const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
 
-    CERT_INFO_HANDLE result = interface->hsm_client_crypto_get_certificate(hsm_handle,
+    CERT_INFO_HANDLE result = iface->hsm_client_crypto_get_certificate(hsm_handle,
                                                                            EDGE_DEVICE_ALIAS);
     if (result == NULL)
     {
@@ -273,8 +273,8 @@ static int edge_x509_sign_with_private_key
     }
     else
     {
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-        result = interface->hsm_client_crypto_sign_with_private_key(hsm_handle,
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+        result = iface->hsm_client_crypto_sign_with_private_key(hsm_handle,
                                                                     EDGE_DEVICE_ALIAS,
                                                                     data,
                                                                     data_size,

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ft/certificate_info_ft.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ft/certificate_info_ft.c
@@ -24,7 +24,6 @@
 //#############################################################################
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
@@ -165,7 +164,6 @@ BEGIN_TEST_SUITE(certificate_info_func_tests)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
         umock_c_init(test_hook_on_umock_c_error);
@@ -174,7 +172,6 @@ BEGIN_TEST_SUITE(certificate_info_func_tests)
     TEST_SUITE_CLEANUP(TestClassCleanup)
     {
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -203,8 +200,8 @@ BEGIN_TEST_SUITE(certificate_info_func_tests)
         //assert
         ASSERT_IS_NOT_NULL(cert_handle);
         ASSERT_IS_NULL(pk);
-        ASSERT_ARE_EQUAL(size_t, 0, pk_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_UNKNOWN, pk_type, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pk_size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_UNKNOWN, pk_type, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(cert_handle);
@@ -222,10 +219,10 @@ BEGIN_TEST_SUITE(certificate_info_func_tests)
 
         //assert
         ASSERT_IS_NOT_NULL(cert_handle);
-        ASSERT_ARE_EQUAL(size_t, TEST_PRIVATE_KEY_LEN, pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_PRIVATE_KEY_LEN, pk_size, "Line:" MU_TOSTRING(__LINE__));
         int cmp = memcmp(pk, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LEN);
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_PAYLOAD, pk_type, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_PAYLOAD, pk_type, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(cert_handle);
@@ -243,10 +240,10 @@ BEGIN_TEST_SUITE(certificate_info_func_tests)
 
         //assert
         ASSERT_IS_NOT_NULL(cert_handle);
-        ASSERT_ARE_EQUAL(size_t, TEST_PRIVATE_KEY_LEN, pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_PRIVATE_KEY_LEN, pk_size, "Line:" MU_TOSTRING(__LINE__));
         int cmp = memcmp(pk, TEST_PRIVATE_KEY, TEST_PRIVATE_KEY_LEN);
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_REFERENCE, pk_type, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, PRIVATE_KEY_REFERENCE, pk_type, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(cert_handle);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ut/certificate_info_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/certificate_info_ut/certificate_info_ut.c
@@ -84,7 +84,6 @@ extern time_t get_utc_time_from_asn_string(const unsigned char *time_value, size
 // Test defines and data
 //#############################################################################
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
@@ -335,57 +334,57 @@ static void test_helper_parse_cert_common_callstack
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(gballoc_malloc(certificate_size));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     // *************** Load and parse certificate **************
     EXPECTED_CALL(BIO_s_mem());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(BIO_new(TEST_BIO_METHOD));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
-    ASSERT_IS_FALSE(certificate_len > INT_MAX, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_FALSE(certificate_len > INT_MAX, "Line:" MU_TOSTRING(__LINE__));
     STRICT_EXPECTED_CALL(BIO_write(TEST_BIO, IGNORED_PTR_ARG, (int)certificate_len));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(PEM_read_bio_X509(TEST_BIO, NULL, NULL, NULL));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
     // *************************************************
 
     // *************** Parse validity timestamps **************
     STRICT_EXPECTED_CALL(mocked_X509_get_notAfter(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(mocked_X509_get_notBefore(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
     // *************************************************
 
     // *************** Parse common name **************
     STRICT_EXPECTED_CALL(X509_get_subject_name(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(gballoc_malloc(MAX_COMMON_NAME_SIZE));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     // conditionally fail since certificates may not have a CN field
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     if (overrride && overrride->fail_common_name_lookup)
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(TEST_X509_SUBJECT_NAME, NID_commonName, IGNORED_PTR_ARG, MAX_COMMON_NAME_SIZE)).SetReturn(-1);
@@ -398,21 +397,21 @@ static void test_helper_parse_cert_common_callstack
     }
 
     STRICT_EXPECTED_CALL(X509_free(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
     // *************************************************
 
     // *************** Finalize certificate info object **************
     // allocator for the first certificate which includes /r/n ending
     STRICT_EXPECTED_CALL(gballoc_malloc(certificate_size));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     // allocator for the private key
     if (private_key_set)
     {
         STRICT_EXPECTED_CALL(gballoc_malloc(TEST_PRIVATE_KEY_LEN));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     // *************************************************
@@ -437,7 +436,6 @@ BEGIN_TEST_SUITE(certificate_info_ut)
 
     TEST_SUITE_INITIALIZE(suite_init)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -478,7 +476,6 @@ BEGIN_TEST_SUITE(certificate_info_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(method_init)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_client_x509_int/edge_hsm_client_x509_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_client_x509_int/edge_hsm_client_x509_int.c
@@ -28,7 +28,6 @@
 //#############################################################################
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 #define TEST_CA_ALIAS "test_ca_alias"
 #define TEST_SERVER_ALIAS "test_server_alias"
@@ -132,9 +131,9 @@ static char* prepare_file_path(const char* base_dir, const char* file_name)
 {
     size_t path_size = get_max_file_path_size();
     char *file_path = calloc(path_size, 1);
-    ASSERT_IS_NOT_NULL(file_path, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(file_path, "Line:" MU_TOSTRING(__LINE__));
     int status = snprintf(file_path, path_size, "%s%s%s", base_dir, SLASH, file_name);
-    ASSERT_IS_TRUE(((status > 0) || (status < (int)path_size)), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < (int)path_size)), "Line:" MU_TOSTRING(__LINE__));
 
     return file_path;
 }
@@ -144,8 +143,8 @@ static void test_helper_setup_homedir(void)
     int status;
 
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" MU_TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
@@ -155,11 +154,11 @@ static void test_helper_setup_homedir(void)
     TEST_DEVICE_ID_PK_RSA_FILE = prepare_file_path(TEST_IOTEDGE_HOMEDIR, TEST_DEVICE_ID_PK_RSA_FILE_NAME);
 
     status = write_cstring_to_file(TEST_DEVICE_ID_CERT_RSA_FILE, TEST_RSA_CERT);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     printf("Write device certificate to: [%s]\r\n", TEST_DEVICE_ID_CERT_RSA_FILE);
 
     status = write_buffer_to_file(TEST_DEVICE_ID_PK_RSA_FILE, TEST_PRIVATE_KEY, sizeof(TEST_PRIVATE_KEY), false);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     printf("Write device private key to: [%s]\r\n", TEST_DEVICE_ID_PK_RSA_FILE);
 }
 
@@ -191,7 +190,6 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
         test_helper_setup_homedir();
@@ -201,7 +199,6 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
     {
         test_helper_teardown_homedir();
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -235,19 +232,19 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
         //arrange
         hsm_test_util_setenv(ENV_DEVICE_ID_CERTIFICATE_PATH, TEST_DEVICE_ID_CERT_RSA_FILE);
         hsm_test_util_setenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH, TEST_DEVICE_ID_PK_RSA_FILE);
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
-        ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
+        ASSERT_IS_NOT_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // act
-        char* certificate = interface->hsm_client_get_cert(hsm_handle);
+        char* certificate = iface->hsm_client_get_cert(hsm_handle);
 
         // assert
-        ASSERT_IS_NULL(certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(certificate, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(ENV_DEVICE_ID_CERTIFICATE_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH);
@@ -258,19 +255,19 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
         //arrange
         hsm_test_util_setenv(ENV_DEVICE_ID_CERTIFICATE_PATH, TEST_DEVICE_ID_CERT_RSA_FILE);
         hsm_test_util_setenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH, TEST_DEVICE_ID_PK_RSA_FILE);
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
-        ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
+        ASSERT_IS_NOT_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // act
-        char* key = interface->hsm_client_get_key(hsm_handle);
+        char* key = iface->hsm_client_get_key(hsm_handle);
 
         // assert
-        ASSERT_IS_NULL(key, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(ENV_DEVICE_ID_CERTIFICATE_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH);
@@ -281,19 +278,19 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
         //arrange
         hsm_test_util_setenv(ENV_DEVICE_ID_CERTIFICATE_PATH, TEST_DEVICE_ID_CERT_RSA_FILE);
         hsm_test_util_setenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH, TEST_DEVICE_ID_PK_RSA_FILE);
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
-        ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
+        ASSERT_IS_NOT_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // act
-        char* name = interface->hsm_client_get_common_name(hsm_handle);
+        char* name = iface->hsm_client_get_common_name(hsm_handle);
 
         // assert
-        ASSERT_IS_NULL(name, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(name, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(ENV_DEVICE_ID_CERTIFICATE_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH);
@@ -302,19 +299,19 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
     TEST_FUNCTION(hsm_client_x509_get_certificate_info_with_missing_env_vars_fails)
     {
         //arrange
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
-        ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
+        ASSERT_IS_NOT_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_get_cert_info(hsm_handle);
+        CERT_INFO_HANDLE result = iface->hsm_client_get_cert_info(hsm_handle);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(ENV_DEVICE_ID_CERTIFICATE_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH);
@@ -325,26 +322,26 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
         //arrange
         hsm_test_util_setenv(ENV_DEVICE_ID_CERTIFICATE_PATH, TEST_DEVICE_ID_CERT_RSA_FILE);
         hsm_test_util_setenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH, TEST_DEVICE_ID_PK_RSA_FILE);
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_get_cert_info(hsm_handle);
+        CERT_INFO_HANDLE result = iface->hsm_client_get_cert_info(hsm_handle);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         int cmp_result = strcmp(TEST_RSA_CERT, certificate_info_get_certificate(result));
-        ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
         size_t result_pk_size = 0;
         const void * result_pk = certificate_info_get_private_key(result, &result_pk_size);
-        ASSERT_ARE_EQUAL(size_t, sizeof(TEST_PRIVATE_KEY), result_pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, sizeof(TEST_PRIVATE_KEY), result_pk_size, "Line:" MU_TOSTRING(__LINE__));
         cmp_result = memcmp(TEST_PRIVATE_KEY, result_pk, result_pk_size);
-        ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(result);
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(ENV_DEVICE_ID_CERTIFICATE_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH);
@@ -355,19 +352,19 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
         //arrange
         hsm_test_util_setenv(ENV_DEVICE_ID_CERTIFICATE_PATH, "blah.txt");
         hsm_test_util_setenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH, TEST_DEVICE_ID_PK_RSA_FILE);
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_get_cert_info(hsm_handle);
+        CERT_INFO_HANDLE result = iface->hsm_client_get_cert_info(hsm_handle);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(result);
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(ENV_DEVICE_ID_CERTIFICATE_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH);
@@ -377,19 +374,19 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
     {
         //arrange
         hsm_test_util_setenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH, TEST_DEVICE_ID_PK_RSA_FILE);
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_get_cert_info(hsm_handle);
+        CERT_INFO_HANDLE result = iface->hsm_client_get_cert_info(hsm_handle);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(result);
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH);
     }
@@ -399,19 +396,19 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
         //arrange
         hsm_test_util_setenv(ENV_DEVICE_ID_CERTIFICATE_PATH, TEST_DEVICE_ID_CERT_RSA_FILE);
         hsm_test_util_setenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH, "blah.txt");
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_get_cert_info(hsm_handle);
+        CERT_INFO_HANDLE result = iface->hsm_client_get_cert_info(hsm_handle);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(result);
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(ENV_DEVICE_ID_CERTIFICATE_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_ID_PRIVATE_KEY_PATH);
@@ -421,19 +418,19 @@ BEGIN_TEST_SUITE(edge_hsm_client_x509_int)
     {
         //arrange
         hsm_test_util_setenv(ENV_DEVICE_ID_CERTIFICATE_PATH, TEST_DEVICE_ID_CERT_RSA_FILE);
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         hsm_client_x509_init(TEST_VALIDITY);
-        HSM_CLIENT_CREATE hsm_handle = interface->hsm_client_x509_create();
+        HSM_CLIENT_CREATE hsm_handle = iface->hsm_client_x509_create();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_get_cert_info(hsm_handle);
+        CERT_INFO_HANDLE result = iface->hsm_client_get_cert_info(hsm_handle);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         certificate_info_destroy(result);
-        interface->hsm_client_x509_destroy(hsm_handle);
+        iface->hsm_client_x509_destroy(hsm_handle);
         hsm_client_x509_deinit();
         hsm_test_util_unsetenv(TEST_DEVICE_ID_CERT_RSA_FILE);
     }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_int/edge_hsm_crypto_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_int/edge_hsm_crypto_int.c
@@ -28,7 +28,6 @@
 //#############################################################################
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 #define TEST_CA_ALIAS "test_ca_alias"
 #define TEST_SERVER_ALIAS "test_server_alias"
@@ -98,7 +97,7 @@ static CERT_PROPS_HANDLE test_helper_create_certificate_props
 )
 {
     CERT_PROPS_HANDLE cert_props_handle = cert_properties_create();
-    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" MU_TOSTRING(__LINE__));
     set_validity_seconds(cert_props_handle, validity);
     set_common_name(cert_props_handle, common_name);
     set_country_name(cert_props_handle, "US");
@@ -130,7 +129,7 @@ static void test_helper_generate_pki_certificate
                                            cert_file,
                                            issuer_private_key_file,
                                            issuer_cert_file);
-    ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 }
 
 static void test_helper_generate_self_signed
@@ -149,7 +148,7 @@ static void test_helper_generate_self_signed
                                                       private_key_file,
                                                       cert_file,
                                                       key_props);
-    ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 }
 
 static void test_helper_prepare_transparent_gateway_certs(void)
@@ -230,9 +229,9 @@ static void test_helper_prepare_transparent_gateway_certs(void)
     const char *trusted_files[1] = { NULL };
     trusted_files[0] = int_ca_2_path;
     char* trusted_ca_certs = concat_files_to_cstring(trusted_files, sizeof(trusted_files)/sizeof(trusted_files[0]));
-    ASSERT_IS_NOT_NULL(trusted_ca_certs, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(trusted_ca_certs, "Line:" MU_TOSTRING(__LINE__));
     status = write_cstring_to_file(trusted_ca_path, trusted_ca_certs);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     // cleanup
     free(trusted_ca_certs);
@@ -247,53 +246,53 @@ static void test_helper_setup_homedir(void)
     int status;
 
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" MU_TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
     printf("IoT Edge home dir set to %s\n", TEST_IOTEDGE_HOMEDIR);
 
     STRING_HANDLE BASE_TG_CERTS_PATH = STRING_construct(TEST_IOTEDGE_HOMEDIR);
-    ASSERT_IS_NOT_NULL(BASE_TG_CERTS_PATH, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(BASE_TG_CERTS_PATH, "Line:" MU_TOSTRING(__LINE__));
     status = STRING_concat(BASE_TG_CERTS_PATH, SLASH);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     VALID_DEVICE_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(VALID_DEVICE_CA_PATH, "device_ca_cert.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     VALID_DEVICE_PK_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(VALID_DEVICE_PK_PATH, "device_pk_cert.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     VALID_TRUSTED_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(VALID_TRUSTED_CA_PATH, "trusted_ca_certs.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     ROOT_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(ROOT_CA_PATH, "root_ca_cert.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     ROOT_PK_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(ROOT_PK_PATH, "root_ca_pk.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     INT_1_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(INT_1_CA_PATH, "int_1_ca_cert.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     INT_1_PK_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(INT_1_PK_PATH, "int_1_ca_pk.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     INT_2_CA_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(INT_2_CA_PATH, "int_2_ca_cert.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     INT_2_PK_PATH = STRING_clone(BASE_TG_CERTS_PATH);
     status = STRING_concat(INT_2_PK_PATH, "int_2_ca_pk.pem");
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     test_helper_prepare_transparent_gateway_certs();
 
@@ -353,24 +352,24 @@ static HSM_CLIENT_HANDLE test_helper_crypto_init(void)
 {
     int status;
     status = hsm_client_crypto_init(CA_VALIDITY);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-    const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-    HSM_CLIENT_HANDLE result = interface->hsm_client_crypto_create();
-    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+    const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+    HSM_CLIENT_HANDLE result = iface->hsm_client_crypto_create();
+    ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
     return result;
 }
 
 static void test_helper_crypto_deinit(HSM_CLIENT_HANDLE hsm_handle)
 {
-    const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-    interface->hsm_client_crypto_destroy(hsm_handle);
+    const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+    iface->hsm_client_crypto_destroy(hsm_handle);
     hsm_client_crypto_deinit();
 }
 
 static CERT_PROPS_HANDLE test_helper_create_ca_cert_properties(void)
 {
     CERT_PROPS_HANDLE certificate_props = cert_properties_create();
-    ASSERT_IS_NOT_NULL(certificate_props, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(certificate_props, "Line:" MU_TOSTRING(__LINE__));
     set_common_name(certificate_props, TEST_CA_COMMON_NAME);
     set_validity_seconds(certificate_props, 3600);
     set_alias(certificate_props, TEST_CA_ALIAS);
@@ -382,7 +381,7 @@ static CERT_PROPS_HANDLE test_helper_create_ca_cert_properties(void)
 static CERT_PROPS_HANDLE test_helper_create_server_cert_properties(void)
 {
     CERT_PROPS_HANDLE certificate_props = cert_properties_create();
-    ASSERT_IS_NOT_NULL(certificate_props, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(certificate_props, "Line:" MU_TOSTRING(__LINE__));
     set_common_name(certificate_props, TEST_SERVER_COMMON_NAME);
     set_validity_seconds(certificate_props, 3600);
     set_alias(certificate_props, TEST_SERVER_ALIAS);
@@ -394,7 +393,7 @@ static CERT_PROPS_HANDLE test_helper_create_server_cert_properties(void)
 static CERT_PROPS_HANDLE test_helper_create_client_cert_properties(void)
 {
     CERT_PROPS_HANDLE certificate_props = cert_properties_create();
-    ASSERT_IS_NOT_NULL(certificate_props, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(certificate_props, "Line:" MU_TOSTRING(__LINE__));
     set_common_name(certificate_props, TEST_CLIENT_COMMON_NAME);
     set_validity_seconds(certificate_props, 3600);
     set_alias(certificate_props, TEST_CLIENT_ALIAS);
@@ -410,7 +409,6 @@ static CERT_PROPS_HANDLE test_helper_create_client_cert_properties(void)
 BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
         test_helper_setup_homedir();
@@ -420,7 +418,6 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         test_helper_teardown_homedir();
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -453,18 +450,18 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         //arrange
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         unsigned char unexpected_buffer[4];
         unsigned char output_buffer[4];
         memset(unexpected_buffer, 0, sizeof(unexpected_buffer));
         memset(output_buffer, 0, sizeof(output_buffer));
 
         // act
-        int result = interface->hsm_client_get_random_bytes(hsm_handle, output_buffer, sizeof(output_buffer));
+        int result = iface->hsm_client_get_random_bytes(hsm_handle, output_buffer, sizeof(output_buffer));
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, sizeof(unexpected_buffer)), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, sizeof(unexpected_buffer)), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         test_helper_crypto_deinit(hsm_handle);
@@ -474,17 +471,17 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         //arrange
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE certificate_props = test_helper_create_ca_cert_properties();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(certificate_props);
         test_helper_crypto_deinit(hsm_handle);
@@ -495,33 +492,33 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         //arrange
         size_t pk_size = 0;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
-        CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE ca_cert_info = iface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" MU_TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_server_cert_properties();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         const char *certificate = certificate_info_get_certificate(result);
         const char *chain_certificate = certificate_info_get_chain(result);
         const void *private_key = certificate_info_get_private_key(result, &pk_size);
         const char *common_name = certificate_info_get_common_name(result);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(private_key, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(private_key, "Line:" MU_TOSTRING(__LINE__));
         int cmp = strcmp(TEST_SERVER_COMMON_NAME, common_name);
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(certificate_props);
         certificate_info_destroy(ca_cert_info);
@@ -533,19 +530,19 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         //arrange
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE certificate_props = test_helper_create_ca_cert_properties();
 
         // act
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(certificate_props);
         test_helper_crypto_deinit(hsm_handle);
@@ -556,38 +553,38 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         //arrange
         size_t pk_size = 0;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         set_validity_seconds(ca_certificate_props, 3600);
-        CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE ca_cert_info = iface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" MU_TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_server_cert_properties();
         set_validity_seconds(certificate_props, 3600 * 2);
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         const char *certificate = certificate_info_get_certificate(result);
         const char *chain_certificate = certificate_info_get_chain(result);
         const void *private_key = certificate_info_get_private_key(result, &pk_size);
         const char *common_name = certificate_info_get_common_name(result);
         int64_t expiration_time = certificate_info_get_valid_to(result);
         int64_t issuer_expiration_time = certificate_info_get_valid_to(ca_cert_info);
-        ASSERT_IS_TRUE((expiration_time <= issuer_expiration_time), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((expiration_time <= issuer_expiration_time), "Line:" MU_TOSTRING(__LINE__));
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(private_key, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(private_key, "Line:" MU_TOSTRING(__LINE__));
         int cmp = strcmp(TEST_SERVER_COMMON_NAME, common_name);
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(certificate_props);
         certificate_info_destroy(ca_cert_info);
@@ -600,38 +597,38 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         //arrange
         size_t pk_size = 0;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         set_validity_seconds(ca_certificate_props, 3600 * 2);
-        CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE ca_cert_info = iface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" MU_TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_server_cert_properties();
         set_validity_seconds(certificate_props, 3600);
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         const char *certificate = certificate_info_get_certificate(result);
         const char *chain_certificate = certificate_info_get_chain(result);
         const void *private_key = certificate_info_get_private_key(result, &pk_size);
         const char *common_name = certificate_info_get_common_name(result);
         int64_t expiration_time = certificate_info_get_valid_to(result);
         int64_t issuer_expiration_time = certificate_info_get_valid_to(ca_cert_info);
-        ASSERT_IS_TRUE((expiration_time < issuer_expiration_time), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((expiration_time < issuer_expiration_time), "Line:" MU_TOSTRING(__LINE__));
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(private_key, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(private_key, "Line:" MU_TOSTRING(__LINE__));
         int cmp = strcmp(TEST_SERVER_COMMON_NAME, common_name);
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(certificate_props);
         certificate_info_destroy(ca_cert_info);
@@ -643,38 +640,38 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         //arrange
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
-        CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE ca_cert_info = iface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" MU_TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_client_cert_properties();
 
         // act, assert multiple calls to create certificate only creates if not created
         CERT_INFO_HANDLE result_first, result_second;
-        result_first = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL(result_first, "Line:" TOSTRING(__LINE__));
-        result_second = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL(result_second, "Line:" TOSTRING(__LINE__));
+        result_first = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        ASSERT_IS_NOT_NULL(result_first, "Line:" MU_TOSTRING(__LINE__));
+        result_second = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        ASSERT_IS_NOT_NULL(result_second, "Line:" MU_TOSTRING(__LINE__));
         const char *first_certificate = certificate_info_get_certificate(result_first);
         const char *second_certificate = certificate_info_get_certificate(result_second);
         size_t first_len = strlen(first_certificate);
         size_t second_len = strlen(second_certificate);
-        ASSERT_ARE_EQUAL(size_t, first_len, second_len, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, first_len, second_len, "Line:" MU_TOSTRING(__LINE__));
         int cmp_result = memcmp(first_certificate, second_certificate, first_len);
-        ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
 
         // destroy the certificate in the HSM and create a new one and test if different from prior call
         certificate_info_destroy(result_second);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
-        result_second = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL(result_second, "Line:" TOSTRING(__LINE__));
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
+        result_second = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        ASSERT_IS_NOT_NULL(result_second, "Line:" MU_TOSTRING(__LINE__));
         second_certificate = certificate_info_get_certificate(result_second);
         cmp_result = memcmp(first_certificate, second_certificate, first_len);
-        ASSERT_ARE_NOT_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result_first);
         certificate_info_destroy(result_second);
         cert_properties_destroy(certificate_props);
@@ -687,10 +684,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         //arrange
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
 
         // act
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
 
         // assert
 
@@ -702,24 +699,24 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         //arrange
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
-        CERT_INFO_HANDLE ca_cert_info = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE ca_cert_info = iface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
+        ASSERT_IS_NOT_NULL(ca_cert_info, "Line:" MU_TOSTRING(__LINE__));
         CERT_PROPS_HANDLE certificate_props = test_helper_create_client_cert_properties();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
         const char *common_name = certificate_info_get_common_name(result);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         int cmp = strcmp(TEST_CLIENT_COMMON_NAME, common_name);
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CLIENT_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(certificate_props);
         certificate_info_destroy(ca_cert_info);
@@ -732,18 +729,18 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         //arrange
         size_t pk_size = 0;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
 
         // act
-        CERT_INFO_HANDLE result = interface->hsm_client_get_trust_bundle(hsm_handle);
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE result = iface->hsm_client_get_trust_bundle(hsm_handle);
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         // assert
         const char *certificate = certificate_info_get_certificate(result);
         const void *private_key = certificate_info_get_private_key(result, &pk_size);
-        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(private_key, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(private_key, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pk_size, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         certificate_info_destroy(result);
@@ -754,18 +751,18 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         // arrange
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         int status;
 
         // act, assert
-        status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_destroy_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
-        status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_create_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
-        status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_destroy_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         test_helper_crypto_deinit(hsm_handle);
@@ -776,7 +773,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         // arrange
         int status;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         SIZED_BUFFER id = {TEST_ID, TEST_ID_SIZE};
         SIZED_BUFFER pt = {TEST_PLAINTEXT, TEST_PLAINTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -784,25 +781,25 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         SIZED_BUFFER plaintext_result = { NULL, 0 };
 
         // act, assert
-        status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_create_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
-        status = interface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(ciphertext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_NOT_EQUAL(size_t, 0, ciphertext_result.size, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ciphertext_result.buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(size_t, 0, ciphertext_result.size, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(TEST_PLAINTEXT, ciphertext_result.buffer, TEST_PLAINTEXT_SIZE);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
-        status = interface->hsm_client_decrypt_data(hsm_handle, &id, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, TEST_PLAINTEXT_SIZE, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_decrypt_data(hsm_handle, &id, &ciphertext_result, &iv, &plaintext_result);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(plaintext_result.buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_PLAINTEXT_SIZE, plaintext_result.size, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(TEST_PLAINTEXT, plaintext_result.buffer, TEST_PLAINTEXT_SIZE);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
-        status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_destroy_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(plaintext_result.buffer);
@@ -815,33 +812,33 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         // arrange
         int status;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         SIZED_BUFFER id = {TEST_ID, TEST_ID_SIZE};
         SIZED_BUFFER pt = {TEST_PLAINTEXT, TEST_PLAINTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
         SIZED_BUFFER ciphertext_result_1 = { NULL, 0 };
         SIZED_BUFFER ciphertext_result_2 = { NULL, 0 };
 
-        status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        status = interface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result_1);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_create_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        status = iface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result_1);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         // destroy crypto and then recreate to make sure the same master key is used
         test_helper_crypto_deinit(hsm_handle);
         hsm_handle = test_helper_crypto_init();
 
         // act, assert
-        status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        status = interface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result_2);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_create_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        status = iface->hsm_client_encrypt_data(hsm_handle, &id, &pt, &iv, &ciphertext_result_2);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
-        ASSERT_ARE_EQUAL(size_t, ciphertext_result_1.size, ciphertext_result_2.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ciphertext_result_1.size, ciphertext_result_2.size, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(ciphertext_result_1.buffer, ciphertext_result_2.buffer, ciphertext_result_1.size);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
-        status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        status = iface->hsm_client_destroy_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result_1.buffer);
@@ -854,17 +851,17 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         // arrange
         int status;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-        status = interface->hsm_client_create_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+        status = iface->hsm_client_create_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        status = iface->hsm_client_destroy_master_encryption_key(hsm_handle);
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // act
-        status = interface->hsm_client_destroy_master_encryption_key(hsm_handle);
+        status = iface->hsm_client_destroy_master_encryption_key(hsm_handle);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         test_helper_crypto_deinit(hsm_handle);
     }
@@ -879,17 +876,17 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
 
         // act, assert
-        CERT_INFO_HANDLE result = interface->hsm_client_get_trust_bundle(hsm_handle);
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE result = iface->hsm_client_get_trust_bundle(hsm_handle);
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         const char *certificate = certificate_info_get_certificate(result);
-        ASSERT_IS_NOT_NULL(certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(certificate, "Line:" MU_TOSTRING(__LINE__));
         char *expected_trust_bundle = read_file_into_cstring(trusted_ca_path, NULL);
-        ASSERT_ARE_EQUAL(size_t, strlen(certificate), strlen(expected_trust_bundle), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, strlen(certificate), strlen(expected_trust_bundle), "Line:" MU_TOSTRING(__LINE__));
         int cmp = memcmp(certificate, expected_trust_bundle, strlen(certificate));
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(expected_trust_bundle);
@@ -910,22 +907,22 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
 
         // act, assert
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         const char *chain_certificate = certificate_info_get_chain(result);
-        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" MU_TOSTRING(__LINE__));
         char *expected_chain_certificate = read_file_into_cstring(device_ca_path, NULL);
-        ASSERT_ARE_EQUAL(size_t, strlen(expected_chain_certificate), strlen(chain_certificate), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, strlen(expected_chain_certificate), strlen(chain_certificate), "Line:" MU_TOSTRING(__LINE__));
         int cmp = memcmp(expected_chain_certificate, chain_certificate, strlen(chain_certificate));
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(expected_chain_certificate);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(ca_certificate_props);
         test_helper_crypto_deinit(hsm_handle);
@@ -938,21 +935,21 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
     {
         // arrange
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE ca_certificate_props = test_helper_create_ca_cert_properties();
         set_validity_seconds(ca_certificate_props, 1);
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
         // act
         ThreadAPI_Sleep(2000);
-        CERT_INFO_HANDLE temp_info_handle = interface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
+        CERT_INFO_HANDLE temp_info_handle = iface->hsm_client_create_certificate(hsm_handle, ca_certificate_props);
 
         // assert
-        ASSERT_IS_NULL(temp_info_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(temp_info_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(ca_certificate_props);
         test_helper_crypto_deinit(hsm_handle);
@@ -968,23 +965,23 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE certificate_props = test_helper_create_server_cert_properties();
         set_issuer_alias(certificate_props, hsm_get_device_ca_alias());
 
         // act, assert
-        CERT_INFO_HANDLE result = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE result = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         const char *chain_certificate = certificate_info_get_chain(result);
-        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(chain_certificate, "Line:" MU_TOSTRING(__LINE__));
         char *expected_chain_certificate = read_file_into_cstring(device_ca_path, NULL);
-        ASSERT_ARE_EQUAL(size_t, strlen(expected_chain_certificate), strlen(chain_certificate), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, strlen(expected_chain_certificate), strlen(chain_certificate), "Line:" MU_TOSTRING(__LINE__));
         int cmp = memcmp(expected_chain_certificate, chain_certificate, strlen(chain_certificate));
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(expected_chain_certificate);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_SERVER_ALIAS);
         certificate_info_destroy(result);
         cert_properties_destroy(certificate_props);
         test_helper_crypto_deinit(hsm_handle);
@@ -1010,43 +1007,43 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         hsm_test_util_unsetenv(ENV_DEVICE_PK_PATH);
         hsm_test_util_unsetenv(ENV_TRUSTED_CA_CERTS_PATH);
         status = hsm_client_crypto_init(CA_VALIDITY);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         hsm_test_util_unsetenv(ENV_DEVICE_CA_PATH);
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_unsetenv(ENV_TRUSTED_CA_CERTS_PATH);
         status = hsm_client_crypto_init(CA_VALIDITY);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         hsm_test_util_setenv(ENV_DEVICE_CA_PATH, device_ca_path);
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_unsetenv(ENV_TRUSTED_CA_CERTS_PATH);
         status = hsm_client_crypto_init(CA_VALIDITY);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         hsm_test_util_unsetenv(ENV_DEVICE_CA_PATH);
         hsm_test_util_unsetenv(ENV_DEVICE_PK_PATH);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         status = hsm_client_crypto_init(CA_VALIDITY);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         hsm_test_util_setenv(ENV_DEVICE_CA_PATH, device_ca_path);
         hsm_test_util_unsetenv(ENV_DEVICE_PK_PATH);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         status = hsm_client_crypto_init(CA_VALIDITY);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         hsm_test_util_unsetenv(ENV_DEVICE_CA_PATH);
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, device_pk_path);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, trusted_ca_path);
         status = hsm_client_crypto_init(CA_VALIDITY);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         hsm_test_util_setenv(ENV_DEVICE_CA_PATH, INVALID_PATH);
         hsm_test_util_setenv(ENV_DEVICE_PK_PATH, INVALID_PATH);
         hsm_test_util_setenv(ENV_TRUSTED_CA_CERTS_PATH, INVALID_PATH);
         status = hsm_client_crypto_init(CA_VALIDITY);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         hsm_test_util_unsetenv(ENV_DEVICE_CA_PATH);
@@ -1059,10 +1056,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         // arrange
         int status;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
         CERT_PROPS_HANDLE certificate_props = test_helper_create_ca_cert_properties();
-        CERT_INFO_HANDLE ca_handle = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL(ca_handle, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE ca_handle = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        ASSERT_IS_NOT_NULL(ca_handle, "Line:" MU_TOSTRING(__LINE__));
 
         unsigned char data[] = { 'a', 'b', 'c' };
         size_t data_size = sizeof(data);
@@ -1070,17 +1067,17 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         size_t digest_size = 0;
 
         // act
-        status = interface->hsm_client_crypto_sign_with_private_key(hsm_handle, TEST_CA_ALIAS, data, data_size, &digest, &digest_size);
+        status = iface->hsm_client_crypto_sign_with_private_key(hsm_handle, TEST_CA_ALIAS, data, data_size, &digest, &digest_size);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(digest, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_TRUE((HMAC_SHA256_DIGEST_LEN <= digest_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((HMAC_SHA256_DIGEST_LEN <= digest_size), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(digest);
         certificate_info_destroy(ca_handle);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         cert_properties_destroy(certificate_props);
         test_helper_crypto_deinit(hsm_handle);
     }
@@ -1091,39 +1088,39 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_int_tests)
         int status;
         CERT_INFO_HANDLE result;
         HSM_CLIENT_HANDLE hsm_handle = test_helper_crypto_init();
-        const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+        const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
 
         // act, 1 ensure certificate get fails when it has not yet been created
-        result = interface->hsm_client_crypto_get_certificate(hsm_handle, TEST_CA_ALIAS);
+        result = iface->hsm_client_crypto_get_certificate(hsm_handle, TEST_CA_ALIAS);
 
         // assert 1
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
 
 
         // arrange 2
         CERT_PROPS_HANDLE certificate_props = test_helper_create_ca_cert_properties();
-        CERT_INFO_HANDLE ca_handle = interface->hsm_client_create_certificate(hsm_handle, certificate_props);
-        ASSERT_IS_NOT_NULL(ca_handle, "Line:" TOSTRING(__LINE__));
+        CERT_INFO_HANDLE ca_handle = iface->hsm_client_create_certificate(hsm_handle, certificate_props);
+        ASSERT_IS_NOT_NULL(ca_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // act 2 get the same certificate
-        result = interface->hsm_client_crypto_get_certificate(hsm_handle, TEST_CA_ALIAS);
+        result = iface->hsm_client_crypto_get_certificate(hsm_handle, TEST_CA_ALIAS);
 
         // assert 2 ensure both certificate and key returned are identical
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         status = strcmp(certificate_info_get_certificate(ca_handle), certificate_info_get_certificate(result));
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         size_t ca_pk_size = 0, result_pk_size = 0;
         const void *ca_pk = certificate_info_get_private_key(ca_handle, &ca_pk_size);
         const void *result_pk = certificate_info_get_private_key(result, &result_pk_size);
-        ASSERT_ARE_EQUAL(size_t, ca_pk_size, result_pk_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ca_pk_size, result_pk_size, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(ca_pk, result_pk, ca_pk_size);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_TRUE((certificate_info_private_key_type(ca_handle) == certificate_info_private_key_type(result)), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((certificate_info_private_key_type(ca_handle) == certificate_info_private_key_type(result)), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         certificate_info_destroy(result);
         certificate_info_destroy(ca_handle);
-        interface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
+        iface->hsm_client_destroy_certificate(hsm_handle, TEST_CA_ALIAS);
         cert_properties_destroy(certificate_props);
         test_helper_crypto_deinit(hsm_handle);
     }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_ut/edge_hsm_crypto_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_crypto_ut/edge_hsm_crypto_ut.c
@@ -106,7 +106,6 @@ MOCKABLE_FUNCTION(, int, generate_rand_buffer, unsigned char*, buffer, size_t, n
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 static const char* TEST_ALIAS_STRING = "test_alias";
 static const char* TEST_ISSUER_ALIAS_STRING = "test_issuer_alias";
@@ -414,15 +413,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
 
         TEST_SUITE_INITIALIZE(TestClassInitialize)
         {
-            TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
             g_testByTest = TEST_MUTEX_CREATE();
             ASSERT_IS_NOT_NULL(g_testByTest);
 
             umock_c_init(test_hook_on_umock_c_error);
 
-            REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_INTERFACE, void*);
+            REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_INTERFACE*, void*);
             REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_HANDLE, void*);
-            REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_KEY_INTERFACE, void*);
+            REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_KEY_INTERFACE*, void*);
             REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_HANDLE, void*);
             REGISTER_UMOCK_ALIAS_TYPE(KEY_HANDLE, void*);
             REGISTER_UMOCK_ALIAS_TYPE(TEST_CERT_INFO_HANDLE, void*);
@@ -528,7 +526,6 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             umock_c_deinit();
 
             TEST_MUTEX_DESTROY(g_testByTest);
-            TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
         }
 
         TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -562,8 +559,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -578,15 +575,15 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             umock_c_reset_all_calls();
 
             // act
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -619,7 +616,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 status = hsm_client_crypto_init(TEST_CA_VALIDITY);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -641,7 +638,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_crypto_deinit();
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
         }
@@ -667,8 +664,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -686,19 +683,19 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             const HSM_CLIENT_CRYPTO_INTERFACE* result = hsm_client_crypto_interface();
 
             // assert
-            ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_crypto_create, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_crypto_destroy, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_get_random_bytes, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_create_master_encryption_key, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_destroy_master_encryption_key, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_create_certificate, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_destroy_certificate, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_encrypt_data, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_decrypt_data, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_get_trust_bundle, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_free_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_crypto_create, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_crypto_destroy, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_get_random_bytes, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_create_master_encryption_key, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_destroy_master_encryption_key, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_create_certificate, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_destroy_certificate, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_encrypt_data, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_decrypt_data, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_get_trust_bundle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_free_buffer, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
         }
@@ -710,8 +707,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_crypto_create_fails_when_crypto_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
             hsm_client_crypto_deinit();
             umock_c_reset_all_calls();
 
@@ -719,8 +716,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
 
             // assert
-            ASSERT_IS_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -732,10 +729,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(gballoc_calloc(1, IGNORED_NUM_ARG));
@@ -745,8 +742,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
 
             // assert
-            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -765,10 +762,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
 
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(gballoc_calloc(1, IGNORED_NUM_ARG));
@@ -785,7 +782,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
 
                 // assert
-                ASSERT_IS_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -800,8 +797,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_crypto_destroy_does_nothing_with_invalid_handle)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             hsm_client_crypto_deinit();
             umock_c_reset_all_calls();
 
@@ -809,7 +806,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_crypto_destroy(NULL);
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -819,8 +816,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_crypto_destroy_does_nothing_when_crypto_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             hsm_client_crypto_deinit();
             umock_c_reset_all_calls();
 
@@ -828,7 +825,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_crypto_destroy(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -840,10 +837,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             umock_c_reset_all_calls();
 
@@ -854,8 +851,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_crypto_destroy(hsm_handle);
 
             // assert
-            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -869,8 +866,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status;
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_GET_RANDOM_BYTES hsm_client_get_random_bytes = interface->hsm_client_get_random_bytes;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_GET_RANDOM_BYTES hsm_client_get_random_bytes = iface->hsm_client_get_random_bytes;
             unsigned char test_input[] = {'r', 'a', 'n' , 'd'};
             unsigned char test_output[] = {'r', 'a', 'n' , 'd'};
             hsm_client_crypto_deinit();
@@ -880,11 +877,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_get_random_bytes(TEST_HSM_CLIENT_HANDLE, test_output, sizeof(test_output));
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
             for (int idx = 0; idx < (int)sizeof(test_output); idx++)
             {
-                ASSERT_ARE_EQUAL(char, test_input[idx], test_output[idx], "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(char, test_input[idx], test_output[idx], "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -896,28 +893,28 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_GET_RANDOM_BYTES hsm_client_get_random_bytes = interface->hsm_client_get_random_bytes;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_GET_RANDOM_BYTES hsm_client_get_random_bytes = iface->hsm_client_get_random_bytes;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             unsigned char test_input[] = {'r', 'a', 'n' , 'd'};
             unsigned char test_output[] = {'r', 'a', 'n' , 'd'};
 
             // act, assert
             status = hsm_client_get_random_bytes(NULL, test_output, sizeof(test_output));
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             for (int idx = 0; idx < (int)sizeof(test_output); idx++)
             {
-                ASSERT_ARE_EQUAL(char, test_input[idx], test_output[idx], "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(char, test_input[idx], test_output[idx], "Line:" MU_TOSTRING(__LINE__));
             }
 
             status = hsm_client_get_random_bytes(hsm_handle, NULL, sizeof(test_output));
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             status = hsm_client_get_random_bytes(hsm_handle, test_output, 0);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -933,10 +930,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             unsigned char test_output[] = {'r', 'a', 'n' , 'd'};
             umock_c_reset_all_calls();
@@ -944,11 +941,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             STRICT_EXPECTED_CALL(generate_rand_buffer(test_output, sizeof(test_output)));
 
             // act
-            status = interface->hsm_client_get_random_bytes(hsm_handle, test_output, sizeof(test_output));
+            status = iface->hsm_client_get_random_bytes(hsm_handle, test_output, sizeof(test_output));
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -966,10 +963,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             unsigned char test_output[] = {'r', 'a', 'n' , 'd'};
             umock_c_reset_all_calls();
@@ -984,10 +981,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 umock_c_negative_tests_fail_call(i);
 
                 // act
-                status = interface->hsm_client_get_random_bytes(hsm_handle, test_output, sizeof(test_output));
+                status = iface->hsm_client_get_random_bytes(hsm_handle, test_output, sizeof(test_output));
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1004,9 +1001,9 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status;
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE_MASTER_ENCRYPTION_KEY hsm_client_create_master_encryption_key;
-            hsm_client_create_master_encryption_key = interface->hsm_client_create_master_encryption_key;
+            hsm_client_create_master_encryption_key = iface->hsm_client_create_master_encryption_key;
             hsm_client_crypto_deinit();
             umock_c_reset_all_calls();
 
@@ -1014,8 +1011,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_create_master_encryption_key(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1026,14 +1023,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
             HSM_CLIENT_CREATE_MASTER_ENCRYPTION_KEY hsm_client_create_master_encryption_key;
-            hsm_client_create_master_encryption_key = interface->hsm_client_create_master_encryption_key;
+            hsm_client_create_master_encryption_key = iface->hsm_client_create_master_encryption_key;
 
             // act, assert
             status = hsm_client_create_master_encryption_key(NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1047,17 +1044,17 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             HSM_CLIENT_CREATE_MASTER_ENCRYPTION_KEY hsm_client_create_master_encryption_key;
-            hsm_client_create_master_encryption_key = interface->hsm_client_create_master_encryption_key;
+            hsm_client_create_master_encryption_key = iface->hsm_client_create_master_encryption_key;
 
             // act, assert
             status = hsm_client_create_master_encryption_key(hsm_handle);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1072,9 +1069,9 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status;
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
             HSM_CLIENT_DESTROY_MASTER_ENCRYPTION_KEY hsm_client_destroy_master_encryption_key;
-            hsm_client_destroy_master_encryption_key = interface->hsm_client_destroy_master_encryption_key;
+            hsm_client_destroy_master_encryption_key = iface->hsm_client_destroy_master_encryption_key;
             hsm_client_crypto_deinit();
 
             umock_c_reset_all_calls();
@@ -1083,8 +1080,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_destroy_master_encryption_key(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1095,14 +1092,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
             HSM_CLIENT_DESTROY_MASTER_ENCRYPTION_KEY hsm_client_destroy_master_encryption_key;
-            hsm_client_destroy_master_encryption_key = interface->hsm_client_destroy_master_encryption_key;
+            hsm_client_destroy_master_encryption_key = iface->hsm_client_destroy_master_encryption_key;
 
             // act, assert
             status = hsm_client_destroy_master_encryption_key(NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1116,17 +1113,17 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             HSM_CLIENT_DESTROY_MASTER_ENCRYPTION_KEY hsm_client_destroy_master_encryption_key;
-            hsm_client_destroy_master_encryption_key = interface->hsm_client_destroy_master_encryption_key;
+            hsm_client_destroy_master_encryption_key = iface->hsm_client_destroy_master_encryption_key;
 
             // act, assert
             status = hsm_client_destroy_master_encryption_key(hsm_handle);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1140,8 +1137,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_create_certificate_cert_does_nothing_when_crypto_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = interface->hsm_client_create_certificate;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = iface->hsm_client_create_certificate;
             CERT_INFO_HANDLE cert_info_handle;
             hsm_client_crypto_deinit();
             umock_c_reset_all_calls();
@@ -1150,8 +1147,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_create_certificate(TEST_HSM_CLIENT_HANDLE, TEST_CERT_PROPS_HANDLE);
 
             // assert
-            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1162,19 +1159,19 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = interface->hsm_client_create_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = iface->hsm_client_create_certificate;
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
 
             // act, assert
             cert_info_handle = hsm_client_create_certificate(NULL, TEST_CERT_PROPS_HANDLE);
-            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             cert_info_handle = hsm_client_create_certificate(TEST_HSM_CLIENT_HANDLE, NULL);
-            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1189,11 +1186,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = interface->hsm_client_create_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = iface->hsm_client_create_certificate;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
@@ -1207,8 +1204,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_create_certificate(hsm_handle, TEST_CERT_PROPS_HANDLE);
 
             // assert
-            ASSERT_ARE_EQUAL(void_ptr, TEST_CERT_INFO_HANDLE, cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(void_ptr, TEST_CERT_INFO_HANDLE, cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1226,11 +1223,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = interface->hsm_client_create_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_CREATE_CERTIFICATE hsm_client_create_certificate = iface->hsm_client_create_certificate;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
@@ -1251,7 +1248,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 cert_info_handle = hsm_client_create_certificate(hsm_handle, TEST_CERT_PROPS_HANDLE);
 
                 // assert
-                ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1267,8 +1264,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_get_trust_bundle_does_nothing_when_crypto_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = interface->hsm_client_get_trust_bundle;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = iface->hsm_client_get_trust_bundle;
             CERT_INFO_HANDLE cert_info_handle;
             hsm_client_crypto_deinit();
             umock_c_reset_all_calls();
@@ -1277,8 +1274,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_get_trust_bundle(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1289,15 +1286,15 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = interface->hsm_client_get_trust_bundle;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = iface->hsm_client_get_trust_bundle;
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
 
             // act, assert
             cert_info_handle = hsm_client_get_trust_bundle(NULL);
-            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1312,11 +1309,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = interface->hsm_client_get_trust_bundle;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = iface->hsm_client_get_trust_bundle;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
@@ -1327,8 +1324,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_get_trust_bundle(hsm_handle);
 
             // assert
-            ASSERT_ARE_EQUAL(void_ptr, TEST_TRUST_BUNDLE_CERT_INFO_HANDLE, cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(void_ptr, TEST_TRUST_BUNDLE_CERT_INFO_HANDLE, cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1346,11 +1343,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = interface->hsm_client_get_trust_bundle;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_GET_TRUST_BUNDLE hsm_client_get_trust_bundle = iface->hsm_client_get_trust_bundle;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
@@ -1368,7 +1365,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 cert_info_handle = hsm_client_get_trust_bundle(hsm_handle);
 
                 // assert
-                ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1384,8 +1381,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_destroy_certificate_does_nothing_when_crypto_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = interface->hsm_client_destroy_certificate;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = iface->hsm_client_destroy_certificate;
             hsm_client_crypto_deinit();
             umock_c_reset_all_calls();
 
@@ -1393,7 +1390,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_destroy_certificate(TEST_HSM_CLIENT_HANDLE, TEST_ALIAS_STRING);
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1404,14 +1401,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = interface->hsm_client_destroy_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = iface->hsm_client_destroy_certificate;
             umock_c_reset_all_calls();
 
             // act, assert
             hsm_client_destroy_certificate(TEST_HSM_CLIENT_HANDLE, NULL);
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1425,14 +1422,14 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = interface->hsm_client_destroy_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = iface->hsm_client_destroy_certificate;
             umock_c_reset_all_calls();
 
             // act, assert
             hsm_client_destroy_certificate(NULL, TEST_ALIAS_STRING);
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1447,11 +1444,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = interface->hsm_client_destroy_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = iface->hsm_client_destroy_certificate;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             umock_c_reset_all_calls();
 
@@ -1461,7 +1458,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             hsm_client_destroy_certificate(hsm_handle, TEST_ALIAS_STRING);
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1479,11 +1476,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = interface->hsm_client_destroy_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_DESTROY_CERTIFICATE hsm_client_destroy_certificate = iface->hsm_client_destroy_certificate;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             umock_c_reset_all_calls();
 
@@ -1500,7 +1497,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 hsm_client_destroy_certificate(hsm_handle, TEST_ALIAS_STRING);
 
                 // assert
-                ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1516,8 +1513,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_get_certificate_cert_does_nothing_when_crypto_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CRYPTO_GET_CERTIFICATE hsm_client_crypto_get_certificate = interface->hsm_client_crypto_get_certificate;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CRYPTO_GET_CERTIFICATE hsm_client_crypto_get_certificate = iface->hsm_client_crypto_get_certificate;
             CERT_INFO_HANDLE cert_info_handle;
             hsm_client_crypto_deinit();
             umock_c_reset_all_calls();
@@ -1526,8 +1523,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_crypto_get_certificate(TEST_HSM_CLIENT_HANDLE, TEST_ALIAS_STRING);
 
             // assert
-            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1538,19 +1535,19 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         {
             //arrange
             int status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CRYPTO_GET_CERTIFICATE hsm_client_crypto_get_certificate = interface->hsm_client_crypto_get_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CRYPTO_GET_CERTIFICATE hsm_client_crypto_get_certificate = iface->hsm_client_crypto_get_certificate;
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
 
             // act, assert
             cert_info_handle = hsm_client_crypto_get_certificate(NULL, TEST_ALIAS_STRING);
-            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             cert_info_handle = hsm_client_crypto_get_certificate(TEST_HSM_CLIENT_HANDLE, NULL);
-            ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1565,11 +1562,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_CRYPTO_GET_CERTIFICATE hsm_client_crypto_get_certificate = interface->hsm_client_crypto_get_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_CRYPTO_GET_CERTIFICATE hsm_client_crypto_get_certificate = iface->hsm_client_crypto_get_certificate;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
@@ -1580,8 +1577,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             cert_info_handle = hsm_client_crypto_get_certificate(hsm_handle, TEST_ALIAS_STRING);
 
             // assert
-            ASSERT_ARE_EQUAL(void_ptr, TEST_CERT_INFO_HANDLE, cert_info_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(void_ptr, TEST_CERT_INFO_HANDLE, cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1599,11 +1596,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_CRYPTO_GET_CERTIFICATE hsm_client_crypto_get_certificate = interface->hsm_client_crypto_get_certificate;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_CRYPTO_GET_CERTIFICATE hsm_client_crypto_get_certificate = iface->hsm_client_crypto_get_certificate;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             CERT_INFO_HANDLE cert_info_handle;
             umock_c_reset_all_calls();
@@ -1621,7 +1618,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 cert_info_handle = hsm_client_crypto_get_certificate(hsm_handle, TEST_ALIAS_STRING);
 
                 // assert
-                ASSERT_IS_NULL(cert_info_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(cert_info_handle, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1637,8 +1634,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_crypto_sign_with_private_key_does_nothing_when_crypto_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CRYPTO_SIGN_WITH_PRIVATE_KEY hsm_client_crypto_sign_with_private_key = interface->hsm_client_crypto_sign_with_private_key;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CRYPTO_SIGN_WITH_PRIVATE_KEY hsm_client_crypto_sign_with_private_key = iface->hsm_client_crypto_sign_with_private_key;
             unsigned char *digest;
             size_t digest_size;
             int status;
@@ -1649,8 +1646,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_crypto_sign_with_private_key(TEST_HSM_CLIENT_HANDLE, TEST_ALIAS_STRING, TEST_TBS, TEST_TBS_SIZE, &digest, &digest_size);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1660,8 +1657,8 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
         TEST_FUNCTION(edge_hsm_client_crypto_sign_with_private_key_invalid_param_validation)
         {
             //arrange
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CRYPTO_SIGN_WITH_PRIVATE_KEY hsm_client_crypto_sign_with_private_key = interface->hsm_client_crypto_sign_with_private_key;
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CRYPTO_SIGN_WITH_PRIVATE_KEY hsm_client_crypto_sign_with_private_key = iface->hsm_client_crypto_sign_with_private_key;
             unsigned char *digest;
             size_t digest_size;
             int status;
@@ -1670,27 +1667,27 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
 
             // act, assert
             status = hsm_client_crypto_sign_with_private_key(NULL, TEST_ALIAS_STRING, TEST_TBS, TEST_TBS_SIZE, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             status = hsm_client_crypto_sign_with_private_key(TEST_HSM_CLIENT_HANDLE, NULL, TEST_TBS, TEST_TBS_SIZE, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             status = hsm_client_crypto_sign_with_private_key(TEST_HSM_CLIENT_HANDLE, TEST_ALIAS_STRING, NULL, TEST_TBS_SIZE, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             status = hsm_client_crypto_sign_with_private_key(TEST_HSM_CLIENT_HANDLE, TEST_ALIAS_STRING, TEST_TBS, 0, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             status = hsm_client_crypto_sign_with_private_key(TEST_HSM_CLIENT_HANDLE, TEST_ALIAS_STRING, TEST_TBS, TEST_TBS_SIZE, NULL, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             status = hsm_client_crypto_sign_with_private_key(TEST_HSM_CLIENT_HANDLE, TEST_ALIAS_STRING, TEST_TBS, TEST_TBS_SIZE, &digest, NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_deinit();
@@ -1705,11 +1702,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             //arrange
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_CRYPTO_SIGN_WITH_PRIVATE_KEY hsm_client_crypto_sign_with_private_key = interface->hsm_client_crypto_sign_with_private_key;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_CRYPTO_SIGN_WITH_PRIVATE_KEY hsm_client_crypto_sign_with_private_key = iface->hsm_client_crypto_sign_with_private_key;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             unsigned char *digest = NULL;
             size_t digest_size = 0;
@@ -1723,10 +1720,10 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             status = hsm_client_crypto_sign_with_private_key(hsm_handle, TEST_ALIAS_STRING, TEST_TBS, TEST_TBS_SIZE, &digest, &digest_size);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(void_ptr, TEST_DIGEST_BUFFER, digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, TEST_DIGEST_BUFFER_SIZE, digest_size, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(void_ptr, TEST_DIGEST_BUFFER, digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, TEST_DIGEST_BUFFER_SIZE, digest_size, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_crypto_destroy(hsm_handle);
@@ -1744,11 +1741,11 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status;
             status = hsm_client_crypto_init(TEST_CA_VALIDITY);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_CRYPTO_INTERFACE* interface = hsm_client_crypto_interface();
-            HSM_CLIENT_CREATE hsm_client_crypto_create = interface->hsm_client_crypto_create;
-            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = interface->hsm_client_crypto_destroy;
-            HSM_CLIENT_CRYPTO_SIGN_WITH_PRIVATE_KEY hsm_client_crypto_sign_with_private_key = interface->hsm_client_crypto_sign_with_private_key;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_CRYPTO_INTERFACE* iface = hsm_client_crypto_interface();
+            HSM_CLIENT_CREATE hsm_client_crypto_create = iface->hsm_client_crypto_create;
+            HSM_CLIENT_DESTROY hsm_client_crypto_destroy = iface->hsm_client_crypto_destroy;
+            HSM_CLIENT_CRYPTO_SIGN_WITH_PRIVATE_KEY hsm_client_crypto_sign_with_private_key = iface->hsm_client_crypto_sign_with_private_key;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_crypto_create();
             unsigned char *digest = NULL;
             size_t digest_size = 0;
@@ -1769,7 +1766,7 @@ BEGIN_TEST_SUITE(edge_hsm_crypto_unittests)
                 status = hsm_client_crypto_sign_with_private_key(hsm_handle, TEST_ALIAS_STRING, TEST_TBS, TEST_TBS_SIZE, &digest, &digest_size);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_key_intf_sas_ut/edge_hsm_key_intf_sas_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_key_intf_sas_ut/edge_hsm_key_intf_sas_ut.c
@@ -65,7 +65,6 @@ MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 #define TEST_DIGEST_PTR (unsigned char*)0x5000
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 static unsigned char TEST_KEY_DATA[] = {'A', 'B', 'C', 'D'};
 static unsigned char TEST_DIGEST_DATA[] = {'D', 'I', 'G', 'E', 'S', 'T'};
 static unsigned char TEST_DERIVED_DIGEST_DATA[] = {'D', 'I', 'G', 'E', 'S', 'T',
@@ -94,7 +93,7 @@ static unsigned char* test_hook_BUFFER_u_char(BUFFER_HANDLE handle)
     {
         result = TEST_DERIVED_DIGEST_DATA;
     }
-    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
     return result;
 }
 
@@ -109,7 +108,7 @@ static size_t test_hook_BUFFER_length(BUFFER_HANDLE handle)
     {
         result = sizeof(TEST_DERIVED_DIGEST_DATA);
     }
-    ASSERT_ARE_NOT_EQUAL(size_t, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_NOT_EQUAL(size_t, 0, result, "Line:" MU_TOSTRING(__LINE__));
     return result;
 }
 
@@ -137,13 +136,13 @@ static HMACSHA256_RESULT test_hook_HMACSHA256_ComputeHash
 static KEY_HANDLE test_helper_create_key(const unsigned char* key, size_t key_len)
 {
     KEY_HANDLE key_handle = create_sas_key(key, key_len);
-    ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
     return key_handle;
 }
 
 static void test_helper_destroy_key(KEY_HANDLE key_handle)
 {
-    ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
     const HSM_CLIENT_KEY_INTERFACE* key_if = hsm_client_key_interface();
     key_if->hsm_client_key_destroy(key_handle);
 }
@@ -156,7 +155,6 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
 
         TEST_SUITE_INITIALIZE(TestClassInitialize)
         {
-            TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
             g_testByTest = TEST_MUTEX_CREATE();
             ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -194,7 +192,6 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             umock_c_deinit();
 
             TEST_MUTEX_DESTROY(g_testByTest);
-            TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
         }
 
         TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -220,12 +217,12 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             const HSM_CLIENT_KEY_INTERFACE* key_if = hsm_client_key_interface();
 
             // assert
-            ASSERT_IS_NOT_NULL(key_if, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_sign, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_derive_and_sign, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_encrypt, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_decrypt, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_destroy, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_sign, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_derive_and_sign, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_encrypt, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_decrypt, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_if->hsm_client_key_destroy, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -240,8 +237,8 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             KEY_HANDLE key_handle = create_sas_key(TEST_KEY_DATA, sizeof(TEST_KEY_DATA));
 
             // assert
-            ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             test_helper_destroy_key(key_handle);
@@ -266,7 +263,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
                 KEY_HANDLE key_handle = create_sas_key(TEST_KEY_DATA, sizeof(TEST_KEY_DATA));
 
                 // assert
-                ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -280,9 +277,9 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
 
             // act, assert
             key_handle = create_sas_key(TEST_KEY_DATA, 0);
-            ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
             key_handle = create_sas_key(NULL, sizeof(TEST_KEY_DATA));
-            ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -297,7 +294,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             key_if->hsm_client_key_destroy(key_handle);
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -316,7 +313,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             key_if->hsm_client_key_destroy(key_handle);
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -334,35 +331,35 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
 
             // act, assert
             status = key_if->hsm_client_key_sign(NULL, data_to_be_signed, data_len, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_sign(key_handle, NULL, data_len, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, 0, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, data_len, NULL, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, data_len, &digest, NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             test_helper_destroy_key(key_handle);
@@ -392,11 +389,11 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, data_len, &digest, &digest_size);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, sizeof(TEST_DIGEST_DATA), digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, sizeof(TEST_DIGEST_DATA), digest_size, "Line:" MU_TOSTRING(__LINE__));
             status = memcmp(TEST_DIGEST_DATA, digest, sizeof(TEST_DIGEST_DATA));
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             test_hook_gballoc_free(digest);
@@ -437,7 +434,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
                 status = key_if->hsm_client_key_sign(key_handle, data_to_be_signed, data_len, &digest, &digest_size);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -460,49 +457,49 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
 
             // act, assert
             status = key_if->hsm_client_key_derive_and_sign(NULL, data_to_be_signed, data_len, identity, identity_size, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, NULL, data_len, identity, identity_size, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, 0, identity, identity_size, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, NULL, identity_size, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, 0, &digest, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, identity_size, NULL, &digest_size);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
             digest = TEST_DIGEST_PTR;
             digest_size = 10;
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, identity_size, &digest, NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             test_helper_destroy_key(key_handle);
@@ -542,12 +539,12 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
             status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, identity_size, &digest, &digest_size);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             status = memcmp(TEST_DERIVED_DIGEST_DATA, digest, sizeof(TEST_DERIVED_DIGEST_DATA));
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, sizeof(TEST_DERIVED_DIGEST_DATA), digest_size, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, sizeof(TEST_DERIVED_DIGEST_DATA), digest_size, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
             // cleanup
             test_hook_gballoc_free(digest);
             test_helper_destroy_key(key_handle);
@@ -611,7 +608,7 @@ BEGIN_TEST_SUITE(edge_hsm_key_interface_sas_key_unittests)
                     status = key_if->hsm_client_key_derive_and_sign(key_handle, data_to_be_signed, data_len, identity, identity_size, &digest, &digest_size);
 
                     // assert
-                    ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                    ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
                 }
             }
 

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_sas_auth_int/edge_hsm_sas_auth_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_sas_auth_int/edge_hsm_sas_auth_int.c
@@ -36,7 +36,6 @@ static char* TEST_IOTEDGE_HOMEDIR = NULL;
 static char* TEST_IOTEDGE_HOMEDIR_GUID = NULL;
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 //#############################################################################
 // Test helpers
@@ -45,8 +44,8 @@ static TEST_MUTEX_HANDLE g_dllByDll;
 static void test_helper_setup_homedir(void)
 {
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" MU_TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
@@ -69,10 +68,10 @@ static HSM_CLIENT_HANDLE tpm_provision(void)
 {
     int status;
     status = hsm_client_tpm_init();
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
-    HSM_CLIENT_HANDLE result = interface->hsm_client_tpm_create();
-    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+    const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_interface();
+    HSM_CLIENT_HANDLE result = iface->hsm_client_tpm_create();
+    ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
     return result;
 }
 
@@ -83,9 +82,9 @@ static void tpm_activate_key
     size_t key_size
 )
 {
-    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
-    int status = interface->hsm_client_activate_identity_key(hsm_handle, key, key_size);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_interface();
+    int status = iface->hsm_client_activate_identity_key(hsm_handle, key, key_size);
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 }
 
 static int tpm_sign
@@ -98,46 +97,46 @@ static int tpm_sign
     BUFFER_HANDLE hash
 )
 {
-    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
+    const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_interface();
     unsigned char *digest;
     size_t digest_size;
     int status;
     if (derived_identity == NULL)
     {
-        status = interface->hsm_client_sign_with_identity(hsm_handle, data, data_len,
+        status = iface->hsm_client_sign_with_identity(hsm_handle, data, data_len,
                                                           &digest, &digest_size);
     }
     else
     {
-        status = interface->hsm_client_derive_and_sign_with_identity(hsm_handle,
+        status = iface->hsm_client_derive_and_sign_with_identity(hsm_handle,
                                                                      data, data_len,
                                                                      derived_identity,
                                                                      derived_identity_size,
                                                                      &digest,
                                                                      &digest_size);
     }
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     status = BUFFER_build(hash, digest, digest_size);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     free(digest);
     return status;
 }
 
 static void tpm_deprovision(HSM_CLIENT_HANDLE hsm_handle)
 {
-    const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_interface();
-    interface->hsm_client_tpm_destroy(hsm_handle);
+    const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_interface();
+    iface->hsm_client_tpm_destroy(hsm_handle);
     hsm_client_tpm_deinit();
 }
 
 static BUFFER_HANDLE test_helper_base64_converter(const char* input)
 {
     BUFFER_HANDLE result = Azure_Base64_Decode(input);
-    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
     size_t out_len = BUFFER_length(result);
-    ASSERT_ARE_NOT_EQUAL(size_t, 0, out_len, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_NOT_EQUAL(size_t, 0, out_len, "Line:" MU_TOSTRING(__LINE__));
     unsigned char* out_buffer = BUFFER_u_char(result);
-    ASSERT_IS_NOT_NULL(out_buffer, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(out_buffer, "Line:" MU_TOSTRING(__LINE__));
     return result;
 }
 
@@ -150,10 +149,10 @@ static BUFFER_HANDLE test_helper_compute_hmac
 {
     int status;
     BUFFER_HANDLE result = BUFFER_new();
-    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
     status = HMACSHA256_ComputeHash(BUFFER_u_char(key_handle), BUFFER_length(key_handle),
                                     input, input_size, result);
-    ASSERT_ARE_EQUAL(int, (int)HMACSHA256_OK, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, (int)HMACSHA256_OK, status, "Line:" MU_TOSTRING(__LINE__));
     return result;
 }
 
@@ -243,7 +242,6 @@ static STRING_HANDLE tpm_construct_sas_token
 BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
         test_helper_setup_homedir();
@@ -253,7 +251,6 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
     {
         test_helper_tear_down_homedir();
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -289,7 +286,7 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
 
         // act
         BUFFER_HANDLE test_output_digest = BUFFER_new();
-        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" MU_TOSTRING(__LINE__));
         HSM_CLIENT_HANDLE hsm_handle = test_helper_init_tpm_and_activate_key(decoded_key);
         tpm_sign(hsm_handle, NULL, 0, test_data_to_be_signed,
                  test_data_to_be_signed_size, test_output_digest);
@@ -338,7 +335,7 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
 
         // act
         BUFFER_HANDLE test_output_digest = BUFFER_new();
-        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" MU_TOSTRING(__LINE__));
         HSM_CLIENT_HANDLE hsm_handle = test_helper_init_tpm_and_activate_key(decoded_key);
         tpm_sign(hsm_handle, (unsigned char*)primary_fqmid, strlen(primary_fqmid),
                  test_data_to_be_signed, test_data_to_be_signed_size, test_output_digest);
@@ -383,9 +380,9 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
 
         // act
         BUFFER_HANDLE test_output_primary_key_buf = BUFFER_new();
-        ASSERT_IS_NOT_NULL(test_output_primary_key_buf, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_primary_key_buf, "Line:" MU_TOSTRING(__LINE__));
         BUFFER_HANDLE test_output_secondary_key_buf = BUFFER_new();
-        ASSERT_IS_NOT_NULL(test_output_secondary_key_buf, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_secondary_key_buf, "Line:" MU_TOSTRING(__LINE__));
 
         HSM_CLIENT_HANDLE hsm_handle = test_helper_init_tpm_and_activate_key(decoded_key);
         tpm_sign(hsm_handle, NULL, 0, (unsigned char*)primary_fqmid, strlen(primary_fqmid), test_output_primary_key_buf);
@@ -434,7 +431,7 @@ BEGIN_TEST_SUITE(edge_hsm_sas_auth_int_tests)
         HSM_CLIENT_HANDLE hsm_handle = tpm_provision();
         tpm_activate_key(hsm_handle, BUFFER_u_char(decoded_key), BUFFER_length(decoded_key));
         STRING_HANDLE token = tpm_construct_sas_token(hsm_handle, NULL, 0, hostname, device_id, expiry_time);
-        ASSERT_IS_NOT_NULL(token, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(token, "Line:" MU_TOSTRING(__LINE__));
         printf("TPM Generated Token: [%s]\n", STRING_c_str(token));
 
         // cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_int/edge_hsm_store_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_int/edge_hsm_store_int.c
@@ -38,7 +38,6 @@ static char* TEST_IOTEDGE_HOMEDIR = NULL;
 static char* TEST_IOTEDGE_HOMEDIR_GUID = NULL;
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 // 90 days.
 static const uint64_t TEST_CA_VALIDITY =  90 * 24 * 3600;
@@ -50,8 +49,8 @@ static const uint64_t TEST_CA_VALIDITY =  90 * 24 * 3600;
 static void test_helper_setup_homedir(void)
 {
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" MU_TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
@@ -80,7 +79,7 @@ static CERT_PROPS_HANDLE test_helper_create_certificate_props
 )
 {
     CERT_PROPS_HANDLE cert_props_handle = cert_properties_create();
-    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" MU_TOSTRING(__LINE__));
     set_validity_seconds(cert_props_handle, validity);
     set_common_name(cert_props_handle, common_name);
     set_country_name(cert_props_handle, "US");
@@ -97,11 +96,11 @@ static CERT_PROPS_HANDLE test_helper_create_certificate_props
 static BUFFER_HANDLE test_helper_base64_converter(const char* input)
 {
     BUFFER_HANDLE result = Azure_Base64_Decode(input);
-    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
     size_t out_len = BUFFER_length(result);
-    ASSERT_ARE_NOT_EQUAL(size_t, 0, out_len, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_NOT_EQUAL(size_t, 0, out_len, "Line:" MU_TOSTRING(__LINE__));
     unsigned char* out_buffer = BUFFER_u_char(result);
-    ASSERT_IS_NOT_NULL(out_buffer, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(out_buffer, "Line:" MU_TOSTRING(__LINE__));
     return result;
 }
 
@@ -114,10 +113,10 @@ static BUFFER_HANDLE test_helper_compute_hmac
 {
     int status;
     BUFFER_HANDLE result = BUFFER_new();
-    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
     status = HMACSHA256_ComputeHash(BUFFER_u_char(key_handle), BUFFER_length(key_handle),
                                     input, input_size, result);
-    ASSERT_ARE_EQUAL(int, (int)HMACSHA256_OK, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, (int)HMACSHA256_OK, status, "Line:" MU_TOSTRING(__LINE__));
     return result;
 }
 
@@ -140,7 +139,7 @@ static void test_helper_sas_key_sign
     KEY_HANDLE key_handle = store_if->hsm_client_store_open_key(store_handle,
                                                                 HSM_KEY_SAS,
                                                                 key_name);
-    ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
     if (derived_identity != NULL)
     {
         status = key_if->hsm_client_key_derive_and_sign(key_handle,
@@ -159,12 +158,12 @@ static void test_helper_sas_key_sign
                                              &digest,
                                              &digest_size);
     }
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     status = BUFFER_build(hash, digest, digest_size);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     free(digest);
     status = store_if->hsm_client_store_close_key(store_handle, key_handle);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 }
 
 static void test_helper_cert_key_sign
@@ -183,18 +182,18 @@ static void test_helper_cert_key_sign
     KEY_HANDLE key_handle = store_if->hsm_client_store_open_key(store_handle,
                                                                 HSM_KEY_ASYMMETRIC_PRIVATE_KEY,
                                                                 key_name);
-    ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
     status = key_if->hsm_client_key_sign(key_handle,
                                          data,
                                          data_len,
                                          &digest,
                                          &digest_size);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(digest, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_TRUE((digest_size >= HMAC_SHA256_SIZE), "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((digest_size >= HMAC_SHA256_SIZE), "Line:" MU_TOSTRING(__LINE__));
     free(digest);
     status = store_if->hsm_client_store_close_key(store_handle, key_handle);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 }
 
 //#############################################################################
@@ -205,7 +204,6 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
         test_helper_setup_homedir();
@@ -215,7 +213,6 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
     {
         test_helper_teardown_homedir();
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -235,68 +232,68 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
     {
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" MU_TOSTRING(__LINE__));
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME, TEST_CA_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(open_close_smoke)
     {
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME, TEST_CA_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(insert_remove_sas_key_smoke)
     {
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME, TEST_CA_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_remove_key(store_handle, HSM_KEY_SAS, "bad_sas_key_name");
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_insert_sas_key(store_handle, "my_sas_key", (unsigned char*)"ABCD", 5);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_insert_sas_key(store_handle, "my_sas_key", (unsigned char*)"1234", 5);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_remove_key(store_handle, HSM_KEY_SAS, "my_sas_key");
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(insert_overwrite_sign_remove_sas_key_smoke)
@@ -314,24 +311,24 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
                                                                       test_data_to_be_signed_size);
 
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME, TEST_CA_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // act
         BUFFER_HANDLE test_output_digest = BUFFER_new();
-        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output_digest, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_insert_sas_key(store_handle, "my_sas_key", (unsigned char*)"ABCD", 5);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         result = store_if->hsm_client_store_insert_sas_key(store_handle, "my_sas_key",
                                                            BUFFER_u_char(decoded_key),
                                                            BUFFER_length(decoded_key));
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         test_helper_sas_key_sign(store_handle,
                                  "my_sas_key",
@@ -353,9 +350,9 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
         BUFFER_delete(test_expected_digest);
         BUFFER_delete(decoded_key);
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(insert_default_trusted_ca_cert_smoke)
@@ -363,27 +360,27 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
         // arrange
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME, TEST_CA_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // act
         CERT_INFO_HANDLE cert_info = store_if->hsm_client_store_get_pki_trusted_certs(store_handle);
 
         // assert
-        ASSERT_IS_NOT_NULL(cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(cert_info, "Line:" MU_TOSTRING(__LINE__));
         // todo validate cert props
 
         // cleanup
         certificate_info_destroy(cert_info);
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
     }
 
     TEST_FUNCTION(insert_generated_cert_and_perform_key_sign_smoke)
@@ -391,16 +388,16 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
         // arrange
         int result;
         const HSM_CLIENT_STORE_INTERFACE *store_if = hsm_client_store_interface();
-        ASSERT_IS_NOT_NULL(store_if, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_if, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create(EDGE_STORE_NAME, TEST_CA_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         HSM_CLIENT_STORE_HANDLE store_handle = store_if->hsm_client_store_open(EDGE_STORE_NAME);
-        ASSERT_IS_NOT_NULL(store_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(store_handle, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_remove_pki_cert(store_handle, "my_test_alias");
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         CERT_PROPS_HANDLE cert_props = test_helper_create_certificate_props("test_cn",
                                                                             "my_test_alias",
@@ -409,13 +406,13 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
                                                                             3600);
         // act, assert
         CERT_INFO_HANDLE cert_info = store_if->hsm_client_store_get_pki_cert(store_handle, "my_test_alias");
-        ASSERT_IS_NULL(cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(cert_info, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create_pki_cert(store_handle, cert_props);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         cert_info = store_if->hsm_client_store_get_pki_cert(store_handle, "my_test_alias");
-        ASSERT_IS_NOT_NULL(cert_info, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(cert_info, "Line:" MU_TOSTRING(__LINE__));
         // todo validate cert props
 
         // perform a key sign test using the created key
@@ -423,15 +420,15 @@ BEGIN_TEST_SUITE(edge_hsm_store_int_tests)
         test_helper_cert_key_sign(store_handle, "my_test_alias", tbs, sizeof(tbs));
 
         result = store_if->hsm_client_store_remove_pki_cert(store_handle, "my_test_alias");
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         cert_properties_destroy(cert_props);
         certificate_info_destroy(cert_info);
         result = store_if->hsm_client_store_close(store_handle);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         result = store_if->hsm_client_store_destroy(EDGE_STORE_NAME);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
     }
 
 END_TEST_SUITE(edge_hsm_store_int_tests)

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_ut/edge_hsm_store_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_store_ut/edge_hsm_store_ut.c
@@ -100,7 +100,6 @@ MOCKABLE_FUNCTION(, const char*, get_issuer_alias, CERT_PROPS_HANDLE, handle);
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 //#############################################################################
 // Mocked functions test hooks
@@ -237,15 +236,14 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
         umock_c_init(test_hook_on_umock_c_error);
 
-        REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_INTERFACE, void*);
+        REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_INTERFACE*, void*);
         REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_HANDLE, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_KEY_INTERFACE, void*);
+        REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_KEY_INTERFACE*, void*);
         REGISTER_UMOCK_ALIAS_TYPE(KEY_HANDLE, void*);
         REGISTER_UMOCK_ALIAS_TYPE(CERT_PROPS_HANDLE, void*);
         REGISTER_UMOCK_ALIAS_TYPE(SINGLYLINKEDLIST_HANDLE, void*);
@@ -290,7 +288,6 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -316,10 +313,10 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // act, assert
         result = store_if->hsm_client_store_create(NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_create("");
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -332,10 +329,10 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // act, assert
         result = store_if->hsm_client_store_destroy(NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         result = store_if->hsm_client_store_destroy("");
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -370,7 +367,7 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // assert
         ASSERT_IS_NOT_NULL(result);
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(result);
@@ -391,7 +388,7 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // assert
         ASSERT_IS_NOT_NULL(handle_2);
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(handle_2);
@@ -436,11 +433,11 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // act, assert
         result = store_if->hsm_client_store_close(NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
 
         result = store_if->hsm_client_store_close(TEST_STORE_HANDLE);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -462,8 +459,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         result = store_if->hsm_client_store_close(handle);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -485,8 +482,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         result = store_if->hsm_client_store_close(handle);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -507,8 +504,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         int result = store_if->hsm_client_store_close(handle_2);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(handle_1);
@@ -525,7 +522,7 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         handle_2 = store_if->hsm_client_store_open(TEST_STORE_NAME);
         ASSERT_IS_NOT_NULL(handle_2);
         int result = store_if->hsm_client_store_close(handle_2);
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         umock_c_reset_all_calls();
 
         call_stack_helper_store_close(0);
@@ -534,8 +531,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         result = store_if->hsm_client_store_close(handle_1);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -553,23 +550,23 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(NULL, TEST_SAS_KEY_NAME_1, TEST_SAS_KEY_VALUE_1, strlen(TEST_SAS_KEY_VALUE_1) + 1);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(handle, NULL, TEST_SAS_KEY_VALUE_1, strlen(TEST_SAS_KEY_VALUE_1) + 1);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(handle, "", TEST_SAS_KEY_VALUE_1, strlen(TEST_SAS_KEY_VALUE_1) + 1);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(handle, TEST_SAS_KEY_NAME_1, NULL, strlen(TEST_SAS_KEY_VALUE_1) + 1);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // act, assert
         store_if->hsm_client_store_insert_sas_key(handle, TEST_SAS_KEY_NAME_1, TEST_SAS_KEY_VALUE_1, 0);
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(handle);
@@ -603,8 +600,8 @@ BEGIN_TEST_SUITE(edge_hsm_store_unittests)
         result = store_if->hsm_client_store_insert_sas_key(handle, TEST_SAS_KEY_NAME_1, TEST_SAS_KEY_VALUE_1, strlen(TEST_SAS_KEY_VALUE_1) + 1);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         (void)store_if->hsm_client_store_close(handle);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_tpm_ut/edge_hsm_tpm_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_tpm_ut/edge_hsm_tpm_ut.c
@@ -98,7 +98,6 @@ MOCKABLE_FUNCTION(, const HSM_CLIENT_KEY_INTERFACE*, hsm_client_key_interface);
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 static unsigned char TEST_EDGE_MODULE_IDENTITY[] = {'s', 'a', 'm', 'p', 'l', 'e'};
 
 // 90 days.
@@ -358,15 +357,14 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
 
         TEST_SUITE_INITIALIZE(TestClassInitialize)
         {
-            TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
             g_testByTest = TEST_MUTEX_CREATE();
             ASSERT_IS_NOT_NULL(g_testByTest);
 
             umock_c_init(test_hook_on_umock_c_error);
 
-            REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_INTERFACE, void*);
+            REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_INTERFACE*, void*);
             REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_STORE_HANDLE, void*);
-            REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_KEY_INTERFACE, void*);
+            REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_KEY_INTERFACE*, void*);
             REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_HANDLE, void*);
             REGISTER_UMOCK_ALIAS_TYPE(KEY_HANDLE, void*);
             REGISTER_UMOCK_ALIAS_TYPE(HSM_KEY_T, int);
@@ -455,7 +453,6 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             umock_c_deinit();
 
             TEST_MUTEX_DESTROY(g_testByTest);
-            TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
         }
 
         TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -489,8 +486,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_tpm_store_init();
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_store_deinit();
@@ -522,7 +519,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 status = hsm_client_tpm_store_init();
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -544,8 +541,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_tpm_store_init();
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_store_deinit();
@@ -565,7 +562,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             hsm_client_tpm_store_deinit();
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
         }
@@ -591,8 +588,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_tpm_store_init();
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_store_deinit();
@@ -610,15 +607,15 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             const HSM_CLIENT_TPM_INTERFACE* result = hsm_client_tpm_store_interface();
 
             // assert
-            ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_tpm_create, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_tpm_destroy, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_activate_identity_key, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_get_ek, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_get_srk, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_sign_with_identity, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(result->hsm_client_derive_and_sign_with_identity, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_tpm_create, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_tpm_destroy, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_activate_identity_key, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_get_ek, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_get_srk, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_sign_with_identity, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(result->hsm_client_derive_and_sign_with_identity, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
         }
@@ -630,16 +627,16 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         TEST_FUNCTION(edge_hsm_client_tpm_create_fails_when_tpm_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
             umock_c_reset_all_calls();
 
             // act
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
 
             // assert
-            ASSERT_IS_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -651,10 +648,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             //arrange
             int status;
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
             umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(gballoc_calloc(1, IGNORED_NUM_ARG));
@@ -664,8 +661,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
 
             // assert
-            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -684,10 +681,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
 
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
             umock_c_reset_all_calls();
 
             STRICT_EXPECTED_CALL(gballoc_calloc(1, IGNORED_NUM_ARG));
@@ -704,7 +701,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
 
                 // assert
-                ASSERT_IS_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -719,14 +716,14 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         TEST_FUNCTION(edge_hsm_client_tpm_destroy_does_nothing_with_invalid_handle)
         {
             //arrange
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
 
             // act
             hsm_client_tpm_destroy(NULL);
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -736,14 +733,14 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         TEST_FUNCTION(edge_hsm_client_tpm_destroy_does_nothing_when_tpm_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
 
             // act
             hsm_client_tpm_destroy(TEST_HSM_CLIENT_HANDLE);
 
             // assert
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -755,10 +752,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             //arrange
             int status;
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             umock_c_reset_all_calls();
 
@@ -769,8 +766,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             hsm_client_tpm_destroy(hsm_handle);
 
             // assert
-            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(hsm_handle, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_store_deinit();
@@ -785,21 +782,21 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             //arrange
             int status;
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_ACTIVATE_IDENTITY_KEY hsm_client_activate_identity_key = interface->hsm_client_activate_identity_key;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_ACTIVATE_IDENTITY_KEY hsm_client_activate_identity_key = iface->hsm_client_activate_identity_key;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
 
             // act, assert
             status = hsm_client_activate_identity_key(NULL, test_input, sizeof(test_input));
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             status = hsm_client_activate_identity_key(hsm_handle, NULL, sizeof(test_input));
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             status = hsm_client_activate_identity_key(hsm_handle, test_input, 0);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -815,11 +812,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             //arrange
             int status;
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_ACTIVATE_IDENTITY_KEY hsm_client_activate_identity_key = interface->hsm_client_activate_identity_key;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_ACTIVATE_IDENTITY_KEY hsm_client_activate_identity_key = iface->hsm_client_activate_identity_key;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             umock_c_reset_all_calls();
@@ -830,8 +827,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_activate_identity_key(hsm_handle, test_input, sizeof(test_input));
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -850,11 +847,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             ASSERT_ARE_EQUAL(int, 0, test_result);
 
             status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_ACTIVATE_IDENTITY_KEY hsm_client_activate_identity_key = interface->hsm_client_activate_identity_key;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_ACTIVATE_IDENTITY_KEY hsm_client_activate_identity_key = iface->hsm_client_activate_identity_key;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             umock_c_reset_all_calls();
@@ -872,7 +869,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 status = hsm_client_activate_identity_key(hsm_handle, test_input, sizeof(test_input));
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -888,8 +885,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         TEST_FUNCTION(edge_hsm_client_get_ek_does_nothing_when_tpm_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_GET_ENDORSEMENT_KEY hsm_client_get_ek = interface->hsm_client_get_ek;
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_GET_ENDORSEMENT_KEY hsm_client_get_ek = iface->hsm_client_get_ek;
             int status;
             unsigned char *test_output_buffer = (unsigned char*)0x5000;
             size_t test_output_len = 10;
@@ -899,10 +896,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_get_ek(TEST_HSM_CLIENT_HANDLE, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -913,11 +910,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_GET_ENDORSEMENT_KEY hsm_client_get_ek = interface->hsm_client_get_ek;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_GET_ENDORSEMENT_KEY hsm_client_get_ek = iface->hsm_client_get_ek;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char *test_output_buffer = (unsigned char*)0x5000;
             size_t test_output_len = 10;
@@ -927,10 +924,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_get_ek(hsm_handle, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -945,32 +942,32 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_GET_ENDORSEMENT_KEY hsm_client_get_ek = interface->hsm_client_get_ek;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_GET_ENDORSEMENT_KEY hsm_client_get_ek = iface->hsm_client_get_ek;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char *test_output_buffer = (unsigned char*)0x5000;
             size_t test_output_len = 10;
 
             // act, assert
             status = hsm_client_get_ek(NULL, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = (unsigned char*)0x5000;
             test_output_len = 10;
             status = hsm_client_get_ek(hsm_handle, NULL, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = (unsigned char*)0x5000;
             test_output_len = 10;
             status = hsm_client_get_ek(hsm_handle, &test_output_buffer, NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -984,8 +981,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         TEST_FUNCTION(edge_hsm_client_get_srk_does_nothing_when_tpm_not_initialized)
         {
             //arrange
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_GET_STORAGE_ROOT_KEY hsm_client_get_srk = interface->hsm_client_get_srk;
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_GET_STORAGE_ROOT_KEY hsm_client_get_srk = iface->hsm_client_get_srk;
             unsigned char *test_output_buffer = (unsigned char*)0x5000;
             size_t test_output_len = 10;
             int status;
@@ -995,10 +992,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_get_srk(TEST_HSM_CLIENT_HANDLE, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1009,11 +1006,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_GET_STORAGE_ROOT_KEY hsm_client_get_srk = interface->hsm_client_get_srk;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_GET_STORAGE_ROOT_KEY hsm_client_get_srk = iface->hsm_client_get_srk;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char *test_output_buffer = (unsigned char*)0x5000;
             size_t test_output_len = 10;
@@ -1023,10 +1020,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_get_srk(hsm_handle, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1041,32 +1038,32 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_GET_STORAGE_ROOT_KEY hsm_client_get_srk = interface->hsm_client_get_srk;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_GET_STORAGE_ROOT_KEY hsm_client_get_srk = iface->hsm_client_get_srk;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char *test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             size_t test_output_len = 10;
 
             // act, assert
             status = hsm_client_get_srk(NULL, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_get_srk(hsm_handle, NULL, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_get_srk(hsm_handle, &test_output_buffer, NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1081,8 +1078,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status;
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_SIGN_WITH_IDENTITY hsm_client_sign_with_identity = interface->hsm_client_sign_with_identity;
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_SIGN_WITH_IDENTITY hsm_client_sign_with_identity = iface->hsm_client_sign_with_identity;
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             unsigned char *test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             size_t test_output_len = 10;
@@ -1092,11 +1089,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_sign_with_identity(TEST_HSM_CLIENT_HANDLE, test_input, sizeof(test_input), &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1107,11 +1104,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_SIGN_WITH_IDENTITY hsm_client_sign_with_identity = interface->hsm_client_sign_with_identity;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_SIGN_WITH_IDENTITY hsm_client_sign_with_identity = iface->hsm_client_sign_with_identity;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             unsigned char *test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
@@ -1119,35 +1116,35 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
 
             // act, assert
             status = hsm_client_sign_with_identity(NULL, test_input, sizeof(test_input), &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_sign_with_identity(hsm_handle, NULL, sizeof(test_input), &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_sign_with_identity(hsm_handle, test_input, 0, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_sign_with_identity(hsm_handle, test_input, sizeof(test_input), NULL, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_sign_with_identity(hsm_handle, test_input, sizeof(test_input), &test_output_buffer, NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1162,11 +1159,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_SIGN_WITH_IDENTITY hsm_client_sign_with_identity = interface->hsm_client_sign_with_identity;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_SIGN_WITH_IDENTITY hsm_client_sign_with_identity = iface->hsm_client_sign_with_identity;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             unsigned char *test_output_buffer = NULL;
@@ -1181,8 +1178,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_sign_with_identity(hsm_handle, test_input, sizeof(test_input), &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1199,11 +1196,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             int test_result = umock_c_negative_tests_init();
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_SIGN_WITH_IDENTITY hsm_client_sign_with_identity = interface->hsm_client_sign_with_identity;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_SIGN_WITH_IDENTITY hsm_client_sign_with_identity = iface->hsm_client_sign_with_identity;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             unsigned char *test_output_buffer = NULL;
@@ -1225,7 +1222,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 status = hsm_client_sign_with_identity(hsm_handle, test_input, sizeof(test_input), &test_output_buffer, &test_output_len);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup
@@ -1242,8 +1239,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status;
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_DERIVE_AND_SIGN_WITH_IDENTITY hsm_client_derive_and_sign_with_identity = interface->hsm_client_derive_and_sign_with_identity;
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_DERIVE_AND_SIGN_WITH_IDENTITY hsm_client_derive_and_sign_with_identity = iface->hsm_client_derive_and_sign_with_identity;
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             unsigned char *test_output_buffer = NULL;
             size_t test_output_len = 0;
@@ -1254,10 +1251,10 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_derive_and_sign_with_identity(TEST_HSM_CLIENT_HANDLE, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
         }
 
         /**
@@ -1268,11 +1265,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_DERIVE_AND_SIGN_WITH_IDENTITY hsm_client_derive_and_sign_with_identity = interface->hsm_client_derive_and_sign_with_identity;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_DERIVE_AND_SIGN_WITH_IDENTITY hsm_client_derive_and_sign_with_identity = iface->hsm_client_derive_and_sign_with_identity;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             unsigned char *test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
@@ -1283,49 +1280,49 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(NULL, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, NULL, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, 0, TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), NULL, identity_size, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, 0, &test_output_buffer, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, NULL, &test_output_len);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_TRUE((test_output_len == 0), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((test_output_len == 0), "Line:" MU_TOSTRING(__LINE__));
 
             test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
             test_output_len = 10;
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(test_output_buffer, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output_buffer, "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1340,11 +1337,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
         {
             //arrange
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_DERIVE_AND_SIGN_WITH_IDENTITY hsm_client_derive_and_sign_with_identity = interface->hsm_client_derive_and_sign_with_identity;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_DERIVE_AND_SIGN_WITH_IDENTITY hsm_client_derive_and_sign_with_identity = iface->hsm_client_derive_and_sign_with_identity;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             unsigned char *test_output_buffer = TEST_OUTPUT_DIGEST_PTR;
@@ -1361,8 +1358,8 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
             //cleanup
             hsm_client_tpm_destroy(hsm_handle);
@@ -1379,11 +1376,11 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
             int test_result = umock_c_negative_tests_init();
             ASSERT_ARE_EQUAL(int, 0, test_result);
             int status = hsm_client_tpm_store_init();
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            const HSM_CLIENT_TPM_INTERFACE* interface = hsm_client_tpm_store_interface();
-            HSM_CLIENT_CREATE hsm_client_tpm_create = interface->hsm_client_tpm_create;
-            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = interface->hsm_client_tpm_destroy;
-            HSM_CLIENT_DERIVE_AND_SIGN_WITH_IDENTITY hsm_client_derive_and_sign_with_identity = interface->hsm_client_derive_and_sign_with_identity;
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            const HSM_CLIENT_TPM_INTERFACE* iface = hsm_client_tpm_store_interface();
+            HSM_CLIENT_CREATE hsm_client_tpm_create = iface->hsm_client_tpm_create;
+            HSM_CLIENT_DESTROY hsm_client_tpm_destroy = iface->hsm_client_tpm_destroy;
+            HSM_CLIENT_DERIVE_AND_SIGN_WITH_IDENTITY hsm_client_derive_and_sign_with_identity = iface->hsm_client_derive_and_sign_with_identity;
             HSM_CLIENT_HANDLE hsm_handle = hsm_client_tpm_create();
             unsigned char test_input[] = {'t', 'e', 's', 't'};
             unsigned char *test_output_buffer = NULL;
@@ -1407,7 +1404,7 @@ BEGIN_TEST_SUITE(edge_hsm_tpm_unittests)
                 status = hsm_client_derive_and_sign_with_identity(hsm_handle, test_input, sizeof(test_input), TEST_EDGE_MODULE_IDENTITY, identity_size, &test_output_buffer, &test_output_len);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
 
             //cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_util_int/edge_hsm_util_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_util_int/edge_hsm_util_int.c
@@ -54,7 +54,6 @@ static unsigned char NUMERIC[] = {'1', '2', '3', '4'};
 static unsigned char NUMERIC_NEWLINE[] = {'1', '2', '\n', '4', '5', '\n'};
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 static char* TEST_TEMP_DIR = NULL;
 static char* TEST_TEMP_DIR_GUID = NULL;
@@ -66,8 +65,8 @@ static char* TEST_TEMP_DIR_GUID = NULL;
 static void test_helper_setup_testdir(void)
 {
     TEST_TEMP_DIR = hsm_test_util_create_temp_dir(&TEST_TEMP_DIR_GUID);
-    ASSERT_IS_NOT_NULL(TEST_TEMP_DIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(TEST_TEMP_DIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_TEMP_DIR_GUID, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_TEMP_DIR, "Line:" MU_TOSTRING(__LINE__));
     printf("Temp dir created: [%s]\r\n", TEST_TEMP_DIR);
 }
 
@@ -128,9 +127,9 @@ static char* prepare_file_path(const char* base_dir, const char* file_name)
 {
     size_t path_size = get_max_file_path_size();
     char *file_path = calloc(path_size, 1);
-    ASSERT_IS_NOT_NULL(file_path, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(file_path, "Line:" MU_TOSTRING(__LINE__));
     int status = snprintf(file_path, path_size, "%s%s", base_dir, file_name);
-    ASSERT_IS_TRUE(((status > 0) || (status < (int)path_size)), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < (int)path_size)), "Line:" MU_TOSTRING(__LINE__));
 
     return file_path;
 }
@@ -143,7 +142,6 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
         TEST_SUITE_INITIALIZE(TestClassInitialize)
         {
-            TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
             g_testByTest = TEST_MUTEX_CREATE();
             ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -186,7 +184,6 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             free(TEST_WRITE_FILE_FOR_DELETE); TEST_WRITE_FILE_FOR_DELETE = NULL;
             test_helper_teardown_testdir();
             TEST_MUTEX_DESTROY(g_testByTest);
-            TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
         }
 
         TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -215,8 +212,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -235,8 +232,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -252,7 +249,7 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // assert
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -267,7 +264,7 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // assert
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -282,13 +279,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             output_size = 100;
             output_string = (unsigned char *)read_file_into_cstring(NULL, &output_size);
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             output_size = 100;
             output_string = (unsigned char *)read_file_into_cstring("", &output_size);
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -306,8 +303,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_buffer);
             int cmp_result = memcmp(expected_buffer, output_buffer, expected_buffer_size);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_buffer_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_buffer_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_buffer);
@@ -326,8 +323,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_buffer);
             int cmp_result = memcmp(expected_buffer, output_buffer, expected_buffer_size);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_buffer_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_buffer_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_buffer);
@@ -343,13 +340,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             output_size = 100;
             output_buffer = read_file_into_buffer(NULL, &output_size);
             ASSERT_IS_NULL(output_buffer);
-            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // act, assert
             output_size = 100;
             output_buffer = read_file_into_buffer("", &output_size);
             ASSERT_IS_NULL(output_buffer);
-            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -364,7 +361,7 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // assert
             ASSERT_IS_NULL(output_buffer);
-            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -379,7 +376,7 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // assert
             ASSERT_IS_NULL(output_buffer);
-            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -420,8 +417,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -444,8 +441,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -469,8 +466,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -494,8 +491,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // assert
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -526,13 +523,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             result = is_directory_valid(NULL);
-            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" MU_TOSTRING(__LINE__));
 
             result = is_directory_valid("");
-            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" MU_TOSTRING(__LINE__));
 
             result = is_directory_valid("some_bad_dir");
-            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -543,10 +540,10 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             bool result;
             // act, assert
             result = is_directory_valid(".");
-            ASSERT_IS_TRUE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE(result, "Line:" MU_TOSTRING(__LINE__));
 
             result = is_directory_valid("..");
-            ASSERT_IS_TRUE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE(result, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -558,13 +555,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             result = is_file_valid(NULL);
-            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" MU_TOSTRING(__LINE__));
 
             result = is_file_valid("");
-            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" MU_TOSTRING(__LINE__));
 
             result = is_file_valid(TEST_FILE_BAD);
-            ASSERT_IS_FALSE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_FALSE(result, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -576,10 +573,10 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             result = is_file_valid(TEST_FILE_ALPHA);
-            ASSERT_IS_TRUE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE(result, "Line:" MU_TOSTRING(__LINE__));
 
             result = is_file_valid(TEST_FILE_NUMERIC);
-            ASSERT_IS_TRUE(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE(result, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -598,11 +595,11 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             char *output_string = read_file_into_cstring(TEST_WRITE_FILE, &output_size);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
             ASSERT_IS_NOT_NULL(output_string);
             int cmp_result = strcmp(expected_string, output_string);
-            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, cmp_result, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output_string);
@@ -616,13 +613,13 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             output = write_cstring_to_file(NULL, "abcd");
-            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
 
             output = write_cstring_to_file("", "abcd");
-            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
 
             output = write_cstring_to_file(TEST_WRITE_FILE, NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -641,9 +638,9 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             char *output_string = read_file_into_cstring(TEST_WRITE_FILE, &output_size);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -655,18 +652,18 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             const char *input_string = "abcd";
 
             int status = write_cstring_to_file(TEST_WRITE_FILE_FOR_DELETE, input_string);
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
             // act
             int output = delete_file(TEST_WRITE_FILE_FOR_DELETE);
-            ASSERT_ARE_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
             size_t output_size = 10;
             char *output_string = read_file_into_cstring(TEST_WRITE_FILE_FOR_DELETE, &output_size);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
             ASSERT_IS_NULL(output_string);
-            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, expected_string_size, output_size, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -678,10 +675,10 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
 
             // act, assert
             output = delete_file(NULL);
-            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
 
             output = delete_file("");
-            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, output, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }
@@ -695,11 +692,11 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             // act
             status = hsm_get_env(NULL,&output);
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             // act
             status = hsm_get_env("TEST_ENV_1",NULL);
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             // cleanup
         }
 
@@ -715,9 +712,9 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             status = hsm_get_env("TEST_ENV_1", &output);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(char_ptr, input_data, output, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, strlen(input_data), strlen(output), "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(char_ptr, input_data, output, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, strlen(input_data), strlen(output), "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
             free(output);
@@ -730,8 +727,8 @@ BEGIN_TEST_SUITE(edge_hsm_util_int_tests)
             status = hsm_get_env("TEST_ENV_1", &output);
 
             // assert
-            ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NULL(output, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NULL(output, "Line:" MU_TOSTRING(__LINE__));
 
             // cleanup
         }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_x509_ut/edge_hsm_x509_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_hsm_x509_ut/edge_hsm_x509_ut.c
@@ -105,7 +105,6 @@ MOCKABLE_FUNCTION(, const void*, certificate_info_get_private_key, CERT_INFO_HAN
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 const char* TEST_ALIAS_STRING = "test_alias";
 const char* TEST_ISSUER_ALIAS_STRING = "test_issuer_alias";
@@ -291,27 +290,27 @@ static void test_helper_setup_create_cert_info_callstack
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(hsm_get_env(ENV_DEVICE_ID_CERTIFICATE_PATH, IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(hsm_get_env(ENV_DEVICE_ID_PRIVATE_KEY_PATH, IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(hsm_client_crypto_interface());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(mocked_hsm_client_crypto_get_certificate(handle, EDGE_DEVICE_ALIAS));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 }
 
@@ -329,39 +328,39 @@ static void test_helper_setup_sign_with_private_key_callstack
     umock_c_reset_all_calls();
 
     STRICT_EXPECTED_CALL(hsm_get_env(ENV_DEVICE_ID_CERTIFICATE_PATH, IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(hsm_get_env(ENV_DEVICE_ID_PRIVATE_KEY_PATH, IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(hsm_client_crypto_interface());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(mocked_hsm_client_crypto_get_certificate(handle, EDGE_DEVICE_ALIAS));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     EXPECTED_CALL(hsm_client_crypto_interface());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(mocked_hsm_client_crypto_sign_with_private_key(handle, EDGE_DEVICE_ALIAS, IGNORED_PTR_ARG, IGNORED_NUM_ARG, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(certificate_info_destroy(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 }
 
@@ -374,7 +373,6 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -454,7 +452,6 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -486,8 +483,8 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         status = hsm_client_x509_init(TEST_VALIDITY);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         hsm_client_x509_deinit();
@@ -502,15 +499,15 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         umock_c_reset_all_calls();
 
         // act
         status = hsm_client_x509_init(TEST_VALIDITY);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         hsm_client_x509_deinit();
@@ -540,7 +537,7 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
             status = hsm_client_x509_init(TEST_VALIDITY);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         }
 
         //cleanup
@@ -559,15 +556,15 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         const HSM_CLIENT_X509_INTERFACE* result = hsm_client_x509_interface();
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(result->hsm_client_x509_create, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(result->hsm_client_x509_destroy, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(result->hsm_client_get_cert, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(result->hsm_client_get_key, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(result->hsm_client_get_common_name, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(result->hsm_client_free_buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(result->hsm_client_sign_with_private_key, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result->hsm_client_x509_create, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result->hsm_client_x509_destroy, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result->hsm_client_get_cert, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result->hsm_client_get_key, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result->hsm_client_get_common_name, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result->hsm_client_free_buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result->hsm_client_sign_with_private_key, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }
@@ -581,21 +578,21 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         umock_c_reset_all_calls();
         EXPECTED_CALL(hsm_client_crypto_interface());
         EXPECTED_CALL(mocked_hsm_client_crypto_create());
 
         // act
-        CERT_INFO_HANDLE handle = interface->hsm_client_x509_create();
+        CERT_INFO_HANDLE handle = iface->hsm_client_x509_create();
 
         // assert
-        ASSERT_IS_NOT_NULL(handle, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(handle, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
     }
 
@@ -606,14 +603,14 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
     TEST_FUNCTION(hsm_client_x509_create_without_init_fails)
     {
         //arrange
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
 
         // act
-        CERT_INFO_HANDLE handle = interface->hsm_client_x509_create();
+        CERT_INFO_HANDLE handle = iface->hsm_client_x509_create();
 
         // assert
-        ASSERT_IS_NULL(handle, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(handle, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }
@@ -630,8 +627,8 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
 
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         umock_c_reset_all_calls();
         EXPECTED_CALL(hsm_client_crypto_interface());
         EXPECTED_CALL(mocked_hsm_client_crypto_create());
@@ -644,10 +641,10 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
             umock_c_negative_tests_fail_call(i);
 
             // act
-            CERT_INFO_HANDLE handle = interface->hsm_client_x509_create();
+            CERT_INFO_HANDLE handle = iface->hsm_client_x509_create();
 
             // assert
-            ASSERT_IS_NULL(handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(handle, "Line:" MU_TOSTRING(__LINE__));
         }
 
         //cleanup
@@ -664,15 +661,15 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         umock_c_reset_all_calls();
 
         // act
-        interface->hsm_client_x509_destroy(NULL);
+        iface->hsm_client_x509_destroy(NULL);
 
         // assert
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         hsm_client_x509_deinit();
@@ -687,20 +684,20 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
-        CERT_INFO_HANDLE handle = interface->hsm_client_x509_create();
-        ASSERT_IS_NOT_NULL(handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
+        CERT_INFO_HANDLE handle = iface->hsm_client_x509_create();
+        ASSERT_IS_NOT_NULL(handle, "Line:" MU_TOSTRING(__LINE__));
         umock_c_reset_all_calls();
         EXPECTED_CALL(hsm_client_crypto_interface());
         STRICT_EXPECTED_CALL(mocked_hsm_client_crypto_destroy(handle));
 
         // act
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
 
         // assert
 
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         hsm_client_x509_deinit();
@@ -713,14 +710,14 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
     TEST_FUNCTION(hsm_client_x509_destroy_without_does_nothing)
     {
         //arrange
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         umock_c_reset_all_calls();
 
         // act
-        interface->hsm_client_x509_destroy(TEST_CERT_INFO_HANDLE);
+        iface->hsm_client_x509_destroy(TEST_CERT_INFO_HANDLE);
 
         // assert
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }
@@ -734,21 +731,21 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         umock_c_reset_all_calls();
         EXPECTED_CALL(hsm_client_crypto_interface());
         EXPECTED_CALL(mocked_hsm_client_crypto_create());
 
         // act
-        HSM_CLIENT_CREATE handle = interface->hsm_client_x509_create();
+        HSM_CLIENT_CREATE handle = iface->hsm_client_x509_create();
 
         // assert
-        ASSERT_IS_NOT_NULL(handle, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(handle, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
     }
 
@@ -759,15 +756,15 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
     TEST_FUNCTION(hsm_client_get_cert_info_invalid_param_does_nothing)
     {
         //arrange
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         umock_c_reset_all_calls();
 
         // act
-        CERT_INFO_HANDLE cert_info = interface->hsm_client_get_cert_info(NULL);
+        CERT_INFO_HANDLE cert_info = iface->hsm_client_get_cert_info(NULL);
 
         // assert
-        ASSERT_IS_NULL(cert_info, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(cert_info, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }
@@ -781,23 +778,23 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
-        HSM_CLIENT_CREATE handle = interface->hsm_client_x509_create();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
+        HSM_CLIENT_CREATE handle = iface->hsm_client_x509_create();
 
         size_t failed_function_size = MAX_FAILED_FUNCTION_LIST_SIZE;
         char failed_function_list[MAX_FAILED_FUNCTION_LIST_SIZE];
         test_helper_setup_create_cert_info_callstack(handle, failed_function_list, failed_function_size);
 
         // act
-        CERT_INFO_HANDLE cert_info = interface->hsm_client_get_cert_info(handle);
+        CERT_INFO_HANDLE cert_info = iface->hsm_client_get_cert_info(handle);
 
         // assert
-        ASSERT_IS_NOT_NULL(cert_info, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(cert_info, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
     }
 
@@ -813,9 +810,9 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
 
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
-        HSM_CLIENT_CREATE handle = interface->hsm_client_x509_create();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
+        HSM_CLIENT_CREATE handle = iface->hsm_client_x509_create();
 
         size_t failed_function_size = MAX_FAILED_FUNCTION_LIST_SIZE;
         char failed_function_list[MAX_FAILED_FUNCTION_LIST_SIZE];
@@ -830,15 +827,15 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
             if (failed_function_list[i] == 1)
             {
                 // act
-                CERT_INFO_HANDLE cert_info = interface->hsm_client_get_cert_info(handle);
+                CERT_INFO_HANDLE cert_info = iface->hsm_client_get_cert_info(handle);
 
                 // assert
-                ASSERT_IS_NULL(cert_info, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(cert_info, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
         umock_c_negative_tests_deinit();
     }
@@ -852,20 +849,20 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
-        HSM_CLIENT_CREATE handle = interface->hsm_client_x509_create();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
+        HSM_CLIENT_CREATE handle = iface->hsm_client_x509_create();
         umock_c_reset_all_calls();
 
         // act
-        char *result = interface->hsm_client_get_cert(handle);
+        char *result = iface->hsm_client_get_cert(handle);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
     }
 
@@ -878,20 +875,20 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
-        HSM_CLIENT_CREATE handle = interface->hsm_client_x509_create();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
+        HSM_CLIENT_CREATE handle = iface->hsm_client_x509_create();
         umock_c_reset_all_calls();
 
         // act
-        char *result = interface->hsm_client_get_key(handle);
+        char *result = iface->hsm_client_get_key(handle);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
     }
 
@@ -904,20 +901,20 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
-        HSM_CLIENT_CREATE handle = interface->hsm_client_x509_create();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
+        HSM_CLIENT_CREATE handle = iface->hsm_client_x509_create();
         umock_c_reset_all_calls();
 
         // act
-        char *result = interface->hsm_client_get_common_name(handle);
+        char *result = iface->hsm_client_get_common_name(handle);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
     }
 
@@ -929,22 +926,22 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
     TEST_FUNCTION(hsm_client_crypto_sign_with_private_key_invalid_param_does_nothing)
     {
         //arrange
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
         unsigned char data[3] = {'0', '0', '0'};
         unsigned char *digest = NULL;
         size_t digest_size = 0;
         umock_c_reset_all_calls();
 
         // act
-        int result = interface->hsm_client_sign_with_private_key(NULL,
+        int result = iface->hsm_client_sign_with_private_key(NULL,
                                                                  data,
                                                                  sizeof(data),
                                                                  &digest,
                                                                  &digest_size);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }
@@ -958,9 +955,9 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         //arrange
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
-        HSM_CLIENT_CREATE handle = interface->hsm_client_x509_create();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
+        HSM_CLIENT_CREATE handle = iface->hsm_client_x509_create();
         unsigned char data[3] = {'0', '0', '0'};
         unsigned char *digest = NULL;
         size_t digest_size = 0;
@@ -970,18 +967,18 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
         test_helper_setup_sign_with_private_key_callstack(handle, failed_function_list, failed_function_size);
 
         // act
-        int result = interface->hsm_client_sign_with_private_key(handle,
+        int result = iface->hsm_client_sign_with_private_key(handle,
                                                                  data,
                                                                  sizeof(data),
                                                                  &digest,
                                                                  &digest_size);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
     }
 
@@ -998,9 +995,9 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
 
         int status;
         status = hsm_client_x509_init(TEST_VALIDITY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        const HSM_CLIENT_X509_INTERFACE* interface = hsm_client_x509_interface();
-        HSM_CLIENT_CREATE handle = interface->hsm_client_x509_create();
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        const HSM_CLIENT_X509_INTERFACE* iface = hsm_client_x509_interface();
+        HSM_CLIENT_CREATE handle = iface->hsm_client_x509_create();
 
         size_t failed_function_size = MAX_FAILED_FUNCTION_LIST_SIZE;
         char failed_function_list[MAX_FAILED_FUNCTION_LIST_SIZE];
@@ -1019,19 +1016,19 @@ BEGIN_TEST_SUITE(edge_hsm_x509_unittests)
             if (failed_function_list[i] == 1)
             {
                 // act
-                int result = interface->hsm_client_sign_with_private_key(handle,
+                int result = iface->hsm_client_sign_with_private_key(handle,
                                                                         data,
                                                                         sizeof(data),
                                                                         &digest,
                                                                         &digest_size);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
         //cleanup
-        interface->hsm_client_x509_destroy(handle);
+        iface->hsm_client_x509_destroy(handle);
         hsm_client_x509_deinit();
         umock_c_negative_tests_deinit();
     }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_common_ut/edge_openssl_common_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_common_ut/edge_openssl_common_ut.c
@@ -59,7 +59,6 @@ MOCKABLE_FUNCTION(, void, mocked_ERR_load_crypto_strings);
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 //#############################################################################
 // Mocked functions test hooks
@@ -96,7 +95,6 @@ BEGIN_TEST_SUITE(edge_openssl_common_ut)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -113,7 +111,6 @@ BEGIN_TEST_SUITE(edge_openssl_common_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -146,7 +143,7 @@ BEGIN_TEST_SUITE(edge_openssl_common_ut)
         initialize_openssl();
 
         // assert 1
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         umock_c_reset_all_calls();
 
@@ -154,7 +151,7 @@ BEGIN_TEST_SUITE(edge_openssl_common_ut)
         initialize_openssl();
 
         // assert 2
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_int/edge_openssl_enc_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_int/edge_openssl_enc_int.c
@@ -25,7 +25,6 @@
 //#############################################################################
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 static char* TEST_IOTEDGE_HOMEDIR = NULL;
 static char* TEST_IOTEDGE_HOMEDIR_GUID = NULL;
@@ -103,8 +102,8 @@ size_t TEST_CIPHER_SIZE = sizeof(TEST_CIPHER);
 static void test_helper_setup_homedir(void)
 {
     TEST_IOTEDGE_HOMEDIR = hsm_test_util_create_temp_dir(&TEST_IOTEDGE_HOMEDIR_GUID);
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR_GUID, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(TEST_IOTEDGE_HOMEDIR, "Line:" MU_TOSTRING(__LINE__));
 
     printf("Temp dir created: [%s]\r\n", TEST_IOTEDGE_HOMEDIR);
     hsm_test_util_setenv("IOTEDGE_HOMEDIR", TEST_IOTEDGE_HOMEDIR);
@@ -131,7 +130,6 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
         test_helper_setup_homedir();
@@ -141,7 +139,6 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
     {
         test_helper_teardown_homedir();
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -162,7 +159,7 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -171,19 +168,19 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
 
         // act, assert (encrypt)
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, (TEST_STRING_SIZE + TEST_CIPHERTEXT_HEADER_SIZE), ciphertext_result.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char, TEST_VERSION, ciphertext_result.buffer[0], "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, (TEST_STRING_SIZE + TEST_CIPHERTEXT_HEADER_SIZE), ciphertext_result.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char, TEST_VERSION, ciphertext_result.buffer[0], "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(ciphertext_result.buffer + TEST_TAG_OFFSET, TEST_TAG, TEST_TAG_SIZE);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(ciphertext_result.buffer + TEST_CIPHERTEXT_OFFSET, TEST_CIPHER, TEST_CIPHER_SIZE);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // act, assert (decrypt)
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(plaintext_result.buffer, TEST_STRING, TEST_STRING_SIZE);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -196,7 +193,7 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER id2 = {TEST_ID_2, TEST_ID_2_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
@@ -204,13 +201,13 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // act
         status = key_decrypt(key_handle, &id2, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -222,22 +219,22 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         // corrupt tag bits
         ciphertext_result.buffer[TEST_TAG_OFFSET] ^= 1;
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -249,22 +246,22 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         // corrupt data bit
         ciphertext_result.buffer[TEST_CIPHERTEXT_OFFSET] ^= 1;
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -276,7 +273,7 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         unsigned char data[] = {'a'};
         size_t data_size = sizeof(data);
@@ -289,8 +286,8 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, (TEST_CIPHERTEXT_HEADER_SIZE + data_size), ciphertext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, (TEST_CIPHERTEXT_HEADER_SIZE + data_size), ciphertext_result.size, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -302,7 +299,7 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         unsigned char data[] = {'a'};
         size_t data_size = sizeof(data);
@@ -311,16 +308,16 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, data_size, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, data_size, plaintext_result.size, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(data, plaintext_result.buffer, plaintext_result.size);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(plaintext_result.buffer);
@@ -333,11 +330,11 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         size_t data_size = 2048;
         unsigned char *data = malloc(data_size);
-        ASSERT_IS_NOT_NULL(data, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(data, "Line:" MU_TOSTRING(__LINE__));
         memset(data, 0xDE, data_size);
         SIZED_BUFFER plaintext = {data, data_size};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -348,8 +345,8 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_HEADER_SIZE + data_size, ciphertext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_HEADER_SIZE + data_size, ciphertext_result.size, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -362,27 +359,27 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         size_t data_size = 2048;
         unsigned char *data = malloc(data_size);
-        ASSERT_IS_NOT_NULL(data, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(data, "Line:" MU_TOSTRING(__LINE__));
         memset(data, 0xDE, data_size);
         SIZED_BUFFER plaintext = {data, data_size};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, data_size, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, data_size, plaintext_result.size, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(data, plaintext_result.buffer, plaintext_result.size);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(plaintext_result.buffer);
@@ -396,23 +393,23 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV_LARGE, TEST_IV_LARGE_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // act
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, TEST_STRING_SIZE, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_STRING_SIZE, plaintext_result.size, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(TEST_STRING, plaintext_result.buffer, plaintext_result.size);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(plaintext_result.buffer);
@@ -425,14 +422,14 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         // arrange
         int status;
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, TEST_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_ID_1, TEST_ID_1_SIZE};
         SIZED_BUFFER plaintext = {TEST_STRING, TEST_STRING_SIZE};
         SIZED_BUFFER iv = {TEST_IV_LARGE, TEST_IV_LARGE_SIZE};
         SIZED_BUFFER ciphertext_result = {NULL, 0};
         SIZED_BUFFER plaintext_result = {NULL, 0};
         status = key_encrypt(key_handle, &id, &plaintext, &iv, &ciphertext_result);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         // corrupt one bit in the iv
         iv.buffer[iv.size - 1] ^= 1;
 
@@ -440,9 +437,9 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         status = key_decrypt(key_handle, &id, &ciphertext_result, &iv, &plaintext_result);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(plaintext_result.buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, plaintext_result.size, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ciphertext_result.buffer);
@@ -460,17 +457,17 @@ BEGIN_TEST_SUITE(edge_openssl_enc_tests)
         status = generate_encryption_key(&key1, &key1_size);
 
         // assert 1
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key1_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key1_size, "Line:" MU_TOSTRING(__LINE__));
 
         // act 2
         status = generate_encryption_key(&key2, &key2_size);
 
         // assert 2
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key2_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key2_size, "Line:" MU_TOSTRING(__LINE__));
         status = memcmp(key1, key2, ENCRYPTION_KEY_SIZE);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(key1);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_ut/edge_openssl_enc_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_enc_ut/edge_openssl_enc_ut.c
@@ -85,7 +85,6 @@ static unsigned char TEST_KEY[ENCRYPTION_KEY_SIZE] = {
     0, 1
 };
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 #define TEST_VERSION_SIZE 1
 #define TEST_TAG_SIZE 16
@@ -338,7 +337,6 @@ static uint64_t test_stack_helper_decrypt(void)
 BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -399,7 +397,6 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -431,13 +428,13 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         // act, assert
         key_size = 10;
         status = generate_encryption_key(NULL, &key_size);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, key_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, key_size, "Line:" MU_TOSTRING(__LINE__));
 
         key = (unsigned char*)0x1000;
         status = generate_encryption_key(&key, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(key, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -461,10 +458,10 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         status = generate_encryption_key(&key, &key_size);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(key, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, ENCRYPTION_KEY_SIZE, key_size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         gballoc_free(key);
@@ -501,9 +498,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
                status = generate_encryption_key(&key, &key_size);
 
                // assert
-               ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-               ASSERT_IS_NULL(key, "Line:" TOSTRING(__LINE__));
-               ASSERT_ARE_EQUAL(size_t, 0, key_size, "Line:" TOSTRING(__LINE__));
+               ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+               ASSERT_IS_NULL(key, "Line:" MU_TOSTRING(__LINE__));
+               ASSERT_ARE_EQUAL(size_t, 0, key_size, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -523,16 +520,16 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
 
         // act, assert
         key_handle = create_encryption_key(NULL, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
 
         key_handle = create_encryption_key(key, 0);
-        ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
 
         key_handle = create_encryption_key(key, ENCRYPTION_KEY_SIZE - 1);
-        ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
 
         key_handle = create_encryption_key(key, ENCRYPTION_KEY_SIZE + 1);
-        ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -553,8 +550,8 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
 
         // assert
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(key_handle);
@@ -586,7 +583,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
             key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
 
             // assert
-            ASSERT_IS_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         }
 
         //cleanup
@@ -601,7 +598,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         umock_c_reset_all_calls();
 
         EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
@@ -611,7 +608,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         key_destroy(key_handle);
 
         // assert
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -623,7 +620,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     TEST_FUNCTION(key_encrypt_invalid_params)
     {
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER pt = {TEST_PLAINTEXT, TEST_PLAINTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -637,69 +634,69 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         // act, assert
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, NULL, &pt, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &inv1, &pt, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &inv2, &pt, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, NULL, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &inv1, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         inv_pt_size.size = 0;
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &inv_pt_size, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         inv_pt_size.size = INT_MAX - TEST_CIPHERTEXT_HEADER_SIZE + 1;
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &inv_pt_size, &iv, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &pt, NULL, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &pt, &inv1, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &pt, &inv2, &ct);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         ct.size = 10; ct.buffer = (unsigned char*)0xA000;
         status = key_encrypt(key_handle, &id, &pt, &iv, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(key_handle);
@@ -713,7 +710,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER pt = {TEST_PLAINTEXT, TEST_PLAINTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -727,10 +724,10 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         status = key_encrypt(key_handle, &id, &pt, &iv, &ct);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_HEADER_SIZE+TEST_PLAINTEXT_SIZE, ct.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_HEADER_SIZE+TEST_PLAINTEXT_SIZE, ct.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(ct.buffer);
@@ -747,7 +744,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         int test_result = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, test_result);
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER pt = {TEST_PLAINTEXT, TEST_PLAINTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -767,9 +764,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
                 int status = key_encrypt(key_handle, &id, &pt, &iv, &ct);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-                ASSERT_IS_NULL(ct.buffer, "Line:" TOSTRING(__LINE__));
-                ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+                ASSERT_IS_NULL(ct.buffer, "Line:" MU_TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(size_t, 0, ct.size, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -785,7 +782,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     TEST_FUNCTION(key_decrypt_invalid_params)
     {
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER ct = {TEST_CIPHERTEXT, TEST_CIPHERTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -800,97 +797,97 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         // act, assert
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, NULL, &ct, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &inv1, &ct, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &inv2, &ct, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, NULL, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv1, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         inv_ct_size.size = 0;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_size, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         inv_ct_size.size = TEST_CIPHERTEXT_HEADER_SIZE - 1;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_size, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         inv_ct_size.size = TEST_CIPHERTEXT_HEADER_SIZE;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_size, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         inv_ct_size.size = ((size_t)INT_MAX + 1);
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_size, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         inv_ct_version.buffer[0] = 0;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_version, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         inv_ct_version.buffer[0] = 2;
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &inv_ct_version, &iv, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &ct, NULL, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &ct, &inv1, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &ct, &inv2, &pt);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
 
         pt.size = 10; pt.buffer = (unsigned char*)0xA000;
         status = key_decrypt(key_handle, &id, &ct, &iv, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(key_handle);
@@ -904,7 +901,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER ct = {TEST_CIPHERTEXT, TEST_CIPHERTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -918,10 +915,10 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         status = key_decrypt(key_handle, &id, &ct, &iv, &pt);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_SIZE-TEST_CIPHERTEXT_HEADER_SIZE, pt.size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NOT_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, TEST_CIPHERTEXT_SIZE-TEST_CIPHERTEXT_HEADER_SIZE, pt.size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(pt.buffer);
@@ -938,7 +935,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         int test_result = umock_c_negative_tests_init();
         ASSERT_ARE_EQUAL(int, 0, test_result);
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         SIZED_BUFFER id = {TEST_IDENTITY, TEST_IDENTITY_SIZE};
         SIZED_BUFFER ct = {TEST_CIPHERTEXT, TEST_CIPHERTEXT_SIZE};
         SIZED_BUFFER iv = {TEST_IV, TEST_IV_SIZE};
@@ -958,9 +955,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
                 int status = key_decrypt(key_handle, &id, &ct, &iv, &pt);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-                ASSERT_IS_NULL(pt.buffer, "Line:" TOSTRING(__LINE__));
-                ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+                ASSERT_IS_NULL(pt.buffer, "Line:" MU_TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(size_t, 0, pt.size, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -977,7 +974,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         unsigned char TBS[] = "data";
         unsigned char *output = (unsigned char*)0x1000;
         size_t output_size = 1234;
@@ -986,9 +983,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
         int status = key_sign(key_handle, TBS, sizeof(TBS), &output, &output_size);
 
         // arrange
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(output, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(output, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         key_destroy(key_handle);
@@ -1002,7 +999,7 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
     {
         // arrange
         KEY_HANDLE key_handle = create_encryption_key(TEST_KEY, ENCRYPTION_KEY_SIZE);
-        ASSERT_IS_NOT_NULL(key_handle, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "Line:" MU_TOSTRING(__LINE__));
         unsigned char TBS[] = "data";
         unsigned char *output = (unsigned char*)0x1000;
         size_t output_size = 1234;
@@ -1013,9 +1010,9 @@ BEGIN_TEST_SUITE(edge_openssl_encryption_unittests)
                                          &output, &output_size);
 
         // arrange
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(output, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, output_size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(output, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         key_destroy(key_handle);

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_int/edge_openssl_int.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_int/edge_openssl_int.c
@@ -34,7 +34,6 @@
 //#############################################################################
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 static char* TEST_IOTEDGE_HOMEDIR = NULL;
 static char* TEST_IOTEDGE_HOMEDIR_GUID = NULL;
@@ -181,8 +180,8 @@ static void test_helper_setup_temp_dir(char **pp_temp_dir, char **pp_temp_dir_gu
 {
     char *temp_dir, *guid;
     temp_dir = hsm_test_util_create_temp_dir(&guid);
-    ASSERT_IS_NOT_NULL(guid, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(temp_dir, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(guid, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(temp_dir, "Line:" MU_TOSTRING(__LINE__));
     printf("Temp dir created: [%s]\r\n", temp_dir);
     *pp_temp_dir = temp_dir;
     *pp_temp_dir_guid = guid;
@@ -190,13 +189,13 @@ static void test_helper_setup_temp_dir(char **pp_temp_dir, char **pp_temp_dir_gu
 
 static void test_helper_teardown_temp_dir(char **pp_temp_dir, char **pp_temp_dir_guid)
 {
-    ASSERT_IS_NOT_NULL(pp_temp_dir, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(pp_temp_dir_guid, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(pp_temp_dir, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(pp_temp_dir_guid, "Line:" MU_TOSTRING(__LINE__));
 
     char *temp_dir = *pp_temp_dir;
     char *guid = *pp_temp_dir_guid;
-    ASSERT_IS_NOT_NULL(temp_dir, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_NOT_NULL(guid, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(temp_dir, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(guid, "Line:" MU_TOSTRING(__LINE__));
 
     hsm_test_util_delete_dir(guid);
     free(temp_dir);
@@ -209,9 +208,9 @@ static char* prepare_file_path(const char* base_dir, const char* file_name)
 {
     size_t path_size = get_max_file_path_size();
     char *file_path = calloc(path_size, 1);
-    ASSERT_IS_NOT_NULL(file_path, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(file_path, "Line:" MU_TOSTRING(__LINE__));
     int status = snprintf(file_path, path_size, "%s%s", base_dir, file_name);
-    ASSERT_IS_TRUE(((status > 0) || (status < (int)path_size)), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < (int)path_size)), "Line:" MU_TOSTRING(__LINE__));
 
     return file_path;
 }
@@ -233,7 +232,7 @@ static CERT_PROPS_HANDLE test_helper_create_certificate_props
 )
 {
     CERT_PROPS_HANDLE cert_props_handle = cert_properties_create();
-    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cert_props_handle, "Line:" MU_TOSTRING(__LINE__));
     set_validity_seconds(cert_props_handle, validity);
     set_common_name(cert_props_handle, common_name);
     set_country_name(cert_props_handle, "US");
@@ -265,7 +264,7 @@ static void test_helper_generate_pki_certificate
                                            cert_file,
                                            issuer_private_key_file,
                                            issuer_cert_file);
-    ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 }
 
 static void test_helper_generate_self_signed
@@ -284,7 +283,7 @@ static void test_helper_generate_self_signed
                                                       private_key_file,
                                                       cert_file,
                                                       key_props);
-    ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 }
 
 void test_helper_server_chain_validator(const PKI_KEY_PROPS *key_props)
@@ -339,21 +338,21 @@ void test_helper_server_chain_validator(const PKI_KEY_PROPS *key_props)
     // assert
     bool cert_verified = false;
     int status = verify_certificate(TEST_CA_CERT_RSA_FILE_2, TEST_CA_PK_RSA_FILE_2, TEST_CA_CERT_RSA_FILE_1, &cert_verified);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_TRUE(cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(cert_verified, "Line:" MU_TOSTRING(__LINE__));
     cert_verified = false;
     status = verify_certificate(TEST_SERVER_CERT_RSA_FILE_3, TEST_SERVER_PK_RSA_FILE_3, TEST_CA_CERT_RSA_FILE_2, &cert_verified);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_TRUE(cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(cert_verified, "Line:" MU_TOSTRING(__LINE__));
     cert_verified = false;
     status = verify_certificate(TEST_SERVER_CERT_RSA_FILE_3, TEST_SERVER_PK_RSA_FILE_3, TEST_SERVER_CERT_RSA_FILE_3, &cert_verified);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_TRUE(cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(cert_verified, "Line:" MU_TOSTRING(__LINE__));
     cert_verified = false;
     status = verify_certificate(TEST_SERVER_CERT_RSA_FILE_3, TEST_SERVER_PK_RSA_FILE_3, TEST_CA_CERT_RSA_FILE_1, &cert_verified);
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-    ASSERT_IS_FALSE(cert_verified, "Line:" TOSTRING(__LINE__));
-    ASSERT_ARE_EQUAL(int, 0, cert_verified, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_IS_FALSE(cert_verified, "Line:" MU_TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, cert_verified, "Line:" MU_TOSTRING(__LINE__));
 
     // cleanup
     delete_file(TEST_SERVER_PK_RSA_FILE_3);
@@ -370,11 +369,11 @@ void test_helper_server_chain_validator(const PKI_KEY_PROPS *key_props)
 static X509* test_helper_load_certificate_file(const char* cert_file_name)
 {
     BIO* cert_file = BIO_new_file(cert_file_name, "rb");
-    ASSERT_IS_NOT_NULL(cert_file, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cert_file, "Line:" MU_TOSTRING(__LINE__));
     X509* x509_cert = PEM_read_bio_X509(cert_file, NULL, NULL, NULL);
     // make sure the file is closed before asserting below
     BIO_free_all(cert_file);
-    ASSERT_IS_NOT_NULL(x509_cert, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(x509_cert, "Line:" MU_TOSTRING(__LINE__));
     return x509_cert;
 }
 
@@ -410,10 +409,10 @@ static void test_helper_validate_extension
         X509_EXTENSION *ext;
 
         ext = sk_X509_EXTENSION_value(ext_list, ext_idx);
-        ASSERT_IS_NOT_NULL(ext, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(ext, "Line:" MU_TOSTRING(__LINE__));
 
         obj = X509_EXTENSION_get_object(ext);
-        ASSERT_IS_NOT_NULL(obj, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(obj, "Line:" MU_TOSTRING(__LINE__));
 
         memset(output_buffer, 0, MAX_X509_EXT_SIZE);
         sz = i2t_ASN1_OBJECT(output_buffer, MAX_X509_EXT_SIZE, obj);
@@ -428,14 +427,14 @@ static void test_helper_validate_extension
             printf("\r\nTesting Extension Contents: [%s]\r\n", output_buffer);
 
             BIO *mem_bio = BIO_new(BIO_s_mem());
-            ASSERT_IS_NOT_NULL(mem_bio, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(mem_bio, "Line:" MU_TOSTRING(__LINE__));
             // print the extension contents into the mem_bio
             X509V3_EXT_print(mem_bio, ext, 0, 0);
             sz = BIO_get_mem_data(mem_bio, &memst);
-            ASSERT_IS_TRUE((sz > 0), "Line:" TOSTRING(__LINE__));
-            ASSERT_IS_NOT_NULL(memst, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_TRUE((sz > 0), "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(memst, "Line:" MU_TOSTRING(__LINE__));
             char *output_str = calloc(sz + 1, 1);
-            ASSERT_IS_NOT_NULL(output_str, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NOT_NULL(output_str, "Line:" MU_TOSTRING(__LINE__));
             memcpy(output_str, memst, sz);
             printf("\r\n Obtained Extension value from cert. Size:[%ld] Data:[%s]", sz, output_str);
             for (size_t idx = 0; idx < num_expted_vals; idx++)
@@ -496,7 +495,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_key_usage_vals_size = 2;
         expected_key_usage_vals = calloc(expected_key_usage_vals_size, sizeof(SIZED_BUFFER));
-        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" MU_TOSTRING(__LINE__));
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_DIG_SIG;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_KEY_CERT_SIGN;
 
@@ -509,7 +508,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_key_usage_vals_size = 4;
         expected_key_usage_vals = calloc(expected_key_usage_vals_size, sizeof(void*));
-        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" MU_TOSTRING(__LINE__));
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_DIG_SIG;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_NON_REPUDIATION;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_KEY_ENCIPHER;
@@ -518,7 +517,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_ext_key_usage_vals_size = 1;
         expected_ext_key_usage_vals = calloc(expected_ext_key_usage_vals_size, sizeof(void*));
-        ASSERT_IS_NOT_NULL(expected_ext_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_ext_key_usage_vals, "Line:" MU_TOSTRING(__LINE__));
         expected_ext_key_usage_vals[idx++] = TEST_X509_KEY_EXT_USAGE_CLIENT_AUTH;
     }
     else
@@ -526,7 +525,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_key_usage_vals_size = 5;
         expected_key_usage_vals = calloc(expected_key_usage_vals_size, sizeof(void*));
-        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_key_usage_vals, "Line:" MU_TOSTRING(__LINE__));
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_DIG_SIG;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_NON_REPUDIATION;
         expected_key_usage_vals[idx++] = TEST_X509_KEY_USAGE_KEY_ENCIPHER;
@@ -536,7 +535,7 @@ static void test_helper_validate_all_x509_extensions
         idx = 0;
         expected_ext_key_usage_vals_size = 1;
         expected_ext_key_usage_vals = calloc(expected_ext_key_usage_vals_size, sizeof(SIZED_BUFFER));
-        ASSERT_IS_NOT_NULL(expected_ext_key_usage_vals, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(expected_ext_key_usage_vals, "Line:" MU_TOSTRING(__LINE__));
         expected_ext_key_usage_vals[idx++] = TEST_X509_KEY_EXT_USAGE_SERVER_AUTH;
     }
     X509* cert = test_helper_load_certificate_file(cert_file_path);
@@ -593,13 +592,13 @@ void test_helper_x509_ext_validator(const PKI_KEY_PROPS *key_props)
     const char* server_san_list[] = {"URI:edgetest://server/test1", "DNS:test.contoso.com"};
     const char* client_san_list[] = {"URI:edgetest://client/test2", "email:test@contoso.com"};
     status = set_san_entries(ca_root_handle, ca_san_list, sizeof(ca_san_list)/sizeof(ca_san_list[0]));
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     status = set_san_entries(int_ca_root_handle, int_ca_san_list, sizeof(int_ca_san_list)/sizeof(int_ca_san_list[0]));
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     status = set_san_entries(server_root_handle, server_san_list, sizeof(server_san_list)/sizeof(server_san_list[0]));
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     status = set_san_entries(client_root_handle, client_san_list, sizeof(client_san_list)/sizeof(client_san_list[0]));
-    ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
     // act
     test_helper_generate_self_signed(ca_root_handle,
@@ -662,7 +661,6 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
         test_helper_setup_homedir();
@@ -696,11 +694,11 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
 
         TEST_RSA_PRIVATE_KEY_FILE = prepare_file_path(TEST_TEMP_DIR, TEST_RSA_PRIVATE_KEY_FILE_NAME);
         int status = write_cstring_to_file(TEST_RSA_PRIVATE_KEY_FILE, TEST_RSA_ASYMMETRIC_PRIVATE_KEY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         TEST_RSA_PUBLIC_KEY_FILE = prepare_file_path(TEST_TEMP_DIR, TEST_RSA_PUBLIC_KEY_FILE_NAME);
         status = write_cstring_to_file(TEST_RSA_PUBLIC_KEY_FILE, TEST_RSA_ASYMMETRIC_PUBLIC_KEY);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
     }
 
     TEST_SUITE_CLEANUP(TestClassCleanup)
@@ -737,7 +735,6 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
         test_helper_teardown_temp_dir(&TEST_TEMP_DIR, &TEST_TEMP_DIR_GUID);
         test_helper_teardown_temp_dir(&TEST_IOTEDGE_HOMEDIR, &TEST_IOTEDGE_HOMEDIR_GUID);
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -826,7 +823,7 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
                                                           TEST_SERVER_CERT_RSA_FILE_1,
                                                           &key_props);
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         cert_properties_destroy(cert_props_handle);
@@ -1030,10 +1027,10 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
         int result = key_sign(key_handle, (unsigned char*)tbs, tbs_size, &digest, &digest_size);
 
         // assert
-        ASSERT_IS_NOT_NULL(digest, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, HMAC_SHA256_DIGEST_LEN, digest_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, HMAC_SHA256_DIGEST_LEN, digest_size, "Line:" MU_TOSTRING(__LINE__));
         output_b64 = Azure_Base64_Encode_Bytes(digest, digest_size);
-        ASSERT_ARE_EQUAL(int, 0, strcmp(expected_base64_sig, STRING_c_str(output_b64)), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, strcmp(expected_base64_sig, STRING_c_str(output_b64)), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(digest);
@@ -1055,13 +1052,13 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
         int result = generate_rand_buffer(output_buffer, buffer_sz);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         // if this assertion fails it implies that the call to generate_rand_buffer
         // never updated the buffer and yet returned a success OR
         // the statistically improbable event occured that the random bytes returned
         // exactly what the unexpected_buffer of size N was setup with
         // P(test failure) = P(0xF1) * P(0xF1) * ... * P(0xF1) = ((1/256) ^ N) == very small
-        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, buffer_sz), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, buffer_sz), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }
@@ -1080,13 +1077,13 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
         int result = generate_rand_buffer(output_buffer, buffer_sz);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         // if this assertion fails it implies that the call to generate_rand_buffer
         // never updated the buffer and yet returned a success OR
         // the statistically improbable event occured that the random bytes returned
         // exactly what the unexpected_buffer of size N was setup with
         // P(test failure) = P(0xF1) * P(0xF1) * ... * P(0xF1) = ((1/256) ^ N) == very small
-        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, buffer_sz), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, buffer_sz), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }
@@ -1105,13 +1102,13 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
         int result = generate_rand_buffer(output_buffer, buffer_sz);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         // if this assertion fails it implies that the call to generate_rand_buffer
         // never updated the buffer and yet returned a success OR
         // the statistically improbable event occured that the random bytes returned
         // exactly what the unexpected_buffer of size N was setup with
         // P(test failure) = P(0xF1) * P(0xF1) * ... * P(0xF1) = ((1/256) ^ N) == very small
-        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, buffer_sz), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(unexpected_buffer, output_buffer, buffer_sz), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }
@@ -1132,14 +1129,14 @@ BEGIN_TEST_SUITE(edge_openssl_int_tests)
         result_2 = generate_rand_buffer(output_buffer_2, buffer_sz);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result_1, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, 0, result_2, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result_1, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result_2, "Line:" MU_TOSTRING(__LINE__));
         // if this assertion fails it implies that the call to generate_rand_buffer
         // never updated the buffer and yet returned a success OR
         // the statistically improbable event occured that the random bytes returned
         // exactly what the output_buffer_2 of size N was setup with
         // P(test failure) = P(0xF1) * P(0xF1) * ... * P(0xF1) = ((1/256) ^ N) == very small
-        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(output_buffer_1, output_buffer_2, buffer_sz), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, memcmp(output_buffer_1, output_buffer_2, buffer_sz), "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
     }

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/edge_openssl_pki_ut/edge_openssl_pki_ut.c
@@ -201,7 +201,6 @@ MOCKABLE_FUNCTION(, int, RAND_bytes, unsigned char*, buf, int, num);
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 #define MAX_FAILED_FUNCTION_LIST_SIZE 128
 
@@ -717,7 +716,7 @@ static void* test_hook_read_file_into_buffer
     size_t test_data_len = strlen(TEST_ISSUER_CERT_DATA);
     size_t test_data_size = test_data_len + 1;
     void *data = test_hook_gballoc_malloc(test_data_size);
-    ASSERT_IS_NOT_NULL(data, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(data, "Line:" MU_TOSTRING(__LINE__));
     memset(data, 0, test_data_size);
     memcpy(data, TEST_ISSUER_CERT_DATA, test_data_len);
     if (output_buffer_size) *output_buffer_size = test_data_size;
@@ -1244,7 +1243,7 @@ static char *test_helper_strdup(const char *s)
     size_t len = strlen(s);
     size_t size = len + 1;
     char *result = test_hook_gballoc_malloc(size);
-    ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
     memset(result, 0, size);
     strcpy(result, s);
     return result;
@@ -1255,35 +1254,35 @@ void test_helper_generate_rsa_key(int key_len, size_t *index, char *failed_funct
     size_t i = *index;
 
     EXPECTED_CALL(EVP_PKEY_new());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(BN_new());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(BN_set_word(TEST_BIGNUM, RSA_F4));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(RSA_new());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(RSA_generate_key_ex(TEST_RSA, key_len, TEST_BIGNUM, NULL));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_PKEY_set1_RSA(TEST_EVP_KEY, TEST_RSA));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(RSA_free(TEST_RSA));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(BN_free(TEST_BIGNUM));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     *index = i;
@@ -1296,59 +1295,59 @@ void test_helper_generate_ecc_key(bool is_self_signed, size_t *index, char *fail
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(EVP_PKEY_get1_EC_KEY(TEST_ISSUER_PUB_KEY));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(EC_KEY_get0_group(TEST_EC_PUB_KEY));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(EC_GROUP_get_curve_name(TEST_PUB_GROUP));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(OBJ_nid2sn(TEST_CURVE_NAME_ID));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(EVP_PKEY_bits(TEST_ISSUER_PUB_KEY));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
     // generate_ecc_key
     STRICT_EXPECTED_CALL(OBJ_txt2nid(TEST_CURVE_NAME));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(EC_KEY_new_by_curve_name(TEST_ECC_GROUP));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EC_KEY_set_asn1_flag(TEST_EC_KEY, OPENSSL_EC_NAMED_CURVE));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(EC_KEY_generate_key(TEST_EC_KEY));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(EVP_PKEY_new());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_PKEY_set1_EC_KEY(TEST_EVP_KEY, TEST_EC_KEY));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EC_KEY_free(TEST_EC_KEY));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(EC_KEY_free(TEST_EC_PUB_KEY));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
@@ -1382,53 +1381,53 @@ static void test_helper_cert_create_with_subject
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(initialize_openssl());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(get_validity_seconds(TEST_CERT_PROPS_HANDLE));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(get_common_name(TEST_CERT_PROPS_HANDLE));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(get_certificate_type(TEST_CERT_PROPS_HANDLE)).SetReturn(cert_type);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(BIO_new_file(TEST_ISSUER_CERT_FILE, "rb"));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(PEM_read_bio_X509(TEST_BIO, NULL, NULL, NULL)).SetReturn(TEST_ISSUER_X509);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(BIO_new_file(TEST_ISSUER_KEY_FILE, "rb"));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(PEM_read_bio_PrivateKey(TEST_BIO, NULL, NULL, NULL)).SetReturn(TEST_ISSUER_EVP_KEY);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_get_pubkey(TEST_ISSUER_X509)).SetReturn(TEST_ISSUER_PUB_KEY);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(EVP_PKEY_base_id(TEST_ISSUER_PUB_KEY)).SetReturn(key_type);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
@@ -1444,134 +1443,134 @@ static void test_helper_cert_create_with_subject
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(EVP_PKEY_free(TEST_ISSUER_PUB_KEY));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
     if (test_helper_is_windows())
     {
         STRICT_EXPECTED_CALL(BIO_new_file(TEST_KEY_FILE, "wb")).SetReturn(TEST_BIO_WRITE_KEY);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     else
     {
         STRICT_EXPECTED_CALL(mocked_OPEN(TEST_KEY_FILE, EXPECTED_CREATE_FLAGS, EXPECTED_MODE_FLAGS)).SetReturn(TEST_WRITE_PRIVATE_KEY_FD);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BIO_new_fd(TEST_WRITE_PRIVATE_KEY_FD, 0)).SetReturn(TEST_BIO_WRITE_KEY);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     STRICT_EXPECTED_CALL(PEM_write_bio_PrivateKey(TEST_BIO_WRITE_KEY, TEST_EVP_KEY, NULL, NULL, 0, NULL, NULL));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO_WRITE_KEY));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if (!test_helper_is_windows())
     {
         STRICT_EXPECTED_CALL(mocked_CLOSE(TEST_WRITE_PRIVATE_KEY_FD));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(X509_new());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_set_version(TEST_X509, 0x2));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_get_serialNumber(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(ASN1_INTEGER_set(TEST_ASN1_SERIAL_NUM, TEST_SERIAL_NUMBER));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_set_pubkey(TEST_X509, TEST_EVP_KEY));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(mocked_X509_get_notBefore(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_gmtime_adj(&TEST_ASN1_TIME_BEFORE, 0));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(mocked_X509_get_notAfter(TEST_ISSUER_X509));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(get_utc_time_from_asn_string(TEST_ASN1_TIME_AFTER.data, VALID_ASN1_TIME_STRING_UTC_LEN));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     STRICT_EXPECTED_CALL(mocked_X509_get_notAfter(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_gmtime_adj(&TEST_ASN1_TIME_AFTER, TEST_UTC_TIME_FROM_ASN1));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     if (cert_type == CERTIFICATE_TYPE_CA)
     {
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_new()).SetReturn(&TEST_CA_BASIC_CONSTRAINTS);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(ASN1_INTEGER_new());
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(ASN1_INTEGER_set(TEST_ASN1_INTEGER, TEST_PATH_LEN_CA));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(X509_add1_ext_i2d(TEST_X509, NID_basic_constraints, &TEST_CA_BASIC_CONSTRAINTS, 1, X509V3_ADD_DEFAULT));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_free(&TEST_CA_BASIC_CONSTRAINTS));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
     else
     {
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_new()).SetReturn(&TEST_NON_CA_BASIC_CONSTRAINTS);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(X509_add1_ext_i2d(TEST_X509, NID_basic_constraints, &TEST_NON_CA_BASIC_CONSTRAINTS, 0, X509V3_ADD_DEFAULT));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BASIC_CONSTRAINTS_free(&TEST_NON_CA_BASIC_CONSTRAINTS));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
     if (cert_type == CERTIFICATE_TYPE_CA)
     {
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, digitalSignature, keyCertSign"));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1580,22 +1579,22 @@ static void test_helper_cert_create_with_subject
     else if (cert_type == CERTIFICATE_TYPE_CLIENT)
     {
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment"));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
         i++;
 
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_ext_key_usage, "clientAuth"));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1604,22 +1603,22 @@ static void test_helper_cert_create_with_subject
     else
     {
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_key_usage, "critical, nonRepudiation, digitalSignature, keyEncipherment, dataEncipherment, keyAgreement"));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
         i++;
 
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_ext_key_usage, "serverAuth"));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1632,11 +1631,11 @@ static void test_helper_cert_create_with_subject
     for (size_t san_idx = 0; san_idx < TEST_NUM_SAN_ENTRIES; san_idx++)
     {
         STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, NULL, NID_subject_alt_name, (char*)TEST_SAN_ENTRIES[san_idx]));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1649,7 +1648,7 @@ static void test_helper_cert_create_with_subject
         issuer_subject = TEST_X509_SUBJECT_ISSUER_NAME;
 
         STRICT_EXPECTED_CALL(X509_get_subject_name(TEST_ISSUER_X509)).SetReturn(issuer_subject);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     else
@@ -1658,128 +1657,128 @@ static void test_helper_cert_create_with_subject
     }
 
     STRICT_EXPECTED_CALL(X509_get_subject_name(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     const char *country = TEST_PROPS_COUNTRY_NAME_DEFLT;
     if (set_return_subject != NULL) country = set_return_subject->country_name;
     STRICT_EXPECTED_CALL(get_country_name(TEST_CERT_PROPS_HANDLE)).SetReturn(country);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (country == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_countryName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (country != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "C", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     const char *state = TEST_PROPS_STATE_NAME_DEFLT;
     if (set_return_subject != NULL) state = set_return_subject->state_name;
     STRICT_EXPECTED_CALL(get_state_name(TEST_CERT_PROPS_HANDLE)).SetReturn(state);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (state == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_stateOrProvinceName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (state != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "ST", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     const char *locality = TEST_PROPS_LOCALITY_NAME_DEFLT;
     if (set_return_subject != NULL) locality = set_return_subject->locality_name;
     STRICT_EXPECTED_CALL(get_locality(TEST_CERT_PROPS_HANDLE)).SetReturn(locality);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (locality == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_localityName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (locality != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "L", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     const char *organization = TEST_PROPS_ORG_NAME_DEFLT;
     if (set_return_subject != NULL) organization = set_return_subject->organization_name;
     STRICT_EXPECTED_CALL(get_organization_name(TEST_CERT_PROPS_HANDLE)).SetReturn(organization);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (organization == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_organizationName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (organization != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "O", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     const char *organization_unit = TEST_PROPS_ORG_UNIT_NAME_DEFLT;
     if (set_return_subject != NULL) organization_unit = set_return_subject->organization_unit_name;
     STRICT_EXPECTED_CALL(get_organization_unit(TEST_CERT_PROPS_HANDLE)).SetReturn(organization_unit);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if ((!is_self_signed) && (organization_unit == NULL))
     {
         STRICT_EXPECTED_CALL(X509_NAME_get_text_by_NID(issuer_subject, NID_organizationalUnitName, IGNORED_PTR_ARG, MAX_SUBJECT_VALUE_SIZE));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (organization_unit != NULL)
     {
         STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "OU", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     STRICT_EXPECTED_CALL(X509_NAME_add_entry_by_txt(TEST_X509_SUBJECT_NAME, "CN", MBSTRING_ASC, IGNORED_PTR_ARG, -1, -1, 0));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_set_issuer_name(TEST_X509, issuer_subject));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     // subject key identifier
     STRICT_EXPECTED_CALL(X509V3_set_ctx(IGNORED_PTR_ARG, NULL, TEST_X509, NULL, NULL, 0));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, IGNORED_PTR_ARG, NID_subject_key_identifier, "hash"));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
@@ -1789,108 +1788,108 @@ static void test_helper_cert_create_with_subject
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(X509V3_set_ctx(IGNORED_PTR_ARG, TEST_ISSUER_X509, TEST_X509, NULL, NULL, 0));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
     else
     {
         STRICT_EXPECTED_CALL(X509V3_set_ctx(IGNORED_PTR_ARG, TEST_X509, TEST_X509, NULL, NULL, 0));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(mocked_X509V3_EXT_conf_nid(NULL, IGNORED_PTR_ARG, NID_authority_key_identifier, "issuer:always,keyid:always"));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_add_ext(TEST_X509, TEST_NID_EXTENSION, -1));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_EXTENSION_free(TEST_NID_EXTENSION));
     i++;
 
     EXPECTED_CALL(EVP_sha256());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(X509_sign(TEST_X509, TEST_ISSUER_EVP_KEY, TEST_EVP_SHA256_MD));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     else
     {
         STRICT_EXPECTED_CALL(X509_sign(TEST_X509, TEST_EVP_KEY, TEST_EVP_SHA256_MD));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     if (test_helper_is_windows())
     {
         STRICT_EXPECTED_CALL(BIO_new_file(TEST_CERT_FILE, "wb")).SetReturn(TEST_BIO_WRITE_CERT);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
     else
     {
         STRICT_EXPECTED_CALL(mocked_OPEN(TEST_CERT_FILE, EXPECTED_CREATE_FLAGS, EXPECTED_MODE_FLAGS)).SetReturn(TEST_WRITE_CERTIFICATE_FD);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         STRICT_EXPECTED_CALL(BIO_new_fd(TEST_WRITE_CERTIFICATE_FD, 0)).SetReturn(TEST_BIO_WRITE_CERT);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
     }
 
     STRICT_EXPECTED_CALL(PEM_write_bio_X509(TEST_BIO_WRITE_CERT, TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(read_file_into_buffer(TEST_ISSUER_CERT_FILE, IGNORED_PTR_ARG));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         int cert_data_size = (int)(strlen(TEST_ISSUER_CERT_DATA)) + 1;
         STRICT_EXPECTED_CALL(BIO_write(TEST_BIO_WRITE_CERT, IGNORED_PTR_ARG, cert_data_size)).SetReturn(cert_data_size);
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         failed_function_list[i++] = 1;
 
         EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO_WRITE_CERT));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if (!test_helper_is_windows())
     {
         STRICT_EXPECTED_CALL(mocked_CLOSE(TEST_WRITE_CERTIFICATE_FD));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(X509_free(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(EVP_PKEY_free(TEST_EVP_KEY));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if (!is_self_signed)
     {
         STRICT_EXPECTED_CALL(X509_free(TEST_ISSUER_X509));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(EVP_PKEY_free(TEST_ISSUER_EVP_KEY));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 }
@@ -1921,15 +1920,15 @@ static void test_helper_load_cert_file
     size_t i = *index;
 
     STRICT_EXPECTED_CALL(BIO_new_file(file, "rb"));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(PEM_read_bio_X509(TEST_BIO, NULL, NULL, NULL)).SetReturn(set_return);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     *index = i;
@@ -1947,57 +1946,57 @@ static void test_helper_verify_certificate
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(initialize_openssl());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(read_file_into_cstring(params->cert_file, NULL));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(read_file_into_cstring(params->issuer_cert_file, NULL));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     EXPECTED_CALL(gballoc_free(IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_new());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(X509_LOOKUP_file());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_add_lookup(TEST_X509_STORE, TEST_X509_LOOKUP_METHOD_FILE)).SetReturn(TEST_X509_LOOKUP_LOAD_FILE);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_LOOKUP_ctrl(TEST_X509_LOOKUP_LOAD_FILE, IGNORED_NUM_ARG, params->issuer_cert_file, X509_FILETYPE_PEM, NULL));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(X509_LOOKUP_hash_dir());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_add_lookup(TEST_X509_STORE, TEST_X509_LOOKUP_METHOD_HASH)).SetReturn(TEST_X509_LOOKUP_LOAD_HASH);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(X509_LOOKUP_ctrl(TEST_X509_LOOKUP_LOAD_HASH, IGNORED_NUM_ARG, NULL, X509_FILETYPE_DEFAULT, NULL));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     test_helper_load_cert_file(TEST_CERT_FILE, TEST_X509, &i, failed_function_list, failed_function_size);
 
     STRICT_EXPECTED_CALL(X509_STORE_CTX_new());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     unsigned long policy = X509_V_FLAG_X509_STRICT |
@@ -2005,53 +2004,53 @@ static void test_helper_verify_certificate
                            X509_V_FLAG_POLICY_CHECK;
 
     STRICT_EXPECTED_CALL(X509_STORE_set_flags(TEST_X509_STORE, policy));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_CTX_init(TEST_STORE_CTXT, TEST_X509_STORE, TEST_X509, 0));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     ASN1_TIME *asn1_time = (params->force_set_asn1_time != NULL) ? params->force_set_asn1_time : &TEST_ASN1_TIME_AFTER;
     STRICT_EXPECTED_CALL(mocked_X509_get_notAfter(TEST_X509)).SetReturn(asn1_time);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(get_utc_time_from_asn_string(asn1_time->data, VALID_ASN1_TIME_STRING_UTC_LEN));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     int skid_nid_lookup = params->skid_set ? 1 : -1;
     STRICT_EXPECTED_CALL(X509_get_ext_by_NID(TEST_X509, NID_subject_key_identifier, -1)).SetReturn(skid_nid_lookup);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     int return_value = (params->force_set_verify_return_value)?1:0;
     STRICT_EXPECTED_CALL(X509_verify_cert(TEST_STORE_CTXT)).SetReturn(return_value);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     if(!params->force_set_verify_return_value)
     {
         STRICT_EXPECTED_CALL(X509_STORE_CTX_get_error(TEST_STORE_CTXT));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
 
         STRICT_EXPECTED_CALL(X509_verify_cert_error_string(TEST_ERROR_CODE));
-        ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
         i++;
     }
 
     STRICT_EXPECTED_CALL(X509_STORE_CTX_free(TEST_STORE_CTXT));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_free(TEST_X509));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(X509_STORE_free(TEST_X509_STORE));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 }
 
@@ -2067,23 +2066,23 @@ static void test_helper_create_cert_key
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(initialize_openssl());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     STRICT_EXPECTED_CALL(BIO_new_file(TEST_KEY_FILE, "rb"));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(PEM_read_bio_PrivateKey(TEST_BIO, NULL, NULL, NULL)).SetReturn(TEST_EVP_KEY);
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(BIO_free_all(TEST_BIO));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 }
 
@@ -2099,39 +2098,39 @@ static void test_helper_cert_key_interface_sign
     umock_c_reset_all_calls();
 
     EXPECTED_CALL(EVP_MD_CTX_create());
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_get_digestbyname("SHA256"));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_DigestInit_ex(TEST_EVP_MD_CTX, TEST_EVP_MD, NULL));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_DigestSignInit(TEST_EVP_MD_CTX, NULL, TEST_EVP_MD, NULL, IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_DigestSignUpdate(TEST_EVP_MD_CTX, IGNORED_PTR_ARG, IGNORED_NUM_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_DigestSignFinal(TEST_EVP_MD_CTX, NULL, IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     EXPECTED_CALL(gballoc_malloc(IGNORED_NUM_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_DigestSignFinal(TEST_EVP_MD_CTX, IGNORED_PTR_ARG, IGNORED_PTR_ARG));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     failed_function_list[i++] = 1;
 
     STRICT_EXPECTED_CALL(EVP_MD_CTX_destroy(TEST_EVP_MD_CTX));
-    ASSERT_IS_TRUE((i < failed_function_size), "Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE((i < failed_function_size), "Line:" MU_TOSTRING(__LINE__));
     i++;
 }
 
@@ -2143,7 +2142,6 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
 
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -2425,7 +2423,6 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -2454,22 +2451,22 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
 
         // act, assert
         status = generate_pki_cert_and_key(NULL, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, NULL, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, NULL, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, NULL, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, -1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2489,7 +2486,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2509,7 +2506,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2529,7 +2526,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2549,7 +2546,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2572,8 +2569,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2605,7 +2602,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -2631,8 +2628,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2664,7 +2661,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -2690,8 +2687,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2723,7 +2720,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -2749,8 +2746,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2782,7 +2779,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 1, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -2808,8 +2805,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2841,7 +2838,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -2867,8 +2864,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2900,7 +2897,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, 0, TEST_KEY_FILE, TEST_CERT_FILE, TEST_ISSUER_KEY_FILE, TEST_ISSUER_CERT_FILE);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -2920,22 +2917,22 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
 
         // act, assert
         status = generate_pki_cert_and_key_with_props(NULL, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, NULL, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, NULL, &TEST_VALID_KEY_PROPS_RSA);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &INVALID_KEY_PROPS);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, -1, TEST_KEY_FILE, TEST_CERT_FILE, &INVALID_KEY_PROPS);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2955,7 +2952,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, -1, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2975,7 +2972,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -2995,7 +2992,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3015,7 +3012,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, -1, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3037,8 +3034,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3071,7 +3068,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3096,8 +3093,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3130,7 +3127,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3155,8 +3152,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3189,7 +3186,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_RSA);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3214,8 +3211,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3248,7 +3245,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3273,8 +3270,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3307,7 +3304,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3332,8 +3329,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3366,7 +3363,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = generate_pki_cert_and_key_with_props(TEST_CERT_PROPS_HANDLE, TEST_SERIAL_NUMBER, TEST_PATH_LEN_NON_CA, TEST_KEY_FILE, TEST_CERT_FILE, &TEST_VALID_KEY_PROPS_ECC);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3387,21 +3384,21 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         // act, assert
         verify_status = true;
         status = verify_certificate(NULL, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" MU_TOSTRING(__LINE__));
 
         verify_status = true;
         status = verify_certificate(TEST_CERT_FILE, NULL, TEST_ISSUER_CERT_FILE, &verify_status);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" MU_TOSTRING(__LINE__));
 
         verify_status = true;
         status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, NULL, &verify_status);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" MU_TOSTRING(__LINE__));
 
         status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3432,9 +3429,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_TRUE(verify_status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_TRUE(verify_status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3458,9 +3455,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_BAD_CHAIN_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3491,9 +3488,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3524,8 +3521,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3556,8 +3553,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_FALSE(verify_status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3599,8 +3596,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 int status = verify_certificate(TEST_CERT_FILE, TEST_KEY_FILE, TEST_ISSUER_CERT_FILE, &verify_status);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-                ASSERT_IS_FALSE(verify_status, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+                ASSERT_IS_FALSE(verify_status, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3625,8 +3622,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         KEY_HANDLE result = create_cert_key(TEST_KEY_FILE);
 
         // assert
-        ASSERT_IS_NOT_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(result);
@@ -3645,8 +3642,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         KEY_HANDLE result = create_cert_key(NULL);
 
         // assert
-        ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3679,7 +3676,7 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 KEY_HANDLE result = create_cert_key(NULL);
 
                 // assert
-                ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
+                ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3710,11 +3707,11 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
 
         // act, assert
         status = key_derive_and_sign(key_handle, tbs, sizeof(tbs), tbs, sizeof(tbs), &digest, &digest_size);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = key_encrypt(key_handle, &identity, &plaintext, &initialization_vector, &ciphertext);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = key_decrypt(key_handle, &identity, &ciphertext, &initialization_vector, &plaintext);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(key_handle);
@@ -3742,9 +3739,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         status = key_sign(key_handle, tbs, sizeof(tbs), &digest, &digest_size);
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, HMAC_SHA256_SIZE, digest_size, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, HMAC_SHA256_SIZE, digest_size, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         free(digest);
@@ -3768,31 +3765,31 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         digest = (unsigned char*)0x1000;
         digest_size = 10;
         status = key_sign(key_handle, NULL, sizeof(tbs), &digest, &digest_size);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, 0, digest_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
         // act, assert 2
         digest = (unsigned char*)0x1000;
         digest_size = 10;
         status = key_sign(key_handle, tbs, 0, &digest, &digest_size);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, 0, digest_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
         // act, assert 3
         digest = (unsigned char*)0x1000;
         digest_size = 10;
         status = key_sign(key_handle, tbs, sizeof(tbs), NULL, &digest_size);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(int, 0, digest_size, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, digest_size, "Line:" MU_TOSTRING(__LINE__));
 
         // act, assert 4
         digest = (unsigned char*)0x1000;
         digest_size = 10;
         status = key_sign(key_handle, tbs, sizeof(tbs), &digest, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-        ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
         key_destroy(key_handle);
@@ -3833,9 +3830,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
                 status = key_sign(key_handle, tbs, sizeof(tbs), &digest, &digest_size);
 
                 // assert
-                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
-                ASSERT_IS_NULL(digest, "Line:" TOSTRING(__LINE__));
-                ASSERT_IS_NULL(digest_size, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
+                ASSERT_IS_NULL(digest, "Line:" MU_TOSTRING(__LINE__));
+                ASSERT_IS_NULL(digest_size, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 
@@ -3859,26 +3856,26 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         result = generate_rand_buffer(NULL, sizeof(output));
 
         // assert 1
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         cmp = memcmp(output, expected_output, sizeof(expected_output));
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // act 2
         result = generate_rand_buffer(output, 0);
 
         // assert 2
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         cmp = memcmp(output, expected_output, sizeof(expected_output));
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // act 3
         size_t max = INT_MAX;
         result = generate_rand_buffer(output, ++max);
 
         // assert 3
-        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         cmp = memcmp(output, expected_output, sizeof(expected_output));
-        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3898,8 +3895,8 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
         int result = generate_rand_buffer(output, sizeof(output));
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls(), "Line:" MU_TOSTRING(__LINE__));
 
         // cleanup
     }
@@ -3929,9 +3926,9 @@ BEGIN_TEST_SUITE(edge_openssl_pki_unittests)
             {
                 int result = generate_rand_buffer(output, sizeof(output));
 
-                ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_NOT_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
                 int cmp = memcmp(output, expected_output, sizeof(expected_output));
-                ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" TOSTRING(__LINE__));
+                ASSERT_ARE_EQUAL(int, 0, cmp, "Line:" MU_TOSTRING(__LINE__));
             }
         }
 

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_certificate_props_ut/hsm_certificate_props_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_certificate_props_ut/hsm_certificate_props_ut.c
@@ -70,7 +70,6 @@ static const char* TEST_ALIAS_VALUE = "test_alias";
 #define TEST_STRING_129 TEST_STRING_128 "1"
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
@@ -86,7 +85,6 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
     TEST_SUITE_INITIALIZE(suite_init)
     {
         //int result;
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -114,7 +112,6 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(method_init)
@@ -759,21 +756,21 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // invalid handle
         status = set_validity_seconds(NULL, test_validity_value);
-        ASSERT_ARE_NOT_EQUAL(int, 1, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 1, status, "Line:" MU_TOSTRING(__LINE__));
         validity = get_validity_seconds(NULL);
-        ASSERT_ARE_EQUAL(uint64_t, 0, validity, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(uint64_t, 0, validity, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid input data
         status = set_validity_seconds(props_handle, 0);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         validity = get_validity_seconds(props_handle);
-        ASSERT_ARE_EQUAL(uint64_t, 0, validity, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(uint64_t, 0, validity, "Line:" MU_TOSTRING(__LINE__));
 
         // valid input data
         status = set_validity_seconds(props_handle, test_validity_value);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         validity = get_validity_seconds(props_handle);
-        ASSERT_ARE_EQUAL(uint64_t, test_validity_value, validity, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(uint64_t, test_validity_value, validity, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -796,35 +793,35 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_state_name(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid handle
         status = set_common_name(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_common_name(NULL);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_common_name(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_common_name(props_handle, TEST_STRING_65);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_common_name(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_common_name(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // valid input data
         status = set_common_name(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_common_name(props_handle);
-        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid input for get_common_name
         status = set_common_name(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_common_name(NULL);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -847,29 +844,29 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_state_name(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid handle
         status = set_state_name(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_state_name(NULL);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_state_name(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_state_name(props_handle, TEST_STRING_129);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_state_name(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_state_name(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // valid input data
         status = set_state_name(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_state_name(props_handle);
-        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -892,29 +889,29 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_locality(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid handle
         status = set_locality(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_locality(NULL);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_locality(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_locality(props_handle, TEST_STRING_129);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_locality(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_locality(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // valid input data
         status = set_locality(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_locality(props_handle);
-        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -937,29 +934,29 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_organization_name(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid handle
         status = set_organization_name(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_organization_name(NULL);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_organization_name(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_organization_name(props_handle, TEST_STRING_65);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_organization_name(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_organization_name(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // valid input data
         status = set_organization_name(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_organization_name(props_handle);
-        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -982,29 +979,29 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // default value
         test_output_string = get_organization_unit(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid handle
         status = set_organization_unit(NULL, test_input_string);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_organization_unit(NULL);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // invalid paramters and data
         status = set_organization_unit(props_handle, NULL);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_organization_unit(props_handle, TEST_STRING_65);
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         status = set_organization_unit(props_handle, "");
-        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_organization_unit(props_handle);
-        ASSERT_IS_NULL(test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         // valid input data
         status = set_organization_unit(props_handle, test_input_string);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         test_output_string = get_organization_unit(props_handle);
-        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(char_ptr, test_input_string, test_output_string, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -1024,12 +1021,12 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // act 1, assert
         test_output = get_san_entries(NULL, &num_entries);
-        ASSERT_IS_NULL(test_output, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" MU_TOSTRING(__LINE__));
 
         // act 2, assert
         test_output = get_san_entries(props_handle, NULL);
-        ASSERT_IS_NULL(test_output, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -1051,8 +1048,8 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
         test_output = get_san_entries(props_handle, &num_entries);
 
         // assert
-        ASSERT_IS_NULL(test_output, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NULL(test_output, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -1082,11 +1079,11 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
 
         // act 1, assert
         status = set_san_entries(props_handle, san_list_1, san_list_size_1);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         num_entries = 10;
         test_output = get_san_entries(props_handle, &num_entries);
-        ASSERT_IS_NOT_NULL(test_output, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, san_list_size_1, num_entries, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, san_list_size_1, num_entries, "Line:" MU_TOSTRING(__LINE__));
         num_matched = 0;
         for (size_t i = 0; i < san_list_size_1; i++)
         {
@@ -1099,15 +1096,15 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
                 }
             }
         }
-        ASSERT_ARE_EQUAL(size_t, san_list_size_1, num_matched, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, san_list_size_1, num_matched, "Line:" MU_TOSTRING(__LINE__));
 
         // act 2, assert
         status = set_san_entries(props_handle, san_list_2, san_list_size_2);
-        ASSERT_ARE_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         num_entries = 10;
         test_output = get_san_entries(props_handle, &num_entries);
-        ASSERT_IS_NOT_NULL(test_output, "Line:" TOSTRING(__LINE__));
-        ASSERT_ARE_EQUAL(size_t, san_list_size_2, num_entries, "Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(test_output, "Line:" MU_TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, san_list_size_2, num_entries, "Line:" MU_TOSTRING(__LINE__));
         num_matched = 0;
         for (size_t i = 0; i < san_list_size_2; i++)
         {
@@ -1120,7 +1117,7 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
                 }
             }
         }
-        ASSERT_ARE_EQUAL(size_t, san_list_size_2, num_matched, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(size_t, san_list_size_2, num_matched, "Line:" MU_TOSTRING(__LINE__));
 
         //cleanup
         cert_properties_destroy(props_handle);
@@ -1164,10 +1161,10 @@ BEGIN_TEST_SUITE(hsm_certificate_props_ut)
             int status = set_san_entries(props_handle, san_list, num_san_entries);
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
             test_output = get_san_entries(props_handle, &num_entries);
-            ASSERT_IS_NULL(test_output, "Line:" TOSTRING(__LINE__));
-            ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(test_output, "Line:" MU_TOSTRING(__LINE__));
+            ASSERT_ARE_EQUAL(size_t, 0, num_entries, "Line:" MU_TOSTRING(__LINE__));
         }
 
         //cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_client_tpm_ut/hsm_client_tpm_ut.c
@@ -138,7 +138,6 @@ static void on_umock_c_error(UMOCK_C_ERROR_CODE error_code)
 }
 
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 BEGIN_TEST_SUITE(hsm_client_tpm_ut)
 
@@ -146,7 +145,6 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
     {
         int result;
 
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
@@ -159,27 +157,24 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         result = umocktypes_bool_register_types();
         ASSERT_ARE_EQUAL(int, 0, result);
 
-        REGISTER_UMOCK_ALIAS_TYPE(XDA_HANDLE, void*);
         REGISTER_UMOCK_ALIAS_TYPE(BUFFER_HANDLE, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(TPM_HANDLE, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(UINT, unsigned int);
+        REGISTER_UMOCK_ALIAS_TYPE(TPM_HANDLE, unsigned int);
         REGISTER_UMOCK_ALIAS_TYPE(UINT32, unsigned int);
         REGISTER_UMOCK_ALIAS_TYPE(BOOL, int);
         REGISTER_UMOCK_ALIAS_TYPE(TPM_PT, unsigned int);
 
         REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_HANDLE, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(SECURE_DEVICE_TYPE, int);
         REGISTER_UMOCK_ALIAS_TYPE(STRING_HANDLE, void*);
         REGISTER_UMOCK_ALIAS_TYPE(OBJECT_ATTR, int);
-        REGISTER_UMOCK_ALIAS_TYPE(TPM_SE, int);
-        REGISTER_UMOCK_ALIAS_TYPE(TPMI_DH_OBJECT, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(TPMI_ALG_HASH, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(TPMA_SESSION, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(TPMI_DH_ENTITY, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(TPMI_DH_CONTEXT, void*);
+        REGISTER_UMOCK_ALIAS_TYPE(TPM_SE, unsigned char);
+        REGISTER_UMOCK_ALIAS_TYPE(TPMI_DH_OBJECT, unsigned int);
+        REGISTER_UMOCK_ALIAS_TYPE(TPMI_ALG_HASH, unsigned short);
+        REGISTER_UMOCK_ALIAS_TYPE(TPMA_SESSION, unsigned int);
+        REGISTER_UMOCK_ALIAS_TYPE(TPMI_DH_ENTITY, unsigned int);
+        REGISTER_UMOCK_ALIAS_TYPE(TPMI_DH_CONTEXT, unsigned int);
         REGISTER_UMOCK_ALIAS_TYPE(INT32, int);
-        REGISTER_UMOCK_ALIAS_TYPE(TPMI_RH_PROVISION, void*);
-        REGISTER_UMOCK_ALIAS_TYPE(TPMI_DH_PERSISTENT, void*);
+        REGISTER_UMOCK_ALIAS_TYPE(TPMI_RH_PROVISION, unsigned int);
+        REGISTER_UMOCK_ALIAS_TYPE(TPMI_DH_PERSISTENT, unsigned int);
 
         REGISTER_GLOBAL_MOCK_RETURN(TSS_CreatePwAuthSession, TPM_RC_SUCCESS);
         REGISTER_GLOBAL_MOCK_FAIL_RETURN(TSS_CreatePwAuthSession, TPM_RC_FAILURE);
@@ -244,7 +239,6 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
         umock_c_deinit();
 
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(method_init)
@@ -863,7 +857,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            char tmp_msg[64];
+            char tmp_msg[96];
             sprintf(tmp_msg, "hsm_client_tpm_sign_data failure in test %zu/%zu", index, count);
 
             //act
@@ -1074,7 +1068,7 @@ BEGIN_TEST_SUITE(hsm_client_tpm_ut)
             umock_c_negative_tests_reset();
             umock_c_negative_tests_fail_call(index);
 
-            char tmp_msg[96];
+            char tmp_msg[128];
             sprintf(tmp_msg, "hsm_client_derive_and_sign_with_identity failure in test %zu/%zu", index, count);
 
             //act

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_tpm_select_ut/hsm_tpm_select_ut.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/hsm_tpm_select_ut/hsm_tpm_select_ut.c
@@ -36,7 +36,6 @@ MOCKABLE_FUNCTION(, const HSM_CLIENT_TPM_INTERFACE*, hsm_client_tpm_store_interf
 // Test defines and data
 //#############################################################################
 static TEST_MUTEX_HANDLE g_testByTest;
-static TEST_MUTEX_HANDLE g_dllByDll;
 
 MU_DEFINE_ENUM_STRINGS(UMOCK_C_ERROR_CODE, UMOCK_C_ERROR_CODE_VALUES)
 
@@ -113,13 +112,12 @@ const HSM_CLIENT_TPM_INTERFACE* test_hook_hsm_client_tpm_interface(void)
 BEGIN_TEST_SUITE(hsm_tpm_select_ut)
     TEST_SUITE_INITIALIZE(TestClassInitialize)
     {
-        TEST_INITIALIZE_MEMORY_DEBUG(g_dllByDll);
         g_testByTest = TEST_MUTEX_CREATE();
         ASSERT_IS_NOT_NULL(g_testByTest);
 
         umock_c_init(test_hook_on_umock_c_error);
 
-        REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_TPM_INTERFACE, void*);
+        REGISTER_UMOCK_ALIAS_TYPE(HSM_CLIENT_TPM_INTERFACE*, void*);
 
         ASSERT_ARE_EQUAL(int, 0, umocktypes_charptr_register_types() );
 
@@ -144,7 +142,6 @@ BEGIN_TEST_SUITE(hsm_tpm_select_ut)
     {
         umock_c_deinit();
         TEST_MUTEX_DESTROY(g_testByTest);
-        TEST_DEINITIALIZE_MEMORY_DEBUG(g_dllByDll);
     }
 
     TEST_FUNCTION_INITIALIZE(TestMethodInitialize)
@@ -170,7 +167,7 @@ BEGIN_TEST_SUITE(hsm_tpm_select_ut)
         int result = hsm_client_tpm_init();
 
         // assert
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         ASSERT_ARE_EQUAL(char_ptr, umock_c_get_expected_calls(), umock_c_get_actual_calls());
 
         // cleanup
@@ -196,7 +193,7 @@ BEGIN_TEST_SUITE(hsm_tpm_select_ut)
             status = hsm_client_tpm_init();
 
             // assert
-            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" TOSTRING(__LINE__));
+            ASSERT_ARE_NOT_EQUAL(int, 0, status, "Line:" MU_TOSTRING(__LINE__));
         }
 
         // cleanup
@@ -207,7 +204,7 @@ BEGIN_TEST_SUITE(hsm_tpm_select_ut)
     {
         // arrange
         int result = hsm_client_tpm_init();
-        ASSERT_ARE_EQUAL(int, 0, result, "Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, result, "Line:" MU_TOSTRING(__LINE__));
         setup_callstack_hsm_client_tpm_deinit();
 
         // act
@@ -253,7 +250,7 @@ BEGIN_TEST_SUITE(hsm_tpm_select_ut)
             const HSM_CLIENT_TPM_INTERFACE* result = hsm_client_tpm_interface();
 
             // assert
-            ASSERT_IS_NULL(result, "Line:" TOSTRING(__LINE__));
+            ASSERT_IS_NULL(result, "Line:" MU_TOSTRING(__LINE__));
         }
 
         // cleanup

--- a/edgelet/hsm-sys/azure-iot-hsm-c/tests/test_utils/test_utils.c
+++ b/edgelet/hsm-sys/azure-iot-hsm-c/tests/test_utils/test_utils.c
@@ -36,11 +36,11 @@ static char* get_temp_base_dir(void)
 
 #if (defined __WINDOWS__ || defined _WIN32 || defined _WIN64 || defined _Windows)
     DWORD count = GetTempPathA(MAX_FILE_NAME_SIZE, result);
-    ASSERT_IS_TRUE(count < MAX_FILE_NAME_SIZE, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(count < MAX_FILE_NAME_SIZE, "TestUtil Line:" MU_TOSTRING(__LINE__));
 #else
     strcpy_s(result, MAX_FILE_NAME_SIZE, "/tmp/");
 #endif
-    ASSERT_ARE_NOT_EQUAL(size_t, 0, strlen(result), "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_NOT_EQUAL(size_t, 0, strlen(result), "TestUtil Line:" MU_TOSTRING(__LINE__));
 
     return result;
 }
@@ -87,9 +87,9 @@ char *create_temp_dir_path(const char *dir_guid)
 
     tmp_dir = get_temp_base_dir();
     dir_path = calloc(MAX_FILE_NAME_SIZE, 1);
-    ASSERT_IS_NOT_NULL(dir_path, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(dir_path, "TestUtil Line:" MU_TOSTRING(__LINE__));
     status = snprintf(dir_path, MAX_FILE_NAME_SIZE, "%shsm_test_%s", tmp_dir, dir_guid);
-    ASSERT_IS_TRUE(((status > 0) || (status < MAX_FILE_NAME_SIZE)), "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < MAX_FILE_NAME_SIZE)), "TestUtil Line:" MU_TOSTRING(__LINE__));
     free(tmp_dir);
 
     return dir_path;
@@ -100,17 +100,17 @@ char* hsm_test_util_create_temp_dir(char **dir_guid)
     char *dir_path, *guid;
     int status, attempt = 0, dir_made = 0;
 
-    ASSERT_IS_NOT_NULL(dir_guid, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(dir_guid, "TestUtil Line:" MU_TOSTRING(__LINE__));
     guid = (char*)malloc(UID_SIZE);
-    ASSERT_IS_NOT_NULL(guid, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(guid, "TestUtil Line:" MU_TOSTRING(__LINE__));
     do
     {
         memset(guid, 0, UID_SIZE);
         status = UniqueId_Generate(guid, UID_SIZE);
-        ASSERT_ARE_EQUAL(int, UNIQUEID_OK, status, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, UNIQUEID_OK, status, "TestUtil Line:" MU_TOSTRING(__LINE__));
         dir_path = create_temp_dir_path(guid);
         status = make_test_dir(dir_path);
-        ASSERT_ARE_NOT_EQUAL(int, CREATE_DIR_ERROR, status, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_NOT_EQUAL(int, CREATE_DIR_ERROR, status, "TestUtil Line:" MU_TOSTRING(__LINE__));
         if (status == CREATE_DIR_EXISTS)
         {
             free(dir_path);
@@ -123,7 +123,7 @@ char* hsm_test_util_create_temp_dir(char **dir_guid)
         }
     } while (++attempt < MAX_ATTEMPTS);
 
-    ASSERT_ARE_EQUAL(int, 1, dir_made, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 1, dir_made, "TestUtil Line:" MU_TOSTRING(__LINE__));
 
     *dir_guid = guid;
 
@@ -134,7 +134,7 @@ void hsm_test_util_delete_dir(const char *dir_guid)
 {
     int status;
 
-    ASSERT_IS_NOT_NULL(dir_guid, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(dir_guid, "TestUtil Line:" MU_TOSTRING(__LINE__));
     char *dir_path = create_temp_dir_path(dir_guid);
     printf("Deleting temp directory '%s'.\r\n", dir_path);
 
@@ -153,14 +153,14 @@ void hsm_test_util_delete_dir(const char *dir_guid)
     const char *cmd_prefix = "rm -fr ";
     size_t cmd_size = strlen(cmd_prefix) + MAX_FILE_NAME_SIZE + 1;
     char *cmd = calloc(cmd_size, 1);
-    ASSERT_IS_NOT_NULL(cmd, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NOT_NULL(cmd, "TestUtil Line:" MU_TOSTRING(__LINE__));
     status = snprintf(cmd, cmd_size, "%s%s", cmd_prefix, dir_path);
-    ASSERT_IS_TRUE(((status > 0) || (status < (int)cmd_size)), "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_TRUE(((status > 0) || (status < (int)cmd_size)), "TestUtil Line:" MU_TOSTRING(__LINE__));
     printf("Deleting directory using command '%s'.\r\n", cmd);
     status = system(cmd);
     free(cmd);
 #endif
-    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" MU_TOSTRING(__LINE__));
     free(dir_path);
 }
 
@@ -171,12 +171,12 @@ void hsm_test_util_setenv(const char *key, const char *value)
     #else
         int status = setenv(key, value, 1);
     #endif
-    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" MU_TOSTRING(__LINE__));
     const char *retrieved_value = getenv(key);
     if (retrieved_value != NULL)
     {
         int cmp = strcmp(retrieved_value, value);
-        ASSERT_ARE_EQUAL(int, 0, cmp, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, cmp, "TestUtil Line:" MU_TOSTRING(__LINE__));
     }
 }
 
@@ -184,15 +184,15 @@ void hsm_test_util_unsetenv(const char *key)
 {
     #if defined __WINDOWS__ || defined _WIN32 || defined _WIN64 || defined _Windows
         STRING_HANDLE key_handle = STRING_construct(key);
-        ASSERT_IS_NOT_NULL(key_handle, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_IS_NOT_NULL(key_handle, "TestUtil Line:" MU_TOSTRING(__LINE__));
         int ret_val = STRING_concat(key_handle, "=");
-        ASSERT_ARE_EQUAL(int, 0, ret_val, "TestUtil Line:" TOSTRING(__LINE__));
+        ASSERT_ARE_EQUAL(int, 0, ret_val, "TestUtil Line:" MU_TOSTRING(__LINE__));
         errno_t status = _putenv(STRING_c_str(key_handle));
         STRING_delete(key_handle);
     #else
         int status = unsetenv(key);
     #endif
-    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_ARE_EQUAL(int, 0, status, "TestUtil Line:" MU_TOSTRING(__LINE__));
     const char *retrieved_value = getenv(key);
-    ASSERT_IS_NULL(retrieved_value, "TestUtil Line:" TOSTRING(__LINE__));
+    ASSERT_IS_NULL(retrieved_value, "TestUtil Line:" MU_TOSTRING(__LINE__));
 }

--- a/edgelet/iotedge-proxy/src/proxy/service.rs
+++ b/edgelet/iotedge-proxy/src/proxy/service.rs
@@ -100,7 +100,7 @@ mod tests {
     use hyper::service::Service;
     use hyper::{Body, Chunk, Request, Response, StatusCode};
     use serde_json::json;
-    use tokio::runtime::Runtime;
+    use tokio::runtime::current_thread::Runtime;
 
     use crate::proxy::test::config::config;
     use crate::proxy::test::http::client_fn;

--- a/edgelet/iotedge-proxy/src/routine.rs
+++ b/edgelet/iotedge-proxy/src/routine.rs
@@ -9,7 +9,7 @@ use futures::sync::oneshot::Receiver;
 use futures::{Future, IntoFuture};
 use hyper::Server;
 use log::{debug, info, warn};
-use tokio::runtime::Runtime;
+use tokio::runtime::current_thread::Runtime;
 
 use crate::api::ApiService;
 use crate::proxy::{get_config, Client, ProxyService};

--- a/edgelet/kube-client/examples/pod-list.rs
+++ b/edgelet/kube-client/examples/pod-list.rs
@@ -7,7 +7,7 @@ use std::result::Result;
 use futures::prelude::*;
 
 use kube_client::{get_config, Client};
-use tokio::runtime::Runtime;
+use tokio::runtime::current_thread::Runtime;
 
 fn main() -> Result<(), ()> {
     env_logger::init();

--- a/edgelet/kube-client/src/client.rs
+++ b/edgelet/kube-client/src/client.rs
@@ -863,7 +863,7 @@ mod tests {
     use k8s_openapi::api::apps::v1 as api_apps;
     use k8s_openapi::api::core::v1 as api_core;
     use native_tls::TlsConnector;
-    use tokio::runtime::Runtime;
+    use tokio::runtime::current_thread::Runtime;
     use url::percent_encoding::{utf8_percent_encode, USERINFO_ENCODE_SET};
     use url::Url;
 


### PR DESCRIPTION
These are the current latest versions. Among other things, they contain fixes
for building with recent cmake.

API changes:

- `TEST_INITIALIZE_MEMORY_DEBUG` and `TEST_DEINITIALIZE_MEMORY_DEBUG`
  were removed from testrunnerswitch.h

  https://github.com/Azure/c-testrunnerswitcher/commit/07112803685c7b56ea639ce29e2fa39be62630c9

- `TOSTRING` macro was removed from ctest_macros.h in favor of
  `MU_TOSTRING` from macro-utils

  https://github.com/Azure/ctest/commit/6d7a34c5ede38b5567b5296f292cbc3bc15a43ac

- `SECURE_DEVICE_TYPE`, `UINT` and `XDA_HANDLE` are not defined anywhere.

- `REGISTER_UMOCK_ALIAS_TYPE` now requires the aliasing type to be
  the same size as the aliased type.

  https://github.com/Azure/umock-c/commit/2ab7102575b5ca6f59a28d7ac6292213af7a1100

- On Windows, `interface` ends up being `#define`d to `struct`
  by Windows headers, which causes compile errors when it's used as
  a variable name. Rename those variables to `iface`.

Other changes:

- Fix `edgelet-utils` to build with newer Rust since `tools/check_submodules`
  depends on it but does not have its own `rust-toolchain` file.

- Fix `edgelet-kube` tests to use single-thread tokio runtime, because
  the multi-threaded runtime cannot be used in parallel correctly.

- Make some buffers used with `sprintf` larger because newer gcc warns that
  they might not be large enough for the string written to them.