### PR TITLE
Nested Tests: Use tls 1.2 for api proxy

### DIFF
--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_amqp.json
@@ -61,6 +61,9 @@
             "env": {
               "NGINX_DEFAULT_PORT": {
                 "value": "443"
+              },
+              "NGINX_DEFAULT_TLS": {
+                "value": "TLSv1.2"
               }
             }
           }

--- a/e2e_deployment_files/nestededge_middleLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_middleLayerBaseDeployment_mqtt.json
@@ -71,6 +71,9 @@
             "env": {
               "NGINX_DEFAULT_PORT": {
                 "value": "443"
+              },
+              "NGINX_DEFAULT_TLS": {
+                "value": "TLSv1.2"
               }
             }
           }

--- a/e2e_deployment_files/nestededge_middleLayer_connectivity_mqtt.json
+++ b/e2e_deployment_files/nestededge_middleLayer_connectivity_mqtt.json
@@ -71,6 +71,9 @@
                         "env": {
                             "NGINX_DEFAULT_PORT": {
                                 "value": "443"
+                            },
+                            "NGINX_DEFAULT_TLS": {
+                                "value": "TLSv1.2"
                             }
                         }
                     },

--- a/e2e_deployment_files/nestededge_middleLayer_e2e_amqp.json
+++ b/e2e_deployment_files/nestededge_middleLayer_e2e_amqp.json
@@ -61,6 +61,9 @@
                         "env": {
                             "NGINX_DEFAULT_PORT": {
                                 "value": "443"
+                            },
+                            "NGINX_DEFAULT_TLS": {
+                                "value": "TLSv1.2"
                             }
                         }
                     },

--- a/e2e_deployment_files/nestededge_middleLayer_long_haul_mqtt.json
+++ b/e2e_deployment_files/nestededge_middleLayer_long_haul_mqtt.json
@@ -71,6 +71,9 @@
                         "env": {
                             "NGINX_DEFAULT_PORT": {
                                 "value": "443"
+                            },
+                            "NGINX_DEFAULT_TLS": {
+                                "value": "TLSv1.2"
                             }
                         }
                     },

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_amqp.json
@@ -99,6 +99,9 @@
               },
               "DOCKER_REQUEST_ROUTE_ADDRESS": {
                 "value": "dockerContainerRegistry:5000"
+              },
+              "NGINX_DEFAULT_TLS": {
+                "value": "TLSv1.2"
               }
             }
           }

--- a/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
+++ b/e2e_deployment_files/nestededge_topLayerBaseDeployment_mqtt.json
@@ -105,6 +105,9 @@
               },
               "DOCKER_REQUEST_ROUTE_ADDRESS": {
                 "value": "dockerContainerRegistry:5000"
+              },
+              "NGINX_DEFAULT_TLS": {
+                "value": "TLSv1.2"
               }
             }
           }


### PR DESCRIPTION
We need to use tls 1.2 for api proxy to silence S360 flags.