### PR TITLE
Add validation for null props inside objects inside arrays. (#4896)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/ReportedPropertiesValidator.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/twin/ReportedPropertiesValidator.cs
@@ -20,43 +20,40 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
         public void Validate(TwinCollection reportedProperties)
         {
             Preconditions.CheckNotNull(reportedProperties, nameof(reportedProperties));
+
             JToken reportedPropertiesJToken = JToken.Parse(reportedProperties.ToJson());
-            ValidateTwinProperties(reportedPropertiesJToken, 1);
             ValidateTwinCollectionSize(reportedProperties);
-            ValidateArrayContent(reportedPropertiesJToken);
+            // root level has no property name.
+            ValidateToken(string.Empty, reportedPropertiesJToken, 0, false);
         }
 
-        static void ValidateTwinProperties(JToken properties, int currentDepth)
+        static void ValidateToken(string name, JToken item, int currentDepth, bool inArray)
         {
-            foreach (JProperty kvp in ((JObject)properties).Properties())
+            ValidatePropertyNameAndLength(name);
+
+            if (item is JObject @object)
             {
-                ValidatePropertyNameAndLength(kvp.Name);
+                ValidateTwinDepth(currentDepth);
 
-                ValidateValueType(kvp.Name, kvp.Value);
-
-                if (kvp.Value is JValue)
+                // do validation recursively
+                foreach (JProperty kvp in @object.Properties())
                 {
-                    if (kvp.Value.Type is JTokenType.Integer)
-                    {
-                        ValidateIntegerValue(kvp.Name, (long)kvp.Value);
-                    }
-                    else
-                    {
-                        string s = kvp.Value.ToString();
-                        ValidatePropertyValueLength(kvp.Name, s);
-                    }
+                    ValidateToken(kvp.Name, kvp.Value, currentDepth + 1, inArray);
                 }
+            }
 
-                if (kvp.Value != null && kvp.Value is JObject)
-                {
-                    if (currentDepth > TwinPropertyMaxDepth)
-                    {
-                        throw new InvalidOperationException($"Nested depth of twin property exceeds {TwinPropertyMaxDepth}");
-                    }
+            if (item is JValue value)
+            {
+                ValidateValueType(name, value);
+                ValidateValue(name, value, inArray);
+            }
 
-                    // do validation recursively
-                    ValidateTwinProperties(kvp.Value, currentDepth + 1);
-                }
+            if (item is JArray array)
+            {
+                ValidateTwinDepth(currentDepth);
+
+                // do array validation
+                ValidateArrayContent(array, currentDepth + 1);
             }
         }
 
@@ -95,30 +92,48 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
             }
         }
 
-        static void ValidateArrayContent(JToken token)
+        static void ValidateArrayContent(JArray array, int currentDepth)
         {
-            switch (token)
+            foreach (var item in array)
             {
-                case JArray array:
-                    foreach (var item in array)
-                    {
-                        if (item.Type == JTokenType.Null)
-                        {
-                            throw new InvalidOperationException("Arrays cannot contain 'null' as value");
-                        }
+                if (item.Type is JTokenType.Null)
+                {
+                    throw new InvalidOperationException("Arrays cannot contain 'null' as value");
+                }
 
-                        ValidateArrayContent(item);
+                if (item is JArray inner)
+                {
+                    if (currentDepth > TwinPropertyMaxDepth)
+                    {
+                        throw new InvalidOperationException($"Nested depth of twin property exceeds {TwinPropertyMaxDepth}");
                     }
 
-                    break;
+                    // do array validation
+                    ValidateArrayContent(inner, currentDepth + 1);
+                }
+                else
+                {
+                    // items in the array don't have property name.
+                    ValidateToken(string.Empty, item, currentDepth, true);
+                }
+            }
+        }
 
-                case JObject @object:
-                    foreach (var item in @object)
-                    {
-                        ValidateArrayContent(item.Value);
-                    }
+        static void ValidateValue(string name, JValue value, bool inArray)
+        {
+            if (inArray && value.Type is JTokenType.Null)
+            {
+                throw new InvalidOperationException($"Property {name} of an object in an array cannot be 'null'");
+            }
 
-                    break;
+            if (value.Type is JTokenType.Integer)
+            {
+                ValidateIntegerValue(name, (long)value);
+            }
+            else
+            {
+                string s = value.ToString();
+                ValidatePropertyValueLength(name, s);
             }
         }
 
@@ -145,6 +160,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Twin
             if (size > TwinPropertyDocMaxLength)
             {
                 throw new InvalidOperationException($"Twin properties size {size} exceeds maximum {TwinPropertyDocMaxLength}");
+            }
+        }
+
+        static void ValidateTwinDepth(int currentDepth)
+        {
+            if (currentDepth > TwinPropertyMaxDepth)
+            {
+                throw new InvalidOperationException($"Nested depth of twin property exceeds {TwinPropertyMaxDepth}");
             }
         }
     }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
@@ -124,6 +124,57 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
             yield return new object[]
             {
                 new TwinCollection(JsonConvert.SerializeObject(new
+                    {
+                        ok = "ok",
+                        level1 = new
+                        {
+                            // level 2
+                            array1 = new[]
+                                {
+                                    // level 3
+                                    new[]
+                                    {
+                                        // level 4
+                                        new[]
+                                        {
+                                            // level 5
+                                            new[]
+                                            {
+                                                // level 6
+                                                new[]
+                                                {
+                                                    // level 7
+                                                    new[]
+                                                    {
+                                                        // level 8
+                                                        new[]
+                                                        {
+                                                            // level 9
+                                                            new[]
+                                                            {
+                                                                // level 10
+                                                                new[]
+                                                                {
+                                                                    // level 11
+                                                                    new[] { "one", "two", "three" },
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                        }
+                    })),
+                typeof(InvalidOperationException),
+                "Nested depth of twin property exceeds 10"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
                 {
                     array = new[] { 0, 1, 2 }
                 })),
@@ -197,8 +248,33 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
             yield return new object[]
             {
                 new TwinCollection("{ \"ok\": [\"good\"], \"ok2\": [], \"level1\": [{ \"field1\": null }] }"),
-                null,
-                string.Empty
+                typeof(InvalidOperationException),
+                "Property field1 of an object in an array cannot be 'null'"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
+                {
+                    ok = "ok",
+                    complex = new
+                            {
+                                array1 = new object[]
+                                {
+                                    "one",
+                                    "two",
+                                    new
+                                    {
+                                        array2 = new[]
+                                        {
+                                            new { hello = (string)null }
+                                        }
+                                    },
+                                }
+                            }
+                })),
+                typeof(InvalidOperationException),
+                "Property hello of an object in an array cannot be 'null'"
             };
 
             yield return new object[]
@@ -266,6 +342,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
                                 {
                                     new[] { "one", "two", "three" },
                                     new[] { "four", "five", "six" },
+                                    new object[] { "seven", new { ok = "ok" } },
                                 },
                                 pi = 3.14,
                                 sometime = new DateTime(2021, 1, 20),


### PR DESCRIPTION
Add validation for null props inside objects inside arrays.

Since IoT Hub does not support patch operations on arrays (if you want to update array, you need to replace it), they don't allow null values or null properties inside arrays. EdgeHub, on the other hand, allows that. So, validation can pass on the EdgeHub side, but the update will be rejected by the hub. This situation allows for sending bad payloads, that blocks any further twin updates unless bad property is removed/cleared.