### PR TITLE
Fix Edge CA and module cert CSRs to use version 0 (v1) instead of non-existent version 2 (v3).

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "http-common",
  "libc",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "pkcs11",
  "serde",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "http-common",
  "serde",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "serde",
  "toml",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "cc",
 ]
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1892,7 +1892,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#535c67e0c48e8c520d3e65e6432829a4464fcedd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/edgelet-http-workload/src/server/cert/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/mod.rs
@@ -209,7 +209,7 @@ fn create_csr(
 ) -> std::result::Result<Vec<u8>, ErrorStack> {
     let mut csr = openssl::x509::X509Req::builder()?;
 
-    csr.set_version(2)?;
+    csr.set_version(0)?;
 
     let mut subject_name = openssl::x509::X509Name::builder()?;
     subject_name.append_entry_by_text("CN", props.common_name())?;


### PR DESCRIPTION
v3 is correct for certificates (`X509`) but not for CSRs (`X509Req`).