### PR TITLE
E2E: Skipped `edgeAgent_created_pids_total` metric for ARM32 (#5134)

### DIFF
--- a/test/modules/MetricsValidator/src/tests/ValidateDocumentedMetrics.cs
+++ b/test/modules/MetricsValidator/src/tests/ValidateDocumentedMetrics.cs
@@ -67,7 +67,7 @@ namespace MetricsValidator.Tests
 
             // The following metric should not be populated in a happy E2E path.
             // We are going to make a list and remove them here to not consider them as a failure.
-            IEnumerable<string> skippingMetrics = new HashSet<string>
+            var skippingMetrics = new HashSet<string>
             {
                 "edgeAgent_twin_signature_check_count",
                 "edgeAgent_twin_signaturs_check_seconds",
@@ -81,6 +81,12 @@ namespace MetricsValidator.Tests
                 "edgehub_twin_signature_check_seconds",
                 "edgehub_client_disconnect_total"
             };
+
+            if (!System.Environment.Is64BitOperatingSystem)
+            {
+                // This metric is not part of the scrape on ARM32 machine.
+                skippingMetrics.Add("edgeAgent_created_pids_total");
+            }
 
             foreach (string skippingMetric in skippingMetrics)
             {


### PR DESCRIPTION
Skipped `edgeAgent_created_pids_total` metric for ARM32