### PR TITLE
Skip the "twin signing" metrics for E2E tests

### DIFF
--- a/test/modules/MetricsValidator/src/tests/ValidateDocumentedMetrics.cs
+++ b/test/modules/MetricsValidator/src/tests/ValidateDocumentedMetrics.cs
@@ -69,12 +69,16 @@ namespace MetricsValidator.Tests
             // We are going to make a list and remove them here to not consider them as a failure.
             IEnumerable<string> skippingMetrics = new HashSet<string>
             {
+                "edgeAgent_twin_signature_check_count",
+                "edgeAgent_twin_signaturs_check_seconds",
                 "edgeAgent_unsuccessful_iothub_syncs_total",
                 "edgehub_client_connect_failed_total",
                 "edgehub_messages_dropped_total",
                 "edgehub_messages_unack_total",
                 "edgehub_offline_count_total",
                 "edgehub_operation_retry_total",
+                "edgehub_twin_signature_check_count",
+                "edgehub_twin_signature_check_seconds",
                 "edgehub_client_disconnect_total"
             };
 


### PR DESCRIPTION
Skip the "twin signing" metrics for E2E tests until manifest signing is put into the tests.

These metrics are only generated when manifest signing is enabled and not all tests will have manifest signing turned on.