### PR TITLE
Introduce `Timestamps` Option via mgmt.sock

### DIFF
--- a/edgelet/api/README.md
+++ b/edgelet/api/README.md
@@ -1,0 +1,52 @@
+# How to build Management API using Swagger-Codegen
+1. Install Java & Maven 
+```sh
+   sudo apt-get install openjdk-8-jdk
+   ## It only works on JAVA8 see https://computingforgeeks.com/how-to-set-default-java-version-on-ubuntu-debian/ how to switch between Java versions
+   sudo apt install maven
+```
+2. Clone swagger codegen repo:
+```sh
+   cd ~
+   git clone https://github.com/swagger-api/swagger-codegen.git
+```
+3. Test build if installation was done correctly ( https://github.com/swagger-api/swagger-codegen#building ) 
+```sh
+   cd swagger-codegen
+   mvn clean install -N
+   mvn clean package
+```
+4. Build swagger-codegen
+```sh
+   cd modules/swagger-codegen
+   mvn clean package
+
+   ## Make sure /target/*.jar is created
+   ls
+```
+5. Build swagger-codegen-cli
+```sh
+   cd ~/swagger-codegen/modules/swagger-codegen-cli
+   mvn clean package
+
+   ## Make sure /target/*.jar is created
+   ls 
+```
+6. Put it all together and build API
+    - Run the following command 
+```sh
+		 java -cp <abs/path/to/jar/step4>:<abs/path/to/jar/step5> \
+		 io.swagger.codegen.SwaggerCodegen generate \
+		 -l rust \
+		 -i <abs/path/to/iotedge/mgmt/yaml> \
+		 -o <abs/path/to/output/folder>
+
+        ## Example Command
+		 java -cp /home/iotedgeuser/swagger-codegen/modules/swagger-codegen/target/swagger-codegen-2.4.20-SNAPSHOT.jar:/home/iotedgeuser/swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar \
+		 io.swagger.codegen.SwaggerCodegen generate \
+		 -l rust \
+		 -i /home/iotedgeuser/iotedge/edgelet/api/managementVersion_2020_07_07.yaml \
+		 -o /home/iotedgeuser/management
+```
+# Note #
+We've manually fixed up the generated code so that it satisfies rustfmt and clippy. As such, if you ever need to run `swagger-codegen-cli` against new definitions, or need to regenerate existing ones, you will want to perform the same fixups manually. Make sure to run clippy and rustfmt against the new code yourself, and inspect the diffs of modified files before checking in.

--- a/edgelet/api/managementVersion_2020_07_07.yaml
+++ b/edgelet/api/managementVersion_2020_07_07.yaml
@@ -297,6 +297,11 @@ paths:
           type: string
           default: "all"
         - in: query
+          name: timestamps
+          description: Prepend timestamp in rfc3339 format to each line of log.
+          type: boolean
+          default: false
+        - in: query
           name: since
           description: Only return logs since this time, as a duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes), rfc3339 timestamp, or UNIX timestamp.
           type: string

--- a/edgelet/api/managementVersion_2021_05_11.yaml
+++ b/edgelet/api/managementVersion_2021_05_11.yaml
@@ -3,7 +3,7 @@ schemes:
   - http
 info:
   title: IoT Edge Management API
-  version: '2020-07-07'
+  version: '2020-05-11'
 tags:
   - name: Module
     x-displayName: Modules

--- a/edgelet/api/managementVersion_2021_05_11.yaml
+++ b/edgelet/api/managementVersion_2021_05_11.yaml
@@ -297,6 +297,11 @@ paths:
           type: string
           default: "all"
         - in: query
+          name: timestamps
+          description: Return logs with prepended rfc3339 timestamp to each line of log.
+          type: boolean
+          default: false
+        - in: query
           name: since
           description: Only return logs since this time, as a duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes), rfc3339 timestamp, or UNIX timestamp.
           type: string

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -254,6 +254,8 @@ cargo test --all
 
     Note that we've manually fixed up the generated code so that it satisfies rustfmt and clippy. As such, if you ever need to run `swagger-codegen-cli` against new definitions, or need to regenerate existing ones, you will want to perform the same fixups manually. Make sure to run clippy and rustfmt against the new code yourself, and inspect the diffs of modified files before checking in.
 
