### PR TITLE
Limit sysinfo crate FDs usage. (#5055)

### DIFF
--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -336,8 +336,9 @@ impl MakeModuleRuntime for DockerModuleRuntime {
                     })
                     .join(notary_registries)
                     .map(move |(client, (notary_registries, _))| {
-                        let mut system_resources = System::new_all();
-                        system_resources.refresh_all();
+                        // to avoid excessive FD usage, we will not allow sysinfo to keep files open.
+                        sysinfo::set_open_files_limit(0);
+                        let system_resources = System::new_all();
                         info!("Successfully initialized module runtime");
                         let notary_lock = tokio::sync::lock::Lock::new(BTreeMap::new());
                         DockerModuleRuntime {
@@ -842,7 +843,6 @@ impl ModuleRuntime for DockerModuleRuntime {
             .as_ref()
             .lock()
             .expect("Could not acquire system resources lock");
-        system_resources.refresh_all();
 
         let current_time = SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -851,6 +851,7 @@ impl ModuleRuntime for DockerModuleRuntime {
         let start_time = process::id()
             .try_into()
             .map(|id| {
+                system_resources.refresh_process(id);
                 system_resources
                     .get_process(id)
                     .map(|p| p.start_time())
@@ -858,11 +859,12 @@ impl ModuleRuntime for DockerModuleRuntime {
             })
             .unwrap_or_default();
 
+        system_resources.refresh_system();
         let used_cpu = system_resources.get_global_processor_info().get_cpu_usage();
-
         let total_memory = system_resources.get_total_memory() * 1000;
         let used_memory = system_resources.get_used_memory() * 1000;
 
+        system_resources.refresh_disks();
         let disks = system_resources
             .get_disks()
             .iter()


### PR DESCRIPTION
**Context:**
We use [Sysinfo](https://docs.rs/sysinfo/0.18.0/sysinfo/) crate to get host metrics and processes info. By default it keeps `/proc/...` files open for perf optimizations. Unfortunately, there could be many processes/threads in the host system, so `sysinfo` can consume a lot of FDs.

**Solution:**
After looking into details of `sysinfo`, I found out that we can limit the number of FDs it can use.

Also, maybe we don't need to refresh everything if we don't use that?