### PR TITLE
S360: Fix Tls1.2 errors in deployment files

### DIFF
--- a/e2e_deployment_files/long_haul_deployment_constrained.template.json
+++ b/e2e_deployment_files/long_haul_deployment_constrained.template.json
@@ -58,6 +58,9 @@
                             },
                             "mqttSettings_enabled": {
                                 "value": "<EdgeHubMqttEnabled>"
+                            },
+                            "SslProtocols": {
+                                "value": "tls1.2"
                             }
                         },
                         "settings": {

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_mqtt.json
@@ -48,6 +48,9 @@
               },
               "RuntimeLogLevel": {
                 "value": "debug"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
@@ -30,9 +30,6 @@
               },
               "https_proxy": {
                 "value": "<proxyAddress>"
-              },
-              "SslProtocols": {
-                "value": "tls1.2"
               }
             }
           },
@@ -51,6 +48,9 @@
               },
               "https_proxy": {
                 "value": "<proxyAddress>"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
@@ -30,9 +30,6 @@
               },
               "https_proxy": {
                 "value": "<proxyAddress>"
-              },
-              "SslProtocols": {
-                "value": "tls1.2"
               }
             }
           },
@@ -57,6 +54,9 @@
               },
               "https_proxy": {
                 "value": "<proxyAddress>"
+              },
+              "SslProtocols": {
+                "value": "tls1.2"
               }
             },
             "status": "running",


### PR DESCRIPTION
Need to make some fixes to some deployment files to fix their tls1.2 configurations. We should explore making this the default for edgehub, but it is potentially a breaking change which needs to be discussed in more detail. For now we are fixing it in the deployment files.

There are some remaining tls1.2 errors in http endpoints that this change won't fix. Still investigating those.