### PR TITLE
Update edgelet-utils to tokio 1

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.13"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "043164d8ba5c4c3035fec9bbee8647c0261d788f3474306f93bb65901cae0e86"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -67,6 +67,12 @@ name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-trait"
@@ -115,7 +121,7 @@ dependencies = [
  "libc",
  "openssl",
  "serde",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -158,11 +164,11 @@ dependencies = [
  "rand 0.5.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.7.1",
  "tempdir",
- "tokio",
+ "tokio 0.1.22",
  "tokio-signal",
- "url 2.1.1",
+ "url 2.2.1",
  "url_serde",
 ]
 
@@ -198,7 +204,7 @@ dependencies = [
  "http-common",
  "libc",
  "serde",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -269,7 +275,7 @@ source = "git+https://github.com/Azure/iot-identity-service?branch=main#2564eea2
 dependencies = [
  "pkcs11",
  "serde",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -298,7 +304,7 @@ dependencies = [
  "nix 0.18.0",
  "serde",
  "serde_json",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -354,6 +360,15 @@ checksum = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 dependencies = [
  "arrayref",
  "byte-tools",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -435,7 +450,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "typed-headers",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -502,7 +517,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9107d78ed62b3fa5a86e7d18e647abed48cfd8f8fab6c72f4cdb982d196f7e6"
 dependencies = [
  "lazy_static",
- "nom",
+ "nom 4.2.3",
+ "serde",
+]
+
+[[package]]
+name = "config"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1b9d958c2b1368a663f05538fc1b5975adce1e19f435acceae987aceeeb369"
+dependencies = [
+ "lazy_static",
+ "nom 5.1.2",
  "serde",
 ]
 
@@ -522,12 +548,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a079bddaa385eab2a88dc5816a378921852ab3af6646748da14681b2facf502"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "core-foundation"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +562,12 @@ name = "core-foundation-sys"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3a71ab494c0b5b860bdc8407ae08978052417070c2ced38573a9157ad75b8ac"
+
+[[package]]
+name = "cpuid-bool"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
 
 [[package]]
 name = "crc32fast"
@@ -631,12 +657,12 @@ dependencies = [
 
 [[package]]
 name = "crypto-mac"
-version = "0.5.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
+checksum = "25fab6889090c8133f3deb8f73ba3c65a7f456f66436fc012a1b1e272b1e103e"
 dependencies = [
- "constant_time_eq",
- "generic-array",
+ "generic-array 0.14.4",
+ "subtle",
 ]
 
 [[package]]
@@ -645,7 +671,16 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 dependencies = [
- "generic-array",
+ "generic-array 0.9.0",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -680,7 +715,7 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 name = "edgelet-core"
 version = "0.1.0"
 dependencies = [
- "base64 0.9.3",
+ "base64 0.13.0",
  "bytes 0.4.12",
  "chrono",
  "consistenttime",
@@ -691,15 +726,14 @@ dependencies = [
  "lazy_static",
  "log",
  "parse_duration",
- "regex 0.2.11",
+ "regex 1.5.3",
  "serde",
  "serde_derive",
  "serde_json",
- "sha2",
+ "sha2 0.9.3",
  "test-case",
- "tokio",
- "url 2.1.1",
- "url_serde",
+ "tokio 0.1.22",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -730,10 +764,10 @@ dependencies = [
  "tempdir",
  "tempfile",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-process",
  "typed-headers",
- "url 2.1.1",
+ "url 2.2.1",
  "url_serde",
 ]
 
@@ -768,11 +802,11 @@ dependencies = [
  "systemd",
  "tempdir",
  "tempfile",
- "tokio",
+ "tokio 0.1.22",
  "tokio-tls",
  "tokio-uds",
  "typed-headers",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -795,7 +829,7 @@ dependencies = [
  "serde",
  "serde_json",
  "support-bundle",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -828,7 +862,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
+ "tokio 0.1.22",
  "tokio-tls",
  "workload",
 ]
@@ -847,20 +881,20 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "tokio",
+ "tokio 0.1.22",
 ]
 
 [[package]]
 name = "edgelet-utils"
 version = "0.1.0"
 dependencies = [
- "config",
+ "config 0.11.0",
  "failure",
- "futures",
  "log",
  "serde",
  "serde_derive",
  "serde_json",
+ "tokio 1.5.0",
  "yaml-rust",
 ]
 
@@ -879,7 +913,7 @@ dependencies = [
  "atty",
  "humantime",
  "log",
- "regex 1.3.9",
+ "regex 1.5.3",
  "termcolor 1.1.0",
 ]
 
@@ -945,6 +979,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -974,9 +1018,9 @@ checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-cpupool"
@@ -990,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1002,23 +1046,20 @@ dependencies = [
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
-dependencies = [
- "once_cell",
-]
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-core",
  "futures-macro",
  "futures-task",
- "pin-project",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1032,6 +1073,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check 0.9.2",
 ]
 
 [[package]]
@@ -1098,12 +1149,12 @@ checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
 
 [[package]]
 name = "hmac"
-version = "0.5.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
- "digest",
+ "digest 0.9.0",
 ]
 
 [[package]]
@@ -1156,7 +1207,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -1193,7 +1244,7 @@ dependencies = [
  "net2",
  "rustc_version",
  "time",
- "tokio",
+ "tokio 0.1.22",
  "tokio-buf",
  "tokio-executor",
  "tokio-io",
@@ -1243,7 +1294,7 @@ dependencies = [
  "futures",
  "hex 0.3.2",
  "hyper",
- "tokio",
+ "tokio 0.1.22",
  "tokio-io",
  "tokio-uds",
 ]
@@ -1266,7 +1317,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "typed-headers",
- "url 2.1.1",
+ "url 2.2.1",
 ]
 
 [[package]]
@@ -1320,7 +1371,7 @@ dependencies = [
  "chrono",
  "chrono-humanize",
  "clap",
- "config",
+ "config 0.9.3",
  "config-common",
  "docker",
  "edgelet-core",
@@ -1352,10 +1403,10 @@ dependencies = [
  "tabwriter",
  "tempfile",
  "termcolor 0.3.6",
- "tokio",
+ "tokio 0.1.22",
  "toml",
  "typed-headers",
- "url 2.1.1",
+ "url 2.2.1",
  "zip",
 ]
 
@@ -1389,6 +1440,19 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
 
 [[package]]
 name = "libc"
@@ -1456,9 +1520,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
@@ -1622,6 +1686,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "lexical-core",
+ "memchr",
+ "version_check 0.9.2",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1736,6 +1811,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "260e51e7efe62b592207e9e13a68e43692a7a279171d6ba57abd208bf23645ad"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
 name = "openssl"
 version = "0.10.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,13 +1917,13 @@ dependencies = [
 
 [[package]]
 name = "parse_duration"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc8d8324ba4f571dbac55dea78c76f72681fcc488b51a9ee7ddb10263e7e92ae"
+checksum = "7037e5e93e0172a5a96874380bf73bc6ecef022e26fa25f2be26864d6b3ba95d"
 dependencies = [
  "lazy_static",
  "num",
- "regex 1.3.9",
+ "regex 1.5.3",
 ]
 
 [[package]]
@@ -1856,26 +1937,6 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
-
-[[package]]
-name = "pin-project"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca4433fff2ae79342e497d9f8ee990d174071408f28f726d6d83af93e58e48aa"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0e815c3ee9a031fdf5af21c10aa17c573c9c6a566328d99e3936c34e36461f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "pin-project-lite"
@@ -1925,9 +1986,9 @@ checksum = "c36fa947111f5c62a733b652544dd0016a43ce89619538a8ef92724a6f501a20"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.18"
+version = "0.5.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
+checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
@@ -2090,20 +2151,19 @@ dependencies = [
  "aho-corasick 0.6.10",
  "memchr",
  "regex-syntax 0.5.6",
- "thread_local 0.3.6",
+ "thread_local",
  "utf8-ranges",
 ]
 
 [[package]]
 name = "regex"
-version = "1.3.9"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3780fcf44b193bc4d09f36d2a3c87b251da4a046c87795a0d35f4f927ad8e6"
+checksum = "ce5f1ceb7f74abbce32601642fcf8e8508a8a8991e0621c7d750295b9095702b"
 dependencies = [
- "aho-corasick 0.7.13",
+ "aho-corasick 0.7.18",
  "memchr",
- "regex-syntax 0.6.18",
- "thread_local 1.0.1",
+ "regex-syntax 0.6.25",
 ]
 
 [[package]]
@@ -2117,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.18"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -2266,10 +2326,23 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb6be24e4c23a84d7184280d2722f7f2731fcdd4a9d886efbfe4413e4847ea0"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.3.3",
  "byte-tools",
- "digest",
+ "digest 0.7.6",
  "fake-simd",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -2310,6 +2383,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,6 +2404,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+
+[[package]]
 name = "support-bundle"
 version = "0.1.0"
 dependencies = [
@@ -2335,7 +2420,7 @@ dependencies = [
  "futures",
  "regex 0.2.11",
  "tempfile",
- "tokio",
+ "tokio 0.1.22",
  "zip",
 ]
 
@@ -2490,15 +2575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
 name = "time"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2537,6 +2613,17 @@ dependencies = [
  "tokio-timer",
  "tokio-udp",
  "tokio-uds",
+]
+
+[[package]]
+name = "tokio"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
+dependencies = [
+ "autocfg",
+ "pin-project-lite",
+ "tokio-macros",
 ]
 
 [[package]]
@@ -2601,6 +2688,17 @@ dependencies = [
  "bytes 0.4.12",
  "futures",
  "log",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2871,10 +2969,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",

--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
  "env_logger",
  "failure",
  "foreign-types-shared",
- "futures",
+ "futures 0.1.29",
  "http-common",
  "hyper",
  "hyper-tls",
@@ -407,6 +407,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
 name = "bzip2"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,7 +448,7 @@ dependencies = [
  "edgelet-core",
  "edgelet-http",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "log",
  "percent-encoding 2.1.0",
@@ -695,7 +701,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.9.3",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "serde",
  "serde_derive",
@@ -715,13 +721,14 @@ checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
 name = "edgelet-core"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "base64 0.13.0",
- "bytes 0.4.12",
+ "bytes 1.0.1",
  "chrono",
  "consistenttime",
  "edgelet-utils",
  "failure",
- "futures",
+ "futures 0.3.14",
  "hmac",
  "lazy_static",
  "log",
@@ -732,7 +739,8 @@ dependencies = [
  "serde_json",
  "sha2 0.9.3",
  "test-case",
- "tokio 0.1.22",
+ "tokio 1.5.0",
+ "tokio-util",
  "url 2.2.1",
 ]
 
@@ -751,7 +759,7 @@ dependencies = [
  "edgelet-test-utils",
  "edgelet-utils",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "lazy_static",
  "libc",
@@ -781,7 +789,7 @@ dependencies = [
  "edgelet-test-utils",
  "edgelet-utils",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "hyper-proxy",
  "hyper-tls",
@@ -820,7 +828,7 @@ dependencies = [
  "edgelet-http",
  "edgelet-test-utils",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "identity-client",
  "lazy_static",
@@ -850,7 +858,7 @@ dependencies = [
  "edgelet-test-utils",
  "edgelet-utils",
  "failure",
- "futures",
+ "futures 0.1.29",
  "http-common",
  "hyper",
  "identity-client",
@@ -874,7 +882,7 @@ dependencies = [
  "chrono",
  "edgelet-core",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "hyperlocal",
  "objekt",
@@ -1017,6 +1025,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
+name = "futures"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1028,9 +1061,26 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "num_cpus",
 ]
+
+[[package]]
+name = "futures-executor"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-macro"
@@ -1045,6 +1095,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-sink"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
+
+[[package]]
 name = "futures-task"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1056,9 +1112,13 @@ version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
@@ -1111,7 +1171,7 @@ dependencies = [
  "byteorder",
  "bytes 0.4.12",
  "fnv",
- "futures",
+ "futures 0.1.29",
  "http 0.1.21",
  "indexmap",
  "log",
@@ -1186,7 +1246,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "http 0.1.21",
  "tokio-buf",
 ]
@@ -1232,7 +1292,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "futures-cpupool",
  "h2",
  "http 0.1.21",
@@ -1262,7 +1322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f3c9d4782c0eee5fe1e6333d72d37dbba6230dc50618117598ea5de9a90d017"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "http 0.1.21",
  "hyper",
  "hyper-tls",
@@ -1279,7 +1339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "native-tls",
  "tokio-io",
@@ -1291,7 +1351,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d063d6d5658623c6ef16f452e11437c0e7e23a6d327470573fe78892dafbc4fb"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "hex 0.3.2",
  "hyper",
  "tokio 0.1.22",
@@ -1308,7 +1368,7 @@ dependencies = [
  "edgelet-core",
  "edgelet-http",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "hyperlocal",
  "log",
@@ -1381,7 +1441,7 @@ dependencies = [
  "edgelet-test-utils",
  "edgelet-utils",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "hyper-proxy",
  "hyper-tls",
@@ -1490,7 +1550,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.9.3",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "serde",
  "serde_derive",
@@ -2417,7 +2477,7 @@ dependencies = [
  "edgelet-core",
  "edgelet-test-utils",
  "failure",
- "futures",
+ "futures 0.1.29",
  "regex 0.2.11",
  "tempfile",
  "tokio 0.1.22",
@@ -2525,11 +2585,11 @@ dependencies = [
 
 [[package]]
 name = "test-case"
-version = "0.3.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a605baa797821796a751f4a959e1206079b24a4b7e1ed302b7d785d81a9276c9"
+checksum = "956044ef122917dde830c19dec5f76d0670329fde4104836d62ebcb14f4865f1"
 dependencies = [
- "lazy_static",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -2598,7 +2658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "mio",
  "num_cpus",
  "tokio-codec",
@@ -2634,7 +2694,7 @@ checksum = "8fb220f46c53859a4b7ec083e41dec9778ff0b1851c0942b211edb89e0ccdc46"
 dependencies = [
  "bytes 0.4.12",
  "either",
- "futures",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -2644,7 +2704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25b2998660ba0e70d18684de5d06b70b70a3a747469af9dea7618cc59e75976b"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "tokio-io",
 ]
 
@@ -2654,7 +2714,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1de0e32a83f131e002238d7ccde18211c0a5397f60cbfffcb112868c2e0e20e"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "tokio-executor",
 ]
 
@@ -2665,7 +2725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb2d1b8f4548dbf5e1f7818512e9c406860678f29c300cdf0ebac72d1a3a1671"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -2674,7 +2734,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297a1206e0ca6302a0eed35b700d292b275256f596e2f3fea7729d5e629b6ff4"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "tokio-io",
  "tokio-threadpool",
 ]
@@ -2686,7 +2746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "log",
 ]
 
@@ -2708,7 +2768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "382d90f43fa31caebe5d3bc6cfd854963394fff3b8cb59d5146607aaae7e7e43"
 dependencies = [
  "crossbeam-queue 0.1.2",
- "futures",
+ "futures 0.1.29",
  "lazy_static",
  "libc",
  "log",
@@ -2727,7 +2787,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09bc590ec4ba8ba87652da2068d150dcada2cfa2e07faae270a5e0409aa51351"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.29",
  "lazy_static",
  "log",
  "mio",
@@ -2745,7 +2805,7 @@ version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0c34c6e548f101053321cba3da7cbb87a610b85555884c41b07da2eb91aff12"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "libc",
  "mio",
  "mio-uds",
@@ -2763,7 +2823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edfe50152bc8164fcc456dab7891fa9bf8beaf01c5ee7e1dd43a397c3cf87dee"
 dependencies = [
  "fnv",
- "futures",
+ "futures 0.1.29",
 ]
 
 [[package]]
@@ -2773,7 +2833,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98df18ed66e3b72e742f185882a9e201892407957e45fbff8da17ae7a7c51f72"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "iovec",
  "mio",
  "tokio-io",
@@ -2789,7 +2849,7 @@ dependencies = [
  "crossbeam-deque",
  "crossbeam-queue 0.2.3",
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.29",
  "lazy_static",
  "log",
  "num_cpus",
@@ -2804,7 +2864,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93044f2d313c95ff1cb7809ce9a7a05735b012288a888b62d4434fd58c94f296"
 dependencies = [
  "crossbeam-utils 0.7.2",
- "futures",
+ "futures 0.1.29",
  "slab",
  "tokio-executor",
 ]
@@ -2815,7 +2875,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "354b8cd83825b3c20217a9dc174d6a0c67441a2fae5c41bcb1ea6679f6ae0f7c"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "native-tls",
  "tokio-io",
 ]
@@ -2827,7 +2887,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2a0b10e610b39c38b031a2fcab08e4b82f16ece36504988dcbd81dbba650d82"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "log",
  "mio",
  "tokio-codec",
@@ -2842,7 +2902,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab57a4ac4111c8c9dbcf70779f6fc8bc35ae4b2454809febac840ad19bd7e4e0"
 dependencies = [
  "bytes 0.4.12",
- "futures",
+ "futures 0.1.29",
  "iovec",
  "libc",
  "log",
@@ -2851,6 +2911,20 @@ dependencies = [
  "tokio-codec",
  "tokio-io",
  "tokio-reactor",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio 1.5.0",
 ]
 
 [[package]]
@@ -3032,7 +3106,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "log",
  "try-lock",
 ]
@@ -3107,7 +3181,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.9.3",
  "failure",
- "futures",
+ "futures 0.1.29",
  "hyper",
  "serde",
  "serde_derive",

--- a/edgelet/edgelet-core/Cargo.toml
+++ b/edgelet/edgelet-core/Cargo.toml
@@ -6,26 +6,27 @@ publish = false
 edition = "2018"
 
 [dependencies]
-base64 = "0.9"
-bytes = "0.4"
+async-trait = "0.1"
+base64 = "0.13"
+bytes = "1"
 chrono = { version = "0.4", features = ["serde"] }
-consistenttime = "0.2.0"
-futures = "0.1"
+consistenttime = "0.2"
 failure = "0.1"
-hmac = "0.5.0"
-lazy_static = "1.0"
-regex = "0.2"
+futures = "0.3"
+hmac = "0.11"
+lazy_static = "1.4"
+log = "0.4"
+parse_duration = "2.1"
+regex = "1.5"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
-sha2 = "0.7.0"
-log = "0.4"
-parse_duration = "2.0.1"
+sha2 = "0.9"
+tokio = { version = "1", features = ["macros"] }
+tokio-util = { version = "0.6", features = ["codec"] }
 url = { version = "2", features = ["serde"] }
-url_serde = "0.2"
-tokio = "0.1"
 
 edgelet-utils = { path = "../edgelet-utils" }
 
 [dev-dependencies]
-test-case = "0.3.3"
+test-case = "1.1"

--- a/edgelet/edgelet-core/src/authentication.rs
+++ b/edgelet/edgelet-core/src/authentication.rs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft. All rights reserved.
 
-use futures::Future;
-
 use crate::AuthId;
 
+#[async_trait::async_trait]
 pub trait Authenticator {
     type Error;
     type Request;
-    type AuthenticateFuture: Future<Item = AuthId, Error = Self::Error> + Send;
 
-    fn authenticate(&self, req: &Self::Request) -> Self::AuthenticateFuture;
+    async fn authenticate(&self, req: &Self::Request) -> Result<AuthId, Self::Error>;
 }

--- a/edgelet/edgelet-core/src/identity.rs
+++ b/edgelet/edgelet-core/src/identity.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 
 use failure::Fail;
-use futures::Future;
 
 #[derive(Clone, Copy, Debug, serde_derive::Deserialize, PartialEq, serde_derive::Serialize)]
 pub enum AuthType {
@@ -68,20 +67,16 @@ impl IdentitySpec {
     }
 }
 
+#[async_trait::async_trait]
 pub trait IdentityManager {
     type Identity: Identity;
     type Error: Fail;
-    type CreateFuture: Future<Item = Self::Identity, Error = Self::Error> + Send;
-    type UpdateFuture: Future<Item = Self::Identity, Error = Self::Error> + Send;
-    type ListFuture: Future<Item = Vec<Self::Identity>, Error = Self::Error> + Send;
-    type GetFuture: Future<Item = Option<Self::Identity>, Error = Self::Error> + Send;
-    type DeleteFuture: Future<Item = (), Error = Self::Error> + Send;
 
-    fn create(&mut self, id: IdentitySpec) -> Self::CreateFuture;
-    fn update(&mut self, id: IdentitySpec) -> Self::UpdateFuture;
-    fn list(&self) -> Self::ListFuture;
-    fn get(&self, id: IdentitySpec) -> Self::GetFuture;
-    fn delete(&mut self, id: IdentitySpec) -> Self::DeleteFuture;
+    async fn create(&mut self, id: IdentitySpec) -> Result<Self::Identity, Self::Error>;
+    async fn update(&mut self, id: IdentitySpec) -> Result<Self::Identity, Self::Error>;
+    async fn list(&self) -> Result<Vec<Self::Identity>, Self::Error>;
+    async fn get(&self, id: IdentitySpec) -> Result<Option<Self::Identity>, Self::Error>;
+    async fn delete(&mut self, id: IdentitySpec) -> Result<(), Self::Error>;
 }
 
 // Useful for error contexts

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -39,7 +39,7 @@ pub use crypto::{
 };
 pub use error::{Error, ErrorKind};
 pub use identity::{AuthType, Identity, IdentityManager, IdentityOperation, IdentitySpec};
-pub use logs::{Chunked, LogChunk, LogDecode};
+//pub use logs::{Chunked, LogChunk, LogDecode};
 pub use module::{
     DiskInfo, ImagePullPolicy, LogOptions, LogTail, MakeModuleRuntime, Module, ModuleOperation,
     ModuleRegistry, ModuleRuntime, ModuleRuntimeErrorReason, ModuleRuntimeState, ModuleSpec,

--- a/edgelet/edgelet-core/src/logs.rs
+++ b/edgelet/edgelet-core/src/logs.rs
@@ -1,225 +1,226 @@
-// Copyright (c) Microsoft. All rights reserved.
+// // Copyright (c) Microsoft. All rights reserved.
 
-use std::cmp;
-use std::io;
+// use std::cmp;
+// use std::io;
 
-use bytes::{Buf, BufMut, Bytes, BytesMut, IntoBuf};
-use futures::prelude::*;
-use futures::try_ready;
-use tokio::codec::length_delimited;
-use tokio::codec::FramedRead;
-use tokio::io::AsyncRead;
+// use bytes::{Buf, BufMut, Bytes, BytesMut, IntoBuf};
+// use futures::prelude::*;
+// use futures::try_ready;
+// use tokio::io::AsyncRead;
+// use tokio_util::codec::length_delimited;
+// use tokio_util::codec::FramedRead;
 
-/// Logs parser
-/// Logs are emitted with a simple header to specify stdout or stderr
-///
-///
-/// 01 00 00 00 00 00 00 1f 52 6f 73 65 73 20 61 72  65 ...
-/// │  ─────┬── ─────┬─────  R  o  s  e  s     a  r   e ...
-/// │       │        │
-/// └stdout │        │
-///         │        └ 0x0000001f = log message is 31 bytes
-///       unused
-///
-/// The following set of structs converts a `Stream<&[u8]>` into a `Stream<LogChunk>`
-/// by implementing [`AsyncRead`] on `Stream<&[u8]>` and then using the `length_delimited`
-/// decoder in tokio to emit [`BytesMut`] with complete frames. The [`LogChunk`]
-/// is then constructed from these [`BytesMut`]s
+// /// Logs parser
+// /// Logs are emitted with a simple header to specify stdout or stderr
+// ///
+// ///
+// /// 01 00 00 00 00 00 00 1f 52 6f 73 65 73 20 61 72  65 ...
+// /// │  ─────┬── ─────┬─────  R  o  s  e  s     a  r   e ...
+// /// │       │        │
+// /// └stdout │        │
+// ///         │        └ 0x0000001f = log message is 31 bytes
+// ///       unused
+// ///
+// /// The following set of structs converts a `Stream<&[u8]>` into a `Stream<LogChunk>`
+// /// by implementing [`AsyncRead`] on `Stream<&[u8]>` and then using the `length_delimited`
+// /// decoder in tokio to emit [`BytesMut`] with complete frames. The [`LogChunk`]
+// /// is then constructed from these [`BytesMut`]s
 
-#[derive(Debug, PartialEq)]
-pub enum LogChunk {
-    Stdin(Bytes),
-    Stdout(Bytes),
-    Stderr(Bytes),
-    Unknown(Bytes),
-}
+// #[derive(Debug, PartialEq)]
+// pub enum LogChunk {
+//     Stdin(Bytes),
+//     Stdout(Bytes),
+//     Stderr(Bytes),
+//     Unknown(Bytes),
+// }
 
-pub struct LogDecode<T: AsyncRead> {
-    inner: FramedRead<T, length_delimited::LengthDelimitedCodec>,
-}
+// pub struct LogDecode<T: AsyncRead> {
+//     inner: FramedRead<T, length_delimited::LengthDelimitedCodec>,
+// }
 
-impl<T: AsyncRead> LogDecode<T> {
-    pub fn new(inner: T) -> Self {
-        let delimited = length_delimited::Builder::new()
-            .length_field_offset(4)
-            .length_field_length(4)
-            .length_adjustment(8)
-            .num_skip(0)
-            .new_read(inner);
-        LogDecode { inner: delimited }
-    }
-}
+// impl<T: AsyncRead> LogDecode<T> {
+//     pub fn new(inner: T) -> Self {
+//         let delimited = length_delimited::Builder::new()
+//             .length_field_offset(4)
+//             .length_field_length(4)
+//             .length_adjustment(8)
+//             .num_skip(0)
+//             .new_read(inner);
+//         LogDecode { inner: delimited }
+//     }
+// }
 
-impl<T: AsyncRead> Stream for LogDecode<T> {
-    type Item = LogChunk;
-    type Error = io::Error;
+// impl<T: AsyncRead> Stream for LogDecode<T> {
+//     type Item = LogChunk;
+//     type Error = io::Error;
 
-    fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
-        // This parser assumes that the length_delimited decoder
-        // wraps this decoder. In this case, the BytesMut is
-        // guaranteed to have a full frame worth of bytes.
-        // We can simply read the needed bytes out of the BytesMut
-        // to construct the parsed Frame.
+//     fn poll(&mut self) -> Poll<Option<Self::Item>, Self::Error> {
+//         // This parser assumes that the length_delimited decoder
+//         // wraps this decoder. In this case, the BytesMut is
+//         // guaranteed to have a full frame worth of bytes.
+//         // We can simply read the needed bytes out of the BytesMut
+//         // to construct the parsed Frame.
 
-        let option = try_ready!(self.inner.poll());
-        let result = option.map(|bytes| {
-            let mut buf = bytes.into_buf();
-            let stream_type = buf.get_u8();
-            buf.advance(3);
-            let _length = buf.get_u32_be();
-            let payload: Bytes = buf.collect();
+//         let option = try_ready!(self.inner.poll());
+//         let result = option.map(|bytes| {
+//             let mut buf = bytes.into_buf();
+//             let stream_type = buf.get_u8();
+//             buf.advance(3);
+//             let _length = buf.get_u32_be();
+//             let payload: Bytes = buf.collect();
 
-            match stream_type {
-                0 => LogChunk::Stdin(payload),
-                1 => LogChunk::Stdout(payload),
-                2 => LogChunk::Stderr(payload),
-                _ => LogChunk::Unknown(payload),
-            }
-        });
-        Ok(Async::Ready(result))
-    }
-}
+//             match stream_type {
+//                 0 => LogChunk::Stdin(payload),
+//                 1 => LogChunk::Stdout(payload),
+//                 2 => LogChunk::Stderr(payload),
+//                 _ => LogChunk::Unknown(payload),
+//             }
+//         });
+//         Ok(Async::Ready(result))
+//     }
+// }
 
-pub struct Chunked<S, C>
-where
-    C: AsRef<[u8]>,
-    S: Stream<Item = C, Error = io::Error>,
-{
-    inner: S,
-    remaining: Option<Bytes>,
-}
+// pub struct Chunked<S, C>
+// where
+//     C: AsRef<[u8]>,
+//     S: Stream<Item = C, Error = io::Error>,
+// {
+//     inner: S,
+//     remaining: Option<Bytes>,
+// }
 
-impl<S, C> Chunked<S, C>
-where
-    C: AsRef<[u8]>,
-    S: Stream<Item = C, Error = io::Error>,
-{
-    pub fn new(inner: S) -> Self {
-        Chunked {
-            inner,
-            remaining: None,
-        }
-    }
+// impl<S, C> Chunked<S, C>
+// where
+//     C: AsRef<[u8]>,
+//     S: Stream<Item = C, Error = io::Error>,
+// {
+//     pub fn new(inner: S) -> Self {
+//         Chunked {
+//             inner,
+//             remaining: None,
+//         }
+//     }
 
-    fn read_remaining(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        let (result, r) = self.remaining.as_ref().map_or((Ok(0), None), |remaining| {
-            let amt = cmp::min(remaining.len(), buf.len());
-            let (a, b) = remaining.split_at(amt);
-            buf[..amt].copy_from_slice(a);
+//     fn read_remaining(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+//         let (result, r) = self.remaining.as_ref().map_or((Ok(0), None), |remaining| {
+//             let amt = cmp::min(remaining.len(), buf.len());
+//             let (a, b) = remaining.split_at(amt);
+//             buf[..amt].copy_from_slice(a);
 
-            if b.is_empty() {
-                (Ok(amt), None)
-            } else {
-                (Ok(amt), Some(Bytes::from(b)))
-            }
-        });
+//             if b.is_empty() {
+//                 (Ok(amt), None)
+//             } else {
+//                 (Ok(amt), Some(Bytes::from(b)))
+//             }
+//         });
 
-        self.remaining = r;
-        result
-    }
-}
+//         self.remaining = r;
+//         result
+//     }
+// }
 
-impl<S, C> io::Read for Chunked<S, C>
-where
-    C: AsRef<[u8]>,
-    S: Stream<Item = C, Error = io::Error>,
-{
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        match self.inner.poll() {
-            Ok(Async::Ready(Some(ref t))) => {
-                let read = self.read_remaining(buf)?;
-                let (result, new_remaining) = self.remaining.as_mut().map_or_else(
-                    || {
-                        // The remaining buffer was cleared.
-                        // Attempt to read everything from the poll and add to the remaining buffer
-                        // if needed.
-                        let data = Bytes::from(t.as_ref());
-                        let amt = cmp::min(data.len(), buf.len() - read);
-                        let (a, b) = data.split_at(amt);
-                        buf[read..read + amt].copy_from_slice(a);
+// impl<S, C> io::Read for Chunked<S, C>
+// where
+//     C: AsRef<[u8]>,
+//     S: Stream<Item = C, Error = io::Error>,
+// {
+//     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+//         match self.inner.poll() {
+//             Ok(Async::Ready(Some(ref t))) => {
+//                 let read = self.read_remaining(buf)?;
+//                 let (result, new_remaining) = self.remaining.as_mut().map_or_else(
+//                     || {
+//                         // The remaining buffer was cleared.
+//                         // Attempt to read everything from the poll and add to the remaining buffer
+//                         // if needed.
+//                         let data = Bytes::from(t.as_ref());
+//                         let amt = cmp::min(data.len(), buf.len() - read);
+//                         let (a, b) = data.split_at(amt);
+//                         buf[read..read + amt].copy_from_slice(a);
 
-                        if b.is_empty() {
-                            (Ok(amt + read), None)
-                        } else {
-                            (Ok(amt + read), Some(Bytes::from(b)))
-                        }
-                    },
-                    |remaining| {
-                        // There's still some data waiting to be written into the read buffer.
-                        // Append to the remaining buffer
-                        // Return the amount read from remaining
-                        let mut r = BytesMut::with_capacity(remaining.len() + t.as_ref().len());
-                        r.put_slice(remaining);
-                        r.put_slice(t.as_ref());
-                        (Ok(read), Some(r.freeze()))
-                    },
-                );
+//                         if b.is_empty() {
+//                             (Ok(amt + read), None)
+//                         } else {
+//                             (Ok(amt + read), Some(Bytes::from(b)))
+//                         }
+//                     },
+//                     |remaining| {
+//                         // There's still some data waiting to be written into the read buffer.
+//                         // Append to the remaining buffer
+//                         // Return the amount read from remaining
+//                         let mut r = BytesMut::with_capacity(remaining.len() + t.as_ref().len());
+//                         r.put_slice(remaining);
+//                         r.put_slice(t.as_ref());
+//                         (Ok(read), Some(r.freeze()))
+//                     },
+//                 );
 
-                self.remaining = new_remaining;
-                result
-            }
-            Ok(Async::Ready(None)) => self.read_remaining(buf),
-            Ok(Async::NotReady) => Err(io::Error::from(io::ErrorKind::WouldBlock)),
-            Err(e) => Err(e),
-        }
-    }
-}
+//                 self.remaining = new_remaining;
+//                 result
+//             }
+//             Ok(Async::Ready(None)) => self.read_remaining(buf),
+//             Ok(Async::NotReady) => Err(io::Error::from(io::ErrorKind::WouldBlock)),
+//             Err(e) => Err(e),
+//         }
+//     }
+// }
 
-impl<S, C> AsyncRead for Chunked<S, C>
-where
-    C: AsRef<[u8]>,
-    S: Stream<Item = C, Error = io::Error>,
-{
-}
+// /*impl<S, C> AsyncRead for Chunked<S, C>
+// where
+//     C: AsRef<[u8]>,
+//     S: Stream<Item = C, Error = io::Error>,
+// {
+// }
+// */
 
-#[cfg(test)]
-mod tests {
-    use super::{io, Bytes, Chunked, Future, LogChunk, LogDecode, Stream};
+// #[cfg(test)]
+// mod tests {
+//     use super::{io, Bytes, Chunked, Future, LogChunk, LogDecode, Stream};
 
-    use std::io::Read;
+//     use std::io::Read;
 
-    use futures::stream::iter_ok;
+//     use futures::stream::iter_ok;
 
-    #[test]
-    fn smoke_test() {
-        let chunks = vec![
-            &[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, b'R', b'o'][..],
-            &b"ses are"[..],
-            &[b' ', b'r', b'e', b'd', 0x02, 0x00][..],
-            &[0x00, 0x00, 0x00, 0x00, 0x00, 0x10][..],
-            &b"violets"[..],
-            &b" are blue"[..],
-        ];
+//     #[test]
+//     fn smoke_test() {
+//         let chunks = vec![
+//             &[0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, b'R', b'o'][..],
+//             &b"ses are"[..],
+//             &[b' ', b'r', b'e', b'd', 0x02, 0x00][..],
+//             &[0x00, 0x00, 0x00, 0x00, 0x00, 0x10][..],
+//             &b"violets"[..],
+//             &b" are blue"[..],
+//         ];
 
-        let stream = iter_ok::<Vec<&[u8]>, io::Error>(chunks);
-        let decoded = LogDecode::new(Chunked::new(stream))
-            .collect()
-            .wait()
-            .unwrap();
-        let expected = vec![
-            LogChunk::Stdout(Bytes::from("Roses are red")),
-            LogChunk::Stderr(Bytes::from("violets are blue")),
-        ];
+//         let stream = iter_ok::<Vec<&[u8]>, io::Error>(chunks);
+//         let decoded = LogDecode::new(Chunked::new(stream))
+//             .collect()
+//             .wait()
+//             .unwrap();
+//         let expected = vec![
+//             LogChunk::Stdout(Bytes::from("Roses are red")),
+//             LogChunk::Stderr(Bytes::from("violets are blue")),
+//         ];
 
-        assert_eq!(expected, decoded);
-    }
+//         assert_eq!(expected, decoded);
+//     }
 
-    #[test]
-    fn test_read() {
-        let chunks = vec![
-            &b"Ro"[..],
-            &b"ses are"[..],
-            &b" red"[..],
-            &b" violets"[..],
-            &b" are blue"[..],
-        ];
+//     #[test]
+//     fn test_read() {
+//         let chunks = vec![
+//             &b"Ro"[..],
+//             &b"ses are"[..],
+//             &b" red"[..],
+//             &b" violets"[..],
+//             &b" are blue"[..],
+//         ];
 
-        let mut stream = Chunked::new(iter_ok::<Vec<&[u8]>, io::Error>(chunks));
-        let read_buffer = &mut [0_u8; 30];
+//         let mut stream = Chunked::new(iter_ok::<Vec<&[u8]>, io::Error>(chunks));
+//         let read_buffer = &mut [0_u8; 30];
 
-        for slice in &mut read_buffer.chunks_mut(2) {
-            stream.read_exact(slice).unwrap();
-        }
-        assert_eq!(b"Roses are red violets are blue", read_buffer);
-    }
-}
+//         for slice in &mut read_buffer.chunks_mut(2) {
+//             stream.read_exact(slice).unwrap();
+//         }
+//         assert_eq!(b"Roses are red violets are blue", read_buffer);
+//     }
+// }

--- a/edgelet/edgelet-utils/Cargo.toml
+++ b/edgelet/edgelet-utils/Cargo.toml
@@ -6,13 +6,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-config = { version = "0.9", default-features = false }
-failure = "0.1.2"
+config = { version = "0.11", default-features = false }
+failure = "0.1"
 log = "0.4"
 serde = "1.0"
 serde_json = "1.0"
 yaml-rust = "0.4"
 
 [dev_dependencies]
-futures = "0.1"
+tokio = { version = "1", features = ["rt", "macros"]}
 serde_derive = "1.0"

--- a/edgelet/edgelet-utils/src/macros.rs
+++ b/edgelet/edgelet-utils/src/macros.rs
@@ -8,10 +8,6 @@
 //! type defined in `edgelet-utils` to the error type being returned from the
 //! function where the macro is being used.
 //!
-//! All the input validation macros can be prefixed with the letter `f` when
-//! used inside a function that returns a `Box<Future<T, E>>` instead of a
-//! `Result<T, E>`.
-//!
 //! # Examples
 //!
 //! <h3>Custom error types with implicit conversion:</h3>
@@ -47,44 +43,6 @@
 //! }
 //!
 //! let _thing = TheThing::new(5);
-//! ```
-//!
-//! <h3>Functions that return futures:</h3>
-//!
-//! ```
-//! #[macro_use] extern crate edgelet_utils;
-//! extern crate failure;
-//! extern crate futures;
-//!
-//! use failure::Fail;
-//! use futures::future;
-//! use futures::prelude::*;
-//!
-//! use edgelet_utils::Error as UtilsError;
-//!
-//! struct BooError {
-//!     inner: Box<Fail>,
-//! }
-//!
-//! impl From<UtilsError> for BooError {
-//!     fn from(err: UtilsError) -> Self {
-//!         BooError { inner: Box::new(err) }
-//!     }
-//! }
-//!
-//! struct TheThing {
-//!     val: i32,
-//! }
-//!
-//! fn do_the_thing(val: i32) -> Box<Future<Item = TheThing, Error = BooError>> {
-//!     Box::new(
-//!         future::ok(TheThing {
-//!             val: fensure_range!(val, 10, 100)
-//!         })
-//!     )
-//! }
-//!
-//! let _thing_future = do_the_thing(20);
 //! ```
 
 use std::fmt;
@@ -131,20 +89,6 @@ macro_rules! bail {
     };
 }
 
-/// Exits a function early with an `Error`.
-///
-/// Use this macro when your function
-/// returns a `Box<Future<T, E>>` instead of a `Result<T, E>`. For usage
-/// examples see documentation for `bail!`.
-#[macro_export]
-macro_rules! fbail {
-    ($err:expr) => {
-        return Box::new(::futures::future::err(::std::convert::From::from(
-            $crate::Error::from($err),
-        )));
-    };
-}
-
 /// Internal macro used for implementing other validation macros.
 ///
 /// Not to be directly invoked. Use one of the other `ensure*` macros.
@@ -161,7 +105,7 @@ macro_rules! ensure_impl {
 }
 
 /// Check if a condition evaluates to `true` and call the `bail!` macro with an
-/// error if it doesnt.
+/// error if it doesn't.
 ///
 /// # Examples
 ///
@@ -219,24 +163,6 @@ macro_rules! ensure {
     };
 }
 
-/// Check if a condition evaluates to `true` and call the `fbail!` macro with an
-/// error if it doesnt.
-///
-/// Use this macro when your function returns a `Box<Future<T, E>>` instead of
-/// a `Result<T, E>`. For usage examples see documentation for `ensure!`.
-#[macro_export]
-macro_rules! fensure {
-    ($val:expr, $cond:expr, $err:expr) => {
-        ensure_impl!($val, $cond, $err, fbail)
-    };
-    ($val:expr, $cond:expr) => {
-        fensure!($val, $cond, $crate::ErrorKind::Argument("".to_string()));
-    };
-    ($cond:expr) => {
-        fensure!((), $cond);
-    };
-}
-
 /// Internal macro used for implementing other validation macros.
 ///
 /// Not to be directly invoked. Use one of the other `ensure*` macros.
@@ -282,17 +208,6 @@ macro_rules! ensure_range_impl {
 macro_rules! ensure_range {
     ($val:expr, $low:expr, $high:expr) => {
         ensure_range_impl!($val, $low, $high, ensure)
-    };
-}
-
-/// Check if a value falls within the range (low, high].
-///
-/// Use this macro when your function returns a `Box<Future<T, E>>` instead of
-/// a `Result<T, E>`. For usage examples see documentation for `ensure_range!`.
-#[macro_export]
-macro_rules! fensure_range {
-    ($val:expr, $low:expr, $high:expr) => {
-        ensure_range_impl!($val, $low, $high, fensure)
     };
 }
 
@@ -345,17 +260,6 @@ macro_rules! ensure_greater {
     };
 }
 
-/// Check if a value is greater than a minimum and bail with an error if it is not.
-///
-/// Use this macro when your function returns a `Box<Future<T, E>>` instead of
-/// a `Result<T, E>`. For usage examples see documentation for `ensure_greater!`.
-#[macro_export]
-macro_rules! fensure_greater {
-    ($val:expr, $low:expr) => {
-        ensure_greater_impl!($val, $low, fensure)
-    };
-}
-
 /// Internal macro used for implementing other validation macros.
 ///
 /// Not to be directly invoked. Use one of the other `ensure*` macros.
@@ -405,20 +309,6 @@ macro_rules! ensure_not_empty {
     };
 }
 
-/// Check if a string is empty and bail with an error if it is.
-///
-/// Use this macro when your function returns a `Box<Future<T, E>>` instead of
-/// a `Result<T, E>`. For usage examples see documentation for `ensure_not_empty!`.
-#[macro_export]
-macro_rules! fensure_not_empty {
-    ($val:expr, $msg:expr) => {
-        ensure_not_empty_impl!($val, $msg, fensure)
-    };
-    ($val:expr) => {
-        fensure_not_empty!($val, "".to_string())
-    };
-}
-
 pub fn ensure_not_empty_with_context<D, F>(value: &str, context: F) -> Result<(), Context<D>>
 where
     D: fmt::Display + Send + Sync,
@@ -433,225 +323,135 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::fmt::Debug;
-    use std::mem;
-
-    use futures::future;
-    use futures::prelude::*;
-
     use crate::error::{Error, ErrorKind};
 
-    fn check_value<T, F>(expected: &T, f: F)
-    where
-        F: Fn() -> Result<T, Error>,
-        T: PartialEq + Debug,
-    {
-        match f() {
-            Ok(actual) => assert_eq!(expected, &actual),
-            Err(err) => panic!(format!("{:?}", err)),
-        }
+    macro_rules! check_ok {
+        ($expected:expr, $f:block) => {
+            let result: Result<_, Error> = async { $f }.await;
+            assert_eq!($expected, result.unwrap());
+        };
+
+        ($expected:expr, $f:tt) => {
+            let result: Result<_, Error> = $f();
+            assert_eq!($expected, result.unwrap());
+        };
     }
 
-    fn check_fvalue<T, F>(expected: &T, f: F)
-    where
-        F: Fn() -> Box<dyn Future<Item = T, Error = Error>>,
-        T: PartialEq + Debug,
-    {
-        match f().wait() {
-            Ok(actual) => assert_eq!(expected, &actual),
-            Err(err) => panic!(format!("{:?}", err)),
-        }
-    }
+    macro_rules! check_err {
+        ($expected:ident, $f:block) => {
+            let result: Result<_, Error> = async { $f }.await;
+            let err = result.expect_err("expected error but found value");
 
-    fn check_error<T, V, F>(validator: V, f: F)
-    where
-        F: Fn() -> Result<T, Error>,
-        V: Fn(&Error) -> bool,
-        T: PartialEq + Debug,
-    {
-        match f() {
-            Ok(v) => panic!(format!("Expected error but found value {:?}", v)),
-            Err(err) => {
-                if !validator(&err) {
-                    panic!(format!("Unexpected error encountered {:?}", err));
-                }
+            match err.kind() {
+                ErrorKind::$expected(..) => (),
+                _ => panic!(format!("Unexpected error encountered {:#?}", err)),
             }
-        }
-    }
+        };
 
-    fn check_ferror<T, V, F>(validator: V, f: F)
-    where
-        F: Fn() -> Box<dyn Future<Item = T, Error = Error>>,
-        V: Fn(&Error) -> bool,
-        T: PartialEq + Debug,
-    {
-        match f().wait() {
-            Ok(v) => panic!(format!("Expected error but found value {:?}", v)),
-            Err(err) => {
-                if !validator(&err) {
-                    panic!(format!("Unexpected error encountered {:?}", err));
-                }
+        ($expected:ident, $f:tt) => {
+            let result: Result<_, Error> = $f();
+            let err = result.expect_err("expected error but found value");
+
+            match err.kind() {
+                ErrorKind::$expected(..) => (),
+                _ => panic!(format!("Unexpected error encountered {:#?}", err)),
             }
-        }
+        };
     }
 
     #[test]
     fn validate_ensure() {
-        check_value(&15, || Ok(ensure!(15, 15 > 10)));
+        check_ok!(15, (|| Ok(ensure!(15, 15 > 10))));
 
-        #[allow(clippy::eq_op)]
-        check_error(
-            |err| {
-                mem::discriminant(err.kind())
-                    == mem::discriminant(&ErrorKind::Argument("".to_string()))
-            },
-            || Ok(ensure!(10, 10 > 10)),
-        );
+        check_err!(Argument, (|| Ok(ensure!(10, 9 > 10))));
     }
 
-    #[test]
-    fn validate_fensure() {
-        check_fvalue(&15, || Box::new(future::ok(fensure!(15, 15 > 10))));
+    #[tokio::test]
+    async fn validate_ensure_async() {
+        check_ok!(15, { Ok(ensure!(15, 15 > 10)) });
 
-        #[allow(clippy::eq_op)]
-        check_ferror(
-            |err| {
-                mem::discriminant(err.kind())
-                    == mem::discriminant(&ErrorKind::Argument("".to_string()))
-            },
-            || Box::new(future::ok(fensure!(10, 10 > 10))),
-        );
+        check_err!(Argument, { Ok(ensure!(10, 9 > 10)) });
     }
 
     #[test]
     fn validate_ensure_range() {
-        let validator: Box<dyn Fn(&Error) -> bool> = Box::new(|err| {
-            mem::discriminant(err.kind())
-                == mem::discriminant(&ErrorKind::ArgumentOutOfRange(
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                ))
-        });
+        check_ok!(10, (|| Ok(ensure_range!(10, 5, 15))));
+        check_ok!(15, (|| Ok(ensure_range!(15, 5, 15))));
 
-        check_value(&10, || Ok(ensure_range!(10, 5, 15)));
-        check_value(&15, || Ok(ensure_range!(15, 5, 15)));
-        check_error(validator.as_ref(), || Ok(ensure_range!(3, 5, 15)));
-        check_error(validator.as_ref(), || Ok(ensure_range!(5, 5, 15)));
-        check_error(validator.as_ref(), || Ok(ensure_range!(25, 5, 15)));
+        check_err!(ArgumentOutOfRange, (|| Ok(ensure_range!(3, 5, 15))));
+        check_err!(ArgumentOutOfRange, (|| Ok(ensure_range!(5, 5, 15))));
+        check_err!(ArgumentOutOfRange, (|| Ok(ensure_range!(25, 5, 15))));
     }
 
-    #[test]
-    fn validate_fensure_range() {
-        let validator: Box<dyn Fn(&Error) -> bool> = Box::new(|err| {
-            mem::discriminant(err.kind())
-                == mem::discriminant(&ErrorKind::ArgumentOutOfRange(
-                    "".to_string(),
-                    "".to_string(),
-                    "".to_string(),
-                ))
-        });
+    #[tokio::test]
+    async fn validate_ensure_range_async() {
+        check_ok!(10, { Ok(ensure_range!(10, 5, 15)) });
+        check_ok!(15, { Ok(ensure_range!(15, 5, 15)) });
 
-        check_fvalue(&10, || Box::new(future::ok(fensure_range!(10, 5, 15))));
-        check_fvalue(&15, || Box::new(future::ok(fensure_range!(15, 5, 15))));
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_range!(3, 5, 15)))
-        });
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_range!(5, 5, 15)))
-        });
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_range!(25, 5, 15)))
-        });
+        check_err!(ArgumentOutOfRange, { Ok(ensure_range!(3, 5, 15)) });
+        check_err!(ArgumentOutOfRange, { Ok(ensure_range!(5, 5, 15)) });
+        check_err!(ArgumentOutOfRange, { Ok(ensure_range!(25, 5, 15)) });
     }
 
     #[test]
     fn validate_ensure_greater() {
-        let validator: Box<dyn Fn(&Error) -> bool> = Box::new(|err| {
-            mem::discriminant(err.kind())
-                == mem::discriminant(&ErrorKind::ArgumentTooLow("".to_string(), "".to_string()))
-        });
+        check_ok!(10, (|| Ok(ensure_greater!(10, 5))));
 
-        check_value(&10, || Ok(ensure_greater!(10, 5)));
-        check_error(validator.as_ref(), || Ok(ensure_greater!(10, 25)));
+        check_err!(ArgumentTooLow, (|| Ok(ensure_greater!(10, 25))));
     }
 
-    #[test]
-    fn validate_fensure_greater() {
-        let validator: Box<dyn Fn(&Error) -> bool> = Box::new(|err| {
-            mem::discriminant(err.kind())
-                == mem::discriminant(&ErrorKind::ArgumentTooLow("".to_string(), "".to_string()))
-        });
+    #[tokio::test]
+    async fn validate_ensure_greater_async() {
+        check_ok!(10, { Ok(ensure_greater!(10, 5)) });
 
-        check_fvalue(&10, || Box::new(future::ok(fensure_greater!(10, 5))));
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_greater!(10, 25)))
-        });
+        check_err!(ArgumentTooLow, { Ok(ensure_greater!(10, 25)) });
     }
 
     #[test]
     fn validate_ensure_not_empty() {
-        let validator: Box<dyn Fn(&Error) -> bool> = Box::new(|err| {
-            mem::discriminant(err.kind())
-                == mem::discriminant(&ErrorKind::ArgumentEmpty("".to_string()))
-        });
+        check_err!(ArgumentEmpty, (|| Ok(ensure_not_empty!(""))));
+        check_err!(ArgumentEmpty, (|| Ok(ensure_not_empty!("", "empty str"))));
+        check_err!(
+            ArgumentEmpty,
+            (|| Ok(ensure_not_empty!("    ", "white space str")))
+        );
 
-        check_error(validator.as_ref(), || Ok(ensure_not_empty!("")));
-        check_error(validator.as_ref(), || {
-            Ok(ensure_not_empty!("", "empty str"))
-        });
-        check_error(validator.as_ref(), || {
-            Ok(ensure_not_empty!("    ", "white space str"))
-        });
-        check_error(validator.as_ref(), || Ok(ensure_not_empty!("".to_string())));
-        check_error(validator.as_ref(), || {
-            Ok(ensure_not_empty!("".to_string(), "empty String"))
-        });
-        check_error(validator.as_ref(), || {
-            Ok(ensure_not_empty!("    ".to_string(), "white space String"))
-        });
-        check_value(&"  not empty  ", || Ok(ensure_not_empty!("  not empty  ")));
-        check_value(&"  not empty  ".to_string(), || {
-            Ok(ensure_not_empty!("  not empty  ".to_string()))
-        });
+        check_err!(ArgumentEmpty, (|| Ok(ensure_not_empty!("".to_string()))));
+        check_err!(
+            ArgumentEmpty,
+            (|| Ok(ensure_not_empty!("".to_string(), "empty String")))
+        );
+        check_err!(
+            ArgumentEmpty,
+            (|| Ok(ensure_not_empty!("    ".to_string(), "white space String")))
+        );
+
+        check_ok!("  not empty  ", (|| Ok(ensure_not_empty!("  not empty  "))));
+        check_ok!(
+            "  not empty  ".to_string(),
+            (|| Ok(ensure_not_empty!("  not empty  ".to_string())))
+        );
     }
 
-    #[test]
-    fn validate_fensure_not_empty() {
-        let validator: Box<dyn Fn(&Error) -> bool> = Box::new(|err| {
-            mem::discriminant(err.kind())
-                == mem::discriminant(&ErrorKind::ArgumentEmpty("".to_string()))
+    #[tokio::test]
+    async fn validate_ensure_not_empty_async() {
+        check_err!(ArgumentEmpty, { Ok(ensure_not_empty!("")) });
+        check_err!(ArgumentEmpty, { Ok(ensure_not_empty!("", "empty str")) });
+        check_err!(ArgumentEmpty, {
+            Ok(ensure_not_empty!("    ", "white space str"))
         });
 
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_not_empty!("")))
+        check_err!(ArgumentEmpty, { Ok(ensure_not_empty!("".to_string())) });
+        check_err!(ArgumentEmpty, {
+            Ok(ensure_not_empty!("".to_string(), "empty String"))
         });
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_not_empty!("", "empty str")))
+        check_err!(ArgumentEmpty, {
+            Ok(ensure_not_empty!("    ".to_string(), "white space String"))
         });
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_not_empty!("    ", "white space str")))
-        });
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_not_empty!("".to_string())))
-        });
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_not_empty!(
-                "".to_string(),
-                "empty String"
-            )))
-        });
-        check_ferror(validator.as_ref(), || {
-            Box::new(future::ok(fensure_not_empty!(
-                "    ".to_string(),
-                "white space String"
-            )))
-        });
-        check_fvalue(&"  not empty  ", || {
-            Box::new(future::ok(fensure_not_empty!("  not empty  ")))
-        });
-        check_fvalue(&"  not empty  ".to_string(), || {
-            Box::new(future::ok(fensure_not_empty!("  not empty  ".to_string())))
+
+        check_ok!("  not empty  ", { Ok(ensure_not_empty!("  not empty  ")) });
+        check_ok!("  not empty  ".to_string(), {
+            Ok(ensure_not_empty!("  not empty  ".to_string()))
         });
     }
 }


### PR DESCRIPTION
Removes the f-prefixed macros from edgelet-utils since we will no longer be returning boxed futures with tokio 1.

This is going into a new branch, since none of the build checks will work until we finish the refactor.