### PR TITLE
Fix SonarQube's "IEnumerable LINQs should be simplified" / Code Smell

### DIFF
--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/commands/CreateOrUpdateCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/commands/CreateOrUpdateCommandTest.cs
@@ -200,48 +200,48 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
 
             foreach (string key in testData.EnvironmentVariables.Keys)
             {
-                Assert.Equal(testData.EnvironmentVariables[key].Value, environmentVariables.Where(v => v.Key.Equals(key)).First().Value);
+                Assert.Equal(testData.EnvironmentVariables[key].Value, environmentVariables.First(v => v.Key.Equals(key)).Value);
             }
 
-            Assert.Equal(testData.EdgeletWorkloadUri, environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletWorkloadUriVariableName)).First().Value);
-            Assert.Equal(testData.EdgeletAuthScheme, environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletAuthSchemeVariableName)).First().Value);
-            Assert.Equal(testData.ModuleGenerationId, environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletModuleGenerationIdVariableName)).First().Value);
-            Assert.Equal(testData.IoTHubHostname, environmentVariables.Where(v => v.Key.Equals(Constants.IotHubHostnameVariableName)).First().Value);
-            Assert.Equal(testData.DeviceId, environmentVariables.Where(v => v.Key.Equals(Constants.DeviceIdVariableName)).First().Value);
-            Assert.Equal(testData.ModuleId, environmentVariables.Where(v => v.Key.Equals(Constants.ModuleIdVariableName)).First().Value);
-            Assert.Equal(LogEventLevel.Information.ToString(), environmentVariables.Where(v => v.Key.Equals(Logger.RuntimeLogLevelEnvKey)).First().Value);
-            Assert.Equal(testData.UpstreamProtocol, environmentVariables.Where(v => v.Key.Equals(Constants.UpstreamProtocolKey)).First().Value);
-            Assert.Equal(testData.EdgeletApiVersion, environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletApiVersionVariableName)).First().Value);
+            Assert.Equal(testData.EdgeletWorkloadUri, environmentVariables.First(v => v.Key.Equals(Constants.EdgeletWorkloadUriVariableName)).Value);
+            Assert.Equal(testData.EdgeletAuthScheme, environmentVariables.First(v => v.Key.Equals(Constants.EdgeletAuthSchemeVariableName)).Value);
+            Assert.Equal(testData.ModuleGenerationId, environmentVariables.First(v => v.Key.Equals(Constants.EdgeletModuleGenerationIdVariableName)).Value);
+            Assert.Equal(testData.IoTHubHostname, environmentVariables.First(v => v.Key.Equals(Constants.IotHubHostnameVariableName)).Value);
+            Assert.Equal(testData.DeviceId, environmentVariables.First(v => v.Key.Equals(Constants.DeviceIdVariableName)).Value);
+            Assert.Equal(testData.ModuleId, environmentVariables.First(v => v.Key.Equals(Constants.ModuleIdVariableName)).Value);
+            Assert.Equal(LogEventLevel.Information.ToString(), environmentVariables.First(v => v.Key.Equals(Logger.RuntimeLogLevelEnvKey)).Value);
+            Assert.Equal(testData.UpstreamProtocol, environmentVariables.First(v => v.Key.Equals(Constants.UpstreamProtocolKey)).Value);
+            Assert.Equal(testData.EdgeletApiVersion, environmentVariables.First(v => v.Key.Equals(Constants.EdgeletApiVersionVariableName)).Value);
 
             if (testData.ModuleId.Equals(Constants.EdgeAgentModuleIdentityName))
             {
-                Assert.Equal("iotedged", environmentVariables.Where(v => v.Key.Equals(Constants.ModeKey)).First().Value);
-                Assert.Equal(testData.EdgeletManagementUri, environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletManagementUriVariableName)).First().Value);
-                Assert.Equal(testData.NetworkId, environmentVariables.Where(v => v.Key.Equals(Constants.NetworkIdKey)).First().Value);
-                Assert.Equal(testData.EdgeDeviceHostname, environmentVariables.Where(v => v.Key.Equals(Constants.EdgeDeviceHostNameKey)).First().Value);
+                Assert.Equal("iotedged", environmentVariables.First(v => v.Key.Equals(Constants.ModeKey)).Value);
+                Assert.Equal(testData.EdgeletManagementUri, environmentVariables.First(v => v.Key.Equals(Constants.EdgeletManagementUriVariableName)).Value);
+                Assert.Equal(testData.NetworkId, environmentVariables.First(v => v.Key.Equals(Constants.NetworkIdKey)).Value);
+                Assert.Equal(testData.EdgeDeviceHostname, environmentVariables.First(v => v.Key.Equals(Constants.EdgeDeviceHostNameKey)).Value);
                 testData.ParentEdgeHostname.ForEach(value =>
-                    Assert.Equal(value, environmentVariables.Where(v => v.Key.Equals(Constants.GatewayHostnameVariableName)).First().Value));
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.ParentEdgeHostnameVariableName)).FirstOrDefault());
+                    Assert.Equal(value, environmentVariables.First(v => v.Key.Equals(Constants.GatewayHostnameVariableName)).Value));
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.ParentEdgeHostnameVariableName)));
             }
             else if (testData.ModuleId.Equals(Constants.EdgeHubModuleIdentityName))
             {
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.ModeKey)).FirstOrDefault());
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletManagementUriVariableName)).FirstOrDefault());
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.NetworkIdKey)).FirstOrDefault());
-                Assert.Equal(testData.EdgeDeviceHostname, environmentVariables.Where(v => v.Key.Equals(Constants.EdgeDeviceHostNameKey)).First().Value);
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.ModeKey)));
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.EdgeletManagementUriVariableName)));
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.NetworkIdKey)));
+                Assert.Equal(testData.EdgeDeviceHostname, environmentVariables.First(v => v.Key.Equals(Constants.EdgeDeviceHostNameKey)).Value);
                 testData.ParentEdgeHostname.ForEach(value =>
-                    Assert.Equal(value, environmentVariables.Where(v => v.Key.Equals(Constants.GatewayHostnameVariableName)).First().Value));
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.ParentEdgeHostnameVariableName)).FirstOrDefault());
+                    Assert.Equal(value, environmentVariables.First(v => v.Key.Equals(Constants.GatewayHostnameVariableName)).Value));
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.ParentEdgeHostnameVariableName)));
             }
             else
             {
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.ModeKey)).FirstOrDefault());
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.EdgeletManagementUriVariableName)).FirstOrDefault());
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.NetworkIdKey)).FirstOrDefault());
-                Assert.Equal(testData.EdgeDeviceHostname, environmentVariables.Where(v => v.Key.Equals(Constants.GatewayHostnameVariableName)).First().Value);
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.ModeKey)));
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.EdgeletManagementUriVariableName)));
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.NetworkIdKey)));
+                Assert.Equal(testData.EdgeDeviceHostname, environmentVariables.First(v => v.Key.Equals(Constants.GatewayHostnameVariableName)).Value);
                 testData.ParentEdgeHostname.ForEach(value =>
-                    Assert.Equal(value, environmentVariables.Where(v => v.Key.Equals(Constants.ParentEdgeHostnameVariableName)).First().Value));
-                Assert.Null(environmentVariables.Where(v => v.Key.Equals(Constants.EdgeDeviceHostNameKey)).FirstOrDefault());
+                    Assert.Equal(value, environmentVariables.First(v => v.Key.Equals(Constants.ParentEdgeHostnameVariableName)).Value));
+                Assert.Null(environmentVariables.FirstOrDefault(v => v.Key.Equals(Constants.EdgeDeviceHostNameKey)));
             }
         }
 


### PR DESCRIPTION
Hello,

This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "IEnumerable LINQs should be simplified" [rule](https://rules.sonarsource.com/csharp/RSPEC-2971)  in SonarQube.