### PR TITLE
Metrics Collector: Release and publish pipelines

### DIFF
--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -348,10 +348,10 @@ jobs:
           imageName: azureiotedge-relayer
           project: Relayer
 
-     # Metrics Collector
+     # Metrics Collector (test-only)
       - template: templates/image-windows.yaml
         parameters:
-          name: Metrics Collector - Tests only
+          name: Metrics Collector (test-only)
           imageName: azureiotedge-test-metrics-collector
           project: MetricsCollector
 
@@ -383,10 +383,10 @@ jobs:
           imageName: azureiotedge-c2dmessage-tester
           project: CloudToDeviceMessageTester
 
-     # Azure IoT Edge Metrics Collector
+     #  Metrics Collector (customer-facing)
       - template: templates/image-windows.yaml
         parameters:
-          name: Azure IoT Edge Metrics Collector
+          name: Metrics Collector (customer-facing)
           imageName: azureiotedge-metrics-collector
           project: Microsoft.Azure.Devices.Edge.Azure.Monitor
 

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -383,7 +383,7 @@ jobs:
           imageName: azureiotedge-c2dmessage-tester
           project: CloudToDeviceMessageTester
 
-     #  Metrics Collector (customer-facing)
+     # Metrics Collector (customer-facing)
       - template: templates/image-windows.yaml
         parameters:
           name: Metrics Collector (customer-facing)

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -152,7 +152,7 @@ jobs:
           imageName: azureiotedge-test-result-coordinator
           project: TestResultCoordinator
 
-     # Metrics Collector
+     # Metrics Collector (test-only)
       - template: templates/image-linux.yaml
         parameters:
           name: Metrics Collector (test-only)
@@ -180,7 +180,7 @@ jobs:
           imageName: azureiotedge-c2dmessage-tester
           project: CloudToDeviceMessageTester
 
-     # Azure IoT Edge Metrics Collector
+     # Metrics Collector (customer-facing)
       - template: templates/image-linux.yaml
         parameters:
           name: Metrics Collector (customer-facing)

--- a/builds/misc/metrics-collector-images-publish.yaml
+++ b/builds/misc/metrics-collector-images-publish.yaml
@@ -1,0 +1,60 @@
+name: $(version)
+trigger: none
+pr: none
+
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+  
+jobs:
+  - deployment: publishImages
+    displayName: Publish Images
+    pool:
+      vmImage: ubuntu-18.04
+    workspace:
+      clean: all
+    environment: 'Azure-IoT-Edge-Core Release Env'
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - checkout: self
+            clean: true
+            fetchDepth: 100
+        
+          - task: Bash@3
+            displayName: Log into Registries
+            inputs:
+              targetType: Inline
+              script: |
+                docker login $(registry.address) --username $(registry.user) --password $(registry.password)
+        
+          - task: Bash@3
+            displayName: 'Publish Metrics Collector - Linux amd64'
+            inputs:
+              filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+              arguments: '--from $(registry.address)/$(from.registry.namespace)/azureiotedge-metrics-collector:$(version)-linux-amd64 --to $(registry.address)/$(to.registry.namespace)/azureiotedge-metrics-collector:$(version)-linux-amd64'
+      
+          - task: Bash@3
+            displayName: 'Publish Metrics Collector - Linux arm32v7'
+            inputs:
+              filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+              arguments: '--from $(registry.address)/$(from.registry.namespace)/azureiotedge-metrics-collector:$(version)-linux-arm32v7 --to $(registry.address)/$(to.registry.namespace)/azureiotedge-metrics-collector:$(version)-linux-arm32v7'
+      
+          - task: Bash@3
+            displayName: 'Publish Metrics Collector - Linux arm64v8'
+            inputs:
+              filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+              arguments: '--from $(registry.address)/$(from.registry.namespace)/azureiotedge-metrics-collector:$(version)-linux-arm64v8 --to $(registry.address)/$(to.registry.namespace)/azureiotedge-metrics-collector:$(version)-linux-arm64v8'
+
+          - task: Bash@3
+            displayName: 'Publish Metrics Collector - Windows amd64'
+            inputs:
+              filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+              arguments: '--from $(registry.address)/$(from.registry.namespace)/azureiotedge-metrics-collector:$(version)-windows-amd64 --to $(registry.address)/$(to.registry.namespace)/azureiotedge-metrics-collector:$(version)-windows-amd64'
+      
+          - task: Bash@3
+            displayName: 'Publish Metrics Collector Manifest'
+            inputs:
+              targetType: filePath
+              filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+              arguments: '-r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-modules/azure-monitor/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tags)"'

--- a/builds/misc/metrics-collector-images-release.yaml
+++ b/builds/misc/metrics-collector-images-release.yaml
@@ -1,4 +1,6 @@
 name: $(version)
+trigger: none
+pr: none
 
 variables:
   NugetSecurityAnalysisWarningLevel: warn

--- a/builds/misc/metrics-collector-images-release.yaml
+++ b/builds/misc/metrics-collector-images-release.yaml
@@ -7,26 +7,67 @@ variables:
   
 jobs:
 ################################################################################
