### PR TITLE
Make sure to dispose HttpContentStream when done reading module logs.

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/LogsProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/logs/LogsProvider.cs
@@ -31,11 +31,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
                 logOptions.Filter.IncludeTimestamp = Option.Some(true);
             }
 
-            Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, false, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, logOptions.Filter.IncludeTimestamp, cancellationToken);
-            Events.ReceivedStream(id);
+            using (Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, false, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, logOptions.Filter.IncludeTimestamp, cancellationToken))
+            {
+                Events.ReceivedStream(id);
 
-            byte[] logBytes = await this.GetProcessedLogs(id, logsStream, logOptions);
-            return logBytes;
+                byte[] logBytes = await this.GetProcessedLogs(id, logsStream, logOptions);
+                return logBytes;
+            }
         }
 
         // The id parameter is a regex. Logs for all modules that match this regex are processed.
@@ -65,10 +67,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Logs
             Preconditions.CheckNotNull(logOptions, nameof(logOptions));
             Preconditions.CheckNotNull(callback, nameof(callback));
 
-            Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, logOptions.Follow, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, logOptions.Filter.IncludeTimestamp, cancellationToken);
-            Events.ReceivedStream(id);
+            using (Stream logsStream = await this.runtimeInfoProvider.GetModuleLogs(id, logOptions.Follow, logOptions.Filter.Tail, logOptions.Filter.Since, logOptions.Filter.Until, logOptions.Filter.IncludeTimestamp, cancellationToken))
+            {
+                Events.ReceivedStream(id);
 
-            await this.logsProcessor.ProcessLogsStream(id, logsStream, logOptions, callback);
+                await this.logsProcessor.ProcessLogsStream(id, logsStream, logOptions, callback);
+            }
         }
 
         static byte[] ProcessByContentEncoding(byte[] bytes, LogsContentEncoding contentEncoding) =>

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/MetricsScraper.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/MetricsScraper.cs
@@ -81,14 +81,16 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Diagnostics
                 // Temporary. Only needed until edgeHub starts using asp.net to expose endpoints
                 endpoint = this.GetUriWithIpAddress(endpoint);
 
-                HttpResponseMessage result = await this.httpClient.GetAsync(endpoint, cancellationToken);
-                if (result.IsSuccessStatusCode)
+                using (HttpResponseMessage result = await this.httpClient.GetAsync(endpoint, cancellationToken))
                 {
-                    return await result.Content.ReadAsStringAsync();
-                }
-                else
-                {
-                    Log.LogInformation($"Error connecting to {endpoint} with result error code {result.StatusCode}");
+                    if (result.IsSuccessStatusCode)
+                    {
+                        return await result.Content.ReadAsStringAsync();
+                    }
+                    else
+                    {
+                        Log.LogInformation($"Error connecting to {endpoint} with result error code {result.StatusCode}");
+                    }
                 }
             }
             catch (Exception e)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/ProxyReadinessProbe.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/ProxyReadinessProbe.cs
@@ -25,8 +25,10 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes
         {
             try
             {
-                HttpResponseMessage response = await this.client.GetAsync($"/systeminfo?api-version={this.apiVersion}", token);
-                return response.StatusCode == HttpStatusCode.OK ? ProxyReadiness.Ready : ProxyReadiness.Failed;
+                using (HttpResponseMessage response = await this.client.GetAsync($"/systeminfo?api-version={this.apiVersion}", token))
+                {
+                    return response.StatusCode == HttpStatusCode.OK ? ProxyReadiness.Ready : ProxyReadiness.Failed;
+                }
             }
             catch
             {


### PR DESCRIPTION
This another attempt to find and fix a potential issue where we don't dispose sockets in time.

For `GetModuleLogs` operation, we provide `HttpCompletionOption.ResponseHeadersRead` when calling `HttpClient.SendAsync()`. In this case, the response is not loaded into memory at once, but instead can be streamed. It implies, that we also need to properly dispose the stream so the connection is released ASAP.