### PR TITLE
Nested Longhaul Tests: Fix nested longhaul deployment

### DIFF
--- a/builds/e2e/templates/nested-longhaul-deploy.yaml
+++ b/builds/e2e/templates/nested-longhaul-deploy.yaml
@@ -181,7 +181,6 @@ steps:
             -testRuntimeLogLevel "${{ parameters['test.runtimeLogLevel'] }}" \
             -testInfo "$testInfo" \
             -twinUpdateSize "${{ parameters['twinTester.twinUpdateSize'] }}" \
-            -twinUpdateFrequency "${{ parameters['twinTester.twinUpdateFrequency'] }}" \
             -desiredModulesToRestartCSV "${{ parameters['longHaul.desiredModulesToRestartCSV'] }}" \
             -sendReportFrequency "${{ parameters['longHaul.sendReportFrequency'] }}" \
             -upstreamProtocol "${{ parameters['upstream.protocol'] }}" \


### PR DESCRIPTION
A change I made to single node longhaul broke nested longhaul deployment. I made a silly error when doing the test checks, otherwise I would have caught it.

The fix is to remove the twin update frequency param, as this parameter has been removed from the `runTrcE2ETest.sh`