### PR TITLE
Devops Scheduled Test Triggers: Decrease frequency of triggers

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -1,7 +1,7 @@
 trigger: none
 pr: none
 schedules:
-- cron: "0 12 * * *"
+- cron: "0 12 * * 1,2,3,4,5,6"
   displayName: Daily noon build
   branches:
     include:

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -1,12 +1,6 @@
 trigger: none
 pr: none
 schedules:
-- cron: "0 0 * * *"
-  displayName: Daily midnight build
-  branches:
-    include:
-    - release/1.2
-  always: true
 - cron: "0 12 * * *"
   displayName: Daily noon build
   branches:

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -1,5 +1,8 @@
 trigger: none
 pr: none
+
+# Test schedule the same between master and release/1.2, but offset 12 hours.
+# Don't run any scheduled tests on Sunday, as release/1.1 runs its scheduled tests then.
 schedules:
 - cron: "0 12 * * 1,2,3,4,5,6"
   displayName: Daily noon build

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -5,12 +5,6 @@ pr: none
 # Thus the schedules are offset by 6 hours.
 # This will ensure that enough agents are avaiable to service all tests. 
 schedules:
-- cron: "0 0 * * *"
-  displayName: Daily midnight build
-  branches:
-    include:
-    - release/1.2
-  always: true
 - cron: "0 12 * * *"
   displayName: Daily noon build
   branches:

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -7,7 +7,7 @@ pr: none
 # 
 # Test schedule the same between master and release/1.2, but offset 12 hours.
 schedules:
-- cron: "0 12 * * 1,2,3,4,5,6"
+- cron: "0 12 * * *"
   displayName: Daily noon build
   branches:
     include:

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -2,8 +2,10 @@ trigger: none
 pr: none
 
 # Nested E2E and Nested Connectivity share test agents.
-# Thus the schedules between master and release/1.2 branch are offset by 6 hours.
-# This will ensure that enough agents are avaiable to service all tests. 
+# Thus the schedules between these pipelines are offset by 6 hours.
+# This will ensure that enough agents are avaiable to service all tests.
+# 
+# Test schedule the same between master and release/1.2, but offset 12 hours.
 schedules:
 - cron: "0 12 * * 1,2,3,4,5,6"
   displayName: Daily noon build

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 # Nested E2E and Nested Connectivity share test agents.
-# Thus the schedules are offset by 6 hours.
+# Thus the schedules between master and release/1.2 branch are offset by 6 hours.
 # This will ensure that enough agents are avaiable to service all tests. 
 schedules:
 - cron: "0 12 * * *"

--- a/builds/e2e/nested-connectivity.yaml
+++ b/builds/e2e/nested-connectivity.yaml
@@ -5,7 +5,7 @@ pr: none
 # Thus the schedules between master and release/1.2 branch are offset by 6 hours.
 # This will ensure that enough agents are avaiable to service all tests. 
 schedules:
-- cron: "0 12 * * *"
+- cron: "0 12 * * 1,2,3,4,5,6"
   displayName: Daily noon build
   branches:
     include:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -5,7 +5,7 @@ pr: none
 # Thus the schedules between master and release/1.2 branch are offset by 6 hours.
 # This will ensure that enough agents are avaiable to service all tests. 
 schedules:
-- cron: "0 18 * * *"
+- cron: "0 18 * * 1,2,3,4,5,6"
   displayName: Daily evening build
   branches:
     include:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -7,7 +7,7 @@ pr: none
 # 
 # Test schedule the same between master and release/1.2, but offset 12 hours.
 schedules:
-- cron: "0 18 * * 1,2,3,4,5,6"
+- cron: "0 18 * * *"
   displayName: Daily evening build
   branches:
     include:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -2,8 +2,10 @@ trigger: none
 pr: none
 
 # Nested E2E and Nested Connectivity share test agents.
-# Thus the schedules between master and release/1.2 branch are offset by 6 hours.
-# This will ensure that enough agents are avaiable to service all tests. 
+# Thus the schedules between these pipelines are offset by 6 hours.
+# This will ensure that enough agents are avaiable to service all tests.
+# 
+# Test schedule the same between master and release/1.2, but offset 12 hours.
 schedules:
 - cron: "0 18 * * 1,2,3,4,5,6"
   displayName: Daily evening build

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 # Nested E2E and Nested Connectivity share test agents.
-# Thus the schedules are offset by 6 hours.
+# Thus the schedules between master and release/1.2 branch are offset by 6 hours.
 # This will ensure that enough agents are avaiable to service all tests. 
 schedules:
 - cron: "0 18 * * *"

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -5,12 +5,6 @@ pr: none
 # Thus the schedules are offset by 6 hours.
 # This will ensure that enough agents are avaiable to service all tests. 
 schedules:
-- cron: "0 6 * * *"
-  displayName: Daily morning build
-  branches:
-    include:
-    - release/1.2
-  always: true
 - cron: "0 18 * * *"
   displayName: Daily evening build
   branches:


### PR DESCRIPTION
We need to decrease the frequency of these triggers so that we can also run scheduled builds on master branch.