### PR TITLE
Adds SharedAccessSignature to repo with fix for vulnerability (#4943)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/CbsNode.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
     using Microsoft.Azure.Amqp;
     using Microsoft.Azure.Amqp.Framing;
     using Microsoft.Azure.Devices.Common;
-    using Microsoft.Azure.Devices.Common.Security;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Util;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/TokenHelper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/TokenHelper.cs
@@ -2,7 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 {
     using System;
-    using Microsoft.Azure.Devices.Common.Security;
+    using Microsoft.Azure.Devices.Edge.Util;
 
     class TokenHelper
     {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/CloudTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/CloudTokenAuthenticator.cs
@@ -3,7 +3,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Common.Security;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Cloud;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/DeviceScopeTokenAuthenticator.cs
@@ -3,8 +3,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
 {
     using System;
     using System.Net;
-    using Microsoft.Azure.Devices.Common.Data;
-    using Microsoft.Azure.Devices.Common.Security;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/TokenCacheAuthenticator.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/authenticators/TokenCacheAuthenticator.cs
@@ -3,7 +3,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Common.Security;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
     using Microsoft.Azure.Devices.Edge.Util;

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/AuthenticationMiddleware.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Http/middleware/AuthenticationMiddleware.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Http.Middleware
     using System.Threading.Tasks;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Http;
-    using Microsoft.Azure.Devices.Common.Security;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceScopeTokenAuthenticatorTest.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
     using System.Security.Cryptography;
     using System.Text;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Devices.Common.Security;
     using Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Authenticators;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Device;

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SharedAccessSignature.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SharedAccessSignature.cs
@@ -1,0 +1,223 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+    using System.Net;
+    using System.Security.Cryptography;
+    using System.Text;
+
+    /// <summary>
+    /// A shared access signature, which can be used for authorization to an IoT Hub.
+    /// </summary>
+    public sealed class SharedAccessSignature
+    {
+        private readonly string encodedAudience;
+        private readonly string expiry;
+
+        private SharedAccessSignature(
+            string iotHubName,
+            DateTime expiresOn,
+            string expiry,
+            string keyName,
+            string signature,
+            string encodedAudience)
+        {
+            if (string.IsNullOrWhiteSpace(iotHubName))
+            {
+                throw new ArgumentNullException(nameof(iotHubName));
+            }
+
+            this.ExpiresOn = expiresOn;
+
+            if (this.IsExpired())
+            {
+                throw new UnauthorizedAccessException("The specified SAS token is expired");
+            }
+
+            this.IotHubName = iotHubName;
+            this.Signature = signature;
+            this.Audience = WebUtility.UrlDecode(encodedAudience);
+            this.encodedAudience = encodedAudience;
+            this.expiry = expiry;
+            this.KeyName = keyName ?? string.Empty;
+        }
+
+        /// <summary>
+        /// The IoT hub name.
+        /// </summary>
+        public string IotHubName { get; private set; }
+
+        /// <summary>
+        /// The date and time the SAS expires.
+        /// </summary>
+        public DateTime ExpiresOn { get; private set; }
+
+        /// <summary>
+        /// Name of the authorization rule.
+        /// </summary>
+        public string KeyName { get; private set; }
+
+        /// <summary>
+        /// The audience scope to which this signature applies.
+        /// </summary>
+        public string Audience { get; private set; }
+
+        /// <summary>
+        /// The value of the shared access signature.
+        /// </summary>
+        public string Signature { get; private set; }
+
+        /// <summary>
+        /// Parses a shared access signature string representation into a <see cref="SharedAccessSignature"/>./>
+        /// </summary>
+        /// <param name="iotHubName">The IoT Hub name.</param>
+        /// <param name="rawToken">The string representation of the SAS token to parse.</param>
+        /// <returns>The <see cref="SharedAccessSignature"/> instance that represents the passed in raw token.</returns>
+        public static SharedAccessSignature Parse(string iotHubName, string rawToken)
+        {
+            if (string.IsNullOrWhiteSpace(iotHubName))
+            {
+                throw new ArgumentNullException(nameof(iotHubName));
+            }
+
+            if (string.IsNullOrWhiteSpace(rawToken))
+            {
+                throw new ArgumentNullException(nameof(rawToken));
+            }
+
+            IDictionary<string, string> parsedFields = ExtractFieldValues(rawToken);
+
+            if (!parsedFields.TryGetValue(SharedAccessSignatureConstants.SignatureFieldName, out string signature))
+            {
+                throw new FormatException(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Missing field: {0}",
+                    SharedAccessSignatureConstants.SignatureFieldName));
+            }
+
+            if (!parsedFields.TryGetValue(SharedAccessSignatureConstants.ExpiryFieldName, out string expiry))
+            {
+                throw new FormatException(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Missing field: {0}",
+                    SharedAccessSignatureConstants.ExpiryFieldName));
+            }
+
+            // KeyName (skn) is optional.
+            parsedFields.TryGetValue(SharedAccessSignatureConstants.KeyNameFieldName, out string keyName);
+
+            if (!parsedFields.TryGetValue(SharedAccessSignatureConstants.AudienceFieldName, out string encodedAudience))
+            {
+                throw new FormatException(string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Missing field: {0}",
+                    SharedAccessSignatureConstants.AudienceFieldName));
+            }
+
+            return new SharedAccessSignature(
+                iotHubName,
+                SharedAccessSignatureConstants.EpochTime + TimeSpan.FromSeconds(double.Parse(expiry, CultureInfo.InvariantCulture)),
+                expiry,
+                keyName,
+                signature,
+                encodedAudience);
+        }
+
+        /// <summary>
+        /// Indicates if the token has expired.
+        /// </summary>
+        public bool IsExpired() => this.ExpiresOn + SharedAccessSignatureConstants.MaxClockSkew < DateTime.UtcNow;
+
+        /// <summary>
+        /// Authenticate against the IoT Hub using an authorization rule.
+        /// </summary>
+        /// <param name="sasAuthorizationRule">The properties that describe the keys to access the IotHub artifacts.</param>
+        public void Authenticate(SharedAccessSignatureAuthorizationRule sasAuthorizationRule)
+        {
+            if (sasAuthorizationRule == null)
+            {
+                throw new ArgumentNullException(nameof(sasAuthorizationRule), "The SAS Authorization Rule cannot be null.");
+            }
+
+            if (this.IsExpired())
+            {
+                throw new UnauthorizedAccessException("The specified SAS token has expired.");
+            }
+
+            if (sasAuthorizationRule.PrimaryKey != null)
+            {
+                string primaryKeyComputedSignature = ComputeSignature(Convert.FromBase64String(sasAuthorizationRule.PrimaryKey), this.encodedAudience, this.expiry);
+
+                if (CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(this.Signature), Encoding.UTF8.GetBytes(primaryKeyComputedSignature)))
+                {
+                    return;
+                }
+            }
+
+            if (sasAuthorizationRule.SecondaryKey != null)
+            {
+                string secondaryKeyComputedSignature = ComputeSignature(Convert.FromBase64String(sasAuthorizationRule.SecondaryKey), this.encodedAudience, this.expiry);
+
+                if (CryptographicOperations.FixedTimeEquals(Encoding.UTF8.GetBytes(this.Signature), Encoding.UTF8.GetBytes(secondaryKeyComputedSignature)))
+                {
+                    return;
+                }
+            }
+
+            throw new UnauthorizedAccessException("The specified SAS token has an invalid signature. It does not match either the primary or secondary key.");
+        }
+
+        /// <summary>
+        /// Compute the signature string using the SAS fields.
+        /// </summary>
+        /// <param name="key">Key used for computing the signature.</param>
+        /// <returns>The string representation of the signature.</returns>
+        public static string ComputeSignature(byte[] key, string encodedAudience, string expiry)
+        {
+            var fields = new List<string>
+            {
+                encodedAudience,
+                expiry,
+            };
+
+            using var hmac = new HMACSHA256(key);
+            string value = string.Join("\n", fields);
+            return Convert.ToBase64String(hmac.ComputeHash(Encoding.UTF8.GetBytes(value)));
+        }
+
+        private static IDictionary<string, string> ExtractFieldValues(string sharedAccessSignature)
+        {
+            string[] lines = sharedAccessSignature.Split();
+
+            if (!string.Equals(lines[0].Trim(), SharedAccessSignatureConstants.SharedAccessSignature, StringComparison.Ordinal) || lines.Length != 2)
+            {
+                throw new FormatException("Malformed signature");
+            }
+
+            IDictionary<string, string> parsedFields = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string[] fields = lines[1].Trim().Split(new string[] { SharedAccessSignatureConstants.PairSeparator }, StringSplitOptions.None);
+
+            foreach (string field in fields)
+            {
+                if (!string.IsNullOrEmpty(field))
+                {
+                    string[] fieldParts = field.Split(new string[] { SharedAccessSignatureConstants.KeyValueSeparator }, StringSplitOptions.None);
+                    if (string.Equals(fieldParts[0], SharedAccessSignatureConstants.AudienceFieldName, StringComparison.OrdinalIgnoreCase))
+                    {
+                        // We need to preserve the casing of the escape characters in the audience,
+                        // so defer decoding the URL until later.
+                        parsedFields.Add(fieldParts[0], fieldParts[1]);
+                    }
+                    else
+                    {
+                        parsedFields.Add(fieldParts[0], WebUtility.UrlDecode(fieldParts[1]));
+                    }
+                }
+            }
+
+            return parsedFields;
+        }
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SharedAccessSignatureAuthrorizationRule.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SharedAccessSignatureAuthrorizationRule.cs
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+
+    /// <summary>
+    /// A shared access signature based authorization rule for authenticating requests against an IoT Hub.
+    /// </summary>
+    public sealed class SharedAccessSignatureAuthorizationRule : IEquatable<SharedAccessSignatureAuthorizationRule>
+    {
+        private string primaryKey;
+        private string secondaryKey;
+
+        [JsonProperty(PropertyName = "keyName")]
+        public string KeyName { get; set; }
+
+        /// <summary>
+        /// The primary key associated with the shared access policy.
+        /// </summary>
+        [JsonProperty(PropertyName = "primaryKey")]
+        public string PrimaryKey
+        {
+            get => this.primaryKey;
+
+            set
+            {
+                StringValidationHelper.EnsureNullOrBase64String(value, "PrimaryKey");
+                this.primaryKey = value;
+            }
+        }
+
+        /// <summary>
+        /// The secondary key associated with the shared access policy.
+        /// </summary>
+        [JsonProperty(PropertyName = "secondaryKey")]
+        public string SecondaryKey
+        {
+            get => this.secondaryKey;
+
+            set
+            {
+                StringValidationHelper.EnsureNullOrBase64String(value, "SecondaryKey");
+                this.secondaryKey = value;
+            }
+        }
+
+        /// <summary>
+        /// The name of the shared access policy that will be used to grant permission to IoT Hub endpoints.
+        /// </summary>
+        [JsonProperty(PropertyName = "rights")]
+        public AccessRights Rights { get; set; }
+
+        public bool Equals(SharedAccessSignatureAuthorizationRule other)
+        {
+            if (other == null)
+            {
+                return false;
+            }
+
+            bool equals = string.Equals(this.KeyName, other.KeyName, StringComparison.OrdinalIgnoreCase) &&
+                string.Equals(this.PrimaryKey, other.PrimaryKey, StringComparison.Ordinal) &&
+                string.Equals(this.SecondaryKey, other.SecondaryKey, StringComparison.Ordinal) &&
+                Equals(this.Rights, other.Rights);
+
+            return equals;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj) => this.Equals(obj as SharedAccessSignatureAuthorizationRule);
+
+        /// <summary>
+        /// Gets a hash code for a given object.
+        /// </summary>
+        /// <returns>A hash code for the given object.</returns>
+        public static int GetHashCode(SharedAccessSignatureAuthorizationRule rule)
+        {
+            if (rule == null)
+            {
+                return 0;
+            }
+
+            int hashKeyName, hashPrimaryKey, hashSecondaryKey, hashRights;
+
+            hashKeyName = rule.KeyName == null ? 0 : rule.KeyName.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
+
+            hashPrimaryKey = rule.PrimaryKey == null ? 0 : rule.PrimaryKey.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
+
+            hashSecondaryKey = rule.SecondaryKey == null ? 0 : rule.SecondaryKey.GetHashCode(StringComparison.InvariantCultureIgnoreCase);
+
+            hashRights = rule.Rights.GetHashCode();
+
+            return hashKeyName ^ hashPrimaryKey ^ hashSecondaryKey ^ hashRights;
+        }
+
+        /// <summary>
+        /// Gets a hash code for the current object.
+        /// </summary>
+        /// <returns>A hash code for the current object.</returns>
+        public override int GetHashCode() => GetHashCode(this);
+
+        /// <summary>
+        /// Shared access policy permissions of IoT hub.
+        /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-security#iot-hub-permissions"/>.
+        /// </summary>
+        [Flags]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public enum AccessRights
+        {
+            /// <summary>
+            /// Grants read access to the identity registry.
+            /// Identity registry stores information about the devices and modules permitted to connect to the IoT hub.
+            /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry"/>.
+            /// </summary>
+            RegistryRead = 1,
+
+            /// <summary>
+            /// Grants read and write access to the identity registry.
+            /// Identity registry stores information about the devices and modules permitted to connect to the IoT hub.
+            /// For more information, see <see href="https://docs.microsoft.com/en-us/azure/iot-hub/iot-hub-devguide-identity-registry"/>.
+            /// </summary>
+            RegistryWrite = RegistryRead | 2,
+
+            /// <summary>
+            /// Grants access to service facing communication and monitoring endpoints.
+            /// It grants permission to receive device-to-cloud messages, send cloud-to-device messages, retrieve delivery acknowledgments for sent messages
+            /// and file uploads, retrieve desired and reported properties on device twins, update tags and desired properties on device twins,
+            /// and run queries.
+            /// </summary>
+            ServiceConnect = 4,
+
+            /// <summary>
+            /// Grants access to device facing endpoints.
+            /// It grants permission to send device-to-cloud messages, receive cloud-to-device messages, perform file upload from a device, receive device twin
+            /// desired property notifications and update device twin reported properties.
+            /// </summary>
+            DeviceConnect = 8
+        }
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SharedAccessSignatureConstants.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/SharedAccessSignatureConstants.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+
+    static class SharedAccessSignatureConstants
+    {
+        public const string SharedAccessSignature = "SharedAccessSignature";
+        public const string AudienceFieldName = "sr";
+        public const string SignatureFieldName = "sig";
+        public const string KeyNameFieldName = "skn";
+        public const string ExpiryFieldName = "se";
+        public const string KeyValueSeparator = "=";
+        public const string PairSeparator = "&";
+        public static readonly DateTime EpochTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
+        public static readonly TimeSpan MaxClockSkew = TimeSpan.FromMinutes(5);
+    }
+}

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/StringValidationHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/StringValidationHelper.cs
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
+
+    public static class StringValidationHelper
+    {
+        private const char Base64Padding = '=';
+
+        private static readonly HashSet<char> base64Table =
+            new HashSet<char>
+            {
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
+                'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd',
+                'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
+                't', 'u', 'v', 'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7',
+                '8', '9', '+', '/'
+            };
+
+        public static void EnsureNullOrBase64String(string value, string paramName)
+        {
+            if (!IsNullOrBase64String(value))
+            {
+                throw new ArgumentException(GetString("'{0}' is not a valid Base64 encoded string.", value), paramName);
+            }
+        }
+
+        public static bool IsNullOrBase64String(string value)
+        {
+            if (value == null)
+            {
+                return true;
+            }
+
+            return IsBase64String(value);
+        }
+
+        public static bool IsBase64String(string value)
+        {
+            value = value.Replace("\r", string.Empty, StringComparison.Ordinal).Replace("\n", string.Empty, StringComparison.Ordinal);
+
+            if (value.Length == 0 || (value.Length % 4) != 0)
+            {
+                return false;
+            }
+
+            var lengthNoPadding = value.Length;
+            value = value.TrimEnd(Base64Padding);
+            var lengthPadding = value.Length;
+
+            if ((lengthNoPadding - lengthPadding) > 2)
+            {
+                return false;
+            }
+
+            foreach (char c in value)
+            {
+                if (!base64Table.Contains(c))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        internal static string GetString(string value, params object[] args)
+        {
+            if (args != null && args.Length > 0)
+            {
+                for (int i = 0; i < args.Length; i++)
+                {
+                    if (args[i] is string text && text.Length > 1024)
+                    {
+                        args[i] = text.Substring(0, 1021) + "...";
+                    }
+                }
+
+                return string.Format(CultureInfo.InvariantCulture, value, args);
+            }
+
+            return value;
+        }
+    }
+}

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/SharedAccessSignatureTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/SharedAccessSignatureTest.cs
@@ -1,0 +1,179 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Util.Test
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Xunit;
+
+    public class SharedAccessKeySignatureTest
+    {
+        const string IOT_HUB_NAME = "TestHub";
+        const string MISSING_SHAREDACCESSSIGNATURE_RAW_TOKEN = "\nsig=test&se=0&sr=test";
+        const string EXPIRED_RAW_TOKEN = "SharedAccessSignature\nsig=test&se=0&sr=test";
+        const string BAD_TOKEN = "test";
+        const string BAD_TOKEN_MISSING_SIGNATURE = "SharedAccessSignature\nse=0&sr=test";
+        const string BAD_TOKEN_MISSING_EXPIRY = "SharedAccessSignature\nsig=test&sr=test";
+        const string BAD_TOKEN_MISSING_ENCODING_AUDIENCE = "SharedAccessSignature\nsig=test&se=0;";
+        const string WHITE_SPACE = "  ";
+
+        [Fact]
+        [Unit]
+        public void IsExpiredTest()
+        {
+            var sas = SharedAccessSignature.Parse(IOT_HUB_NAME, this.GetAlmostExpiredToken());
+
+            Thread.Sleep(5 * 1000);
+
+            Assert.True(sas.IsExpired());
+
+            sas = SharedAccessSignature.Parse(IOT_HUB_NAME, this.GetNonExpiredToken());
+
+            Assert.False(sas.IsExpired());
+        }
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithNullIotHubNameTest() => Assert.Throws<ArgumentNullException>(() => SharedAccessSignature.Parse(null, EXPIRED_RAW_TOKEN));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithEmptyIotHubNameTest() => Assert.Throws<ArgumentNullException>(() => SharedAccessSignature.Parse(string.Empty, EXPIRED_RAW_TOKEN));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithWhiteSpaceIotHubNameTest() => Assert.Throws<ArgumentNullException>(() => SharedAccessSignature.Parse(WHITE_SPACE, EXPIRED_RAW_TOKEN));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithNullRawTokenTest() => Assert.Throws<ArgumentNullException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, null));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithEmptyRawTokenTest() => Assert.Throws<ArgumentNullException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, string.Empty));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithWhiteSpaceRawTokenTest() => Assert.Throws<ArgumentNullException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, WHITE_SPACE));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithBadRawTokenTest() => Assert.Throws<FormatException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, BAD_TOKEN));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithSignatureMissingFromRawTokenTest() => Assert.Throws<FormatException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, BAD_TOKEN_MISSING_SIGNATURE));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithExpiryMissingFromRawTokenTest() => Assert.Throws<FormatException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, BAD_TOKEN_MISSING_EXPIRY));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithsrMissingFromRawTokenTest() => Assert.Throws<FormatException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, BAD_TOKEN_MISSING_ENCODING_AUDIENCE));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithSharedAccessSignatureMissingFromRawTokenTest() => Assert.Throws<FormatException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, MISSING_SHAREDACCESSSIGNATURE_RAW_TOKEN));
+
+        [Fact]
+        [Unit]
+        public void ParseThrowsWithExpiredRawTokenTest() => Assert.Throws<UnauthorizedAccessException>(() => SharedAccessSignature.Parse(IOT_HUB_NAME, EXPIRED_RAW_TOKEN));
+
+        [Fact]
+        [Unit]
+        public void ParseDoesNotThrowWithNonExpiredRawTokenTest() => this.AssertNoThrow(() => SharedAccessSignature.Parse(IOT_HUB_NAME, this.GetNonExpiredToken()));
+
+        [Fact]
+        [Unit]
+        public void AuthenticateThrowsWhenRuleIsNullTest()
+        {
+            var sas = SharedAccessSignature.Parse(IOT_HUB_NAME, this.GetNonExpiredToken());
+
+            Assert.Throws<ArgumentNullException>(() => sas.Authenticate(null));
+        }
+
+        [Fact]
+        [Unit]
+        public void AuthenticateThrowsIsExpiredTest()
+        {
+            var sas = SharedAccessSignature.Parse(IOT_HUB_NAME, this.GetAlmostExpiredToken());
+
+            var rule = new SharedAccessSignatureAuthorizationRule();
+
+            Thread.Sleep(5 * 1000);
+
+            Assert.Throws<UnauthorizedAccessException>(() => sas.Authenticate(rule));
+        }
+
+        [Fact]
+        [Unit]
+        public void AuthenticateThrowsInvalidSASTest()
+        {
+            var sas = SharedAccessSignature.Parse(IOT_HUB_NAME, this.GetNonExpiredToken());
+
+            var rule = new SharedAccessSignatureAuthorizationRule();
+
+            Assert.Throws<UnauthorizedAccessException>(() => sas.Authenticate(rule));
+        }
+
+        [Fact]
+        [Unit]
+        public void AuthenticateSucceedsWhenValidSASWithPrimaryKeyTest()
+        {
+            var sas = SharedAccessSignature.Parse(IOT_HUB_NAME, this.GetNonExpiredToken());
+
+            var json = new JObject
+            {
+                ["keyName"] = "test",
+                ["primaryKey"] = "test",
+                ["secondaryKey"] = "YmFk"
+            };
+
+            var rule = JsonConvert.DeserializeObject<SharedAccessSignatureAuthorizationRule>(json.ToString());
+
+            this.AssertNoThrow(() => sas.Authenticate(rule));
+        }
+
+        [Fact]
+        [Unit]
+        public void AuthenticateSucceedsWhenValidSASWithSecondaryKeyTest()
+        {
+            var sas = SharedAccessSignature.Parse(IOT_HUB_NAME, this.GetNonExpiredToken());
+
+            var json = new JObject
+            {
+                ["keyName"] = "test",
+                ["primaryKey"] = "YmFk",
+                ["secondaryKey"] = "test"
+            };
+
+            var rule = JsonConvert.DeserializeObject<SharedAccessSignatureAuthorizationRule>(json.ToString());
+
+            this.AssertNoThrow(() => sas.Authenticate(rule));
+        }
+
+        private string GetNonExpiredToken()
+        {
+            // Generate a valid looking sas token
+            var expiry = this.GetExpiry(10).ToString();
+            var sr = "test";
+
+            var sig = SharedAccessSignature.ComputeSignature(Convert.FromBase64String("test"), sr, expiry);
+            sig = WebUtility.UrlEncode(sig);
+
+            return "SharedAccessSignature\nsig=" + sig + "&se=" + expiry + "&sr=" + sr;
+        }
+
+        private string GetAlmostExpiredToken() => "SharedAccessSignature\nsig=test&se=" + this.GetExpiry(2) + "&sr=test";
+
+        private void AssertNoThrow(Func<object> test) => Assert.Null(Record.Exception(test));
+
+        private void AssertNoThrow(Action test) => Assert.Null(Record.Exception(test));
+
+        private int GetExpiry(int secondsInFuture) => (int)Math.Floor((DateTime.UtcNow.AddSeconds(secondsInFuture).Subtract(SharedAccessSignatureConstants.MaxClockSkew) - SharedAccessSignatureConstants.EpochTime).TotalSeconds);
+    }
+}


### PR DESCRIPTION
This is a cherry-pick of https://github.com/Azure/iotedge/pull/4943

This adds a subset of the code from https://github.com/Azure/azure-iot-sdk-csharp for SharedAccessSignature directly into our repo. This will also need to be cherry-picked into 1.1 and 1.2.

Todo:
- [x] Create UTs (UT=unit test) around this code, as there seem to be some tests that use parts of SharedAccessSignature but nothing completely dedicated
- [x] See if more code can be trimmed out that is not being used, just removed things without any references for first pass
- [x] if only using one supported .net then can maybe remove some other code here