### PR TITLE
Metrics transform option

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/CombinedEdgeletConfigProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/CombinedEdgeletConfigProviderTest.cs
@@ -304,7 +304,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test
             }
         }
 
-
         static (IDictionary<string, EnvVal>, string) CreateEnv(params (string key, string value)[] pairs)
         {
             var dict = new Dictionary<string, EnvVal>();

--- a/edge-modules/azure-monitor/src/ExampleDeployment.json
+++ b/edge-modules/azure-monitor/src/ExampleDeployment.json
@@ -63,7 +63,10 @@
                 },
                 "CompressForUpload": {
                     "value": "true"
-                }
+                },
+                "TransformForUpload": {
+                  "value": "false"
+              }
             },
             "status": "running",
             "restartPolicy": "always",

--- a/edge-modules/azure-monitor/src/ExampleDeployment.json
+++ b/edge-modules/azure-monitor/src/ExampleDeployment.json
@@ -64,7 +64,7 @@
                 "CompressForUpload": {
                     "value": "true"
                 },
-                "TransformForUpload": {
+                "TransformForIoTCentral": {
                   "value": "false"
               }
             },

--- a/edge-modules/azure-monitor/src/IotHubUpload/IotHubUpload.cs
+++ b/edge-modules/azure-monitor/src/IotHubUpload/IotHubUpload.cs
@@ -30,9 +30,18 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor.IotHubMetricsUpload
             {
                 Preconditions.CheckNotNull(metrics, nameof(metrics));
 
+                // <TODO>: why transform the Metric to ExportedMetric here. They're almost identical
                 IEnumerable<ExportMetric> outputMetrics = metrics.Select(m => new ExportMetric(m));
 
-                byte[] metricsData = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(outputMetrics));
+                string outputString = JsonConvert.SerializeObject(outputMetrics);
+                if (Settings.Current.TransformForUpload)
+                {
+                    LoggerUtil.Writer.LogInformation("Transforming metrics prior to upload . . .");
+                    outputString = Transform(outputMetrics);
+                }
+                
+                LoggerUtil.Writer.LogDebug(outputString);
+                byte[] metricsData = Encoding.UTF8.GetBytes(outputString);
                 Message metricsMessage = new Message(metricsData);
                 metricsMessage.Properties[IdentifierPropertyName] = Constants.IoTUploadMessageIdentifier;
 
@@ -46,6 +55,159 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor.IotHubMetricsUpload
                 LoggerUtil.Writer.LogError(e, "Error sending metrics via IoT message");
                 return false;
             }
