### PR TITLE
Rename end-to-end test log artifacts

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -54,7 +54,7 @@ steps:
     testResultsFormat: vstest
     testResultsFiles: '**/*.trx'
     searchFolder: $(Build.SourcesDirectory)/TestResults
-    testRunTitle: End-to-end tests ($(Build.BuildNumber) $(os) $(arch))
+    testRunTitle: End-to-end tests ($(Build.BuildNumber) $(System.JobDisplayName))
     buildPlatform: $(arch)
   condition: succeededOrFailed()
 
@@ -75,5 +75,5 @@ steps:
   displayName: Publish logs
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/logs
-    ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(os)-$(arch)-$(artifactName)
+    ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(System.PhaseName)
   condition: succeededOrFailed()

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -68,6 +68,8 @@ steps:
     Copy-Item "$(binDir)/*-test-*.log" "$logDir/"
     Copy-Item "$(binDir)/*-device-*.log" "$logDir/"
     Copy-Item "$(binDir)/testoutput.log" "$logDir/"
+    $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
+    Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
   displayName: Collect Logs
   condition: succeededOrFailed()
 
@@ -75,5 +77,5 @@ steps:
   displayName: Publish logs
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/logs
-    ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(System.PhaseName)
+    ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(artifactSuffix)
   condition: succeededOrFailed()


### PR DESCRIPTION
The end-to-end test logs are published as artifacts in the pipeline run, and have names like `logs-end-to-end-{buildnum}-linux-amd64-iotedged-ubuntu18.04-amd64`. As we add more jobs to the pipeline, we can't tell the logs apart by their names (e.g. we now have two Ubuntu 18.04 jobs, two Ubuntu 20.04 jobs, and two Windows jobs). 

This update changes the names to something like `logs-end-to-end-{buildnum}-ubuntu-1804-docker`, based on the job name. It should make it easier to tell published logs apart from one another.

Note something similar was already done in the main branch, see #3722.