### PR TITLE
Metrics Collector: Remove test-specific additional tags logic

### DIFF
--- a/edge-modules/azure-monitor/src/Program.cs
+++ b/edge-modules/azure-monitor/src/Program.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
         private static void WaitForDebugger()
         {
             LoggerUtil.Writer.LogInformation("Waiting for debugger to attach");
-            for(int i = 0; i < 300 && !Debugger.IsAttached; i++)
+            for (int i = 0; i < 300 && !Debugger.IsAttached; i++)
             {
                 Thread.Sleep(100);
             }
@@ -37,36 +37,37 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             (CancellationTokenSource cts, ManualResetEventSlim completed, Option<object> handler) = ShutdownHandler.Init(TimeSpan.FromSeconds(5), LoggerUtil.Writer);
 
             // wait up to 30 seconds for debugger to attach if in a debug build
-            #if DEBUG
+#if DEBUG
             WaitForDebugger();
 #endif
 
             LoggerUtil.Writer.LogInformation($"Starting metrics collector with the following settings:\r\n{Settings.Current}");
             var transportSetting = new AmqpTransportSettings(TransportType.Amqp_Tcp_Only);
-            
+
             ITransportSettings[] transportSettings = { transportSetting };
             ModuleClient moduleClient = null;
             try
             {
                 moduleClient = await ModuleClient.CreateFromEnvironmentAsync(transportSettings);
                 moduleClient.ProductInfo = Constants.ProductInfo;
-                Option<SortedDictionary<string, string>> additionalTags = await GetAdditionalTagsFromTwin(moduleClient);                
 
                 MetricsScraper scraper = new MetricsScraper(Settings.Current.Endpoints);
                 IMetricsPublisher publisher;
-                if (Settings.Current.UploadTarget == UploadTarget.AzureMonitor) {
+                if (Settings.Current.UploadTarget == UploadTarget.AzureMonitor)
+                {
                     publisher = new FixedSetTableUpload.FixedSetTableUpload(Settings.Current.LogAnalyticsWorkspaceId, Settings.Current.LogAnalyticsWorkspaceKey);
                 }
-                else {
+                else
+                {
                     publisher = new IotHubMetricsUpload.IotHubMetricsUpload(moduleClient);
                 }
 
-                using (MetricsScrapeAndUpload metricsScrapeAndUpload = new MetricsScrapeAndUpload(scraper, publisher, additionalTags))
+                using (MetricsScrapeAndUpload metricsScrapeAndUpload = new MetricsScrapeAndUpload(scraper, publisher))
                 {
                     TimeSpan scrapeAndUploadInterval = TimeSpan.FromSeconds(Settings.Current.ScrapeFrequencySecs);
                     metricsScrapeAndUpload.Start(scrapeAndUploadInterval);
                     // await cts.Token.WhenCanceled();
-                    WaitHandle.WaitAny(new WaitHandle[] {cts.Token.WaitHandle });
+                    WaitHandle.WaitAny(new WaitHandle[] { cts.Token.WaitHandle });
                 }
             }
             catch (Exception e)
@@ -83,46 +84,6 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
 
             LoggerUtil.Writer.LogInformation("MetricsCollector Main() finished.");
             return 0;
-        }
-
-        //TODO: we don't use the module twin for anything, don't bother getting tags?
-        static async Task<Option<SortedDictionary<string, string>>> GetAdditionalTagsFromTwin(ModuleClient moduleClient)
-        {
-            Twin twin = await moduleClient.GetTwinAsync();
-            TwinCollection desiredProperties = twin.Properties.Desired;
-            LoggerUtil.Writer.LogInformation($"Received {desiredProperties.Count} tags from module twin's desired properties that will be added to scraped metrics");
-
-            const string additionalTagsPlaceholder = "additionalTags";
-            Dictionary<string, string> deserializedTwin = JsonConvert.DeserializeObject<Dictionary<string, string>>(twin.Properties.Desired.ToJson());
-            if (deserializedTwin.ContainsKey(additionalTagsPlaceholder))
-            {
-                return Option.Some<SortedDictionary<string, string>>(ParseKeyValuePairs(deserializedTwin[additionalTagsPlaceholder], LoggerUtil.Writer, true));
-            }
-
-            return Option.None<SortedDictionary<string, string>>();
-        }        
-
-        // Test info is used in the longhaul, stress, and connectivity tests to provide contextual information when reporting.
-        // This info is passed from the vsts pipeline and needs to be parsed by the test modules.
-        // Includes information such as build numbers, ids, host platform, etc.
-        // Argument should be in the format key=value[,key=value]
-        public static SortedDictionary<string, string> ParseKeyValuePairs(string keyValuePairs, ILogger logger, bool shouldBeNonEmpty)
-        {
-            LoggerUtil.Writer.LogInformation($"Parsing key value pairs: {keyValuePairs}");
-
-            Dictionary<string, string> unsortedParsedTestInfo = keyValuePairs.Split(",", StringSplitOptions.RemoveEmptyEntries)
-                                .Select(x => (KeyAndValue: x, SplitIndex: x.IndexOf('=')))
-                                .Where(x => x.SplitIndex >= 1)
-                                .ToDictionary(
-                                    x => x.KeyAndValue.Substring(0, x.SplitIndex),
-                                    x => x.KeyAndValue.Substring(x.SplitIndex + 1, x.KeyAndValue.Length - x.SplitIndex - 1));
-
-            if (shouldBeNonEmpty)
-            {
-                Preconditions.CheckArgument(unsortedParsedTestInfo.Count > 0, $"Key value pairs not in correct format: {keyValuePairs}");
-            }
-
-            return new SortedDictionary<string, string>(unsortedParsedTestInfo);
         }
     }
 }


### PR DESCRIPTION
The metrics collector built by the azure monitor team copied some test-specific logic from our metrics collector used for testing. I am removing it as we don't intend to provide this feature for obsv1.