### PR TITLE
multiple workload sockets

### DIFF
--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -28,6 +28,12 @@ jobs:
      - template: nested-get-root-ca.yaml       
      - template: nested-create-identity.yaml   
      - template: nested-agent-deploy.yaml
+     - task: Bash@3
+       displayName: 'bla'
+       inputs:
+         targetType: inline
+         script: |
+           sleep 10m
 
   - job: SetupVM_level4_${{ parameters['upstream.protocol'] }}
     dependsOn: SetupVM_level5_${{ parameters['upstream.protocol'] }}

--- a/builds/e2e/templates/nested-parent-vm-setup.yaml
+++ b/builds/e2e/templates/nested-parent-vm-setup.yaml
@@ -28,12 +28,6 @@ jobs:
      - template: nested-get-root-ca.yaml       
      - template: nested-create-identity.yaml   
      - template: nested-agent-deploy.yaml
-     - task: Bash@3
-       displayName: 'bla'
-       inputs:
-         targetType: inline
-         script: |
-           sleep 10m
 
   - job: SetupVM_level4_${{ parameters['upstream.protocol'] }}
     dependsOn: SetupVM_level5_${{ parameters['upstream.protocol'] }}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -53,6 +53,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string EdgeletWorkloadUriVariableName = "IOTEDGE_WORKLOADURI";
 
+        public const string EdgeletWorkloadListenMntUriVariableName = "IOTEDGE_WORKLOADLISTEN_MNTURI";
+
         public const string IotHubHostnameVariableName = "IOTEDGE_IOTHUBHOSTNAME";
 
         public const string GatewayHostnameVariableName = "IOTEDGE_GATEWAYHOSTNAME";

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker/CombinedEdgeletConfigProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker/CombinedEdgeletConfigProvider.cs
@@ -47,12 +47,14 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker
                 ? JsonConvert.DeserializeObject<CreateContainerParameters>(JsonConvert.SerializeObject(createOptions))
                 : new CreateContainerParameters();
 
-        static void SetMountOptions(CreateContainerParameters createOptions, Uri uri)
+        static void SetMountOptions(CreateContainerParameters createOptions, Uri listenUri, Uri connectUri)
         {
             HostConfig hostConfig = createOptions.HostConfig ?? new HostConfig();
             IList<string> binds = hostConfig.Binds ?? new List<string>();
-            string path = BindPath(uri);
-            binds.Add($"{path}:{path}");
+            string sourcePath = BindPath(listenUri);
+            string targetPath = BindPath(connectUri);
+
+            binds.Add($"{sourcePath}:{targetPath}");
 
             hostConfig.Binds = binds;
             createOptions.HostConfig = hostConfig;
@@ -125,10 +127,18 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker
 
         void MountSockets(IModule module, CreateContainerParameters createOptions)
         {
-            var workloadUri = new Uri(this.configSource.Configuration.GetValue<string>(Constants.EdgeletWorkloadUriVariableName));
-            if (workloadUri.Scheme == "unix")
+            var workloadListenUriMntString = this.configSource.Configuration.GetValue<string>(Constants.EdgeletWorkloadListenMntUriVariableName);
+            var workloadConnectUri = new Uri(this.configSource.Configuration.GetValue<string>(Constants.EdgeletWorkloadUriVariableName));
+            var workloadListenUri = workloadConnectUri;
+
+            if (workloadListenUriMntString != null)
             {
-                SetMountOptions(createOptions, workloadUri);
+                workloadListenUri = new Uri(workloadListenUriMntString + "/" + module.Name + ".sock");
+            }
+
+            if (workloadConnectUri.Scheme == "unix")
+            {
+                SetMountOptions(createOptions, workloadListenUri, workloadConnectUri);
             }
 
             // If Management URI is Unix domain socket, and the module is the EdgeAgent, then mount it into the container.
@@ -136,7 +146,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker
             if (managementUri.Scheme == "unix"
                 && module.Name.Equals(Constants.EdgeAgentModuleName, StringComparison.OrdinalIgnoreCase))
             {
-                SetMountOptions(createOptions, managementUri);
+                SetMountOptions(createOptions, managementUri, managementUri);
             }
         }
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker/CombinedEdgeletConfigProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker/CombinedEdgeletConfigProvider.cs
@@ -129,12 +129,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker
         {
             var workloadListenUriMntString = this.configSource.Configuration.GetValue<string>(Constants.EdgeletWorkloadListenMntUriVariableName);
             var workloadConnectUri = new Uri(this.configSource.Configuration.GetValue<string>(Constants.EdgeletWorkloadUriVariableName));
-            var workloadListenUri = workloadConnectUri;
 
-            if (workloadListenUriMntString != null)
-            {
-                workloadListenUri = new Uri(workloadListenUriMntString + "/" + module.Name + ".sock");
-            }
+            Uri workloadListenUri = !string.IsNullOrEmpty(workloadListenUriMntString)
+              ? new Uri($"{workloadListenUriMntString}/{module.Name}.sock")
+              : workloadConnectUri;
 
             if (workloadConnectUri.Scheme == "unix")
             {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
@@ -180,6 +180,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
                     envVars.Add(new EnvVar(Constants.NetworkIdKey, networkId));
                 }
 
+                string workloadListenMnt = configSource.Configuration.GetValue<string>(Constants.EdgeletWorkloadListenMntUriVariableName);
+                if (!string.IsNullOrEmpty(workloadListenMnt))
+                {
+                    envVars.Add(new EnvVar(Constants.EdgeletWorkloadListenMntUriVariableName, workloadListenMnt));
+                }
+
                 envVars.Add(new EnvVar(Constants.ModeKey, Constants.IotedgedMode));
             }
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/CombinedEdgeletConfigProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/CombinedEdgeletConfigProviderTest.cs
@@ -103,8 +103,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test
             Assert.NotNull(config.CreateOptions.HostConfig);
             Assert.NotNull(config.CreateOptions.HostConfig.Binds);
             Assert.Equal(2, config.CreateOptions.HostConfig.Binds.Count);
-            Assert.Equal("/path/to/homedir/mnt/edgeAgent.sock:/path/to/workload.sock", config.CreateOptions.HostConfig.Binds[0]);
-            Assert.Equal("/path/to/mgmt.sock:/path/to/mgmt.sock", config.CreateOptions.HostConfig.Binds[1]);
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Equal("/path/to/homedir/mnt/edgeAgent.sock:/path/to/workload.sock", config.CreateOptions.HostConfig.Binds[0]);
+                Assert.Equal("/path/to/mgmt.sock:/path/to/mgmt.sock", config.CreateOptions.HostConfig.Binds[1]);
+            }
         }
 
         [Fact]

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/CombinedEdgeletConfigProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/CombinedEdgeletConfigProviderTest.cs
@@ -73,6 +73,41 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test
         }
 
         [Fact]
+        public void TestVolMountEdgelet()
+        {
+            // Arrange
+            var runtimeInfo = new Mock<IRuntimeInfo<DockerRuntimeConfig>>();
+            runtimeInfo.SetupGet(ri => ri.Config).Returns(new DockerRuntimeConfig("1.24", string.Empty));
+
+            var module = new Mock<IModule<DockerConfig>>();
+            module.SetupGet(m => m.Config).Returns(new DockerConfig("nginx:latest"));
+            module.SetupGet(m => m.Name).Returns(Constants.EdgeAgentModuleName);
+
+            var unixUris = new Dictionary<string, string>
+            {
+                { Constants.EdgeletWorkloadUriVariableName, "unix:///path/to/workload.sock" },
+                { Constants.EdgeletWorkloadListenMntUriVariableName, "unix:///path/to/homedir/mnt" },
+                { Constants.EdgeletManagementUriVariableName, "unix:///path/to/mgmt.sock" }
+            };
+
+            IConfigurationRoot configRoot = new ConfigurationBuilder()
+                .AddInMemoryCollection(unixUris).Build();
+            var configSource = Mock.Of<IConfigSource>(s => s.Configuration == configRoot);
+            ICombinedConfigProvider<CombinedDockerConfig> provider = new CombinedEdgeletConfigProvider(new[] { new AuthConfig() }, configSource);
+
+            // Act
+            CombinedDockerConfig config = provider.GetCombinedConfig(module.Object, runtimeInfo.Object);
+
+            // Assert
+            Assert.NotNull(config.CreateOptions);
+            Assert.NotNull(config.CreateOptions.HostConfig);
+            Assert.NotNull(config.CreateOptions.HostConfig.Binds);
+            Assert.Equal(2, config.CreateOptions.HostConfig.Binds.Count);
+            Assert.Equal("/path/to/homedir/mnt/edgeAgent.sock:/path/to/workload.sock", config.CreateOptions.HostConfig.Binds[0]);
+            Assert.Equal("/path/to/mgmt.sock:/path/to/mgmt.sock", config.CreateOptions.HostConfig.Binds[1]);
+        }
+
+        [Fact]
         public void TestNoVolMountForNonUds()
         {
             // Arrange

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/commands/CreateOrUpdateCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/commands/CreateOrUpdateCommandTest.cs
@@ -58,6 +58,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                         Option.None<string>(),
                         "Amqp",
                         "Edgelet_Management_Uri",
+                        "Edgelet_Listen_workload_Uri",
                         "iotedge-network",
                         "2020.01.01",
                         new object())
@@ -83,6 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                         Option.Some("parentEdgeHost999"),
                         "Amqp",
                         "Edgelet_Management_Uri",
