### PR TITLE
Fix security vulnerability in mqtt test module

### DIFF
--- a/test/modules/generic-mqtt-tester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/generic-mqtt-tester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-linux-arm32v7
+ARG base_tag=1.0.1-linux-arm32v7
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rust:${base_tag}
 
 WORKDIR /app

--- a/test/modules/generic-mqtt-tester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/generic-mqtt-tester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.0-linux-arm64v8
+ARG base_tag=1.0.1-linux-arm64v8
 FROM edgebuilds.azurecr.io/microsoft/azureiotedge-module-base-rust:${base_tag}
 
 WORKDIR /app


### PR DESCRIPTION
Fixing this:
https://ubuntu.com/security/notices/USN-4906-1

I pushed the new base images already. This PR is to bump the base image versions so the new base image is used.