### PR TITLE
E2E Tests: Remove legacy method of running specific build (#5389)

### DIFF
--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -22,27 +22,6 @@ steps:
       TestRootCaPassword,
       TestBlobStoreSas
 
-- pwsh: |
-    $imageBuildId = $(resources.pipeline.images.runID)
-    $packageBuildId = $(resources.pipeline.packages.runID)
-    if ('$(az.pipeline.images.buildId)')
-    {
-      Write-Output '>> User supplied az.pipeline.images.buildId=$(az.pipeline.images.buildId)'
-      $imageBuildId = '$(az.pipeline.images.buildId)'
-    }
-    if ('$(az.pipeline.packages.buildId)')
-    {
-      Write-Output '>> User supplied az.pipeline.packages.buildId=$(az.pipeline.packages.buildId)'
-      $packageBuildId = '$(az.pipeline.packages.buildId)'
-    }
-
-    Write-Output "##vso[task.setvariable variable=imageBuildId]$imageBuildId"
-    Write-Output "##vso[task.setvariable variable=packageBuildId]$packageBuildId"
-
-    Write-Output ">> Package Build ID=$packageBuildId"
-    Write-Output ">> Image Build ID=$imageBuildId"
-  displayName: Override artifacts with user-supplied args
-
 - task: DownloadBuildArtifacts@0
   displayName: Get Docker image info
   inputs:
@@ -50,7 +29,7 @@ steps:
     project: $(resources.pipeline.images.projectID)
     pipeline: $(resources.pipeline.images.pipelineName)
     buildVersionToDownload: specific
-    buildId: $(imageBuildId)
+    buildId: $(resources.pipeline.images.runID)
     downloadType: single
     artifactName: $(az.pipeline.images.artifacts)
     allowPartiallySucceededBuilds: true

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -42,7 +42,7 @@ steps:
     project: $(resources.pipeline.packages.projectID)
     pipeline: $(resources.pipeline.packages.pipelineName)
     buildVersionToDownload: specific
-    buildId: $(packageBuildId)
+    buildId: $(resources.pipeline.packages.runID)
     downloadType: single
     artifactName: $(artifactName)
     allowPartiallySucceededBuilds: true


### PR DESCRIPTION
I accidentally added this functionality back but it should stay removed.
