### PR TITLE
DevOps Triggers: Fix trigger setting for branch to be "master"

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -10,14 +10,14 @@ resources:
   pipelines:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
-    branch: 'release/1.2'
+    branch: 'master'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
-    branch: 'release/1.2'
+    branch: 'master'
     trigger:
       branches:
       - master

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -8,14 +8,14 @@ resources:
   pipelines:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
-    branch: 'release/1.2'
+    branch: 'master'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
-    branch: 'release/1.2'
+    branch: 'master'
     trigger:
       branches:
       - master

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -8,14 +8,14 @@ resources:
   pipelines:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
-    branch: 'release/1.2'
+    branch: 'master'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
-    branch: 'release/1.2'
+    branch: 'master'
     trigger:
       branches:
       - master

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -8,14 +8,14 @@ resources:
   pipelines:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
-    branch: 'release/1.2'
+    branch: 'master'
     trigger:
       branches:
       - master
       - release/*
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
-    branch: 'release/1.2'
+    branch: 'master'
     trigger:
       branches:
       - master


### PR DESCRIPTION
During a recent cherry pick from 1.2 -> master, we included an improvement to the triggers. This improvement worked but it set the branch setting to be "release/1.2". I am fixing this here so that the setting is "master".