+                        "Edgelet_Listen_workload_Uri",
                         "iotedge-network",
                         "2020.01.01",
                         new object())
@@ -108,6 +110,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                         Option.None<string>(),
                         "Amqp",
                         "Edgelet_Management_Uri",
+                        "Edgelet_Listen_workload_Uri",
                         "iotedge-network",
                         "2020.01.01",
                         new object())
@@ -133,6 +136,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                         Option.Some("parentEdgeHost999"),
                         "Amqp",
                         "Edgelet_Management_Uri",
+                        "Edgelet_Listen_workload_Uri",
                         "iotedge-network",
                         "2020.01.01",
                         new object())
@@ -158,6 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                         Option.None<string>(),
                         "Amqp",
                         "Edgelet_Management_Uri",
+                        "Edgelet_Listen_workload_Uri",
                         "iotedge-network",
                         "2020.01.01",
                         new object())
@@ -183,6 +188,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                         Option.Some("parentEdgeHost999"),
                         "Amqp",
                         "Edgelet_Management_Uri",
+                        "Edgelet_Listen_workload_Uri",
                         "iotedge-network",
                         "2020.01.01",
                         new object())
@@ -272,6 +278,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                 var edgeletManagementUriConfig = new Mock<IConfigurationSection>();
                 this.Configuration.Setup(c => c.GetSection(Constants.EdgeletManagementUriVariableName)).Returns(edgeletManagementUriConfig.Object);
                 edgeletManagementUriConfig.Setup(c => c.Value).Returns(testData.EdgeletManagementUri);
+                var edgeletWorkloadListenUriMntConfig = new Mock<IConfigurationSection>();
+                this.Configuration.Setup(c => c.GetSection(Constants.EdgeletWorkloadListenMntUriVariableName)).Returns(edgeletWorkloadListenUriMntConfig.Object);
+                edgeletWorkloadListenUriMntConfig.Setup(c => c.Value).Returns(testData.EdgeletWorkloadListenUriMnt);
                 var networkIdConfig = new Mock<IConfigurationSection>();
                 this.Configuration.Setup(c => c.GetSection(Constants.NetworkIdKey)).Returns(networkIdConfig.Object);
                 networkIdConfig.Setup(c => c.Value).Returns(testData.NetworkId);
@@ -308,6 +317,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                 Option<string> parentEdgeHostname,
                 string upstreamProtocol,
                 string edgeletManagementUri,
+                string edgeletWorkloadListenUriMnt,
                 string networkId,
                 string edgeletApiVersion,
                 object settings)
@@ -326,6 +336,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
                 this.ParentEdgeHostname = parentEdgeHostname;
                 this.UpstreamProtocol = Preconditions.CheckNonWhiteSpace(upstreamProtocol, nameof(upstreamProtocol));
                 this.EdgeletManagementUri = Preconditions.CheckNonWhiteSpace(edgeletManagementUri, nameof(edgeletManagementUri));
+                this.EdgeletWorkloadListenUriMnt = Preconditions.CheckNonWhiteSpace(edgeletWorkloadListenUriMnt, nameof(edgeletWorkloadListenUriMnt));
                 this.NetworkId = Preconditions.CheckNonWhiteSpace(networkId, nameof(networkId));
                 this.EdgeletApiVersion = Preconditions.CheckNonWhiteSpace(edgeletApiVersion, nameof(edgeletApiVersion));
                 this.Settings = settings;
@@ -362,6 +373,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
             internal string UpstreamProtocol { get; }
 
             internal string EdgeletManagementUri { get; }
+
+            internal string EdgeletWorkloadListenUriMnt { get; }
 
             internal string NetworkId { get; }
 

--- a/edgelet/aziot-edged/src/error.rs
+++ b/edgelet/aziot-edged/src/error.rs
@@ -50,6 +50,9 @@ pub enum ErrorKind {
 
     #[fail(display = "The workload service encountered an error")]
     WorkloadService,
+
+    #[fail(display = "The workload manager encountered an error")]
+    WorkloadManager,
 }
 
 impl Error {
@@ -141,6 +144,7 @@ pub enum InitializeErrorReason {
     StopExistingModules,
     Tokio,
     WorkloadService,
+    WorkloadManager,
 }
 
 impl fmt::Display for InitializeErrorReason {
@@ -197,6 +201,8 @@ impl fmt::Display for InitializeErrorReason {
             InitializeErrorReason::Tokio => write!(f, "Could not initialize tokio runtime"),
 
             InitializeErrorReason::WorkloadService => write!(f, "Could not start workload service"),
+
+            InitializeErrorReason::WorkloadManager => write!(f, "Could not start workload manager"),
         }
     }
 }

--- a/edgelet/aziot-edged/src/lib.rs
+++ b/edgelet/aziot-edged/src/lib.rs
@@ -65,6 +65,8 @@ use sha2::{Digest, Sha256};
 use crate::watchdog::Watchdog;
 use crate::workload::WorkloadData;
 
+const MGMT_SOCKET_DEFAULT_PERMISSION: u32 = 0o660;
+
 const EDGE_RUNTIME_MODULEID: &str = "$edgeAgent";
 const EDGE_RUNTIME_MODULE_NAME: &str = "edgeAgent";
 const AUTH_SCHEME: &str = "sasToken";
@@ -471,7 +473,6 @@ where
 
     let mgmt = start_management::<M>(settings, runtime, mgmt_rx, mgmt_stop_and_reprovision_tx);
 
