### PR TITLE
Devops Sync Job: Add WasScheduled field to database of builds

### DIFF
--- a/tools/IoTEdgeDevOps/DevOpsLib/BugQueryGenerator.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BugQueryGenerator.cs
@@ -15,6 +15,7 @@ namespace DevOpsLib
         static readonly string[] areas = new string[]
         {
             "IoTEdge",
+            "IoTEdge\\Agility",
             "IoTEdge\\AppModel",
             "IoTEdge\\AppModel\\K8s",
             "IoTEdge\\Connectivity",
@@ -23,7 +24,8 @@ namespace DevOpsLib
             "IoTEdge\\Core\\Infrastructure",
             "IoTEdge\\Core\\Security",
             "IoTEdge\\Documentation",
-            "IoTEdge\\FieldGateway"
+            "IoTEdge\\FieldGateway",
+            "IoTEdge\\PartnerRequests"
         };
 
         public static HashSet<BugQuery> GenerateBugQueries()

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildManagement.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildManagement.cs
@@ -72,7 +72,9 @@ namespace DevOpsLib
                 return buildDefinitionIds.Select(i => VstsBuild.CreateBuildWithNoResult(i, branchName)).ToList();
             }
 
-            return JsonConvert.DeserializeObject<VstsBuild[]>(result["value"].ToString()).ToList();
+            IList<VstsBuild> builds = JsonConvert.DeserializeObject<VstsBuild[]>(result["value"].ToString()).ToList();
+
+            return builds;
         }
 
         private static Url GetBuildsRequestUri(HashSet<BuildDefinitionId> buildDefinitionIds, string branchName, string requestPath, DateTime? minTime, int? maxBuildsPerDefinition)

--- a/tools/IoTEdgeDevOps/DevOpsLib/BuildManagement.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/BuildManagement.cs
@@ -80,7 +80,7 @@ namespace DevOpsLib
             Url requestUri = DevOpsAccessSetting.BaseUrl
                 .AppendPathSegment(requestPath)
                 .SetQueryParam("definitions", string.Join(",", buildDefinitionIds.Select(b => b.IdString())))
-                .SetQueryParam("queryOrder", "finishTimeDescending")                
+                .SetQueryParam("queryOrder", "finishTimeDescending")
                 .SetQueryParam("api-version", "5.1")
                 .SetQueryParam("branchName", branchName);
 

--- a/tools/IoTEdgeDevOps/DevOpsLib/VstsModels/VstsBuild.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/VstsModels/VstsBuild.cs
@@ -9,6 +9,10 @@ namespace DevOpsLib.VstsModels
     [JsonConverter(typeof(JsonPathConverter))]
     public class VstsBuild : IEquatable<VstsBuild>
     {
+
+        [JsonProperty("id")]
+        public String BuildId { get; set; }
+
         [JsonProperty("definition.id")]
         public BuildDefinitionId DefinitionId { get; set; }
 
@@ -48,6 +52,7 @@ namespace DevOpsLib.VstsModels
         public static VstsBuild CreateBuildWithNoResult(BuildDefinitionId buildDefinitionId, string sourceBranch) =>
             new VstsBuild
             {
+                BuildId = string.Empty,
                 DefinitionId = buildDefinitionId,
                 BuildNumber = string.Empty,
                 SourceBranch = sourceBranch,
@@ -59,6 +64,7 @@ namespace DevOpsLib.VstsModels
                 StartTime = DateTime.MinValue,
                 FinishTime = DateTime.MinValue,
                 LastChangedDate = DateTime.MinValue,
+                RequestedBy = new Dictionary<String, Object>()
             };
 
         public bool HasResult()

--- a/tools/IoTEdgeDevOps/DevOpsLib/VstsModels/VstsBuild.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/VstsModels/VstsBuild.cs
@@ -2,6 +2,7 @@
 namespace DevOpsLib.VstsModels
 {
     using System;
+    using System.Collections.Generic;
     using Newtonsoft.Json;
 
     // Schema reference: https://docs.microsoft.com/en-us/rest/api/azure/devops/build/builds/get?view=azure-devops-rest-5.1
@@ -41,6 +42,9 @@ namespace DevOpsLib.VstsModels
         [JsonProperty("lastChangedDate")]
         public DateTime LastChangedDate { get; set; }
 
+        [JsonProperty("requestedBy")]
+        public Dictionary<String, Object> RequestedBy { get; set; }
+
         public static VstsBuild CreateBuildWithNoResult(BuildDefinitionId buildDefinitionId, string sourceBranch) =>
             new VstsBuild
             {
@@ -60,6 +64,16 @@ namespace DevOpsLib.VstsModels
         public bool HasResult()
         {
             return !string.IsNullOrEmpty(this.BuildNumber);
+        }
+
+        public bool WasScheduled()
+        {
+            if (this.RequestedBy["displayName"] != null && (String)this.RequestedBy["displayName"] == "Microsoft.VisualStudio.Services.TFS")
+            {
+                return true;
+            }
+
+            return false;
         }
 
         public bool Equals(VstsBuild other)
@@ -94,7 +108,7 @@ namespace DevOpsLib.VstsModels
                 return false;
             }
 
-            return this.Equals((VstsBuild) obj);
+            return this.Equals((VstsBuild)obj);
         }
 
         public override int GetHashCode() => this.BuildNumber.GetHashCode();

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
@@ -167,6 +167,7 @@ namespace VstsPipelineSync
                 CommandText = "UpsertVstsBuild"
             };
 
