### PR TITLE
Extend timeout for UploadSupportBundle

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -89,6 +89,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string RequestTimeoutSecs = "RequestTimeoutSecs";
 
+        public const string SupportTimeoutSecs = "SupportTaskTimeoutSecs";
+
         public const string AllModulesIdentifier = "all";
 
         public const string CloseOnIdleTimeout = "CloseCloudConnectionOnIdleTimeout";

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/ModuleManagementHttpClient.cs
@@ -17,12 +17,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
     {
         readonly ModuleManagementHttpClientVersioned inner;
 
-        public ModuleManagementHttpClient(Uri managementUri, string serverSupportedApiVersion, string clientSupportedApiVersion)
+        public ModuleManagementHttpClient(Uri managementUri, string serverSupportedApiVersion, string clientSupportedApiVersion, Option<TimeSpan> managementApiTimeout)
         {
             Preconditions.CheckNotNull(managementUri, nameof(managementUri));
             Preconditions.CheckNonWhiteSpace(serverSupportedApiVersion, nameof(serverSupportedApiVersion));
             Preconditions.CheckNonWhiteSpace(clientSupportedApiVersion, nameof(clientSupportedApiVersion));
-            this.inner = GetVersionedModuleManagement(managementUri, serverSupportedApiVersion, clientSupportedApiVersion);
+            this.inner = GetVersionedModuleManagement(managementUri, serverSupportedApiVersion, clientSupportedApiVersion, managementApiTimeout);
         }
 
         public Task<Identity> CreateIdentityAsync(string name, string managedBy) => this.inner.CreateIdentityAsync(name, managedBy);
@@ -63,36 +63,36 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
         public Task<Stream> GetSupportBundle(Option<string> since, Option<string> until, Option<string> iothubHostname, Option<bool> edgeRuntimeOnly, CancellationToken token) =>
             this.inner.GetSupportBundle(since, until, iothubHostname, edgeRuntimeOnly, token);
 
-        internal static ModuleManagementHttpClientVersioned GetVersionedModuleManagement(Uri managementUri, string serverSupportedApiVersion, string clientSupportedApiVersion)
+        internal static ModuleManagementHttpClientVersioned GetVersionedModuleManagement(Uri managementUri, string serverSupportedApiVersion, string clientSupportedApiVersion, Option<TimeSpan> managementApiTimeout)
         {
             ApiVersion supportedVersion = GetSupportedVersion(serverSupportedApiVersion, clientSupportedApiVersion);
 
             if (supportedVersion == ApiVersion.Version20180628)
             {
-                return new Version_2018_06_28.ModuleManagementHttpClient(managementUri);
+                return new Version_2018_06_28.ModuleManagementHttpClient(managementUri, managementApiTimeout);
             }
 
             if (supportedVersion == ApiVersion.Version20190130)
             {
-                return new Version_2019_01_30.ModuleManagementHttpClient(managementUri);
+                return new Version_2019_01_30.ModuleManagementHttpClient(managementUri, managementApiTimeout);
             }
 
             if (supportedVersion == ApiVersion.Version20191022)
             {
-                return new Version_2019_10_22.ModuleManagementHttpClient(managementUri);
+                return new Version_2019_10_22.ModuleManagementHttpClient(managementUri, managementApiTimeout);
             }
 
             if (supportedVersion == ApiVersion.Version20191105)
             {
-                return new Version_2019_11_05.ModuleManagementHttpClient(managementUri);
+                return new Version_2019_11_05.ModuleManagementHttpClient(managementUri, managementApiTimeout);
             }
 
             if (supportedVersion == ApiVersion.Version20200707)
             {
-                return new Version_2020_07_07.ModuleManagementHttpClient(managementUri);
+                return new Version_2020_07_07.ModuleManagementHttpClient(managementUri, managementApiTimeout);
             }
 
-            return new Version_2018_06_28.ModuleManagementHttpClient(managementUri);
+            return new Version_2018_06_28.ModuleManagementHttpClient(managementUri, managementApiTimeout);
         }
 
         static ApiVersion GetSupportedVersion(string serverSupportedApiVersion, string clientSupportedApiVersion)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             string backupConfigFilePath;
             int maxRestartCount;
             TimeSpan intensiveCareTime;
+            TimeSpan supportTaskTime;
             int coolOffTimeUnitInSeconds;
             bool usePersistentStorage;
             string storagePath;
@@ -103,6 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 backupConfigFilePath = configuration.GetValue<string>("BackupConfigFilePath");
                 maxRestartCount = configuration.GetValue<int>("MaxRestartCount");
                 intensiveCareTime = TimeSpan.FromMinutes(configuration.GetValue<int>("IntensiveCareTimeInMinutes"));
+                supportTaskTime = TimeSpan.FromSeconds(configuration.GetValue<int>(Constants.SupportTimeoutSecs, 600));
                 coolOffTimeUnitInSeconds = configuration.GetValue("CoolOffTimeUnitInSeconds", 10);
                 usePersistentStorage = configuration.GetValue("UsePersistentStorage", true);
                 useServerHeartbeat = configuration.GetValue("UseServerHeartbeat", true);
@@ -184,7 +186,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         apiVersion = configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
                         TimeSpan performanceMetricsUpdateFrequency = configuration.GetTimeSpan("PerformanceMetricsUpdateFrequency", TimeSpan.FromMinutes(5));
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize, storageMaxOpenFiles, storageLogLevel));
-                        builder.RegisterModule(new EdgeletModule(iothubHostname, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, performanceMetricsUpdateFrequency, useServerHeartbeat, backupConfigFilePath));
+                        builder.RegisterModule(new EdgeletModule(iothubHostname, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, performanceMetricsUpdateFrequency, supportTaskTime, useServerHeartbeat, backupConfigFilePath));
                         IEnumerable<X509Certificate2> trustBundle =
                             await CertificateHelper.GetTrustBundleFromEdgelet(new Uri(workloadUri), apiVersion, Constants.WorkloadApiVersion, moduleId, moduleGenerationId);
                         CertificateHelper.InstallCertificates(trustBundle, logger);
