### PR TITLE
Custom Mqtt Test Module: Add Initiate and Receive modes

### DIFF
--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
@@ -500,13 +500,13 @@
             "restartPolicy": "always",
             "env": {
               "TEST_SCENARIO": {
-                "value": "Initiate"
+                "value": "InitiateAndRelayReceived"
               },
               "TRACKING_ID": {
                 "value": "<TrackingId>"
               },
               "TEST_START_DELAY": {
-                "value": "10s"
+                "value": "120s"
               }
             },
             "settings": {

--- a/test/modules/generic-mqtt-tester/src/message_channel.rs
+++ b/test/modules/generic-mqtt-tester/src/message_channel.rs
@@ -183,7 +183,7 @@ where
         }
     }
 
-    pub fn message_channel(&self) -> UnboundedSender<ReceivedPublication> {
+    pub fn send_handle(&self) -> UnboundedSender<ReceivedPublication> {
         self.publication_sender.clone()
     }
 

--- a/test/modules/generic-mqtt-tester/src/settings.rs
+++ b/test/modules/generic-mqtt-tester/src/settings.rs
@@ -42,7 +42,7 @@ impl Settings {
 
         let test_scenario: TestScenario = config.get("test_scenario")?;
         match test_scenario {
-            TestScenario::Initate | TestScenario::InitiateAndReceiveRelayed => {
+            TestScenario::Initiate | TestScenario::InitiateAndReceiveRelayed => {
                 config.set("batch_id", Some(Uuid::new_v4().to_string()))?;
             }
             _ => {}
@@ -117,7 +117,7 @@ impl Settings {
 
 #[derive(Debug, Clone, Deserialize)]
 pub enum TestScenario {
-    Initate,
+    Initiate,
     InitiateAndReceiveRelayed,
     Relay,
     Receive,

--- a/test/modules/generic-mqtt-tester/src/settings.rs
+++ b/test/modules/generic-mqtt-tester/src/settings.rs
@@ -41,8 +41,11 @@ impl Settings {
         config.merge(Environment::new())?;
 
         let test_scenario: TestScenario = config.get("test_scenario")?;
-        if let TestScenario::Initiate = test_scenario {
-            config.set("batch_id", Some(Uuid::new_v4().to_string()))?;
+        match test_scenario {
+            TestScenario::Initate | TestScenario::InitiateAndReceiveRelayed => {
+                config.set("batch_id", Some(Uuid::new_v4().to_string()))?;
+            }
+            _ => {}
         }
 
         config.try_into()
@@ -114,6 +117,8 @@ impl Settings {
 
 #[derive(Debug, Clone, Deserialize)]
 pub enum TestScenario {
+    Initate,
+    InitiateAndReceiveRelayed,
     Relay,
-    Initiate,
+    Receive,
 }

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -203,7 +203,7 @@ impl MessageTester {
         let mut message_channel = None;
         let mut message_send_handle = None;
         if let Some(channel) = self.message_channel {
-            message_send_handle = Some(channel.message_channel()); // TODO: rename to send
+            message_send_handle = Some(channel.send_handle());
             message_channel = Some(channel);
         }
 

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -151,7 +151,7 @@ impl MessageTester {
                 publish_handle.clone(),
                 relay_topic,
             ))),
-            TestScenario::Initate => None,
+            TestScenario::Initiate => None,
         };
 
         let mut message_channel = None;
@@ -165,7 +165,7 @@ impl MessageTester {
         let mut message_initiator = None;
         let mut message_initiator_shutdown = None;
         match settings.test_scenario() {
-            TestScenario::Initate | TestScenario::InitiateAndReceiveRelayed => {
+            TestScenario::Initiate | TestScenario::InitiateAndReceiveRelayed => {
                 let initiator = MessageInitiator::new(publish_handle, reporting_client, &settings)?;
 
                 message_initiator_shutdown = Some(initiator.shutdown_handle());
@@ -302,7 +302,7 @@ impl MessageTester {
                 })
                 .await
                 .map_err(MessageTesterError::UpdateSubscription)?,
-            TestScenario::Initate => {}
+            TestScenario::Initiate => {}
         };
 
         info!("finished subscribing to test topics");

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -137,13 +137,9 @@ impl MessageTester {
         let message_handler: Option<Box<dyn MessageHandler + Send>> = match settings.test_scenario()
         {
             TestScenario::InitiateAndReceiveRelayed | TestScenario::Receive => {
-                let batch_id = settings
-                    .batch_id()
-                    .ok_or(MessageTesterError::MissingBatchId)?;
                 Some(Box::new(ReportResultMessageHandler::new(
                     reporting_client.clone(),
                     tracking_id,
-                    batch_id,
                     &module_name,
                 )))
             }

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -103,8 +103,8 @@ impl MessageTesterShutdownHandle {
 /// - Receives messages on initiate topic
 ///
 /// 3: `InitiateAndReceiveRelayed` mode
-/// - Spawn a thread that publishes messages continuously to initiate topic.
-/// - Receives same message routed back on relay topic by other test module
+/// - Sends messages on initiate topic.
+/// - Receives same messages routed back on relay topic by other test module
 /// - Reports the result to the Test Result Coordinator test module.
 ///
 /// 4: `Relay` mode

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -96,18 +96,18 @@ impl MessageTesterShutdownHandle {
 /// This module is designed to test generic (non-iothub) mqtt telemetry in both a single-node and nested environment.
 /// The module will run in one mode listed below. The behavior depends on this mode.
 ///
-/// 1: Initiate mode
+/// 1: `Initiate` mode
 /// - Sends messages on initiate topic
 ///
-/// 2: Receive mode
+/// 2: `Receive` mode
 /// - Receives messages on initiate topic
 ///
-/// 3: InitiateAndReceiveRelayed mode
+/// 3: `InitiateAndReceiveRelayed` mode
 /// - Spawn a thread that publishes messages continuously to initiate topic.
 /// - Receives same message routed back on relay topic by other test module
 /// - Reports the result to the Test Result Coordinator test module.
 ///
-/// 4: Relay mode
+/// 4: `Relay` mode
 /// - Receives messages on initiate topic and relays it back to on relay topic.
 pub struct MessageTester {
     settings: Settings,
@@ -202,12 +202,9 @@ impl MessageTester {
 
         let mut message_channel = None;
         let mut message_send_handle = None;
-        match self.message_channel {
-            Some(channel) => {
-                message_send_handle = Some(channel.message_channel()); // TODO: rename to send
-                message_channel = Some(channel);
-            }
-            None => {}
+        if let Some(channel) = self.message_channel {
+            message_send_handle = Some(channel.message_channel()); // TODO: rename to send
+            message_channel = Some(channel);
         }
 
         let poll_client_join = tokio::spawn(


### PR DESCRIPTION
We originally decided to have a relaying structure for the custom mqtt tests where there is a module sending messages upstream on the bottom edge and a message relaying these same messages back down on the middle edge. The purpose of this is so that all test modules that reported to the TRC could sit on the bottom layer. This leant itself towards a simpler test setup because:
- the test modules on the upper edge device did not need to know the ip address of the lower edge
- the test modules on the upper edge device did not need to worry about transient errors when making http requests to the TRC on the bottom edge
- the TRC on the bottom edge device did not need to have its ports bound to the host

There is a problem though because the middle level edge is not actually generating its own test events, meaning we miss some known bugs (i.e. persistent session in mqtt3 client). In order to fix this we need to restructure the topology of the custom mqtt tester so that the module on the middle level is generating its own test events (i.e. sending messages without needing a message sent from the below).

The first step towards this goal is to add Initiate and Receive modes to the generic mqtt tester. After this is complete there will be another PR that changes the custom mqtt test module topology to have continuous messages flowing bottom->up and also up-> bottom. 

Here is the docsting pasted from the test module:
```
/// Abstracts the test logic for this generic mqtt telemetry test module.
/// This module is designed to test generic (non-iothub) mqtt telemetry in both a single-node and nested environment.
/// The module will run in one mode listed below. The behavior depends on this mode.
///
/// 1: `Initiate` mode
/// - Sends messages on initiate topic
///
/// 2: `Receive` mode
/// - Receives messages on initiate topic
///
/// 3: `InitiateAndReceiveRelayed` mode
/// - Sends messages on initiate topic.
/// - Receives same messages routed back on relay topic by other test module
/// - Reports the result to the Test Result Coordinator test module.
///
/// 4: `Relay` mode
/// - Receives messages on initiate topic and relays it back to on relay topic
```