+            cmd.Parameters.Add(new SqlParameter("@BuildId", build.BuildId));
             cmd.Parameters.Add(new SqlParameter("@BuildNumber", build.BuildNumber));
             cmd.Parameters.Add(new SqlParameter("@DefinitionId", build.DefinitionId));
             cmd.Parameters.Add(new SqlParameter("@DefinitionName", build.DefinitionId.DisplayName()));

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
@@ -178,6 +178,7 @@ namespace VstsPipelineSync
             cmd.Parameters.Add(new SqlParameter("@QueueTime", SqlDbType.DateTime2) { Value = build.QueueTime });
             cmd.Parameters.Add(new SqlParameter("@StartTime", SqlDbType.DateTime2) { Value = build.StartTime });
             cmd.Parameters.Add(new SqlParameter("@FinishTime", SqlDbType.DateTime2) { Value = build.FinishTime });
+            cmd.Parameters.Add(new SqlParameter("@WasScheduled", build.WasScheduled().ToString()));
 
             cmd.ExecuteNonQuery();
         }

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/VstsBuildBatchUpdate.cs
@@ -43,9 +43,11 @@ namespace VstsPipelineSync
 
                 foreach (string branch in this.branches)
                 {
-                    buildLastUpdatePerBranchPerDefinition.Upsert(
-                        branch,
-                        await ImportVstsBuildsDataAsync(buildManagement, branch, BuildExtension.BuildDefinitions));
+                    foreach (BuildDefinitionId buildDefinitionId in BuildExtension.BuildDefinitions)
+                    {
+                        IList<VstsBuild> builds = await GetBuildsAndTrackLastUpdatedAsync(buildManagement, buildDefinitionId, branch);
+                        ImportVstsBuildsDataForSpecificDefinitionAsync(builds, buildDefinitionId);
+                    }
                 }
 
                 foreach (string branch in this.branches)
@@ -56,6 +58,33 @@ namespace VstsPipelineSync
                 Console.WriteLine($"Import Vsts data finished at {DateTime.UtcNow}; wait {waitPeriodAfterEachUpdate} for next update.");
                 await Task.Delay((int)waitPeriodAfterEachUpdate.TotalMilliseconds);
             }