@@ -279,6 +281,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                                 TimeSpan.FromSeconds(configRefreshFrequencySecs),
                                 enableStreams,
                                 TimeSpan.FromSeconds(requestTimeoutSecs),
+                                supportTaskTime,
                                 experimentalFeatures,
                                 manifestTrustBundle));
                         break;

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
@@ -42,6 +42,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly bool closeOnIdleTimeout;
         readonly TimeSpan idleTimeout;
         readonly TimeSpan performanceMetricsUpdateFrequency;
+        readonly Option<TimeSpan> supportTaskTimeout;
         readonly bool useServerHeartbeat;
         readonly string backupConfigFilePath;
 
@@ -58,6 +59,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             bool closeOnIdleTimeout,
             TimeSpan idleTimeout,
             TimeSpan performanceMetricsUpdateFrequency,
+            TimeSpan supportTaskTimeout,
             bool useServerHeartbeat,
             string backupConfigFilePath)
         {
@@ -73,6 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.closeOnIdleTimeout = closeOnIdleTimeout;
             this.idleTimeout = idleTimeout;
             this.performanceMetricsUpdateFrequency = performanceMetricsUpdateFrequency;
+            this.supportTaskTimeout = Option.Maybe<TimeSpan>(supportTaskTimeout);
             this.useServerHeartbeat = useServerHeartbeat;
             this.backupConfigFilePath = Preconditions.CheckNonWhiteSpace(backupConfigFilePath, nameof(backupConfigFilePath));
         }
@@ -93,7 +96,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .SingleInstance();
 
             // IModuleManager
-            builder.Register(c => new ModuleManagementHttpClient(this.managementUri, this.apiVersion, Constants.EdgeletClientApiVersion))
+            builder.Register(c => new ModuleManagementHttpClient(this.managementUri, this.apiVersion, Constants.EdgeletClientApiVersion, this.supportTaskTimeout))
                 .As<IModuleManager>()
                 .As<IIdentityManager>()
                 .As<IDeviceManager>()

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/KubernetesModule.cs
@@ -170,7 +170,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                 .SingleInstance();
 
             // IModuleManager
