### PR TITLE
Use Docker Timestamp When Log Timestamp is not Available in JSON log (#4981)

### DIFF
--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -45,7 +45,12 @@ jobs:
         displayName: Test
         inputs:
           filePath: scripts/linux/runTests.sh
-          arguments: '"--filter Category=Unit"'
+          arguments: '"--filter Category=Unit&Category!=GetLogsTests"'
+      - task: Bash@3
+        displayName: Run GetLogsTests Tests
+        inputs:
+          filePath: scripts/linux/runTests.sh
+          arguments: '"--filter Category=GetLogsTests"'
       - task: PublishTestResults@2
         displayName: Publish Test Results
         inputs:
@@ -75,7 +80,19 @@ jobs:
           testSelector: testAssemblies
           testAssemblyVer2: |
             target\*Test.dll
-          testFiltercriteria: Category=Unit
+          testFiltercriteria: Category=Unit&Category!=GetLogsTests
+          runInParallel: true
+          runTestsInIsolation: true
+          codeCoverageEnabled: true
+          runSettingsFile: CodeCoverage.runsettings
+          publishRunAttachments: true
+      - task: VSTest@2
+        displayName: Run GetLogsTests unit tests with code coverage
+        inputs:
+          testSelector: testAssemblies
+          testAssemblyVer2: |
+            target\*Test.dll
+          testFiltercriteria: Category=GetLogsTests
           runInParallel: true
           runTestsInIsolation: true
           codeCoverageEnabled: true

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IRuntimeInfoProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/IRuntimeInfoProvider.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
     {
         Task<IEnumerable<ModuleRuntimeInfo>> GetModules(CancellationToken cancellationToken);
 
-        Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, CancellationToken cancellationToken);
+        Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, Option<bool> includeTimestamp, CancellationToken cancellationToken);
 
         Task<SystemInfo> GetSystemInfo(CancellationToken cancellationToken);
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ILogMessageParser.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ILogMessageParser.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
 {
     extern alias akka;
     using akka::Akka.IO;
+    using Microsoft.Azure.Devices.Edge.Util;
 
     public interface ILogMessageParser
     {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/LogsProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/LogsProvider.cs
@@ -26,7 +26,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
         {
             Preconditions.CheckNotNull(logOptions, nameof(logOptions));
 
-            Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, false, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, cancellationToken);
+            if (logOptions.ContentType == LogsContentType.Json)
+            {
+                logOptions.Filter.IncludeTimestamp = Option.Some(true);
+            }
+
+            Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, false, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, logOptions.Filter.IncludeTimestamp, cancellationToken);
             Events.ReceivedStream(id);
 
             byte[] logBytes = await this.GetProcessedLogs(id, logsStream, logOptions);
@@ -60,7 +65,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
             Preconditions.CheckNotNull(logOptions, nameof(logOptions));
             Preconditions.CheckNotNull(callback, nameof(callback));
 
-            Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, logOptions.Follow, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, cancellationToken);
+            Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, logOptions.Follow, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, logOptions.Filter.IncludeTimestamp, cancellationToken);
             Events.ReceivedStream(id);
 
             await this.logsProcessor.ProcessLogsStream(id, logsStream, logOptions, callback);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogFilter.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/ModuleLogFilter.cs
@@ -10,21 +10,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
 
     public class ModuleLogFilter : IEquatable<ModuleLogFilter>
     {
-        public static ModuleLogFilter Empty = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<string>());
+        public static ModuleLogFilter Empty = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>());
 
-        public ModuleLogFilter(Option<int> tail, Option<string> since, Option<string> until, Option<int> logLevel, Option<string> regex)
+        public ModuleLogFilter(Option<int> tail, Option<string> since, Option<string> until, Option<int> logLevel, Option<bool> includeTimestamp, Option<string> regex)
         {
             this.Tail = tail;
             this.Since = since;
             this.Until = until;
             this.LogLevel = logLevel;
             this.RegexString = regex;
+            this.IncludeTimestamp = includeTimestamp;
             this.Regex = regex.Map(r => new Regex(r));
         }
 
         [JsonConstructor]
