### PR TITLE
Add ComponentName to message properties (#5234)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/AmqpMessageConverter.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/AmqpMessageConverter.cs
@@ -64,6 +64,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
                 systemProperties.AddIfNonEmpty(SystemProperties.InterfaceId, hubInterfaceId);
             }
 
+            if (sourceMessage.MessageAnnotations.Map.TryGetValue(SystemProperties.ComponentName, out string componentName))
+            {
+                systemProperties.AddIfNonEmpty(SystemProperties.ComponentName, componentName);
+            }
+
             if (sourceMessage.ApplicationProperties != null)
             {
                 foreach (KeyValuePair<MapKey, object> property in sourceMessage.ApplicationProperties.Map)
@@ -186,6 +191,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
             else if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.ConnectionModuleId, out string connectionModuleId))
             {
                 amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionModuleId] = connectionModuleId;
+            }
+
+            if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.ComponentName, out string componentName))
+            {
+                amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsComponentName] = componentName;
             }
 
             if (message.SystemProperties.TryGetNonEmptyValue(SystemProperties.MessageSchema, out string messageSchema))

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Constants.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Amqp/Constants.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp
         public const string MessageAnnotationsInputNameKey = "x-opt-input-name";
         public const string MessageAnnotationsConnectionDeviceId = "iothub-connection-device-id";
         public const string MessageAnnotationsConnectionModuleId = "iothub-connection-module-id";
+        public const string MessageAnnotationsComponentName = "dt-subject";
         public const string WebSocketSubProtocol = "AMQPWSB10";
         public const string WebSocketListenerName = WebSocketSubProtocol + "-listener";
         public const string ServiceBusCbsSaslMechanismName = "MSSBCBS";

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceClientMessageConverter.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/DeviceClientMessageConverter.cs
@@ -70,6 +70,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                     message.MessageSchema = messageSchema;
                 }
 
+                if (inputMessage.SystemProperties.TryGetNonEmptyValue(SystemProperties.ComponentName, out string componentName))
+                {
+                    message.ComponentName = componentName;
+                }
+
                 if (inputMessage.SystemProperties.TryGetNonEmptyValue(SystemProperties.InterfaceId, out string interfaceId)
                     && interfaceId.Equals(Constants.SecurityMessageIoTHubInterfaceId, StringComparison.OrdinalIgnoreCase))
                 {
@@ -95,6 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             message.SystemProperties.AddIfNonEmpty(SystemProperties.MessageSchema, sourceMessage.MessageSchema);
             message.SystemProperties.AddIfNonEmpty(SystemProperties.LockToken, sourceMessage.LockToken);
             message.SystemProperties.AddIfNonEmpty(SystemProperties.DeliveryCount, sourceMessage.DeliveryCount.ToString());
+            message.SystemProperties.AddIfNonEmpty(SystemProperties.ComponentName, sourceMessage.ComponentName);
 
             if (sourceMessage.SequenceNumber > 0)
             {

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/SystemProperties.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/SystemProperties.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
         public const string SequenceNumber = "sequenceNumber";
         public const string InterfaceId = "iothub-interface-id";
         public const string ModelId = "modelId";
+        public const string ComponentName = "dt-subject";
 
         public const string RpConnectionDeviceIdInternal = "rpSenderDeviceId";
         public const string RpConnectionModuleIdInternal = "rpSenderModuleId";
@@ -53,7 +54,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             { OnTheWireSystemPropertyNames.MessageSchemaOnTheWireName, MessageSchema },
             { OnTheWireSystemPropertyNames.OperationOnTheWireName, Operation },
             { OnTheWireSystemPropertyNames.CreationTimeOnTheWireName, CreationTime },
-            { OnTheWireSystemPropertyNames.InterfaceIdOnTheWireName, InterfaceId }
+            { OnTheWireSystemPropertyNames.InterfaceIdOnTheWireName, InterfaceId },
+            { OnTheWireSystemPropertyNames.ComponentNameOnTheWireName, ComponentName }
         };
 
         public static readonly Dictionary<string, string> OutgoingSystemPropertiesMap = new Dictionary<string, string>
@@ -71,6 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             { CreationTime, OnTheWireSystemPropertyNames.CreationTimeOnTheWireName },
             { ConnectionDeviceId, OnTheWireSystemPropertyNames.ConnectionDeviceIdOnTheWireName },
             { ConnectionModuleId, OnTheWireSystemPropertyNames.ConnectionModuleIdOnTheWireName },
+            { ComponentName, OnTheWireSystemPropertyNames.ComponentNameOnTheWireName },
             { RpConnectionDeviceIdInternal, OnTheWireSystemPropertyNames.ConnectionDeviceIdOnTheWireName },
             { RpConnectionModuleIdInternal, OnTheWireSystemPropertyNames.ConnectionModuleIdOnTheWireName }
         };