-            builder.Register(c => new ModuleManagementHttpClient(this.managementUri, this.apiVersion, Core.Constants.EdgeletClientApiVersion))
+            builder.Register(c => new ModuleManagementHttpClient(this.managementUri, this.apiVersion, Core.Constants.EdgeletClientApiVersion, Option.Some(TimeSpan.FromMinutes(5))))
                 .As<IModuleManager>()
                 .As<IIdentityManager>()
                 .As<IDeviceManager>()

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/TwinConfigSourceModule.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly string iotHubHostName;
         readonly bool enableStreams;
         readonly TimeSpan requestTimeout;
+        readonly TimeSpan supportTaskTimeout;
         readonly ExperimentalFeatures experimentalFeatures;
         readonly Option<X509Certificate2> manifestTrustBundle;
 
@@ -46,6 +47,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             TimeSpan configRefreshFrequency,
             bool enableStreams,
             TimeSpan requestTimeout,
+            TimeSpan supportTaskTimeout,
             ExperimentalFeatures experimentalFeatures,
             Option<X509Certificate2> manifestTrustBundle)
         {
@@ -56,6 +58,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.configRefreshFrequency = configRefreshFrequency;
             this.enableStreams = enableStreams;
             this.requestTimeout = requestTimeout;
+            this.supportTaskTimeout = supportTaskTimeout;
             this.experimentalFeatures = experimentalFeatures;
             this.manifestTrustBundle = manifestTrustBundle;
         }
@@ -101,7 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                         var logsProviderTask = c.Resolve<Task<ILogsProvider>>();
                         IRuntimeInfoProvider runtimeInfoProvider = await runtimeInfoProviderTask;
                         ILogsProvider logsProvider = await logsProviderTask;
-                        return new ModuleLogsUploadRequestHandler(requestUploader, logsProvider, runtimeInfoProvider) as IRequestHandler;
+                        return new ModuleLogsUploadRequestHandler(requestUploader, logsProvider, runtimeInfoProvider, this.supportTaskTimeout) as IRequestHandler;
                     })
                 .As<Task<IRequestHandler>>()
                 .SingleInstance();
@@ -123,7 +126,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             builder.Register(
                     c =>
                     {
-                        IRequestHandler handler = new SupportBundleRequestHandler(c.Resolve<IModuleManager>().GetSupportBundle, c.Resolve<IRequestsUploader>(), this.iotHubHostName);
+                        IRequestHandler handler = new SupportBundleRequestHandler(c.Resolve<IModuleManager>().GetSupportBundle, c.Resolve<IRequestsUploader>(), this.iotHubHostName, this.supportTaskTimeout);
                         return Task.FromResult(handler);
                     })
                 .As<Task<IRequestHandler>>()

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/requests/LogsUploadRequestHandlerTest.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
             var runtimeInfoProvider = Mock.Of<IRuntimeInfoProvider>(r => r.GetModules(It.IsAny<CancellationToken>()) == Task.FromResult(moduleRuntimeInfoList));
 
             // Act
-            var logsUploadRequestHandler = new ModuleLogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, runtimeInfoProvider);
+            var logsUploadRequestHandler = new ModuleLogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, runtimeInfoProvider, TimeSpan.FromSeconds(10));
             Option<string> response = await logsUploadRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
 
             // Assert
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
                 .Returns(Task.CompletedTask);
 
             // Act
-            var logsUploadRequestHandler = new ModuleLogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, runtimeInfoProvider.Object);
+            var logsUploadRequestHandler = new ModuleLogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, runtimeInfoProvider.Object, TimeSpan.FromSeconds(10));
             Option<string> response = await logsUploadRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None);
 
             // Assert
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test.Requests
             var runtimeInfoProvider = Mock.Of<IRuntimeInfoProvider>();
 
             // Act
-            var logsUploadRequestHandler = new ModuleLogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, runtimeInfoProvider);
+            var logsUploadRequestHandler = new ModuleLogsUploadRequestHandler(logsUploader.Object, logsProvider.Object, runtimeInfoProvider, TimeSpan.FromSeconds(10));
             await Assert.ThrowsAsync(exception, () => logsUploadRequestHandler.HandleRequest(Option.Maybe(payload), CancellationToken.None));
         }
     }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleManagementHttpClientTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleManagementHttpClientTest.cs
