### PR TITLE
Upgrade Image Publication Pipeline

### DIFF
--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -1,0 +1,198 @@
+# Required variable from pipeline:
+#    from.registry.address: ''
+#    from.registry.namespace: ''
+#    to.registry.address: ''
+#    to.registry.namespace: ''
+#    pool.linux.name: ''
+
+variables:
+  NugetSecurityAnalysisWarningLevel: warn
+
+resources:
+  pipelines:
+  - pipeline: images
+    source: 'Azure-IoT-Edge-Core Images Release YAML'
+    branch: 'release/1.2'
+
+jobs:
+################################################################################
+  - job: safe_guard
+################################################################################
+    timeoutInMinutes: 180
+    displayName: Safe Guards
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+    steps:
+      - bash: |
+          VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
+          
+          if [[ "$(resources.pipeline.images.runName)" == "$VERSION" ]]; then
+            echo "Input image build has the same version as the targetting release tags."
+            echo "    Input Image Build Version: $(resources.pipeline.images.runName)"
+            echo "    Targeting Release Version: $VERSION"
+          else
+            echo "Input image build has a differnt version as the targetting release tags."
+            echo "Please make sure the input image resource is correctly selected."
+            echo "    Input Image Build Version: $(resources.pipeline.images.runName)"
+            echo "    Targeting Release Version: $VERSION"
+            exit 1;
+          fi
+        displayName: Verify Input Images Version
+
+################################################################################
+  - job: publish_linux_images
+################################################################################
+    timeoutInMinutes: 180
+    displayName: Publish Linux Images
+    dependsOn: safe_guard
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+    steps:
+      - task: Docker@2
+        displayName: Docker login edgerelease
+        inputs:
+          command: login
+          containerRegistry: iotedge-release-acr
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Agent - Linux amd64'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-amd64'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Agent - Linux arm32v7'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm32v7'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Agent - Linux arm64v8'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm64v8'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Hub - Linux amd64'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-amd64'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Hub - Linux arm32v7'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm32v7'
+
+      - task: ShellScript@2
+        displayName: 'Publish Edge Hub - Linux arm64v8'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm64v8'
+
+      - task: ShellScript@2
+        displayName: 'Publish Temp Sensor - Linux amd64'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-amd64'
+
+      - task: ShellScript@2
+        displayName: 'Publish Temp Sensor - Linux arm32v7'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm32v7'
+
+      - task: ShellScript@2
+        displayName: 'Publish Temp Sensor - Linux arm64v8'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm64v8'
+
+      - task: ShellScript@2
+        displayName: 'Publish diagnostics - Linux amd64'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-amd64'
+
+      - task: ShellScript@2
+        displayName: 'Publish diagnostics - Linux arm32v7'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm32v7'
+
+      - task: ShellScript@2
+        displayName: 'Publish diagnostics - Linux arm64v8'
+        inputs:
+          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm64v8'
+
+################################################################################
+  - job: publish_manifest_images
+################################################################################
+    timeoutInMinutes: 180
+    displayName: Publish Manifest Images
+    dependsOn: publish_linux_images
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+    steps:
+      - task: Docker@2
+        displayName: Docker login edgerelease
+        inputs:
+          command: login
+          containerRegistry: iotedge-release-acr
+
+      - bash: |
+          VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
+          TAGS=$(echo "${VERSION%.*}")
+
+          TAGS_STR=$(echo "['$TAGS']")
+          TEMP_SENSOR_TAGS_STR=$(echo "['$TAGS','latest']")
+
+          echo "Version: $VERSION"
+          echo "tags : $TAGS_STR"
+
+          echo "##vso[task.setvariable variable=tags;]$TAGS_STR"
+          echo "##vso[task.setvariable variable=tempSensor.tags;]$TEMP_SENSOR_TAGS_STR"
+        displayName: Set Version and Tags
+
+      - task: Bash@3
+        displayName: 'Publish Edge Agent Manifest'
+        inputs:
+          targetType: filePath
+          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+        env:
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+
+      - task: Bash@3
+        displayName: 'Publish Edge Hub Manifest'
+        inputs:
+          targetType: filePath
+          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+        env:
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+
+      - task: Bash@3
+        displayName: 'Publish Temperature Sensor Manifest'
+        inputs:
+          targetType: filePath
+          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
+        env:
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+
+      - task: Bash@3
+        displayName: 'Publish diagnostics Manifest'
+        inputs:
+          targetType: filePath
+          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+        env:
+          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -12,7 +12,7 @@ resources:
   pipelines:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Images Release YAML'
-    branch: 'release/1.2'
+    branch: 'master'
 
 jobs:
 ################################################################################

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -16,183 +16,219 @@ resources:
 
 jobs:
 ################################################################################
-  - job: safe_guard
+  - deployment: safe_guard
 ################################################################################
     timeoutInMinutes: 180
     displayName: Safe Guards
