### PR TITLE
Testing: Apply tls 1.2 settings for all tests

### DIFF
--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -54,6 +54,9 @@
               },
               "NestedEdgeEnabled": {
                 "value": "false"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/dm_module_to_module_deployment.json
+++ b/e2e_deployment_files/dm_module_to_module_deployment.json
@@ -42,6 +42,9 @@
               },
               "NestedEdgeEnabled": {
                 "value": "false"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/edgehub_restart_deployment.template.json
+++ b/e2e_deployment_files/edgehub_restart_deployment.template.json
@@ -54,6 +54,9 @@
               },
               "NestedEdgeEnabled": {
                 "value": "false"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/long_haul_deployment.template.json
+++ b/e2e_deployment_files/long_haul_deployment.template.json
@@ -49,6 +49,9 @@
               },
               "RuntimeLogLevel": {
                 "value": "debug"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "settings": {

--- a/e2e_deployment_files/module_to_functions_deployment.template.json
+++ b/e2e_deployment_files/module_to_functions_deployment.template.json
@@ -34,6 +34,9 @@
             "env": {
               "NestedEdgeEnabled": {
                 "value": "false"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/module_to_module_deployment.template.json
+++ b/e2e_deployment_files/module_to_module_deployment.template.json
@@ -34,6 +34,9 @@
             "env": {
               "NestedEdgeEnabled": {
                 "value": "false"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_connectivity_mqtt.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_connectivity_mqtt.template.json
@@ -57,6 +57,9 @@
               },
               "RuntimeLogLevel": {
                 "value": "debug"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_amqp.template.json
@@ -43,6 +43,9 @@
             "env": {
               "RuntimeLogLevel": {
                 "value": "Debug"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "settings": {

--- a/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
+++ b/e2e_deployment_files/nestededge_bottomLayerBaseDeployment_long_haul_mqtt.template.json
@@ -52,6 +52,9 @@
               },
               "RuntimeLogLevel": {
                 "value": "debug"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "settings": {

--- a/e2e_deployment_files/nestededge_isa95_smoke_test_BaseDeployment.json
+++ b/e2e_deployment_files/nestededge_isa95_smoke_test_BaseDeployment.json
@@ -36,6 +36,9 @@
               },
               "https_proxy": {
                 "value": "<proxyAddress>"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
@@ -38,6 +38,9 @@
               },
               "RuntimeLogLevel": {
                 "value": "debug"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_mqtt.json
@@ -85,6 +85,9 @@
               },
               "TEST_START_DELAY": {
                 "value": "10s"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "settings": {

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
@@ -30,6 +30,9 @@
               },
               "https_proxy": {
                 "value": "<proxyAddress>"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             }
           },

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
@@ -30,6 +30,9 @@
               },
               "https_proxy": {
                 "value": "<proxyAddress>"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             }
           },

--- a/e2e_deployment_files/quickstart_deployment.template.json
+++ b/e2e_deployment_files/quickstart_deployment.template.json
@@ -35,6 +35,9 @@
             "env": {
               "NestedEdgeEnabled": {
                 "value": "false"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/runtime_only_deployment.template.json
+++ b/e2e_deployment_files/runtime_only_deployment.template.json
@@ -35,6 +35,9 @@
             "env": {
               "NestedEdgeEnabled": {
                 "value": "false"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/stress_deployment.template.json
+++ b/e2e_deployment_files/stress_deployment.template.json
@@ -54,6 +54,9 @@
               },
               "NestedEdgeEnabled": {
                 "value": "false"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
@@ -40,15 +40,15 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             CancellationToken token,
             bool nestedEdge)
         {
-            (string, string)[] hubEnvVar;
+            (string, string)[] hubEnvVar = new (string, string)[] { ("RuntimeLogLevel", "debug"), ("SslProtocols", "tls1.2") };
 
             if (nestedEdge == true)
             {
-                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("DeviceScopeCacheRefreshDelaySecs", "0") };
+                hubEnvVar.Append(("DeviceScopeCacheRefreshDelaySecs", "0"));
             }
             else
             {
-                hubEnvVar = new[] { ("RuntimeLogLevel", "debug"), ("NestedEdgeEnabled", "false"), };
+                hubEnvVar.Append(("NestedEdgeEnabled", "false"));
             }
 
             var builder = new EdgeConfigBuilder(this.DeviceId);


### PR DESCRIPTION
We need to resolve an s360 error for non tls 1.2 violations in our test environment. I am switching all tests to use tls 1.2 via edgehub environment.

Relevant config added in #2052.