### PR TITLE
Changing ssl protocols and ciphers

### DIFF
--- a/edge-modules/api-proxy-module/readme.md
+++ b/edge-modules/api-proxy-module/readme.md
@@ -112,6 +112,8 @@ For easiness of use, the API proxy module comes with a default configuration tha
 | Config variable  | comments |
 | ------------- |  ------------- |
 | NGINX_DEFAULT_PORT  | Changes the port Nginx listens on. If you update this environment variable, make sure the port you select is also exposed in the module dockerfile and the port binding. Default is 443.  |
+| NGINX_DEFAULT_TLS | Changes the ssl protocols nginx support. See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols for more details. |
+| NGINX_DEFAULT_CIPHERS | Changes the ciphers nginx support. See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_ciphers for more details. |
 | DOCKER_REQUEST_ROUTE_ADDRESS | Address to route docker requests. By default it points to the parent.  |
 | BLOB_UPLOAD_ROUTE_ADDRESS| Address to route blob registry requests. By default it points to the parent. |
 | IOTEDGE_PARENTHOSTNAME | Read only variable. Do not assign, its value is automatically assigned to Parent hostname when container starts |

--- a/edge-modules/api-proxy-module/src/monitors/config_parser.rs
+++ b/edge-modules/api-proxy-module/src/monitors/config_parser.rs
@@ -378,7 +378,10 @@ mod tests {
 
         //**************************Check ACR config***************************************
         std::env::set_var("NGINX_DEFAULT_PORT", "8000");
-        std::env::set_var("BLOB_UPLOAD_ROUTE_ADDRESS", "AzureBlobStorageonIoTEdge:11002");
+        std::env::set_var(
+            "BLOB_UPLOAD_ROUTE_ADDRESS",
+            "AzureBlobStorageonIoTEdge:11002",
+        );
         std::env::set_var("CONNECTED_ACR_ROUTE_ADDRESS", "connected-registry:8080");
         std::env::set_var("IOTEDGE_PARENTHOSTNAME", "10.0.0.1");
         let config_parser = ConfigParser::new().unwrap();
@@ -387,7 +390,9 @@ mod tests {
         let config = std::str::from_utf8(&byte_str).unwrap();
         assert_eq!(config, RAW_ACR_CONFIG_TEXT);
 
-        let config = config_parser.get_parsed_config(RAW_ACR_CONFIG_TEXT).unwrap();
+        let config = config_parser
+            .get_parsed_config(RAW_ACR_CONFIG_TEXT)
+            .unwrap();
 
         assert_eq!(&config, PARSED_ACR_CONFIG);
 

--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -26,6 +26,14 @@ http {
 
         chunked_transfer_encoding on;
 
+        #if_tag ${NGINX_DEFAULT_TLS}	
+        ssl_protocols ${NGINX_DEFAULT_TLS};
+        #endif_tag ${NGINX_DEFAULT_TLS}
+
+        #if_tag ${NGINX_DEFAULT_CIPHERS}
+        ssl_ciphers ${NGINX_DEFAULT_CIPHERS};
+        #endif_tag ${NGINX_DEFAULT_CIPHERS}
+
         ssl_certificate        server.crt;
         ssl_certificate_key    private_key_server.pem; 
         ssl_client_certificate trustedCA.crt;


### PR DESCRIPTION
Changing ssl protocols and ciphers.
If user don't define anything, nothing will be added and default config will be used.
If use define the env vars NGINX_DEFAULT_TLS   then it will appear like this in the config:
![image](https://user-images.githubusercontent.com/33438817/126708599-2e2f006e-a70e-4bd9-98cb-d978387da076.png)