-        ModuleLogFilter(int? tail, string since, string until, int? loglevel, string regex)
-            : this(Option.Maybe(tail), Option.Maybe(since), Option.Maybe(until), Option.Maybe(loglevel), Option.Maybe(regex))
+        ModuleLogFilter(int? tail, string since, string until, int? loglevel, bool? includeTimestamp, string regex)
+            : this(Option.Maybe(tail), Option.Maybe(since), Option.Maybe(until), Option.Maybe(loglevel), Option.Maybe(includeTimestamp), Option.Maybe(regex))
         {
         }
 
@@ -45,6 +46,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
         public Option<int> LogLevel { get; }
 
         [JsonIgnore]
+        public Option<bool> IncludeTimestamp { get; set; }
+
+        [JsonIgnore]
         public Option<Regex> Regex { get; }
 
         [JsonProperty("regex")]
@@ -59,6 +63,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
                this.Tail.Equals(other.Tail) &&
                this.Since.Equals(other.Since) &&
                this.LogLevel.Equals(other.LogLevel) &&
+               this.IncludeTimestamp.Equals(other.IncludeTimestamp) &&
                this.RegexString.Equals(other.RegexString);
 
         public override int GetHashCode()
@@ -67,6 +72,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
             hashCode = hashCode * -1521134295 + EqualityComparer<Option<int>>.Default.GetHashCode(this.Tail);
             hashCode = hashCode * -1521134295 + EqualityComparer<Option<string>>.Default.GetHashCode(this.Since);
             hashCode = hashCode * -1521134295 + EqualityComparer<Option<int>>.Default.GetHashCode(this.LogLevel);
+            hashCode = hashCode * -1521134295 + EqualityComparer<Option<bool>>.Default.GetHashCode(this.IncludeTimestamp);
             hashCode = hashCode * -1521134295 + EqualityComparer<Option<string>>.Default.GetHashCode(this.RegexString);
             return hashCode;
         }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RuntimeInfoProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/RuntimeInfoProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             return modules;
         }
 
-        public Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, CancellationToken cancellationToken)
+        public Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, Option<bool> includeTimestamp, CancellationToken cancellationToken)
         {
             var containerLogsParameters = new ContainerLogsParameters
             {
@@ -89,6 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
             };
             tail.ForEach(t => containerLogsParameters.Tail = t.ToString());
             since.ForEach(t => containerLogsParameters.Since = t.ToString());
+            includeTimestamp.ForEach(t => containerLogsParameters.Timestamps = t);
 
             return this.client.Containers.GetContainerLogsAsync(module, containerLogsParameters, cancellationToken);
         }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/IModuleManager.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/IModuleManager.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
 
         Task PrepareUpdateAsync(ModuleSpec moduleSpec);
 
-        Task<Stream> GetModuleLogs(string name, bool follow, Option<int> tail, Option<string> since, Option<string> until, CancellationToken cancellationToken);
+        Task<Stream> GetModuleLogs(string name, bool follow, Option<int> tail, Option<string> since, Option<string> until, Option<bool> includeTimestamp, CancellationToken cancellationToken);
 
         Task<Stream> GetSupportBundle(Option<string> since, Option<string> until, Option<string> iothubHostname, Option<bool> edgeRuntimeOnly, CancellationToken token);
     }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/ModuleManagementHttpClient.cs
@@ -57,8 +57,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
 
         public Task ReprovisionDeviceAsync() => this.inner.ReprovisionDeviceAsync();
 
-        public Task<Stream> GetModuleLogs(string name, bool follow, Option<int> tail, Option<string> since, Option<string> until, CancellationToken cancellationToken) =>
-            this.inner.GetModuleLogs(name, follow, tail, since, until, cancellationToken);
+        public Task<Stream> GetModuleLogs(string name, bool follow, Option<int> tail, Option<string> since, Option<string> until, Option<bool> includeTimestamp, CancellationToken cancellationToken) =>
+            this.inner.GetModuleLogs(name, follow, tail, since, until, includeTimestamp, cancellationToken);
 
         public Task<Stream> GetSupportBundle(Option<string> since, Option<string> until, Option<string> iothubHostname, Option<bool> edgeRuntimeOnly, CancellationToken token) =>
             this.inner.GetSupportBundle(since, until, iothubHostname, edgeRuntimeOnly, token);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/RuntimeInfoProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/RuntimeInfoProvider.cs
