### PR TITLE
Devops Sync Job: Refactor to facilitate incoming bug opening automation changes

### DIFF
--- a/tools/IoTEdgeDevOps/DevOpsLib/BugQueryGenerator.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BugQueryGenerator.cs
@@ -15,6 +15,7 @@ namespace DevOpsLib
         static readonly string[] areas = new string[]
         {
             "IoTEdge",
+            "IoTEdge\\Agility",
             "IoTEdge\\AppModel",
             "IoTEdge\\AppModel\\K8s",
             "IoTEdge\\Connectivity",
@@ -23,7 +24,8 @@ namespace DevOpsLib
             "IoTEdge\\Core\\Infrastructure",
             "IoTEdge\\Core\\Security",
             "IoTEdge\\Documentation",
-            "IoTEdge\\FieldGateway"
+            "IoTEdge\\FieldGateway",
+            "IoTEdge\\PartnerRequests"
         };
 
         public static HashSet<BugQuery> GenerateBugQueries()

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildManagement.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildManagement.cs
@@ -80,7 +80,7 @@ namespace DevOpsLib
             Url requestUri = DevOpsAccessSetting.BaseUrl
                 .AppendPathSegment(requestPath)
                 .SetQueryParam("definitions", string.Join(",", buildDefinitionIds.Select(b => b.IdString())))
-                .SetQueryParam("queryOrder", "finishTimeDescending")                
+                .SetQueryParam("queryOrder", "finishTimeDescending")
                 .SetQueryParam("api-version", "5.1")
                 .SetQueryParam("branchName", branchName);
 

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
@@ -43,9 +43,11 @@ namespace VstsPipelineSync
 
                 foreach (string branch in this.branches)
                 {
-                    buildLastUpdatePerBranchPerDefinition.Upsert(
-                        branch,
-                        await ImportVstsBuildsDataAsync(buildManagement, branch, BuildExtension.BuildDefinitions));
+                    foreach (BuildDefinitionId buildDefinitionId in BuildExtension.BuildDefinitions)
+                    {
+                        IList<VstsBuild> builds = await GetBuildsAndTrackLastUpdatedAsync(buildManagement, buildDefinitionId, branch);
+                        ImportVstsBuildsDataForSpecificDefinitionAsync(builds, buildDefinitionId);
+                    }
                 }
 
                 foreach (string branch in this.branches)
@@ -56,6 +58,33 @@ namespace VstsPipelineSync
                 Console.WriteLine($"Import Vsts data finished at {DateTime.UtcNow}; wait {waitPeriodAfterEachUpdate} for next update.");
                 await Task.Delay((int)waitPeriodAfterEachUpdate.TotalMilliseconds);
             }
+        }
+
+        async Task<IList<VstsBuild>> GetBuildsAndTrackLastUpdatedAsync(BuildManagement buildManagement, BuildDefinitionId buildDefinitionId, string branch)
+        {
+            Dictionary<BuildDefinitionId, DateTime> buildDefinitionIdToLastUpdate = this.buildLastUpdatePerBranchPerDefinition.GetIfExists(branch);
+            if (buildDefinitionIdToLastUpdate == null)
+            {
+                buildDefinitionIdToLastUpdate = new Dictionary<BuildDefinitionId, DateTime>();
+            }
+
+            DateTime lastUpdate = buildDefinitionIdToLastUpdate.GetIfExists(buildDefinitionId);
+            IList<VstsBuild> buildResults = await buildManagement.GetBuildsAsync(new HashSet<BuildDefinitionId> { buildDefinitionId }, branch, lastUpdate);
+            Console.WriteLine($"Query VSTS builds for branch [{branch}] and build definition [{buildDefinitionId.ToString()}]: last update={lastUpdate} => result count={buildResults.Count}");
+
+            DateTime maxLastChange = DateTime.MinValue;
+            foreach (VstsBuild build in buildResults.Where(r => r.HasResult()))
+            {
+                if (build.LastChangedDate > maxLastChange)
+                {
+                    maxLastChange = build.LastChangedDate;
+                }
+            }
+
+            buildDefinitionIdToLastUpdate.Upsert(buildDefinitionId, maxLastChange);
+            this.buildLastUpdatePerBranchPerDefinition.Upsert(branch, buildDefinitionIdToLastUpdate);
+
+            return buildResults;
         }
 
         async Task ImportVstsBugDataAsync(BugManagement bugManagement, HashSet<BugQuery> bugQueries)
@@ -85,30 +114,9 @@ namespace VstsPipelineSync
             }
         }
 
