### PR TITLE
Update logging for connectivity test output

### DIFF
--- a/test/connectivity/scripts/connectivityTest.sh
+++ b/test/connectivity/scripts/connectivityTest.sh
@@ -137,6 +137,9 @@ function print_test_run_logs() {
     print_highlighted_message 'directMethodReceiver2 LOGS'
     docker logs directMethodReceiver2 || true
 
+    print_highlighted_message 'directMethodSender3 LOGS'
+    docker logs directMethodSender3 || true
+
     print_highlighted_message 'directMethodReceiver3 LOGS'
     docker logs directMethodReceiver3 || true
 

--- a/test/connectivity/scripts/connectivityTest.sh
+++ b/test/connectivity/scripts/connectivityTest.sh
@@ -137,6 +137,9 @@ function print_test_run_logs() {
     print_highlighted_message 'directMethodReceiver2 LOGS'
     docker logs directMethodReceiver2 || true
 
+    print_highlighted_message 'directMethodReceiver3 LOGS'
+    docker logs directMethodReceiver3 || true
+
     print_highlighted_message 'twinTester1 LOGS'
     docker logs twinTester1 || true
 


### PR DESCRIPTION
We were missing `directMethodSender3` in the connectivity log output