### PR TITLE
Send connection device Id information on twin change notifications #4…

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/AmqpMessageConverter.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/AmqpMessageConverter.cs
@@ -170,12 +170,20 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsInputNameKey] = inputName;
             }
 
-            if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.ConnectionDeviceId, out string connectionDeviceId))
+            if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.RpConnectionDeviceIdInternal, out string rpConnectionDeviceId))
+            {
+                amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionDeviceId] = rpConnectionDeviceId;
+            }
+            else if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.ConnectionDeviceId, out string connectionDeviceId))
             {
                 amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionDeviceId] = connectionDeviceId;
             }
 
-            if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.ConnectionModuleId, out string connectionModuleId))
+            if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.RpConnectionModuleIdInternal, out string rpConnectionModuleId))
+            {
+                amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionModuleId] = rpConnectionModuleId;
+            }
+            else if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.ConnectionModuleId, out string connectionModuleId))
             {
                 amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionModuleId] = connectionModuleId;
             }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Constants.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const string InternalOriginInterface = "internal";
         public const string DownstreamOriginInterface = "downstream";
 
+        public const string EdgeHubModuleId = "$edgeHub";
         public const string IotEdgeIdentityCapability = "iotEdge";
         public const string ServiceIdentityRefreshMethodName = "RefreshDeviceScopeIdentityCache";
         public const string IoTEdgeProductInfoIdentifier = "EdgeHub";

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/IEdgeHub.cs
@@ -15,6 +15,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
     /// </summary>
     public interface IEdgeHub : IDisposable
     {
+        string GetEdgeDeviceId();
+
         Task ProcessDeviceMessage(IIdentity identity, IMessage message);
 
         Task ProcessDeviceMessageBatch(IIdentity identity, IEnumerable<IMessage> message);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SystemProperties.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/SystemProperties.cs
@@ -36,6 +36,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const string InterfaceId = "iothub-interface-id";
         public const string ModelId = "modelId";
 
+        public const string RpConnectionDeviceIdInternal = "rpSenderDeviceId";
+        public const string RpConnectionModuleIdInternal = "rpSenderModuleId";
+
         public static readonly Dictionary<string, string> IncomingSystemPropertiesMap = new Dictionary<string, string>
         {
             { OnTheWireSystemPropertyNames.ExpiryTimeUtcOnTheWireName, ExpiryTimeUtc },
@@ -67,7 +70,9 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             { Operation, OnTheWireSystemPropertyNames.OperationOnTheWireName },
             { CreationTime, OnTheWireSystemPropertyNames.CreationTimeOnTheWireName },
             { ConnectionDeviceId, OnTheWireSystemPropertyNames.ConnectionDeviceIdOnTheWireName },
-            { ConnectionModuleId, OnTheWireSystemPropertyNames.ConnectionModuleIdOnTheWireName }
+            { ConnectionModuleId, OnTheWireSystemPropertyNames.ConnectionModuleIdOnTheWireName },
+            { RpConnectionDeviceIdInternal, OnTheWireSystemPropertyNames.ConnectionDeviceIdOnTheWireName },
+            { RpConnectionModuleIdInternal, OnTheWireSystemPropertyNames.ConnectionModuleIdOnTheWireName }
         };
 
         static class OnTheWireSystemPropertyNames

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/device/DeviceMessageHandler.cs
@@ -213,13 +213,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Device
             switch (this.Identity)
             {
                 case IModuleIdentity moduleIdentity:
-                    reportedPropertiesMessage.SystemProperties[SystemProperties.ConnectionDeviceId] = moduleIdentity.DeviceId;
-                    reportedPropertiesMessage.SystemProperties[SystemProperties.ConnectionModuleId] = moduleIdentity.ModuleId;
+                    reportedPropertiesMessage.SystemProperties[SystemProperties.RpConnectionDeviceIdInternal] = moduleIdentity.DeviceId;
+                    reportedPropertiesMessage.SystemProperties[SystemProperties.RpConnectionModuleIdInternal] = moduleIdentity.ModuleId;
                     break;
                 case IDeviceIdentity deviceIdentity:
-                    reportedPropertiesMessage.SystemProperties[SystemProperties.ConnectionDeviceId] = deviceIdentity.DeviceId;
+                    reportedPropertiesMessage.SystemProperties[SystemProperties.RpConnectionDeviceIdInternal] = deviceIdentity.DeviceId;
                     break;
             }
+
+            reportedPropertiesMessage.SystemProperties[SystemProperties.ConnectionDeviceId] = this.edgeHub.GetEdgeDeviceId();
+            reportedPropertiesMessage.SystemProperties[SystemProperties.ConnectionModuleId] = Constants.EdgeHubModuleId;
 
             try
             {

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/routing/RoutingEdgeHub.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             this.subscriptionProcessor = Preconditions.CheckNotNull(subscriptionProcessor, nameof(subscriptionProcessor));
         }
 
+        public string GetEdgeDeviceId() => this.edgeDeviceId;
+
         public Task ProcessDeviceMessage(IIdentity identity, IMessage message)
         {
             Preconditions.CheckNotNull(message, nameof(message));
@@ -99,9 +101,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Routing
             Preconditions.CheckNotNull(reportedPropertiesMessage, nameof(reportedPropertiesMessage));
             Events.UpdateReportedPropertiesReceived(identity);
             Task cloudSendMessageTask = this.twinManager.UpdateReportedPropertiesAsync(identity.Id, reportedPropertiesMessage);
-
-            reportedPropertiesMessage.SystemProperties[SystemProperties.ConnectionDeviceId] = this.edgeDeviceId;
-            reportedPropertiesMessage.SystemProperties[SystemProperties.ConnectionModuleId] = this.edgeModuleId;
 
             IRoutingMessage routingMessage = this.ProcessMessageInternal(reportedPropertiesMessage, false);
             Task routingSendMessageTask = this.router.RouteAsync(routingMessage);

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/ProtocolGatewayMessageConverter.cs
@@ -93,6 +93,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
                 }
             }
 