-    //let workload = start_workload::<_, M>(settings, runtime, work_rx, workload_config, tokio_runtime, create_socket_channel_rcv);
     WorkloadManager::start_manager::<M>(
         settings,
         runtime,
@@ -703,7 +704,7 @@ where
             let service = LoggingService::new(label, service);
 
             let run = Http::new()
-                .bind_url(url.clone(), service)
+                .bind_url(url.clone(), service, MGMT_SOCKET_DEFAULT_PERMISSION)
                 .map_err(|err| {
                     err.context(ErrorKind::Initialize(
                         InitializeErrorReason::ManagementService,

--- a/edgelet/aziot-edged/src/workload_manager.rs
+++ b/edgelet/aziot-edged/src/workload_manager.rs
@@ -1,0 +1,287 @@
+use std::{
+    collections::HashMap,
+    fs,
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+
+use crate::error::{Error, ErrorKind, InitializeErrorReason};
+use aziot_key_client::Client;
+use cert_client::CertificateClient;
+use edgelet_core::{
+    Authenticator, Listen, MakeModuleRuntime, Module, ModuleAction, ModuleRuntime,
+    ModuleRuntimeErrorReason, RuntimeSettings, UrlExt, WorkloadConfig,
+};
+
+use edgelet_http::{logging::LoggingService, HyperExt};
+use edgelet_http_workload::WorkloadService;
+use edgelet_utils::log_failure;
+use failure::{Fail, ResultExt};
+use futures::{
+    sync::{mpsc::UnboundedReceiver, oneshot, oneshot::Sender},
+    Future, Stream,
+};
+use hyper::{server::conn::Http, Body, Request};
+use identity_client::IdentityClient;
+use log::{error, info, warn, Level};
+use serde::{de::DeserializeOwned, Serialize};
+use url::Url;
+
+pub struct WorkloadManager<M, W>
+where
+    M: ModuleRuntime + 'static + Authenticator<Request = Request<Body>> + Clone + Send + Sync,
+    for<'r> &'r <M as ModuleRuntime>::Error: Into<ModuleRuntimeErrorReason>,
+{
+    module_runtime: M,
+    shutdown_senders: HashMap<String, oneshot::Sender<()>>,
+    legacy_workload_uri: Url,
+    home_dir: PathBuf,
+    key_client: Arc<Client>,
+    cert_client: Arc<Mutex<CertificateClient>>,
+    identity_client: Arc<Mutex<IdentityClient>>,
+    config: W,
+}
+
+impl<M, W> WorkloadManager<M, W>
+where
+    W: WorkloadConfig + Clone + Send + Sync + 'static,
+    M: ModuleRuntime + 'static + Authenticator<Request = Request<Body>> + Clone + Send + Sync,
+    <<M as Authenticator>::AuthenticateFuture as Future>::Error: Fail,
+    for<'r> &'r <M as ModuleRuntime>::Error: Into<ModuleRuntimeErrorReason>,
+    <<M as ModuleRuntime>::Module as Module>::Config: Clone + DeserializeOwned + Serialize,
+    <M as ModuleRuntime>::Logs: Into<Body>,
+{
+    pub fn start_manager<F>(
+        settings: &F::Settings,
+        runtime: &M,
+        config: W,
+        tokio_runtime: &mut tokio::runtime::Runtime,
+        create_socket_channel_rcv: UnboundedReceiver<ModuleAction>,
+    ) -> Result<(), Error>
+    where
+        F: MakeModuleRuntime + 'static,
+    {
+        let shutdown_senders: HashMap<String, oneshot::Sender<()>> = HashMap::new();
+
+        let legacy_workload_uri = settings.listen().legacy_workload_uri().clone();
+        let keyd_url = settings.endpoints().aziot_keyd_url().clone();
+        let certd_url = settings.endpoints().aziot_certd_url().clone();
+        let identityd_url = settings.endpoints().aziot_identityd_url().clone();
+
+        let home_dir = settings.homedir().to_path_buf();
+
+        let key_connector = http_common::Connector::new(&keyd_url).expect("Connector");
+        let key_client = Arc::new(aziot_key_client::Client::new(
+            aziot_key_common_http::ApiVersion::V2020_09_01,
+            key_connector,
+        ));
+
+        let cert_client = Arc::new(Mutex::new(cert_client::CertificateClient::new(
+            aziot_cert_common_http::ApiVersion::V2020_09_01,
+            &certd_url,
+        )));
+        let identity_client = Arc::new(Mutex::new(identity_client::IdentityClient::new(
+            aziot_identity_common_http::ApiVersion::V2020_09_01,
+            &identityd_url,
+        )));
+
+        let module_runtime = runtime.clone();
+
+        let workload_manager = WorkloadManager {
+            module_runtime,
+            shutdown_senders,
+            legacy_workload_uri,
+            home_dir,
+            key_client,
+            cert_client,
+            identity_client,
+            config,
+        };
+
+        let module_list: Vec<<M as ModuleRuntime>::Module> =
+            tokio_runtime.block_on(runtime.list()).map_err(|err| {
+                err.context(ErrorKind::Initialize(
+                    InitializeErrorReason::WorkloadService,
+                ))
+            })?;
+
+        tokio_runtime.block_on(futures::future::lazy(move || {
+            server(workload_manager, &module_list, create_socket_channel_rcv)
+                .map_err(|err| Error::from(err.context(ErrorKind::WorkloadService)))
+        }))?;
+
+        Ok(())
+    }
+
+    fn spawn_listener(
+        &mut self,
+        workload_uri: Url,
+        signal_socket_created: Option<Sender<()>>,
+        module_id: &str,
+    ) -> Result<(), Error> {
+        let label = "work".to_string();
+
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+
+        self.shutdown_senders
+            .insert(module_id.to_string(), shutdown_sender);
+
+        let future = WorkloadService::new(
+            &self.module_runtime,
+            self.identity_client.clone(),
+            self.cert_client.clone(),
+            self.key_client.clone(),
+            self.config.clone(),
+        )
+        .then(move |service| -> Result<_, Error> {
+            let service = service.context(ErrorKind::Initialize(
+                InitializeErrorReason::WorkloadService,
+            ))?;
+            let service = LoggingService::new(label, service);
+
+            let run = Http::new()
+                .bind_url(workload_uri.clone(), service)
+                .map_err(|err| {
+                    err.context(ErrorKind::Initialize(
+                        InitializeErrorReason::WorkloadService,
+                    ))
+                })?;
+
+            // Send signal back to module runtime that socket and folder are created.
+            if let Some(signal_socket_created) = signal_socket_created {
+                signal_socket_created
+                    .send(())
+                    .map_err(|()| ErrorKind::Initialize(InitializeErrorReason::WorkloadService))?;
+            }
+
+            let run = run
+                .run_until(shutdown_receiver.map_err(|_| ()))
+                .map_err(|err| Error::from(err.context(ErrorKind::WorkloadService)));
+            info!(
+                "Listening on {} with 1 thread for workload API.",
+                workload_uri
+            );
+            Ok(run)
+        })
+        .flatten()
+        .map_err(|_| ());
+
+        tokio::spawn(future);
+
+        Ok(())
+    }
+
+    fn get_listener_uri(&self, module_id: &str) -> Result<Url, Error> {
+        let uri = if let Some(home_dir) = self.home_dir.to_str() {
+            Listen::workload_uri(home_dir, module_id).map_err(|err| {
+                log_failure(Level::Error, &err);
+                Error::from(err.context(ErrorKind::WorkloadManager))
+            })
+        } else {
+            error!("No home dir found");
+            Err(Error::from(ErrorKind::WorkloadManager))
+        }?;
+
+        Ok(uri)
+    }
+
+    fn start(
+        &mut self,
+        module_id: &str,
+        signal_socket_created: Option<Sender<()>>,
+    ) -> Result<(), Error> {
+        info!("String new listener for module {}", module_id);
+        let workload_uri = self.get_listener_uri(module_id)?;
+
+        self.spawn_listener(workload_uri, signal_socket_created, module_id)
+    }
+
+    fn stop(&mut self, module_id: &str) -> Result<(), Error> {
+        info!("Stopping listener for module {}", module_id);
+
+        let shutdown_sender = self.shutdown_senders.remove(module_id);
+
+        if let Some(shutdown_sender) = shutdown_sender {
+            if shutdown_sender.send(()).is_err() {
+                warn!("Received message that a module stopped, but was unable to close the socket server");
+                Err(Error::from(ErrorKind::WorkloadManager))
+            } else {
+                Ok(())
+            }
+        } else {
+            warn!("Couldn't find a matching module Id in the list of shutdown channels");
+            Err(Error::from(ErrorKind::WorkloadManager))
+        }
+    }
+
+    fn remove(&mut self, module_id: &str) -> Result<(), Error> {
+        info!("Removing listener for module {}", module_id);
+
+        // If the container is removed, also remove the socket file to limit the leaking of socket file
+        let workload_uri = self.get_listener_uri(module_id)?;
+
+        let path = workload_uri.to_uds_file_path().map_err(|_| {
+            warn!("Could not convert uri {} to path", workload_uri);
+            ErrorKind::WorkloadManager
+        })?;
+
+        fs::remove_file(path).with_context(|_| {
+            warn!("Could not remove socket with uri {}", workload_uri);
+            ErrorKind::WorkloadManager
+        })?;
+
+        Ok(())
+    }
+}
+
+fn server<M, W>(
+    mut workload_manager: WorkloadManager<M, W>,
+    module_list: &[<M as ModuleRuntime>::Module],
+    create_socket_channel_rcv: UnboundedReceiver<ModuleAction>,
+) -> Result<(), Error>
+where
+    W: WorkloadConfig + Clone + Send + Sync + 'static,
+    M: ModuleRuntime + 'static + Authenticator<Request = Request<Body>> + Clone + Send + Sync,
+    <<M as Authenticator>::AuthenticateFuture as Future>::Error: Fail,
+    for<'r> &'r <M as ModuleRuntime>::Error: Into<ModuleRuntimeErrorReason>,
+    <<M as ModuleRuntime>::Module as Module>::Config: Clone + DeserializeOwned + Serialize,
+    <M as ModuleRuntime>::Logs: Into<Body>,
+{
+    // Spawn a listener for module that are still running and uses old listen socket
+    workload_manager.spawn_listener(
+        workload_manager.legacy_workload_uri.clone(),
+        None,
+        &String::new(),
+    )?;
+
+    // Spawn listeners for all module that are still running
+    module_list
+        .iter()
+        .try_for_each(|m: &<M as ModuleRuntime>::Module| -> Result<(), Error> {
+            workload_manager
+                .start(m.name(), None)
+                .map_err(|err| Error::from(err.context(ErrorKind::WorkloadService)))
+        })?;
+
+    // Ignore error, we don't want the server to close on error.
+    let server = create_socket_channel_rcv.for_each(move |module_id| match module_id {
+        ModuleAction::Start(module_id, sender) => {
+            workload_manager
+                .start(&module_id, Some(sender))
+                .unwrap_or(());
+            Ok(())
+        }
+        ModuleAction::Stop(module_id) => {
+            workload_manager.stop(&module_id).unwrap_or(());
+            Ok(())
+        }
+        ModuleAction::Remove(module_id) => {
+            workload_manager.remove(&module_id).unwrap_or(());
+            Ok(())
+        }
+    });
+
+    tokio::spawn(server);
+
+    Ok(())
+}

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -41,10 +41,10 @@ pub use error::{Error, ErrorKind};
 pub use identity::{AuthType, Identity, IdentityManager, IdentityOperation, IdentitySpec};
 pub use logs::{Chunked, LogChunk, LogDecode};
 pub use module::{
-    DiskInfo, ImagePullPolicy, LogOptions, LogTail, MakeModuleRuntime, Module, ModuleOperation,
-    ModuleRegistry, ModuleRuntime, ModuleRuntimeErrorReason, ModuleRuntimeState, ModuleSpec,
-    ModuleStatus, ModuleTop, ProvisioningInfo, RegistryOperation, RuntimeOperation, SystemInfo,
-    SystemResources,
+    DiskInfo, ImagePullPolicy, LogOptions, LogTail, MakeModuleRuntime, Module, ModuleAction,
+    ModuleOperation, ModuleRegistry, ModuleRuntime, ModuleRuntimeErrorReason, ModuleRuntimeState,
+    ModuleSpec, ModuleStatus, ModuleTop, ProvisioningInfo, RegistryOperation, RuntimeOperation,
+    SystemInfo, SystemResources,
 };
 pub use network::{Ipam, IpamConfig, MobyNetwork, Network};
 pub use parse_since::parse_since;

--- a/edgelet/edgelet-core/src/settings.rs
+++ b/edgelet/edgelet-core/src/settings.rs
@@ -7,7 +7,7 @@ use std::path::{Path, PathBuf};
 use std::str::FromStr;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use url::Url;
+use url::{ParseError, Url};
 
 use crate::module::ModuleSpec;
 
@@ -64,8 +64,16 @@ pub struct Listen {
 }
 
 impl Listen {
-    pub fn workload_uri(&self) -> &Url {
+    pub fn legacy_workload_uri(&self) -> &Url {
         &self.workload_uri
+    }
+
+    pub fn workload_mnt_uri(home_dir: &str) -> String {
+        "unix://".to_string() + home_dir + "/mnt"
+    }
+
+    pub fn workload_uri(home_dir: &str, module_id: &str) -> Result<Url, ParseError> {
+        Url::parse(&("unix://".to_string() + home_dir + "/mnt/" + module_id + ".sock"))
     }
 
     pub fn management_uri(&self) -> &Url {

--- a/edgelet/edgelet-docker/src/error.rs
+++ b/edgelet/edgelet-docker/src/error.rs
@@ -73,6 +73,9 @@ pub enum ErrorKind {
     #[fail(display = "Invalid socket URI: {:?}", _0)]
     InvalidSocketUri(String),
 
+    #[fail(display = "Invalid socket URI")]
+    InvalidHomeDirPath,
+
     #[fail(display = "{}", _0)]
     LaunchNotary(String),
 

--- a/edgelet/edgelet-docker/src/error.rs
+++ b/edgelet/edgelet-docker/src/error.rs
@@ -73,7 +73,7 @@ pub enum ErrorKind {
     #[fail(display = "Invalid socket URI: {:?}", _0)]
     InvalidSocketUri(String),
 
-    #[fail(display = "Invalid socket URI")]
+    #[fail(display = "Invalid home directory")]
     InvalidHomeDirPath,
 
     #[fail(display = "{}", _0)]

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -10,10 +10,13 @@ use std::time::Duration;
 use failure::{Fail, ResultExt};
 use futures::future::Either;
 use futures::prelude::*;
+use futures::sync::mpsc::UnboundedSender;
+use futures::sync::oneshot;
+use futures::sync::oneshot::{Receiver, Sender};
 use futures::{future, stream, Async, Stream};
 use hyper::{Body, Chunk as HyperChunk, Client, Request};
 use lazy_static::lazy_static;
-use log::{debug, info, warn, Level};
+use log::{debug, error, info, warn, Level};
 use url::Url;
 
 use docker::apis::client::APIClient;
@@ -21,9 +24,9 @@ use docker::apis::configuration::Configuration;
 use docker::models::{ContainerCreateBody, HostConfig, InlineResponse200, Ipam, NetworkConfig};
 use edgelet_core::{
     AuthId, Authenticator, Ipam as CoreIpam, LogOptions, MakeModuleRuntime, MobyNetwork, Module,
-    ModuleId, ModuleRegistry, ModuleRuntime, ModuleRuntimeState, ModuleSpec, ProvisioningInfo,
-    RegistryOperation, RuntimeOperation, RuntimeSettings, SystemInfo as CoreSystemInfo,
-    SystemResources, UrlExt,
+    ModuleAction, ModuleId, ModuleRegistry, ModuleRuntime, ModuleRuntimeState, ModuleSpec,
+    ProvisioningInfo, RegistryOperation, RuntimeOperation, RuntimeSettings,
+    SystemInfo as CoreSystemInfo, SystemResources, UrlExt,
 };
 use edgelet_http::{Pid, UrlConnector};
 use edgelet_utils::{ensure_not_empty_with_context, log_failure};
@@ -66,6 +69,7 @@ pub struct DockerModuleRuntime {
     notary_registries: BTreeMap<String, PathBuf>,
     notary_lock: tokio::sync::lock::Lock<BTreeMap<String, String>>,
     allow_elevated_docker_permissions: bool,
+    create_socket_channel: UnboundedSender<ModuleAction>,
 }
 
 impl DockerModuleRuntime {
@@ -247,7 +251,10 @@ impl MakeModuleRuntime for DockerModuleRuntime {
     type Error = Error;
     type Future = Box<dyn Future<Item = Self, Error = Self::Error> + Send>;
 
-    fn make_runtime(settings: Settings) -> Self::Future {
+    fn make_runtime(
+        settings: Settings,
+        create_socket_channel: UnboundedSender<ModuleAction>,
+    ) -> Self::Future {
         info!("Initializing module runtime...");
 
         let created = match init_client(settings.moby_runtime().uri()) {
@@ -350,6 +357,7 @@ impl MakeModuleRuntime for DockerModuleRuntime {
                             allow_elevated_docker_permissions: settings
                                 .base
                                 .allow_elevated_docker_permissions,
+                            create_socket_channel,
                         }
                     });
                 future::Either::A(fut)
@@ -618,23 +626,44 @@ impl ModuleRuntime for DockerModuleRuntime {
             return Box::new(future::err(Error::from(err)));
         }
 
+        let (signal_socket_created, receiver): (Sender<()>, Receiver<()>) = oneshot::channel();
+
+        if let Err(err) = self
+            .create_socket_channel
+            .unbounded_send(ModuleAction::Start(id.clone(), signal_socket_created))
+            .map_err(|_| {
+                Error::from(ErrorKind::RuntimeOperation(RuntimeOperation::GetModule(
+                    id.clone(),
+                )))
+            })
+        {
+            return Box::new(future::err(err));
+        }
+
+        let future = self.client.container_api().container_start(&id, "");
+
+        let id2 = id.clone();
+
         Box::new(
-            self.client
-                .container_api()
-                .container_start(&id, "")
-                .then(|result| match result {
-                    Ok(_) => {
-                        info!("Successfully started module {}", id);
-                        Ok(())
-                    }
-                    Err(err) => {
-                        let err = Error::from_docker_error(
-                            err,
-                            ErrorKind::RuntimeOperation(RuntimeOperation::StartModule(id)),
-                        );
-                        log_failure(Level::Warn, &err);
-                        Err(err)
-                    }
+            receiver
+                .map_err(move |_| {
+                    Error::from(ErrorKind::RuntimeOperation(RuntimeOperation::GetModule(id)))
+                })
+                .and_then(move |()| {
+                    future.then(move |result| match result {
+                        Ok(_) => {
+                            info!("Successfully started module {}", id2);
+                            Ok(())
+                        }
+                        Err(err) => {
+                            let err = Error::from_docker_error(
+                                err,
+                                ErrorKind::RuntimeOperation(RuntimeOperation::StartModule(id2)),
+                            );
+                            log_failure(Level::Warn, &err);
+                            Err(err)
+                        }
+                    })
                 }),
         )
     }
@@ -655,14 +684,26 @@ impl ModuleRuntime for DockerModuleRuntime {
             s => s as i32,
         });
 
+        let create_socket_channel = self.create_socket_channel.clone();
         Box::new(
             self.client
                 .container_api()
                 .container_stop(&id, wait_timeout)
-                .then(|result| match result {
+                .then(move |result| match result {
                     Ok(_) => {
-                        info!("Successfully stopped module {}", id);
-                        Ok(())
+                        match create_socket_channel.unbounded_send(ModuleAction::Stop(id.clone())) {
+                            Ok(()) => {
+                                info!("Successfully stoppedmodule {}", id);
+                                Ok(())
+                            },
+                            Err(err) => {
+                                log_failure(Level::Warn, &err);
+                                info!("Successfully stoppedmodule {}, but could not stop listener on socket", id);
+                                Err(Error::from(ErrorKind::RuntimeOperation(
+                                    RuntimeOperation::GetModule(id),
+                                )))
+                            }
+                        }
                     }
                     Err(err) => {
                         let err = Error::from_docker_error(
@@ -718,6 +759,8 @@ impl ModuleRuntime for DockerModuleRuntime {
             return Box::new(future::err(Error::from(err)));
         }
 
+        let create_socket_channel = self.create_socket_channel.clone();
+
         Box::new(
             self.client
                 .container_api()
@@ -725,10 +768,25 @@ impl ModuleRuntime for DockerModuleRuntime {
                     &id, /* remove volumes */ false, /* force */ true,
                     /* remove link */ false,
                 )
-                .then(|result| match result {
+                .then(move |result| match result {
                     Ok(_) => {
-                        info!("Successfully removed module {}", id);
-                        Ok(())
+                        match create_socket_channel.unbounded_send(ModuleAction::Remove(id.clone()))
+                        {
+                            Ok(()) => {
+                                info!("Successfully removed module {}", id);
+                                Ok(())
+                            }
+                            Err(err) => {
+                                log_failure(Level::Warn, &err);
+                                error!(
+                                    "Successfully removed module {}, but could not remove socket",
+                                    id
+                                );
+                                Err(Error::from(ErrorKind::RuntimeOperation(
+                                    RuntimeOperation::GetModule(id),
+                                )))
+                            }
+                        }
                     }
                     Err(err) => {
                         let err = Error::from_docker_error(
@@ -1354,6 +1412,7 @@ mod tests {
 
     use std::path::Path;
 
+    use edgelet_core::ModuleAction;
     use futures::future::FutureResult;
     use futures::stream::Empty;
 
@@ -1361,6 +1420,7 @@ mod tests {
         settings::AutoReprovisioningMode, Connect, Endpoints, Listen, ModuleRegistry, ModuleTop,
         RuntimeSettings, WatchdogSettings,
     };
+    use futures::sync::mpsc::UnboundedSender;
 
     #[test]
     fn merge_env_empty() {
@@ -1740,7 +1800,10 @@ mod tests {
         type Error = Error;
         type Future = FutureResult<Self, Self::Error>;
 
-        fn make_runtime(_settings: Self::Settings) -> Self::Future {
+        fn make_runtime(
+            _settings: Self::Settings,
+            _recv: UnboundedSender<ModuleAction>,
+        ) -> Self::Future {
             unimplemented!()
         }
     }

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -626,11 +626,11 @@ impl ModuleRuntime for DockerModuleRuntime {
             return Box::new(future::err(Error::from(err)));
         }
 
-        let (signal_socket_created, receiver): (Sender<()>, Receiver<()>) = oneshot::channel();
+        let (sender, receiver): (Sender<()>, Receiver<()>) = oneshot::channel();
 
         if let Err(err) = self
             .create_socket_channel
-            .unbounded_send(ModuleAction::Start(id.clone(), signal_socket_created))
+            .unbounded_send(ModuleAction::Start(id.clone(), sender))
             .map_err(|_| {
                 Error::from(ErrorKind::RuntimeOperation(RuntimeOperation::GetModule(
                     id.clone(),

--- a/edgelet/edgelet-docker/src/settings.rs
+++ b/edgelet/edgelet-docker/src/settings.rs
@@ -176,20 +176,30 @@ fn agent_vol_mount(settings: &mut Settings) -> Result<(), LoadSettingsError> {
         .unwrap_or_else(HostConfig::new);
     let mut binds = host_config.binds().map_or_else(Vec::new, ToOwned::to_owned);
 
+    let home_dir = settings
+        .homedir()
+        .to_str()
+        .ok_or_else(|| ErrorKind::InvalidHomeDirPath)?;
+
+    let workload_listen_uri = &Listen::workload_uri(home_dir, settings.agent().name())
+        .map_err(|err| err.context(ErrorKind::InvalidHomeDirPath))?;
+
+    let workload_connect_uri = settings.connect().workload_uri();
+
+    let management_listen_uri = settings.connect().management_uri();
+
+    let management_connect_uri = settings.connect().management_uri();
+
     // if the url is a domain socket URL then vol mount it into the container
-    for uri in &[
-        settings.connect().management_uri(),
-        settings.connect().workload_uri(),
+    for (listen_uri, connect_uri) in &[
+        (management_listen_uri, management_connect_uri),
+        (workload_listen_uri, workload_connect_uri),
     ] {
-        if uri.scheme() == UNIX_SCHEME {
-            let path = uri
-                .to_uds_file_path()
-                .context(ErrorKind::InvalidSocketUri(uri.to_string()))?;
-            let path = path
-                .to_str()
-                .ok_or_else(|| ErrorKind::InvalidSocketUri(uri.to_string()))?
-                .to_string();
-            let bind = format!("{}:{}", &path, &path);
+        if connect_uri.scheme() == UNIX_SCHEME {
+            let source_path = get_path_from_uri(listen_uri)?;
+            let target_path = get_path_from_uri(connect_uri)?;
+
+            let bind = format!("{}:{}", &source_path, &target_path);
             if !binds.contains(&bind) {
                 binds.push(bind);
             }
@@ -207,6 +217,16 @@ fn agent_vol_mount(settings: &mut Settings) -> Result<(), LoadSettingsError> {
     }
 
     Ok(())
+}
+
+fn get_path_from_uri(uri: &Url) -> Result<String, LoadSettingsError> {
+    let path = uri
+        .to_uds_file_path()
+        .context(ErrorKind::InvalidSocketUri(uri.to_string()))?;
+    Ok(path
+        .to_str()
+        .ok_or_else(|| ErrorKind::InvalidSocketUri(uri.to_string()))?
+        .to_string())
 }
 
 fn agent_env(settings: &mut Settings) {

--- a/edgelet/edgelet-docker/tests/runtime.rs
+++ b/edgelet/edgelet-docker/tests/runtime.rs
@@ -942,7 +942,7 @@ network = "azure-iot-edge"
                 sender.send(()).unwrap();
                 Ok(())
             }
-            ModuleAction::Stop(_module_id) => Ok(()),
+            ModuleAction::Stop(_module_id) | ModuleAction::Remove(_module_id) => Ok(()),
         });
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();

--- a/edgelet/edgelet-docker/tests/runtime.rs
+++ b/edgelet/edgelet-docker/tests/runtime.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use failure::Fail;
 use futures::future;
 use futures::prelude::*;
+use futures::sync::mpsc;
 use hyper::{Body, Method, Request, Response, StatusCode};
 use maplit::btreemap;
 use serde_json::{self, json};
@@ -25,8 +26,8 @@ use docker::models::{
 };
 
 use edgelet_core::{
-    ImagePullPolicy, LogOptions, LogTail, MakeModuleRuntime, Module, ModuleRegistry, ModuleRuntime,
-    ModuleSpec, RegistryOperation, RuntimeOperation,
+    ImagePullPolicy, LogOptions, LogTail, MakeModuleRuntime, Module, ModuleAction, ModuleRegistry,
+    ModuleRuntime, ModuleSpec, RegistryOperation, RuntimeOperation,
 };
 use edgelet_docker::{DockerConfig, DockerModuleRuntime, Settings};
 use edgelet_docker::{Error, ErrorKind};
@@ -230,23 +231,26 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| {
-        let auth = AuthConfig::new()
-            .with_username("u1".to_string())
-            .with_password("bleh".to_string())
-            .with_email("u1@bleh.com".to_string())
-            .with_serveraddress("svr1".to_string());
-        let config = DockerConfig::new(
-            INVALID_IMAGE_NAME.to_string(),
-            ContainerCreateBody::new(),
-            None,
-            Some(auth),
-        )
-        .unwrap();
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd).and_then(
+        |runtime| {
+            let auth = AuthConfig::new()
+                .with_username("u1".to_string())
+                .with_password("bleh".to_string())
+                .with_email("u1@bleh.com".to_string())
+                .with_serveraddress("svr1".to_string());
+            let config = DockerConfig::new(
+                INVALID_IMAGE_NAME.to_string(),
+                ContainerCreateBody::new(),
+                None,
+                Some(auth),
+            )
+            .unwrap();
 
-        runtime.pull(&config)
-    });
+            runtime.pull(&config)
+        },
+    );
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -334,23 +338,26 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| {
-        let auth = AuthConfig::new()
-            .with_username("u1".to_string())
-            .with_password("bleh".to_string())
-            .with_email("u1@bleh.com".to_string())
-            .with_serveraddress("svr1".to_string());
-        let config = DockerConfig::new(
-            INVALID_IMAGE_HOST.to_string(),
-            ContainerCreateBody::new(),
-            None,
-            Some(auth),
-        )
-        .unwrap();
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd).and_then(
+        |runtime| {
+            let auth = AuthConfig::new()
+                .with_username("u1".to_string())
+                .with_password("bleh".to_string())
+                .with_email("u1@bleh.com".to_string())
+                .with_serveraddress("svr1".to_string());
+            let config = DockerConfig::new(
+                INVALID_IMAGE_HOST.to_string(),
+                ContainerCreateBody::new(),
+                None,
+                Some(auth),
+            )
+            .unwrap();
 
-        runtime.pull(&config)
-    });
+            runtime.pull(&config)
+        },
+    );
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -452,24 +459,27 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| {
-        // password is written to guarantee base64 encoding has '-' and/or '_'
-        let auth = AuthConfig::new()
-            .with_username("us1".to_string())
-            .with_password("ac?ac~aaac???".to_string())
-            .with_email("u1@bleh.com".to_string())
-            .with_serveraddress("svr1".to_string());
-        let config = DockerConfig::new(
-            IMAGE_NAME.to_string(),
-            ContainerCreateBody::new(),
-            None,
-            Some(auth),
-        )
-        .unwrap();
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd).and_then(
+        |runtime| {
+            // password is written to guarantee base64 encoding has '-' and/or '_'
+            let auth = AuthConfig::new()
+                .with_username("us1".to_string())
+                .with_password("ac?ac~aaac???".to_string())
+                .with_email("u1@bleh.com".to_string())
+                .with_serveraddress("svr1".to_string());
+            let config = DockerConfig::new(
+                IMAGE_NAME.to_string(),
+                ContainerCreateBody::new(),
+                None,
+                Some(auth),
+            )
+            .unwrap();
 
-        runtime.pull(&config)
-    });
+            runtime.pull(&config)
+        },
+    );
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -554,23 +564,26 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| {
-        let auth = AuthConfig::new()
-            .with_username("u1".to_string())
-            .with_password("bleh".to_string())
-            .with_email("u1@bleh.com".to_string())
-            .with_serveraddress("svr1".to_string());
-        let config = DockerConfig::new(
-            IMAGE_NAME.to_string(),
-            ContainerCreateBody::new(),
-            None,
-            Some(auth),
-        )
-        .unwrap();
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd).and_then(
+        |runtime| {
+            let auth = AuthConfig::new()
+                .with_username("u1".to_string())
+                .with_password("bleh".to_string())
+                .with_email("u1@bleh.com".to_string())
+                .with_serveraddress("svr1".to_string());
+            let config = DockerConfig::new(
+                IMAGE_NAME.to_string(),
+                ContainerCreateBody::new(),
+                None,
+                Some(auth),
+            )
+            .unwrap();
 
-        runtime.pull(&config)
-    });
+            runtime.pull(&config)
+        },
+    );
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -644,22 +657,26 @@ network = "azure-iot-edge"
         port
     ));
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| {
-        let auth = AuthConfig::new()
-            .with_username("u1".to_string())
-            .with_password("bleh".to_string())
-            .with_email("u1@bleh.com".to_string())
-            .with_serveraddress("svr1".to_string());
-        let config = DockerConfig::new(
-            IMAGE_NAME.to_string(),
-            ContainerCreateBody::new(),
-            None,
-            Some(auth),
-        )
-        .unwrap();
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-        runtime.pull(&config)
-    });
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd).and_then(
+        |runtime| {
+            let auth = AuthConfig::new()
+                .with_username("u1".to_string())
+                .with_password("bleh".to_string())
+                .with_email("u1@bleh.com".to_string())
+                .with_serveraddress("svr1".to_string());
+            let config = DockerConfig::new(
+                IMAGE_NAME.to_string(),
+                ContainerCreateBody::new(),
+                None,
+                Some(auth),
+            )
+            .unwrap();
+
+            runtime.pull(&config)
+        },
+    );
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -710,7 +727,9 @@ network = "azure-iot-edge"
         port
     ));
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| ModuleRegistry::remove(&runtime, IMAGE_NAME));
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
@@ -824,53 +843,57 @@ network = "azure-iot-edge"
         port
     ));
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| {
-        let mut env = BTreeMap::new();
-        env.insert("k1".to_string(), "v1".to_string());
-        env.insert("k2".to_string(), "v2".to_string());
-        env.insert("k3".to_string(), "v3".to_string());
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-        // add some create options
-        let mut port_bindings = BTreeMap::new();
-        port_bindings.insert(
-            "22/tcp".to_string(),
-            vec![HostConfigPortBindings::new().with_host_port("11022".to_string())],
-        );
-        port_bindings.insert(
-            "80/tcp".to_string(),
-            vec![HostConfigPortBindings::new().with_host_port("8080".to_string())],
-        );
-        let memory: i64 = 3_221_225_472;
-        let mut volumes = ::std::collections::BTreeMap::new();
-        volumes.insert("test1".to_string(), json!({}));
-        let create_options = ContainerCreateBody::new()
-            .with_host_config(
-                HostConfig::new()
-                    .with_port_bindings(port_bindings)
-                    .with_memory(memory),
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd).and_then(
+        |runtime| {
+            let mut env = BTreeMap::new();
+            env.insert("k1".to_string(), "v1".to_string());
+            env.insert("k2".to_string(), "v2".to_string());
+            env.insert("k3".to_string(), "v3".to_string());
+
+            // add some create options
+            let mut port_bindings = BTreeMap::new();
+            port_bindings.insert(
+                "22/tcp".to_string(),
+                vec![HostConfigPortBindings::new().with_host_port("11022".to_string())],
+            );
+            port_bindings.insert(
+                "80/tcp".to_string(),
+                vec![HostConfigPortBindings::new().with_host_port("8080".to_string())],
+            );
+            let memory: i64 = 3_221_225_472;
+            let mut volumes = ::std::collections::BTreeMap::new();
+            volumes.insert("test1".to_string(), json!({}));
+            let create_options = ContainerCreateBody::new()
+                .with_host_config(
+                    HostConfig::new()
+                        .with_port_bindings(port_bindings)
+                        .with_memory(memory),
+                )
+                .with_cmd(vec![
+                    "/do/the/custom/command".to_string(),
+                    "with these args".to_string(),
+                ])
+                .with_entrypoint(vec![
+                    "/also/do/the/entrypoint".to_string(),
+                    "and this".to_string(),
+                ])
+                .with_env(vec!["k4=v4".to_string(), "k5=v5".to_string()])
+                .with_volumes(volumes);
+
+            let module_config = ModuleSpec::new(
+                "m1".to_string(),
+                "docker".to_string(),
+                DockerConfig::new("nginx:latest".to_string(), create_options, None, None).unwrap(),
+                env,
+                ImagePullPolicy::default(),
             )
-            .with_cmd(vec![
-                "/do/the/custom/command".to_string(),
-                "with these args".to_string(),
-            ])
-            .with_entrypoint(vec![
-                "/also/do/the/entrypoint".to_string(),
-                "and this".to_string(),
-            ])
-            .with_env(vec!["k4=v4".to_string(), "k5=v5".to_string()])
-            .with_volumes(volumes);
+            .unwrap();
 
-        let module_config = ModuleSpec::new(
-            "m1".to_string(),
-            "docker".to_string(),
-            DockerConfig::new("nginx:latest".to_string(), create_options, None, None).unwrap(),
-            env,
-            ImagePullPolicy::default(),
-        )
-        .unwrap();
-
-        runtime.create(module_config)
-    });
+            runtime.create(module_config)
+        },
+    );
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -908,10 +931,24 @@ network = "azure-iot-edge"
         port
     ));
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| runtime.start("m1"));
+    let (create_socket_channel_snd, create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
+        .and_then(|runtime| runtime.start("m1"));
+
+    let simulate_workload_manager =
+        create_socket_channel_rcv.for_each(move |module_id: ModuleAction| match module_id {
+            ModuleAction::Start(_module_id, sender) => {
+                sender.send(()).unwrap();
+                Ok(())
+            }
+            ModuleAction::Stop(_module_id) => Ok(()),
+        });
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
+    runtime.spawn(simulate_workload_manager);
+
     runtime.block_on(task).unwrap();
 }
 
@@ -946,8 +983,10 @@ network = "azure-iot-edge"
         port
     ));
 
-    let task =
-        DockerModuleRuntime::make_runtime(settings).and_then(|runtime| runtime.stop("m1", None));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
+        .and_then(|runtime| runtime.stop("m1", None));
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -985,8 +1024,9 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.stop("m1", Some(Duration::from_secs(600))));
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
@@ -1024,8 +1064,9 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| ModuleRuntime::remove(&runtime, "m1"));
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
@@ -1146,8 +1187,10 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| runtime.list());
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
+        .and_then(|runtime| runtime.list());
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -1229,16 +1272,19 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task = DockerModuleRuntime::make_runtime(settings).and_then(|runtime| {
-        let options = LogOptions::new()
-            .with_follow(true)
-            .with_tail(LogTail::All)
-            .with_since(100_000)
-            .with_until(200_000);
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd).and_then(
+        |runtime| {
+            let options = LogOptions::new()
+                .with_follow(true)
+                .with_tail(LogTail::All)
+                .with_since(100_000)
+                .with_until(200_000);
 
-        runtime.logs("mod1", &options)
-    });
+            runtime.logs("mod1", &options)
+        },
+    );
 
     let expected_body = [
         0x01_u8, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0d, 0x52, 0x6f, 0x73, 0x65, 0x73, 0x20,
@@ -1273,7 +1319,9 @@ network = "azure-iot-edge"
 
     let image_name = "     ";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| ModuleRegistry::remove(&runtime, image_name))
         .then(|res| match res {
             Ok(_) => Err("Expected error but got a result.".to_string()),
@@ -1311,7 +1359,9 @@ network = "azure-iot-edge"
 
     let name = "not_docker";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| {
             let module_config = ModuleSpec::new(
                 "m1".to_string(),
@@ -1359,7 +1409,9 @@ network = "azure-iot-edge"
 
     let name = "";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.start(name))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1395,7 +1447,9 @@ network = "azure-iot-edge"
 
     let name = "      ";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.start(name))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1431,7 +1485,9 @@ network = "azure-iot-edge"
 
     let name = "";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.stop(name, None))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1467,7 +1523,9 @@ network = "azure-iot-edge"
 
     let name = "     ";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.stop(name, None))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1503,7 +1561,9 @@ network = "azure-iot-edge"
 
     let name = "";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.restart(name))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1539,7 +1599,9 @@ network = "azure-iot-edge"
 
     let name = "      ";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.restart(name))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1575,7 +1637,9 @@ network = "azure-iot-edge"
 
     let name = "";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| ModuleRuntime::remove(&runtime, name))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1611,7 +1675,9 @@ network = "azure-iot-edge"
 
     let name = "      ";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| ModuleRuntime::remove(&runtime, name))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1647,7 +1713,9 @@ network = "azure-iot-edge"
 
     let name = "";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.get(name))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1683,7 +1751,9 @@ network = "azure-iot-edge"
 
     let name = "    ";
 
-    let task = DockerModuleRuntime::make_runtime(settings)
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
+
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
         .and_then(|runtime| runtime.get(name))
         .then(|result| match result {
             Ok(_) => panic!("Expected test to fail but it didn't!"),
@@ -1735,9 +1805,10 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
     //act
-    let task = DockerModuleRuntime::make_runtime(settings);
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd);
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -1815,9 +1886,10 @@ ip_range = "172.20.0.0/24"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
     //act
-    let task = DockerModuleRuntime::make_runtime(settings);
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd);
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -1879,9 +1951,10 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
     //act
-    let task = DockerModuleRuntime::make_runtime(settings);
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd);
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -1944,9 +2017,10 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task =
-        DockerModuleRuntime::make_runtime(settings).and_then(|runtime| runtime.system_info());
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
+        .and_then(|runtime| runtime.system_info());
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);
@@ -2004,9 +2078,10 @@ network = "azure-iot-edge"
 "#,
         port
     ));
+    let (create_socket_channel_snd, _create_socket_channel_rcv) = mpsc::unbounded::<ModuleAction>();
 
-    let task =
-        DockerModuleRuntime::make_runtime(settings).and_then(|runtime| runtime.system_info());
+    let task = DockerModuleRuntime::make_runtime(settings, create_socket_channel_snd)
+        .and_then(|runtime| runtime.system_info());
 
     let mut runtime = tokio::runtime::current_thread::Runtime::new().unwrap();
     runtime.spawn(server);

--- a/edgelet/edgelet-http-mgmt/src/server/module/delete.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/delete.rs
@@ -63,9 +63,10 @@ where
 mod tests {
     use chrono::prelude::*;
 
-    use edgelet_core::{MakeModuleRuntime, ModuleRuntimeState, ModuleStatus};
+    use edgelet_core::{MakeModuleRuntime, ModuleAction, ModuleRuntimeState, ModuleStatus};
     use edgelet_http::route::Parameters;
     use edgelet_test_utils::module::{TestConfig, TestModule, TestRuntime, TestSettings};
+    use futures::sync::mpsc;
 
     use super::{Body, DeleteModule, Future, Handler, Request, StatusCode};
     use crate::server::module::tests::Error;
@@ -83,7 +84,10 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));
@@ -114,7 +118,11 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));

