### PR TITLE
Enable aziot-edged in CentOS package

### DIFF
--- a/edgelet/Makefile
+++ b/edgelet/Makefile
@@ -135,7 +135,7 @@ deb: release
 	cd $(TARGET)/$(PACKAGE) && dpkg-buildpackage $(DPKGFLAGS)
 
 rpm:
-	$(INSTALL_DATA) -D $(srcdir)/contrib/centos/00-aziot-edged.preset $(presetdir)/00-aziot-edged.preset
+	cp $(srcdir)/contrib/centos/00-aziot-edged.preset $(rpmbuilddir)/SPECS
 	$(SED) "s/@version@/${RPM_VERSION}/g; s/@release@/${RPM_RELEASE}/g;" $(srcdir)/contrib/centos/aziot-edge.spec > $(rpmbuilddir)/SPECS/aziot-edge.spec
 	rpmbuild $(RPMBUILDFLAGS) $(rpmbuilddir)/SPECS/aziot-edge.spec
 
@@ -192,6 +192,9 @@ install: release
 	$(GZIP) $(DESTDIR)$(docdir)/LICENSE
 	$(GZIP) $(DESTDIR)$(docdir)/ThirdPartyNotices
 
+install-rpm: install
+	$(INSTALL_DATA) -D ../../SOURCES/00-aziot-edged.preset $(DESTDIR)$(presetdir)/00-aziot-edged.preset
+
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/aziot-edged
 	rm -f $(DESTDIR)$(bindir)/iotedge
@@ -213,4 +216,4 @@ version:
 	@echo "rpm version:  ${RPM_VERSION}"
 	@echo "rpm release:  ${RPM_RELEASE}"
 
-.PHONY: all clean deb dist install rpm rpm-dist uninstall version
+.PHONY: all clean deb dist install install-rpm rpm rpm-dist uninstall version

--- a/edgelet/Makefile
+++ b/edgelet/Makefile
@@ -33,6 +33,7 @@ man1=$(mandir)/man1
 man8=$(mandir)/man8
 srcdir?=.
 unitdir?=/lib/systemd/system
+presetdir?=/usr/lib/systemd/system-preset
 
 rpmbuilddir?=$(HOME)/rpmbuild
 vendordir?=vendor
@@ -134,6 +135,7 @@ deb: release
 	cd $(TARGET)/$(PACKAGE) && dpkg-buildpackage $(DPKGFLAGS)
 
 rpm:
+	$(INSTALL_DATA) -D $(srcdir)/contrib/centos/00-aziot-edged.preset $(presetdir)/00-aziot-edged.preset
 	$(SED) "s/@version@/${RPM_VERSION}/g; s/@release@/${RPM_RELEASE}/g;" $(srcdir)/contrib/centos/aziot-edge.spec > $(rpmbuilddir)/SPECS/aziot-edge.spec
 	rpmbuild $(RPMBUILDFLAGS) $(rpmbuilddir)/SPECS/aziot-edge.spec
 

--- a/edgelet/Makefile
+++ b/edgelet/Makefile
@@ -135,7 +135,7 @@ deb: release
 	cd $(TARGET)/$(PACKAGE) && dpkg-buildpackage $(DPKGFLAGS)
 
 rpm:
-	cp $(srcdir)/contrib/centos/00-aziot-edged.preset $(rpmbuilddir)/SPECS
+	cp $(srcdir)/contrib/centos/00-aziot-edged.preset $(rpmbuilddir)/SOURCES
 	$(SED) "s/@version@/${RPM_VERSION}/g; s/@release@/${RPM_RELEASE}/g;" $(srcdir)/contrib/centos/aziot-edge.spec > $(rpmbuilddir)/SPECS/aziot-edge.spec
 	rpmbuild $(RPMBUILDFLAGS) $(rpmbuilddir)/SPECS/aziot-edge.spec
 
@@ -193,7 +193,7 @@ install: release
 	$(GZIP) $(DESTDIR)$(docdir)/ThirdPartyNotices
 
 install-rpm: install
-	$(INSTALL_DATA) -D ../../SOURCES/00-aziot-edged.preset $(DESTDIR)$(presetdir)/00-aziot-edged.preset
+	$(INSTALL_DATA) -D $(rpmbuilddir)/SOURCES/00-aziot-edged.preset $(DESTDIR)$(presetdir)/00-aziot-edged.preset
 
 uninstall:
 	rm -f $(DESTDIR)$(bindir)/aziot-edged

--- a/edgelet/contrib/centos/00-aziot-edged.preset
+++ b/edgelet/contrib/centos/00-aziot-edged.preset
@@ -1,0 +1,3 @@
+# Enable aziot-edged to start automatically.
+
+enable aziot-edged.service

--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -51,6 +51,7 @@ make \
     LISTEN_WORKLOAD_URI=unix://%{iotedge_socketdir}/workload.sock \
     DESTDIR=$RPM_BUILD_ROOT \
     unitdir=%{_unitdir} \
+    presetdir=%{_presetdir} \
     docdir=%{_docdir}/%{name} \
     install
 
@@ -163,6 +164,7 @@ fi
 
 # systemd
 %{_unitdir}/aziot-edged.service
+%{_presetdir}/00-aziot-edged.preset
 
 # sockets
 %attr(660, %{iotedge_user}, %{iotedge_group}) %{iotedge_socketdir}/mgmt.sock

--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -53,7 +53,7 @@ make \
     unitdir=%{_unitdir} \
     presetdir=%{_presetdir} \
     docdir=%{_docdir}/%{name} \
-    install
+    install-rpm
 
 %clean
 rm -rf $RPM_BUILD_ROOT


### PR DESCRIPTION
Enables aziot-edged during postinstall so that it starts automatically.