### PR TITLE
Docker login: Removing typo and not-needed script help

### DIFF
--- a/builds/misc/addons-publish.yaml
+++ b/builds/misc/addons-publish.yaml
@@ -32,7 +32,7 @@ jobs:
             displayName: Docker login edgerelease
             inputs:
               command: login
-              containerRegistry: iotedge-release-acr,
+              containerRegistry: iotedge-release-acr
         
           - task: Bash@3
             displayName: 'Publish Api Proxy - Linux amd64'

--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -35,7 +35,7 @@ jobs:
         displayName: Docker login edgerelease
         inputs:
           command: login
-          containerRegistry: iotedge-release-acr,
+          containerRegistry: iotedge-release-acr
       # Build API Proxy executable
       - template: templates/build-api-proxy.yaml
       # Build API Proxy Image
@@ -70,7 +70,7 @@ jobs:
       displayName: Docker login edgerelease
       inputs:
         command: login
-        containerRegistry: iotedge-release-acr,
+        containerRegistry: iotedge-release-acr
     - bash: |
           if [ -z '$(version)' ]; then
             echo '##vso[task.setvariable variable=buildVersion]$(Build.BuildNumber)'

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -19,12 +19,12 @@ jobs:
         displayName: Docker login edgebuilds
         inputs:
           command: login
-          containerRegistry: iotedge-edgebuilds-acr,
+          containerRegistry: iotedge-edgebuilds-acr
       - task: Docker@2
         displayName: Docker login edgerelease
         inputs:
           command: login
-          containerRegistry: iotedge-release-acr,
+          containerRegistry: iotedge-release-acr
       # Dotnet 2 needed for codesign
       - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
@@ -344,7 +344,7 @@ jobs:
       displayName: Docker login edgerelease
       inputs:
         command: login
-        containerRegistry: iotedge-release-acr,
+        containerRegistry: iotedge-release-acr
     - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
       displayName: 'Publish azureiotedge-diagnostics Manifest'
     - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'

--- a/scripts/linux/buildImage.sh
+++ b/scripts/linux/buildImage.sh
@@ -53,8 +53,6 @@ usage()
     echo " -i, --image-name     Image name (e.g. edge-agent)"
     echo " -P, --project        Project to build image for (e.g. Microsoft.Azure.Devices.Edge.Agent.Service)"
     echo " -r, --registry       Docker registry required to build, tag and run the module"
-    echo " -u, --username       Docker Registry Username"
-    echo " -p, --password       Docker Username's password"
     echo " -n, --namespace      Docker namespace (default: $DEFAULT_DOCKER_NAMESPACE)"
     echo " -v, --image-version  Docker Image Version. Either use this option or set env variable BUILD_BUILDNUMBER"
     echo " -t, --target-arch    Target architecture (default: uname -m)"

--- a/scripts/linux/buildManifest.sh
+++ b/scripts/linux/buildManifest.sh
@@ -36,8 +36,6 @@ usage()
     echo ""
     echo "options"
     echo " -r, --registry                 Docker registry required to build, tag and run the module"
-    echo " -u, --username                 Docker Registry Username"
-    echo " -p, --password                 Docker Username's password"
     echo " -n, --namespace                Docker namespace (default: $DEFAULT_DOCKER_NAMESPACE)"
     echo " -i, --image-name               Docker image name (Optional if specified in template yaml)"
     echo " -v, --image-version            Docker Image Version."


### PR DESCRIPTION
In #5109 we missed a comma. Even though the builds still worked we need to clean it up. 

Also there was some script help that I mistakenly did not remove.