### PR TITLE
Upgrade Image Publication Pipeline

### DIFF
--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -39,78 +39,78 @@ jobs:
           command: login
           containerRegistry: iotedge-release-acr
 
-      # BEARWASHERE -- Use the $(Release.Artifacts.images.BuildNumber) from Resource option 
+      # BEARWASHERE -- Use the $(resources.pipeline.images.runName) from Resource option 
       - task: ShellScript@2
         displayName: 'Publish Edge Agent - Linux amd64'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-amd64'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Agent - Linux arm32v7'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm32v7'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Agent - Linux arm64v8'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm64v8'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Hub - Linux amd64'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-amd64'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Hub - Linux arm32v7'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm32v7'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Hub - Linux arm64v8'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm64v8'
 
       - task: ShellScript@2
         displayName: 'Publish Temp Sensor - Linux amd64'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-amd64'
 
       - task: ShellScript@2
         displayName: 'Publish Temp Sensor - Linux arm32v7'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm32v7'
 
       - task: ShellScript@2
         displayName: 'Publish Temp Sensor - Linux arm64v8'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm64v8'
 
       - task: ShellScript@2
         displayName: 'Publish diagnostics - Linux amd64'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-amd64'
 
       - task: ShellScript@2
         displayName: 'Publish diagnostics - Linux arm32v7'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm32v7'
 
       - task: ShellScript@2
         displayName: 'Publish diagnostics - Linux arm64v8'
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm64v8'
 
 ################################################################################
   - job: publish_manifest_images
@@ -141,7 +141,7 @@ jobs:
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
 
@@ -150,7 +150,7 @@ jobs:
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
 
@@ -159,7 +159,7 @@ jobs:
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
+          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
 
@@ -168,6 +168,6 @@ jobs:
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,9 +1,9 @@
-name: $(version)
+name: $(resources.pipeline.images.runName)
 variables:
   NugetSecurityAnalysisWarningLevel: warn
-  from.registry.address: 'edgebuilds.azurecr.io'
+  from.registry.address: ''
   from.registry.namespace: 'microsoft'
-  to.registry.address: 'edgebuilds.azurecr.io'
+  to.registry.address: ''
   to.registry.namespace: 'public'
   pool.linux.name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
   tags: '7.8.21'

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -5,8 +5,6 @@ variables:
   to.registry.address: ''
   to.registry.namespace: 'public'
   pool.linux.name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
-  tags: '7.8.21'
-  tempSensor.tags: '7.8.21'
 
 resources:
   pipelines:
@@ -38,17 +36,6 @@ jobs:
           command: login
           containerRegistry: iotedge-release-acr
 
-      - bash: |
-          BASE_VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
-          VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
-          echo "Version: $VERSION"
-          echo "##vso[task.setvariable variable=version;]$VERSION"
-        # BEARWASHERE -- Correct the version
-          echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
-          echo "##vso[task.setvariable variable=PACKAGE_OS;]$(os)"
-        displayName: Set Version
-
-      # BEARWASHERE -- Use the $(resources.pipeline.images.runName) from Resource option 
       - task: ShellScript@2
         displayName: 'Publish Edge Agent - Linux amd64'
         inputs:
@@ -144,6 +131,20 @@ jobs:
         inputs:
           command: login
           containerRegistry: iotedge-release-acr
+
+      - bash: |
+          VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
+          TAGS=$(echo "${VERSION%.*}")
+
+          TAGS_STR=$(echo "['$TAGS']")
+          TEMP_SENSOR_TAGS_STR=$(echo "['$TAGS','latest']")
+
+          echo "Version: $VERSION"
+          echo "tags : $TAGS_STR"
+
+          echo "##vso[task.setvariable variable=tags;]$TAGS_STR"
+          echo "##vso[task.setvariable variable=tempSensor.tags;]$TEMP_SENSOR_TAGS_STR"
+        displayName: Set Version and Tags
 
       - task: Bash@3
         displayName: 'Publish Edge Agent Manifest'

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -31,7 +31,7 @@ jobs:
           else
             echo "Input image build has a differnt version as the targetting release tags."
             echo "Please make sure the input image resource is correctly selected."
