### PR TITLE
Add validation for null props inside objects inside arrays. (#4896) (…

### DIFF
--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/twin/ReportedPropertiesValidatorTest.cs
@@ -124,6 +124,57 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
             yield return new object[]
             {
                 new TwinCollection(JsonConvert.SerializeObject(new
+                    {
+                        ok = "ok",
+                        level1 = new
+                        {
+                            // level 2
+                            array1 = new[]
+                                {
+                                    // level 3
+                                    new[]
+                                    {
+                                        // level 4
+                                        new[]
+                                        {
+                                            // level 5
+                                            new[]
+                                            {
+                                                // level 6
+                                                new[]
+                                                {
+                                                    // level 7
+                                                    new[]
+                                                    {
+                                                        // level 8
+                                                        new[]
+                                                        {
+                                                            // level 9
+                                                            new[]
+                                                            {
+                                                                // level 10
+                                                                new[]
+                                                                {
+                                                                    // level 11
+                                                                    new[] { "one", "two", "three" },
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                        }
+                    })),
+                typeof(InvalidOperationException),
+                "Nested depth of twin property exceeds 10"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
                 {
                     array = new[] { 0, 1, 2 }
                 })),
@@ -197,6 +248,106 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test.Twin
             yield return new object[]
             {
                 new TwinCollection("{ \"ok\": [\"good\"], \"ok2\": [], \"level1\": [{ \"field1\": null }] }"),
+                typeof(InvalidOperationException),
+                "Property field1 of an object in an array cannot be 'null'"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
+                {
+                    ok = "ok",
+                    complex = new
+                            {
+                                array1 = new object[]
+                                {
+                                    "one",
+                                    "two",
+                                    new
+                                    {
+                                        array2 = new[]
+                                        {
+                                            new { hello = (string)null }
+                                        }
+                                    },
+                                }
+                            }
+                })),
+                typeof(InvalidOperationException),
+                "Property hello of an object in an array cannot be 'null'"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
+                {
+                    ok = "ok",
+                    array = new string[] { "foo", null, "boo" }
+                })),
+                typeof(InvalidOperationException),
+                "Arrays cannot contain 'null' as value"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
+                {
+                    ok = "ok",
+                    complex = new
+                              {
+                                ok = "ok",
+                                pi = 3.14,
+                                sometime = new DateTime(2021, 1, 20),
+                                array = new[]
+                                {
+                                    "one",
+                                    "two",
+                                    null,
+                                    "four",
+                                }
+                              }
+                })),
+                typeof(InvalidOperationException),
+                "Arrays cannot contain 'null' as value"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
+                {
+                    ok = "ok",
+                    complex = new
+                              {
+                                ok = "ok",
+                                array = new[]
+                                {
+                                    new[] { "one", "two", "three" },
+                                    new[] { "four", null, "six" },
+                                }
+                              }
+                })),
+                typeof(InvalidOperationException),
+                "Arrays cannot contain 'null' as value"
+            };
+
+            yield return new object[]
+            {
+                new TwinCollection(JsonConvert.SerializeObject(new
+                {
+                    ok = "ok",
+                    complex = new
+                              {
+                                ok = "ok",
+                                array = new[]
+                                {
+                                    new[] { "one", "two", "three" },
+                                    new[] { "four", "five", "six" },
+                                    new object[] { "seven", new { ok = "ok" } },
+                                },
+                                pi = 3.14,
+                                sometime = new DateTime(2021, 1, 20),
+                              }
+                })),
                 null,
                 string.Empty
             };


### PR DESCRIPTION
…#4941)

Since IoT Hub does not support patch operations on arrays (if you want to update array, you need to replace it), they don't allow null values or null properties inside arrays. EdgeHub, on the other hand, allows that. So, validation can pass on the EdgeHub side, but the update will be rejected by the hub. This situation allows for sending bad payloads, that blocks any further twin updates unless bad property is removed/cleared.