### PR TITLE
Fix provisioning behavior when DPS changes

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "http-common",
  "libc",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "pkcs11",
  "serde",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "http-common",
  "serde",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "serde",
  "toml",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1752,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "cc",
 ]
@@ -1789,7 +1789,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1798,7 +1798,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1892,7 +1892,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1909,7 +1909,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#e784e6d7296d88f8163db4f6abd30115e27f5e94"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#427fe7624954118577bc083b83fa216430c2a085"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/aziot-edged/src/lib.rs
+++ b/edgelet/aziot-edged/src/lib.rs
@@ -302,9 +302,15 @@ where
                 Err(err) => {
                     log_failure(Level::Warn, &err);
 
-                    std::thread::sleep(IS_GET_DEVICE_INFO_RETRY_INTERVAL_SECS);
+                    log::warn!("Requesting device reprovision.");
 
-                    log::warn!("Retrying getting edge device provisioning information.");
+                    if let Err(err) =
+                        tokio_runtime.block_on(reprovision_device(&client, provisioning_cache))
+                    {
+                        log::warn!("{}", err);
+                    }
+
+                    std::thread::sleep(IS_GET_DEVICE_INFO_RETRY_INTERVAL_SECS);
                 }
             };
         }

--- a/edgelet/iotedge/src/system.rs
+++ b/edgelet/iotedge/src/system.rs
@@ -87,8 +87,11 @@ impl System {
             .expect("hard-coded URI should parse");
         let client = IdentityClient::new(ApiVersion::V2020_09_01, &uri);
 
+        let provisioning_cache =
+            std::path::Path::new("/var/lib/aziot/edged/cache/provisioning_state").to_path_buf();
+
         runtime
-            .block_on(client.reprovision_device())
+            .block_on(client.reprovision_device(provisioning_cache))
             .map_err(|err| {
                 eprintln!("Failed to reprovision: {}", err);
                 Error::from(ErrorKind::System)


### PR DESCRIPTION
- Clear the provisioning state cache when a reprovision is triggered.
- Request reprovisioning if edged cannot get device information on startup.

Depends on https://github.com/Azure/iot-identity-service/pull/229