-            echo "    Input Image Built Version: $(resources.pipeline.images.runName)"
+            echo "    Input Image Build Version: $(resources.pipeline.images.runName)"
             echo "    Targeting Release Version: $VERSION"
             exit 1;
           fi
@@ -42,6 +42,7 @@ jobs:
 ################################################################################
     timeoutInMinutes: 180
     displayName: Publish Linux Images
+    dependsOn: safe_guard
     pool:
       name: $(pool.linux.name)
       demands:

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -34,73 +34,73 @@ jobs:
       - task: ShellScript@2
         displayName: 'Publish Edge Agent - Linux amd64'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Agent - Linux arm32v7'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Agent - Linux arm64v8'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Hub - Linux amd64'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Hub - Linux arm32v7'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
 
       - task: ShellScript@2
         displayName: 'Publish Edge Hub - Linux arm64v8'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
 
       - task: ShellScript@2
         displayName: 'Publish Temp Sensor - Linux amd64'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
 
       - task: ShellScript@2
         displayName: 'Publish Temp Sensor - Linux arm32v7'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
 
       - task: ShellScript@2
         displayName: 'Publish Temp Sensor - Linux arm64v8'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
 
       - task: ShellScript@2
         displayName: 'Publish diagnostics - Linux amd64'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
 
       - task: ShellScript@2
         displayName: 'Publish diagnostics - Linux arm32v7'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
 
       - task: ShellScript@2
         displayName: 'Publish diagnostics - Linux arm64v8'
         inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
 
 ################################################################################
@@ -131,34 +131,34 @@ jobs:
         displayName: 'Publish Edge Agent Manifest'
         inputs:
           targetType: filePath
-          filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/repo/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+          filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
-          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
 
       - task: Bash@3
         displayName: 'Publish Edge Hub Manifest'
         inputs:
           targetType: filePath
-          filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/repo/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+          filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
-          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
 
       - task: Bash@3
         displayName: 'Publish Temperature Sensor Manifest'
         inputs:
           targetType: filePath
-          filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/repo/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
+          filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
         env:
-          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
 
       - task: Bash@3
         displayName: 'Publish diagnostics Manifest'
         inputs:
           targetType: filePath
-          filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/repo/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+          filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
-          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,9 +1,7 @@
 name: $(resources.pipeline.images.runName)
 variables:
   NugetSecurityAnalysisWarningLevel: warn
-  from.registry.address: ''
   from.registry.namespace: 'microsoft'
-  to.registry.address: ''
   to.registry.namespace: 'public'
   pool.linux.name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
   tags: '7.8.21'

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -52,13 +52,6 @@ jobs:
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     steps:
-      # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
-      - task: Docker@2
-        displayName: Docker login beariotedgedevcontainerreg1
-        inputs:
-          command: login
-          containerRegistry: beariotedgedevcontainerreg1
-
       - task: Docker@2
         displayName: Docker login edgerelease
         inputs:
@@ -148,13 +141,6 @@ jobs:
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     steps:
-      # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
-      - task: Docker@2
-        displayName: Docker login beariotedgedevcontainerreg1
-        inputs:
-          command: login
-          containerRegistry: beariotedgedevcontainerreg1
-
       - task: Docker@2
         displayName: Docker login edgerelease
         inputs:

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,10 +1,11 @@
 name: $(version)
 variables:
   NugetSecurityAnalysisWarningLevel: warn
-  from.registry.address: 'edgerelease.azurecr.io'
+  from.registry.address: 'edgebuilds.azurecr.io'
   from.registry.namespace: 'microsoft'
-  to.registry.address: 'edgerelease.azurecr.io'
+  to.registry.address: 'edgebuilds.azurecr.io'
   to.registry.namespace: 'public'
+  pool.linux.name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
 
 jobs:
 ################################################################################
@@ -13,9 +14,10 @@ jobs:
     timeoutInMinutes: 180
     displayName: Publish Linux Images
     pool:
