### PR TITLE
Mark tests as failed on failure. (#5105)

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -58,7 +58,6 @@ steps:
     sudo --preserve-env dotnet test $testFile --logger:trx --testcasefilter:$filter
 
   displayName: Run tests ${{ parameters.test_type }}
-  continueOnError: true
   env:
     E2E_DPS_GROUP_KEY: $(TestDpsGroupKeySymmetric)
     E2E_EVENT_HUB_ENDPOINT: ${{ parameters['EventHubCompatibleEndpoint'] }}


### PR DESCRIPTION
`continueOnError: true` has one unfortunate side effect - it marks the step as `Warning` instead of `Error`. It can lead to some confusion and inability to easily retry the pipeline.

I'd like to revert the change where we mark failed tests as warnings. If we need any other steps to run after failed tests, we should use `condition: succeededOrFailed()` on those steps.