### PR TITLE
Update Base Images for a Security Patch 

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.15-bionic-arm32v7
+﻿ARG base_tag=3.1.16-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.15-bionic-arm64v8
+﻿ARG base_tag=3.1.16-bionic-arm64v8
 ARG num_procs=4
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}

--- a/edge-agent/docker/windows/amd64/Dockerfile
+++ b/edge-agent/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # In order to set system PATH, ContainerAdministrator must be used

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.15-bionic-arm32v7
+﻿ARG base_tag=3.1.16-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-hub/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.15-bionic-arm64v8
+﻿ARG base_tag=3.1.16-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/windows/amd64/Dockerfile
+++ b/edge-hub/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/windows/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.15-bionic-arm32v7
+﻿ARG base_tag=3.1.16-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.15-bionic-arm64v8
+﻿ARG base_tag=3.1.16-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/azure-monitor/docker/linux/amd64/Dockerfile
+++ b/edge-modules/azure-monitor/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.12
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/azure-monitor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/azure-monitor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/azure-monitor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/azure-monitor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/azure-monitor/docker/windows/amd64/Dockerfile
+++ b/edge-modules/azure-monitor/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/edgehub-proxy/docker/linux/amd64/Dockerfile
+++ b/edge-modules/edgehub-proxy/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM haproxy:1.8.23-alpine
+﻿FROM haproxy:1.8.23-alpine
 
 RUN apk add --no-cache curl jq
 

--- a/edge-modules/functions/samples/docker/linux/amd64/Dockerfile
+++ b/edge-modules/functions/samples/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/azure-functions/dotnet:3.0
+﻿FROM mcr.microsoft.com/azure-functions/dotnet:3.0
 
 ENV AzureWebJobsScriptRoot=/app
 

--- a/edge-modules/functions/samples/docker/windows/amd64/Dockerfile
+++ b/edge-modules/functions/samples/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-# escape=`
+﻿# escape=`
 
 FROM mcr.microsoft.com/azure-functions/dotnet:3.0-nanoserver-1809
 

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/windows/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-util/docker/linux/amd64/Dockerfile
+++ b/edge-util/docker/linux/amd64/Dockerfile
@@ -1,5 +1,5 @@
-# docker file for azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64
-FROM alpine:3.10
+﻿# docker file for azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64
+FROM alpine:3.13
 
 ARG num_procs=4
 

--- a/edgelet/iotedge-proxy/docker/linux/amd64/Dockerfile
+++ b/edgelet/iotedge-proxy/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.10
+﻿FROM alpine:3.13
 
 RUN addgroup -S proxy && adduser -S proxy -G proxy
 USER proxy

--- a/edgelet/iotedged/docker/linux/amd64/Dockerfile
+++ b/edgelet/iotedged/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim
+﻿FROM debian:10-slim
 
 # package installation needs to exec as root
 RUN apt-get update && apt-get install -y \

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-# -*- mode: dockerfile -*-
+﻿# -*- mode: dockerfile -*-
 
 # You can override this `--build-arg BASE_IMAGE=...` to use different
 # version of Rust or OpenSSL.

--- a/smoke/docker/linux/amd64/Dockerfile
+++ b/smoke/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-# Base image runs systemd, allows us to install/run iotedged in a container for testing
+﻿# Base image runs systemd, allows us to install/run iotedged in a container for testing
 FROM solita/ubuntu-systemd:bionic
 
 # Install dependencies

--- a/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 # Network controller arm32 and arm64 require different base images. This is because arm32 needs iproute tooling and thus needs module-base-full.
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
 # Network controller arm32 and arm64 require different base images. This is because arm32 needs iproute tooling and thus needs module-base-full.
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/windows/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ENV MODULE_NAME "CloudToDeviceMessageTester.dll"

--- a/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/DeploymentTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ENV MODULE_NAME "DeploymentTester.dll"

--- a/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/windows/amd64/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/windows/amd64/Dockerfile
+++ b/test/modules/MetricsValidator/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/windows/amd64/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/windows/amd64/Dockerfile
+++ b/test/modules/NumberLogger/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/amd64/Dockerfile
+++ b/test/modules/Relayer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/windows/amd64/Dockerfile
+++ b/test/modules/Relayer/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ENV MODULE_NAME "Relayer.dll"

--- a/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/windows/amd64/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.15-bionic-arm32v7
+﻿ARG base_tag=3.1.16-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.15-bionic-arm64v8
+﻿ARG base_tag=3.1.16-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/test/modules/TestAnalyzer/docker/windows/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/windows/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 # base dockerfile is located at \edge-util\docker\linux\amd64
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/windows/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/amd64/Dockerfile
+++ b/test/modules/load-gen/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-alpine3.13
+﻿ARG base_tag=3.1.16-alpine3.13
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm32v7
+ARG base_tag=1.0.5.12-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.5.11-linux-arm64v8
+ARG base_tag=1.0.5.12-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/windows/amd64/Dockerfile
+++ b/test/modules/load-gen/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=3.1.15-nanoserver-1809
+﻿ARG base_tag=3.1.16-nanoserver-1809
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/tools/snitch/prep-mail/docker/linux/amd64/Dockerfile
+++ b/tools/snitch/prep-mail/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ekidd/rust-musl-builder AS builder
+﻿FROM ekidd/rust-musl-builder AS builder
 
 ARG SRC_DIR=.
 

--- a/tools/snitch/snitcher/docker/linux/amd64/Dockerfile
+++ b/tools/snitch/snitcher/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 AS builder
+﻿FROM ubuntu:18.04 AS builder
 
 ARG SRC_DIR=.
 

--- a/tools/snitch/snitcher/docker/windows/amd64/Dockerfile
+++ b/tools/snitch/snitcher/docker/windows/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/windows:1809-amd64 AS builder
+﻿FROM mcr.microsoft.com/windows:1809-amd64 AS builder
 
 RUN powershell.exe -Command Invoke-WebRequest "https://aka.ms/vs/16/release/VC_redist.x64.exe" -OutFile C:\VC_redist.x64.exe
 RUN C:\VC_redist.x64.exe /install /quiet /norestart


### PR DESCRIPTION
Update Base Images for Security Patch
- ARM32/64 🠘 3.1.16-bionic-arm*
- Linux AMD64 🠘 3.1.16-alpine3.13
- Winwods AMD64 🠘 3.1.16-nanoserver-1809