### PR TITLE
Custom Mqtt Test Module: Restore E2E tests (#4913)

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     builder.AddModule(GenericMqttInitiatorModuleName, genericMqttTesterImage, false)
                         .WithEnvironment(new[]
                         {
-                            ("TEST_SCENARIO", "Initiate"),
+                            ("TEST_SCENARIO", "InitiateAndReceiveRelayed"),
                             ("TRACKING_ID", trackingId),
                             ("TEST_START_DELAY", GenericMqttTesterTestStartDelay),
                             ("MESSAGES_TO_SEND", GenericMqttTesterMaxMessages),

--- a/test/modules/generic-mqtt-tester/README.md
+++ b/test/modules/generic-mqtt-tester/README.md
@@ -1,12 +1,4 @@
 # Generic MQTT Test Module
 
-This module is designed to test generic (non-iothub) mqtt telemetry in both a single-node and nested environment. The module will run in one of two modes. The behavior depends on this mode.
-
-1: Initiate mode
-- If nested scenario, test module runs on the lowest node in the topology.
-- Spawn a thread that publishes messages continuously to upstream edge.
-- Receives same message routed back from upstream edge and reports the result to the Test Result Coordinator test module.
-
-2: Relay mode
-- If nested scenario, test module runs on the middle node in the topology.
-- Receives a message from downstream edge and relays it back to downstream edge.
+See description here:
+[link](src/tester.rs#L96)

--- a/test/modules/generic-mqtt-tester/src/tester.rs
+++ b/test/modules/generic-mqtt-tester/src/tester.rs
@@ -10,9 +10,10 @@ use tracing_futures::Instrument;
 
 use mqtt3::{
     proto::{QoS, SubscribeTo},
-    Client, Event, ReceivedPublication, SubscriptionUpdateEvent, UpdateSubscriptionHandle,
+    Client, Event, PublishHandle, ReceivedPublication, SubscriptionUpdateEvent,
+    UpdateSubscriptionHandle,
 };
-use mqtt_broker_tests_util::client;
+use mqtt_broker_tests_util::client::{self};
 use mqtt_util::ClientIoSource;
 use trc_client::TrcClient;
 
@@ -128,27 +129,7 @@ impl MessageTester {
             .publish_handle()
             .map_err(MessageTesterError::PublishHandle)?;
 
-        let tracking_id = settings.tracking_id();
-        let relay_topic = settings.relay_topic();
-        let module_name = settings.module_name();
-        let test_result_coordinator_url = settings.trc_url();
-        let reporting_client = TrcClient::new(test_result_coordinator_url);
-
-        let message_handler: Option<Box<dyn MessageHandler + Send>> = match settings.test_scenario()
-        {
-            TestScenario::InitiateAndReceiveRelayed | TestScenario::Receive => {
-                Some(Box::new(ReportResultMessageHandler::new(
-                    reporting_client.clone(),
-                    tracking_id,
-                    &module_name,
-                )))
-            }
-            TestScenario::Relay => Some(Box::new(RelayingMessageHandler::new(
-                publish_handle.clone(),
-                relay_topic,
-            ))),
-            TestScenario::Initiate => None,
-        };
+        let message_handler = message_handler(&settings, publish_handle.clone());
 
         let mut message_channel = None;
         let mut message_channel_shutdown = None;
@@ -157,6 +138,9 @@ impl MessageTester {
             message_channel_shutdown = Some(channel.shutdown_handle());
             message_channel = Some(channel);
         }
+
+        let test_result_coordinator_url = settings.trc_url();
+        let reporting_client = TrcClient::new(test_result_coordinator_url);
 
         let mut message_initiator = None;
         let mut message_initiator_shutdown = None;
@@ -306,6 +290,28 @@ impl MessageTester {
     }
 }
 
+fn message_handler(
+    settings: &Settings,
+    publish_handle: PublishHandle,
+) -> Option<Box<dyn MessageHandler + Send>> {
+    let tracking_id = settings.tracking_id();
+    let relay_topic = settings.relay_topic();
+    let module_name = settings.module_name();
+    let test_result_coordinator_url = settings.trc_url();
+    let reporting_client = TrcClient::new(test_result_coordinator_url);
+
+    match settings.test_scenario() {
+        TestScenario::InitiateAndReceiveRelayed | TestScenario::Receive => Some(Box::new(
+            ReportResultMessageHandler::new(reporting_client, tracking_id, &module_name),
+        )),
+        TestScenario::Relay => Some(Box::new(RelayingMessageHandler::new(
+            publish_handle,
+            relay_topic,
+        ))),
+        TestScenario::Initiate => None,
+    }
+}
+
 async fn poll_client(
     message_send_handle: Option<UnboundedSender<ReceivedPublication>>,
     mut client: Client<ClientIoSource>,
@@ -321,7 +327,7 @@ async fn poll_client(
         match future::select(event, shutdown).await {
             Either::Left((event, _)) => {
                 if let Ok(Some(event)) = event {
-                    process_event(event, &message_send_handle)?;
+                    process_event(event, message_send_handle)?;
                 }
             }
             Either::Right((shutdown, _)) => {
@@ -341,7 +347,7 @@ async fn poll_client(
 
 fn process_event(
     event: Event,
-    message_send_handle: &Option<UnboundedSender<ReceivedPublication>>,
+    message_send_handle: Option<UnboundedSender<ReceivedPublication>>,
 ) -> Result<(), MessageTesterError> {
     match event {
         Event::NewConnection { .. } => {


### PR DESCRIPTION
I accidentally broke end to end tests when adding a new mode to the custom mqtt test module. I took this as an opportunity to address some of Roberts comments on my cherry pick I didn't address before. Also fixed the README.