### PR TITLE
Resolve security concern in logging

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Logger.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/Logger.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Azure.Devices.Edge.Util
         static ILoggerFactory GetLoggerFactory()
         {
             string outputTemplate = logLevel > LogEventLevel.Debug
-                ? "<{Severity}> {Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] - {Message}{NewLine}{Exception}"
-                : "<{Severity}> {Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{SourceContext:1}] - {Message}{NewLine}{Exception}";
+                ? "<{Severity}> {Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] - {Message:j}{NewLine}{Exception}"
+                : "<{Severity}> {Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [{SourceContext:1}] - {Message:j}{NewLine}{Exception}";
 
             LoggerConfiguration ConsoleSinkMap(LoggerSinkConfiguration loggerSinkConfiguration)
                 => loggerSinkConfiguration.Console(outputTemplate: outputTemplate);

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/LoggerTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/LoggerTest.cs
@@ -46,6 +46,34 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             Assert.Equal("3", emittedEvents[0].Properties["Severity"].ToString());
         }
 
+        [Fact]
+        public void NoNewLinesTest()
+        {
+
+            using (var writer = new System.IO.StringWriter())
+            {
+                System.Console.SetOut(writer);
+
+                ILogger logger = Logger.Factory.CreateLogger("test");
+                Assert.NotNull(logger);
+
+                var testObject = new TestObject("Hello\n World\n!\n");
+                logger.LogInformation("{@TestObject}", testObject);
+                var msg = writer.ToString();
+                Assert.Contains("Hello\\n World\\n!\\n", msg);
+            }
+        }
+
+        class TestObject
+        {
+            public string Message { get; set; }
+
+            public TestObject(string message)
+            {
+                this.Message = message;
+            }
+        }
+
         class TestSink : ILogEventSink
         {
             List<LogEvent> emittedEvents = new List<LogEvent>();

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/LoggerTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/LoggerTest.cs
@@ -49,7 +49,6 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
         [Fact]
         public void NoNewLinesTest()
         {
-
             using (var writer = new System.IO.StringWriter())
             {
                 System.Console.SetOut(writer);

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/LoggerTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/LoggerTest.cs
@@ -1,7 +1,9 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Util.Test
 {
+    using System;
     using System.Collections.Generic;
+    using System.IO;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Extensions.Logging;
     using Serilog;
@@ -49,9 +51,9 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
         [Fact]
         public void NoNewLinesTest()
         {
-            using (var writer = new System.IO.StringWriter())
+            using (var writer = new StringWriter())
             {
-                System.Console.SetOut(writer);
+                Console.SetOut(writer);
 
                 ILogger logger = Logger.Factory.CreateLogger("test");
                 Assert.NotNull(logger);


### PR DESCRIPTION
This is to address [security bug in logging](https://msazure.visualstudio.com/One/_workitems/edit/9554724)

According to the bug, we can use the `j` format specifier to reduce to a single-line JSON string. Also, from documentation we can apply this on the outputTemplate itself: https://github.com/serilog/serilog/wiki/Formatting-Output