@@ -20,8 +20,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
         public Task<IEnumerable<ModuleRuntimeInfo>> GetModules(CancellationToken token) =>
             this.moduleManager.GetModules<T>(token);
 
-        public Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, CancellationToken cancellationToken) =>
-             this.moduleManager.GetModuleLogs(module, follow, tail, since, until, cancellationToken);
+        public Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, Option<bool> includeTimestamp, CancellationToken cancellationToken) =>
+             this.moduleManager.GetModuleLogs(module, follow, tail, since, until, includeTimestamp, cancellationToken);
 
         public Task<SystemInfo> GetSystemInfo(CancellationToken token) => this.moduleManager.GetSystemInfoAsync(token);
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/blob/AzureBlobRequestsUploader.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/blob/AzureBlobRequestsUploader.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Blob
                 string blobName = this.GetBlobName(id, GetLogsExtension(logsContentEncoding, logsContentType));
                 var container = new CloudBlobContainer(containerUri);
                 Events.Uploading(blobName, container.Name);
+
                 await ExecuteWithRetry(
                     () =>
                     {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesRuntimeInfoProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/KubernetesRuntimeInfoProvider.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
             return await Task.FromResult(moduleRuntimeInfoList);
         }
 
-        public Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, CancellationToken cancellationToken)
+        public Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, Option<bool> includeTimestamp, CancellationToken cancellationToken)
         {
             return Task.FromResult(Stream.Null);
         }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/logs/LogsProcessorTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/logs/LogsProcessorTest.cs
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(TestLogBytes);
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.Some(regex));
 
             // Act
             IEnumerable<string> textLines = await logsProcessor.GetText(moduleId, stream, filter);
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(TestLogBytes);
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.Some(regex));
 
             // Act
             IEnumerable<ModuleLogMessage> logMessages = await logsProcessor.GetMessages(moduleId, stream, filter);
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<string>());
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.None<string>());
 
             // Act
             List<string> textLines = (await logsProcessor.GetText(moduleId, stream, filter)).ToList();
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<string>());
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.None<string>());
 
             // Act
             IEnumerable<ModuleLogMessage> logMessages = await logsProcessor.GetMessages(moduleId, stream, filter);
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.Some(regex));
 
             // Act
             List<string> textLines = (await logsProcessor.GetText(moduleId, stream, filter)).ToList();
@@ -264,7 +264,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.Some(regex));
 
             // Act
             IEnumerable<ModuleLogMessage> logMessages = await logsProcessor.GetMessages(moduleId, stream, filter);
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.Some(regex));
             var logOptions = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
 
             var receivedBytes = new List<byte>();
@@ -328,7 +328,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.Some(regex));
             var logOptions = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Json, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
 
             var receivedBytes = new List<byte>();
@@ -365,7 +365,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.Some(regex));
             var logOptions = new ModuleLogOptions(LogsContentEncoding.Gzip, LogsContentType.Text, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
 
             var receivedBytes = new List<byte>();
@@ -400,7 +400,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.Some(regex));
             var logOptions = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, filter, LogOutputFraming.SimpleLength, Option.None<LogsOutputGroupingConfig>(), false);
 
             var receivedBytes = new List<byte>();
@@ -435,7 +435,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
             var stream = new MemoryStream(DockerFraming.Frame(TestLogTexts));
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.Some(regex));
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(logLevel), Option.None<bool>(), Option.Some(regex));
             var logOptions = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Json, filter, LogOutputFraming.SimpleLength, Option.None<LogsOutputGroupingConfig>(), false);
 
             var receivedBytes = new List<byte>();
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             string moduleId = "mod1";
             var logMessageParser = new LogMessageParser(iotHub, deviceId);
             var logsProcessor = new LogsProcessor(logMessageParser);
-            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<string>());
+            var filter = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>());
 
             var stream1 = new MemoryStream(DockerFraming.Frame(TestLogTexts));
             var logOptions1 = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/logs/LogsProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/logs/LogsProviderTest.cs
