### PR TITLE
[k8s] update k8s client. (#5210) (#5250)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Kubernetes/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="KubernetesClient" Version="1.6.10" />
+    <PackageReference Include="KubernetesClient" Version="5.0.13" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/DeploymentSecretBackupTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/DeploymentSecretBackupTest.cs
@@ -85,7 +85,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             };
 
             var client = new Mock<IKubernetes>(MockBehavior.Strict);
-            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(DefaultSecretName, DefaultNamespace, It.IsAny<bool?>(), It.IsAny<bool?>(), null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    It.IsAny<string>(), // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
 
             var backupSource = new DeploymentSecretBackup(DefaultSecretName, DefaultNamespace, DefaultOwner, serde, client.Object);
@@ -110,7 +115,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             };
 
             var client = new Mock<IKubernetes>(MockBehavior.Strict);
-            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(DefaultSecretName, DefaultNamespace, It.IsAny<bool?>(), It.IsAny<bool?>(), null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    It.IsAny<string>(), // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
 
             var backupSource = new DeploymentSecretBackup(DefaultSecretName, DefaultNamespace, DefaultOwner, serde, client.Object);
@@ -138,7 +148,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             };
 
             var client = new Mock<IKubernetes>(MockBehavior.Strict);
-            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(DefaultSecretName, DefaultNamespace, It.IsAny<bool?>(), It.IsAny<bool?>(), null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    It.IsAny<string>(), // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
 
             var backupSource = new DeploymentSecretBackup(DefaultSecretName, DefaultNamespace, DefaultOwner, serde, client.Object);
@@ -166,7 +181,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             };
 
             var client = new Mock<IKubernetes>(MockBehavior.Strict);