+        }
+
+        private string Transform(IEnumerable<ExportMetric> metrics)
+        {
+            DateTime timeGeneratedUtc = DateTime.MaxValue;
+            string deviceName = string.Empty;
+            string instanceNumber = string.Empty;
+            Dictionary<string, List<Dictionary<string, object>>> categorizedMetrics = new Dictionary<string, List<Dictionary<string, object>>>();
+            foreach (ExportMetric metric in metrics)
+            {
+                if (timeGeneratedUtc == DateTime.MaxValue)
+                {
+                    timeGeneratedUtc = metric.TimeGeneratedUtc;
+                }
+
+                if (deviceName == string.Empty)
+                {
+                    deviceName = metric.Labels.GetValueOrDefault("edge_device", string.Empty);
+                }
+
+                if (instanceNumber == string.Empty)
+                {
+                    instanceNumber = metric.Labels.GetValueOrDefault("instance_number", string.Empty);
+                }
+
+                if (double.IsNaN(metric.Value) ||
+                    double.IsNegativeInfinity(metric.Value) ||
+                    double.IsPositiveInfinity(metric.Value))
+                {
+                    continue;
+                }
+
+                var labels = TransformMetricLabels(metric);
+                if (categorizedMetrics.ContainsKey(metric.Name))
+                {
+                    List<Dictionary<string, object>> list;
+                    if (categorizedMetrics.TryGetValue(metric.Name, out list))
+                    {
+                        list.Add(labels);
+                    }
+                }
+                else
+                {
+                    List<Dictionary<string, object>> list = new List<Dictionary<string, object>>();
+                    list.Add(labels);
+                    categorizedMetrics.Add(metric.Name, list);
+                }
+            }
+
+            string outputMessageString = "{" + $"\"TimeGeneratedUtc\":\"{timeGeneratedUtc}\", \"edge_device\":\"{deviceName}\", \"instance_number\":\"{instanceNumber}\"";
+            foreach (KeyValuePair<string, List<Dictionary<string, object>>> kvp in categorizedMetrics)
+            {
+                foreach (var obj in kvp.Value)
+                {
+                    outputMessageString += $",\"{kvp.Key}\":" + JsonConvert.SerializeObject(obj);
+                }
+            }
+
+            outputMessageString += "}";
+            return outputMessageString;
+        }
+
+        private Dictionary<string, object> TransformMetricLabels(ExportMetric metric)
+        {
+            var labels = new Dictionary<string, object>();
+            labels.Add("value", metric.Value);
+
+            string command = metric.Labels.GetValueOrDefault("command", string.Empty);
+            if (command != string.Empty)
+            {
+                labels.Add("command", command);
+            }
+
+            string diskName = metric.Labels.GetValueOrDefault("disk_name", string.Empty);
+            if (diskName != string.Empty)
+            {
+                labels.Add("disk_name", diskName);
+            }
+
+            string from = metric.Labels.GetValueOrDefault("from", string.Empty);
+            if (from == string.Empty)
+            {
+                from = metric.Labels.GetValueOrDefault("id", string.Empty);
+                if (from == string.Empty)
+                {
+                    from = metric.Labels.GetValueOrDefault("module_name", string.Empty);
+                }
+            }
+            if (from != string.Empty)
+            {
+                labels.Add("from", from);
+            }
+
+            string fromRouteOutput = metric.Labels.GetValueOrDefault("from_route_output", string.Empty);
+            if (fromRouteOutput == string.Empty)
+            {
+                fromRouteOutput = metric.Labels.GetValueOrDefault("route_output", string.Empty);
+                if (fromRouteOutput == string.Empty)
+                {
+                    fromRouteOutput = metric.Labels.GetValueOrDefault("source", string.Empty);
+                }
+            }
+            if (fromRouteOutput != string.Empty)
+            {
+                labels.Add("from_route_output", fromRouteOutput);
+            }
+
+            string to = metric.Labels.GetValueOrDefault("to", string.Empty);
+            if (to == string.Empty)
+            {
+                to = metric.Labels.GetValueOrDefault("to_route_input", string.Empty);
+                if (to == string.Empty)
+                {
+                    to = metric.Labels.GetValueOrDefault("target", string.Empty);
+                }
+            }
+            if (to != string.Empty)
+            {
+                labels.Add("to", to);
+            }
+
+            string priorityString = metric.Labels.GetValueOrDefault("priority", string.Empty);
+            if (priorityString != string.Empty)
+            {
+                try
+                {
+                    long priority = Convert.ToInt64(priorityString);
+                    labels.Add("priority", priority);
+                }
+                catch
+                {
+                    LoggerUtil.Writer.LogInformation($"skipped transforming priority: '{priorityString}' in metric: '{metric.Name}'");
+                }
+            }
+
+            string quantileString = metric.Labels.GetValueOrDefault("quantile", string.Empty);
+            if (quantileString != string.Empty)
+            {
+                double quantile;
+                if (double.TryParse(quantileString, out quantile) &&
+                    !(double.IsNaN(quantile) ||
+                      double.IsNegativeInfinity(quantile) ||
+                      double.IsNegativeInfinity(quantile)))
+                {
+                    labels.Add("quantile", quantile);
+                }
+                else
+                {
+                    LoggerUtil.Writer.LogInformation($"skipped transforming quantile: '{quantileString}' in metric: '{metric.Name}'");
+                }
+            }
+
+            return labels;
         }
 
         class ExportMetric

--- a/edge-modules/azure-monitor/src/IotHubUpload/IotHubUpload.cs
+++ b/edge-modules/azure-monitor/src/IotHubUpload/IotHubUpload.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor.IotHubMetricsUpload
                 string outputString = JsonConvert.SerializeObject(outputMetrics);
                 LoggerUtil.Writer.LogDebug("Metrics selected for upload . . .");
                 LoggerUtil.Writer.LogDebug(outputString);
