### PR TITLE
Fix Privileged Flag

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "http-common",
  "libc",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "pkcs11",
  "serde",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "http-common",
  "serde",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "serde",
  "toml",
@@ -1141,7 +1141,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1697,7 +1697,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "cc",
 ]
@@ -1734,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1743,7 +1743,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1806,7 +1806,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1823,7 +1823,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#6accb4a869e5c4c25f39a56d8c17ce9c6a651ba9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#4dbc2a5c9171b882c202fddb57e492987407107f"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -19,7 +19,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.2.0-1
+Requires:       aziot-identity-service = 1.2.1-1
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/contrib/debian/control
+++ b/edgelet/contrib/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/azure/iotedge
 
 Package: aziot-edge
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, aziot-identity-service (= 1.2.0-1), sed
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, aziot-identity-service (= 1.2.1-1), sed
 Description: Azure IoT Edge Module Runtime
  Azure IoT Edge is a fully managed service that delivers cloud intelligence
  locally by deploying and running artificial intelligence (AI), Azure services,

--- a/edgelet/docker-rs/src/models/host_config.rs
+++ b/edgelet/docker-rs/src/models/host_config.rs
@@ -169,19 +169,11 @@ pub struct HostConfig {
     #[serde(rename = "Mounts", skip_serializing_if = "Option::is_none")]
     mounts: Option<Vec<crate::models::Mount>>,
     /// A list of kernel capabilities to add to the container.
-    #[serde(
-        rename = "CapAdd",
-        default = "Vec::new",
-        skip_serializing_if = "Vec::is_empty"
-    )]
-    cap_add: Vec<String>,
+    #[serde(rename = "CapAdd", skip_serializing_if = "Option::is_none")]
+    cap_add: Option<Vec<String>>,
     /// A list of kernel capabilities to drop from the container.
-    #[serde(
-        rename = "CapDrop",
-        default = "Vec::new",
-        skip_serializing_if = "Vec::is_empty"
-    )]
-    cap_drop: Vec<String>,
+    #[serde(rename = "CapDrop", skip_serializing_if = "Option::is_none")]
+    cap_drop: Option<Vec<String>>,
     // /// A list of DNS servers for the container to use.
     // #[serde(rename = "Dns", skip_serializing_if = "Option::is_none")]
     // dns: Option<Vec<String>>,