@@ -30,17 +30,18 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
         public static IEnumerable<object[]> GetNeedToProcessStreamTestData()
         {
             yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, ModuleLogFilter.Empty, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), false };
-            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<string>()), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), false };
+            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>()), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), false };
             yield return new object[] { new ModuleLogOptions(LogsContentEncoding.Gzip, LogsContentType.Text, ModuleLogFilter.Empty, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
-            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.Some(3), Option.Some("foo")), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
-            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.Some(3), Option.None<string>()), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
-            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.Some("foo")), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
-            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Json, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<string>()), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
-            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<string>()), LogOutputFraming.SimpleLength, Option.None<LogsOutputGroupingConfig>(), false), true };
-            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<string>()), LogOutputFraming.None, Option.Some(new LogsOutputGroupingConfig(100, TimeSpan.FromMilliseconds(1000))), false), false };
+            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.Some(3), Option.None<bool>(), Option.Some("foo")), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
+            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.Some(3), Option.None<bool>(), Option.None<string>()), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
+            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.Some("foo")), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
+            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Json, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>()), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false), true };
+            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>()), LogOutputFraming.SimpleLength, Option.None<LogsOutputGroupingConfig>(), false), true };
+            yield return new object[] { new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(10), Option.Some("100"), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>()), LogOutputFraming.None, Option.Some(new LogsOutputGroupingConfig(100, TimeSpan.FromMilliseconds(1000))), false), false };
         }
 
         [Fact]
+        [Trait("Category", "GetLogsTests")]
         public async Task GetLogsAsTextTest()
         {
             // Arrange
@@ -49,11 +50,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             string moduleId = "mod1";
             Option<int> tail = Option.None<int>();
             Option<string> since = Option.None<string>();
+            Option<string> until = Option.None<string>();
+            Option<bool> includeTimestamp = Option.None<bool>();
             CancellationToken cancellationToken = CancellationToken.None;
             string expectedLogText = TestLogTexts.Join(string.Empty);
 
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, false, tail, since, Option.None<string>(), cancellationToken))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, false, tail, since, until, includeTimestamp, cancellationToken))
                 .ReturnsAsync(new MemoryStream(DockerFraming.Frame(TestLogTexts)));
 
             var logsProcessor = new LogsProcessor(new LogMessageParser(iotHub, deviceId));
@@ -70,19 +73,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
         }
 
         [Fact]
+        [Trait("Category", "GetLogsTests")]
         public async Task GetLogsAsTextWithCompressionTest()
         {
             // Arrange
             string iotHub = "foo.azure-devices.net";
-            string deviceId = "dev1";
-            string moduleId = "mod1";
+            string deviceId = "dev2";
+            string moduleId = "mod2";
             Option<int> tail = Option.None<int>();
             Option<string> since = Option.None<string>();
+            Option<string> until = Option.None<string>();
+            Option<bool> includeTimestamp = Option.None<bool>();
             CancellationToken cancellationToken = CancellationToken.None;
             string expectedLogText = TestLogTexts.Join(string.Empty);
 
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, false, tail, since, Option.None<string>(), cancellationToken))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, false, tail, since, until, includeTimestamp, cancellationToken))
                 .ReturnsAsync(new MemoryStream(DockerFraming.Frame(TestLogTexts)));
 
             var logsProcessor = new LogsProcessor(new LogMessageParser(iotHub, deviceId));
@@ -108,16 +114,20 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             string moduleId = "mod1";
             Option<int> tail = Option.None<int>();
             Option<string> since = Option.None<string>();
+            Option<string> until = Option.None<string>();
+            Option<bool> includeTimestamp = Option.Some(true);
             CancellationToken cancellationToken = CancellationToken.None;
 
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, false, tail, since, Option.None<string>(), cancellationToken))
+            // Note: EdgeAgent automatically includes the timestamp for log parsing by default for content type JSON
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, false, tail, since, until, includeTimestamp, cancellationToken))
                 .ReturnsAsync(new MemoryStream(DockerFraming.Frame(TestLogTexts)));
 
             var logsProcessor = new LogsProcessor(new LogMessageParser(iotHub, deviceId));
             var logsProvider = new LogsProvider(runtimeInfoProvider.Object, logsProcessor);
 