@@ -92,6 +95,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
             public const string CreationTimeOnTheWireName = "$.ctime";
             public const string OperationOnTheWireName = "iothub-operation";
             public const string InterfaceIdOnTheWireName = "$.ifid";
+            public const string ComponentNameOnTheWireName = "$.sub";
         }
     }
 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/SystemProperties.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/SystemProperties.cs
@@ -14,5 +14,6 @@ namespace Microsoft.Azure.Devices.Routing.Core
         public const string AuthMethod = "connectionAuthMethod";
         public const string ContentType = "contentType";
         public const string ContentEncoding = "contentEncoding";
+        public const string ComponentName = "componentName";
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/AmqpMessageConverterTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/AmqpMessageConverterTest.cs
@@ -107,6 +107,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             string messageSchema = "testSchema";
             string operation = "foo";
             string outputName = "output1";
+            string componentName = "testComponent";
 
             using (AmqpMessage amqpMessage = AmqpMessage.Create(new Data { Value = new ArraySegment<byte>(bytes) }))
             {
@@ -122,6 +123,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                 amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsDeliveryCountKey] = deliveryCount;
                 amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsLockTokenName] = lockToken;
                 amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsSequenceNumberName] = sequenceNumber;
+                amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsComponentName] = componentName;
 
                 amqpMessage.ApplicationProperties.Map[Constants.MessagePropertiesMessageSchemaKey] = messageSchema;
                 amqpMessage.ApplicationProperties.Map[Constants.MessagePropertiesCreationTimeKey] = creationTime;
@@ -140,7 +142,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             // Assert
             Assert.NotNull(receivedMessage);
             Assert.Equal(receivedMessage.Body, bytes);
-            Assert.Equal(15, receivedMessage.SystemProperties.Count);
+            Assert.Equal(16, receivedMessage.SystemProperties.Count);
             Assert.Equal(2, receivedMessage.Properties.Count);
 
             Assert.Equal(receivedMessage.SystemProperties[SystemProperties.MessageId], messageId);
@@ -158,6 +160,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             Assert.Equal(receivedMessage.SystemProperties[SystemProperties.CreationTime], creationTime);
             Assert.Equal(receivedMessage.SystemProperties[SystemProperties.Operation], operation);
             Assert.Equal(receivedMessage.SystemProperties[SystemProperties.OutputName], outputName);
+            Assert.Equal(receivedMessage.SystemProperties[SystemProperties.ComponentName], componentName);
 
             Assert.Equal("Value1", receivedMessage.Properties["Prop1"]);
             Assert.Equal("Value2", receivedMessage.Properties["Prop2"]);
@@ -270,6 +273,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
             string outputName = "outputName";
             string connectionDeviceId = "edgeDevice1";
             string connectionModuleId = "module1";