-        async Task<Dictionary<BuildDefinitionId, DateTime>> ImportVstsBuildsDataAsync(BuildManagement buildManagement, string branch, HashSet<BuildDefinitionId> buildDefinitionIds)
-        {
-            Console.WriteLine($"Import VSTS builds from branch [{branch}] started at {DateTime.UtcNow}.");
-            Dictionary<BuildDefinitionId, DateTime> lastUpdatePerDefinition = this.buildLastUpdatePerBranchPerDefinition.GetIfExists(branch);
-
-            if (lastUpdatePerDefinition == null)
-            {
-                lastUpdatePerDefinition = new Dictionary<BuildDefinitionId, DateTime>();
-            }
-
-            foreach (BuildDefinitionId buildDefinitionId in buildDefinitionIds)
-            {
-                DateTime maxLastChange = await ImportVstsBuildsDataForSpecificDefinitionAsync(buildManagement, branch, buildDefinitionId, lastUpdatePerDefinition.GetIfExists(buildDefinitionId));
-                lastUpdatePerDefinition.Upsert(buildDefinitionId, maxLastChange);
-            }
-
-            return lastUpdatePerDefinition;
-        }
-
-        async Task<DateTime> ImportVstsBuildsDataForSpecificDefinitionAsync(
-            BuildManagement buildManagement,
-            string branch,
-            BuildDefinitionId buildDefinitionId,
-            DateTime lastUpdate)
+        void ImportVstsBuildsDataForSpecificDefinitionAsync(
+            IList<VstsBuild> builds,
+            BuildDefinitionId buildDefinitionId)
         {
             SqlConnection sqlConnection = null;
 
@@ -117,21 +125,10 @@ namespace VstsPipelineSync
                 sqlConnection = new SqlConnection(this.dbConnectionString);
                 sqlConnection.Open();
 
-                IList<VstsBuild> buildResults = await buildManagement.GetBuildsAsync(new HashSet<BuildDefinitionId> { buildDefinitionId }, branch, lastUpdate);
-                Console.WriteLine($"Query VSTS builds for branch [{branch}] and build definition [{buildDefinitionId.ToString()}]: last update={lastUpdate} => result count={buildResults.Count}");
-                DateTime maxLastChange = lastUpdate;
-
-                foreach (VstsBuild build in buildResults.Where(r => r.HasResult()))
+                foreach (VstsBuild build in builds.Where(r => r.HasResult()))
                 {
                     UpsertVstsBuildToDb(sqlConnection, build);
-
-                    if (build.LastChangedDate > maxLastChange)
-                    {
-                        maxLastChange = build.LastChangedDate;
-                    }
                 }
-
-                return maxLastChange;
             }
             catch (Exception)
             {
@@ -213,13 +210,13 @@ namespace VstsPipelineSync
                         {
                             UpsertVstsReleaseEnvironmentToDb(sqlConnection, release.Id, releaseEnvironment, kvp.Value);
 
-                            foreach(IoTEdgeReleaseDeployment deployment in releaseEnvironment.Deployments)
+                            foreach (IoTEdgeReleaseDeployment deployment in releaseEnvironment.Deployments)
                             {
                                 UpsertVstsReleaseDeploymentToDb(sqlConnection, releaseEnvironment.Id, deployment);
 
                                 const string testTaskPrefix = "Test:";
 
-                                foreach(IoTEdgePipelineTask pipelineTask in deployment.Tasks.Where(x => IsTestTask(x, testTaskPrefix)))
+                                foreach (IoTEdgePipelineTask pipelineTask in deployment.Tasks.Where(x => IsTestTask(x, testTaskPrefix)))
                                 {
                                     UpsertVstsReleaseTaskToDb(sqlConnection, deployment.Id, pipelineTask, testTaskPrefix);
                                 }
@@ -229,7 +226,7 @@ namespace VstsPipelineSync
 
                     releaseCount++;
 
-                    if (releaseCount % 10 ==0)
+                    if (releaseCount % 10 == 0)
                     {
                         Console.WriteLine($"Query VSTS releases for branch [{branch}] and release definition [{releaseDefinitionId.ToString()}]: release count={releaseCount} at {DateTime.UtcNow}.");
                     }


### PR DESCRIPTION
For the bug opening changes, it will be cleaner if we refactor the sync job to promote cleaner modifications.

Currently the reverse callstack for the relevant part of the sync job works like this:
```
- RunAsync
  - foreach branch
    - ImportVstsBuildsData
      - ImportVstsBuildsDataForSpecificDefinition
        - GetBuildsAsync(definition)
        - UpsertToDB
        - Get the most recent build timestamp, track this, then pass it all the way up the callstack to store in double hashmap
```

It will be cleaner if we get the builds and update the most recent timestamps upfront in some encapsulated function. Then we can pass the list of bugs into the ImportVstsBuildsDataForSpecificDefinition and whatever function I create in a future PR to automatically log bugs. Here is what the new reverse callstack looks like:
```
- RunAsync
  - foreach branch
    - foreach buildDefintionId
      - helper function for getting builds and updating most recent timestamp
      - ImportVstsBuildsDataForSpecificDefinition
        - UpsertToDB
      - LogDevopsBugForFailingBuilds *TODO
```

I also noticed that the areas for the dashboard bug chart were missing some categories so I added them.