### PR TITLE
Remove PII from log.

### DIFF
--- a/edge-modules/azure-monitor/src/FixedSetTableUpload/AzureFixedSetTable.cs
+++ b/edge-modules/azure-monitor/src/FixedSetTableUpload/AzureFixedSetTable.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor.FixedSetTableUpload
 
                         if (contentLength > 1024 * 1024 )
                         {
-                            LoggerUtil.Writer.LogDebug( 
+                            LoggerUtil.Writer.LogDebug(
                                 "HTTP post content greater than 1mb" + " " +
                                 "Length - " + contentLength.ToString());
                         }
@@ -112,19 +112,17 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor.FixedSetTableUpload
                         LoggerUtil.Writer.LogDebug(
                             ((int)response.StatusCode).ToString() + " " +
                             response.ReasonPhrase + " " +
-                        responseMsg);
+                            responseMsg);
 
                         if ((int)response.StatusCode != 200) {
                             failurecount += 1;
 
                             if (DateTime.Now - lastFailureReportedTime > TimeSpan.FromMinutes(1)) {
-                                LoggerUtil.Writer.LogDebug(                                
+                                LoggerUtil.Writer.LogDebug(
                                     "abnormal HTTP response code - " +
                                     "responsecode: " + ((int)response.StatusCode).ToString() + " " +
                                     "reasonphrase: " + response.ReasonPhrase + " " +
                                     "responsemsg: " + responseMsg + " " +
-                                    "requestheaders: " + client.DefaultRequestHeaders.ToString() + contentMsg.Headers  + " " +
-                                    "requestcontent: " + contentMsg.ReadAsStringAsync().Result + " " +
                                     "count: " + failurecount);
                                 failurecount = 0;
                                 lastFailureReportedTime = DateTime.Now;
@@ -158,7 +156,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor.FixedSetTableUpload
         {
             // TODO: test
 
-            // "Deflate" compression often instead refers to a Zlib format which requies a 2 byte header and checksum (RFC 1950). 
+            // "Deflate" compression often instead refers to a Zlib format which requies a 2 byte header and checksum (RFC 1950).
             // The C# built in deflate stream doesn't support this, so use an external library.
             // Hopefully a built-in Zlib stream will be included in .net 5 (https://github.com/dotnet/runtime/issues/2236)
             var deflater = new Deflater(5, false);

--- a/edge-modules/azure-monitor/src/IotHubUpload/IotHubUpload.cs
+++ b/edge-modules/azure-monitor/src/IotHubUpload/IotHubUpload.cs
@@ -32,13 +32,10 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor.IotHubMetricsUpload
                 IEnumerable<ExportMetric> outputMetrics = metrics.Select(m => new ExportMetric(m));
 
                 string outputString = JsonConvert.SerializeObject(outputMetrics);
-                // LoggerUtil.Writer.LogDebug("Metrics selected for upload . . .");
-                // LoggerUtil.Writer.LogDebug(outputString);
+
                 if (Settings.Current.TransformForIoTCentral)
                 {
                     outputString = Transform(outputMetrics);
-                    // LoggerUtil.Writer.LogDebug("Metrics transformed prior to upload . . .");
-                    // LoggerUtil.Writer.LogDebug(outputString);
                 }
 
                 byte[] metricsData = Encoding.UTF8.GetBytes(outputString);

--- a/edge-modules/azure-monitor/src/Program.cs
+++ b/edge-modules/azure-monitor/src/Program.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             WaitForDebugger();
 #endif
 
-            LoggerUtil.Writer.LogInformation($"Metrics collector initialized with the following settings:\r\n{Settings.Current}");
+            LoggerUtil.Writer.LogInformation($"Metrics collector initialized with the following settings:\r\n{Settings.Information}");
             var transportSetting = new AmqpTransportSettings(TransportType.Amqp_Tcp_Only);
 
             ITransportSettings[] transportSettings = { transportSetting };

--- a/edge-modules/azure-monitor/src/Settings.cs
+++ b/edge-modules/azure-monitor/src/Settings.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Text.RegularExpressions;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
@@ -15,6 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
     internal class Settings
     {
         public static Settings Current = Create();
+        public static Settings Information = GetInformation();
 
         private Settings(
             string logAnalyticsWorkspaceId,
@@ -94,6 +96,26 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                 Environment.Exit(2);
                 throw new Exception();  // to make code analyzers happy (this line will never run)
             }
+        }
+
+        private static Settings GetInformation()
+        {
+            Settings settings = Current;
+
+            Regex regex = new Regex("(\\/subscriptions\\/)(.*?)(\\/resourceGroups\\/)(.*?)(\\/providers\\/)");
+
+            return new Settings(
+                settings.LogAnalyticsWorkspaceId,
+                settings.LogAnalyticsWorkspaceKey,
+                string.Join(',', settings.Endpoints),
+                settings.ScrapeFrequencySecs,
+                settings.UploadTarget,
+                settings.CompressForUpload,
+                settings.TransformForIoTCentral,
+                settings.AllowedMetrics.ToString(),
+                settings.BlockedMetrics.ToString(),
+                regex.Replace(settings.ResourceId, "$1" + "XXX" + "$3" + "XXX" + "$5"),
+                settings.Version);
         }
 
         public string LogAnalyticsWorkspaceId { get; }


### PR DESCRIPTION
Obfuscate the subscription ID and resource group name from the metrics collector logs to reduce the chance of unintended exposure on public forums (e.g. Github issues).