### PR TITLE
Nested Longhaul Tests: Fix scheduled runs

### DIFF
--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -8,10 +8,10 @@ resources:
   pipelines:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
-    branch: master
+    branch: 'release/1.2'
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
-    branch: master
+    branch: 'release/1.2'
 
 stages:
 - stage: SetupVMs


### PR DESCRIPTION
Nested longhaul is misconfigured for the release 1.2 branch. Fixing this so that scheduled runs work.