### PR TITLE
E2E: Disable flaky tests

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -8,8 +8,8 @@ steps:
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
     $test_type = '${{ parameters.test_type }}'
 
-    # Filter out unstable tests.
-    $filter = 'Category!=Unstable'
+    # Filter out flaky tests.
+    $filter = 'Category!=Flaky'
 
     if ('$(minimal)' -eq 'true')
     {
@@ -22,7 +22,7 @@ steps:
     }
     elseif ('$(arch)' -eq 'arm32v7' -Or '$(arch)' -eq 'arm64v8')
     {
-      $filter += '&Category!=UnstableOnArm'
+      $filter += '&Category!=FlakyOnArm'
     }
     
     if ($test_type -eq 'nestededge_mqtt')
@@ -31,6 +31,10 @@ steps:
       $filter += '&Category!=NestedEdgeAmqpOnly'
       $filter += '&Category!=LegacyMqttRequired'
     
+      $filter += '&Category!=FlakyOnNested'
+
+      # Below tests were disabled and marked for re-enable when a blocking item was resolved.
+      # When it was resolved the tests were never enabled. We need to re-enable these.
       $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_amqp')
@@ -38,6 +42,10 @@ steps:
       $filter += '&Category!=SingleNodeOnly'
       $filter += '&Category!=BrokerRequired'
 
+      $filter += '&Category!=FlakyOnNested'
+
+      # Below tests were disabled and marked for re-enable when a blocking item was resolved.
+      # When it was resolved the tests were never enabled. We need to re-enable these.
       $filter += '&FullyQualifiedName!~Provisioning&FullyQualifiedName!~SasOutOfScope&FullyQualifiedName!~X509ManualProvision&FullyQualifiedName!~AuthorizationPolicyUpdateTest&FullyQualifiedName!~AuthorizationPolicyExplicitPolicyTest'
     }
     elseif ($test_type -eq 'nestededge_isa95')

--- a/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         [Test]
         [Category("CentOsSafe")]
         [Category("NestedEdgeOnly")]
+        [Category("FlakyOnNested")]
         public async Task QuickstartChangeSasKey()
         {
             CancellationToken token = this.TestToken;
@@ -192,6 +193,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         [Test]
         [Category("CentOsSafe")]
+        [Category("FlakyOnNested")]
         public async Task DisableReenableParentEdge()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     class DeviceWithCustomCertificates : CustomCertificatesFixture
     {
         [Test]
+        [Category("Flaky")]
         public async Task TransparentGateway(
             [Values] TestAuthenticationType testAuth,
             [Values(Protocol.Mqtt, Protocol.Amqp)] Protocol protocol)
@@ -75,6 +76,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         [Test]
         [Category("NestedEdgeOnly")]
+        [Category("FlakyOnNested")]
         [Description("A test to verify a leaf device can be registered under grandparent device scope.")]
         public async Task GrandparentScopeDevice(
             [Values(

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("Flaky")]
         public async Task TestGetModuleLogs()
         {
             string moduleName = "NumberLogger";

--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         public const string ModuleName = "metricsValidator";
 
         [Test]
+        [Category("FlakyOnArm")]
         public async Task ValidateMetrics()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("FlakyOnArm")]
         // Test Temperature Filter Function: https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-deploy-function
         public async Task TempFilterFunc()
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string DefaultLoadGenTestStartDelay = "00:00:20";
 
         [Test]
-        [Category("UnstableOnArm")]
+        [Category("FlakyOnArm")]
         public async Task PriorityQueueModuleToModuleMessages()
         {
             CancellationToken token = this.TestToken;
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
-        [Category("UnstableOnArm")]
+        [Category("Flaky")]
         public async Task PriorityQueueModuleToHubMessages()
         {
             CancellationToken token = this.TestToken;
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
-        [Category("UnstableOnArm")]
+        [Category("FlakyOnArm")]
         public async Task PriorityQueueTimeToLive()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         [Test]
         [Category("CentOsSafe")]
+        [Category("FlakyOnArm")]
         public async Task DpsSymmetricKey()
         {
             string idScope = Context.Current.DpsIdScope.Expect(() => new InvalidOperationException("Missing DPS ID scope (check dpsIdScope in context.json)"));
@@ -80,6 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("FlakyOnArm")]
         public async Task DpsX509()
         {
             (string, string, string) rootCa =

--- a/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Test.Common;
-    using Microsoft.Azure.Devices.Edge.Test.Common.Certs;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -17,6 +16,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     class X509Device : X509ManualProvisioningFixture
     {
         [Test]
+        [Category("Flaky")]
         public async Task X509ManualProvision()
         {
             CancellationToken token = this.TestToken;


### PR DESCRIPTION
We need to disable some flaky E2E tests to make sure we are getting good signal from the pipelines. These work items to re-enable are tracked with bugs.