### PR TITLE
Add timeout to support bundle calls

### DIFF
--- a/edgelet/support-bundle/src/support_bundle.rs
+++ b/edgelet/support-bundle/src/support_bundle.rs
@@ -216,7 +216,7 @@ where
             // Getting modules requires the management socket, which might not be available if
             // aziot-edged hasn't started. Require this operation to complete within a timeout
             // so it doesn't block forever on an unavailable socket.
-            .timeout(std::time::Duration::from_secs(5))
+            .timeout(std::time::Duration::from_secs(30))
             .then(move |result| {
                 future::ok(if let Ok(modules) = result {
                     modules

--- a/edgelet/support-bundle/src/support_bundle.rs
+++ b/edgelet/support-bundle/src/support_bundle.rs
@@ -218,20 +218,19 @@ where
             // so it doesn't block forever on an unavailable socket.
             .timeout(std::time::Duration::from_secs(5))
             .then(move |result| {
-                future::ok(match result {
-                    Ok(modules) => modules
+                future::ok(if let Ok(modules) = result {
+                    modules
                         .into_iter()
                         .map(|(module, _s)| module.name().to_owned())
                         .filter(move |name| {
                             !include_ms_only || MS_MODULES.iter().any(|ms| ms == name)
                         })
-                        .collect(),
-                    Err(_) => {
-                        println!(
-                            "Warning: Unable to call management socket. Module list not available."
-                        );
-                        Vec::new()
-                    }
+                        .collect()
+                } else {
+                    println!(
+                        "Warning: Unable to call management socket. Module list not available."
+                    );
+                    Vec::new()
                 })
             });
 

--- a/edgelet/support-bundle/src/support_bundle.rs
+++ b/edgelet/support-bundle/src/support_bundle.rs
@@ -227,9 +227,11 @@ where
                         })
                         .collect(),
                     Err(_) => {
-                        println!("Warning: Unable to call management socket. Module list not available.");
+                        println!(
+                            "Warning: Unable to call management socket. Module list not available."
+                        );
                         Vec::new()
-                    },
+                    }
                 })
             });
 


### PR DESCRIPTION
Listing modules when generating a support bundle requires the management socket. If the management socket has not started, then the support bundle request blocks forever.

This PR adds a timeout to management socket requests to prevent the request from hanging.