### PR TITLE
Longhaul: Remove connectivity specific `VerificationDelay` from TRC (#4901)

### DIFF
--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -355,9 +355,6 @@
               "testStartDelay": {
                 "value": "<TestStartDelay>"
               },
-              "verificationDelay": {
-                "value": "<TestResultCoordinator.VerificationDelay>"
-              },
               "sendReportFrequency": {
                 "value": "<SendReportFrequency>"
               },

--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
@@ -352,9 +352,6 @@
               "testStartDelay": {
                 "value": "<TestStartDelay>"
               },
-              "verificationDelay": {
-                "value": "<TestResultCoordinator.VerificationDelay>"
-              },
               "sendReportFrequency": {
                 "value": "<SendReportFrequency>"
               },

--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
@@ -361,9 +361,6 @@
               "testStartDelay": {
                 "value": "<TestStartDelay>"
               },
-              "verificationDelay": {
-                "value": "<TestResultCoordinator.VerificationDelay>"
-              },
               "sendReportFrequency": {
                 "value": "<SendReportFrequency>"
               },

--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -189,7 +189,6 @@ function prepare_test_from_artifacts() {
 
     sed -i -e "s@<TestResultCoordinator.ConsumerGroupId>@$EVENT_HUB_CONSUMER_GROUP_ID@g" "$deployment_working_file"
     sed -i -e "s@<TestResultCoordinator.EventHubConnectionString>@$EVENTHUB_CONNECTION_STRING@g" "$deployment_working_file"
-    sed -i -e "s@<TestResultCoordinator.VerificationDelay>@$VERIFICATION_DELAY@g" "$deployment_working_file"
     sed -i -e "s@<TestResultCoordinator.OptimizeForPerformance>@$optimize_for_performance@g" "$deployment_working_file"
     sed -i -e "s@<TestResultCoordinator.LogAnalyticsLogType>@$LOG_ANALYTICS_LOGTYPE@g" "$deployment_working_file"
     sed -i -e "s@<TestResultCoordinator.logUploadEnabled>@$log_upload_enabled@g" "$deployment_working_file"
@@ -225,6 +224,7 @@ function prepare_test_from_artifacts() {
         sed -i -e "s@<DeploymentTester1.DeploymentUpdatePeriod>@$DEPLOYMENT_TEST_UPDATE_PERIOD@g" "$deployment_working_file"
         sed -i -e "s@<EdgeHubRestartTest.RestartPeriod>@$RESTART_TEST_RESTART_PERIOD@g" "$deployment_working_file"
         sed -i -e "s@<EdgeHubRestartTest.SdkOperationTimeout>@$RESTART_TEST_SDK_OPERATION_TIMEOUT@g" "$deployment_working_file"
+        sed -i -e "s@<TestResultCoordinator.VerificationDelay>@$VERIFICATION_DELAY@g" "$deployment_working_file"
     fi
 }
 
@@ -855,7 +855,6 @@ EVENT_HUB_CONSUMER_GROUP_ID=${EVENT_HUB_CONSUMER_GROUP_ID:-\$Default}
 EDGE_RUNTIME_BUILD_NUMBER=${EDGE_RUNTIME_BUILD_NUMBER:-$ARTIFACT_IMAGE_BUILD_NUMBER}
 LOADGEN_MESSAGE_FREQUENCY="${LOADGEN_MESSAGE_FREQUENCY:-00:00:01}"
 TEST_START_DELAY="${TEST_START_DELAY:-00:02:00}"
-VERIFICATION_DELAY="${VERIFICATION_DELAY:-00:15:00}"
 UPSTREAM_PROTOCOL="${UPSTREAM_PROTOCOL:-Amqp}"
 TIME_FOR_REPORT_GENERATION="${TIME_FOR_REPORT_GENERATION:-00:10:00}"
 TWIN_UPDATE_SIZE="${TWIN_UPDATE_SIZE:-1}"
@@ -895,6 +894,7 @@ if [[ "${TEST_NAME,,}" == "${LONGHAUL_TEST_NAME,,}" ]]; then
 elif [[ "${TEST_NAME,,}" == "${CONNECTIVITY_TEST_NAME,,}" ]]; then
     NETWORK_CONTROLLER_RUNPROFILE=${NETWORK_CONTROLLER_RUNPROFILE:-Offline}
     TEST_DURATION="${TEST_DURATION:-01:00:00}"
+    VERIFICATION_DELAY="${VERIFICATION_DELAY:-00:15:00}"
 
     TEST_INFO="$TEST_INFO,TestDuration=${TEST_DURATION}"
 


### PR DESCRIPTION


Simple fix needed to remove connectivity specific settings from TRC env vars in longhaul deployment.