### PR TITLE
Nested E2E: Add filters for broker-specific tests

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -25,17 +25,11 @@ steps:
       $filter += '&Category!=SingleNodeOnly'
       $filter += '&Category!=NestedEdgeAmqpOnly'
       $filter += '&Category!=LegacyMqttRequired'
-    
-      #We are disabling some additional tests. See  PBI #9171870. Once this is fixed we should run what's directly below.
-      #$filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope'
-      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_amqp')
     {
       $filter += '&Category!=SingleNodeOnly'
-      $filter += '&Category!=BrokerRequired'
-
-      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
+      $filter += '&Category!=UsesBroker'
     }
     elseif ($test_type -eq 'nestededge_isa95')
     {

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -25,11 +25,17 @@ steps:
       $filter += '&Category!=SingleNodeOnly'
       $filter += '&Category!=NestedEdgeAmqpOnly'
       $filter += '&Category!=LegacyMqttRequired'
+    
+      #We are disabling some additional tests. See  PBI #9171870. Once this is fixed we should run what's directly below.
+      #$filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope'
+      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_amqp')
     {
       $filter += '&Category!=SingleNodeOnly'
-      $filter += '&Category!=UsesBroker'
+      $filter += '&Category!=BrokerRequired'
+
+      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_isa95')
     {

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -26,7 +26,7 @@ steps:
       $filter += '&Category!=NestedEdgeAmqpOnly'
       $filter += '&Category!=LegacyMqttRequired'
     
-      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
+      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_amqp')
     {

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -25,11 +25,17 @@ steps:
       $filter += '&Category!=SingleNodeOnly'
       $filter += '&Category!=NestedEdgeAmqpOnly'
       $filter += '&Category!=LegacyMqttRequired'
+    
+      #We are disabling some additional tests. See  PBI #9171870. Once this is fixed we should run what's directly below.
+      #$filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope'
+      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_amqp')
     {
       $filter += '&Category!=SingleNodeOnly'
       $filter += '&Category!=BrokerRequired'
+
+      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_isa95')
     {

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -24,6 +24,7 @@ steps:
     {
       $filter += '&Category!=SingleNodeOnly'
       $filter += '&Category!=NestedEdgeAmqpOnly'
+      $filter += '&Category!=LegacyMqttRequired'
     
       #We are disabling some additional tests. See  PBI #9171870. Once this is fixed we should run what's directly below.
       #$filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope'
@@ -32,6 +33,8 @@ steps:
     elseif ($test_type -eq 'nestededge_amqp')
     {
       $filter += '&Category!=SingleNodeOnly'
+      $filter += '&Category!=BrokerRequired'
+
       $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_isa95')

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -26,8 +26,6 @@ steps:
       $filter += '&Category!=NestedEdgeAmqpOnly'
       $filter += '&Category!=LegacyMqttRequired'
     
-      #We are disabling some additional tests. See  PBI #9171870. Once this is fixed we should run what's directly below.
-      #$filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope'
       $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_amqp')

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -25,17 +25,11 @@ steps:
       $filter += '&Category!=SingleNodeOnly'
       $filter += '&Category!=NestedEdgeAmqpOnly'
       $filter += '&Category!=LegacyMqttRequired'
-    
-      #We are disabling some additional tests. See  PBI #9171870. Once this is fixed we should run what's directly below.
-      #$filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope'
-      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_amqp')
     {
       $filter += '&Category!=SingleNodeOnly'
       $filter += '&Category!=BrokerRequired'
-
-      $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_isa95')
     {

--- a/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
+        [Category("BrokerRequired")]
         public async Task AuthorizationPolicyUpdateTest()
         {
             CancellationToken token = this.TestToken;
@@ -182,6 +183,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
+        [Category("BrokerRequired")]
         public async Task AuthorizationPolicyExplicitPolicyTest()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
-        [Category("BrokerRequired")]
+        [Category("UsesBroker")]
         public async Task AuthorizationPolicyUpdateTest()
         {
             CancellationToken token = this.TestToken;
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
-        [Category("BrokerRequired")]
+        [Category("UsesBroker")]
         public async Task AuthorizationPolicyExplicitPolicyTest()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/AuthorizationPolicy.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
-        [Category("UsesBroker")]
+        [Category("BrokerRequired")]
         public async Task AuthorizationPolicyUpdateTest()
         {
             CancellationToken token = this.TestToken;
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
-        [Category("UsesBroker")]
+        [Category("BrokerRequired")]
         public async Task AuthorizationPolicyExplicitPolicyTest()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
-        [Category("UsesBroker")]
+        [Category("BrokerRequired")]
         public async Task GenericMqttTelemetry()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
+        [Category("BrokerRequired")]
         public async Task GenericMqttTelemetry()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// </summary>
         /// <returns><see cref="Task"/> representing the asynchronous unit test.</returns>
         [Test]
-        [Category("BrokerRequired")]
+        [Category("UsesBroker")]
         public async Task GenericMqttTelemetry()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/MqttBridgeConfig.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/MqttBridgeConfig.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// - Validate the successful result.
         /// </summary>
         [Test]
-        [Category("BrokerRequired")]
+        [Category("UsesBroker")]
         public async Task BridgeConfigUpdateTest()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/MqttBridgeConfig.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/MqttBridgeConfig.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// - Validate the successful result.
         /// </summary>
         [Test]
-        [Category("UsesBroker")]
+        [Category("BrokerRequired")]
         public async Task BridgeConfigUpdateTest()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/MqttBridgeConfig.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/MqttBridgeConfig.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         /// - Validate the successful result.
         /// </summary>
         [Test]
+        [Category("BrokerRequired")]
         public async Task BridgeConfigUpdateTest()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -20,27 +20,15 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string TestModelId = "dtmi:edgeE2ETest:TestCapabilityModel;1";
         const string LoadGenModuleName = "loadGenModule";
 
-        [TestCase(Protocol.MqttWs, false)]
-        [TestCase(Protocol.AmqpWs, false)]
-        [TestCase(Protocol.MqttWs, true)]
-        [TestCase(Protocol.AmqpWs, true)]
-        public async Task PlugAndPlayDeviceClient(Protocol protocol, bool brokerOn)
+        [TestCase(Protocol.Mqtt)]
+        [TestCase(Protocol.Amqp)]
+        [Category("LegacyMqttRequired")]
+        public async Task PlugAndPlayDeviceClient(Protocol protocol)
         {
             CancellationToken token = this.TestToken;
             string leafDeviceId = DeviceId.Current.Generate();
 
-            // If broker is on, MQTT will be used by default in nested environment. And new MQTT won't work for P&P
-            if (Context.Current.NestedEdge && brokerOn)
-            {
-                Assert.Ignore();
-            }
-
             Action<EdgeConfigBuilder> config = this.BuildAddEdgeHubConfig(protocol);
-            if (brokerOn)
-            {
-                config += MqttBrokerUtil.BuildAddBrokerToDeployment(true);
-            }
-
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(
                 config,
                 token,
@@ -73,28 +61,17 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 });
         }
 
-        [TestCase(Protocol.MqttWs, false)]
-        [TestCase(Protocol.AmqpWs, false)]
-        [TestCase(Protocol.MqttWs, true)]
-        [TestCase(Protocol.AmqpWs, true)]
+        [TestCase(Protocol.Mqtt)]
+        [TestCase(Protocol.Amqp)]
+        [Category("LegacyMqttRequired")]
         [Test]
-        public async Task PlugAndPlayModuleClient(Protocol protocol, bool brokerOn)
+        public async Task PlugAndPlayModuleClient(Protocol protocol)
         {
             CancellationToken token = this.TestToken;
 
-            // If broker is on, MQTT will be used by default in nested environment. And new MQTT won't work for P&P
-            if (Context.Current.NestedEdge && brokerOn)
-            {
-                Assert.Ignore();
-            }
-
             string loadGenImage = Context.Current.LoadGenImage.Expect(() => new ArgumentException("loadGenImage parameter is required for Priority Queues test"));
-            Action<EdgeConfigBuilder> config = this.BuildAddEdgeHubConfig(protocol) + this.BuildAddLoadGenConfig(protocol, loadGenImage);
-            if (brokerOn)
-            {
-                config += MqttBrokerUtil.BuildAddBrokerToDeployment(true);
-            }
 
+            Action<EdgeConfigBuilder> config = this.BuildAddEdgeHubConfig(protocol) + this.BuildAddLoadGenConfig(protocol, loadGenImage);
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(
                 config,
                 token,


### PR DESCRIPTION
Three things in this PR:
1. Our nested E2E tests are running broker-specific tests without the broker which is causing test failures (i.e. BridgeConfigUpdate). We need to implement a filter so that we don't run these broker specific tests without the broker enabled. I named this filter ```BrokerRequired```.
2. I am also adding a filter to the PlugAndPlay (```LegacyMqttRequired```)tests to only run with the legacy mqtt protocol head. These currently have very confusing logic around an extra broker enabled flag that always gets ignored. A filter will work much better.
3. Some tests were manually being filtered because of an outstanding PBI. The PBI is now done so I have removed the manual filter.

I think in general we should move to replace these manual test filters with Category filters. I am not sure why are currently filtering this:
```
FullyQualifiedName!~PriorityQueueModuleToHubMessages&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
```