-                if (Settings.Current.TransformForUpload)
+                if (Settings.Current.TransformForIoTCentral)
                 {
                     outputString = Transform(outputMetrics);
                     LoggerUtil.Writer.LogDebug("Metrics transformed prior to upload . . .");

--- a/edge-modules/azure-monitor/src/IotHubUpload/IotHubUpload.cs
+++ b/edge-modules/azure-monitor/src/IotHubUpload/IotHubUpload.cs
@@ -32,13 +32,13 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor.IotHubMetricsUpload
                 IEnumerable<ExportMetric> outputMetrics = metrics.Select(m => new ExportMetric(m));
 
                 string outputString = JsonConvert.SerializeObject(outputMetrics);
-                LoggerUtil.Writer.LogDebug("Metrics selected for upload . . .");
-                LoggerUtil.Writer.LogDebug(outputString);
+                // LoggerUtil.Writer.LogDebug("Metrics selected for upload . . .");
+                // LoggerUtil.Writer.LogDebug(outputString);
                 if (Settings.Current.TransformForIoTCentral)
                 {
                     outputString = Transform(outputMetrics);
-                    LoggerUtil.Writer.LogDebug("Metrics transformed prior to upload . . .");
-                    LoggerUtil.Writer.LogDebug(outputString);
+                    // LoggerUtil.Writer.LogDebug("Metrics transformed prior to upload . . .");
+                    // LoggerUtil.Writer.LogDebug(outputString);
                 }
 
                 byte[] metricsData = Encoding.UTF8.GetBytes(outputString);

--- a/edge-modules/azure-monitor/src/README.md
+++ b/edge-modules/azure-monitor/src/README.md
@@ -53,6 +53,10 @@ Optional config items:
     - This should really only be turned off in extremely CPU-bound applications, if at all.
     - ex: `true`
     - Defaults to true.
+- `TransformForUpload`
+    - If the metrics data needs to be flattened prior to published as IoT messages.
+    - ex: `false`
+    - Defaults to false.
 
 
 ## Upload Target:
@@ -76,6 +80,34 @@ Metrics published as IoT messages are emitted as UTF8-encoded json from the endp
         "name": "AzureMonitorForIotEdgeModule"
     }
 }]
+```
+
+Turning on TransformForUpload, the format of IoT messages changes to:
+
+```
+{
+  "TimeGeneratedUtc": "<time generated>",
+  "edge_device": "<device bame>",
+  "instance_number": "<instance number>",
+  "<prometheus metric name>": {
+    "value": <decimal value>,
+    "from": "<value of: 'from', 'module_name', or 'id' if exists>",
+    "from_route_output": "<value of: 'from_route_output', 'route_output', or 'source' if exists>",
+    "to": "<value of: 'to', 'to_route_input', or 'target' if exists>",
+    "priority": <integer value of 'priority' if exists>,
+    "quantile": <decimal value of 'quantile' if exists>,
+    "command": "<value of 'command' if exists>",
+    "disk_name": "<value of 'disk_name' if exists>"
+  },
+  "edgeAgent_used_memory_bytes": {
+    "value": 54992896.0,
+    "from": "edgeAgent"
+  },
+  "edgeAgent_used_memory_bytes": {
+    "value": 131170304.0,
+    "from": "edgeHub"
+  }
+}
 ```
 
 

--- a/edge-modules/azure-monitor/src/README.md
+++ b/edge-modules/azure-monitor/src/README.md
@@ -53,8 +53,11 @@ Optional config items:
     - This should really only be turned off in extremely CPU-bound applications, if at all.
     - ex: `true`
     - Defaults to true.
-- `TransformForUpload`
+- `TransformForIoTCentral`
     - If the metrics data needs to be flattened prior to published as IoT messages.
+    - Metrics module emits metrics in Prometheus data format. Metrics are emitted as an array of key/value pair. Enabling IoT       Central to build dashboards, The data needs to be flattened out to match the device template interfaces.
+    - Turning this option on, it reduces the data size by 70%
+    - This can only be turned on if `UploadTarget` set to `IotMessage`
     - ex: `false`
     - Defaults to false.
 
@@ -82,7 +85,7 @@ Metrics published as IoT messages are emitted as UTF8-encoded json from the endp
 }]
 ```
 