-            var logOptions = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Json, ModuleLogFilter.Empty, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
+            ModuleLogFilter filter = new ModuleLogFilter(tail, since, until, Option.None<int>(), includeTimestamp, Option.None<string>());
+            var logOptions = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Json, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
 
             // Act
             byte[] bytes = await logsProvider.GetLogs(moduleId, logOptions, cancellationToken);
@@ -149,16 +159,20 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             string moduleId = "mod1";
             Option<int> tail = Option.None<int>();
             Option<string> since = Option.None<string>();
+            Option<string> until = Option.None<string>();
+            Option<bool> includeTimestamp = Option.Some(true);
             CancellationToken cancellationToken = CancellationToken.None;
 
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, false, tail, since, Option.None<string>(), cancellationToken))
+            // Note: EdgeAgent automatically includes the timestamp for log parsing by default for content type JSON
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, false, tail, since, until, includeTimestamp, cancellationToken))
                 .ReturnsAsync(new MemoryStream(DockerFraming.Frame(TestLogTexts)));
 
             var logsProcessor = new LogsProcessor(new LogMessageParser(iotHub, deviceId));
             var logsProvider = new LogsProvider(runtimeInfoProvider.Object, logsProcessor);
 
-            var logOptions = new ModuleLogOptions(LogsContentEncoding.Gzip, LogsContentType.Json, ModuleLogFilter.Empty, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
+            ModuleLogFilter filter = new ModuleLogFilter(tail, since, until, Option.None<int>(), includeTimestamp, Option.None<string>());
+            var logOptions = new ModuleLogOptions(LogsContentEncoding.Gzip, LogsContentType.Json, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
 
             // Act
             byte[] bytes = await logsProvider.GetLogs(moduleId, logOptions, cancellationToken);
@@ -183,19 +197,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
         }
 
         [Fact]
+        [Trait("Category", "GetLogsTests")]
         public async Task GetLogsStreamTest()
         {
             // Arrange
             string iotHub = "foo.azure-devices.net";
-            string deviceId = "dev1";
-            string moduleId = "mod1";
+            string deviceId = "dev3";
+            string moduleId = "mod3";
             Option<int> tail = Option.None<int>();
             Option<string> since = Option.None<string>();
+            Option<string> until = Option.None<string>();
+            Option<bool> includeTimestamp = Option.None<bool>();
             CancellationToken cancellationToken = CancellationToken.None;
 
             byte[] dockerLogsStreamBytes = DockerFraming.Frame(TestLogTexts);
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, true, tail, since, Option.None<string>(), cancellationToken))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, true, tail, since, until, includeTimestamp, cancellationToken))
                 .ReturnsAsync(new MemoryStream(dockerLogsStreamBytes));
             runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new[] { new ModuleRuntimeInfo(moduleId, "docker", ModuleStatus.Running, "foo", 0, Option.None<DateTime>(), Option.None<DateTime>()) });
@@ -234,7 +251,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
 
             byte[] dockerLogsStreamBytes = DockerFraming.Frame(TestLogTexts);
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, true, tail, since, Option.None<string>(), cancellationToken))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId, true, tail, since, Option.None<string>(), Option.None<bool>(), cancellationToken))
                 .ReturnsAsync(new MemoryStream(dockerLogsStreamBytes));
             runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new[] { new ModuleRuntimeInfo(moduleId, "docker", ModuleStatus.Running, "foo", 0, Option.None<DateTime>(), Option.None<DateTime>()) });
@@ -242,7 +259,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             var logsProcessor = new LogsProcessor(new LogMessageParser(iotHub, deviceId));
             var logsProvider = new LogsProvider(runtimeInfoProvider.Object, logsProcessor);
 
