### PR TITLE
Catch parse error in e2e test

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
@@ -85,7 +85,16 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             HttpClient client = new HttpClient();
             HttpResponseMessage response = await client.GetAsync("http://localhost:5001/api/report");
             var jsonstring = await response.Content.ReadAsStringAsync();
-            bool isPassed = (bool)JArray.Parse(jsonstring)[0]["IsPassed"];
+            bool isPassed;
+            try
+            {
+                isPassed = (bool)JArray.Parse(jsonstring)[0]["IsPassed"];
+            }
+            catch
+            {
+                isPassed = false;
+            }
+
             if (!isPassed)
             {
                 Log.Information("Test Result Coordinator response: {Response}", jsonstring);


### PR DESCRIPTION
This prints the test result json instead of an unhelpful json parse error