### PR TITLE
E2E Tests: Re-enable priority proxy tests 

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -60,7 +60,7 @@ steps:
       $filter += '&Category!=NestedEdgeOnly'
     }
 
-    sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.PriorityQueues.PriorityQueueModuleToHubMessages"
+    sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
 
   displayName: Run tests ${{ parameters.test_type }}
   env:

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -60,7 +60,7 @@ steps:
       $filter += '&Category!=NestedEdgeOnly'
     }
 
-    sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
+    sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "FullyQualifiedName~Microsoft.Azure.Devices.Edge.Test.PriorityQueues.PriorityQueueModuleToHubMessages"
 
   displayName: Run tests ${{ parameters.test_type }}
   env:

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -22,6 +22,25 @@ steps:
       TestRootCaPassword,
       TestBlobStoreSas
 
+- pwsh: |
+    $imageBuildId = $(resources.pipeline.images.runID)
+    $packageBuildId = $(resources.pipeline.packages.runID)
+    if ('$(az.pipeline.images.buildId)')
+    {
+      Write-Output '>> User supplied az.pipeline.images.buildId=$(az.pipeline.images.buildId)'
+      $imageBuildId = '$(az.pipeline.images.buildId)'
+    }
+    if ('$(az.pipeline.packages.buildId)')
+    {
+      Write-Output '>> User supplied az.pipeline.packages.buildId=$(az.pipeline.packages.buildId)'
+      $packageBuildId = '$(az.pipeline.packages.buildId)'
+    }
+    Write-Output "##vso[task.setvariable variable=imageBuildId]$imageBuildId"
+    Write-Output "##vso[task.setvariable variable=packageBuildId]$packageBuildId"
+    Write-Output ">> Package Build ID=$packageBuildId"
+    Write-Output ">> Image Build ID=$imageBuildId"
+  displayName: Override artifacts with user-supplied args
+
 - task: DownloadBuildArtifacts@0
   displayName: Get Docker image info
   inputs:
@@ -29,7 +48,7 @@ steps:
     project: $(resources.pipeline.images.projectID)
     pipeline: $(resources.pipeline.images.pipelineName)
     buildVersionToDownload: specific
-    buildId: $(resources.pipeline.images.runID)
+    buildId: $(imageBuildId)
     downloadType: single
     artifactName: $(az.pipeline.images.artifacts)
     allowPartiallySucceededBuilds: true

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
@@ -18,6 +18,12 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
         public static Action<EdgeConfigBuilder> BuildAddNetworkControllerConfig(string trackingId, string networkControllerImage)
         {
+            string transportType = "Amqp";
+            if (Context.Current.TestRunnerProxy.HasValue)
+            {
+                transportType = "Amqp_WebSocket_Only";
+            }
+
             return new Action<EdgeConfigBuilder>(
                 builder =>
                 {
@@ -30,9 +36,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                             ("RunFrequencies__0__OnlineFrequency", "00:00:00"),
                             ("RunFrequencies__0__RunsCount", "0"),
                             ("NetworkControllerRunProfile", "Online"),
-                            ("StartAfter", "00:00:00")
+                            ("StartAfter", "00:00:00"),
+                            ("TransportType", transportType)
                         })
-                        .WithSettings(new[] { ("createOptions", "{\"HostConfig\":{\"Binds\":[\"/var/run/docker.sock:/var/run/docker.sock\"], \"NetworkMode\":\"host\", \"Privileged\":true},\"NetworkingConfig\":{\"EndpointsConfig\":{\"host\":{}}}}") });
+                        .WithSettings(new[] { ("createOptions", "{\"HostConfig\":{\"Binds\":[\"/var/run/docker.sock:/var/run/docker.sock\"], \"NetworkMode\":\"host\", \"Privileged\":true},\"NetworkingConfig\":{\"EndpointsConfig\":{\"host\":{}}}}") })
+                        .WithProxy(Context.Current.TestRunnerProxy);
                 });
         }
 