-            var filter = new ModuleLogFilter(tail, since, Option.None<string>(), Option.Some(6), Option.Some("Starting"));
+            var filter = new ModuleLogFilter(tail, since, Option.None<string>(), Option.Some(6), Option.None<bool>(), Option.Some("Starting"));
             var logOptions = new ModuleLogOptions(LogsContentEncoding.Gzip, LogsContentType.Text, filter, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), true);
 
             var receivedBytes = new List<byte>();
@@ -278,8 +295,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             string moduleId1 = "mod1";
             string moduleId2 = "mod2";
 
-            var filter1 = new ModuleLogFilter(tail, since, Option.None<string>(), Option.Some(6), Option.Some("Starting"));
-            var filter2 = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.Some("bad"));
+            var filter1 = new ModuleLogFilter(tail, since, Option.None<string>(), Option.Some(6), Option.None<bool>(), Option.Some("Starting"));
+            var filter2 = new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.Some("bad"));
 
             byte[] dockerLogsStreamBytes1 = DockerFraming.Frame(TestLogTexts);
             byte[] dockerLogsStreamBytes2 = DockerFraming.Frame(TestLogTexts);
@@ -291,9 +308,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             };
 
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId1, true, tail, since, Option.None<string>(), cancellationToken))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId1, true, tail, since, Option.None<string>(), Option.None<bool>(), cancellationToken))
                 .ReturnsAsync(new MemoryStream(dockerLogsStreamBytes1));
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId2, true, Option.None<int>(), Option.None<string>(), Option.None<string>(), cancellationToken))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId2, true, Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<bool>(), cancellationToken))
                 .ReturnsAsync(new MemoryStream(dockerLogsStreamBytes2));
             runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(modulesList);
@@ -351,7 +368,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             string moduleId1 = "mod1";
             string moduleId2 = "mod2";
 
-            var filter = new ModuleLogFilter(tail, since, Option.None<string>(), Option.None<int>(), Option.Some("bad"));
+            var filter = new ModuleLogFilter(tail, since, Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.Some("bad"));
 
             byte[] dockerLogsStreamBytes1 = DockerFraming.Frame(TestLogTexts);
             byte[] dockerLogsStreamBytes2 = DockerFraming.Frame(TestLogTexts);
