### PR TITLE
Revert "Update functions to 3.0"

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -78,7 +78,6 @@ Included items must then not match any entries in the exclude list to remain inc
                 <ModulePath>.*testanalyzer\..*</ModulePath>
                 <ModulePath>.*testresultcoordinator\..*</ModulePath>
                 <ModulePath>.*twintester\..*</ModulePath>
-                <ModulePath>.*microsoft.azure.webjobs.*</ModulePath>
               </Exclude>
             </ModulePaths>
 

--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -31,6 +31,7 @@ jobs:
     pool:
       vmImage: "ubuntu-18.04"
     steps:
+      - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
       - task: Bash@3
         displayName: Install Prerequisites

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -31,6 +31,7 @@ jobs:
             IotDevice3ConnStr2,
             IotHubConnStr2,
             IotHubMqttHeadCert
+      - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
       - task: Bash@3
         displayName: Install Prerequisites

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -19,6 +19,7 @@ jobs:
             docker login '$(build.registry.address)' --username '$(build.registry.user)' --password '$(build.registry.password)'
             docker login '$(registry.address)' --username '$(registry.user)' --password '$(registry.password)'
         displayName: 'Docker Login'
+      - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
       - template: ../templates/dotnet3-globaljson.yaml # use dotnet 3 as primary install for build
       # Build

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -18,6 +18,7 @@ jobs:
     pool:
       vmImage: 'ubuntu-18.04'
     steps:
+      - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
 
       - bash: 'docker login $(registry.address) --username $(registry.user) --password $(registry.password)'

--- a/builds/templates/install-dotnet2.yaml
+++ b/builds/templates/install-dotnet2.yaml
@@ -1,0 +1,6 @@
+steps:
+  - task: UseDotNet@2
+    displayName: Install .NET Core sdk
+    inputs:
+      packageType: sdk
+      version: 2.2.207

--- a/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
+++ b/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\..\..\netcoreappVersion.props" />
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
   
   <PropertyGroup>
     <AzureFunctionsVersion></AzureFunctionsVersion>
@@ -19,7 +21,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/edge-modules/functions/samples/README.md
+++ b/edge-modules/functions/samples/README.md
@@ -1,5 +1,0 @@
-# Azure functions module for IoT Edge
-This is a sample on how to use EdgeHub binding for Azure functions in an IoT Edge module. 
-It contains a C# function that gets triggered when a message is received from EdgeHub and also contains docker files needed to build the module image.
-
-Current version is based on Azure functions runtime 3.0 which has a larger docker image size compared to previous version. If image size is a concern older version of EdgeHub binding (<=1.0.7) has to be used which is based on Azure functions 2.0

--- a/edge-modules/functions/samples/docker/linux/amd64/Dockerfile
+++ b/edge-modules/functions/samples/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0
+FROM mcr.microsoft.com/azure-functions/dotnet:2.0-iot-edge
 
 ENV AzureWebJobsScriptRoot=/app
 

--- a/edge-modules/functions/samples/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/functions/samples/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0-arm32v7
+FROM mcr.microsoft.com/azure-functions/dotnet:2.0-arm32v7
 
 ENV AzureWebJobsScriptRoot=/app
 

--- a/edge-modules/functions/samples/docker/windows/amd64/Dockerfile
+++ b/edge-modules/functions/samples/docker/windows/amd64/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
 
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0-nanoserver-1809
+FROM mcr.microsoft.com/azure-functions/dotnet:2.0-nanoserver-1809
 
 COPY . /approot

--- a/scripts/linux/buildBranch.sh
+++ b/scripts/linux/buildBranch.sh
@@ -245,8 +245,8 @@ publish_app "MetricsValidator"
 publish_app "NumberLogger"
 publish_app "CloudToDeviceMessageTester"
 publish_app "IotedgeDiagnosticsDotnet"
-publish_app "EdgeHubTriggerCSharp"
 
+publish_lib "EdgeHubTriggerCSharp"
 publish_lib "Microsoft.Azure.WebJobs.Extensions.EdgeHub"
 
 publish_files $SRC_SCRIPTS_DIR $PUBLISH_FOLDER

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                 TempFilterToCloud = $"FROM /messages/modules/{filterName}/outputs/alertOutput INTO $upstream",
                                 TempSensorToTempFilter = $"FROM /messages/modules/{SensorName}/outputs/temperatureOutput INTO BrokeredEndpoint('/modules/{filterName}/inputs/input1')"
                             }
-                        });
+                        } );
                 },
                 token,
                 Context.Current.NestedEdge);
@@ -116,6 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("Unstable")]
         // Test Temperature Filter Function: https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-deploy-function
         public async Task TempFilterFunc()
         {


### PR DESCRIPTION
Reverts Azure/iotedge#4856

I believe this change broke CI and checkin pipeline. https://dev.azure.com/msazure/One/_build/results?buildId=41761951&view=results