### PR TITLE
Change default UUID 1.2

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -11,7 +11,7 @@ RUN apk update && \
 
 # create a default user to allow agent to run as non-root
 ARG EDGEAGENTUSER_ID
-ENV EDGEAGENTUSER_ID ${EDGEAGENTUSER_ID:-1000}
+ENV EDGEAGENTUSER_ID ${EDGEAGENTUSER_ID:-13622}
 RUN adduser -Ds /bin/sh -u ${EDGEAGENTUSER_ID} edgeagentuser 
 
 # Install RocksDB

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
 
 # create a user to allow agent to optionally run as non-root
 ARG EDGEAGENTUSER_ID
-ENV EDGEAGENTUSER_ID ${EDGEAGENTUSER_ID:-1000}
+ENV EDGEAGENTUSER_ID ${EDGEAGENTUSER_ID:-13622}
 RUN useradd -ms /bin/bash -u ${EDGEAGENTUSER_ID} edgeagentuser 
 
 COPY librocksdb.so /usr/lib/

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
 
 # create a user to allow agent to optionally run as non-root
 ARG EDGEAGENTUSER_ID
-ENV EDGEAGENTUSER_ID ${EDGEAGENTUSER_ID:-1000}
+ENV EDGEAGENTUSER_ID ${EDGEAGENTUSER_ID:-13622}
 RUN useradd -ms /bin/bash -u ${EDGEAGENTUSER_ID} edgeagentuser 
 
 COPY  librocksdb.so /usr/lib

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.csproj
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Microsoft.Azure.Devices.Edge.Hub.Service.csproj
@@ -54,6 +54,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="hubStart.sh">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="scripts\linux\generate-cert.sh">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/hubStart.sh
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/hubStart.sh
@@ -29,7 +29,19 @@ cuid=$(id -u)
 
 if [ $cuid -eq 0 ]
 then
-
+  # Create the agent user id if it does not exist
+  if ! getent passwd "${TARGET_UID}" >/dev/null
+  then
+    echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Creating UID ${TARGET_UID} as agent${TARGET_UID}"
+    # Use "useradd" if it is available.
+    if command -v useradd >/dev/null
+    then
+      useradd -ms /bin/bash -u "${TARGET_UID}" "agent${TARGET_UID}"
+    else
+      adduser -Ds /bin/sh -u "${TARGET_UID}" "agent${TARGET_UID}"
+    fi
+  fi
+  
   username=$(getent passwd "${TARGET_UID}" | awk -F ':' '{ print $1; }')
 
   # If "StorageFolder" env variable exists, use as basepath, else use /tmp

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/hubStart.sh
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/hubStart.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+
+###############################################################################
+# Set up EdgeHub to run as a non-root user at runtime, if allowed.
+# 
+# If this script is started as root:
+#  1. It reads the EDGEHUBUSER_ID environment variable, default UID=13623.
+#  2. If the User ID does not exist as a user, create it.
+#  3. If "StorageFolder" env variable exists, use as basepath, else use /tmp
+#     Do same for backuppath
+#  4. If basepath/edgehub exists, make sure all files are owned by EDGEHUBUSER_ID
+#     Do same for backuppath/edgehub_backup
+#  5. Make sure /app/backup.json is writeable.
+#  6. Set user id as EDGEHUBUSER_ID.
+# then start Edge Hub.
+#
+# This preserves backwards compatibility with earlier versions of edgeHub and
+# allows some flexibility in the assignment of the edgehub user id. The default 
+# is UID 13623.
+#
+# A user is created because at this time DotNet Core 2.x and 3.x can only install
+# trust bundles into system stores or user stores.  We choose a user store in
+# the code, so a writeable user directory is required.
+###############################################################################
+echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Starting Edge Hub"
+
+TARGET_UID="${EDGEHUBUSER_ID:-13623}"
+cuid=$(id -u)
+
+if [ $cuid -eq 0 ]
+then
+
+  username=$(getent passwd "${TARGET_UID}" | awk -F ':' '{ print $1; }')
+
+  # If "StorageFolder" env variable exists, use as basepath, else use /tmp
+  # same for BackupFolder
+  hubstorage=$(env | grep -m 1 -i StorageFolder | awk -F '=' '{ print $2; }')
+  hubbackup=$(env | grep -m 1 -i BackupFolder | awk -F '=' '{ print $2; }')
+  storagepath=${hubstorage:-/tmp}/edgehub
+  backuppath=${hubbackup:-/tmp}/edgehub_backup
+  # If basepath/edgehub exists, make sure all files are owned by TARGET_UID
+  if [ -d $storagepath ]
+  then
+    echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Changing ownership of storage folder: ${storagepath} to ${TARGET_UID}"
+    chown -fR "${TARGET_UID}" "${storagepath}"
+   fi
+  # same for BackupFolder
+  if [ -d $backuppath ]
+  then
+    echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Changing ownership of backup folder: ${backuppath} to ${TARGET_UID}"
+    chown -fR "${TARGET_UID}" "${backuppath}"
+  fi
+
+  exec su "$username" -c "/usr/local/bin/watchdog"
+else
+  exec /usr/local/bin/watchdog
+fi

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -3,6 +3,8 @@ FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
+ARG EXE_DIR=.
+
 ADD ./watchdog/x86_64-unknown-linux-musl/release/watchdog /usr/local/bin/watchdog
 ADD ./mqtt/x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd
 ADD ./mqtt/broker.json /app/mqttd/broker.json
