### PR TITLE
Metrics Collector Release: Update Changelog

### DIFF
--- a/edge-modules/azure-monitor/CHANGELOG.md
+++ b/edge-modules/azure-monitor/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.0.1 (2021-07-13)
+
+### Bug Fixes
+
+- Add configuration for iothub reconnect frequency and azure domain. Fix edge case with hub resource id log filter. (057da6a)[https://github.com/Azure/iotedge/commit/057da6a80bd844c99d64ea56afd433a3a9daf7f6]
+
 # 1.0.0 (2021-06-03)
 
 Initial release of the Metrics Collector module


### PR DESCRIPTION
Updating the changelog with the commits going into the 1.0.1 release. When this commit lands I will tag the metrics collector release on the 1.1 branch.