@@ -98,7 +106,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 
             if (!isPassed)
             {
-                Log.Verbose("Test Result Coordinator response: {Response}", jsonstring);
+                Log.Information("Test Result Coordinator response: {Response}", jsonstring);
             }
 
             Assert.IsTrue(isPassed);

--- a/test/connectivity/modules/NetworkController/Program.cs
+++ b/test/connectivity/modules/NetworkController/Program.cs
@@ -36,7 +36,7 @@ namespace NetworkController
                 {
                     await networkInterfaceName.ForEachAsync(async name =>
                     {
-                        string hubHostname = !string.IsNullOrEmpty(Settings.Current.ParentHostname) ? Settings.Current.ParentHostname : Settings.Current.IotHubHostname;
+                        string hubHostname = GetHostnameForExternalTraffic();
                         var offline = new OfflineController(name, hubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
                         var satellite = new SatelliteController(name, hubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
                         var cellular = new CellularController(name, hubHostname, Settings.Current.NetworkRunProfile.ProfileSetting);
@@ -112,11 +112,35 @@ namespace NetworkController
             INetworkStatusReporter reporter = new NetworkStatusReporter(Settings.Current.TestResultCoordinatorEndpoint, Settings.Current.ModuleId, Settings.Current.TrackingId);
             NetworkProfileSetting customNetworkProfileSetting = Settings.Current.NetworkRunProfile.ProfileSetting;
             customNetworkProfileSetting.PackageLoss = 100;
-            string hubHostname = !string.IsNullOrEmpty(Settings.Current.ParentHostname) ? Settings.Current.ParentHostname : Settings.Current.IotHubHostname;
+            string hubHostname = GetHostnameForExternalTraffic();
             var controller = new OfflineController(networkInterfaceName, hubHostname, customNetworkProfileSetting);
             NetworkControllerStatus networkControllerStatus = networkOnValue ? NetworkControllerStatus.Disabled : NetworkControllerStatus.Enabled;
             await SetNetworkControllerStatus(controller, networkControllerStatus, reporter, token);
             return new MethodResponse((int)HttpStatusCode.OK);
+        }
+
+        private static string GetHostnameForExternalTraffic()
+        {
+            string externalTrafficHostname = string.Empty;
+            string proxy = Environment.GetEnvironmentVariable("https_proxy");
+            if (!string.IsNullOrEmpty(proxy))
+            {
+                // Proxy hostname will in the format http://<hostname>:<port>
+                // Since we want just the hostname part we need to extract it
+                string hostnameWithPort = proxy.Split("://")[1];
+                externalTrafficHostname = hostnameWithPort.Split(":")[0];
+            }
+            else if (!string.IsNullOrEmpty(Settings.Current.ParentHostname))
+            {
+                externalTrafficHostname = Settings.Current.ParentHostname;
+            }
+            else
+            {
+                externalTrafficHostname = Settings.Current.IotHubHostname;
+            }
+
+            Log.LogInformation("Determined external traffic ip: {0}", externalTrafficHostname);
+            return externalTrafficHostname;
         }
 
         static async Task StartAsync(INetworkController controller, CancellationToken cancellationToken)


### PR DESCRIPTION
The test `PriorityQueueModuleToHubMessages` was failing behind a proxy for the following reasons:
1. The network controller in the deployment was not setup with the proxy environment variable `https_proxy`
2. The network controller in the deployment was using a hacky configuration. It used a module client but overrode the `IOTEDGE_GATEWAYHOSTNAME` with empty string so that it would connect itself directly to iothub.  Since the `ModuleClient` was not initialized with a `TransportType` compatible with a proxy, the module never connected to iothub and hung.
3. Even once the network controller was configured with fixes for the above, it needed further proxy support in order to correctly apply the network rules to the proxy ip address, rather than iothub.

All of these issues are now fixed. I also restored the ability for E2E tests to run with custom bits which was accidentally removed in someone else's PR.