### PR TITLE
Custom Mqtt Tests: Fix error from optional topic suffix 

### DIFF
--- a/test/modules/generic-mqtt-tester/README.md
+++ b/test/modules/generic-mqtt-tester/README.md
@@ -17,6 +17,6 @@ Defaults can be seen here:
 |TEST_START_DELAY| Specifies the delay before the test logic starts running. Needed to give time for the environment to spin up and get everything ready.|
 |MESSAGE_FREQUENCY| Specifies the frequency of messages being sent from any initiator-based test scenario.|
 |MESSAGE_SIZE_IN_BYTES| Bytes in each message. All dummy data.|
-|TOPIC_SUFFIX | Specifies the suffix to be used when publishing or subscribing. Messages will be sent and received on `initiate/<topic_suffix>`.|
+|TOPIC_SUFFIX | Specifies the suffix to be used when publishing or subscribing. Messages will be sent and received on `initiate/<topic_suffix>`. If not specified will take the batchid.|
 |MESSAGES_TO_SEND| Specifies the amount of messages that will be sent from any initiator-based test scenario before the test module shuts down.|
 

--- a/test/modules/generic-mqtt-tester/src/settings.rs
+++ b/test/modules/generic-mqtt-tester/src/settings.rs
@@ -46,7 +46,7 @@ impl Settings {
                 let batch_id = Uuid::new_v4().to_string();
                 config.set("batch_id", Some(batch_id.clone()))?;
 
-                if config.get::<Option<String>>("topic_suffix")?.is_none() {
+                if config.get::<Option<String>>("topic_suffix").is_err() {
                     config.set("topic_suffix", Some(batch_id))?;
                 }
             }


### PR DESCRIPTION
Switched to is_none() rather than is_err() before merging my earlier PR. This addresses the problem.