-  - job: MetricsCollector
+  - job: MetricsCollector_Linux
 ################################################################################
-    displayName: MetricsCollector
-    timeoutInMinutes: 120
+    displayName: Metrics Collector Linux Build
+    timeoutInMinutes: 30
     pool:
       vmImage: 'ubuntu-18.04'
     steps:
+      - template: ../templates/install-dotnet2.yaml
+      - template: ../templates/install-dotnet3.yaml
+
       - bash: |
             # Need to login to EdgeBuilds Container Registry for base images.
             docker login '$(registry.address)' --username '$(registry.user)' --password '$(registry.password)'
         displayName: 'Docker Login'
+
       - script: scripts/linux/buildBranch.sh -c $(Build.Configuration) --no-rocksdb-bin
         name: build
         displayName: Build ($(Build.Configuration))
+
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifacts'
         inputs:
           PathtoPublish: '$(Build.BinariesDirectory)/publish'
           ArtifactName: 'core-linux'
+
       - template: templates/image-linux.yaml
+        parameters:
+          name: Metrics Collector (customer-facing)
+          imageName: azureiotedge-metrics-collector
+          project: Microsoft.Azure.Devices.Edge.Azure.Monitor
+
+################################################################################
+  - job: MetricsCollector_Windows
+################################################################################
+    displayName: Metrics Collector Windows Build
+    timeoutInMinutes: 30
+    pool:
+      name: Azure-IoT-Edge-Core
+      demands:
+        - Build-Image -equals true
+        - win-rs5
+    workspace:
+      clean: all
+    steps:
+      - template: ../templates/install-dotnet2.yaml
+      - template: ../templates/install-dotnet3.yaml
+
+      - script: echo $(registry.password)|docker login "edgebuilds.azurecr.io" -u "$(registry.user)" --password-stdin
+        displayName: Docker Login
+
+      - powershell: scripts/windows/build/Publish-Branch.ps1 -Configuration:"$(Build.Configuration)" -PublishTests:$False -UpdateVersion
+        name: build
+        displayName: Build ($(Build.Configuration))
+
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts'
+        inputs:
+          PathtoPublish: '$(Build.BinariesDirectory)/publish'
+          ArtifactName: 'core-windows'
+
+      - template: templates/image-windows.yaml
         parameters:
           name: Metrics Collector (customer-facing)
           imageName: azureiotedge-metrics-collector
@@ -39,7 +80,8 @@ jobs:
     pool:
       vmImage: 'ubuntu-18.04'
     dependsOn:
-      - MetricsCollector
+      - MetricsCollector_Linux
+      - MetricsCollector_Windows
     steps:
     - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-modules/azure-monitor/docker/manifest.yaml.template -n microsoft --tags "$(tags)"
-      displayName: 'Publish azureiotedge-api-proxy Manifest'
+      displayName: 'Publish Metrics Collector Manifest'

--- a/builds/misc/metrics-collector-images-release.yaml
+++ b/builds/misc/metrics-collector-images-release.yaml
@@ -1,0 +1,43 @@
+name: $(version)
+
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+  
+jobs:
+################################################################################
+  - job: MetricsCollector
+################################################################################
+    displayName: MetricsCollector
+    timeoutInMinutes: 120
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+      - bash: |
+            # Need to login to EdgeBuilds Container Registry for base images.
+            docker login '$(registry.address)' --username '$(registry.user)' --password '$(registry.password)'
+        displayName: 'Docker Login'
+      - script: scripts/linux/buildBranch.sh -c $(Build.Configuration) --no-rocksdb-bin
+        name: build
+        displayName: Build ($(Build.Configuration))
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts'
+        inputs:
+          PathtoPublish: '$(Build.BinariesDirectory)/publish'
+          ArtifactName: 'core-linux'
+      - template: templates/image-linux.yaml
+        parameters:
+          name: Metrics Collector (customer-facing)
+          imageName: azureiotedge-metrics-collector
+          project: Microsoft.Azure.Devices.Edge.Azure.Monitor
+
+################################################################################
+  - job: manifest
+################################################################################
+    displayName: Publish Manifest Images
+    pool:
+      vmImage: 'ubuntu-18.04'
+    dependsOn:
+      - MetricsCollector
+    steps:
+    - script: scripts/linux/buildManifest.sh -r $(registry.address) -u $(registry.user) -p $(registry.password) -v $(version) -t $(System.DefaultWorkingDirectory)/edge-modules/azure-monitor/docker/manifest.yaml.template -n microsoft --tags "$(tags)"
+      displayName: 'Publish azureiotedge-api-proxy Manifest'

--- a/builds/misc/metrics-collector-images-release.yaml
+++ b/builds/misc/metrics-collector-images-release.yaml
@@ -4,6 +4,7 @@ pr: none
 
 variables:
   NugetSecurityAnalysisWarningLevel: warn
+  Build.Configuration: release
   
 jobs:
 ################################################################################


### PR DESCRIPTION
Adding images release and publish pipelines for the metrics collector. Approach was taken from the implementation we have in `master` branch for the api proxy.