### PR TITLE
Nested Longhaul Test: Fix duplicate trigger

### DIFF
--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -1,7 +1,5 @@
 trigger: none
 pr: none
-trigger: none
-pr: none
 schedules:
 - cron: "0 23 * * 4"
   displayName: Weekly run Thursday night


### PR DESCRIPTION
In #5264 I made a typo and added a duplicate `trigger` and `pr` block. Removing it here.