### PR TITLE
Registration ID is optional in super-config

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -160,7 +160,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempdir",
- "tokio",
+ "tokio 0.1.22",
  "tokio-signal",
  "url 2.1.1",
  "url_serde",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "http-common",
  "libc",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "pkcs11",
  "serde",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "http-common",
  "serde",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "serde",
  "toml",
@@ -697,7 +697,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "test-case",
- "tokio",
+ "tokio 0.1.22",
  "url 2.1.1",
  "url_serde",
 ]
@@ -730,7 +730,7 @@ dependencies = [
  "tempdir",
  "tempfile",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-process",
  "typed-headers",
  "url 2.1.1",
@@ -768,7 +768,7 @@ dependencies = [
  "systemd",
  "tempdir",
  "tempfile",
- "tokio",
+ "tokio 0.1.22",
  "tokio-tls",
  "tokio-uds",
  "typed-headers",
@@ -828,7 +828,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
+ "tokio 0.1.22",
  "tokio-tls",
  "workload",
 ]
@@ -847,7 +847,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio",
+ "tokio 0.1.22",
 ]
 
 [[package]]
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1155,6 +1155,7 @@ dependencies = [
  "percent-encoding 2.1.0",
  "serde",
  "serde_json",
+ "tokio-io-timeout",
  "tracing",
  "url 2.1.1",
 ]
@@ -1193,7 +1194,7 @@ dependencies = [
  "net2",
  "rustc_version",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
  "tokio-io",
@@ -1243,7 +1244,7 @@ dependencies = [
  "futures",
  "hex 0.3.2",
  "hyper",
- "tokio",
+ "tokio 0.1.22",
  "tokio-io",
  "tokio-uds",
 ]
@@ -1352,7 +1353,7 @@ dependencies = [
  "tabwriter",
  "tempfile",
  "termcolor 0.3.6",
- "tokio",
+ "tokio 0.1.22",
  "toml",
  "typed-headers",
  "url 2.1.1",
@@ -1752,7 +1753,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "cc",
 ]
@@ -1789,7 +1790,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1798,7 +1799,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1892,7 +1893,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1909,7 +1910,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea24af3664fa82814b54e85deea60ec6fa5"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2df97b987c36a337fe143d12b3c6d38f32b3c0a5"
 
 [[package]]
 name = "pkg-config"
@@ -2335,7 +2336,7 @@ dependencies = [
  "futures",
  "regex 0.2.11",
  "tempfile",
- "tokio",
+ "tokio 0.1.22",
  "zip",
 ]
 
@@ -2540,6 +2541,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "tokio-buf"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2601,6 +2612,16 @@ dependencies = [
  "bytes 0.4.12",
  "futures",
  "log",
+]
+
+[[package]]
+name = "tokio-io-timeout"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c49f106be240de154571dd31fbe48acb10ba6c6dd6f6517ad603abffa42de9"
+dependencies = [
+ "pin-project-lite",
+ "tokio 1.5.0",
 ]
 
 [[package]]

--- a/edgelet/iotedge/src/config/import/mod.rs
+++ b/edgelet/iotedge/src/config/import/mod.rs
@@ -269,9 +269,7 @@ fn execute_inner(
                         global_endpoint,
                         id_scope: scope_id,
                         attestation: common_config::super_config::DpsAttestationMethod::X509 {
-                            // TODO: Remove this when IS supports registration ID being optional for DPS-X509
-                            registration_id: registration_id
-                                .ok_or_else(|| "registration ID is currently required")?,
+                            registration_id,
                             identity: common_config::super_config::X509Identity::Preloaded {
                                 identity_cert,
                                 identity_pk: {

--- a/edgelet/iotedge/test-files/config/dps-x509/identityd.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/identityd.toml
@@ -11,7 +11,6 @@ scope_id = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "device-id"
 identity_pk = "device-id"
 

--- a/edgelet/iotedge/test-files/config/dps-x509/old-config.yaml
+++ b/edgelet/iotedge/test-files/config/dps-x509/old-config.yaml
@@ -4,8 +4,6 @@ provisioning:
   scope_id: '0ab1234C5D6'
   attestation:
     method: 'x509'
-    # TODO: Remove this when IS supports registration ID being optional for DPS-X509
-    registration_id: 'my-device'
     identity_cert: 'file:///var/secrets/device-id.pem'
     identity_pk: 'file:///var/secrets/device-id.key.pem'
   dynamic_reprovisioning: true

--- a/edgelet/iotedge/test-files/config/dps-x509/super-config.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/super-config.toml
@@ -8,7 +8,6 @@ id_scope = "0ab1234C5D6"
 
 [provisioning.attestation]
 method = "x509"
-registration_id = "my-device"
 identity_cert = "file:///var/secrets/device-id.pem"
 identity_pk = "file:///var/secrets/device-id.key.pem"
 


### PR DESCRIPTION
The `iotedge config import` tool will now support 1.1 configuration where registration_id was optional for DPS X.509 provisioning.

This PR is dependent on https://github.com/Azure/iot-identity-service/pull/212