### PR TITLE
Medium Duration Tests: Add scheduled triggers through yaml

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -1,14 +1,14 @@
 trigger: none
 pr: none
 schedules:
-- cron: "0 6 * * *"
-  displayName: Daily morning build
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
   branches:
     include:
     - release/1.2
   always: true
-- cron: "0 18 * * *"
-  displayName: Daily nightly build
+- cron: "0 12 * * *"
+  displayName: Daily noon build
   branches:
     include:
     - release/1.2

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -1,5 +1,18 @@
 trigger: none
 pr: none
+schedules:
+- cron: "0 6 * * *"
+  displayName: Daily morning build
+  branches:
+    include:
+    - release/1.2
+  always: true
+- cron: "0 18 * * *"
+  displayName: Daily nightly build
+  branches:
+    include:
+    - release/1.2
+  always: true
 
 variables:
   NugetSecurityAnalysisWarningLevel: warn

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -1,14 +1,8 @@
 trigger: none
 pr: none
 schedules:
-- cron: "0 6 * * *"
-  displayName: Daily morning build
-  branches:
-    include:
-    - release/1.2
-  always: true
-- cron: "0 18 * * *"
-  displayName: Daily nightly build
+- cron: "0 23 * * 4"
+  displayName: Weekly run Thursday night
   branches:
     include:
     - release/1.2

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -1,5 +1,18 @@
 trigger: none
 pr: none
+schedules:
+- cron: "0 6 * * *"
+  displayName: Daily morning build
+  branches:
+    include:
+    - release/1.2
+  always: true
+- cron: "0 18 * * *"
+  displayName: Daily nightly build
+  branches:
+    include:
+    - release/1.2
+  always: true
 
 variables:
   NugetSecurityAnalysisWarningLevel: warn

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -1,14 +1,14 @@
 trigger: none
 pr: none
 schedules:
-- cron: "0 6 * * *"
-  displayName: Daily morning build
+- cron: "0 0 * * *"
+  displayName: Daily midnight build
   branches:
     include:
     - release/1.2
   always: true
-- cron: "0 18 * * *"
-  displayName: Daily nightly build
+- cron: "0 12 * * *"
+  displayName: Daily noon build
   branches:
     include:
     - release/1.2

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -1,5 +1,9 @@
 trigger: none
 pr: none
+
+# Nested E2E and Nested Connectivity share test agents.
+# Thus the schedules are offset by 6 hours.
+# This will ensure that enough agents are avaiable to service all tests. 
 schedules:
 - cron: "0 0 * * *"
   displayName: Daily midnight build

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -1,5 +1,18 @@
 trigger: none
 pr: none
+schedules:
+- cron: "0 6 * * *"
+  displayName: Daily morning build
+  branches:
+    include:
+    - release/1.2
+  always: true
+- cron: "0 18 * * *"
+  displayName: Daily nightly build
+  branches:
+    include:
+    - release/1.2
+  always: true
 
 variables:
   NugetSecurityAnalysisWarningLevel: warn

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -1,5 +1,9 @@
 trigger: none
 pr: none
+
+# Nested E2E and Nested Connectivity share test agents.
+# Thus the schedules are offset by 6 hours.
+# This will ensure that enough agents are avaiable to service all tests. 
 schedules:
 - cron: "0 6 * * *"
   displayName: Daily morning build

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -8,7 +8,7 @@ schedules:
     - release/1.2
   always: true
 - cron: "0 18 * * *"
-  displayName: Daily nightly build
+  displayName: Daily evening build
   branches:
     include:
     - release/1.2

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -1,5 +1,18 @@
 trigger: none
 pr: none
+schedules:
+- cron: "0 3 * * *"
+  displayName: Daily morning build
+  branches:
+    include:
+    - release/1.2
+  always: true
+- cron: "0 15 * * *"
+  displayName: Daily nightly build
+  branches:
+    include:
+    - release/1.2
+  always: true
 
 variables:
   NugetSecurityAnalysisWarningLevel: warn

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -1,13 +1,13 @@
 trigger: none
 pr: none
 schedules:
-- cron: "0 3 * * *"
+- cron: "0 6 * * *"
   displayName: Daily morning build
   branches:
     include:
     - release/1.2
   always: true
-- cron: "0 15 * * *"
+- cron: "0 18 * * *"
   displayName: Daily nightly build
   branches:
     include:

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -1,14 +1,10 @@
 trigger: none
 pr: none
+trigger: none
+pr: none
 schedules:
-- cron: "0 6 * * *"
-  displayName: Daily morning build
-  branches:
-    include:
-    - release/1.2
-  always: true
-- cron: "0 18 * * *"
-  displayName: Daily nightly build
+- cron: "0 23 * * 4"
+  displayName: Weekly run Thursday night
   branches:
     include:
     - release/1.2

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -1,5 +1,18 @@
 trigger: none
 pr: none
+schedules:
+- cron: "0 6 * * *"
+  displayName: Daily morning build
+  branches:
+    include:
+    - release/1.2
+  always: true
+- cron: "0 18 * * *"
+  displayName: Daily nightly build
+  branches:
+    include:
+    - release/1.2
+  always: true
 
 variables:
   NugetSecurityAnalysisWarningLevel: warn


### PR DESCRIPTION
Setting up a daily morning and a daily nightly schedule for the following pipelines:
- Connectivity
- Nested Connectivity
- Nested E2E
- Longhaul
- Nested Longhaul

Since Nested Connectivity and Nested E2E share agents I have offset the start times by 6 hours.

Followed instructions from here:
https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml