### PR TITLE
Longhaul Tests: Add tolerance for unauthorized exceptions (#5157)

### DIFF
--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/DirectMethodLongHaulReportData.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/DirectMethodLongHaulReportData.cs
@@ -28,7 +28,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     },
                     7,
                     true,
-                    7, 0, 0, 0, 0, 0
+                    7, 0, 0, 0, 0, 0, 0
                 },
             new object[]
                 {
@@ -47,7 +47,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     },
                     7,
                     false,
-                    6, 0, 0, 0, 0, 1
+                    6, 0, 0, 0, 0, 0, 1
                 },
             new object[]
                 {
@@ -66,7 +66,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     },
                     7,
                     false,
-                    6, 1, 0, 0, 0, 0
+                    6, 1, 0, 0, 0, 0, 0
                 },
             new object[]
                 {
@@ -85,7 +85,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     },
                     7,
                     false,
-                    6, 0, 1, 0, 0, 0
+                    6, 0, 0, 1, 0, 0, 0
                 },
             new object[]
                 {
@@ -104,7 +104,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     },
                     7,
                     false,
-                    6, 0, 0, 1, 0, 0
+                    6, 0, 0, 0, 1, 0, 0
                 },
             new object[]
                 {
@@ -123,16 +123,13 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     },
                     7,
                     false,
-                    6, 0, 0, 0, 1, 0
+                    6, 0, 0, 0, 0, 1, 0
                 },
-        };
-
-        public static object[] GetStatusCodeTestData =>
             new object[]
                 {
                     Enumerable.Range(1, 7).Select(v => (ulong)v),
                     Enumerable.Range(1, 7).Select(v => (ulong)v),
-                    new List<HttpStatusCode> { HttpStatusCode.OK, (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), "0"), HttpStatusCode.InternalServerError, HttpStatusCode.NotFound, HttpStatusCode.FailedDependency, HttpStatusCode.InternalServerError, HttpStatusCode.ServiceUnavailable },
+                    new List<HttpStatusCode> { HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.Unauthorized, HttpStatusCode.OK, HttpStatusCode.OK },
                     new DateTime[]
                     {
                         new DateTime(2020, 1, 1, 9, 10, 12, 10),
@@ -145,8 +142,30 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     },
                     7,
                     false,
-                    1L, 1L, 1L, 1L, 1L,
-                    new Dictionary<HttpStatusCode, long> { { HttpStatusCode.InternalServerError, 2 } }
+                    6, 0, 1, 0, 0, 0, 0
+                },
+        };
+
+        public static object[] GetStatusCodeTestData =>
+            new object[]
+                {
+                    Enumerable.Range(1, 7).Select(v => (ulong)v),
+                    Enumerable.Range(1, 7).Select(v => (ulong)v),
+                    new List<HttpStatusCode> { HttpStatusCode.OK, (HttpStatusCode)Enum.Parse(typeof(HttpStatusCode), "0"), HttpStatusCode.Unauthorized, HttpStatusCode.NotFound, HttpStatusCode.FailedDependency, HttpStatusCode.InternalServerError, HttpStatusCode.ServiceUnavailable },
+                    new DateTime[]
+                    {
+                        new DateTime(2020, 1, 1, 9, 10, 12, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 13, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 21, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 22, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 23, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 24, 10),
+                        new DateTime(2020, 1, 1, 9, 10, 24, 15)
+                    },
+                    7,
+                    false,
+                    1L, 1L, 1L, 1L, 1L, 1L,
+                    new Dictionary<HttpStatusCode, long> { { HttpStatusCode.InternalServerError, 1 } }
                 };
     }
 }

--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/DirectMethodLongHaulReportGeneratorTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/DirectMethodLongHaulReportGeneratorTest.cs
@@ -173,6 +173,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
             bool expectedIsPassed,
             long expectedOk,
             long expectedStatusCodeZero,
+            long expectedUnauthorizedError,
             long expectedDeviceNotFound,
             long expectedTransientError,
             long expectedResourceError,
