### PR TITLE
Migrate images-release pipeline to use 1es agents

### DIFF
--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -386,11 +386,9 @@ jobs:
 ################################################################################
     displayName: Windows
     pool:
-      name: Azure-IoT-Edge-Core
+      name: $(pool.windows.name)
       demands: 
-        - Build-Image -equals true
-        - win-rs5
-        - DotNetFramework
+       - ImageOverride -equals agent-aziotedge-win10-entn2019-test
     steps: 
       # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
       - task: Docker@2

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -388,7 +388,7 @@ jobs:
     pool:
       name: $(pool.windows.name)
       demands: 
-       - ImageOverride -equals agent-aziotedge-win10-entn2019-test
+       - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
     steps: 
       # Both docker logins needed for if we need to test this job. In this case images should go to edgebuilds.
       - task: Docker@2

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -405,9 +405,9 @@ jobs:
       - template: ../templates/install-dotnet3.yaml
       - task: JavaToolInstaller@0
         inputs:
-        versionSpec: '8'
-        jdkArchitectureOption: 'x64'
-        jdkSourceOption: 'PreInstalled'
+          versionSpec: '8'
+          jdkArchitectureOption: 'x64'
+          jdkSourceOption: 'PreInstalled'
       - powershell: "scripts/windows/build/Publish-Branch.ps1 -Configuration:\"$(configuration)\" -PublishTests:$False -UpdateVersion"
         displayName: "Build ($(configuration))"
         name: build

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -403,6 +403,11 @@ jobs:
           containerRegistry: iotedge-release-acr
       - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
+      - task: JavaToolInstaller@0
+        inputs:
+        versionSpec: '8'
+        jdkArchitectureOption: 'x64'
+        jdkSourceOption: 'PreInstalled'
       - powershell: "scripts/windows/build/Publish-Branch.ps1 -Configuration:\"$(configuration)\" -PublishTests:$False -UpdateVersion"
         displayName: "Build ($(configuration))"
         name: build

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -403,11 +403,6 @@ jobs:
           containerRegistry: iotedge-release-acr
       - template: ../templates/install-dotnet2.yaml
       - template: ../templates/install-dotnet3.yaml
-      - task: JavaToolInstaller@0
-        inputs:
-          versionSpec: '8'
-          jdkArchitectureOption: 'x64'
-          jdkSourceOption: 'PreInstalled'
       - powershell: "scripts/windows/build/Publish-Branch.ps1 -Configuration:\"$(configuration)\" -PublishTests:$False -UpdateVersion"
         displayName: "Build ($(configuration))"
         name: build


### PR DESCRIPTION
This only affects the Windows job because the Linux jobs use Microsoft hosted agents.