@@ -299,8 +291,8 @@ impl HostConfig {
             // volume_driver: None,
             // volumes_from: None,
             mounts: None,
-            cap_add: Vec::new(),
-            cap_drop: Vec::new(),
+            cap_add: None,
+            cap_drop: None,
             // dns: None,
             // dns_options: None,
             // dns_search: None,
@@ -1054,37 +1046,37 @@ impl HostConfig {
     }
 
     pub fn set_cap_add(&mut self, cap_add: Vec<String>) {
-        self.cap_add = cap_add;
+        self.cap_add = Some(cap_add);
     }
 
     pub fn with_cap_add(mut self, cap_add: Vec<String>) -> Self {
-        self.cap_add = cap_add;
+        self.cap_add = Some(cap_add);
         self
     }
 
-    pub fn cap_add(&self) -> &Vec<String> {
-        &self.cap_add
+    pub fn cap_add(&self) -> Option<&Vec<String>> {
+        self.cap_add.as_ref()
     }
 
     pub fn reset_cap_add(&mut self) {
-        self.cap_add = Vec::new();
+        self.cap_add = None;
     }
 
     pub fn set_cap_drop(&mut self, cap_drop: Vec<String>) {
-        self.cap_drop = cap_drop;
+        self.cap_drop = Some(cap_drop);
     }
 
     pub fn with_cap_drop(mut self, cap_drop: Vec<String>) -> Self {
-        self.cap_drop = cap_drop;
+        self.cap_drop = Some(cap_drop);
         self
     }
 
-    pub fn cap_drop(&self) -> &Vec<String> {
-        &self.cap_drop
+    pub fn cap_drop(&self) -> Option<&Vec<String>> {
+        self.cap_drop.as_ref()
     }
 
     pub fn reset_cap_drop(&mut self) {
-        self.cap_drop = Vec::new();
+        self.cap_drop = None;
     }
 
     // pub fn set_dns(&mut self, dns: Vec<String>) {

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -1295,7 +1295,7 @@ fn unset_privileged(
         return;
     }
     if let Some(config) = create_options.host_config() {
-        if config.privileged() == Some(&true) || !config.cap_add().is_empty() {
+        if config.privileged() == Some(&true) || config.cap_add().map_or(0, Vec::len) != 0 {
             warn!("Privileged capabilities are disallowed on this device. Privileged capabilities can be used to gain root access. If a module needs to run as privileged, and you are aware of the consequences, set `allow_elevated_docker_permissions` to `true` in the config.toml and restart the service.");
             let mut config = config.clone();
 
@@ -1325,10 +1325,13 @@ fn drop_unsafe_privileges(
     #[allow(clippy::option_if_let_else)]
     let host_config = if let Some(config) = create_options.host_config() {
         // Don't drop caps that the user added explicitly
-        caps_to_drop.retain(|cap_drop| !config.cap_add().contains(cap_drop));
-
+        if let Some(cap_add) = config.cap_add() {
+            caps_to_drop.retain(|cap_drop| !cap_add.contains(cap_drop));
+        }
         // Add customer specified cap_drops
-        caps_to_drop.extend_from_slice(config.cap_drop());
+        if let Some(cap_drop) = config.cap_drop() {
+            caps_to_drop.extend_from_slice(cap_drop);
+        }
 
         config.clone().with_cap_drop(caps_to_drop)
     } else {
@@ -1549,11 +1552,9 @@ mod tests {
         // Doesn't remove privileged
         unset_privileged(true, &mut create_options);
         assert!(create_options.host_config().unwrap().privileged().unwrap());
-
         // Removes privileged
         unset_privileged(false, &mut create_options);
         assert!(!create_options.host_config().unwrap().privileged().unwrap());
-
         create_options.set_host_config(
             HostConfig::new().with_cap_add(vec!["CAP1".to_owned(), "CAP2".to_owned()]),
         );
@@ -1562,39 +1563,33 @@ mod tests {
         unset_privileged(true, &mut create_options);
         assert_eq!(
             create_options.host_config().unwrap().cap_add(),
-            &vec!["CAP1".to_owned(), "CAP2".to_owned()]
+            Some(&vec!["CAP1".to_owned(), "CAP2".to_owned()])
         );
 
         // Removes caps
         unset_privileged(false, &mut create_options);
-        assert!(create_options.host_config().unwrap().cap_add().is_empty());
+        assert_eq!(create_options.host_config().unwrap().cap_add(), None);
     }
 
     #[test]
     fn drop_unsafe_privileges_works() {
         let mut create_options = ContainerCreateBody::new().with_host_config(HostConfig::new());
-
         // Do nothing if privileged is allowed
         drop_unsafe_privileges(true, &mut create_options);
-        assert_eq!(
-            create_options.host_config().unwrap().cap_drop(),
-            &Vec::<String>::new()
-        );
-
+        assert_eq!(create_options.host_config().unwrap().cap_drop(), None);
         // Drops privileges by if privileged is false
         drop_unsafe_privileges(false, &mut create_options);
         assert_eq!(
             create_options.host_config().unwrap().cap_drop(),
-            &vec!["CAP_CHOWN".to_owned(), "CAP_SETUID".to_owned()]
+            Some(&vec!["CAP_CHOWN".to_owned(), "CAP_SETUID".to_owned()])
         );
-
         // Doesn't drop caps if specified
         create_options
             .set_host_config(HostConfig::new().with_cap_add(vec!["CAP_CHOWN".to_owned()]));
         drop_unsafe_privileges(false, &mut create_options);
         assert_eq!(
             create_options.host_config().unwrap().cap_drop(),
-            &vec!["CAP_SETUID".to_owned()]
+            Some(&vec!["CAP_SETUID".to_owned()])
         );
     }
 


### PR DESCRIPTION
One of the review changes for the privileged flag, changing the CapAdd and CapDrop fields to Vec instead of Option<Vec> causes the all calls to docker to fail. I believe this is because it serializes as `null` instead of not being serialized at all. 

Changing it back to an option fixes the issue.

This also bumps the apt packages dependency to IS 1.2.1. This change is already in release/1.2, but got skipped in master