### PR TITLE
Test Metrics Collector: Use aspnet base image

### DIFF
--- a/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ﻿ARG base_tag=3.1.18-alpine3.13
-FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
+FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 ARG base_tag=1.0.5.13-linux-arm32v7
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
 ARG base_tag=1.0.5.13-linux-arm64v8
-FROM azureiotedge/azureiotedge-module-base:${base_tag}
+FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.
 

--- a/edge-modules/MetricsCollector/docker/windows/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/windows/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ﻿ARG base_tag=3.1.18-nanoserver-1809
-FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
+FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ARG EXE_DIR=.
 


### PR DESCRIPTION
With the new version of prometheus, we now need to use aspnet base images for anything taking a dep on edge agent diagnostics csproj