@@ -216,6 +217,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
             Assert.Equal(expectedIsPassed, report.IsPassed);
             Assert.Equal(expectedOk, report.SenderSuccesses);
             Assert.Equal(expectedStatusCodeZero, report.StatusCodeZero);
+            Assert.Equal(expectedUnauthorizedError, report.Unauthorized);
             Assert.Equal(expectedDeviceNotFound, report.DeviceNotFound);
             Assert.Equal(expectedTransientError, report.TransientError);
             Assert.Equal(expectedResourceError, report.ResourceError);
@@ -235,9 +237,10 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
             long expectedOk = (long)x[6];
             long expectedStatusCodeZero = (long)x[7];
             long expectedDeviceNotFound = (long)x[8];
-            long expectedTransientError = (long)x[9];
-            long expectedResourceError = (long)x[10];
-            Dictionary<HttpStatusCode, long> expectedOtherDict = (Dictionary<HttpStatusCode, long>)x[11];
+            long expectedUnauthorized = (long)x[9];
+            long expectedTransientError = (long)x[10];
+            long expectedResourceError = (long)x[11];
+            Dictionary<HttpStatusCode, long> expectedOtherDict = (Dictionary<HttpStatusCode, long>)x[12];
 
             string senderSource = "senderSource";
             string receiverSource = "receiverSource";
@@ -277,6 +280,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
             Assert.Equal(expectedIsPassed, report.IsPassed);
             Assert.Equal(expectedOk, report.SenderSuccesses);
             Assert.Equal(expectedStatusCodeZero, report.StatusCodeZero);
+            Assert.Equal(expectedUnauthorized, report.Unauthorized);
             Assert.Equal(expectedDeviceNotFound, report.DeviceNotFound);
             Assert.Equal(expectedTransientError, report.TransientError);
             Assert.Equal(expectedResourceError, report.ResourceError);
@@ -310,7 +314,10 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
             Assert.Equal(0L, report.ReceiverSuccesses);
             Assert.Equal(0L, report.SenderSuccesses);
             Assert.Equal(0L, report.StatusCodeZero);
+            Assert.Equal(0L, report.Unauthorized);
             Assert.Equal(0L, report.DeviceNotFound);
+            Assert.Equal(0L, report.TransientError);
+            Assert.Equal(0L, report.ResourceError);
             Assert.Equal(0L, report.Other.Sum(x => x.Value));
             Assert.True(report.IsPassed);
         }

--- a/test/modules/TestResultCoordinator/Reports/CountingReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/CountingReport.cs
@@ -50,7 +50,7 @@ namespace TestResultCoordinator.Reports
             this.ActualSource = Preconditions.CheckNonWhiteSpace(actualSource, nameof(actualSource));
             this.TotalExpectCount = totalExpectCount;
             this.TotalMatchCount = totalMatchCount;
-            this.TotalUnmatchedCount = Convert.ToUInt64(unmatchedResults.Count);
+            this.TotalUnmatchedCount = TotalExpectCount - TotalMatchCount;
             this.TotalDuplicateExpectedResultCount = totalDuplicateExpectedResultCount;
             this.TotalDuplicateActualResultCount = totalDuplicateActualResultCount;
             this.TotalMisorderedActualResultCount = totalMisorderedActualResultCount;

--- a/test/modules/TestResultCoordinator/Reports/DirectMethod/LongHaul/DirectMethodLongHaulReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/DirectMethod/LongHaul/DirectMethodLongHaulReport.cs
@@ -17,6 +17,7 @@ namespace TestResultCoordinator.Reports.DirectMethod.LongHaul
             long senderSuccesses,
             long receiverSuccesses,
             long statusCodeZero,
+            long unauthorized,
             long deviceNotFound,
             long transientError,
             long resourceError,
@@ -28,6 +29,7 @@ namespace TestResultCoordinator.Reports.DirectMethod.LongHaul
             this.SenderSuccesses = senderSuccesses;
             this.ReceiverSuccesses = receiverSuccesses;
             this.StatusCodeZero = statusCodeZero;
