### PR TITLE
[E2E]: Enable aziot-edge install from Microsoft prod

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
             string debPackages = $"https://packages.microsoft.com/config/{this.os}/{this.version}/multiarch/prod.list";
             if (this.os.ToLower() == "ubuntu" && this.version == "20.04")
             {
-                // Should be chanbed to 20.04 when we publish to that repo.
+                // Should be changed to 20.04 when we publish to that repo.
                 debPackages = $"https://packages.microsoft.com/config/{this.os}/18.04/multiarch/prod.list";
             }
             return this.packageExtension switch

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -68,6 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 // Should be changed to 20.04 when we publish to that repo.
                 debPackages = $"https://packages.microsoft.com/config/{this.os}/18.04/multiarch/prod.list";
             }
+
             return this.packageExtension switch
             {
                 SupportedPackageExtension.Deb => new[]

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -60,27 +60,36 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
             };
         }
 
-        public string[] GetInstallCommandsFromMicrosoftProd(Option<Uri> proxy) => this.packageExtension switch
+        public string[] GetInstallCommandsFromMicrosoftProd(Option<Uri> proxy)
         {
-            SupportedPackageExtension.Deb => new[]
+            string debPackages = $"https://packages.microsoft.com/config/{this.os}/{this.version}/multiarch/prod.list";
+            if (this.os.ToLower() == "ubuntu" && this.version == "20.04")
             {
-                $"curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
-                "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
-                $"apt-get update",
-                $"apt-get install --yes aziot-edge"
-            },
-            SupportedPackageExtension.Rpm => new[]
+                // Should be chanbed to 20.04 when we publish to that repo.
+                debPackages = $"https://packages.microsoft.com/config/{this.os}/18.04/multiarch/prod.list";
+            }
+            return this.packageExtension switch
             {
-                $"rpm -iv --replacepkgs https://packages.microsoft.com/config/{this.os}/{this.version}/packages-microsoft-prod.rpm",
-                $"yum updateinfo",
-                $"yum install --yes aziot-edge",
-                "pathToSystemdConfig=$(systemctl cat aziot-edge | head -n 1)",
-                "sed 's/=on-failure/=no/g' ${pathToSystemdConfig#?} > ~/override.conf",
-                "sudo mv -f ~/override.conf ${pathToSystemdConfig#?}",
-                "sudo systemctl daemon-reload"
-            },
-            _ => throw new NotImplementedException($"Don't know how to install daemon on for '.{this.packageExtension}'"),
-        };
+                SupportedPackageExtension.Deb => new[]
+                {
+                    $"curl {debPackages} > /etc/apt/sources.list.d/microsoft-prod.list",
+                    "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
+                    $"apt-get update",
+                    $"apt-get install --yes aziot-edge"
+                },
+                SupportedPackageExtension.Rpm => new[]
+                {
+                    $"rpm -iv --replacepkgs https://packages.microsoft.com/config/{this.os}/{this.version}/packages-microsoft-prod.rpm",
+                    $"yum updateinfo",
+                    $"yum install --yes aziot-edge",
+                    "pathToSystemdConfig=$(systemctl cat aziot-edge | head -n 1)",
+                    "sed 's/=on-failure/=no/g' ${pathToSystemdConfig#?} > ~/override.conf",
+                    "sudo mv -f ~/override.conf ${pathToSystemdConfig#?}",
+                    "sudo systemctl daemon-reload"
+                },
+                _ => throw new NotImplementedException($"Don't know how to install daemon on for '.{this.packageExtension}'"),
+            };
+        }
 
         public string[] GetUninstallCommands() => this.packageExtension switch
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -62,18 +62,19 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
 
         public string[] GetInstallCommandsFromMicrosoftProd(Option<Uri> proxy)
         {
-            string debPackages = $"https://packages.microsoft.com/config/{this.os}/{this.version}/multiarch/prod.list";
-            if (this.os.ToLower() == "ubuntu" && this.version == "20.04")
+            // we really support only two options for now.
+            string repository = this.os.ToLower() switch
             {
-                // Should be changed to 20.04 when we publish to that repo.
-                debPackages = $"https://packages.microsoft.com/config/{this.os}/18.04/multiarch/prod.list";
-            }
+                "ubuntu" => $"https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list",
+                "debian" => $"https://packages.microsoft.com/config/debian/stretch/multiarch/prod.list",
+                _ => throw new NotImplementedException($"Don't know how to install daemon for '{this.os}'"),
+            };
 
             return this.packageExtension switch
             {
                 SupportedPackageExtension.Deb => new[]
                 {
-                    $"curl {debPackages} > /etc/apt/sources.list.d/microsoft-prod.list",
+                    $"curl {repository} > /etc/apt/sources.list.d/microsoft-prod.list",
                     "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
                     $"apt-get update",
                     $"apt-get install --yes aziot-edge"


### PR DESCRIPTION
I want to enable aziot-edge install from Microsoft prod. This is useful for dev box scenarios where we don't care about specific version of runtime, but fine with the latest officially published.

This is first PR from a possible series of PRs to make our E2E tests dev box friendly.