### PR TITLE
Implement throttling mechanism to prevent spamming of workload socket

### DIFF
--- a/edgelet/aziot-edged/src/lib.rs
+++ b/edgelet/aziot-edged/src/lib.rs
@@ -44,7 +44,7 @@ use edgelet_core::{
     ModuleRuntimeErrorReason, ModuleSpec, RuntimeSettings, WorkloadConfig,
 };
 use edgelet_http::logging::LoggingService;
-use edgelet_http::{HyperExt, API_VERSION};
+use edgelet_http::{ConcurrencyThrottling, HyperExt, API_VERSION};
 use edgelet_http_mgmt::ManagementService;
 use edgelet_utils::log_failure;
 pub use error::{Error, ErrorKind, InitializeErrorReason};
@@ -710,7 +710,7 @@ where
                         InitializeErrorReason::ManagementService,
                     ))
                 })?
-                .run_until(shutdown.map_err(|_| ()))
+                .run_until(shutdown.map_err(|_| ()), ConcurrencyThrottling::NoLimit)
                 .map_err(|err| Error::from(err.context(ErrorKind::ManagementService)));
             info!("Listening on {} with 1 thread for management API.", url);
             Ok(run)

--- a/edgelet/edgelet-http/src/lib.rs
+++ b/edgelet/edgelet-http/src/lib.rs
@@ -19,6 +19,7 @@ use std::fmt::{Debug, Formatter};
 use std::net;
 #[cfg(target_os = "linux")]
 use std::os::unix::io::FromRawFd;
+use std::sync::atomic::{AtomicU32, Ordering};
 #[cfg(unix)]
 use std::sync::Arc;
 
@@ -69,6 +70,12 @@ const HTTP_SCHEME: &str = "http";
 const TCP_SCHEME: &str = "tcp";
 #[cfg(target_os = "linux")]
 const FD_SCHEME: &str = "fd";
+
+#[derive(Clone, Copy)]
+pub enum ConcurrencyThrottling {
+    Limited(u32),
+    NoLimit,
+}
 
 #[derive(Clone)]
 pub struct PemCertificate {
@@ -202,10 +209,10 @@ where
     <S::Service as Service>::Future: Send + 'static,
 {
     pub fn run(self) -> Run {
-        self.run_until(future::empty())
+        self.run_until(future::empty(), ConcurrencyThrottling::NoLimit)
     }
 
-    pub fn run_until<F>(self, shutdown_signal: F) -> Run
+    pub fn run_until<F>(self, shutdown_signal: F, concurrency: ConcurrencyThrottling) -> Run
     where
         F: Future<Item = (), Error = ()> + Send + 'static,
     {
@@ -217,34 +224,64 @@ where
 
         let protocol = Arc::new(protocol);
 
-        let srv = incoming.for_each(move |(socket, addr)| {
-            let protocol = protocol.clone();
+        let lock = if let ConcurrencyThrottling::Limited(limit) = concurrency {
+            Some((Arc::new(AtomicU32::new(limit)), limit))
+        } else {
+            None
+        };
 
+        let srv = incoming.for_each(move |(socket, addr)| {
+
+            if let Some((lock, limit)) = lock.clone() {
+                let limit_reached = lock.fetch_update( Ordering::AcqRel,
+                    Ordering::Acquire,
+                    |current| current.checked_sub(1),
+                    ).is_err();
+
+                if limit_reached {
+                    error!("Maximum concurrency reached, {} simultaneous connections, dropping the connection request", limit);
+                    // Return Ok so the stream is not stopped.
+                    return Ok(());
+                }
+            }
+
+            let protocol = protocol.clone();
             debug!("accepted new connection ({})", addr);
             let pid = socket.pid()?;
             let fut = new_service
                 .new_service()
-                .then(move |srv| match srv {
+                .then({
+                    let lock = lock.clone();
+                    move |srv| match srv {
                     Ok(srv) => Ok((srv, addr)),
                     Err(err) => {
                         error!("server connection error: ({})", addr);
+                        if let Some((lock, _)) = lock {
+                            lock.fetch_add(1, Ordering::AcqRel);
+                        }
                         log_failure(Level::Error, &err);
                         Err(())
                     }
-                })
-                .and_then(move |(srv, addr)| {
+                }})
+                .and_then({
+                    let lock = lock.clone();
+                    move |(srv, addr)| {
                     let service = PidService::new(pid, srv);
                     protocol
                         .serve_connection(socket, service)
-                        .then(move |result| match result {
+                        .then(move |result| {
+                            if let Some((lock, _)) = lock {
+                                lock.fetch_add(1, Ordering::AcqRel);
+                            }
+                            match result {
                             Ok(_) => Ok(()),
                             Err(err) => {
                                 error!("server connection error: ({})", addr);
                                 log_failure(Level::Error, &err);
                                 Err(())
                             }
-                        })
-                });
+                        }})
+                }});
             tokio::spawn(fut);
             Ok(())
         });


### PR DESCRIPTION
Implement throttling mechanism to prevent spamming of workload socket.

Test:
Created a separate module and ran the following command with the module.
 seq 1 30000 | xargs -I % -P 1000 curl --unix-socket /var/run/iotedge/workload.sock  http://127.0.0.1/modules?api-version=2020-07-07 &> /dev/null&

I could not reproduce the broken pipe error but I could see parallelism go up to high 80s.
By adding the throttling it is limited to ~10