### PR TITLE
Nested Longhaul Tests: Fix typo in test scenario

### DIFF
--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
@@ -497,7 +497,7 @@
             "restartPolicy": "always",
             "env": {
               "TEST_SCENARIO": {
-                "value": "InitiateAndRelayReceived"
+                "value": "InitiateAndReceiveRelayed"
               },
               "TRACKING_ID": {
                 "value": "<TrackingId>"


### PR DESCRIPTION
Fixing a typo in the `generic-mqtt-tester` TestScenario enum.