### PR TITLE
Fix provisioning behavior when DPS changes

### DIFF
--- a/edgelet/aziot-edged/src/lib.rs
+++ b/edgelet/aziot-edged/src/lib.rs
@@ -305,9 +305,15 @@ where
                 Err(err) => {
                     log_failure(Level::Warn, &err);
 
-                    std::thread::sleep(IS_GET_DEVICE_INFO_RETRY_INTERVAL_SECS);
+                    log::warn!("Requesting device reprovision.");
 
-                    log::warn!("Retrying getting edge device provisioning information.");
+                    if let Err(err) =
+                        tokio_runtime.block_on(reprovision_device(&client, provisioning_cache))
+                    {
+                        log::warn!("{}", err);
+                    }
+
+                    std::thread::sleep(IS_GET_DEVICE_INFO_RETRY_INTERVAL_SECS);
                 }
             };
         }

--- a/edgelet/aziot-edged/src/lib.rs
+++ b/edgelet/aziot-edged/src/lib.rs
@@ -196,10 +196,11 @@ where
                 &url,
             )));
 
+            let provisioning_cache = cache_subdir_path.join(EDGE_PROVISIONING_STATE_FILENAME);
+
             match settings.auto_reprovisioning_mode() {
-                AutoReprovisioningMode::AlwaysOnStartup => {
-                    tokio_runtime.block_on(reprovision_device(&client))?
-                }
+                AutoReprovisioningMode::AlwaysOnStartup => tokio_runtime
+                    .block_on(reprovision_device(&client, provisioning_cache.clone()))?,
                 AutoReprovisioningMode::Dynamic | AutoReprovisioningMode::OnErrorOnly => {}
             }
 
@@ -294,7 +295,7 @@ where
                     )?;
 
                     if should_reprovision {
-                        tokio_runtime.block_on(reprovision_device(&client))?;
+                        tokio_runtime.block_on(reprovision_device(&client, provisioning_cache))?;
                     }
 
                     if code != StartApiReturnStatus::Restart {
@@ -318,10 +319,11 @@ where
 
 fn reprovision_device(
     identity_client: &Arc<Mutex<IdentityClient>>,
+    provisioning_cache: std::path::PathBuf,
 ) -> impl Future<Item = (), Error = Error> {
     let id_mgr = identity_client.lock().unwrap();
     id_mgr
-        .reprovision_device()
+        .reprovision_device(provisioning_cache)
         .map_err(|err| Error::from(err.context(ErrorKind::ReprovisionFailure)))
 }
 

--- a/edgelet/iotedge/src/system.rs
+++ b/edgelet/iotedge/src/system.rs
@@ -87,8 +87,11 @@ impl System {
             .expect("hard-coded URI should parse");
         let client = IdentityClient::new(ApiVersion::V2020_09_01, &uri);
 
+        let provisioning_cache =
+            std::path::Path::new("/var/lib/aziot/edged/cache/provisioning_state").to_path_buf();
+
         runtime
-            .block_on(client.reprovision_device())
+            .block_on(client.reprovision_device(provisioning_cache))
             .map_err(|err| {
                 eprintln!("Failed to reprovision: {}", err);
                 Error::from(ErrorKind::System)


### PR DESCRIPTION
- Clear the provisioning state cache when a reprovision is triggered.
- Request reprovisions if edged cannot get device information on startup.

Depends on https://github.com/Azure/iot-identity-service/pull/228