### PR TITLE
DevOps Sync Job: Improve and clean up filters, improve logging

### DIFF
--- a/tools/IoTEdgeDevOps/DevOpsLib/VstsModels/VstsBuild.cs
+++ b/tools/IoTEdgeDevOps/DevOpsLib/VstsModels/VstsBuild.cs
@@ -63,7 +63,7 @@ namespace DevOpsLib.VstsModels
                 StartTime = DateTime.MinValue,
                 FinishTime = DateTime.MinValue,
                 LastChangedDate = DateTime.MinValue,
-                RequestedBy = new Dictionary<string, Object>()
+                RequestedBy = new Dictionary<string, object>()
             };
 
         public bool HasResult()

--- a/tools/IoTEdgeDevOps/VstsPipelineSync/docker/linux-amd64/Dockerfile
+++ b/tools/IoTEdgeDevOps/VstsPipelineSync/docker/linux-amd64/Dockerfile
@@ -8,4 +8,4 @@ WORKDIR /app
 COPY $EXE_DIR/ ./
 
 CMD echo "$(date --utc +"[%Y-%m-%d %H:%M:%S %:z]"): Starting Module" && \
-    exec /usr/bin/dotnet VstsPipelineSync.dll refs/heads/master,refs/heads/release/1.0.9,refs/heads/release/1.0.8,refs/heads/release/1.2,refs/heads/release/1.1 00:01:00
+    exec /usr/bin/dotnet VstsPipelineSync.dll "refs/heads/master,refs/heads/release/1.1,refs/heads/release/1.2" "00:01:00"


### PR DESCRIPTION
The main fix in this PR is changing the filter for date is by `QueueTime` to `FinishTime`. Using `QueueTime` will lead to problems for builds who take longer than 1 hr to complete.

I also improved the logic around filtering and also improved the logging.