-      vmImage: ubuntu-18.04
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     steps:
-
       # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
       - task: Docker@2
         displayName: Docker login edgebuilds
@@ -100,3 +102,63 @@ jobs:
         inputs:
           scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
           args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
+
+################################################################################
+  - job: publish_manifest_images
+################################################################################
+    timeoutInMinutes: 180
+    displayName: Publish Manifest Images
+    dependsOn: publish_linux_images
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+    steps:
+      # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
+      - task: Docker@2
+        displayName: Docker login edgebuilds
+        inputs:
+          command: login
+          containerRegistry: iotedge-edgebuilds-acr
+
+      - task: Docker@2
+        displayName: Docker login edgerelease
+        inputs:
+          command: login
+          containerRegistry: iotedge-release-acr
+
+      - task: Bash@3
+        displayName: 'Publish Edge Agent Manifest'
+        inputs:
+          targetType: filePath
+          filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
+          arguments: '-r $(to.registry.address) -v $(Release.Artifacts.images.BuildNumber) -t $(System.DefaultWorkingDirectory)/repo/edge-agent/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tags)"'
+        env:
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
+
+      - task: Bash@3
+        displayName: 'Publish Edge Hub Manifest'
+        inputs:
+          targetType: filePath
+          filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
+          arguments: '-r $(to.registry.address) -v $(Release.Artifacts.images.BuildNumber) -t $(System.DefaultWorkingDirectory)/repo/edge-hub/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tags)"'
+        env:
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
+
+      - task: Bash@3
+        displayName: 'Publish Temperature Sensor Manifest'
+        inputs:
+          targetType: filePath
+          filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
+          arguments: '-r $(to.registry.address) -v $(Release.Artifacts.images.BuildNumber) -t $(System.DefaultWorkingDirectory)/repo/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tempSensor.tags)"'
+        env:
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
+
+      - task: Bash@3
+        displayName: 'Publish diagnostics Manifest'
+        inputs:
+          targetType: filePath
+          filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
+          arguments: '-r $(to.registry.address) -v $(Release.Artifacts.images.BuildNumber) -t $(System.DefaultWorkingDirectory)/repo/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tags)"'
+        env:
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -28,6 +28,8 @@ jobs:
           
           if [[ "$(resources.pipeline.images.runName)" == "$VERSION" ]]; then
             echo "Input image build has the same version as the targetting release tags."
+            echo "    Input Image Build Version: $(resources.pipeline.images.runName)"
+            echo "    Targeting Release Version: $VERSION"
           else
             echo "Input image build has a differnt version as the targetting release tags."
             echo "Please make sure the input image resource is correctly selected."

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -17,7 +17,7 @@ jobs:
   - job: safe_guard
 ################################################################################
     timeoutInMinutes: 180
-    displayName: Publish Linux Images
+    displayName: Safe Guards
     pool:
       name: $(pool.linux.name)
       demands:

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,0 +1,102 @@
+name: $(version)
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+  from.registry.address: 'edgerelease.azurecr.io'
+  from.registry.namespace: 'microsoft'
+  to.registry.address: 'edgerelease.azurecr.io'
+  to.registry.namespace: 'public'
+
+jobs:
+################################################################################
+  - job: publish_linux_images
+################################################################################
+    timeoutInMinutes: 180
+    displayName: Publish Linux Images
+    pool:
+      vmImage: ubuntu-18.04
+    steps:
+
+      # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
+      - task: Docker@2
+        displayName: Docker login edgebuilds
+        inputs:
+          command: login
+          containerRegistry: iotedge-edgebuilds-acr
+
+      - task: Docker@2
+        displayName: Docker login edgerelease
+        inputs:
+          command: login
+          containerRegistry: iotedge-release-acr
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Agent - Linux amd64'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Agent - Linux arm32v7'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Agent - Linux arm64v8'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Hub - Linux amd64'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Hub - Linux arm32v7'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Hub - Linux arm64v8'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
+
+      - task: ShellScript@2
+        displayName: 'Publish Temp Sensor - Linux amd64'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
+
+      - task: ShellScript@2
+        displayName: 'Publish Temp Sensor - Linux arm32v7'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
+
+      - task: ShellScript@2
+        displayName: 'Publish Temp Sensor - Linux arm64v8'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'
+
+      - task: ShellScript@2
+        displayName: 'Publish diagnostics - Linux amd64'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-amd64'
+
+      - task: ShellScript@2
+        displayName: 'Publish diagnostics - Linux arm32v7'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm32v7'
+
+      - task: ShellScript@2
+        displayName: 'Publish diagnostics - Linux arm64v8'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/repo/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(Release.Artifacts.images.BuildNumber)-linux-arm64v8'

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -150,7 +150,7 @@ jobs:
         displayName: 'Publish Edge Agent Manifest'
         inputs:
           targetType: filePath