--- a/edgelet/edgelet-http-mgmt/src/server/module/list.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/list.rs
@@ -98,10 +98,10 @@ where
 #[cfg(test)]
 mod tests {
     use chrono::prelude::*;
-    use edgelet_core::{MakeModuleRuntime, ModuleRuntimeState, ModuleStatus};
+    use edgelet_core::{MakeModuleRuntime, ModuleAction, ModuleRuntimeState, ModuleStatus};
     use edgelet_http::route::Parameters;
     use edgelet_test_utils::module::{TestConfig, TestModule, TestRuntime, TestSettings};
-    use futures::Stream;
+    use futures::{sync::mpsc, Stream};
     use management::models::{ErrorResponse, ModuleList};
 
     use super::{Body, Future, Handler, ListModules, Request};
@@ -120,7 +120,10 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));
@@ -172,7 +175,10 @@ mod tests {
     #[test]
     fn list_failed() {
         // arrange
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Err(Error::General));
@@ -205,7 +211,10 @@ mod tests {
         // arrange
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module = TestModule::new("test-module".to_string(), config, Err(Error::General));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));

--- a/edgelet/edgelet-http-mgmt/src/server/module/logs.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/logs.rs
@@ -116,9 +116,9 @@ fn parse_options(query: &str) -> Result<LogOptions, Error> {
 #[cfg(test)]
 mod tests {
     use chrono::prelude::*;
-    use edgelet_core::{MakeModuleRuntime, ModuleRuntimeState, ModuleStatus};
+    use edgelet_core::{MakeModuleRuntime, ModuleAction, ModuleRuntimeState, ModuleStatus};
     use edgelet_test_utils::module::{TestConfig, TestModule, TestRuntime, TestSettings};
-    use futures::Stream;
+    use futures::{sync::mpsc, Stream};
     use management::models::ErrorResponse;
 
     use super::{
@@ -193,7 +193,10 @@ mod tests {
             Ok(state),
             vec![&[b'A', b'B', b'C']],
         );
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));
@@ -222,7 +225,10 @@ mod tests {
 
     #[test]
     fn runtime_error() {
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Err(Error::General));
@@ -265,7 +271,10 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));