+            string componentName = "testComponent";
 
             var systemProperties = new Dictionary<string, string>
             {
@@ -290,7 +294,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                 [SystemProperties.InputName] = inputName,
                 [SystemProperties.OutputName] = outputName,
                 [SystemProperties.ConnectionDeviceId] = connectionDeviceId,
-                [SystemProperties.ConnectionModuleId] = connectionModuleId
+                [SystemProperties.ConnectionModuleId] = connectionModuleId,
+                [SystemProperties.ComponentName] = componentName,
             };
 
             var properties = new Dictionary<string, string>
@@ -333,6 +338,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Amqp.Test
                 Assert.Equal(inputName, amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsInputNameKey]);
                 Assert.Equal(connectionDeviceId, amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionDeviceId]);
                 Assert.Equal(connectionModuleId, amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsConnectionModuleId]);
+                Assert.Equal(componentName, amqpMessage.MessageAnnotations.Map[Constants.MessageAnnotationsComponentName]);
 
                 Assert.Equal(messageSchema, amqpMessage.ApplicationProperties.Map[Constants.MessagePropertiesMessageSchemaKey]);
                 Assert.Equal(creationTime, amqpMessage.ApplicationProperties.Map[Constants.MessagePropertiesCreationTimeKey]);

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceClientMessageConverterTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/DeviceClientMessageConverterTest.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                 [SystemProperties.MsgCorrelationId] = "1234",
                 [SystemProperties.MessageId] = "m1",
                 [SystemProperties.CreationTime] = creationTime,
-                [SystemProperties.InterfaceId] = Constants.SecurityMessageIoTHubInterfaceId
+                [SystemProperties.InterfaceId] = Constants.SecurityMessageIoTHubInterfaceId,
+                [SystemProperties.ComponentName] = "Test Component"
             };
 
             var message = Mock.Of<IMessage>(
@@ -159,6 +160,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.Equal("m1", clientMessage.MessageId);
             Assert.Equal(creationTime, clientMessage.CreationTimeUtc.ToString("o"));
             Assert.True(clientMessage.IsSecurityMessage);
+            Assert.Equal("Test Component", clientMessage.ComponentName);
         }
 
         [Unit]
@@ -180,6 +182,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             clientMessage.CorrelationId = "1234";
             clientMessage.MessageId = "m1";
             clientMessage.CreationTimeUtc = creationTime;
+            clientMessage.ComponentName = "Test Component";
 
             IMessageConverter<Message> messageConverter = new DeviceClientMessageConverter();
             IMessage message = messageConverter.ToMessage(clientMessage);
@@ -189,7 +192,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.Equal("Bar", message.Properties["Foo"]);
             Assert.Equal("Value2", message.Properties["Prop2"]);
 
-            Assert.Equal(10, message.SystemProperties.Count);
+            Assert.Equal(11, message.SystemProperties.Count);
             Assert.Equal("utf-8", message.SystemProperties[SystemProperties.ContentEncoding]);
             Assert.Equal("application/json", message.SystemProperties[SystemProperties.ContentType]);
             Assert.Equal("schema1", message.SystemProperties[SystemProperties.MessageSchema]);
@@ -199,6 +202,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             Assert.Equal(creationTime.ToString("o"), message.SystemProperties[SystemProperties.CreationTime]);
             Assert.Equal(DateTime.Parse(message.SystemProperties[SystemProperties.CreationTime], null, DateTimeStyles.RoundtripKind), creationTime);
             Assert.Equal("0", message.SystemProperties[SystemProperties.DeliveryCount]);
+            Assert.Equal("Test Component", message.SystemProperties[SystemProperties.ComponentName]);
         }
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/ProtocolGatewayMessageConverterTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/ProtocolGatewayMessageConverterTest.cs
@@ -140,6 +140,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             address.Append($"&{HttpUtility.UrlEncode("$.schema")}=someschema");
             // creation time
             address.Append($"&{HttpUtility.UrlEncode("$.ctime")}={HttpUtility.UrlEncode("2018-01-31")}");
+            // component name
+            address.Append($"&{HttpUtility.UrlEncode("$.sub")}=testComponent");
 
             // add custom properties
             address.Append("&Foo=Bar&Prop2=Value2&Prop3=Value3/");