+            if (message.SystemProperties.TryGetValue(SystemProperties.RpConnectionDeviceIdInternal, out string rpDeviceId))
+            {
+                properties[SystemProperties.OutgoingSystemPropertiesMap[SystemProperties.RpConnectionDeviceIdInternal]] = rpDeviceId;
+            }
+
+            if (message.SystemProperties.TryGetValue(SystemProperties.RpConnectionModuleIdInternal, out string rpModuleId))
+            {
+                properties[SystemProperties.OutgoingSystemPropertiesMap[SystemProperties.RpConnectionModuleIdInternal]] = rpModuleId;
+            }
+
             if (!this.addressConvertor.TryBuildProtocolAddressFromEdgeHubMessage(uriTemplateKey, message, properties, out string address))
             {
                 throw new InvalidOperationException("Could not derive destination address using message system properties");

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/AmqpMessageConverterTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/AmqpMessageConverterTest.cs
@@ -343,5 +343,31 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                 Assert.Equal("Value2", amqpMessage.ApplicationProperties.Map["Prop2"].ToString());
             }
         }
+
+        [Fact]
+        public void TestConnectionDeviceIdTest()
+        {
+            // Setup
+            var systemProperties = new Dictionary<string, string>
+            {
+                [SystemProperties.ConnectionDeviceId] = "edgeDeviceId",
+                [SystemProperties.ConnectionModuleId] = "$edgeHub",
+                [SystemProperties.RpConnectionDeviceIdInternal] = "leafDevice1",
+                [SystemProperties.RpConnectionModuleIdInternal] = "leafModule1",
+            };
+
+            byte[] bytes = { 1, 2, 3, 4 };
+
+            var message = new EdgeMessage(bytes, new Dictionary<string, string>(), systemProperties);
+            var messageConverter = new AmqpMessageConverter();
+
+            // Act
+            using (AmqpMessage amqpMessage = messageConverter.FromMessage(message))
+            {
+                // Assert
+                Assert.Equal("leafDevice1", amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionDeviceId]);
+                Assert.Equal("leafModule1", amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionModuleId]);
+            }
+        }
     }
 }

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/DeviceMessageHandlerTest.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             edgeHub.Setup(e => e.UpdateReportedPropertiesAsync(It.IsAny<IIdentity>(), It.IsAny<IMessage>()))
                 .Callback<IIdentity, IMessage>((id, m) => receivedMessage = m)
                 .Returns(Task.CompletedTask);
+            edgeHub.Setup(e => e.GetEdgeDeviceId()).Returns("edgeDeviceId1");
             Mock.Get(connMgr).Setup(c => c.GetCloudConnection(It.IsAny<string>())).Returns(Task.FromResult(Option.Some(cloudProxy)));
             var listener = new DeviceMessageHandler(identity, edgeHub.Object, connMgr, DefaultMessageAckTimeout, Option.None<string>());
             var underlyingDeviceProxy = new Mock<IDeviceProxy>();
@@ -126,8 +127,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
             Assert.NotNull(receivedMessage);
             Assert.Equal(Constants.TwinChangeNotificationMessageSchema, receivedMessage.SystemProperties[SystemProperties.MessageSchema]);
             Assert.Equal(Constants.TwinChangeNotificationMessageType, receivedMessage.SystemProperties[SystemProperties.MessageType]);
-            Assert.Equal("device1", receivedMessage.SystemProperties[SystemProperties.ConnectionDeviceId]);
-            Assert.Equal("module1", receivedMessage.SystemProperties[SystemProperties.ConnectionModuleId]);
+            Assert.Equal("edgeDeviceId1", receivedMessage.SystemProperties[SystemProperties.ConnectionDeviceId]);
+            Assert.Equal("$edgeHub", receivedMessage.SystemProperties[SystemProperties.ConnectionModuleId]);
+            Assert.Equal("device1", receivedMessage.SystemProperties[SystemProperties.RpConnectionDeviceIdInternal]);
+            Assert.Equal("module1", receivedMessage.SystemProperties[SystemProperties.RpConnectionModuleIdInternal]);
             Assert.True(receivedMessage.SystemProperties.ContainsKey(SystemProperties.EnqueuedTime));
         }
 


### PR DESCRIPTION
…762 (#4888)

Cherry-pick: https://github.com/Azure/iotedge/commit/fa60e528706371c2bff0c7a7c3f795b737678646

Issue: EdgeHub supports routing twin change notifications, which basically includes routing RP updates to other modules. The message that gets routed should have information about the device that sent the RP update.
But because of a recent change in EH, this information got dropped.

Fix: Fix is to route the information about the device/module that sent the RP update to the receiving module.