-          filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
           arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
@@ -159,7 +159,7 @@ jobs:
         displayName: 'Publish Edge Hub Manifest'
         inputs:
           targetType: filePath
-          filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
           arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
@@ -168,7 +168,7 @@ jobs:
         displayName: 'Publish Temperature Sensor Manifest'
         inputs:
           targetType: filePath
-          filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
           arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
@@ -177,7 +177,7 @@ jobs:
         displayName: 'Publish diagnostics Manifest'
         inputs:
           targetType: filePath
-          filePath: './$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
           arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,10 +1,12 @@
+# Required variable from pipeline:
+#    from.registry.address: ''
+#    from.registry.namespace: ''
+#    to.registry.address: ''
+#    to.registry.namespace: ''
+#    pool.linux.name: ''
+
 variables:
   NugetSecurityAnalysisWarningLevel: warn
-  from.registry.address: 'edgerelease.azurecr.io'
-  from.registry.namespace: 'microsoft'
-  to.registry.address: 'beariotedgedevcontainerreg1.azurecr.io'
-  to.registry.namespace: 'public'
-  pool.linux.name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
 
 resources:
   pipelines:

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,8 +1,8 @@
 variables:
   NugetSecurityAnalysisWarningLevel: warn
-  from.registry.address: ''
+  from.registry.address: 'edgerelease.azurecr.io'
   from.registry.namespace: 'microsoft'
-  to.registry.address: ''
+  to.registry.address: 'beariotedgedevcontainerreg1.azurecr.io'
   to.registry.namespace: 'public'
   pool.linux.name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
 
@@ -25,10 +25,10 @@ jobs:
     steps:
       # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
       - task: Docker@2
-        displayName: Docker login edgebuilds
+        displayName: Docker login beariotedgedevcontainerreg1
         inputs:
           command: login
-          containerRegistry: iotedge-edgebuilds-acr
+          containerRegistry: beariotedgedevcontainerreg1
 
       - task: Docker@2
         displayName: Docker login edgerelease
@@ -121,10 +121,10 @@ jobs:
     steps:
       # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
       - task: Docker@2
-        displayName: Docker login edgebuilds
+        displayName: Docker login beariotedgedevcontainerreg1
         inputs:
           command: login
-          containerRegistry: iotedge-edgebuilds-acr
+          containerRegistry: beariotedgedevcontainerreg1
 
       - task: Docker@2
         displayName: Docker login edgerelease

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,7 +1,8 @@
-name: $(version)
 variables:
   NugetSecurityAnalysisWarningLevel: warn
+  from.registry.address: ''
   from.registry.namespace: 'microsoft'
+  to.registry.address: ''
   to.registry.namespace: 'public'
   pool.linux.name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
   tags: '7.8.21'
@@ -36,6 +37,16 @@ jobs:
         inputs:
           command: login
           containerRegistry: iotedge-release-acr