+            this.Unauthorized = unauthorized;
             this.DeviceNotFound = deviceNotFound;
             this.TransientError = transientError;
             this.ResourceError = resourceError;
@@ -39,6 +41,7 @@ namespace TestResultCoordinator.Reports.DirectMethod.LongHaul
         public long SenderSuccesses { get; }
         public long ReceiverSuccesses { get; }
         public long StatusCodeZero { get; }
+        public long Unauthorized { get; }
         public long DeviceNotFound { get; }
         public long TransientError { get; }
         public long ResourceError { get; }
@@ -64,12 +67,13 @@ namespace TestResultCoordinator.Reports.DirectMethod.LongHaul
             // TODO: When the SDK allows edgehub to de-register from subscriptions and we make the fix in edgehub, then we can fail tests for any status code 0.
             long allStatusCount = this.SenderSuccesses + this.StatusCodeZero + this.Other.Sum(x => x.Value);
             bool statusCodeZeroBelowThreshold = (this.StatusCodeZero == 0) || (this.StatusCodeZero < ((double)allStatusCount / 1000));
+            bool unauthorizedBelowThreshold = (this.Unauthorized == 0) || (this.Unauthorized < ((double)allStatusCount / 1000));
             bool deviceNotFoundBelowThreshold = (this.DeviceNotFound == 0) || (this.DeviceNotFound < ((double)allStatusCount / 100));
             bool transientErrorBelowThreshold = (this.TransientError == 0) || (this.TransientError < ((double)allStatusCount / 100));
             bool resourceErrorBelowThreshold = (this.ResourceError == 0) || (this.ResourceError < ((double)allStatusCount / 100));
 
             // Pass if below the thresholds, and sender and receiver got same amount of successess (or receiver has no results)
-            return statusCodeZeroBelowThreshold && deviceNotFoundBelowThreshold && transientErrorBelowThreshold && senderAndReceiverSuccessesPass;
+            return statusCodeZeroBelowThreshold && unauthorizedBelowThreshold && deviceNotFoundBelowThreshold && transientErrorBelowThreshold && senderAndReceiverSuccessesPass;
         }
     }
 }

--- a/test/modules/TestResultCoordinator/Reports/DirectMethod/LongHaul/DirectMethodLongHaulReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/Reports/DirectMethod/LongHaul/DirectMethodLongHaulReportGenerator.cs
@@ -52,12 +52,13 @@ namespace TestResultCoordinator.Reports.DirectMethod.LongHaul
 
         public async Task<ITestResultReport> CreateReportAsync()
         {
-            long senderSuccesses = 0;
-            long receiverSuccesses = 0;
             long statusCodeZero = 0;
+            long senderSuccesses = 0;
+            long unauthorized = 0;
             long deviceNotFound = 0;
             long transientError = 0;
             long resourceError = 0;
+            long receiverSuccesses = 0;
             Dictionary<HttpStatusCode, long> other = new Dictionary<HttpStatusCode, long>();
             while (await this.SenderTestResults.MoveNextAsync())
             {
@@ -71,6 +72,9 @@ namespace TestResultCoordinator.Reports.DirectMethod.LongHaul
                         break;
                     case 200:
                         senderSuccesses++;
+                        break;
+                    case 401:
+                        unauthorized++;
                         break;
                     case 404:
                         deviceNotFound++;
@@ -114,6 +118,7 @@ namespace TestResultCoordinator.Reports.DirectMethod.LongHaul
                 senderSuccesses,
                 receiverSuccesses,
                 statusCodeZero,
+                unauthorized,
                 deviceNotFound,
                 transientError,
                 resourceError,


### PR DESCRIPTION
We get a few unauthorized exceptions in longhaul which Varun and I believe to be service errors. He has recommended that we add a tolerance so that is what I am doing in this PR.

Also, I took this as an opportunity to fix the unmatchedResultsCount returning a value smaller than the true value. This happened because we were getting the unmatchedResultsCount from the collection of unmatchedResults, but this collection size is capped.