### PR TITLE
Introduce `Timestamps` Option via mgmt.sock (#4970)

### DIFF
--- a/edgelet/api/README.md
+++ b/edgelet/api/README.md
@@ -1,0 +1,52 @@
+# How to build Management API using Swagger-Codegen
+1. Install Java & Maven 
+```sh
+   sudo apt-get install openjdk-8-jdk
+   ## It only works on JAVA8 see https://computingforgeeks.com/how-to-set-default-java-version-on-ubuntu-debian/ how to switch between Java versions
+   sudo apt install maven
+```
+2. Clone swagger codegen repo:
+```sh
+   cd ~
+   git clone https://github.com/swagger-api/swagger-codegen.git
+```
+3. Test build if installation was done correctly ( https://github.com/swagger-api/swagger-codegen#building ) 
+```sh
+   cd swagger-codegen
+   mvn clean install -N
+   mvn clean package
+```
+4. Build swagger-codegen
+```sh
+   cd modules/swagger-codegen
+   mvn clean package
+
+   ## Make sure /target/*.jar is created
+   ls
+```
+5. Build swagger-codegen-cli
+```sh
+   cd ~/swagger-codegen/modules/swagger-codegen-cli
+   mvn clean package
+
+   ## Make sure /target/*.jar is created
+   ls 
+```
+6. Put it all together and build API
+    - Run the following command 
+```sh
+		 java -cp <abs/path/to/jar/step4>:<abs/path/to/jar/step5> \
+		 io.swagger.codegen.SwaggerCodegen generate \
+		 -l rust \
+		 -i <abs/path/to/iotedge/mgmt/yaml> \
+		 -o <abs/path/to/output/folder>
+
+        ## Example Command
+		 java -cp /home/iotedgeuser/swagger-codegen/modules/swagger-codegen/target/swagger-codegen-2.4.20-SNAPSHOT.jar:/home/iotedgeuser/swagger-codegen/modules/swagger-codegen-cli/target/swagger-codegen-cli.jar \
+		 io.swagger.codegen.SwaggerCodegen generate \
+		 -l rust \
+		 -i /home/iotedgeuser/iotedge/edgelet/api/managementVersion_2020_07_07.yaml \
+		 -o /home/iotedgeuser/management
+```
+# Note #
+We've manually fixed up the generated code so that it satisfies rustfmt and clippy. As such, if you ever need to run `swagger-codegen-cli` against new definitions, or need to regenerate existing ones, you will want to perform the same fixups manually. Make sure to run clippy and rustfmt against the new code yourself, and inspect the diffs of modified files before checking in.

--- a/edgelet/api/managementVersion_2021_05_11.yaml
+++ b/edgelet/api/managementVersion_2021_05_11.yaml
@@ -1,0 +1,809 @@
+swagger: '2.0'
+schemes:
+  - http
+info:
+  title: IoT Edge Management API
+  version: '2020-05-11'
+tags:
+  - name: Module
+    x-displayName: Modules
+    description: |
+      Create and manage modules.
+  - name: Identity
+    x-displayName: Identities
+    description: |
+      Create and manage module identity.
+  - name: SystemInformation
+    x-displayName: SystemInformation
+    description: |
+      Get information about the runtime.
+paths:
+  /modules:
+    get:
+      tags:
+        - Module
+      summary: List modules.
+      produces:
+        - application/json
+      description: |
+        This returns the list of currently running modules and their statuses.
+      operationId: ListModules
+      parameters:
+        - $ref: '#/parameters/api-version'
+      responses:
+        '200':
+          description: Ok
+          schema:
+            $ref: '#/definitions/ModuleList'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+    post:
+      tags:
+        - Module
+      summary: Create module.
+      operationId: CreateModule
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: body
+          name: module
+          required: true
+          schema:
+            $ref: '#/definitions/ModuleSpec'
+      responses:
+        '201':
+          description: Created
+          schema:
+            $ref: '#/definitions/ModuleDetails'
+        '409':
+          description: Conflict. Returned if module already exists.
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  '/modules/{name}':
+    get:
+      tags:
+        - Module
+      summary: Get a module's status.
+      operationId: GetModule
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the module to get. (urlencoded)
+          required: true
+          type: string
+      responses:
+        '200':
+          description: Ok
+          schema:
+            $ref: '#/definitions/ModuleDetails'
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+    put:
+      tags:
+        - Module
+      summary: Update a module.
+      operationId: UpdateModule
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the module to update. (urlencoded)
+          required: true
+          type: string
+        - name: start
+          in: query
+          description: Flag indicating whether module should be started after updating.
+          required: false
+          type: boolean
+          default: false
+          allowEmptyValue: true
+        - in: body
+          name: module
+          required: true
+          schema:
+            $ref: '#/definitions/ModuleSpec'
+      responses:
+        '200':
+          description: Ok
+          schema:
+            $ref: '#/definitions/ModuleDetails'
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+    delete:
+      tags:
+        - Module
+      summary: Delete a module.
+      operationId: DeleteModule
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the module to delete. (urlencoded)
+          required: true
+          type: string
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  '/modules/{name}/prepareupdate':
+    post:
+      tags:
+        - Module
+      summary: Prepare to update a module.
+      operationId: PrepareUpdateModule
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the module to update. (urlencoded)
+          required: true
+          type: string
+        - in: body
+          name: module
+          required: true
+          schema:
+            $ref: '#/definitions/ModuleSpec'
+      responses:
+        '204':
+          description: No Content
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  '/modules/{name}/start':
+    post:
+      tags:
+        - Module
+      summary: Start a module.
+      operationId: StartModule
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the module to start. (urlencoded)
+          required: true
+          type: string
+      responses:
+        '204':
+          description: No Content
+        '304':
+          description: Not Modified
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  '/modules/{name}/stop':
+    post:
+      tags:
+        - Module
+      summary: Stop a module.
+      operationId: StopModule
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the module to stop. (urlencoded)
+          required: true
+          type: string
+      responses:
+        '204':
+          description: No Content
+        '304':
+          description: Not Modified
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  '/modules/{name}/restart':
+    post:
+      tags:
+        - Module
+      summary: Restart a module.
+      operationId: RestartModule
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the module to restart. (urlencoded)
+          required: true
+          type: string
+      responses:
+        '204':
+          description: No Content
+        '304':
+          description: Not Modified
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  '/modules/{name}/logs':
+    get:
+      tags:
+        - Module
+      summary: Get module logs.
+      operationId: ModuleLogs
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the module to obtain logs for. (urlencoded)
+          required: true
+          type: string
+        - in: query
+          name: follow
+          description: Return the logs as a stream.
+          type: boolean
+          default: false
+        - in: query
+          name: tail
+          description: Only return this number of lines from the end of the logs.
+          type: string
+          default: "all"
+        - in: query
+          name: timestamps
+          description: Return logs with prepended rfc3339 timestamp to each line of log.
+          type: boolean
+          default: false
+        - in: query
+          name: since
+          description: Only return logs since this time, as a duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes), rfc3339 timestamp, or UNIX timestamp.
+          type: string
+          default: "0"
+      responses:
+        '101':
+          description: Logs returned as a stream
+        '200':
+          description: Logs returned as a string in response body
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
+  '/identities/':
+    get:
+      tags:
+        - Identity
+      summary: List identities.
+      produces:
+        - application/json
+      description: |
+        This returns the list of current known idenities.
+      operationId: ListIdentities
+      parameters:
+        - $ref: '#/parameters/api-version'
+      responses:
+        '200':
+          description: Ok
+          schema:
+            $ref: '#/definitions/IdentityList'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+    post:
+      tags:
+        - Identity
+      summary: Create an identity.
+      operationId: CreateIdentity
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: body
+          name: identity
+          required: true
+          schema:
+            $ref: '#/definitions/IdentitySpec'
+      responses:
+        '200':
+          description: Created
+          schema:
+            $ref: '#/definitions/Identity'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  '/identities/{name}':
+    put:
+      tags:
+        - Identity
+      summary: Update an identity.
+      operationId: UpdateIdentity
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the identity to update. (urlencoded)
+          required: true
+          type: string
+        - in: body
+          name: updateinfo
+          required: true
+          schema:
+            $ref: '#/definitions/UpdateIdentity'
+      responses:
+        '200':
+          description: Updated
+          schema:
+            $ref: '#/definitions/Identity'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+    delete:
+      tags:
+        - Identity
+      summary: Delete an identity.
+      operationId: DeleteIdentity
+      produces:
+        - application/json
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: path
+          name: name
+          description: The name of the identity to delete. (urlencoded)
+          required: true
+          type: string
+      responses:
+        '204':
+          description: Ok
+        '404':
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+            
+  /systeminfo:
+    get:
+      tags:
+        - SystemInformation
+      summary: Return host system information.
+      produces:
+        - application/json
+      operationId: GetSystemInfo
+      parameters:
+        - $ref: '#/parameters/api-version'
+      responses:
+        '200':
+          description: Ok
+          schema:
+            $ref: '#/definitions/SystemInfo'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
+  '/systeminfo/resources':
+    get:
+      tags:
+        - SystemInformation
+      summary: Return host resource usage (DISK, RAM, CPU).
+      produces:
+        - application/json
+      operationId: GetSystemResources
+      parameters:
+        - $ref: '#/parameters/api-version'
+      responses:
+        '200':
+          description: Ok
+          schema:
+            $ref: '#/definitions/SystemResources'
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+  
+  '/systeminfo/supportbundle':
+    get:
+      tags:
+        - SystemInformation
+      summary: Return zip of support bundle.
+      produces:
+        - application/zip
+      operationId: GetSupportBundle
+      parameters:
+        - $ref: '#/parameters/api-version'
+        - in: query
+          name: since
+          description: Duration to get logs from. Can be relative (1d, 10m, 1h30m etc.) or absolute (unix timestamp or rfc 3339)
+          required: false
+          type: string
+        - in: query
+          name: host
+          description: Path to the management host
+          required: false
+          type: string
+        - in: query
+          name: iothub_hostname
+          description: Hub to use when calling iotedge check
+          required: false
+          type: string
+        - in: query
+          name: edge_runtime_only
+          description: Exclude customer module logs
+          required: false
+          type: boolean
+          default: false
+      responses:
+        '200':
+          description: Ok
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+
+  '/device/reprovision':
+    post:
+      tags:
+        - DeviceActions
+      summary: Trigger a device reprovisioning flow.
+      operationId: ReprovisionDevice
+      parameters:
+        - $ref: '#/parameters/api-version'
+      responses:
+        '200':
+          description: Ok
+        default:
+          description: Error
+          schema:
+            $ref: '#/definitions/ErrorResponse'
+            
+definitions:
+  ModuleList:
+    type: object
+    properties:
+      modules:
+        type: array
+        items:
+          $ref: '#/definitions/ModuleDetails'
+    required:
+      - modules
+  ModuleDetails:
+    type: object
+    properties:
+      id:
+        type: string
+        description: System generated unique identitier.
+        example: happy_hawking
+      name:
+        type: string
+        description: The name of the module.
+        example: edgeHub
+      type:
+        type: string
+        description: The type of a module.
+        example: docker
+      config:
+        $ref: '#/definitions/Config'
+      status:
+        $ref: '#/definitions/Status'
+    required:
+      - id
+      - name
+      - type
+      - config
+      - status
+  ModuleSpec:
+    type: object
+    properties:
+      name:
+        type: string
+        description: The name of a the module.
+        example: edgeHub
+      type:
+        type: string
+        example: docker
+      imagePullPolicy:
+        type: string
+        enum:
+          - On-Create
+          - Never
+        example: "On-Create"
+      config:
+        $ref: '#/definitions/Config'
+    required:
+      - name
+      - type
+      - config
+  Config:
+    type: object
+    properties:
+      settings:
+        type: object
+        example:
+          image: "microsoft/azureiotedge-hub:1.0"
+          createOptions:
+            HostConfig:
+              PortBindings:
+                "22/tcp":
+                  - HostPort: "11022"
+      env:
+        type: array
+        items:
+          $ref: '#/definitions/EnvVar'
+    required:
+      - settings
+  Status:
+    type: object
+    properties:
+      startTime:
+        type: string
+        format: date-time
+      exitStatus:
+        $ref: '#/definitions/ExitStatus'
+      runtimeStatus:
+        $ref: '#/definitions/RuntimeStatus'
+    required:
+      - runtimeStatus
+  EnvVar:
+    type: object
+    properties:
+      key:
+        type: string
+        example: the_key
+      value:
+        type: string
+        example: the_value
+    required:
+      - key
+      - value
+  ExitStatus:
+    type: object
+    properties:
+      exitTime:
+        type: string
+        format: date-time
+      statusCode:
+        type: string
+    required:
+      - exitTime
+      - statusCode
+    example:
+      exitTime: '2018-04-03T09:31:00.000Z'
+      statusCode: '101'
+  RuntimeStatus:
+    type: object
+    properties:
+      status:
+        type: string
+      description:
+        type: string
+    required:
+      - status
+    example:
+      status: the status
+      description: the description
+  SystemInfo:
+    type: object
+    properties:
+      osType:
+        type: string
+      architecture:
+        type: string
+      version:
+        type: string
+      provisioning:
+        type: '#/definitions/Provisioning'
+      server_version:
+        type: string
+      kernel_version:
+        type: string
+      operating_system:
+        type: string
+      cpus:
+        type: integer
+      virtualized:
+        type: string        
+    required:
+      - osType
+      - architecture
+    example:
+      osType: "linux/windows"
+      architecture: "arm/amd64/x86"
+  SystemResources:
+    type: object
+    properties:
+      host_uptime:
+        type: integer
+        format: int64
+      process_uptime:
+        type: integer
+        format: int64
+      used_cpu:
+        type: number
+      used_ram:
+        type: integer
+        format: int64
+      total_ram:
+        type: integer
+        format: int64
+      disks:
+        type: array
+        items:
+          $ref: '#/definitions/Disk'
+      docker_stats:
+        type: string
+    required:
+      - host_uptime
+      - process_uptime
+      - used_cpu
+      - used_ram
+      - total_ram
+      - disks
+      - docker_stats
+  Disk:
+    type: object
+    properties:
+      name:
+        type: string
+      available_space:
+        type: integer
+        format: int64
+      total_space:
+        type: integer
+        format: int64
+      file_system:
+        type: string
+      file_type:
+        type: string
+    required:
+      - name
+      - available_space
+      - total_space
+      - file_system
+      - file_type
+  IdentityList:
+    type: object
+    properties:
+      identities:
+        type: array
+        items:
+          $ref: '#/definitions/Identity'
+    required:
+      - identities
+  IdentitySpec:
+    type: object
+    properties:
+      moduleId:
+        type: string
+        example: "edgeHub"
+      managedBy:
+        type: string
+        example: "IotEdge"
+    required:
+      - moduleId
+  UpdateIdentity:
+    type: object
+    properties:
+      generationId:
+        type: string
+        example: "636463636967581550"
+      managedBy:
+        type: string
+        example: "IotEdge"
+    required:
+      - generationId
+  Identity:
+    type: object
+    properties:
+      moduleId:
+        type: string
+        example: "edgeHub"
+      managedBy:
+        type: string
+        example: "iot-edge"
+      generationId:
+        type: string
+        example: "636463636967581550"
+      authType:
+        type: string
+        enum:
+          - None
+          - Sas
+          - X509
+        example: "Sas"
+    required:
+      - moduleId
+      - managedBy
+      - generationId
+      - authType
+  ErrorResponse:
+    type: object
+    properties:
+      message:
+        type: string
+    required:
+      - message
+  Provisioning:
+    type: object
+    properties:
+      type:
+        type: string
+      dynamicReprovisioning:
+        type: boolean
+        default: false
+      alwaysReprovisionOnStartup:
+        type: boolean
+        default: true
+    required:
+      - type
+      - dynamicReprovisioning
+
+parameters:
+  api-version:
+    name: api-version
+    in: query
+    description: The version of the API.
+    required: true
+    type: string
+    default: '2018-06-28'

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -254,6 +254,8 @@ cargo test --all
 
     Note that we've manually fixed up the generated code so that it satisfies rustfmt and clippy. As such, if you ever need to run `swagger-codegen-cli` against new definitions, or need to regenerate existing ones, you will want to perform the same fixups manually. Make sure to run clippy and rustfmt against the new code yourself, and inspect the diffs of modified files before checking in.
 
+    For more details, please visit [**How to build Management API using Swagger-Codegen**](../api/README.md)
+
 - IDE
 
     [VS Code](https://code.visualstudio.com/) has good support for Rust. Consider installing the following extensions:

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -311,6 +311,7 @@ impl ToString for LogTail {
 pub struct LogOptions {
     follow: bool,
     tail: LogTail,
+    timestamps: bool,
     since: i32,
     until: Option<i32>,
 }
@@ -320,6 +321,7 @@ impl LogOptions {
         LogOptions {
             follow: false,
             tail: LogTail::All,
+            timestamps: false,
             since: 0,
             until: None,
         }
@@ -345,6 +347,11 @@ impl LogOptions {
         self
     }
 
+    pub fn with_timestamps(mut self, timestamps: bool) -> Self {
+        self.timestamps = timestamps;
+        self
+    }
+
     pub fn follow(&self) -> bool {
         self.follow
     }
@@ -359,6 +366,10 @@ impl LogOptions {
 
     pub fn until(&self) -> Option<i32> {
         self.until
+    }
+
+    pub fn timestamps(&self) -> bool {
+        self.timestamps
     }
 }
 

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -997,7 +997,7 @@ impl ModuleRuntime for DockerModuleRuntime {
                 true,
                 options.since(),
                 options.until(),
-                false,
+                options.timestamps(),
                 tail,
             )
             .then(|result| match result {

--- a/edgelet/edgelet-http-mgmt/src/client/module.rs
+++ b/edgelet/edgelet-http-mgmt/src/client/module.rs
@@ -322,6 +322,7 @@ impl ModuleRuntime for ModuleClient {
                 &id,
                 options.follow(),
                 tail,
+                options.timestamps(),
                 options.since(),
             )
             .then(|logs| match logs {

--- a/edgelet/edgelet-http-mgmt/src/server/module/logs.rs
+++ b/edgelet/edgelet-http-mgmt/src/server/module/logs.rs
@@ -84,9 +84,15 @@ fn parse_options(query: &str) -> Result<LogOptions, Error> {
         .find(|&(ref key, _)| key == "since")
         .map_or_else(|| Ok(0), |(_, val)| parse_since(val))
         .context(ErrorKind::MalformedRequestParameter("since"))?;
+    let timestamps = parse
+        .iter()
+        .find(|&(ref key, _)| key == "timestamps")
+        .map_or_else(|| Ok(false), |(_, val)| val.parse::<bool>())
+        .context(ErrorKind::MalformedRequestParameter("timestamps"))?;
     let mut options = LogOptions::new()
         .with_follow(follow)
         .with_tail(tail)
+        .with_timestamps(timestamps)
         .with_since(since);
 
     if let Some(until) = parse

--- a/edgelet/management/docs/Identity.md
+++ b/edgelet/management/docs/Identity.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 **module_id** | **String** |  | [default to null]
 **managed_by** | **String** |  | [default to null]
 **generation_id** | **String** |  | [default to null]
+**auth_type** | **String** |  | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/edgelet/management/docs/IdentityApi.md
+++ b/edgelet/management/docs/IdentityApi.md
@@ -4,21 +4,21 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**create_identity**](IdentityApi.md#create_identity) | **Put** /identities/{name} | Create or update an identity.
+[**create_identity**](IdentityApi.md#create_identity) | **Post** /identities/ | Create an identity.
 [**delete_identity**](IdentityApi.md#delete_identity) | **Delete** /identities/{name} | Delete an identity.
 [**list_identities**](IdentityApi.md#list_identities) | **Get** /identities/ | List identities.
+[**update_identity**](IdentityApi.md#update_identity) | **Put** /identities/{name} | Update an identity.
 
 
 # **create_identity**
-> ::models::Identity create_identity(api_version, name, identity)
-Create or update an identity.
+> ::models::Identity create_identity(api_version, identity)
+Create an identity.
 
 ### Required Parameters
 
 Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
   **api_version** | **String**| The version of the API. | [default to 2018-06-28]
-  **name** | **String**| The name of the identity to create/update. (urlencoded) | 
   **identity** | [**IdentitySpec**](IdentitySpec.md)|  | 
 
 ### Return type
@@ -85,6 +85,33 @@ No authorization required
 ### HTTP request headers
 
  - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **update_identity**
+> ::models::Identity update_identity(api_version, name, updateinfo)
+Update an identity.
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+  **name** | **String**| The name of the identity to update. (urlencoded) | 
+  **updateinfo** | [**UpdateIdentity**](UpdateIdentity.md)|  | 
+
+### Return type
+
+[**::models::Identity**](Identity.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
  - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/edgelet/management/docs/IdentitySpec.md
+++ b/edgelet/management/docs/IdentitySpec.md
@@ -4,6 +4,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **module_id** | **String** |  | [default to null]
+**managed_by** | **String** |  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/edgelet/management/docs/ModuleApi.md
+++ b/edgelet/management/docs/ModuleApi.md
@@ -9,6 +9,7 @@ Method | HTTP request | Description
 [**get_module**](ModuleApi.md#get_module) | **Get** /modules/{name} | Get a module&#39;s status.
 [**list_modules**](ModuleApi.md#list_modules) | **Get** /modules | List modules.
 [**module_logs**](ModuleApi.md#module_logs) | **Get** /modules/{name}/logs | Get module logs.
+[**prepare_update_module**](ModuleApi.md#prepare_update_module) | **Post** /modules/{name}/prepareupdate | Prepare to update a module.
 [**restart_module**](ModuleApi.md#restart_module) | **Post** /modules/{name}/restart | Restart a module.
 [**start_module**](ModuleApi.md#start_module) | **Post** /modules/{name}/start | Start a module.
 [**stop_module**](ModuleApi.md#stop_module) | **Post** /modules/{name}/stop | Stop a module.
@@ -140,9 +141,9 @@ Name | Type | Description  | Notes
  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
  **name** | **String**| The name of the module to obtain logs for. (urlencoded) | 
  **follow** | **bool**| Return the logs as a stream. | [default to false]
- **stdout** | **bool**| Return logs from &#x60;stdout&#x60; | [default to false]
- **stderr** | **bool**| Return logs from &#x60;stderr&#x60; | [default to false]
  **tail** | **String**| Only return this number of lines from the end of the logs. | [default to all]
+ **timestamps** | **bool**| Return logs with prepended rfc3339 timestamp to each line of log. | [default to false]
+ **since** | **String**| Only return logs since this time, as a duration (1 day, 1d, 90m, 2 days 3 hours 2 minutes), rfc3339 timestamp, or UNIX timestamp. | [default to 0]
 
 ### Return type
 
@@ -156,6 +157,33 @@ No authorization required
 
  - **Content-Type**: Not defined
  - **Accept**: Not defined
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **prepare_update_module**
+> prepare_update_module(api_version, name, module)
+Prepare to update a module.
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+  **name** | **String**| The name of the module to update. (urlencoded) | 
+  **module** | [**ModuleSpec**](ModuleSpec.md)|  | 
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: application/json
+ - **Accept**: application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
@@ -238,7 +266,7 @@ No authorization required
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **update_module**
-> ::models::ModuleDetails update_module(api_version, name, module)
+> ::models::ModuleDetails update_module(api_version, name, module, optional)
 Update a module.
 
 ### Required Parameters
@@ -248,6 +276,17 @@ Name | Type | Description  | Notes
   **api_version** | **String**| The version of the API. | [default to 2018-06-28]
   **name** | **String**| The name of the module to update. (urlencoded) | 
   **module** | [**ModuleSpec**](ModuleSpec.md)|  | 
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+ **name** | **String**| The name of the module to update. (urlencoded) | 
+ **module** | [**ModuleSpec**](ModuleSpec.md)|  | 
+ **start** | **bool**| Flag indicating whether module should be started after updating. | [default to false]
 
 ### Return type
 

--- a/edgelet/management/docs/ModuleSpec.md
+++ b/edgelet/management/docs/ModuleSpec.md
@@ -5,6 +5,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **String** | The name of a the module. | [default to null]
 **_type** | **String** |  | [default to null]
+**image_pull_policy** | **String** |  | [optional] [default to null]
 **config** | [***::models::Config**](Config.md) |  | [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/edgelet/management/docs/SystemInfo.md
+++ b/edgelet/management/docs/SystemInfo.md
@@ -5,6 +5,12 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **os_type** | **String** |  | [default to null]
 **architecture** | **String** |  | [default to null]
+**version** | **String** |  | [optional] [default to null]
+**server_version** | **String** |  | [optional] [default to null]
+**kernel_version** | **String** |  | [optional] [default to null]
+**operating_system** | **String** |  | [optional] [default to null]
+**cpus** | **i32** |  | [optional] [default to null]
+**virtualized** | **String** |  | [optional] [default to null]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/edgelet/management/docs/SystemInformationApi.md
+++ b/edgelet/management/docs/SystemInformationApi.md
@@ -4,8 +4,47 @@ All URIs are relative to *http://localhost*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
+[**get_support_bundle**](SystemInformationApi.md#get_support_bundle) | **Get** /systeminfo/supportbundle | Return zip of support bundle.
 [**get_system_info**](SystemInformationApi.md#get_system_info) | **Get** /systeminfo | Return host system information.
+[**get_system_resources**](SystemInformationApi.md#get_system_resources) | **Get** /systeminfo/resources | Return host resource usage (DISK, RAM, CPU).
 
+
+# **get_support_bundle**
+> get_support_bundle(api_version, optional)
+Return zip of support bundle.
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+ **optional** | **map[string]interface{}** | optional parameters | nil if no parameters
+
+### Optional Parameters
+Optional parameters are passed through a map[string]interface{}.
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+ **since** | **String**| Duration to get logs from. Can be relative (1d, 10m, 1h30m etc.) or absolute (unix timestamp or rfc 3339) | 
+ **host** | **String**| Path to the management host | 
+ **iothub_hostname** | **String**| Hub to use when calling iotedge check | 
+ **edge_runtime_only** | **bool**| Exclude customer module logs | [default to false]
+
+### Return type
+
+ (empty response body)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/zip
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **get_system_info**
 > ::models::SystemInfo get_system_info(api_version)
@@ -20,6 +59,31 @@ Name | Type | Description  | Notes
 ### Return type
 
 [**::models::SystemInfo**](SystemInfo.md)
+
+### Authorization
+
+No authorization required
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **get_system_resources**
+> ::models::SystemResources get_system_resources(api_version)
+Return host resource usage (DISK, RAM, CPU).
+
+### Required Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+  **api_version** | **String**| The version of the API. | [default to 2018-06-28]
+
+### Return type
+
+[**::models::SystemResources**](SystemResources.md)
 
 ### Authorization
 

--- a/edgelet/management/src/apis/module_api.rs
+++ b/edgelet/management/src/apis/module_api.rs
@@ -53,6 +53,7 @@ pub trait ModuleApi: Send + Sync {
         name: &str,
         follow: bool,
         tail: &str,
+        timestamps: bool,
         since: i32,
     ) -> Box<dyn Future<Item = hyper::Body, Error = Error<serde_json::Value>> + Send>;
     fn restart_module(
@@ -323,6 +324,7 @@ where
         name: &str,
         follow: bool,
         tail: &str,
+        timestamps: bool,
         since: i32,
     ) -> Box<dyn Future<Item = hyper::Body, Error = Error<serde_json::Value>> + Send> {
         let configuration: &configuration::Configuration<C> = self.configuration.borrow();
@@ -333,6 +335,7 @@ where
             .append_pair("api-version", &api_version.to_string())
             .append_pair("follow", &follow.to_string())
             .append_pair("tail", &tail.to_string())
+            .append_pair("timestamps", &timestamps.to_string())
             .append_pair("since", &since.to_string())
             .finish();
         let uri_str = format!(


### PR DESCRIPTION
- Allow Management socket to accept `timestamps` option to be pass through docker socket API.
- Update the documents for the latest API version
- The latest API is being manually added since there is a gigantic out-of-sync between the template interface `managementVersion_2020_07_07.yaml` and `/edgelet/management` generated code.