@@ -12,7 +14,8 @@ RUN apk update && \
     apk add --no-cache snappy libcap	
 
 # Add an unprivileged user account for running Edge Hub	
-ARG EDGEHUBUSER_ID=1000	
+ARG EDGEHUBUSER_ID	
+ENV EDGEHUBUSER_ID ${EDGEHUBUSER_ID:-13623}
 RUN adduser -Ds /bin/sh -u ${EDGEHUBUSER_ID} edgehubuser 	
 
 # Add the CAP_NET_BIND_SERVICE capability to the dotnet binary because	
@@ -22,9 +25,11 @@ RUN setcap 'cap_net_bind_service=+ep' /usr/share/dotnet/dotnet
 # Install RocksDB	
 COPY --from=builder publish/* /usr/local/lib/	
 
-WORKDIR /app	
+WORKDIR /app
 
 COPY Microsoft.Azure.Devices.Edge.Hub.Service/ ./
+COPY $EXE_DIR/Microsoft.Azure.Devices.Edge.Hub.Service/hubStart.sh ./
+RUN ["chmod", "+x", "hubStart.sh"]
 
 # Expose MQTT, AMQP and HTTPS ports	
 EXPOSE 1883/tcp
@@ -32,7 +37,5 @@ EXPOSE 8883/tcp
 EXPOSE 5671/tcp	
 EXPOSE 443/tcp	
 
-USER edgehubuser	
-
 CMD echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Starting Edge Hub" && \
-    /usr/local/bin/watchdog
+    exec /app/hubStart.sh

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -29,7 +29,6 @@ WORKDIR /app
 
 COPY Microsoft.Azure.Devices.Edge.Hub.Service/ ./
 COPY $EXE_DIR/Microsoft.Azure.Devices.Edge.Hub.Service/hubStart.sh ./
-RUN ["chmod", "+x", "hubStart.sh"]
 
 # Expose MQTT, AMQP and HTTPS ports	
 EXPOSE 1883/tcp

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -15,8 +15,11 @@ EXPOSE 8883/tcp
 EXPOSE 5671/tcp
 EXPOSE 443/tcp
 
-USER edgehubuser
 ENV OptimizeForPerformance false
 ENV MqttEventsProcessorThreadCount 1
+
+COPY Microsoft.Azure.Devices.Edge.Hub.Service/ ./
+COPY $EXE_DIR/Microsoft.Azure.Devices.Edge.Hub.Service/hubStart.sh ./
+
 CMD echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Starting Edge Hub" && \
-    /usr/local/bin/watchdog
+    exec /app/hubStart.sh

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./watchdog/armv7-unknown-linux-gnueabihf/release/watchdog /usr/local/bin/watchdog

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub
-ARG EDGEHUBUSER_ID=1000
+ARG EDGEHUBUSER_ID=13623
 RUN useradd -ms /bin/bash -u ${EDGEHUBUSER_ID} edgehubuser
 ENV EdgeHubUser=edgehubuser
 

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./watchdog/aarch64-unknown-linux-gnu/release/watchdog /usr/local/bin/watchdog

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -15,8 +15,11 @@ EXPOSE 8883/tcp
 EXPOSE 5671/tcp
 EXPOSE 443/tcp
 
-USER edgehubuser
 ENV OptimizeForPerformance false
 ENV MqttEventsProcessorThreadCount 1
+
+COPY Microsoft.Azure.Devices.Edge.Hub.Service/ ./
+COPY $EXE_DIR/Microsoft.Azure.Devices.Edge.Hub.Service/hubStart.sh ./
+
 CMD echo "$(date --utc +"%Y-%m-%d %H:%M:%S %:z") Starting Edge Hub" && \
-    /usr/local/bin/watchdog
+    exec /app/hubStart.sh

--- a/edge-hub/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/base/Dockerfile
@@ -2,7 +2,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub
-ARG EDGEHUBUSER_ID=1000
+ARG EDGEHUBUSER_ID=13623
 RUN useradd -ms /bin/bash -u ${EDGEHUBUSER_ID} edgehubuser
 ENV EdgeHubUser=edgehubuser
 

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -5,6 +5,8 @@
 %define iotedge_socketdir %{_localstatedir}/lib/iotedge
 %define aziot_confdir %{_sysconfdir}/aziot
 %define iotedge_confdir %{aziot_confdir}/edged
+%define iotedge_agent_user edgeagentuser
+%define iotedge_agent_uid 13622
 
 Name:           aziot-edge
 Version:        @version@
@@ -87,6 +89,11 @@ fi
 # Add iotedge user to systemd-journal group so it can get system logs
 if /usr/bin/getent group systemd-journal >/dev/null; then
     %{_sbindir}/usermod -aG systemd-journal %{iotedge_user}
+fi
+
+# Create an edgeagentuser and add it to iotedge group
+if ! /usr/bin/getent passwd %{iotedge_agent_user} >/dev/null; then
+    %{_sbindir}/useradd -g %{iotedge_group} -c "edgeAgent user" -ms /bin/bash -u %{iotedge_agent_uid} %{iotedge_agent_user}
 fi
 
 # Add iotedge user to aziot-identity-service groups

--- a/edgelet/contrib/debian/preinst
+++ b/edgelet/contrib/debian/preinst
@@ -12,6 +12,11 @@ add_groups()
     fi
     mkdir -p /var/lib/aziot/edged
 
+    # Create an edgeagentuser and add it to iotedge group
+    if ! getent passwd edgeagentuser >/dev/null; then
+        useradd -g iotedge -c "edgeAgent user" -ms /bin/bash -u 13622 edgeagentuser
+    fi
+
     # add iotedge user to docker group so that it can talk to the docker socket
     if getent group docker >/dev/null; then
         usermod -aG docker iotedge

--- a/edgelet/contrib/systemd/debian/aziot-edged.mgmt.socket
+++ b/edgelet/contrib/systemd/debian/aziot-edged.mgmt.socket
@@ -7,7 +7,7 @@ PartOf=aziot-edged.service
 ListenStream=/var/run/iotedge/mgmt.sock
 SocketMode=0660
 DirectoryMode=0755
-SocketUser=iotedge
+SocketUser=edgeagentuser
 SocketGroup=iotedge
 Service=aziot-edged.service
 

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 # Use the same base image as prod edgehub images
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm32v7
+ARG base_tag=1.0.6.11-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.10-linux-arm64v8
+ARG base_tag=1.0.6.11-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.


### PR DESCRIPTION
Cherry pick: https://github.com/Azure/iotedge/pull/4998
This PR address bug# 9701835.

Start edgeAgent with default uid 13622
Start edgeHub with default uid 13623
Tested on E2E test pipeline.
Tested on local setup manually to check backward compatibility.
arm32 image tested on amd64 target with emulator (checking it boots)
Centos script tested manually on centos image.