+
+      - bash: |
+          BASE_VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
+          VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
+          echo "Version: $VERSION"
+          echo "##vso[task.setvariable variable=version;]$VERSION"
+        # BEARWASHERE -- Correct the version
+          echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
+          echo "##vso[task.setvariable variable=PACKAGE_OS;]$(os)"
+        displayName: Set Version
 
       # BEARWASHERE -- Use the $(resources.pipeline.images.runName) from Resource option 
       - task: ShellScript@2

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -6,6 +6,14 @@ variables:
   to.registry.address: 'edgebuilds.azurecr.io'
   to.registry.namespace: 'public'
   pool.linux.name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
+  tags: '7.8.21'
+  tempSensor.tags: '7.8.21'
+
+resources:
+  pipelines:
+  - pipeline: images
+    source: 'Azure-IoT-Edge-Core Images Release YAML'
+    branch: 'release/1.2'
 
 jobs:
 ################################################################################
@@ -31,6 +39,7 @@ jobs:
           command: login
           containerRegistry: iotedge-release-acr
 
+      # BEARWASHERE -- Use the $(Release.Artifacts.images.BuildNumber) from Resource option 
       - task: ShellScript@2
         displayName: 'Publish Edge Agent - Linux amd64'
         inputs:

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -132,7 +132,7 @@ jobs:
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
-          arguments: '-r $(to.registry.address) -v $(Release.Artifacts.images.BuildNumber) -t $(System.DefaultWorkingDirectory)/repo/edge-agent/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tags)"'
+          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/repo/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
 
@@ -141,7 +141,7 @@ jobs:
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
-          arguments: '-r $(to.registry.address) -v $(Release.Artifacts.images.BuildNumber) -t $(System.DefaultWorkingDirectory)/repo/edge-hub/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tags)"'
+          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/repo/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
 
@@ -150,7 +150,7 @@ jobs:
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
-          arguments: '-r $(to.registry.address) -v $(Release.Artifacts.images.BuildNumber) -t $(System.DefaultWorkingDirectory)/repo/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tempSensor.tags)"'
+          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/repo/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo
 
@@ -159,6 +159,6 @@ jobs:
         inputs:
           targetType: filePath
           filePath: './$(System.DefaultWorkingDirectory)/repo/scripts/linux/buildManifest.sh'
-          arguments: '-r $(to.registry.address) -v $(Release.Artifacts.images.BuildNumber) -t $(System.DefaultWorkingDirectory)/repo/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n $(to.registry.namespace) --tags "$(tags)"'
+          arguments: '-r "$(to.registry.address)" -v "$(Release.Artifacts.images.BuildNumber)" -t $(System.DefaultWorkingDirectory)/repo/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
         env:
           BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)/repo

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,4 +1,4 @@
-name: $(resources.pipeline.images.runName)
+name: $(version)
 variables:
   NugetSecurityAnalysisWarningLevel: warn
   from.registry.namespace: 'microsoft'

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -14,6 +14,30 @@ resources:
 
 jobs:
 ################################################################################
+  - job: safe_guard
+################################################################################
+    timeoutInMinutes: 180
+    displayName: Publish Linux Images
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+    steps:
+      - bash: |
+          VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
+          
+          if [[ "$(resources.pipeline.images.runName)" == "$VERSION" ]]; then
+            echo "Input image build has the same version as the targetting release tags."
+          else
+            echo "Input image build has a differnt version as the targetting release tags."
+            echo "Please make sure the input image resource is correctly selected."
+            echo "    Input Image Built Version: $(resources.pipeline.images.runName)"
+            echo "    Targeting Release Version: $VERSION"
+            exit 1;
+          fi
+        displayName: Verify Input Images Version
+
+################################################################################
   - job: publish_linux_images
 ################################################################################
     timeoutInMinutes: 180


### PR DESCRIPTION
Upgrade Image Publication Pipeline. 
I added a new nice to have feature here as well: 
- Safe guard ensuring the input build image version is correct with what specified in /versionInfo.json. (So we don't accidentally grab 1.1.4 image and publish as 1.2.4 to MCR)
- One button click and done. A user no longer need to fill in miscellaneous parameters which prone to error. The pipeline will look into the repo & construct those parameters for you.  
- Utilized 1ES-Hosted pool for image build consistency. 