@@ -154,7 +156,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             IMessage message = protocolGatewayMessageConverter.ToMessage(protocolGatewayMessage);
             Assert.NotNull(message);
 
-            Assert.Equal(10, message.SystemProperties.Count);
+            Assert.Equal(11, message.SystemProperties.Count);
             Assert.Equal("1234", message.SystemProperties[SystemProperties.MsgCorrelationId]);
             Assert.Equal("mid1", message.SystemProperties[SystemProperties.MessageId]);
             Assert.Equal("d2", message.SystemProperties[SystemProperties.To]);
@@ -165,6 +167,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Assert.Equal("someschema", message.SystemProperties[SystemProperties.MessageSchema]);
             Assert.Equal("2018-01-31", message.SystemProperties[SystemProperties.CreationTime]);
             Assert.Equal("Device_6", message.SystemProperties[SystemProperties.ConnectionDeviceId]);
+            Assert.Equal("testComponent", message.SystemProperties[SystemProperties.ComponentName]);
 
             Assert.Equal(3, message.Properties.Count);
             Assert.Equal("Bar", message.Properties["Foo"]);
@@ -215,7 +218,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
                 [SystemProperties.MsgCorrelationId] = "1234",
                 [SystemProperties.MessageId] = "m1",
                 [SystemProperties.ConnectionDeviceId] = "fromDevice1",
-                [SystemProperties.ConnectionModuleId] = "fromModule1"
+                [SystemProperties.ConnectionModuleId] = "fromModule1",
+                [SystemProperties.ComponentName] = "testComponent"
             };
 
             var message = Mock.Of<IMessage>(
@@ -227,8 +231,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             var protocolGatewayMessageConverter = new ProtocolGatewayMessageConverter(converter, ByteBufferConverter);
             IProtocolGatewayMessage pgMessage = protocolGatewayMessageConverter.FromMessage(message);
             Assert.NotNull(pgMessage);
-            Assert.Equal(@"devices/Device1/modules/Module1/inputs/input1/Foo=Bar&Prop2=Value2&Prop3=Value3&%24.ce=utf-8&%24.ct=application%2Fjson&%24.schema=schema1&%24.to=foo&%24.uid=user1&%24.cid=1234&%24.mid=m1&%24.cdid=fromDevice1&%24.cmid=fromModule1", pgMessage.Address);
-            Assert.Equal(12, pgMessage.Properties.Count);
+            Assert.Equal(@"devices/Device1/modules/Module1/inputs/input1/Foo=Bar&Prop2=Value2&Prop3=Value3&%24.ce=utf-8&%24.ct=application%2Fjson&%24.schema=schema1&%24.to=foo&%24.uid=user1&%24.cid=1234&%24.mid=m1&%24.cdid=fromDevice1&%24.cmid=fromModule1&%24.sub=testComponent", pgMessage.Address);
+            Assert.Equal(13, pgMessage.Properties.Count);
             Assert.Equal("Bar", pgMessage.Properties["Foo"]);
             Assert.Equal("Value2", pgMessage.Properties["Prop2"]);
             Assert.Equal("Value3", pgMessage.Properties["Prop3"]);
@@ -241,6 +245,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Assert.Equal("m1", pgMessage.Properties["$.mid"]);
             Assert.Equal("fromDevice1", pgMessage.Properties["$.cdid"]);
             Assert.Equal("fromModule1", pgMessage.Properties["$.cmid"]);
+            Assert.Equal("testComponent", pgMessage.Properties["$.sub"]);
             Assert.False(pgMessage.Properties.ContainsKey("$.on"));
             Assert.True(DateTime.UtcNow - pgMessage.CreatedTimeUtc < TimeSpan.FromSeconds(3));
         }


### PR DESCRIPTION
This adds support for the new ComponentName message property to edgeHub. This is a property used by pnp devices and was added to the SDK already