+    For more details, please visit [**How to build Management API using Swagger-Codegen**](../api/README.md)
+
 - IDE
 
     [VS Code](https://code.visualstudio.com/) has good support for Rust. Consider installing the following extensions:

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -311,6 +311,7 @@ impl ToString for LogTail {
 pub struct LogOptions {
     follow: bool,
     tail: LogTail,
+    timestamps: bool,
     since: i32,
     until: Option<i32>,
 }
@@ -320,6 +321,7 @@ impl LogOptions {
         LogOptions {
             follow: false,
             tail: LogTail::All,
+            timestamps: false,
             since: 0,
             until: None,
         }
@@ -345,6 +347,11 @@ impl LogOptions {
         self
     }
 
+    pub fn with_timestamps(mut self, timestamps: bool) -> Self {
+        self.timestamps = timestamps;
+        self
+    }
+
     pub fn follow(&self) -> bool {
         self.follow
     }
@@ -359,6 +366,10 @@ impl LogOptions {
 
     pub fn until(&self) -> Option<i32> {
         self.until
+    }
+
+    pub fn timestamps(&self) -> bool {
+        self.timestamps
     }
 }
 

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -983,7 +983,7 @@ impl ModuleRuntime for DockerModuleRuntime {
                 true,
                 options.since(),
                 options.until(),
-                false,
+                options.timestamps(),
                 tail,
             )
             .then(|result| match result {

--- a/edgelet/edgelet-http-mgmt/src/client/module.rs
+++ b/edgelet/edgelet-http-mgmt/src/client/module.rs
@@ -322,6 +322,7 @@ impl ModuleRuntime for ModuleClient {
                 &id,
                 options.follow(),
                 tail,
+                options.timestamps(),
                 options.since(),
             )
             .then(|logs| match logs {

--- a/edgelet/edgelet-http-mgmt/src/server/module/logs.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/logs.rs
@@ -84,9 +84,15 @@ fn parse_options(query: &str) -> Result<LogOptions, Error> {
         .find(|&(ref key, _)| key == "since")
         .map_or_else(|| Ok(0), |(_, val)| parse_since(val))
         .context(ErrorKind::MalformedRequestParameter("since"))?;
+    let timestamps = parse
+        .iter()
+        .find(|&(ref key, _)| key == "timestamps")
+        .map_or_else(|| Ok(false), |(_, val)| val.parse::<bool>())
+        .context(ErrorKind::MalformedRequestParameter("timestamps"))?;
     let mut options = LogOptions::new()
         .with_follow(follow)
         .with_tail(tail)
+        .with_timestamps(timestamps)
         .with_since(since);
 
     if let Some(until) = parse

--- a/edgelet/management/docs/Identity.md
+++ b/edgelet/management/docs/Identity.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **module_id** | **String** |  | [default to null]
 **managed_by** | **String** |  | [default to null]
 **generation_id** | **String** |  | [default to null]
+**auth_type** | **String** |  | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/edgelet/management/docs/IdentityApi.md
+++ b/edgelet/management/docs/IdentityApi.md
@@ -4,21 +4,21 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**create_identity**](IdentityApi.md#create_identity) | **Put** /identities/{name} | Create or update an identity.
+[**create_identity**](IdentityApi.md#create_identity) | **Post** /identities/ | Create an identity.
 [**delete_identity**](IdentityApi.md#delete_identity) | **Delete** /identities/{name} | Delete an identity.
 [**list_identities**](IdentityApi.md#list_identities) | **Get** /identities/ | List identities.
+[**update_identity**](IdentityApi.md#update_identity) | **Put** /identities/{name} | Update an identity.
 
 
 # **create_identity**
-> ::models::Identity create_identity(api_version, name, identity)
-Create or update an identity.
+> ::models::Identity create_identity(api_version, identity)
+Create an identity.
 
 ### Required Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
   **api_version** | **String**| The version of the API. | [default to 2018-06-28]
-  **name** | **String**| The name of the identity to create/update. (urlencoded) | 
   **identity** | [**IdentitySpec**](IdentitySpec.md)|  | 
 
 ### Return type
@@ -85,6 +85,33 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **update_identity**
+> ::models::Identity update_identity(api_version, name, updateinfo)
+Update an identity.
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+  **name** | **String**| The name of the identity to update. (urlencoded) | 
+  **updateinfo** | [**UpdateIdentity**](UpdateIdentity.md)|  | 
+
+### Return type
+
+[**::models::Identity**](Identity.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/edgelet/management/docs/IdentitySpec.md
+++ b/edgelet/management/docs/IdentitySpec.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **module_id** | **String** |  | [default to null]
+**managed_by** | **String** |  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/edgelet/management/docs/ModuleApi.md
+++ b/edgelet/management/docs/ModuleApi.md
@@ -143,6 +143,7 @@ Name | Type | Description  | Notes
  **stdout** | **bool**| Return logs from &#x60;stdout&#x60; | [default to false]
  **stderr** | **bool**| Return logs from &#x60;stderr&#x60; | [default to false]
  **tail** | **String**| Only return this number of lines from the end of the logs. | [default to all]
+ **timestamps** | **bool**| Return logs with prepended rfc3339 timestamp to each line of log.  | [default to false]
 
 ### Return type
 

--- a/edgelet/management/docs/ModuleApi.md
+++ b/edgelet/management/docs/ModuleApi.md
@@ -9,6 +9,7 @@ Method | HTTP request | Description
 [**get_module**](ModuleApi.md#get_module) | **Get** /modules/{name} | Get a module&#39;s status.
 [**list_modules**](ModuleApi.md#list_modules) | **Get** /modules | List modules.
 [**module_logs**](ModuleApi.md#module_logs) | **Get** /modules/{name}/logs | Get module logs.
+[**prepare_update_module**](ModuleApi.md#prepare_update_module) | **Post** /modules/{name}/prepareupdate | Prepare to update a module.
 [**restart_module**](ModuleApi.md#restart_module) | **Post** /modules/{name}/restart | Restart a module.
 [**start_module**](ModuleApi.md#start_module) | **Post** /modules/{name}/start | Start a module.
 [**stop_module**](ModuleApi.md#stop_module) | **Post** /modules/{name}/stop | Stop a module.
@@ -140,10 +141,9 @@ Name | Type | Description  | Notes
  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
  **name** | **String**| The name of the module to obtain logs for. (urlencoded) | 
  **follow** | **bool**| Return the logs as a stream. | [default to false]
- **stdout** | **bool**| Return logs from &#x60;stdout&#x60; | [default to false]
- **stderr** | **bool**| Return logs from &#x60;stderr&#x60; | [default to false]
  **tail** | **String**| Only return this number of lines from the end of the logs. | [default to all]
- **timestamps** | **bool**| Return logs with prepended rfc3339 timestamp to each line of log.  | [default to false]
+ **timestamps** | **bool**| Return logs with prepended rfc3339 timestamp to each line of log. | [default to false]
+ **since** | **String**| Only return logs since this time, as a duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes), rfc3339 timestamp, or UNIX timestamp. | [default to 0]
 
 ### Return type
 
@@ -157,6 +157,33 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **prepare_update_module**
+> prepare_update_module(api_version, name, module)
+Prepare to update a module.
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+  **name** | **String**| The name of the module to update. (urlencoded) | 
+  **module** | [**ModuleSpec**](ModuleSpec.md)|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -239,7 +266,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update_module**
-> ::models::ModuleDetails update_module(api_version, name, module)
+> ::models::ModuleDetails update_module(api_version, name, module, optional)
 Update a module.
 
 ### Required Parameters
@@ -249,6 +276,17 @@ Name | Type | Description  | Notes
   **api_version** | **String**| The version of the API. | [default to 2018-06-28]
   **name** | **String**| The name of the module to update. (urlencoded) | 
   **module** | [**ModuleSpec**](ModuleSpec.md)|  | 
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+ **name** | **String**| The name of the module to update. (urlencoded) | 
+ **module** | [**ModuleSpec**](ModuleSpec.md)|  | 
+ **start** | **bool**| Flag indicating whether module should be started after updating. | [default to false]
 
 ### Return type
 

--- a/edgelet/management/docs/ModuleSpec.md
+++ b/edgelet/management/docs/ModuleSpec.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **String** | The name of a the module. | [default to null]
 **_type** | **String** |  | [default to null]
+**image_pull_policy** | **String** |  | [optional] [default to null]
 **config** | [***::models::Config**](Config.md) |  | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/edgelet/management/docs/SystemInfo.md
+++ b/edgelet/management/docs/SystemInfo.md
@@ -5,6 +5,12 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **os_type** | **String** |  | [default to null]
 **architecture** | **String** |  | [default to null]
+**version** | **String** |  | [optional] [default to null]
+**server_version** | **String** |  | [optional] [default to null]
+**kernel_version** | **String** |  | [optional] [default to null]
+**operating_system** | **String** |  | [optional] [default to null]
+**cpus** | **i32** |  | [optional] [default to null]
+**virtualized** | **String** |  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/edgelet/management/docs/SystemInformationApi.md
+++ b/edgelet/management/docs/SystemInformationApi.md
@@ -4,8 +4,47 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**get_support_bundle**](SystemInformationApi.md#get_support_bundle) | **Get** /systeminfo/supportbundle | Return zip of support bundle.
 [**get_system_info**](SystemInformationApi.md#get_system_info) | **Get** /systeminfo | Return host system information.
+[**get_system_resources**](SystemInformationApi.md#get_system_resources) | **Get** /systeminfo/resources | Return host resource usage (DISK, RAM, CPU).
 
+
+# **get_support_bundle**
+> get_support_bundle(api_version, optional)
+Return zip of support bundle.
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+ **since** | **String**| Duration to get logs from. Can be relative (1d, 10m, 1h30m etc.) or absolute (unix timestamp or rfc 3339) | 
+ **host** | **String**| Path to the management host | 
+ **iothub_hostname** | **String**| Hub to use when calling iotedge check | 
+ **edge_runtime_only** | **bool**| Exclude customer module logs | [default to false]
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/zip
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_system_info**
 > ::models::SystemInfo get_system_info(api_version)
@@ -20,6 +59,31 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**::models::SystemInfo**](SystemInfo.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **get_system_resources**
+> ::models::SystemResources get_system_resources(api_version)
+Return host resource usage (DISK, RAM, CPU).
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+
+### Return type
+
+[**::models::SystemResources**](SystemResources.md)
 
 ### Authorization
 

--- a/edgelet/management/src/apis/module_api.rs
+++ b/edgelet/management/src/apis/module_api.rs
@@ -53,6 +53,7 @@ pub trait ModuleApi: Send + Sync {
         name: &str,
         follow: bool,
         tail: &str,
+        timestamps: bool,
         since: i32,
     ) -> Box<dyn Future<Item = hyper::Body, Error = Error<serde_json::Value>> + Send>;
     fn restart_module(
@@ -323,6 +324,7 @@ where
         name: &str,
         follow: bool,
         tail: &str,
+        timestamps: bool,
         since: i32,
     ) -> Box<dyn Future<Item = hyper::Body, Error = Error<serde_json::Value>> + Send> {
         let configuration: &configuration::Configuration<C> = self.configuration.borrow();
@@ -333,6 +335,7 @@ where
             .append_pair("api-version", &api_version.to_string())
             .append_pair("follow", &follow.to_string())
             .append_pair("tail", &tail.to_string())
+            .append_pair("timestamps", &timestamps.to_string())
             .append_pair("since", &since.to_string())
             .finish();
         let uri_str = format!(


### PR DESCRIPTION
- Allow Management socket to accept `timestamps` option to be pass through docker socket API.
- Update the documents for the latest API version
- The latest API is being manually added since there is a gigantic out-of-sync between the template interface `managementVersion_2020_07_07.yaml` and `/edgelet/management` generated code. 