### PR TITLE
Fix host cpu metric incorrectly reported at 100%

### DIFF
--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -336,6 +336,8 @@ impl MakeModuleRuntime for DockerModuleRuntime {
                     })
                     .join(notary_registries)
                     .map(move |(client, (notary_registries, _))| {
+                        // to avoid excessive FD usage, we will not allow sysinfo to keep files open.
+                        sysinfo::set_open_files_limit(0);
                         let mut system_resources = System::new_all();
                         system_resources.refresh_all();
                         info!("Successfully initialized module runtime");


### PR DESCRIPTION
We made some changes to the system resource collection, where we called slightly different sysinfo apis in an attempt to optimize. This led to what I am guessing is a bug in the sysinfo crate. 

We can quickly resolve it if we roll back the commit that made these sysinfo modifications. However we should also keep the main improvement which was to set the open file descriptor limit. 