### PR TITLE
Update Base Images for Security Patch

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.13-bionic-arm32v7
+﻿ARG base_tag=3.1.15-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.13-bionic-arm64v8
+﻿ARG base_tag=3.1.15-bionic-arm64v8
 ARG num_procs=4
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}

--- a/edge-agent/docker/windows/amd64/Dockerfile
+++ b/edge-agent/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # In order to set system PATH, ContainerAdministrator must be used

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.13-bionic-arm32v7
+﻿ARG base_tag=3.1.15-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.13-bionic-arm64v8
+﻿ARG base_tag=3.1.15-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/windows/amd64/Dockerfile
+++ b/edge-hub/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/windows/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.13-bionic-arm32v7
+﻿ARG base_tag=3.1.15-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.13-bionic-arm64v8
+﻿ARG base_tag=3.1.15-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/azure-monitor/docker/linux/amd64/Dockerfile
+++ b/edge-modules/azure-monitor/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.12-alpine3.12
+ARG base_tag=3.1.15-alpine3.12
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/azure-monitor/docker/linux/amd64/Dockerfile
+++ b/edge-modules/azure-monitor/docker/linux/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ARG base_tag=3.1.12-alpine3.12
-FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
+FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/azure-monitor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/azure-monitor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.8-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/azure-monitor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/azure-monitor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.8-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/azure-monitor/docker/windows/amd64/Dockerfile
+++ b/edge-modules/azure-monitor/docker/windows/amd64/Dockerfile
@@ -1,5 +1,5 @@
-ARG base_tag=3.1.12-nanoserver-1809
-FROM mcr.microsoft.com/dotnet/core/runtime:${base_tag}
+ARG base_tag=3.1.15-nanoserver-1809
+FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/windows/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 # Network controller arm32 and arm64 require different base images. This is because arm32 needs iproute tooling and thus needs module-base-full.
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
 # Network controller arm32 and arm64 require different base images. This is because arm32 needs iproute tooling and thus needs module-base-full.
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/windows/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ENV MODULE_NAME "CloudToDeviceMessageTester.dll"

--- a/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/DeploymentTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ENV MODULE_NAME "DeploymentTester.dll"

--- a/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/windows/amd64/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/windows/amd64/Dockerfile
+++ b/test/modules/MetricsValidator/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/windows/amd64/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/windows/amd64/Dockerfile
+++ b/test/modules/NumberLogger/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/amd64/Dockerfile
+++ b/test/modules/Relayer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/windows/amd64/Dockerfile
+++ b/test/modules/Relayer/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ENV MODULE_NAME "Relayer.dll"

--- a/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/windows/amd64/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.13-bionic-arm32v7
+﻿ARG base_tag=3.1.15-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.13-bionic-arm64v8
+﻿ARG base_tag=3.1.15-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/test/modules/TestAnalyzer/docker/windows/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/windows/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/amd64/Dockerfile
+++ b/test/modules/load-gen/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-alpine3.13
+ARG base_tag=3.1.15-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm32v7
+ARG base_tag=1.0.5.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.10-linux-arm64v8
+ARG base_tag=1.0.5.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/windows/amd64/Dockerfile
+++ b/test/modules/load-gen/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.13-nanoserver-1809
+ARG base_tag=3.1.15-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.


### PR DESCRIPTION
Update Base Images for Security Patch
- ARM32/64 🠘 3.1.15-bionic-arm32v7
- AMD64 🠘 3.1.15-alpine3.13
- Windows64🠘 3.1.15-nanoserver-1809