+        }
+
+        async Task<IList<VstsBuild>> GetBuildsAndTrackLastUpdatedAsync(BuildManagement buildManagement, BuildDefinitionId buildDefinitionId, string branch)
+        {
+            Dictionary<BuildDefinitionId, DateTime> buildDefinitionIdToLastUpdate = this.buildLastUpdatePerBranchPerDefinition.GetIfExists(branch);
+            if (buildDefinitionIdToLastUpdate == null)
+            {
+                buildDefinitionIdToLastUpdate = new Dictionary<BuildDefinitionId, DateTime>();
+            }
+
+            DateTime lastUpdate = buildDefinitionIdToLastUpdate.GetIfExists(buildDefinitionId);
+            IList<VstsBuild> buildResults = await buildManagement.GetBuildsAsync(new HashSet<BuildDefinitionId> { buildDefinitionId }, branch, lastUpdate);
+            Console.WriteLine($"Query VSTS builds for branch [{branch}] and build definition [{buildDefinitionId.ToString()}]: last update={lastUpdate} => result count={buildResults.Count}");
+
+            DateTime maxLastChange = DateTime.MinValue;
+            foreach (VstsBuild build in buildResults.Where(r => r.HasResult()))
+            {
+                if (build.LastChangedDate > maxLastChange)
+                {
+                    maxLastChange = build.LastChangedDate;
+                }
+            }
+
+            buildDefinitionIdToLastUpdate.Upsert(buildDefinitionId, maxLastChange);
+            this.buildLastUpdatePerBranchPerDefinition.Upsert(branch, buildDefinitionIdToLastUpdate);
+
+            return buildResults;
         }
 
         async Task ImportVstsBugDataAsync(BugManagement bugManagement, HashSet<BugQuery> bugQueries)
@@ -85,30 +114,9 @@ namespace VstsPipelineSync
             }
         }
 
