### PR TITLE
Medium Duration Tests: Disable automatic triggers in favor of periodic triggers

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -11,17 +11,9 @@ resources:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
     branch: 'release/1.2'
-    trigger:
-      branches:
-      - master
-      - release/*
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
     branch: 'release/1.2'
-    trigger:
-      branches:
-      - master
-      - release/*
 
 jobs:
 ################################################################################

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -9,17 +9,9 @@ resources:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
     branch: 'release/1.2'
-    trigger:
-      branches:
-      - master
-      - release/*
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
     branch: 'release/1.2'
-    trigger:
-      branches:
-      - master
-      - release/*
 
 stages:
 - stage: SetupVMs

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -9,17 +9,9 @@ resources:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
     branch: 'release/1.2'
-    trigger:
-      branches:
-      - master
-      - release/*
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
     branch: 'release/1.2'
-    trigger:
-      branches:
-      - master
-      - release/*
 
 stages:
 - stage: SetupVM


### PR DESCRIPTION
Disable automatic triggers in favor of periodic triggers for:
1. Nested E2E
2. Connectivity
3. Nested Connectivity

Once this is checked in I will add the periodic triggers through the DevOps interface.