@@ -21,6 +21,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
     [Unit]
     public class ModuleManagementHttpClientTest : IClassFixture<EdgeletFixture>
     {
+        static readonly Option<TimeSpan> DefaultTimeout = Option.Some(TimeSpan.FromSeconds(10));
         static readonly string[] Versions = new string[] { "2018-06-28", "2019-01-30", "2019-10-22" };
         readonly Uri serverUrl;
         readonly EdgeletFixture edgeletFixture;
@@ -38,54 +39,54 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
         {
             string serverApiVersion = "2018-06-28";
             string clientApiVersion = "2018-06-28";
-            var versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            var versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2018_06_28.ModuleManagementHttpClient);
 
             serverApiVersion = "2018-06-28";
             clientApiVersion = "2019-01-30";
-            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2018_06_28.ModuleManagementHttpClient);
 
             serverApiVersion = "2019-01-30";
             clientApiVersion = "2018-06-28";
-            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2018_06_28.ModuleManagementHttpClient);
 
             serverApiVersion = "2019-01-30";
             clientApiVersion = "2019-01-30";
-            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2019_01_30.ModuleManagementHttpClient);
 
             serverApiVersion = "2019-01-30";
             clientApiVersion = "2019-10-22";
-            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2019_01_30.ModuleManagementHttpClient);
 
             serverApiVersion = "2019-10-22";
             clientApiVersion = "2018-06-28";
-            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2018_06_28.ModuleManagementHttpClient);
 
             serverApiVersion = "2019-10-22";
             clientApiVersion = "2019-01-30";
-            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2019_01_30.ModuleManagementHttpClient);
 
             serverApiVersion = "2019-10-22";
             clientApiVersion = "2019-10-22";
-            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2019_10_22.ModuleManagementHttpClient);
 
             // Unsupported server.
             serverApiVersion = "2019-02-30";
             clientApiVersion = "2019-01-30";
-            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion);
+            versionedClient = ModuleManagementHttpClient.GetVersionedModuleManagement(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             Assert.True(versionedClient is Version_2019_01_30.ModuleManagementHttpClient);
 
             // Unsupported client.
             serverApiVersion = "2019-01-30";
             clientApiVersion = "2019-02-30";
-            Assert.Throws<InvalidOperationException>(() => new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion));
+            Assert.Throws<InvalidOperationException>(() => new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout));
         }
 
         [Theory]
@@ -93,7 +94,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
         public async Task IdentityTest(string serverApiVersion, string clientApiVersion)
         {
             // Arrange
-            IIdentityManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
+            IIdentityManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
 
             // Act
             Identity identity1 = await client.CreateIdentityAsync("Foo", Constants.ModuleIdentityEdgeManagedByValue);
@@ -168,7 +169,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
         public async Task ModulesTest(string serverApiVersion, string clientApiVersion)
         {
             // Arrange
-            IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
+            IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             var moduleSpec = new ModuleSpec("Module1", "Docker", ImagePullPolicy.OnCreate, JObject.Parse("{ \"image\": \"testimage\" }"), new ObservableCollection<EnvVar> { new EnvVar("E1", "P1") });
 
             // Act
@@ -250,7 +251,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
                 ImagePullPolicy.OnCreate,
                 JObject.Parse("{ \"image\": \"testimage\" }"),
                 new ObservableCollection<EnvVar> { new EnvVar("E1", "P1") });
-            IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
+            IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
             await client.PrepareUpdateAsync(moduleSpec);
         }
 
@@ -259,7 +260,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
         public async Task ModuleLogsTest(string serverApiVersion, string clientApiVersion)
         {
             // Arrange
-            IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
+            IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
 
             // Act
             Stream logsStream = await client.GetModuleLogs("edgeHub", false, Option.None<int>(), Option.None<string>(), Option.None<string>(),  Option.Some(false), CancellationToken.None);
@@ -276,7 +277,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
         public async Task Test_ReprovisionDevice_ShouldSucceed(string serverApiVersion, string clientApiVersion)
         {
             // Arrange
-            IDeviceManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
+            IDeviceManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion, DefaultTimeout);
 
             // Act and Assert
             await client.ReprovisionDeviceAsync();


### PR DESCRIPTION
Setting "SupportTaskTimeoutSecs" as an environment
variable will set the maximum amount of time that the
management client will wait for support tasks, specifically
UploadSupportBundle and UploadModuleLogs.