@@ -363,9 +380,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
             };
 
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId1, true, tail, since, Option.None<string>(), cancellationToken))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId1, true, tail, since, Option.None<string>(), Option.None<bool>(), cancellationToken))
                 .ReturnsAsync(new MemoryStream(dockerLogsStreamBytes1));
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId2, true, tail, since, Option.None<string>(), cancellationToken))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(moduleId2, true, tail, since, Option.None<string>(), Option.None<bool>(), cancellationToken))
                 .ReturnsAsync(new MemoryStream(dockerLogsStreamBytes2));
             runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(modulesList);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/logs/LogsRequestToOptionsMapperTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/logs/LogsRequestToOptionsMapperTests.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Logs
         {
             var logOptions1 = new ModuleLogOptions(LogsContentEncoding.Gzip, LogsContentType.Json, ModuleLogFilter.Empty, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
             var logOptions2 = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, ModuleLogFilter.Empty, LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
-            var logOptions3 = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(100), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<string>()), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
+            var logOptions3 = new ModuleLogOptions(LogsContentEncoding.None, LogsContentType.Text, new ModuleLogFilter(Option.Some(100), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>()), LogOutputFraming.None, Option.None<LogsOutputGroupingConfig>(), false);
 
             yield return new object[]
             {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsRequestHandlerTests.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsRequestHandlerTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         [Fact]
         public async Task GetJsonLogsTest()
         {
-            var filter = new ModuleLogFilter(Option.Some(100), Option.Some("1501000"), Option.None<string>(), Option.Some(3), Option.Some("ERR"));
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some("1501000"), Option.None<string>(), Option.Some(3), Option.None<bool>(), Option.Some("ERR"));
             LogsContentEncoding contentEncoding = LogsContentEncoding.None;
             LogsContentType contentType = LogsContentType.Json;
 
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         [Fact]
         public async Task GetTextLogsTest()
         {
-            var filter = new ModuleLogFilter(Option.Some(100), Option.Some("1501000"), Option.None<string>(), Option.Some(3), Option.Some("ERR"));
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some("1501000"), Option.None<string>(), Option.Some(3), Option.None<bool>(), Option.Some("ERR"));
             LogsContentEncoding contentEncoding = LogsContentEncoding.None;
             LogsContentType contentType = LogsContentType.Text;
 
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         [Fact]
         public async Task GetJsonGzipLogsTest()
         {
-            var filter = new ModuleLogFilter(Option.Some(100), Option.Some("1501000"), Option.None<string>(), Option.Some(3), Option.Some("ERR"));
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some("1501000"), Option.None<string>(), Option.Some(3), Option.None<bool>(), Option.Some("ERR"));
             LogsContentEncoding contentEncoding = LogsContentEncoding.Gzip;
             LogsContentType contentType = LogsContentType.Json;
 
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
         [Fact]
         public async Task GetTextGzipLogsTest()
         {
-            var filter = new ModuleLogFilter(Option.Some(100), Option.Some("1501000"), Option.None<string>(), Option.Some(3), Option.Some("ERR"));
+            var filter = new ModuleLogFilter(Option.Some(100), Option.Some("1501000"), Option.None<string>(), Option.Some(3), Option.None<bool>(), Option.Some("ERR"));
             LogsContentEncoding contentEncoding = LogsContentEncoding.Gzip;
             LogsContentType contentType = LogsContentType.Text;
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             var runtimeInfoProvider = await RuntimeInfoProvider.CreateAsync(dockerClient);
 
             // Act
-            Stream receivedLogsStream = await runtimeInfoProvider.GetModuleLogs(id, false, Option.None<int>(), Option.None<string>(), Option.None<string>(), CancellationToken.None);
+            Stream receivedLogsStream = await runtimeInfoProvider.GetModuleLogs(id, false, Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<bool>(), CancellationToken.None);
 
             // Assert
             Assert.NotNull(receivedContainerLogsParameters);
@@ -301,7 +301,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             Assert.Equal(dummyLogs, receivedLogs);
 
             // Act
-            receivedLogsStream = await runtimeInfoProvider.GetModuleLogs(id, true, Option.Some(1000), Option.None<string>(), Option.None<string>(), CancellationToken.None);
+            receivedLogsStream = await runtimeInfoProvider.GetModuleLogs(id, true, Option.Some(1000), Option.None<string>(), Option.None<string>(), Option.None<bool>(), CancellationToken.None);
 
             // Assert
             Assert.NotNull(receivedContainerLogsParameters);
@@ -317,7 +317,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             Assert.Equal(dummyLogs, receivedLogs);
 
             // Act
-            receivedLogsStream = await runtimeInfoProvider.GetModuleLogs(id, true, Option.None<int>(), Option.Some("1552887267"), Option.None<string>(), CancellationToken.None);
+            receivedLogsStream = await runtimeInfoProvider.GetModuleLogs(id, true, Option.None<int>(), Option.Some("1552887267"), Option.None<string>(), Option.None<bool>(), CancellationToken.None);
 
             // Assert
             Assert.NotNull(receivedContainerLogsParameters);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleManagementHttpClientTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleManagementHttpClientTest.cs
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
             IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
 
             // Act
-            Stream logsStream = await client.GetModuleLogs("edgeHub", false, Option.None<int>(), Option.None<string>(), Option.None<string>(), CancellationToken.None);
+            Stream logsStream = await client.GetModuleLogs("edgeHub", false, Option.None<int>(), Option.None<string>(), Option.None<string>(),  Option.Some(false), CancellationToken.None);
 
             // Assert
             Assert.NotNull(logsStream);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/RuntimeInfoProviderTest.cs
@@ -101,13 +101,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
             Stream GetLogsStream() => new MemoryStream(Encoding.UTF8.GetBytes(dummyLogs));
 
             var moduleManager = new Mock<IModuleManager>();
-            moduleManager.Setup(m => m.GetModuleLogs(id, It.IsAny<bool>(), It.IsAny<Option<int>>(), It.IsAny<Option<string>>(), It.IsAny<Option<string>>(), It.IsAny<CancellationToken>()))
+            moduleManager.Setup(m => m.GetModuleLogs(id, It.IsAny<bool>(), It.IsAny<Option<int>>(), It.IsAny<Option<string>>(), It.IsAny<Option<string>>(), Option.None<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(GetLogsStream);
 
             var runtimeInfoProvider = new RuntimeInfoProvider<TestConfig>(moduleManager.Object);
 
             // Act
-            Stream receivedLogsStream = await runtimeInfoProvider.GetModuleLogs(id, false, Option.None<int>(), Option.None<string>(), Option.None<string>(), CancellationToken.None);
+            Stream receivedLogsStream = await runtimeInfoProvider.GetModuleLogs(id, false, Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<bool>(), CancellationToken.None);
 
             // Assert
             var buffer = new byte[1024];

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/stream/LogsStreamRequestHandlerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/stream/LogsStreamRequestHandlerTest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Stream
 
             string id = "m1";
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(id, true, Option.None<int>(), Option.None<string>(), Option.None<string>(), It.IsAny<CancellationToken>()))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(id, true, Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new MemoryStream(buffer));
             runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new[] { new ModuleRuntimeInfo(id, "docker", ModuleStatus.Running, "foo", 0, Option.None<DateTime>(), Option.None<DateTime>()) });
@@ -86,7 +86,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.Stream
 
             string id = "m1";
             var runtimeInfoProvider = new Mock<IRuntimeInfoProvider>();
-            runtimeInfoProvider.Setup(r => r.GetModuleLogs(id, true, Option.None<int>(), Option.None<string>(), Option.None<string>(), It.IsAny<CancellationToken>()))
+            runtimeInfoProvider.Setup(r => r.GetModuleLogs(id, true, Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<bool>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new MemoryStream(buffer));
             runtimeInfoProvider.Setup(r => r.GetModules(It.IsAny<CancellationToken>()))
                 .ReturnsAsync(new[] { new ModuleRuntimeInfo(id, "docker", ModuleStatus.Running, "foo", 0, Option.None<DateTime>(), Option.None<DateTime>()) });

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/DummyModuleManager.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest/DummyModuleManager.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.IntegrationTest
 
         public Task PrepareUpdateAsync(ModuleSpec moduleSpec) => throw new NotImplementedException();
 
-        public Task<Stream> GetModuleLogs(string name, bool follow, Option<int> tail, Option<string> since, Option<string> until, CancellationToken cancellationToken) => throw new NotImplementedException();
+        public Task<Stream> GetModuleLogs(string name, bool follow, Option<int> tail, Option<string> since, Option<string> until, Option<bool> includeTimestamp, CancellationToken cancellationToken) => throw new NotImplementedException();
 
         public Task<Stream> GetSupportBundle(Option<string> since, Option<string> until, Option<string> iothubHostname, Option<bool> edgeRuntimeOnly, CancellationToken token) => throw new NotImplementedException();
     }

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             string since = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd'T'HH:mm:sZ");
             string until = DateTime.Now.AddDays(+1).ToString("yyyy-MM-dd'T'HH:mm:sZ");
 
-            var request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.Some(10), Option.Some(since), Option.Some(until), Option.None<int>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
+            var request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.Some(10), Option.Some(since), Option.Some(until), Option.None<int>(), Option.None<bool>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
 
             var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
 
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Context.Current.NestedEdge);
             await Task.Delay(30000);
 
-            var request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
+            var request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
 
             var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
 
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             await Task.Delay(10000);
 
             // check it restarted
-            var logsRequest = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
+            var logsRequest = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.None<int>(), Option.None<bool>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
             result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(logsRequest)), token);
 
             Assert.AreEqual((int)HttpStatusCode.OK, result.Status);


### PR DESCRIPTION
Context:
It generates the attached file, if a module does not use the prescribed logging format (which most module do not), the timestamp is 0. This makes the logs not very useful. The timestamp irrespective of logging format is actually available from Docker log API.

Solution: 
This PR issues `timestamps` from edgeAgent via mgmt.sock to prepending the returning log with timestamp.  edgeAgent then parse the timestamp & return the value in json format to portal.

Note: 
This feature requires https://github.com/Azure/iotedge/pull/4970