-            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(DefaultSecretName, DefaultNamespace, It.IsAny<bool?>(), It.IsAny<bool?>(), null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    It.IsAny<string>(), // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
 
             var backupSource = new DeploymentSecretBackup(DefaultSecretName, DefaultNamespace, DefaultOwner, serde, client.Object);
@@ -196,7 +216,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
 
             byte[] receivedData = default(byte[]);
             var client = new Mock<IKubernetes>(MockBehavior.Strict);
-            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(DefaultSecretName, DefaultNamespace, It.IsAny<bool?>(), It.IsAny<bool?>(), null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    It.IsAny<string>(), // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpOperationException("Not Found"));
             client.Setup(c => c.CreateNamespacedSecretWithHttpMessagesAsync(It.IsAny<V1Secret>(), DefaultNamespace, null, null, null, null, It.IsAny<CancellationToken>()))
                 .Callback((V1Secret body, string namespaceParameter, string dryRun, string fieldManager, string pretty, Dictionary<string, List<string>> customHeaders, CancellationToken cancellationToken) =>
@@ -244,9 +269,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
 
             byte[] receivedData = default(byte[]);
             var client = new Mock<IKubernetes>(MockBehavior.Strict);
-            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(DefaultSecretName, DefaultNamespace, It.IsAny<bool?>(), It.IsAny<bool?>(), null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    It.IsAny<string>(), // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(readResponse);
-            client.Setup(c => c.ReplaceNamespacedSecretWithHttpMessagesAsync(It.IsAny<V1Secret>(), DefaultSecretName, DefaultNamespace, null, null, null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReplaceNamespacedSecretWithHttpMessagesAsync(
+                    It.IsAny<V1Secret>(),
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    null, // dryRun
+                    null, // fieldmanager
+                    null, // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .Callback((V1Secret body, string name, string namespaceParameter, string dryRun, string fieldManager, string pretty, Dictionary<string, List<string>> customHeaders, CancellationToken cancellationToken) =>
                 {
                     Assert.True(body.Data != null);
@@ -281,7 +319,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             };
 
             var client = new Mock<IKubernetes>(MockBehavior.Strict);
-            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(DefaultSecretName, DefaultNamespace, It.IsAny<bool?>(), It.IsAny<bool?>(), null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    It.IsAny<string>(), // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(readResponse);
 
             var backupSource = new DeploymentSecretBackup(DefaultSecretName, DefaultNamespace, DefaultOwner, serde, client.Object);
@@ -313,9 +356,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             };
 
             var client = new Mock<IKubernetes>(MockBehavior.Strict);
-            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(DefaultSecretName, DefaultNamespace, It.IsAny<bool?>(), It.IsAny<bool?>(), null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReadNamespacedSecretWithHttpMessagesAsync(
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    It.IsAny<string>(), // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ReturnsAsync(readResponse);
-            client.Setup(c => c.ReplaceNamespacedSecretWithHttpMessagesAsync(It.IsAny<V1Secret>(), DefaultSecretName, DefaultNamespace, null, null, null, null, It.IsAny<CancellationToken>()))
+            client.Setup(c => c.ReplaceNamespacedSecretWithHttpMessagesAsync(
+                    It.IsAny<V1Secret>(),
+                    DefaultSecretName,
+                    DefaultNamespace,
+                    null, // dryRun
+                    null, // fieldmanager
+                    null, // pretty
+                    null, // customHeaders
+                    It.IsAny<CancellationToken>()))
                 .ThrowsAsync(new HttpOperationException("Not Permitted"));
 
             var backupSource = new DeploymentSecretBackup(DefaultSecretName, DefaultNamespace, DefaultOwner, serde, client.Object);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/EdgeDeploymentCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/EdgeDeploymentCommandTest.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             EdgeDeploymentDefinition edgeDeploymentDefinition = null;
             client.SetupCreateEdgeDeploymentDefinition()
                 .Callback(
-                    (object body, string group, string version, string ns, string plural, string name, Dictionary<string, List<string>> headers, CancellationToken token) => { edgeDeploymentDefinition = ((JObject)body).ToObject<EdgeDeploymentDefinition>(); })
+                    (object body, string group, string version, string ns, string plural, string dryRun, string fieldManager, string pretty, Dictionary<string, List<string>> headers, CancellationToken token) => { edgeDeploymentDefinition = ((JObject)body).ToObject<EdgeDeploymentDefinition>(); })
                 .ReturnsAsync(() => CreateResponse<object>(edgeDeploymentDefinition));
 
             var cmd = new EdgeDeploymentCommand(ResourceName, Selector, Namespace, client.Object, new[] { dockerModule }, Option.None<EdgeDeploymentDefinition>(), Runtime, configProvider.Object, EdgeletModuleOwner);
@@ -255,25 +255,29 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         public static ISetup<IKubernetes, Task<HttpOperationResponse<object>>> SetupCreateEdgeDeploymentDefinition(this Mock<IKubernetes> client) =>
             client.Setup(
                 c => c.CreateNamespacedCustomObjectWithHttpMessagesAsync(
-                    It.IsAny<object>(),
+                    It.IsAny<object>(), // body
                     KubernetesConstants.EdgeDeployment.Group,
                     KubernetesConstants.EdgeDeployment.Version,
-                    It.IsAny<string>(),
+                    It.IsAny<string>(), // namespace
                     KubernetesConstants.EdgeDeployment.Plural,
-                    It.IsAny<string>(),
-                    null,
+                    It.IsAny<string>(), // dryRun
+                    It.IsAny<string>(), // fieldManager
+                    It.IsAny<string>(), // pretty
+                    It.IsAny<Dictionary<string, List<string>>>(), // customHeaders
                     It.IsAny<CancellationToken>()));
 
         public static ISetup<IKubernetes, Task<HttpOperationResponse<object>>> SetupUpdateEdgeDeploymentDefinition(this Mock<IKubernetes> client) =>
             client.Setup(
                 c => c.ReplaceNamespacedCustomObjectWithHttpMessagesAsync(
-                    It.IsAny<object>(),
+                    It.IsAny<object>(), // body
                     KubernetesConstants.EdgeDeployment.Group,
                     KubernetesConstants.EdgeDeployment.Version,
-                    It.IsAny<string>(),
+                    It.IsAny<string>(), // namespace
                     KubernetesConstants.EdgeDeployment.Plural,
-                    It.IsAny<string>(),
-                    null,
+                    It.IsAny<string>(), // name
+                    It.IsAny<string>(), // dryRun
+                    It.IsAny<string>(), // fieldManager
+                    It.IsAny<Dictionary<string, List<string>>>(), // customHeaders
                     It.IsAny<CancellationToken>()));
     }
 
@@ -282,28 +286,29 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
         public static ISetup<IKubernetes, Task<HttpOperationResponse<V1SecretList>>> SetupListSecrets(this Mock<IKubernetes> client) =>
             client.Setup(
                 c => c.ListNamespacedSecretWithHttpMessagesAsync(
-                    It.IsAny<string>(),
-                    It.IsAny<bool?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<int?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<int?>(),
-                    It.IsAny<bool?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<Dictionary<string, List<string>>>(),
+                    It.IsAny<string>(), // namespace
+                    It.IsAny<bool?>(), // allowWatchBookmarks
+                    It.IsAny<string>(), // continueParameter
+                    It.IsAny<string>(), // fieldSelector
+                    It.IsAny<string>(), // labelSelector
+                    It.IsAny<int?>(), // limit
+                    It.IsAny<string>(), // resourceVersion
+                    It.IsAny<string>(), // resourceVersionMatch
+                    It.IsAny<int?>(), // timeoutSeconds
+                    It.IsAny<bool?>(), // watch
+                    It.IsAny<string>(), // pretty
+                    It.IsAny<Dictionary<string, List<string>>>(), // customHeaders
                     It.IsAny<CancellationToken>()));
 
         public static ISetup<IKubernetes, Task<HttpOperationResponse<V1Secret>>> SetupCreateSecret(this Mock<IKubernetes> client) =>
             client.Setup(
                 c => c.CreateNamespacedSecretWithHttpMessagesAsync(
                     It.IsAny<V1Secret>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<Dictionary<string, List<string>>>(),
+                    It.IsAny<string>(), // namespace
+                    It.IsAny<string>(), // dryRun
+                    It.IsAny<string>(), // fieldManager
+                    It.IsAny<string>(), // pretty
+                    It.IsAny<Dictionary<string, List<string>>>(), // customHeaders
                     It.IsAny<CancellationToken>()));
 
         public static void VerifyCreateSecret(this Mock<IKubernetes> client, Times times) =>
@@ -322,12 +327,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             client.Setup(
                 c => c.ReplaceNamespacedSecretWithHttpMessagesAsync(
                     It.IsAny<V1Secret>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<Dictionary<string, List<string>>>(),
+                    It.IsAny<string>(), // name
+                    It.IsAny<string>(), // namespace
+                    It.IsAny<string>(), // dryRun
+                    It.IsAny<string>(), // fieldmanager
+                    It.IsAny<string>(), // pretty
+                    It.IsAny<Dictionary<string, List<string>>>(), // customHeaders
                     It.IsAny<CancellationToken>()));
 
         public static ISetup<IKubernetes, Task<HttpOperationResponse<V1Secret>>> SetupGetSecret(this Mock<IKubernetes> client, string name) =>
@@ -335,8 +340,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
                 c => c.ReadNamespacedSecretWithHttpMessagesAsync(
                     name,
                     It.IsAny<string>(),
-                    It.IsAny<bool?>(),
-                    It.IsAny<bool?>(),
                     It.IsAny<string>(),
                     It.IsAny<Dictionary<string, List<string>>>(),
                     It.IsAny<CancellationToken>()));

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesServiceMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/KubernetesServiceMapperTest.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 
             Assert.Equal(1, service.Spec.Ports.Count);
-            AssertPort(new V1ServicePort(10, "hostport-10-tcp", null, "TCP", 10), service.Spec.Ports.First());
+            AssertPort(new V1ServicePort(10, name: "hostport-10-tcp", protocol: "TCP", targetPort: 10), service.Spec.Ports.First());
             Assert.Equal("ClusterIP", service.Spec.Type);
         }
 
@@ -201,7 +201,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 
             Assert.Equal(1, service.Spec.Ports.Count);
-            AssertPort(new V1ServicePort(10, "exposedport-10-tcp", null, "TCP"), service.Spec.Ports.First());
+            AssertPort(new V1ServicePort(10, name: "exposedport-10-tcp", protocol: "TCP"), service.Spec.Ports.First());
             Assert.Equal("ClusterIP", service.Spec.Type);
         }
 
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test
             var service = mapper.CreateService(moduleId, module, moduleLabels).OrDefault();
 
             Assert.Equal(1, service.Spec.Ports.Count);
-            AssertPort(new V1ServicePort(10, "hostport-10-tcp", null, "TCP", 10), service.Spec.Ports.First());
+            AssertPort(new V1ServicePort(10, name: "hostport-10-tcp", protocol: "TCP", targetPort: 10), service.Spec.Ports.First());
             Assert.Equal("ClusterIP", service.Spec.Type);
         }
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/EdgeDeploymentOperatorTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/EdgeDeploymentOperatorTest.cs
@@ -43,8 +43,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                 .ReturnsAsync(returnedStatus);
 
             var client = Mock.Of<IKubernetes>();
-            Mock.Get(client).Setup(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
-                .Callback((object o, string group, string version, string _namespace, string plural, string name, Dictionary<string, List<string>> headers, CancellationToken token) =>
+            Mock.Get(client).Setup(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+                .Callback((object o, string group, string version, string _namespace, string plural, string name, string dryRun, string fieldmanager, Dictionary<string, List<string>> headers, CancellationToken token) =>
                 {
                     Assert.True(o is JObject);
                     EdgeDeploymentDefinition e = ((JObject)o).ToObject<EdgeDeploymentDefinition>();
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                 .ReturnsAsync(returnedStatus);
 
             var client = Mock.Of<IKubernetes>();
-            Mock.Get(client).Setup(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            Mock.Get(client).Setup(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
                 .ReturnsAsync(response);
 
             var edgeOperator = new EdgeDeploymentOperator(
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
             await edgeOperator.EdgeDeploymentOnEventHandlerAsync(WatchEventType.Modified, edgeDefinition);
 
             Mock.Get(controller).Verify(c => c.DeployModulesAsync(It.IsAny<ModuleSet>(), It.IsAny<ModuleSet>()), Times.Exactly(2));
-            Mock.Get(client).Verify(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), null, It.IsAny<CancellationToken>()), Times.Once);
+            Mock.Get(client).Verify(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Fact]
@@ -157,8 +157,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                 .ThrowsAsync(controllerException);
 
             var client = Mock.Of<IKubernetes>();
-            Mock.Get(client).Setup(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
-                .Callback((object o, string group, string version, string _namespace, string plural, string name, Dictionary<string, List<string>> headers, CancellationToken token) =>
+            Mock.Get(client).Setup(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+                .Callback((object o, string group, string version, string _namespace, string plural, string name, string dryRun, string fieldmanager, Dictionary<string, List<string>> headers, CancellationToken token) =>
                 {
                     Assert.True(o is JObject);
                     EdgeDeploymentDefinition e = ((JObject)o).ToObject<EdgeDeploymentDefinition>();
@@ -201,8 +201,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment
                 .ThrowsAsync(controllerException);
 
             var client = Mock.Of<IKubernetes>();
-            Mock.Get(client).Setup(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
-                .Callback((object o, string group, string version, string _namespace, string plural, string name, Dictionary<string, List<string>> headers, CancellationToken token) =>
+            Mock.Get(client).Setup(c => c.ReplaceNamespacedCustomObjectStatusWithHttpMessagesAsync(It.IsAny<object>(), Constants.EdgeDeployment.Group, Constants.EdgeDeployment.Version, DeviceNamespace, Constants.EdgeDeployment.Plural, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+                .Callback((object o, string group, string version, string _namespace, string plural, string name, string dryRun, string fieldmanager, Dictionary<string, List<string>> headers, CancellationToken token) =>
                 {
                     Assert.True(o is JObject);
                     EdgeDeploymentDefinition e = ((JObject)o).ToObject<EdgeDeploymentDefinition>();

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test/edgedeployment/service/KubernetesServiceMapperTest.cs
@@ -177,11 +177,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
             V1ServicePort port80 = service.Spec.Ports.Single(p => p.Port == 8080);
             Assert.Equal("hostport-80-tcp", port80.Name);
             Assert.Equal("TCP", port80.Protocol);
-            Assert.Equal(80, (int)port80.TargetPort);
+            Assert.Equal("80", port80.TargetPort.Value);
             V1ServicePort port5000 = service.Spec.Ports.Single(p => p.Port == 5050);
             Assert.Equal("hostport-5000-udp", port5000.Name);
             Assert.Equal("UDP", port5000.Protocol);
-            Assert.Equal(5000, (int)port5000.TargetPort);
+            Assert.Equal("5000", port5000.TargetPort.Value);
         }
 
         [Fact]
@@ -196,11 +196,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Kubernetes.Test.EdgeDeployment.Serv
             V1ServicePort port80 = service.Spec.Ports.Single(p => p.Port == 8080);
             Assert.Equal("hostport-80-tcp", port80.Name);
             Assert.Equal("TCP", port80.Protocol);
-            Assert.Equal(80, (int)port80.TargetPort);
+            Assert.Equal("80", port80.TargetPort.Value);
             V1ServicePort port5000 = service.Spec.Ports.Single(p => p.Port == 5050);
             Assert.Equal("hostport-5000-udp", port5000.Name);
             Assert.Equal("UDP", port5000.Protocol);
-            Assert.Equal(5000, (int)port5000.TargetPort);
+            Assert.Equal("5000", port5000.TargetPort.Value);
         }
 
         [Fact]


### PR DESCRIPTION
Cherry-pick k8s change 1.1->master

* Update to latest k8s client to address vulnerabilities in dependencies.

(This project is not used in master, but it still referenced, so this needed to be updated.)