### PR TITLE
$upstream support for container registry address (#4932)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/CombinedDockerConfigProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Docker/CombinedDockerConfigProvider.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
     public class CombinedDockerConfigProvider : ICombinedConfigProvider<CombinedDockerConfig>
     {
         readonly IEnumerable<AuthConfig> authConfigs;
+        private NestedEdgeParentUriParser parser = new NestedEdgeParentUriParser();
 
         public CombinedDockerConfigProvider(IEnumerable<AuthConfig> authConfigs)
         {
@@ -36,7 +37,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker
 
             // Convert registry credentials from config to AuthConfig objects
             List<AuthConfig> deploymentAuthConfigs = dockerRuntimeConfig.Config.RegistryCredentials
-                .Select(c => new AuthConfig { ServerAddress = c.Value.Address, Username = c.Value.Username, Password = c.Value.Password })
+                .Select(c =>
+                {
+                    string address = this.parser.ParseURI(c.Value.Address).GetOrElse(c.Value.Address);
+                    return new AuthConfig { ServerAddress = address, Username = c.Value.Username, Password = c.Value.Password };
+                })
                 .ToList();
 
             // First try to get matching auth config from the runtime info. If no match is found,

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -4,6 +4,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Security.Cryptography.X509Certificates;
     using System.Threading;

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -120,6 +120,15 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 dockerLoggingDriver = configuration.GetValue<string>("DockerLoggingDriver");
                 dockerLoggingOptions = configuration.GetSection("DockerLoggingOptions").Get<Dictionary<string, string>>() ?? new Dictionary<string, string>();
                 dockerAuthConfig = configuration.GetSection("DockerRegistryAuth").Get<List<global::Docker.DotNet.Models.AuthConfig>>() ?? new List<global::Docker.DotNet.Models.AuthConfig>();
+
+                NestedEdgeParentUriParser parser = new NestedEdgeParentUriParser();
+                dockerAuthConfig = dockerAuthConfig.Select(c =>
+                {
+                    c.Password = parser.ParseURI(c.Password).GetOrElse(c.Password);
+                    return c;
+                })
+                .ToList();
+
                 configRefreshFrequencySecs = configuration.GetValue("ConfigRefreshFrequencySecs", 3600);
             }
             catch (Exception ex)

--- a/edgelet/aziot-edged/src/lib.rs
+++ b/edgelet/aziot-edged/src/lib.rs
@@ -288,7 +288,7 @@ where
 
         settings
             .agent_mut()
-            .parent_hostname_resolve_image(&provisioning_result.gateway_host_name);
+            .parent_hostname_resolve(&provisioning_result.gateway_host_name);
 
         let cfg = WorkloadData::new(
             provisioning_result.hub_name,

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -188,15 +188,15 @@ where
 /// A proper rework of settings loading should be undertaken when there is more
 /// time, but for now, this will have to do...
 pub trait NestedEdgeBodge {
-    fn parent_hostname_resolve_image(&mut self, parent_hostname: &str);
+    fn parent_hostname_resolve(&mut self, parent_hostname: &str);
 }
 
 impl<T> ModuleSpec<T>
 where
     T: NestedEdgeBodge,
 {
-    pub fn parent_hostname_resolve_image(&mut self, parent_hostname: &str) {
-        self.config.parent_hostname_resolve_image(parent_hostname)
+    pub fn parent_hostname_resolve(&mut self, parent_hostname: &str) {
+        self.config.parent_hostname_resolve(parent_hostname);
     }
 }
 

--- a/edgelet/edgelet-docker/src/config.rs
+++ b/edgelet/edgelet-docker/src/config.rs
@@ -94,9 +94,23 @@ impl DockerConfig {
 pub const UPSTREAM_PARENT_KEYWORD: &str = "$upstream";
 
 impl NestedEdgeBodge for DockerConfig {
-    fn parent_hostname_resolve_image(&mut self, parent_hostname: &str) {
+    fn parent_hostname_resolve(&mut self, parent_hostname: &str) {
         if let Some(rest) = self.image.strip_prefix(UPSTREAM_PARENT_KEYWORD) {
             self.image = format!("{}{}", parent_hostname, rest);
+        }
+
+        let auth = match &self.auth {
+            Some(auth) => auth,
+            _ => return,
+        };
+
+        if let Some(serveraddress) = auth.serveraddress() {
+            if let Some(rest) = serveraddress.strip_prefix(UPSTREAM_PARENT_KEYWORD) {
+                let url = rest.to_string();
+                if let Some(auth) = &mut self.auth {
+                    auth.set_serveraddress(format!("{}{}", parent_hostname, url))
+                }
+            }
         }
     }
 }

--- a/edgelet/iotedge/src/check/checks/check_agent_image.rs
+++ b/edgelet/iotedge/src/check/checks/check_agent_image.rs
@@ -1,11 +1,6 @@
-use std::borrow::Cow;
-
+use edgelet_core::RuntimeSettings;
 use failure::{Context, ResultExt};
 use regex::Regex;
-
-use edgelet_core::module::NestedEdgeBodge;
-use edgelet_core::RuntimeSettings;
-use edgelet_docker::UPSTREAM_PARENT_KEYWORD;
 
 use crate::check::{checker::Checker, Check, CheckResult};
 
@@ -31,8 +26,18 @@ impl Checker for CheckAgentImage {
 impl CheckAgentImage {
     #[allow(clippy::unused_self)]
     fn inner_execute(&mut self, check: &mut Check) -> Result<CheckResult, failure::Error> {
-        let settings = if let Some(settings) = &check.settings {
+        let settings = if let Some(settings) = &mut check.settings {
             settings
+        } else {
+            return Ok(CheckResult::Skipped);
+        };
+
+        let parent_hostname: String;
+        let upstream_hostname = if let Some(upstream_hostname) = check.parent_hostname.as_ref() {
+            parent_hostname = upstream_hostname.to_string();
+            &parent_hostname
+        } else if let Some(iothub_hostname) = &check.iothub_hostname {
+            iothub_hostname
         } else {
             return Ok(CheckResult::Skipped);
         };
@@ -43,11 +48,11 @@ impl CheckAgentImage {
             return Ok(CheckResult::Skipped);
         };
 
-        let mut agent_config = settings.agent().config().clone();
-        if let Some(parent_hostname) = &check.parent_hostname {
-            agent_config.parent_hostname_resolve_image(parent_hostname);
-        }
-        let agent_image = agent_config.image();
+        settings
+            .agent_mut()
+            .parent_hostname_resolve(upstream_hostname);
+
+        let agent_image = settings.agent().config().image().to_string();
 
         if check.parent_hostname.is_some() {
             match check_agent_image_version_nested(&agent_image) {
@@ -61,15 +66,6 @@ impl CheckAgentImage {
             .config()
             .auth()
             .and_then(docker::models::AuthConfig::serveraddress);
-        let server_address = server_address.map(|server_address| {
-            if let Some(parent_hostname) = &check.parent_hostname {
-                if let Some(rest) = server_address.strip_prefix(UPSTREAM_PARENT_KEYWORD) {
-                    return Cow::Owned(format!("{}{}", parent_hostname, rest));
-                }
-            }
-
-            Cow::Borrowed(server_address)
-        });
 
         if let (Some(username), Some(password), Some(server_address)) = (
             &settings


### PR DESCRIPTION
$upstream support for container address.
1. Support in azure portal
2. Support in aziot-edged

Tests:
Created a registry on lvl5 with a password then put $upstream in config and $upstream in portal. Checked that image got pulled.

Put a wrong password in portal, checked images failed with unauthorized (to confirm image were getting pulled from the right place)