+    environment: 'Azure-IoT-Edge-Core Release Env'
     pool:
       name: $(pool.linux.name)
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
-    steps:
-      - bash: |
-          VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
-          
-          if [[ "$(resources.pipeline.images.runName)" == "$VERSION" ]]; then
-            echo "Input image build has the same version as the targetting release tags."
-            echo "    Input Image Build Version: $(resources.pipeline.images.runName)"
-            echo "    Targeting Release Version: $VERSION"
-          else
-            echo "Input image build has a differnt version as the targetting release tags."
-            echo "Please make sure the input image resource is correctly selected."
-            echo "    Input Image Build Version: $(resources.pipeline.images.runName)"
-            echo "    Targeting Release Version: $VERSION"
-            exit 1;
-          fi
-        displayName: Verify Input Images Version
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+              clean: true
+              fetchDepth: 100
+
+            - bash: |
+                VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
+                
+                if [[ "$(resources.pipeline.images.runName)" == "$VERSION" ]]; then
+                  echo "Input image build has the same version as the targetting release tags."
+                  echo "    Input Image Build Version: $(resources.pipeline.images.runName)"
+                  echo "    Targeting Release Version: $VERSION"
+                else
+                  echo "Input image build has a differnt version as the targetting release tags."
+                  echo "Please make sure the input image resource is correctly selected."
+                  echo "    Input Image Build Version: $(resources.pipeline.images.runName)"
+                  echo "    Targeting Release Version: $VERSION"
+                  exit 1;
+                fi
+              displayName: Verify Input Images Version
 
 ################################################################################
-  - job: publish_linux_images
+  - deployment: publish_linux_images
 ################################################################################
     timeoutInMinutes: 180
     displayName: Publish Linux Images
     dependsOn: safe_guard
+    environment: 'Azure-IoT-Edge-Core Release Env'
     pool:
       name: $(pool.linux.name)
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
-    steps:
-      - task: Docker@2
-        displayName: Docker login edgerelease
-        inputs:
-          command: login
-          containerRegistry: iotedge-release-acr
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+              clean: true
+              fetchDepth: 100
 
-      - task: ShellScript@2
-        displayName: 'Publish Edge Agent - Linux amd64'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-amd64'
+            - task: Docker@2
+              displayName: Docker login edgerelease
+              inputs:
+                command: login
+                containerRegistry: iotedge-release-acr
 
-      - task: ShellScript@2
-        displayName: 'Publish Edge Agent - Linux arm32v7'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm32v7'
+            - task: Docker@2
+              displayName: Docker login $(to.registry.address)
+              inputs:
+                command: login
+                containerRegistry: $(to.registry.serviceConnection)
 
-      - task: ShellScript@2
-        displayName: 'Publish Edge Agent - Linux arm64v8'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm64v8'
+            - task: ShellScript@2
+              displayName: 'Publish Edge Agent - Linux amd64'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-amd64'
 
-      - task: ShellScript@2
-        displayName: 'Publish Edge Hub - Linux amd64'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-amd64'
+            - task: ShellScript@2
+              displayName: 'Publish Edge Agent - Linux arm32v7'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm32v7'
 
-      - task: ShellScript@2
-        displayName: 'Publish Edge Hub - Linux arm32v7'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm32v7'
+            - task: ShellScript@2
+              displayName: 'Publish Edge Agent - Linux arm64v8'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-agent:$(resources.pipeline.images.runName)-linux-arm64v8'
 
-      - task: ShellScript@2
-        displayName: 'Publish Edge Hub - Linux arm64v8'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm64v8'
+            - task: ShellScript@2
+              displayName: 'Publish Edge Hub - Linux amd64'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-amd64'
 
-      - task: ShellScript@2
-        displayName: 'Publish Temp Sensor - Linux amd64'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-amd64'
+            - task: ShellScript@2
+              displayName: 'Publish Edge Hub - Linux arm32v7'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm32v7'
 
-      - task: ShellScript@2
-        displayName: 'Publish Temp Sensor - Linux arm32v7'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm32v7'
+            - task: ShellScript@2
+              displayName: 'Publish Edge Hub - Linux arm64v8'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-hub:$(resources.pipeline.images.runName)-linux-arm64v8'
 
-      - task: ShellScript@2
-        displayName: 'Publish Temp Sensor - Linux arm64v8'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm64v8'
+            - task: ShellScript@2
+              displayName: 'Publish Temp Sensor - Linux amd64'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-amd64'
 
-      - task: ShellScript@2
-        displayName: 'Publish diagnostics - Linux amd64'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-amd64'
+            - task: ShellScript@2
+              displayName: 'Publish Temp Sensor - Linux arm32v7'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm32v7'
 
-      - task: ShellScript@2
-        displayName: 'Publish diagnostics - Linux arm32v7'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm32v7'
+            - task: ShellScript@2
+              displayName: 'Publish Temp Sensor - Linux arm64v8'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-simulated-temperature-sensor:$(resources.pipeline.images.runName)-linux-arm64v8'
 
