### PR TITLE
Create identities for leaf (#5381)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ServiceIdentityTree.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/ServiceIdentityTree.cs
@@ -360,11 +360,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core
 
             public void AddChild(ServiceIdentityTreeNode childNode)
             {
-                if (!this.Identity.IsEdgeDevice)
-                {
-                    throw new ArgumentException($"{this.Identity.Id} is not an Edge device, only Edge devices can have children");
-                }
-
                 this.children.Add(childNode);
                 childNode.Parent = Option.Some(this);
                 childNode.UpdateAuthChainFromParent(this, this.currentDepth + 1);


### PR DESCRIPTION
Fixing #5155, it is now possible to connect device module through edgeHub as well as creating new modules.

Test:
Connected module through edgeHub using SAS token
Created new module through edgeHub.