### PR TITLE
Remove redundant tests and wait for device to be disconnected

### DIFF
--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Cloud2DeviceTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Cloud2DeviceTest.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
 
                 // Wait for the connection to be closed on the Edge side by checking device connection state
                 Task timerTask = Task.Delay(TimeSpan.FromSeconds(60));
-                Task checkTask = WaitForDeviceDisconnected(rm, deviceName);
+                Task checkTask = this.WaitForDeviceDisconnected(rm, deviceName);
 
                 Task completedTask = await Task.WhenAny(checkTask, timerTask);
                 if (completedTask == timerTask)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Cloud2DeviceTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Cloud2DeviceTest.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
         [AssertionMethod]
         async Task VerifyReceivedC2DMessage(DeviceClient deviceClient, string payload, string p1Value)
         {
-            Client.Message receivedMessage = await deviceClient.ReceiveAsync(TimeSpan.FromSeconds(20));
+            Client.Message receivedMessage = await deviceClient.ReceiveAsync();
 
             if (receivedMessage != null)
             {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Cloud2DeviceTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Cloud2DeviceTest.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 await deviceClient.CloseAsync();
 
                 // Wait for the connection to be closed on the Edge side by checking device connection state
-                Task timerTask = Task.Delay(TimeSpan.FromSeconds(60));
+                Task timerTask = Task.Delay(TimeSpan.FromMinutes(4));
                 Task checkTask = this.WaitForDeviceDisconnected(rm, deviceName);
 
                 Task completedTask = await Task.WhenAny(checkTask, timerTask);
@@ -222,7 +222,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
         {
             if (deviceClient != null)
             {
-                await deviceClient.CloseAsync();
+                try
+                {
+                    await deviceClient.CloseAsync();
+                }
+                catch
+                {
+                    // ignore
+                }
             }
 
             if (serviceClient != null)

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TwinDiffE2ETest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TwinDiffE2ETest.cs
@@ -377,6 +377,26 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 }
             }
 
+            for (int i = 0; i < 5; i++)
+            {
+                try
+                {
+                    var device = await rm.GetDeviceAsync(deviceName);
+                    if (device.ConnectionState != DeviceConnectionState.Connected)
+                        throw new Exception("Device not connected to cloud");
+                    break;
+                }
+                catch (Exception)
+                {
+                    if (i == 4)
+                    {
+                        throw;
+                    }
+
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                }
+            }
+
             return (deviceClient, deviceName);
         }
 


### PR DESCRIPTION
Removed a tests which tested the same actions as another test that was left.
Test was flaky because sometimes the c2d message was sent in the same time the device was disconnected and sometimes edgeHub received it and immediately the device proxy was not available. Fixed to check the device in IotHub that the device was disconnected before sending C2D message.