--- a/edgelet/edgelet-http-mgmt/src/server/module/restart.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/restart.rs
@@ -62,9 +62,10 @@ where
 #[cfg(test)]
 mod tests {
     use chrono::prelude::*;
-    use edgelet_core::{MakeModuleRuntime, ModuleRuntimeState, ModuleStatus};
+    use edgelet_core::{MakeModuleRuntime, ModuleAction, ModuleRuntimeState, ModuleStatus};
     use edgelet_http::route::Parameters;
     use edgelet_test_utils::module::{TestConfig, TestModule, TestRuntime, TestSettings};
+    use futures::sync::mpsc;
 
     use super::{Body, Future, Handler, Request, RestartModule, StatusCode};
     use crate::server::module::tests::Error;
@@ -82,7 +83,10 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));
@@ -113,7 +117,10 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));

--- a/edgelet/edgelet-http-mgmt/src/server/module/start.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/start.rs
@@ -62,9 +62,10 @@ where
 #[cfg(test)]
 mod tests {
     use chrono::prelude::*;
-    use edgelet_core::{MakeModuleRuntime, ModuleRuntimeState, ModuleStatus};
+    use edgelet_core::{MakeModuleRuntime, ModuleAction, ModuleRuntimeState, ModuleStatus};
     use edgelet_http::route::Parameters;
     use edgelet_test_utils::module::{TestConfig, TestModule, TestRuntime, TestSettings};
+    use futures::sync::mpsc;
 
     use super::{Body, Future, Handler, Request, StartModule, StatusCode};
     use crate::server::module::tests::Error;
@@ -82,7 +83,10 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));
@@ -113,7 +117,11 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));