-      - task: ShellScript@2
-        displayName: 'Publish diagnostics - Linux arm64v8'
-        inputs:
-          scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
-          args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm64v8'
+            - task: ShellScript@2
+              displayName: 'Publish diagnostics - Linux amd64'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-amd64 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-amd64'
+
+            - task: ShellScript@2
+              displayName: 'Publish diagnostics - Linux arm32v7'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm32v7 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm32v7'
+
+            - task: ShellScript@2
+              displayName: 'Publish diagnostics - Linux arm64v8'
+              inputs:
+                scriptPath: '$(System.DefaultWorkingDirectory)/scripts/linux/moveImage.sh'
+                args: '--from $(from.registry.address)/$(from.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm64v8 --to $(to.registry.address)/$(to.registry.namespace)/azureiotedge-diagnostics:$(resources.pipeline.images.runName)-linux-arm64v8'
 
 ################################################################################
-  - job: publish_manifest_images
+  - deployment: publish_manifest_images
 ################################################################################
     timeoutInMinutes: 180
     displayName: Publish Manifest Images
+    environment: 'Azure-IoT-Edge-Core Release Env'
     dependsOn: publish_linux_images
     pool:
       name: $(pool.linux.name)
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
-    steps:
-      - task: Docker@2
-        displayName: Docker login edgerelease
-        inputs:
-          command: login
-          containerRegistry: iotedge-release-acr
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - checkout: self
+              clean: true
+              fetchDepth: 100
 
-      - bash: |
-          VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
-          TAGS=$(echo "${VERSION%.*}")
+            - task: Docker@2
+              displayName: Docker login edgerelease
+              inputs:
+                command: login
+                containerRegistry: iotedge-release-acr
 
-          TAGS_STR=$(echo "['$TAGS']")
-          TEMP_SENSOR_TAGS_STR=$(echo "['$TAGS','latest']")
+            - task: Docker@2
+              displayName: Docker login $(to.registry.address)
+              inputs:
+                command: login
+                containerRegistry: $(to.registry.serviceConnection)
 
-          echo "Version: $VERSION"
-          echo "tags : $TAGS_STR"
+            - bash: |
+                VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
+                TAGS=$(echo "${VERSION%.*}")
 
-          echo "##vso[task.setvariable variable=tags;]$TAGS_STR"
-          echo "##vso[task.setvariable variable=tempSensor.tags;]$TEMP_SENSOR_TAGS_STR"
-        displayName: Set Version and Tags
+                TAGS_STR=$(echo "['$TAGS']")
+                TEMP_SENSOR_TAGS_STR=$(echo "['$TAGS','latest']")
 
-      - task: Bash@3
-        displayName: 'Publish Edge Agent Manifest'
-        inputs:
-          targetType: filePath
-          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
-        env:
-          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+                echo "Version: $VERSION"
+                echo "tags : $TAGS_STR"
 
-      - task: Bash@3
-        displayName: 'Publish Edge Hub Manifest'
-        inputs:
-          targetType: filePath
-          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
-        env:
-          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+                echo "##vso[task.setvariable variable=tags;]$TAGS_STR"
+                echo "##vso[task.setvariable variable=tempSensor.tags;]$TEMP_SENSOR_TAGS_STR"
+              displayName: Set Version and Tags
 
-      - task: Bash@3
-        displayName: 'Publish Temperature Sensor Manifest'
-        inputs:
-          targetType: filePath
-          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
-        env:
-          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+            - task: Bash@3
+              displayName: 'Publish Edge Agent Manifest'
+              inputs:
+                targetType: filePath
+                filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+                arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+              env:
+                BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
 
-      - task: Bash@3
-        displayName: 'Publish diagnostics Manifest'
-        inputs:
-          targetType: filePath
-          filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
-          arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
-        env:
-          BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+            - task: Bash@3
+              displayName: 'Publish Edge Hub Manifest'
+              inputs:
+                targetType: filePath
+                filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+                arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+              env:
+                BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+
+            - task: Bash@3
+              displayName: 'Publish Temperature Sensor Manifest'
+              inputs:
+                targetType: filePath
+                filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+                arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tempSensor.tags)"'
+              env:
+                BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)
+
+            - task: Bash@3
+              displayName: 'Publish diagnostics Manifest'
+              inputs:
+                targetType: filePath
+                filePath: '$(System.DefaultWorkingDirectory)/scripts/linux/buildManifest.sh'
+                arguments: '-r "$(to.registry.address)" -v "$(resources.pipeline.images.runName)" -t $(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template -n "$(to.registry.namespace)" --tags "$(tags)"'
+              env:
+                BUILD_REPOSITORY_LOCALPATH: $(System.DefaultWorkingDirectory)


### PR DESCRIPTION
Upgrade Image Publication Pipeline. 
I added a new nice to have feature here as well: 
- Safe guard ensuring the input build image version is correct with what specified in /versionInfo.json. (So we don't accidentally grab 1.1.4 image and publish as 1.2.4 to MCR)
- One button click and done. A user no longer need to fill in miscellaneous parameters which prone to error. The pipeline will look into the repo & construct those parameters for you.  
- Utilized 1ES-Hosted pool for image build consistency. 

Cherry-picked from: https://github.com/Azure/iotedge/commit/cd89f1b7e1f74aa9e6bd6472825d4cb66e424897 , https://github.com/Azure/iotedge/commit/ae31328977d8f73f0752f4876d3c8e65a1421db4 + Update the default image from master.