### PR TITLE
Update `GetModuleLogs` method when `tail + since + until` options are provided

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/LogsProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/LogsProvider.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
         public async Task<byte[]> GetLogs(string id, ModuleLogOptions logOptions, CancellationToken cancellationToken)
         {
             Preconditions.CheckNotNull(logOptions, nameof(logOptions));
+
             Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, false, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, cancellationToken);
             Events.ReceivedStream(id);
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
@@ -91,9 +91,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
                 string baseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri).TrimEnd('/');
                 var logsUrl = new StringBuilder();
                 logsUrl.AppendFormat(CultureInfo.InvariantCulture, LogsUrlTemplate, baseUrl, module, this.Version.Name, follow.ToString().ToLowerInvariant());
-                tail.ForEach(t => logsUrl.AppendFormat($"&{LogsUrlTailParameter}={t}"));
                 since.ForEach(s => logsUrl.AppendFormat($"&{LogsUrlSinceParameter}={Uri.EscapeUriString(s)}"));
                 until.ForEach(u => logsUrl.AppendFormat($"&{LogsUrlUntilParameter}={Uri.EscapeUriString(u)}"));
+
+                if (!(tail.HasValue && since.HasValue && until.HasValue))
+                {
+                    tail.ForEach(t => logsUrl.AppendFormat($"&{LogsUrlTailParameter}={t}"));
+                }
+
                 var logsUri = new Uri(logsUrl.ToString());
                 var httpRequest = new HttpRequestMessage(HttpMethod.Get, logsUri);
                 Stream stream = await this.Execute(

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/uds/HttpChunkedStreamReader.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/uds/HttpChunkedStreamReader.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Uds
             return bytesRead;
         }
 
+        // Underlying Stream does not support Seek()
         public override long Seek(long offset, SeekOrigin origin) => throw new NotImplementedException();
 
         public override void SetLength(long value) => throw new NotImplementedException();


### PR DESCRIPTION
Cherry-picked: https://github.com/Azure/iotedge/commit/2b650a8b90d5b51299ef24c002e5af39c481c253

TL;DR - This PR chances the behavior of `GetModuleLogs` method to better facilitate the portal experience. 

Previous, when the `GetModuleLogs` is triggered from the azure portal with `tail + since + until`, all the 3 options are passed to Docker API management to fetch the log. The Docker API does the following: 
1. Fetch the log of the module
2. Apply `tail` to the log
3. Apply the `since` and `until` to the log
This results in an empty log most of the time which is not a desirable behavior. 

This PR changes the `GetModuleLogs` when the `tail + since + until` are specified together by doing the following:
1. Fetch Docker API with `since + until` log option
2. `tail` the returning log using LogProcessor (post-Akka).
This allows a customer to get a tail of log within a given time frame. 

Note: This PR doesn't change the behavior of any other option combinations (i.e. `tail + since`, `tail`, `since`, etc). These combination are still managed by Docker API.

Note2: I set RequestHandle timeout to be 30s instead of 600s by default