### PR TITLE
Update functions to 3.0 (#4910)

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -77,6 +77,7 @@ Included items must then not match any entries in the exclude list to remain inc
                 <ModulePath>.*testanalyzer\..*</ModulePath>
                 <ModulePath>.*testresultcoordinator\..*</ModulePath>
                 <ModulePath>.*twintester\..*</ModulePath>
+                <ModulePath>.*microsoft.azure.webjobs.*</ModulePath>
               </Exclude>
             </ModulePaths>
 

--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -32,7 +32,6 @@ jobs:
     pool:
       vmImage: ubuntu-18.04
     steps:
-      - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
       - task: Bash@3
         displayName: Install Prerequisites

--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -63,7 +63,6 @@ jobs:
     pool:
       vmImage: "vs2017-win2016"
     steps:
-      - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
       - task: PowerShell@2
         displayName: Build

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -106,7 +106,6 @@ jobs:
             IotDevice3ConnStr2,
             IotHubConnStr2,
             IotHubMqttHeadCert
-      - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
       - powershell: scripts/windows/build/Publish-Branch.ps1 -Configuration $(Build.Configuration) -UpdateVersion
         displayName: Build

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -31,7 +31,6 @@ jobs:
             IotDevice3ConnStr2,
             IotHubConnStr2,
             IotHubMqttHeadCert
-      - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
       - task: Bash@3
         displayName: Install Prerequisites

--- a/builds/templates/install-dotnet2.yaml
+++ b/builds/templates/install-dotnet2.yaml
@@ -1,6 +1,0 @@
-steps:
-  - task: UseDotNet@2
-    displayName: Install .NET Core sdk
-    inputs:
-      packageType: sdk
-      version: 2.2.207

--- a/builds/templates/install-dotnet2.yaml
+++ b/builds/templates/install-dotnet2.yaml
@@ -1,0 +1,6 @@
+steps:
+  - task: UseDotNet@2
+    displayName: Install .NET Core sdk
+    inputs:
+      packageType: sdk
+      version: 2.2.207

--- a/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
+++ b/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
@@ -1,8 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
+  <Import Project="..\..\..\..\netcoreappVersion.props" />
   
   <PropertyGroup>
     <AzureFunctionsVersion></AzureFunctionsVersion>
@@ -21,7 +19,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 

--- a/edge-modules/functions/samples/README.md
+++ b/edge-modules/functions/samples/README.md
@@ -1,0 +1,5 @@
+# Azure functions module for IoT Edge
+This is a sample on how to use EdgeHub binding for Azure functions in an IoT Edge module. 
+It contains a C# function that gets triggered when a message is received from EdgeHub and also contains docker files needed to build the module image.
+
+Current version is based on Azure functions runtime 3.0 which has a larger docker image size compared to previous version. If image size is a concern older version of EdgeHub binding (<=1.0.7) has to be used which is based on Azure functions 2.0

--- a/edge-modules/functions/samples/docker/linux/amd64/Dockerfile
+++ b/edge-modules/functions/samples/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:2.0-iot-edge
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0
 
 ENV AzureWebJobsScriptRoot=/app
 

--- a/edge-modules/functions/samples/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/functions/samples/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:2.0-arm32v7
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0-arm32v7
 
 ENV AzureWebJobsScriptRoot=/app
 

--- a/edge-modules/functions/samples/docker/windows/amd64/Dockerfile
+++ b/edge-modules/functions/samples/docker/windows/amd64/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
 
-FROM mcr.microsoft.com/azure-functions/dotnet:2.0-nanoserver-1809
+FROM mcr.microsoft.com/azure-functions/dotnet:3.0-nanoserver-1809
 
 COPY . /approot

--- a/scripts/linux/buildBranch.sh
+++ b/scripts/linux/buildBranch.sh
@@ -247,8 +247,8 @@ publish_app "NumberLogger"
 publish_app "CloudToDeviceMessageTester"
 publish_app "IotedgeDiagnosticsDotnet"
 publish_app "Microsoft.Azure.Devices.Edge.Azure.Monitor"
+publish_app "EdgeHubTriggerCSharp"
 
-publish_lib "EdgeHubTriggerCSharp"
 publish_lib "Microsoft.Azure.WebJobs.Extensions.EdgeHub"
 
 publish_files $SRC_SCRIPTS_DIR $PUBLISH_FOLDER

--- a/scripts/linux/runTests.sh
+++ b/scripts/linux/runTests.sh
@@ -65,7 +65,7 @@ while read testDll; do
   else
     testProjectDlls="$testProjectDlls $testDll"
   fi  
-done < <(find $OUTPUT_FOLDER -type f -iname $SUFFIX)
+done < <(find $OUTPUT_FOLDER -type f -iname $SUFFIX -not -path "$OUTPUT_FOLDER/bin/*")
 
 testCommandPrefix="$DOTNET_ROOT_PATH/dotnet vstest /Logger:trx;LogFileName=result.trx /TestAdapterPath:\"$OUTPUT_FOLDER\" /Parallel /InIsolation"
 if [ ! -z "$testFilterValue" ]

--- a/scripts/windows/build/Publish-Branch.ps1
+++ b/scripts/windows/build/Publish-Branch.ps1
@@ -154,6 +154,7 @@ $appProjectList.Add("NumberLogger.csproj")
 $appProjectList.Add("CloudToDeviceMessageTester.csproj")
 $appProjectList.Add("IotedgeDiagnosticsDotnet.csproj")
 $appProjectList.Add("Microsoft.Azure.Devices.Edge.Azure.Monitor.csproj")
+$appProjectList.Add("EdgeHubTriggerCSharp.csproj")
 
 # Download latest rocksdb ARM32 library
 $rocksdbARMUri = "https://edgebuild.blob.core.windows.net/rocksdb/rocksdb-arm.dll"
@@ -194,7 +195,6 @@ Write-Host "`nPublishing .NET Core libs`n"
 
 $libProjectList = New-Object 'System.Collections.Generic.List[String]'
 $libProjectList.Add("Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj")
-$libProjectList.Add("EdgeHubTriggerCSharp.csproj")
 
 foreach ($libProjectFileName in $libProjectList) {
     $libProjectFilePath = Get-ChildItem -Include *.csproj -File -Recurse |Where-Object {$_.Name -eq "$libProjectFileName"}|Select-Object -first 1|Select -ExpandProperty "FullName"


### PR DESCRIPTION
This reverts commit 3ab67a3a199f1bb47123f59f3310eb902f13f823.
Filters out bin folder when running tests to fix the tests failure issue. It's not clear why only in some runs the bin folder has the test dlls and not the runtimeconfig.json files which is causing the tests run to fail. Other times it was passing because the bin folder didn't contain the test dlls when running on different pipeline agent (but using same dotnet sdk and everything else looked the same)