### PR TITLE
Update bridge config validation. (#4788)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/BridgeConfig.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/BridgeConfig.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
         public Bridge(string endpoint, IList<Settings> settings)
         {
             this.Endpoint = endpoint;
-            this.Settings = settings;
+            this.Settings = settings ?? new List<Settings>();
         }
 
         [JsonProperty("endpoint", Required = Required.Always)]

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/BrokerConfigValidator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/BrokerConfigValidator.cs
@@ -67,48 +67,50 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
         {
             Preconditions.CheckNotNull(properties, nameof(properties));
 
-            var order = 0;
             var errors = new List<string>();
             foreach (var bridge in properties)
             {
-                ValidateBridge(bridge, order, errors);
-                order++;
+                ValidateBridge(bridge, errors);
             }
 
             return errors;
         }
 
-        static void ValidateBridge(Bridge bridge, int order, List<string> errors)
+        static void ValidateBridge(Bridge bridge, List<string> errors)
         {
             if (string.IsNullOrEmpty(bridge.Endpoint))
             {
-                errors.Add($"Bridge {order}: Endpoint must not be empty");
+                errors.Add($"Bridge endpoint must not be empty");
             }
 
-            if (bridge.Settings.Count == 0)
+            if (!bridge.Endpoint.Equals("$upstream", StringComparison.InvariantCultureIgnoreCase)
+                && bridge.Settings.Count == 0)
             {
-                errors.Add($"Bridge {order}: Settings must not be empty");
+                errors.Add($"Bridge {bridge.Endpoint}: Settings must not be empty");
             }
 
+            var order = 0;
             foreach (var setting in bridge.Settings)
             {
                 if (setting.Topic != null
                     && !IsValidTopicFilter(setting.Topic))
                 {
-                    errors.Add($"Bridge {order}: Topic is invalid: {setting.Topic}");
+                    errors.Add($"Bridge {bridge.Endpoint}: Rule {order}: Topic is invalid: {setting.Topic}");
                 }
 
                 if (setting.InPrefix.Contains("+")
                     || setting.InPrefix.Contains("#"))
                 {
-                    errors.Add($"Bridge {order}: InPrefix must not contain wildcards (+, #)");
+                    errors.Add($"Bridge {bridge.Endpoint}: Rule {order}: InPrefix must not contain wildcards (+, #)");
                 }
 
                 if (setting.OutPrefix.Contains("+")
                     || setting.OutPrefix.Contains("#"))
                 {
-                    errors.Add($"Bridge {order}: OutPrefix must not contain wildcards (+, #)");
+                    errors.Add($"Bridge {bridge.Endpoint}: Rule {order}: OutPrefix must not contain wildcards (+, #)");
                 }
+
+                order++;
             }
         }
 

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/BrokerPropertiesValidatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/config/BrokerPropertiesValidatorTest.cs
@@ -157,8 +157,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Config
             IList<string> errors = validator.ValidateBridgeConfig(bridgeConfig);
 
             Assert.Equal(2, errors.Count);
-            Assert.Equal("Bridge 0: Endpoint must not be empty", errors[0]);
-            Assert.Equal("Bridge 1: Settings must not be empty", errors[1]);
+            Assert.Equal("Bridge endpoint must not be empty", errors[0]);
+            Assert.Equal("Bridge floor2: Settings must not be empty", errors[1]);
         }
 
         [Fact]
@@ -177,9 +177,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Config
             IList<string> errors = validator.ValidateBridgeConfig(bridgeConfig);
 
             Assert.Equal(3, errors.Count);
-            Assert.Equal("Bridge 0: Topic is invalid: topic/#/a", errors[0]);
-            Assert.Equal("Bridge 0: InPrefix must not contain wildcards (+, #)", errors[1]);
-            Assert.Equal("Bridge 0: OutPrefix must not contain wildcards (+, #)", errors[2]);
+            Assert.Equal("Bridge $upstream: Rule 0: Topic is invalid: topic/#/a", errors[0]);
+            Assert.Equal("Bridge $upstream: Rule 0: InPrefix must not contain wildcards (+, #)", errors[1]);
+            Assert.Equal("Bridge $upstream: Rule 0: OutPrefix must not contain wildcards (+, #)", errors[2]);
         }
     }
 }

--- a/mqtt/mqtt-bridge/src/config_update.rs
+++ b/mqtt/mqtt-bridge/src/config_update.rs
@@ -136,11 +136,6 @@ impl BridgeUpdate {
         }
     }
 
-    // TODO update should have name
-    pub fn name(&self) -> &str {
-        &self.endpoint
-    }
-
     pub fn endpoint(&self) -> &str {
         &self.endpoint
     }

--- a/mqtt/mqtt-bridge/src/controller/bridges.rs
+++ b/mqtt/mqtt-bridge/src/controller/bridges.rs
@@ -58,12 +58,16 @@ impl Bridges {
     }
 
     pub(crate) async fn send_update(&mut self, update: BridgeUpdate) {
-        if let Some(config) = self.config_updaters.get_mut(update.name()) {
-            if let Err(e) = config.send_update(update).await {
-                error!("error sending bridge update {:?}", e);
+        let endpoint = update.endpoint().to_owned();
+        if let Some(config) = self.config_updaters.get_mut(&endpoint) {
+            if let Err(err) = config.send_update(update).await {
+                error!(
+                    "error sending bridge update for {}, caused by: {:?}",
+                    &endpoint, err
+                );
             }
         } else {
-            debug!("config for {} not found", update.name());
+            debug!("config for bridge {} not found", update.endpoint());
         }
     }
 

--- a/mqtt/mqtt-bridge/src/controller/mod.rs
+++ b/mqtt/mqtt-bridge/src/controller/mod.rs
@@ -162,7 +162,7 @@ async fn process_update(update: BridgeControllerUpdate, bridges: &mut Bridges) {
     let mut bridge_updates = update
         .into_inner()
         .into_iter()
-        .map(|update| (update.name().to_owned(), update))
+        .map(|update| (update.endpoint().to_owned(), update))
         .collect::<HashMap<_, _>>();
 
     // for now only supports upstream bridge.


### PR DESCRIPTION
Context: We need to properly handle EdgeHub faulty bridge configuration.

After some offline discussion, there are two scenarios that we identified:
- First time deployment: if wrong config is set, EdgeHub should reject the twin, report the error via LastDesiredStatus and stop. It should not proceed with startup and open any public ports b/c we are running the risk of losing messages.
- Subsequent deployments: if wrong config is set, EdgeHub should reject the twin, report LastDesiredStatus and continue with previous configuration. This is (I believe) existing behavior.

In this PR I have updated bridge config validation to allow empty settings for `$upstream` bridge and improved error messages.

Also, removed unnecessary `BridgeUpdate::name()` property in favor of `BridgeUpdate::endpoint()`