### PR TITLE
iotedge config apply: fix auth certs for EST-issued Edge CA

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "http-common",
  "libc",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "pkcs11",
  "serde",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "http-common",
  "serde",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "serde",
  "toml",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "cc",
 ]
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1892,7 +1892,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#b72b5a22725b455579d363ccc448cba4e661b229"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/iotedge/src/config/apply.rs
+++ b/edgelet/iotedge/src/config/apply.rs
@@ -273,6 +273,7 @@ fn execute_inner(
                         &mut certd_config.preloaded_certs,
                         &mut keys,
                         &mut aziotcs_principal,
+                        edgelet_core::AZIOT_EDGED_CA_ALIAS,
                     );
 
                     keyd_config.principal.push(aziotcs_principal);

--- a/edgelet/iotedge/test-files/config/ca-certs-est/certd.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs-est/certd.toml
@@ -9,14 +9,14 @@ method = "est"
 url = "https://example.org/.well-known/est"
 username = "user"
 password = "password"
-identity_cert = "est-id-device-id"
-identity_pk = "est-id-device-id"
-bootstrap_identity_cert = "est-bootstrap-id-device-id"
-bootstrap_identity_pk = "est-bootstrap-id-device-id"
+identity_cert = "est-id-aziot-edged-ca"
+identity_pk = "est-id-aziot-edged-ca"
+bootstrap_identity_cert = "est-bootstrap-id-aziot-edged-ca"
+bootstrap_identity_pk = "est-bootstrap-id-aziot-edged-ca"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca", "trust-bundle-user"]
-est-bootstrap-id-device-id = "file:///var/secrets/est-bootstrap-id.pem"
+est-bootstrap-id-aziot-edged-ca = "file:///var/secrets/est-bootstrap-id.pem"
 trust-bundle-user = "file:///var/secrets/trusted-ca.pem"
 
 [[principal]]

--- a/edgelet/iotedge/test-files/config/ca-certs-est/keyd.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs-est/keyd.toml
@@ -6,7 +6,7 @@ homedir_path = "/var/lib/aziot/keyd"
 
 [preloaded_keys]
 device-id = "file:///var/secrets/aziot/keyd/device-id"
-est-bootstrap-id-device-id = "file:///var/secrets/est-bootstrap-id.key.pem"
+est-bootstrap-id-aziot-edged-ca = "file:///var/secrets/est-bootstrap-id.key.pem"
 
 [[principal]]
 uid = 5556
@@ -18,4 +18,4 @@ keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca", "est-bootstrap-id-device-id", "est-id-device-id"]
+keys = ["aziot-edged-ca", "est-bootstrap-id-aziot-edged-ca", "est-id-aziot-edged-ca"]


### PR DESCRIPTION
Fix a bug where the EST auth certs for the Edge CA cert were using the IDs of the device ID cert.