### PR TITLE
Metrics Collector Release Pipeline: Fix malfunctioning triggers

### DIFF
--- a/builds/misc/metrics-collector-images-publish.yaml
+++ b/builds/misc/metrics-collector-images-publish.yaml
@@ -1,4 +1,3 @@
-name: $(version)
 trigger: none
 pr: none
 

--- a/builds/misc/metrics-collector-images-release.yaml
+++ b/builds/misc/metrics-collector-images-release.yaml
@@ -1,4 +1,3 @@
-name: $(version)
 trigger: none
 pr: none
 


### PR DESCRIPTION
Fixing the malfunctioning triggers. I think the `name` field wasn't being used causing the triggers to not be read properly. This pipeline is currently running for every commit. Once we fix the triggers it will be manual trigger only. 