### PR TITLE
RUSTSEC: Update smallvec for component governance

### DIFF
--- a/mqtt/Cargo.lock
+++ b/mqtt/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,7 +245,7 @@ version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
- "ansi_term",
+ "ansi_term 0.11.0",
  "atty",
  "bitflags",
  "strsim",
@@ -973,12 +982,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1406,15 +1409,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "owning_ref"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ff55baddef9e4ad00f88b6c743a2a8062d4c6ade126c2a528644b8e444d52ce"
-dependencies = [
- "stable_deref_trait",
-]
-
-[[package]]
 name = "page_size"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1455,7 +1449,7 @@ dependencies = [
  "cloudabi 0.0.3",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec",
  "winapi 0.3.9",
 ]
 
@@ -1470,7 +1464,7 @@ dependencies = [
  "instant",
  "libc",
  "redox_syscall",
- "smallvec 1.4.2",
+ "smallvec",
  "winapi 0.3.9",
 ]
 
@@ -2089,6 +2083,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "740223c51853f3145fe7c90360d2d4232f2b62e3449489c207eccde818979982"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2106,18 +2109,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "0.6.13"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7b0758c52e15a8b5e3691eae6cc559f08eee9406e548a4477ba4e67770a82b6"
-dependencies = [
- "maybe-uninit",
-]
-
-[[package]]
-name = "smallvec"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
@@ -2130,12 +2124,6 @@ dependencies = [
  "redox_syscall",
  "winapi 0.3.9",
 ]
-
-[[package]]
-name = "stable_deref_trait"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -2428,20 +2416,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.1.6"
+name = "tracing-serde"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "192ca16595cdd0661ce319e8eede9c975f227cdaabc4faaefdc256f43d852e45"
+checksum = "fb65ea441fbb84f9f6748fd496cf7f63ec9af5bca94dd86456978d055e8eb28b"
 dependencies = [
- "ansi_term",
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+dependencies = [
+ "ansi_term 0.12.1",
  "chrono",
  "lazy_static",
  "matchers",
- "owning_ref",
  "regex",
- "smallvec 0.6.13",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/mqtt/mqtt-broker-tests-util/Cargo.toml
+++ b/mqtt/mqtt-broker-tests-util/Cargo.toml
@@ -14,7 +14,7 @@ tokio = { version = "0.2", features = ["blocking", "stream", "sync", "tcp", "dns
 tokio-io-timeout = "0.4"
 tokio-util = { version = "0.2", features = ["codec"] }
 tracing = "0.1"
-tracing-subscriber = "0.1"
+tracing-subscriber = {version = "0.2", features = ["fmt"]}
 
 mqtt3 = { path = "../mqtt3", features = ["serde1"] }
 mqtt-broker = { path = "../mqtt-broker" }

--- a/mqtt/mqtt-broker/Cargo.toml
+++ b/mqtt/mqtt-broker/Cargo.toml
@@ -44,7 +44,7 @@ proptest = "0.9"
 tempfile = "3"
 test-case = "1.0"
 tokio = { version = "0.2", features = ["dns", "macros", "io-util"] }
-tracing-subscriber = "0.1"
+tracing-subscriber = {version = "0.2", features = ["fmt"]}
 
 mqtt-broker-tests-util = { path = "../mqtt-broker-tests-util" }
 

--- a/mqtt/mqttd/Cargo.toml
+++ b/mqtt/mqttd/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0"
 tokio = { version = "0.2", features = ["dns", "macros", "rt-threaded", "signal", "stream", "tcp", "time"] }
 tracing = "0.1"
 tracing-log = "0.1"
-tracing-subscriber = "0.1"
+tracing-subscriber = {version = "0.2", features = ["fmt"]}
 
 edgelet-client = { path = "../edgelet-client", optional = true }
 mqtt-bridge = { path = "../mqtt-bridge", optional = true }

--- a/mqtt/mqttd/src/tracing/edgehub.rs
+++ b/mqtt/mqttd/src/tracing/edgehub.rs
@@ -28,7 +28,7 @@ pub fn init() {
 
     let subscriber = fmt::Subscriber::builder()
         .with_max_level(Level::TRACE)
-        .on_event(Format::default())
+        .event_format(Format::default())
         .with_env_filter(EnvFilter::new(log_level.clone()))
         .finish();
     let _ = tracing::subscriber::set_global_default(subscriber);

--- a/mqtt/mqttd/src/tracing/generic.rs
+++ b/mqtt/mqttd/src/tracing/generic.rs
@@ -13,7 +13,7 @@ pub fn init() {
     let subscriber = Subscriber::builder()
         .with_max_level(Level::TRACE)
         .with_env_filter(log_level)
-        .on_event(Format::default())
+        .event_format(Format::default())
         .finish();
     let _ = tracing::subscriber::set_global_default(subscriber);
 }


### PR DESCRIPTION
This updates smallvec to 1.6.1 to fix a component governance security issue. It does so by updating tracing-subscriber to 0.2.