-        async Task<Dictionary<BuildDefinitionId, DateTime>> ImportVstsBuildsDataAsync(BuildManagement buildManagement, string branch, HashSet<BuildDefinitionId> buildDefinitionIds)
-        {
-            Console.WriteLine($"Import VSTS builds from branch [{branch}] started at {DateTime.UtcNow}.");
-            Dictionary<BuildDefinitionId, DateTime> lastUpdatePerDefinition = this.buildLastUpdatePerBranchPerDefinition.GetIfExists(branch);
-
-            if (lastUpdatePerDefinition == null)
-            {
-                lastUpdatePerDefinition = new Dictionary<BuildDefinitionId, DateTime>();
-            }
-
-            foreach (BuildDefinitionId buildDefinitionId in buildDefinitionIds)
-            {
-                DateTime maxLastChange = await ImportVstsBuildsDataForSpecificDefinitionAsync(buildManagement, branch, buildDefinitionId, lastUpdatePerDefinition.GetIfExists(buildDefinitionId));
-                lastUpdatePerDefinition.Upsert(buildDefinitionId, maxLastChange);
-            }
-
-            return lastUpdatePerDefinition;
-        }
-
-        async Task<DateTime> ImportVstsBuildsDataForSpecificDefinitionAsync(
-            BuildManagement buildManagement,
-            string branch,
-            BuildDefinitionId buildDefinitionId,
-            DateTime lastUpdate)
+        void ImportVstsBuildsDataForSpecificDefinitionAsync(
+            IList<VstsBuild> builds,
+            BuildDefinitionId buildDefinitionId)
         {
             SqlConnection sqlConnection = null;
 
@@ -117,21 +125,10 @@ namespace VstsPipelineSync
                 sqlConnection = new SqlConnection(this.dbConnectionString);
                 sqlConnection.Open();
 
-                IList<VstsBuild> buildResults = await buildManagement.GetBuildsAsync(new HashSet<BuildDefinitionId> { buildDefinitionId }, branch, lastUpdate);
-                Console.WriteLine($"Query VSTS builds for branch [{branch}] and build definition [{buildDefinitionId.ToString()}]: last update={lastUpdate} => result count={buildResults.Count}");
-                DateTime maxLastChange = lastUpdate;
-
-                foreach (VstsBuild build in buildResults.Where(r => r.HasResult()))
+                foreach (VstsBuild build in builds.Where(r => r.HasResult()))
                 {
                     UpsertVstsBuildToDb(sqlConnection, build);
-
-                    if (build.LastChangedDate > maxLastChange)
-                    {
-                        maxLastChange = build.LastChangedDate;
-                    }
                 }
-
-                return maxLastChange;
             }
             catch (Exception)
             {
@@ -213,13 +210,13 @@ namespace VstsPipelineSync
                         {
                             UpsertVstsReleaseEnvironmentToDb(sqlConnection, release.Id, releaseEnvironment, kvp.Value);
 
-                            foreach(IoTEdgeReleaseDeployment deployment in releaseEnvironment.Deployments)
+                            foreach (IoTEdgeReleaseDeployment deployment in releaseEnvironment.Deployments)
                             {
                                 UpsertVstsReleaseDeploymentToDb(sqlConnection, releaseEnvironment.Id, deployment);
 
                                 const string testTaskPrefix = "Test:";
 
-                                foreach(IoTEdgePipelineTask pipelineTask in deployment.Tasks.Where(x => IsTestTask(x, testTaskPrefix)))
+                                foreach (IoTEdgePipelineTask pipelineTask in deployment.Tasks.Where(x => IsTestTask(x, testTaskPrefix)))
                                 {
                                     UpsertVstsReleaseTaskToDb(sqlConnection, deployment.Id, pipelineTask, testTaskPrefix);
                                 }
@@ -229,7 +226,7 @@ namespace VstsPipelineSync
 
                     releaseCount++;
 
-                    if (releaseCount % 10 ==0)
+                    if (releaseCount % 10 == 0)
                     {
                         Console.WriteLine($"Query VSTS releases for branch [{branch}] and release definition [{releaseDefinitionId.ToString()}]: release count={releaseCount} at {DateTime.UtcNow}.");
                     }

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBuild.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBuild.sql
@@ -1,4 +1,5 @@
 ﻿CREATE PROCEDURE [dbo].[UpsertVstsBuild]
+	@BuildId varchar(20),
 	@BuildNumber varchar(20),
 	@DefinitionId int,
 	@DefinitionName varchar(100),
@@ -15,10 +16,11 @@ AS
 	DECLARE @now datetime2;
 	SET @now = SYSDATETIME();
 
-	IF EXISTS (SELECT 1 FROM dbo.VstsBuild WHERE BuildNumber = @BuildNumber AND DefinitionId = @DefinitionId)
+	IF EXISTS (SELECT 1 FROM dbo.VstsBuild WHERE BuildId = @BuildId)
 	BEGIN
 		UPDATE dbo.VstsBuild
-		SET DefinitionName = @DefinitionName,
+		SET BuildId = @BuildId,
+		    DefinitionName = @DefinitionName,
 		    SourceBranch = @SourceBranch,
 			SourceVersionDisplayUri = @SourceVersionDisplayUri,
 			WebUri = @WebUri,
@@ -29,11 +31,10 @@ AS
 			FinishTime = @FinishTIme,
 			WasScheduled = @WasScheduled,
 			UpdatedAt = @now
-		WHERE BuildNumber = @BuildNumber
-		AND DefinitionId = @DefinitionId
+		WHERE BuildId = @BuildId
 	END
 	ELSE
 	BEGIN
-		INSERT INTO dbo.VstsBuild(BuildNumber, DefinitionId, DefinitionName, SourceBranch, SourceVersionDisplayUri, WebUri, [Status], Result, QueueTime, StartTime, FinishTime, WasScheduled, InsertedAt, UpdatedAt)
-		VALUES (@BuildNumber, @DefinitionId, @DefinitionName, @SourceBranch, @SourceVersionDisplayUri, @WebUri, @Status, @Result, @QueueTime, @StartTime, @FinishTime, @WasScheduled, @now, @now)
+		INSERT INTO dbo.VstsBuild(BuildId, BuildNumber, DefinitionId, DefinitionName, SourceBranch, SourceVersionDisplayUri, WebUri, [Status], Result, QueueTime, StartTime, FinishTime, WasScheduled, InsertedAt, UpdatedAt)
+		VALUES (@BuildId, @BuildNumber, @DefinitionId, @DefinitionName, @SourceBranch, @SourceVersionDisplayUri, @WebUri, @Status, @Result, @QueueTime, @StartTime, @FinishTime, @WasScheduled, @now, @now)
 	END

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBuild.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.UpsertVstsBuild.sql
@@ -9,7 +9,8 @@
 	@Result varchar(20),
 	@QueueTime datetime2,
 	@StartTime datetime2,
-	@FinishTime datetime2
+	@FinishTime datetime2,
+	@WasScheduled varchar(20)
 AS
 	DECLARE @now datetime2;
 	SET @now = SYSDATETIME();
@@ -26,12 +27,13 @@ AS
 			QueueTime = @QueueTime,
 			StartTime = @StartTime,
 			FinishTime = @FinishTIme,
+			WasScheduled = @WasScheduled,
 			UpdatedAt = @now
 		WHERE BuildNumber = @BuildNumber
 		AND DefinitionId = @DefinitionId
 	END
 	ELSE
 	BEGIN
-		INSERT INTO dbo.VstsBuild(BuildNumber, DefinitionId, DefinitionName, SourceBranch, SourceVersionDisplayUri, WebUri, [Status], Result, QueueTime, StartTime, FinishTime, InsertedAt, UpdatedAt)
-		VALUES (@BuildNumber, @DefinitionId, @DefinitionName, @SourceBranch, @SourceVersionDisplayUri, @WebUri, @Status, @Result, @QueueTime, @StartTime, @FinishTime, @now, @now)
+		INSERT INTO dbo.VstsBuild(BuildNumber, DefinitionId, DefinitionName, SourceBranch, SourceVersionDisplayUri, WebUri, [Status], Result, QueueTime, StartTime, FinishTime, WasScheduled, InsertedAt, UpdatedAt)
+		VALUES (@BuildNumber, @DefinitionId, @DefinitionName, @SourceBranch, @SourceVersionDisplayUri, @WebUri, @Status, @Result, @QueueTime, @StartTime, @FinishTime, @WasScheduled, @now, @now)
 	END

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.VstsBuild.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.VstsBuild.sql
@@ -6,6 +6,7 @@ SET QUOTED_IDENTIFIER ON
 GO
 
 CREATE TABLE [dbo].[VstsBuild](
+	[BuildId] [varchar](20) NOT NULL,
 	[BuildNumber] [varchar](20) NOT NULL,
 	[DefinitionId] [int] NOT NULL,
 	[DefinitionName] [varchar](100) NOT NULL,
@@ -20,11 +21,8 @@ CREATE TABLE [dbo].[VstsBuild](
 	[WasScheduled] [varchar](20) NOT NULL,
 	[InsertedAt] [datetime2](7) NOT NULL,
 	[UpdatedAt] [datetime2](7) NOT NULL,
- CONSTRAINT [PK_VstsBuild] PRIMARY KEY CLUSTERED 
-(
-	[BuildNumber] ASC,
-	[DefinitionId] ASC
-)WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
+ CONSTRAINT [PK_VstsBuild] PRIMARY KEY (BuildId) 
+ WITH (STATISTICS_NORECOMPUTE = OFF, IGNORE_DUP_KEY = OFF) ON [PRIMARY]
 ) ON [PRIMARY]
 GO
 

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.VstsBuild.sql
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/db/dbo.VstsBuild.sql
@@ -17,6 +17,7 @@ CREATE TABLE [dbo].[VstsBuild](
 	[QueueTime] [datetime2](7) NOT NULL,
 	[StartTime] [datetime2](7) NOT NULL,
 	[FinishTime] [datetime2](7) NOT NULL,
+	[WasScheduled] [varchar](20) NOT NULL,
 	[InsertedAt] [datetime2](7) NOT NULL,
 	[UpdatedAt] [datetime2](7) NOT NULL,
  CONSTRAINT [PK_VstsBuild] PRIMARY KEY CLUSTERED 


### PR DESCRIPTION
For the devops sync job we only want to open bugs for scheduled builds. This is because devs often misconfigure or try weird things with manual builds.

In order to accomplish this we need to add to the builds database a field for if the build was scheduled or not. I played around with the api and the easiest way to do this is to check who the build is requested for. If it is requested by `` then it is a scheduled build.