--- a/edgelet/edgelet-http-mgmt/src/server/module/stop.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/stop.rs
@@ -62,9 +62,10 @@ where
 #[cfg(test)]
 mod tests {
     use chrono::prelude::*;
-    use edgelet_core::{MakeModuleRuntime, ModuleRuntimeState, ModuleStatus};
+    use edgelet_core::{MakeModuleRuntime, ModuleAction, ModuleRuntimeState, ModuleStatus};
     use edgelet_http::route::Parameters;
     use edgelet_test_utils::module::{TestConfig, TestModule, TestRuntime, TestSettings};
+    use futures::sync::mpsc;
 
     use super::{Body, Future, Handler, Request, StatusCode, StopModule};
     use crate::server::module::tests::Error;
@@ -82,7 +83,10 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));
@@ -113,7 +117,11 @@ mod tests {
         let config = TestConfig::new("microsoft/test-image".to_string());
         let module: TestModule<Error, _> =
             TestModule::new("test-module".to_string(), config, Ok(state));
-        let runtime = TestRuntime::make_runtime(TestSettings::new())
+
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        let runtime = TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module));

--- a/edgelet/edgelet-http/examples/identities.rs
+++ b/edgelet/edgelet-http/examples/identities.rs
@@ -92,7 +92,7 @@ fn main() {
     let addr = "tcp://0.0.0.0:8080".parse().unwrap();
 
     println!("Starting server on {}", addr);
-    let run = Http::new().bind_url(addr, router).unwrap().run();
+    let run = Http::new().bind_url(addr, router, 0o666).unwrap().run();
 
     tokio::runtime::current_thread::Runtime::new()
         .unwrap()

--- a/edgelet/edgelet-http/src/lib.rs
+++ b/edgelet/edgelet-http/src/lib.rs
@@ -274,7 +274,12 @@ where
 }
 
 pub trait HyperExt {
-    fn bind_url<S>(&self, url: Url, new_service: S) -> Result<Server<S>, Error>
+    fn bind_url<S>(
+        &self,
+        url: Url,
+        new_service: S,
+        unix_socket_permission: u32,
+    ) -> Result<Server<S>, Error>
     where
         S: NewService<ReqBody = Body>;
 }
