### PR TITLE
[k8s] Add iotedged.data.runtimeLogLevel to helm chart settings.

### DIFF
--- a/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
+++ b/kubernetes/charts/edge-kubernetes/templates/iotedged-deployment.yaml
@@ -31,8 +31,6 @@ spec:
 {{ toYaml .Values.iotedged.data.resources | indent 12 }}
           {{- end }}
           env:
-          - name: "IOTEDGE_LOG"
-            value: "info"
           {{- if .Values.iotedged.data.httpsProxy }}
           - name: "https_proxy"
             value: {{ .Values.iotedged.data.httpsProxy | quote}}
@@ -41,6 +39,12 @@ spec:
           - name: "no_proxy"
             value: {{ .Values.iotedged.data.noProxy | quote}}
           {{- end}}
+          - name: "IOTEDGE_LOG"
+          {{- if .Values.iotedged.data.runtimeLogLevel}}
+            value: {{ .Values.iotedged.data.runtimeLogLevel | quote }}
+          {{- else }}
+            value: "info"
+          {{- end }}
           volumeMounts:
           - name: config
             mountPath: "/etc/iotedged"

--- a/kubernetes/charts/edge-kubernetes/values.yaml
+++ b/kubernetes/charts/edge-kubernetes/values.yaml
@@ -19,6 +19,8 @@ iotedged:
   data:
     enableGetNodesRBAC: true
     targetPath: /var/lib/iotedge
+    # set iotedged log level.
+    runtimeLogLevel: "info"
     # Normally the iotedged is running as a host process, and has access to 
     # the host's trusted CA certificates.  Use this options to allow the 
     # iotedged deployment to use the host OS's /etc/ssl/certs 


### PR DESCRIPTION
This will allow the users to set the loglevel on iotedged pod for debugging purposes. 
Default is "info" for iotedged.