### PR TITLE
Devops Pipelines: Use new publish test results task

### DIFF
--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -52,7 +52,7 @@ jobs:
         inputs:
           filePath: scripts/linux/runTests.sh
           arguments: '"--filter Category=GetLogsTests"'
-      - task: PublishTestResults@2
+      - task: PublishTestResults@3
         displayName: Publish Test Results
         inputs:
           testRunner: VSTest
@@ -99,7 +99,7 @@ jobs:
           codeCoverageEnabled: true
           runSettingsFile: CodeCoverage.runsettings
           publishRunAttachments: true
-      - task: PublishTestResults@2
+      - task: PublishTestResults@3
         displayName: Publish code coverage
         inputs:
           testRunner: VSTest

--- a/builds/checkin/mqtt.yaml
+++ b/builds/checkin/mqtt.yaml
@@ -47,7 +47,7 @@ jobs:
         displayName: Build with default features
       - bash: mqtt/build/linux/test.sh --report test-results.xml
         displayName: Test
-      - task: PublishTestResults@2
+      - task: PublishTestResults@3
         displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"

--- a/builds/checkin/rust-test-modules.yaml
+++ b/builds/checkin/rust-test-modules.yaml
@@ -43,7 +43,7 @@ jobs:
         displayName: Install Rust
       - bash: scripts/linux/generic-rust/build.sh --project-root "test/modules/generic-mqtt-tester" --packages "Cargo.toml" --manifest-path
         displayName: Build Generic Mqtt Tester Module
-      - task: PublishTestResults@2
+      - task: PublishTestResults@3
         displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -79,7 +79,7 @@ jobs:
 #          sudo -E bash -c './scripts/linux/runTests.sh "--filter $(test.filter)&Category=Kubernetes" $(Build.Configuration)'
 #        displayName: Kubernetes Integration Tests
 #        condition: succeededOrFailed()
-      - task: PublishTestResults@2
+      - task: PublishTestResults@3
         displayName: Publish test results
         inputs:
           testRunner: VSTest

--- a/builds/ci/mqtt.yaml
+++ b/builds/ci/mqtt.yaml
@@ -44,7 +44,7 @@ jobs:
         inputs:
           filePath: mqtt/build/linux/test.sh
           arguments: --report test-results.xml
-      - task: PublishTestResults@2
+      - task: PublishTestResults@3
         displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"
@@ -89,7 +89,7 @@ jobs:
         inputs:
           filePath: mqtt/build/linux/test.sh
           arguments: --target armv7-unknown-linux-gnueabihf --cargo cross --report test-results.xml
-      - task: PublishTestResults@2
+      - task: PublishTestResults@3
         displayName: Publish test results
         inputs:
           testResultsFormat: "JUnit"

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -71,7 +71,7 @@ steps:
     E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
     E2E_BLOB_STORE_SAS: $(TestBlobStoreSas)
 
-- task: PublishTestResults@2
+- task: PublishTestResults@3
   displayName: Publish test results
   inputs:
     testRunner: vstest

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -62,7 +62,7 @@ steps:
     IH_ARG: $(connstr.iotHub)
     IH_KV: $(IotHubConnStr2)
 
-- task: PublishTestResults@2
+- task: PublishTestResults@3
   displayName: Publish test results
   inputs:
     testResultsFormat: vstest


### PR DESCRIPTION
The old `PublishTestResults@2` task uses node6 which logs S360 errors. We need the newer `PublishTestResults@3`.