-Turning on TransformForUpload, the format of IoT messages changes to:
+Turning on TransformForIoTCentral, the format of IoT messages changes to:
 
 ```
 {

--- a/edge-modules/azure-monitor/src/Settings.cs
+++ b/edge-modules/azure-monitor/src/Settings.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             int scrapeFrequencySecs,
             UploadTarget uploadTarget,
             bool compressForUpload,
+            bool transformForUpload,
             string allowedMetrics,
             string blockedMetrics,
             string hubResourceID)
@@ -53,6 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
 
             this.ScrapeFrequencySecs = Preconditions.CheckRange(scrapeFrequencySecs, 1);
             this.CompressForUpload = compressForUpload;
+            this.TransformForUpload = transformForUpload;
 
             // Create list of allowed metrics. If this list is not empty then any metrics not on it should be discarded.
             this.AllowedMetrics = new MetricFilter(allowedMetrics);
@@ -74,6 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                     configuration.GetValue<int>("ScrapeFrequencyInSecs", 300),
                     configuration.GetValue<UploadTarget>("UploadTarget", UploadTarget.AzureMonitor),
                     configuration.GetValue<bool>("CompressForUpload", true),
+                    configuration.GetValue<bool>("TransformForUpload", false),
                     configuration.GetValue<string>("AllowedMetrics", ""),
                     configuration.GetValue<string>("BlockedMetrics", ""),
                     configuration.GetValue<string>("HubResourceID", ""));
@@ -98,6 +101,8 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
 
         public bool CompressForUpload { get; }
 
+        public bool TransformForUpload { get; }
+
         public MetricFilter AllowedMetrics { get; }
 
         public MetricFilter BlockedMetrics { get; }
@@ -115,6 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                 { nameof(this.ScrapeFrequencySecs), this.ScrapeFrequencySecs.ToString() },
                 { nameof(this.UploadTarget), Enum.GetName(typeof(UploadTarget), this.UploadTarget) },
                 { nameof(this.CompressForUpload), this.CompressForUpload.ToString() },
+                { nameof(this.TransformForUpload), this.TransformForUpload.ToString() },
                 { nameof(this.AllowedMetrics), string.Join(",", this.AllowedMetrics) },
                 { nameof(this.BlockedMetrics), string.Join(",", this.BlockedMetrics) },
                 { nameof(this.HubResourceID), this.HubResourceID ?? string.Empty }

--- a/edge-modules/azure-monitor/src/Settings.cs
+++ b/edge-modules/azure-monitor/src/Settings.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             int scrapeFrequencySecs,
             UploadTarget uploadTarget,
             bool compressForUpload,
-            bool transformForUpload,
+            bool transformForIoTCentral,
             string allowedMetrics,
             string blockedMetrics,
             string hubResourceID)
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
 
             this.ScrapeFrequencySecs = Preconditions.CheckRange(scrapeFrequencySecs, 1);
             this.CompressForUpload = compressForUpload;
-            this.TransformForUpload = transformForUpload;
+            this.TransformForIoTCentral = transformForIoTCentral;
 
             // Create list of allowed metrics. If this list is not empty then any metrics not on it should be discarded.
             this.AllowedMetrics = new MetricFilter(allowedMetrics);
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                     configuration.GetValue<int>("ScrapeFrequencyInSecs", 300),
                     configuration.GetValue<UploadTarget>("UploadTarget", UploadTarget.AzureMonitor),
                     configuration.GetValue<bool>("CompressForUpload", true),
-                    configuration.GetValue<bool>("TransformForUpload", false),
+                    configuration.GetValue<bool>("TransformForIoTCentral", false),
                     configuration.GetValue<string>("AllowedMetrics", ""),
                     configuration.GetValue<string>("BlockedMetrics", ""),
                     configuration.GetValue<string>("HubResourceID", ""));
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
 
         public bool CompressForUpload { get; }
 
-        public bool TransformForUpload { get; }
+        public bool TransformForIoTCentral { get; }
 
         public MetricFilter AllowedMetrics { get; }
 
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                 { nameof(this.ScrapeFrequencySecs), this.ScrapeFrequencySecs.ToString() },
                 { nameof(this.UploadTarget), Enum.GetName(typeof(UploadTarget), this.UploadTarget) },
                 { nameof(this.CompressForUpload), this.CompressForUpload.ToString() },
-                { nameof(this.TransformForUpload), this.TransformForUpload.ToString() },
+                { nameof(this.TransformForIoTCentral), this.TransformForIoTCentral.ToString() },
                 { nameof(this.AllowedMetrics), string.Join(",", this.AllowedMetrics) },
                 { nameof(this.BlockedMetrics), string.Join(",", this.BlockedMetrics) },
                 { nameof(this.HubResourceID), this.HubResourceID ?? string.Empty }


### PR DESCRIPTION
Introducing new option to trasnsform/flatten the Metrics prior to publish as IoT Messages.
**Publishing with transform option OFF:**
[{
    "TimeGeneratedUtc": "<time generated>",
    "Name": "<prometheus metric name>",
    "Value": <decimal value>,
    "Label": {
        "<label name>": "<label value>"
    }
}, {
    "TimeGeneratedUtc": "2020-07-28T20:00:43.2770247Z",
    "Name": "docker_container_disk_write_bytes",
    "Value": 0.0,
    "Label": {
        "name": "AzureMonitorForIotEdgeModule"
    }
}]

**Publishing with transform option ON:**
{
  "TimeGeneratedUtc": "<time generated>",
  "edge_device": "<device bame>",
  "instance_number": "<instance number>",
  "<prometheus metric name>": {
    "value": <decimal value>,
    "from": "<value of: 'from', 'module_name', or 'id' if exists>",
    "from_route_output": "<value of: 'from_route_output', 'route_output', or 'source' if exists>",
    "to": "<value of: 'to', 'to_route_input', or 'target' if exists>",
    "priority": <integer value of 'priority' if exists>,
    "quantile": <decimal value of 'quantile' if exists>,
    "command": "<value of 'command' if exists>",
    "disk_name": "<value of 'disk_name' if exists>"
  },
  "edgeAgent_used_memory_bytes": {
    "value": 54992896.0,
    "from": "edgeAgent"
  },
  "edgeAgent_used_memory_bytes": {
    "value": 131170304.0,
    "from": "edgeHub"
  }
}