@@ -282,7 +287,12 @@ pub trait HyperExt {
 // This variable is used on Unix but not Windows
 impl HyperExt for Http {
     #[cfg_attr(not(unix), allow(unused_variables))]
-    fn bind_url<S>(&self, url: Url, new_service: S) -> Result<Server<S>, Error>
+    fn bind_url<S>(
+        &self,
+        url: Url,
+        new_service: S,
+        unix_socket_permission: u32,
+    ) -> Result<Server<S>, Error>
     where
         S: NewService<ReqBody = Body>,
     {
@@ -304,7 +314,7 @@ impl HyperExt for Http {
                 let path = url
                     .to_uds_file_path()
                     .map_err(|_| ErrorKind::InvalidUrl(url.to_string()))?;
-                unix::listener(path)?
+                unix::listener(path, unix_socket_permission)?
             }
             #[cfg(target_os = "linux")]
             FD_SCHEME => {

--- a/edgelet/edgelet-http/src/unix.rs
+++ b/edgelet/edgelet-http/src/unix.rs
@@ -18,9 +18,7 @@ use tokio_uds::UnixListener;
 use crate::error::{Error, ErrorKind};
 use crate::util::{incoming::Incoming, socket_file_exists};
 
-const SOCKET_DEFAULT_PERMISSION: u32 = 0o666;
-
-pub fn listener<P: AsRef<Path>>(path: P) -> Result<Incoming, Error> {
+pub fn listener<P: AsRef<Path>>(path: P, unix_socket_permission: u32) -> Result<Incoming, Error> {
     let listener = if socket_file_exists(path.as_ref()) {
         // get the previous file's metadata
         #[cfg(unix)]
@@ -59,7 +57,7 @@ pub fn listener<P: AsRef<Path>>(path: P) -> Result<Incoming, Error> {
 
         fs::set_permissions(
             path.as_ref(),
-            fs::Permissions::from_mode(SOCKET_DEFAULT_PERMISSION),
+            fs::Permissions::from_mode(unix_socket_permission),
         )
         .map_err(|err| {
             error!("Cannot set directory permissions: {}", err);
@@ -124,7 +122,7 @@ mod tests {
         assert_eq!(0o600, file.metadata().unwrap().mode() & 0o7777);
         drop(file);
 
-        let listener = listener(&path).unwrap();
+        let listener = listener(&path, 0o666).unwrap();
         let _srv = listener.for_each(move |(_socket, _addr)| Ok(()));
 
         let file_stat = stat(&path).unwrap();

--- a/edgelet/edgelet-http/src/unix.rs
+++ b/edgelet/edgelet-http/src/unix.rs
@@ -3,10 +3,11 @@
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::MetadataExt;
+use std::os::unix::prelude::PermissionsExt;
 use std::path::Path;
 
 use failure::ResultExt;
-use log::debug;
+use log::{debug, error};
 #[cfg(unix)]
 use nix::sys::stat::{umask, Mode};
 #[cfg(unix)]
@@ -16,6 +17,8 @@ use tokio_uds::UnixListener;
 
 use crate::error::{Error, ErrorKind};
 use crate::util::{incoming::Incoming, socket_file_exists};
+
+const SOCKET_DEFAULT_PERMISSION: u32 = 0o666;
 
 pub fn listener<P: AsRef<Path>>(path: P) -> Result<Incoming, Error> {
     let listener = if socket_file_exists(path.as_ref()) {
@@ -34,14 +37,35 @@ pub fn listener<P: AsRef<Path>>(path: P) -> Result<Incoming, Error> {
         defer! {{ umask(prev); }}
 
         debug!("binding {}...", path.as_ref().display());
+
         let listener = UnixListener::bind(&path)
             .with_context(|_| ErrorKind::Path(path.as_ref().display().to_string()))?;
         debug!("bound {}", path.as_ref().display());
 
         Incoming::Unix(listener)
     } else {
+        // If parent doesn't exist, create it and socket will be created inside.
+        if let Some(parent) = path.as_ref().parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent).with_context(|err| {
+                    error!("Cannot create directory, error: {}", err);
+                    ErrorKind::Path(path.as_ref().display().to_string())
+                })?;
+            }
+        }
+
         let listener = UnixListener::bind(&path)
             .with_context(|_| ErrorKind::Path(path.as_ref().display().to_string()))?;
+
+        fs::set_permissions(
+            path.as_ref(),
+            fs::Permissions::from_mode(SOCKET_DEFAULT_PERMISSION),
+        )
+        .map_err(|err| {
+            error!("Cannot set directory permissions: {}", err);
+            ErrorKind::Path(path.as_ref().display().to_string())
+        })?;
+
         Incoming::Unix(listener)
     };
 

--- a/edgelet/edgelet-http/tests/systemd.rs
+++ b/edgelet/edgelet-http/tests/systemd.rs
@@ -96,13 +96,17 @@ fn test_fd_ok() {
     env::set_var(ENV_FDS, format!("{}", fd - LISTEN_FDS_START + 1));
 
     let url = Url::parse(&format!("fd://{}", fd - LISTEN_FDS_START)).unwrap();
-    let run = Http::new().bind_url(url, move || {
-        let service = TestService {
-            status_code: StatusCode::OK,
-            error: false,
-        };
-        Ok::<_, io::Error>(service)
-    });
+    let run = Http::new().bind_url(
+        url,
+        move || {
+            let service = TestService {
+                status_code: StatusCode::OK,
+                error: false,
+            };
+            Ok::<_, io::Error>(service)
+        },
+        0o666,
+    );
     if let Err(err) = run {
         unistd::close(fd).unwrap();
         panic!("{:?}", err);
@@ -125,13 +129,17 @@ fn test_fd_err() {
     env::set_var(ENV_FDS, format!("{}", fd - listen_fds_start + 1));
 
     let url = Url::parse("fd://100").unwrap();
-    let run = Http::new().bind_url(url, move || {
-        let service = TestService {
-            status_code: StatusCode::OK,
-            error: false,
-        };
-        Ok::<_, io::Error>(service)
-    });
+    let run = Http::new().bind_url(
+        url,
+        move || {
+            let service = TestService {
+                status_code: StatusCode::OK,
+                error: false,
+            };
+            Ok::<_, io::Error>(service)
+        },
+        0o666,
+    );
 
     unistd::close(fd).unwrap();
     assert!(run.is_err());

--- a/edgelet/edgelet-test-utils/src/module.rs
+++ b/edgelet/edgelet-test-utils/src/module.rs
@@ -2,6 +2,7 @@ use std::marker::PhantomData;
 use std::path::Path;
 use std::time::Duration;
 
+use edgelet_core::ModuleAction;
 use edgelet_core::{
     settings::AutoReprovisioningMode, AuthId, Authenticator, Connect, DiskInfo, Endpoints, Listen,
     LogOptions, MakeModuleRuntime, Module, ModuleRegistry, ModuleRuntime, ModuleRuntimeState,
@@ -11,6 +12,7 @@ use failure::Fail;
 use futures::future::{self, FutureResult};
 use futures::prelude::*;
 use futures::stream;
+use futures::sync::mpsc::UnboundedSender;
 use futures::IntoFuture;
 use hyper::{Body, Request};
 
@@ -298,7 +300,10 @@ where
     type Error = E;
     type Future = FutureResult<Self, Self::Error>;
 
-    fn make_runtime(settings: Self::Settings) -> Self::Future {
+    fn make_runtime(
+        settings: Self::Settings,
+        _create_socket_channel: UnboundedSender<ModuleAction>,
+    ) -> Self::Future {
         future::ok(TestRuntime {
             module: None,
             registry: TestRegistry::new(None),

--- a/edgelet/support-bundle/src/support_bundle.rs
+++ b/edgelet/support-bundle/src/support_bundle.rs
@@ -490,6 +490,8 @@ mod tests {
     use std::path::PathBuf;
     use std::str;
 
+    use edgelet_core::ModuleAction;
+    use futures::sync::mpsc;
     use regex::Regex;
     use tempfile::tempdir;
 
@@ -633,7 +635,10 @@ mod tests {
         let config = TestConfig::new(format!("microsoft/{}", module_name));
         let module = TestModule::new_with_logs(module_name.to_owned(), config, state, logs);
 
-        TestRuntime::make_runtime(TestSettings::new())
+        let (create_socket_channel_snd, _create_socket_channel_rcv) =
+            mpsc::unbounded::<ModuleAction>();
+
+        TestRuntime::make_runtime(TestSettings::new(), create_socket_channel_snd)
             .wait()
             .unwrap()
             .with_module(Ok(module))


### PR DESCRIPTION
This PR aims to address the issue: #9580770

Instead of creating one unix socket that is shared among all containers, instead, one socket is created per containers.
The socket management policy is the following:
1. Socket + listening server is created when socket is started.
2. Server is shutdown when the module is stopped
3. Socket file is cleaned when module is removed. (Arguably socket file could also be cleaned in server shutdown since anyway, binding requires a new socket, but this follows the module logic)

New modules are now mounted with the following settings:
$home_dir/edged/mnt/"imageName".sock : /var/run/iotedge/workload.sock
/var/lib/aziot/edged/mnt/"imageName".sock : /var/run/iotedge/workload.sock

Some modification had to be made to edgeAgent, because currently, images are mounted with the same target and destination address. Additionally, we want edgeAgent able to infer the listen address of a module based on it's name.
edgeagent is able to compute a module listening socket address based on the new environment variable: IOTEDGE_WORKLOADLISTEN_MNTURI that contains the begining of the address of the modules socket: unix:///var/lib/aziot/edged/mnt

Backward compatibility consideration:
To keep previous code compatible, we keep listening on the address /var/run/iotedge/workload.sock.
Additionally, IOTEDGE_WORKLOADURI environment variable is still equal to unix:///var/run/iotedge/workload.sock so older edgeAgent will work.

**Note:** Because of this, if oldedge agent is used to bootstrap the new edgeAgent then the new edgeAgent will use the legacy mode and not mount one socket per module.
This is because the old edgeagent is not aware of the env variable IOTEDGE_WORKLOADLISTEN_MNTURI so it won't mount it on the new edgeAgent. Then the new edgeAgent can't know where are the socket located (home directory could be changed). 
One solution could be to use API version and hardcode socket directory but I don't like this (but I am open to change).

I don't think it is a is drawback, the worse case scenario, which might be confusing for customer is the following: 
new edgeAgent need to be started by edgelet, not the old edge agent. 
So the edgeAgent container has to be killed for the new modules to use their specific workload sockets. 

note2: I know there are merge conflict. I am going to rebase tomorrow, I was hoping for a fix today.

Test:
Note: those tests where run before the rebase because of a bug in master. Only a subset was run after rebase.
Since there are still issues with the pipeline, the included pipeline run is before the rebase.

Config: edgeAgent + edgeHub + registry module.
1. Tested all combination
    1. Tested new edged + edgeAgent 1.2 (bootstrap) + new edgeAgent.
    2. Tested new edged + new edgeAgent. (bootstrap) + new edgeAgent.
    3. Tested new edged + edgeAgent 1.2(bootstrap) + edgeAgent 1.2
    4. Tested new edged + new edgeAgent. (bootstrap) +  edgeAgent 1.2
    5. Old edged + new edgeAgent +  edgeAgent 1.2

2. sudo docker inspect on agent/hub and registry and check that the socket /var/lib/aziot/edged/mnt/"imagename".sock is correctly mounted.
 
3. Stopped registry module in portal and checked that the server is not listening anymore on registry by doing:
"sudo curl  --unix-socket /var/lib/aziot/edged/mnt/registry.sock http:/dummy -v"

4. Killed the registry module by removing it in portal and ran "ls /var/lib/aziot/edged/mnt" and verified that  registry.sock had been correctly removed.

5. Did sudo iotedge system restart and verify that everything comes back online

6. Killed edged process manually and verify that everything comes back online

7. Updated registry image and check it got updated correctly.

8. Ran iotedge check tests and verified everything was green.

9. Pipeline test:
Image: https://dev.azure.com/msazure/One/_build/results?buildId=44031529&view=results
edgelet: https://dev.azure.com/msazure/One/_build/results?buildId=44028903&view=results
Test: 
https://dev.azure.com/msazure/One/_build/results?buildId=44044500&view=results
Test after rebase: https://dev.azure.com/msazure/One/_build/results?buildId=44052792&view=logs&j=4323b27c-bad1-54aa-e27b-49b281e4d21f&t=2ea499ca-cfe0-556e-a400-a67ccaeb494e





