### PR TITLE
Update YAML pipelines to 1ES-hosted agents

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -1,9 +1,6 @@
 trigger: none
 pr: none
 
-variables:
-  NugetSecurityAnalysisWarningLevel: warn
-
 resources:
   pipelines:
   - pipeline: images
@@ -21,6 +18,18 @@ resources:
       - master
       - release/*
 
+variables:
+  # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
+  # environments that are very similar to other platforms/environments in our matrix, Ubuntu 18.04
+  # with the 'docker-ce' package vs. Ubuntu 18.04 with the 'iotedge-moby' package vs. the same
+  # variations in Ubuntu 20.04. In these instances the platforms/environments are so similar that we
+  # don't reasonably expect to encounter differences--if we do, it would likely manifest during
+  # installation, or in running a very basic test. We don't need to repeat the entire test suite.
+  # The 'minimal' variable defaults to 'false'; we override it in specific jobs as needed.
+  minimal: false
+  verbose: false
+  NugetSecurityAnalysisWarningLevel: warn
+
 jobs:
 
 ################################################################################
@@ -29,7 +38,7 @@ jobs:
     displayName: Linux arm32v7
 
     pool:
-      name: $(pool.name)
+      name: $(pool.custom.name)
       demands: rpi3-e2e-tests
 
     variables:
@@ -48,12 +57,57 @@ jobs:
     - template: templates/e2e-run.yaml
 
 ################################################################################
-  - job: linux_amd64
+  - job: ubuntu_1804_msmoby
 ################################################################################
-    displayName: Linux amd64
+    displayName: Ubuntu 18.04 with iotedge-moby
 
     pool:
-      vmImage: ubuntu-20.04
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      identityServiceArtifactName: packages_ubuntu-18.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_1804_docker
+################################################################################
+    displayName: Ubuntu 18.04 with Docker (minimal)
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      identityServiceArtifactName: packages_ubuntu-18.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      minimal: true
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_2004_msmoby
+################################################################################
+    displayName: Ubuntu 20.04 with iotedge-moby
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
 
     variables:
       os: linux
@@ -67,17 +121,39 @@ jobs:
     - template: templates/e2e-run.yaml
 
 ################################################################################
+  - job: ubuntu_2004_docker
+################################################################################
+    displayName: Ubuntu 20.04 with Docker (minimal)
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu20.04-amd64
+      identityServiceArtifactName: packages_ubuntu-20.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      minimal: true
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
   - job: centos7_amd64
 ################################################################################
     displayName: CentOs7 amd64
 
     pool:
-      name: $(pool.name)
+      name: $(pool.custom.name)
       demands:
-        - Agent.OS -equals Linux
-        - Agent.OSArchitecture -equals X64
-        - run-new-e2e-tests -equals true
-        - centos -equals 7
+      - Agent.OS -equals Linux
+      - Agent.OSArchitecture -equals X64
+      - run-new-e2e-tests -equals true
+      - centos -equals 7
 
     variables:
       os: linux
@@ -99,7 +175,7 @@ jobs:
 #     displayName: Linux amd64 behind a proxy
 
 #     pool:
-#       name: $(pool.name)
+#       name: $(pool.custom.name)
 #       demands: new-e2e-proxy
 
 #     variables:
@@ -111,6 +187,8 @@ jobs:
 #       # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
 #       'agent.disablelogplugin.testfilepublisherplugin': true
 #       'agent.disablelogplugin.testresultlogplugin': true
+#       # because we aren't publishing test artifacts for this job, turn on verbose logging instead
+#       verbose: true
 
 #     timeoutInMinutes: 120
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -56,36 +56,42 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_1804_msmoby
-################################################################################
-    displayName: Ubuntu 18.04 with iotedge-moby
+# Using 1ES-hosted agents in master branch causes test failures; disabling
+# until fixed.
+# ################################################################################
+#   - job: ubuntu_1804_msmoby
+# ################################################################################
+#     displayName: Ubuntu 18.04 with iotedge-moby
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-      identityServiceArtifactName: packages_ubuntu-18.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu18.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_1804_docker
 ################################################################################
-    displayName: Ubuntu 18.04 with Docker (minimal)
+    # displayName: Ubuntu 18.04 with Docker (minimal)
+    displayName: Ubuntu 18.04 with Docker
 
     pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+      vmImage: ubuntu-18.04
+      # Using 1ES-hosted agents in master branch causes test failures; disabling
+      # until fixed.
+      # name: $(pool.linux.name)
+      # demands:
+      # - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
 
     variables:
       os: linux
@@ -93,42 +99,49 @@ jobs:
       artifactName: iotedged-ubuntu18.04-amd64
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      minimal: true
+      # When we switch to 1ES-hosted agents, we can make this a minimal pipeline
+      # minimal: true
 
     steps:
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_2004_msmoby
-################################################################################
-    displayName: Ubuntu 20.04 with iotedge-moby
+# Using 1ES-hosted agents in master branch causes test failures; disabling
+# until fixed.
+# ################################################################################
+#   - job: ubuntu_2004_msmoby
+# ################################################################################
+#     displayName: Ubuntu 20.04 with iotedge-moby
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu20.04-amd64
-      identityServiceArtifactName: packages_ubuntu-20.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu20.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_2004_docker
 ################################################################################
-    displayName: Ubuntu 20.04 with Docker (minimal)
+    # displayName: Ubuntu 20.04 with Docker (minimal)
+    displayName: Ubuntu 20.04 with Docker
 
     pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+      vmImage: ubuntu-20.04
+      # Using 1ES-hosted agents in master branch causes test failures; disabling
+      # until fixed.
+      # name: $(pool.linux.name)
+      # demands:
+      # - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
 
     variables:
       os: linux
@@ -136,7 +149,8 @@ jobs:
       artifactName: iotedged-ubuntu20.04-amd64
       identityServiceArtifactName: packages_ubuntu-20.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      minimal: true
+      # When we switch to 1ES-hosted agents, we can make this a minimal pipeline
+      # minimal: true
 
     steps:
     - template: templates/e2e-setup.yaml
@@ -148,9 +162,17 @@ jobs:
     displayName: CentOs7 amd64
 
     pool:
-      name: $(pool.linux.name)
+      name: $(pool.custom.name)
       demands:
-      - ImageOverride -equals agent-aziotedge-centos-7-msmoby
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - run-new-e2e-tests -equals true
+        - centos -equals 7
+      # Using 1ES-hosted agents in master branch causes test failures; disabling
+      # until fixed.
+      # name: $(pool.linux.name)
+      # demands:
+      # - ImageOverride -equals agent-aziotedge-centos-7-msmoby
 
     variables:
       os: linux

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -148,12 +148,9 @@ jobs:
     displayName: CentOs7 amd64
 
     pool:
-      name: $(pool.custom.name)
+      name: $(pool.linux.name)
       demands:
-      - Agent.OS -equals Linux
-      - Agent.OSArchitecture -equals X64
-      - run-new-e2e-tests -equals true
-      - centos -equals 7
+      - ImageOverride -equals agent-aziotedge-centos-7-msmoby
 
     variables:
       os: linux

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -21,6 +21,11 @@ steps:
     # Filter out flaky tests.
     $filter = 'Category!=Flaky'
 
+    if ('$(minimal)' -eq 'true')
+    {
+      $filter += '&Name~TempSensor'
+    }
+
     if ('$(Agent.Name)'.Contains('centos'))
     {
       $filter += '&Category=CentOsSafe'
@@ -71,9 +76,9 @@ steps:
     else
     {
       $filter += '&Category!=NestedEdgeOnly'
-    } 
+    }
 
-    sudo --preserve-env dotnet test $testFile --logger:trx --testcasefilter:$filter
+    sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
 
   displayName: Run tests ${{ parameters.test_type }}
   env:
@@ -83,9 +88,6 @@ steps:
     E2E_REGISTRIES__0__PASSWORD: $(TestContainerRegistryPassword)
     E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
     E2E_BLOB_STORE_SAS: $(TestBlobStoreSas)
-    http_proxy: $(Agent.ProxyUrl)
-    https_proxy: $(Agent.ProxyUrl)
-    no_proxy: 'localhost'
 
 - task: PublishTestResults@2
   displayName: Publish test results
@@ -109,6 +111,8 @@ steps:
     Copy-Item "$(binDir)/*-test-*.log" "$logDir/"
     Copy-Item "$(binDir)/*-device-*.log" "$logDir/"
     Copy-Item "$(binDir)/testoutput.log" "$logDir/"
+    $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
+    Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
   displayName: Collect Logs
   condition: succeededOrFailed()
 
@@ -116,5 +120,5 @@ steps:
   displayName: Publish logs
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/logs${{ parameters.test_type }}
-    ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(System.PhaseName)
+    ArtifactName: logs-end-to-end-$(artifactSuffix)
   condition: succeededOrFailed()

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -26,7 +26,7 @@ steps:
       $filter += '&Name~TempSensor'
     }
 
-    if ('$(Agent.Name)'.Contains('centos'))
+    if ('$(artifactName)'.Contains('centos'))
     {
       $filter += '&Category=CentOsSafe'
     }

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -88,6 +88,7 @@ steps:
     E2E_REGISTRIES__0__PASSWORD: $(TestContainerRegistryPassword)
     E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
     E2E_BLOB_STORE_SAS: $(TestBlobStoreSas)
+    no_proxy: 'localhost'
 
 - task: PublishTestResults@2
   displayName: Publish test results

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -76,9 +76,6 @@ steps:
     $binDir = Convert-Path "$testDir/bin/Debug/netcoreapp3.1"
     Write-Output "##vso[task.setvariable variable=binDir]$binDir"
   displayName: Build tests
-  env:
-    http_proxy: $(Agent.ProxyUrl)
-    https_proxy: $(Agent.ProxyUrl)
 
 - pwsh: |
     $imageId = Get-Content -Encoding Utf8 `
@@ -154,6 +151,7 @@ steps:
       rootCaCertificatePath = "$rootCaCertificatePath";
       rootCaPrivateKeyPath = "$rootCaPrivateKeyPath";
       logFile = Join-Path '$(binDir)' 'testoutput.log';
+      verbose = '$(verbose)'
     }
 
     if ('$(nestededge)' -eq 'true')

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -16,10 +16,10 @@ jobs:
     timeoutInMinutes: 180
     displayName: LinuxDotnet
     pool:
-      vmImage: 'ubuntu-18.04'
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     steps:
-      - template: ../templates/install-dotnet3.yaml
-
       - task: Docker@2
         displayName: Docker login edgebuilds
         inputs:
@@ -194,7 +194,9 @@ jobs:
     timeoutInMinutes: 180
     displayName: linuxAPIProxy
     pool:
-      vmImage: 'ubuntu-18.04'
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     steps:
       - task: Docker@2
         displayName: Docker login edgebuilds
@@ -228,7 +230,9 @@ jobs:
     timeoutInMinutes: 180
     displayName: Rust Test Modules
     pool:
-      vmImage: 'ubuntu-18.04'
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     steps:
       - template: templates/rust-test-module-build.yaml
       - template: templates/rust-test-module-images.yaml
@@ -245,7 +249,9 @@ jobs:
 ################################################################################
     displayName: Manifest
     pool:
-      vmImage: 'ubuntu-18.04'
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     dependsOn:
       - linux_dotnet_projects
       - linux_API_proxy_module

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -11,7 +11,9 @@ jobs:
 ################################################################################
     displayName: Linux
     pool:
-      vmImage: 'ubuntu-18.04'
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
     variables:
       NugetSecurityAnalysisWarningLevel: warn
     strategy:

--- a/scripts/linux/generic-rust/install.sh
+++ b/scripts/linux/generic-rust/install.sh
@@ -48,6 +48,7 @@ function install_rust()
     # We could check if the toolchain file contains "stable" and conditionally issue a `rustup update stable`,
     # but it's simpler to just always `update` whatever toolchain it is. `update` installs the toolchain
     # if it hasn't already been installed, so this also works for pinned versions.
+    source $HOME/.cargo/env
     rustup update "$(< "$PROJECT_ROOT/rust-toolchain")"
 }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeDevice.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeDevice.cs
@@ -76,8 +76,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                     Device device = await iotHub.CreateEdgeDeviceIdentityAsync(deviceId, nestedEdgeConfig.ParentDeviceId, authType, x509Thumbprint, token);
                     return new EdgeDevice(device, true, iotHub, nestedEdgeConfig);
                 },
-                "Created edge device '{Device}' on hub '{IotHub}'",
+                "Created edge device '{Device}' with parent '{ParentDeviceId}' on hub '{IotHub}'",
                 deviceId,
+                nestedEdgeConfig.ParentDeviceId.GetOrElse("<none>"),
                 iotHub.Hostname);
         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeLogs.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeLogs.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 foreach (string name in modules)
                 {
                     string moduleLog = $"{filePrefix}-{name}.log";
-                    output = await Process.RunAsync("iotedge", $"logs {name}", token);
+                    output = await Process.RunAsync("iotedge", $"logs {name}", token, logVerbose: false);
                     await File.WriteAllLinesAsync(moduleLog, output, token);
                     paths.Add(moduleLog);
                 }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeModule.cs
@@ -48,8 +48,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                     {
                         string[] output = await Process.RunAsync("iotedge", "list", token);
 
-                        Log.Verbose(string.Join("\n", output));
-
                         return output
                             .Where(
                                 ln =>
@@ -74,7 +72,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                         // Retry if iotedged's management endpoint is still starting up,
                         // and therefore isn't responding to `iotedge list` yet
                         static bool DaemonNotReady(string details) =>
+                            details.Contains("Incorrect function", StringComparison.OrdinalIgnoreCase) ||
                             details.Contains("Could not list modules", StringComparison.OrdinalIgnoreCase) ||
+                            details.Contains("Operation not permitted", StringComparison.OrdinalIgnoreCase) ||
                             details.Contains("Socket file could not be found", StringComparison.OrdinalIgnoreCase);
 
                         return DaemonNotReady(e.ToString());
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 {
                     if (e is KeyNotFoundException)
                     {
-                        Log.Information("The device has not yet repported all the keys, retrying:" + e);
+                        Log.Verbose("The device has not yet reported all the keys, retrying:" + e);
                         return true;
                     }
                     else

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Common;
+    using Microsoft.Azure.Devices.Common.Exceptions;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.Azure.EventHubs;
@@ -84,13 +85,12 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
         public async Task<Device> CreateEdgeDeviceIdentityAsync(string deviceId, Option<string> parentDeviceId, AuthenticationType authType, X509Thumbprint x509Thumbprint, CancellationToken token)
         {
-            Log.Information($"Creating edge device {deviceId} with parentId: {parentDeviceId.GetOrElse("NO PARENT")}");
             Device edge = await parentDeviceId.Match(
             async p =>
             {
                 Device parentDevice = await this.GetDeviceIdentityAsync(p, token);
                 string parentDeviceScope = parentDevice == null ? string.Empty : parentDevice.Scope;
-                Log.Information($"Parent scope: {parentDeviceScope}");
+                Log.Verbose($"Parent scope: {parentDeviceScope}");
                 return new Device(deviceId)
             {
                 Authentication = new AuthenticationMechanism()
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             return Retry.Do(
                 () => this.ServiceClient.InvokeDeviceMethodAsync(deviceId, method, token),
                 result => result.Status == 200,
-                e => true,
+                e => !(e is DeviceNotFoundException) || ((DeviceNotFoundException)e).IsTransient,
                 TimeSpan.FromSeconds(5),
                 token);
         }
@@ -240,8 +240,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
 
             edge.Status = enabled ? DeviceStatus.Enabled : DeviceStatus.Disabled;
             var updated = await this.RegistryManager.UpdateDeviceAsync(edge);
-            Log.Information($"Updated enabled status for {deviceId}, enabled: {enabled}");
-            Log.Information($"{updated.Id}, enabled: {updated.Status}");
+            Log.Verbose($"Updated enabled status for {deviceId}, enabled: {enabled}");
+            Log.Verbose($"{updated.Id}, enabled: {updated.Status}");
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.33.1-NestedEdge" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RunProcessAsTask" Version="1.2.4" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0" />
     <PackageReference Include="Nett" Version="0.15.0" />
   </ItemGroup>

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/OsPlatform.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             (string name, string args) command,
             CancellationToken token)
         {
-            string[] output = await Process.RunAsync(command.name, command.args, token);
-            Log.Verbose(string.Join("\n", output));
+            await Process.RunAsync(command.name, command.args, token);
 
             var files = new[]
             {
@@ -60,8 +59,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             CancellationToken token)
         {
             Log.Verbose("Executing: " + command.name + ' ' + command.args);
-            string[] output = await Process.RunAsync(command.name, command.args, token);
-            Log.Verbose(string.Join("\n", output));
+            await Process.RunAsync(command.name, command.args, token);
         }
 
         static void CheckFiles(IEnumerable<string> paths, string basePath) => NormalizeFiles(paths, basePath);

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Process.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Process.cs
@@ -1,15 +1,17 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Test.Common
 {
+    using System;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Threading;
     using System.Threading.Tasks;
     using RunProcessAsTask;
+    using Serilog;
 
     public class Process
     {
-        public static async Task<string[]> RunAsync(string name, string args, CancellationToken token)
+        public static async Task RunAsync(string name, string args, Action<string> onStandardOutput, Action<string> onStandardError, CancellationToken token)
         {
             var info = new ProcessStartInfo
             {
@@ -18,11 +20,38 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 RedirectStandardInput = true,
             };
 
-            using (ProcessResults result = await ProcessEx.RunAsync(info, token))
+            using (ProcessResults result = await ProcessEx.RunAsync(info, onStandardOutput, onStandardError, token))
             {
                 if (result.ExitCode != 0)
                 {
-                    throw new Win32Exception(result.ExitCode, $"{string.Join("\n", result.StandardOutput)}\n\n'{name}' failed with: {string.Join("\n", result.StandardError)}");
+                    throw new Win32Exception(result.ExitCode);
+                }
+            }
+        }
+
+        public static async Task<string[]> RunAsync(string name, string args, CancellationToken token, bool logVerbose = true)
+        {
+            var info = new ProcessStartInfo
+            {
+                FileName = name,
+                Arguments = args,
+                RedirectStandardInput = true,
+            };
+
+            Action<string> onStdout = (string o) => Log.Verbose(o);
+            Action<string> onStderr = (string e) => Log.Verbose(e);
+
+            if (!logVerbose)
+            {
+                onStdout = (string o) => { };
+                onStderr = (string e) => { };
+            }
+
+            using (ProcessResults result = await ProcessEx.RunAsync(info, onStdout, onStderr, token))
+            {
+                if (result.ExitCode != 0)
+                {
+                    throw new Win32Exception(result.ExitCode);
                 }
 
                 return result.StandardOutput;

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/ProcessEx.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/ProcessEx.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// Copyright (c) 2013 James Manning
+// Adapted from https://github.com/jamesmanning/RunProcessAsTask
+namespace RunProcessAsTask
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    public static partial class ProcessEx
+    {
+        /// <summary>
+        /// Runs asynchronous process.
+        /// </summary>
+        /// <param name="processStartInfo">The <see cref="T:System.Diagnostics.ProcessStartInfo" /> that contains the information that is used to start the process, including the file name and any command-line arguments.</param>
+        /// <param name="onStandardOutput">Method that will be called when a line is written to standard output</param>
+        /// <param name="onStandardError">Method that will be called when a line is written to standard error</param>
+        /// <param name="cancellationToken">The token to monitor for cancellation requests.</param>
+        public static async Task<ProcessResults> RunAsync(ProcessStartInfo processStartInfo, Action<string> onStandardOutput, Action<string> onStandardError, CancellationToken cancellationToken)
+        {
+            var standardOutput = new List<string>();
+            var standardError = new List<string>();
+
+            // force some settings in the start info so we can capture the output
+            processStartInfo.UseShellExecute = false;
+            processStartInfo.RedirectStandardOutput = true;
+            processStartInfo.RedirectStandardError = true;
+
+            var tcs = new TaskCompletionSource<ProcessResults>();
+
+            var process = new Process
+            {
+                StartInfo = processStartInfo,
+                EnableRaisingEvents = true
+            };
+
+            var standardOutputResults = new TaskCompletionSource<string[]>();
+            process.OutputDataReceived += (sender, args) =>
+            {
+                if (args.Data != null)
+                {
+                    standardOutput.Add(args.Data);
+                    onStandardOutput(args.Data);
+                }
+                else
+                {
+                    standardOutputResults.SetResult(standardOutput.ToArray());
+                }
+            };
+
+            var standardErrorResults = new TaskCompletionSource<string[]>();
+            process.ErrorDataReceived += (sender, args) =>
+            {
+                if (args.Data != null)
+                {
+                    standardError.Add(args.Data);
+                    onStandardError(args.Data);
+                }
+                else
+                {
+                    standardErrorResults.SetResult(standardError.ToArray());
+                }
+            };
+
+            var processStartTime = new TaskCompletionSource<DateTime>();
+
+            process.Exited += async (sender, args) =>
+            {
+                // Since the Exited event can happen asynchronously to the output and error events,
+                // we await the task results for stdout/stderr to ensure they both closed.  We must await
+                // the stdout/stderr tasks instead of just accessing the Result property due to behavior on MacOS.
+                // For more details, see the PR at https://github.com/jamesmanning/RunProcessAsTask/pull/16/
+                tcs.TrySetResult(
+                    new ProcessResults(
+                        process,
+                        await processStartTime.Task.ConfigureAwait(false),
+                        await standardOutputResults.Task.ConfigureAwait(false),
+                        await standardErrorResults.Task.ConfigureAwait(false)));
+            };
+
+            using (cancellationToken.Register(
+                () =>
+                {
+                    tcs.TrySetCanceled();
+                    try
+                    {
+                        if (!process.HasExited)
+                            process.Kill();
+                    }
+                    catch (InvalidOperationException)
+                    {
+                    }
+                }))
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var startTime = DateTime.Now;
+                if (process.Start() == false)
+                {
+                    tcs.TrySetException(new InvalidOperationException("Failed to start process"));
+                }
+                else
+                {
+                    try
+                    {
+                        startTime = process.StartTime;
+                    }
+                    catch (Exception)
+                    {
+                        // best effort to try and get a more accurate start time, but if we fail to access StartTime
+                        // (for instance, process has already existed), we still have a valid value to use.
+                    }
+
+                    processStartTime.SetResult(startTime);
+
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
+                }
+
+                return await tcs.Task.ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/ProcessResults.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/ProcessResults.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft. All rights reserved.
+
+// Copyright (c) 2013 James Manning
+namespace RunProcessAsTask
+{
+    using System;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Contains information about process after it has exited.
+    /// </summary>
+    public sealed class ProcessResults : IDisposable
+    {
+        public ProcessResults(Process process, DateTime processStartTime, string[] standardOutput, string[] standardError)
+        {
+            this.Process = process;
+            this.ExitCode = process.ExitCode;
+            this.RunTime = process.ExitTime - processStartTime;
+            this.StandardOutput = standardOutput;
+            this.StandardError = standardError;
+        }
+
+        public Process Process { get; }
+        public int ExitCode { get; }
+        public TimeSpan RunTime { get; }
+        public string[] StandardOutput { get; }
+        public string[] StandardError { get; }
+        public void Dispose()
+        {
+            this.Process.Dispose();
+        }
+    }
+}

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/EdgeDaemon.cs
@@ -18,29 +18,40 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
 
         public static async Task<EdgeDaemon> CreateAsync(CancellationToken token)
         {
-            string[] platformInfo = await Process.RunAsync("lsb_release", "-sir", token);
-            if (platformInfo.Length == 1)
+            string[] platformInfo = await Process.RunAsync("cat", @"/etc/os-release", token);
+            string os = Array.Find(platformInfo, element => element.StartsWith("ID="));
+            string version = Array.Find(platformInfo, element => element.StartsWith("VERSION_ID="));
+
+            // VERSION_ID is desired but it is an optional field
+            if (version == null)
             {
-                platformInfo = platformInfo[0].Split(' ');
+                version = Array.Find(platformInfo, element => element.StartsWith("VERSION="));
             }
 
-            string os = platformInfo[0].Trim();
-            string version = platformInfo[1].Trim();
+            if (os == null || version == null)
+            {
+                throw new NotImplementedException("Failed to gather operating system information from /etc/os-release file");
+            }
+
+            // Trim potential whitespaces and double quotes
+            char[] trimChr = { ' ', '"' };
+            os = os.Split('=').Last().Trim(trimChr).ToLower();
+            // Split potential version description (in case VERSION_ID was not available, the VERSION line can contain e.g. '7 (Core)')
+            version = version.Split('=').Last().Split(' ').First().Trim(trimChr);
+
             SupportedPackageExtension packageExtension;
 
             switch (os)
             {
-                case "Ubuntu":
-                    os = os.ToLower();
+                case "ubuntu":
                     packageExtension = SupportedPackageExtension.Deb;
                     break;
-                case "Raspbian":
+                case "raspbian":
                     os = "debian";
                     version = "stretch";
                     packageExtension = SupportedPackageExtension.Deb;
                     break;
-                case "CentOS":
-                    os = os.ToLower();
+                case "centos":
                     version = version.Split('.')[0];
                     packageExtension = SupportedPackageExtension.Rpm;
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/OsPlatform.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/OsPlatform.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 "-u docker",
                 $"--since \"{testStartTime:yyyy-MM-dd HH:mm:ss}\"",
                 "--no-pager");
-            string[] output = await Process.RunAsync("journalctl", args, token);
+            string[] output = await Process.RunAsync("journalctl", args, token, logVerbose: false);
 
             string daemonLog = $"{filePrefix}-daemon.log";
             await File.WriteAllLinesAsync(daemonLog, output, token);

--- a/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
@@ -161,7 +161,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     // Send a message from the leaf device
                     DateTime seekTime = DateTime.Now;
                     await leaf.SendEventAsync(token);
-                    Log.Information($"Sent message from {leafDeviceId}");
+                    Log.Verbose($"Sent message from {leafDeviceId}");
 
                     // Verify that the message was received/resent by the relayer module on L4
                     await Profiler.Run(
@@ -198,16 +198,16 @@ namespace Microsoft.Azure.Devices.Edge.Test
         {
             CancellationToken token = this.TestToken;
 
-            Log.Information("Deploying L3 Edge");
+            Log.Verbose("Deploying L3 Edge");
             await this.runtime.DeployConfigurationAsync(token, this.device.NestedEdge.IsNestedEdge);
 
             // Disable the parent Edge device
-            Log.Information("Disabling Edge device");
+            Log.Verbose("Disabling Edge device");
             await this.IotHub.UpdateEdgeEnableStatus(this.runtime.DeviceId, false);
             await Task.Delay(TimeSpan.FromSeconds(10));
 
             // Re-enable parent Edge
-            Log.Information("Re-enabling Edge device");
+            Log.Verbose("Re-enabling Edge device");
             await this.IotHub.UpdateEdgeEnableStatus(this.runtime.DeviceId, true);
             await Task.Delay(TimeSpan.FromSeconds(10));
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -105,9 +105,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig, token, Context.Current.NestedEdge);
             PriorityQueueTestStatus loadGenTestStatus = await this.PollUntilFinishedAsync(LoadGenModuleName, token);
 
-            // Wait long enough for TTL to expire for some of the messages
-            Log.Information($"Waiting for {testInfo.TtlThreshold} seconds for TTL's to expire");
-            await Task.Delay(testInfo.TtlThreshold * 1000);
+            await Profiler.Run(
+                () => Task.Delay(testInfo.TtlThreshold * 1000),
+                "Waited for message TTL to expire");
 
             Action<EdgeConfigBuilder> addRelayerConfig = this.BuildAddRelayerConfig(relayerImage, loadGenTestStatus);
             deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig + addRelayerConfig, token, Context.Current.NestedEdge);

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                         if (Directory.Exists(directory))
                         {
                             Directory.Delete(directory, true);
-                            Log.Information($"Deleted {directory}");
+                            Log.Verbose($"Deleted {directory}");
                         }
                     }
 
@@ -102,10 +102,10 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
                             string edgeAgent = Context.Current.EdgeAgentImage.GetOrElse("mcr.microsoft.com/azureiotedge-agent:1.2");
 
-                            Log.Information("Search parents");
+                            Log.Verbose("Search parents");
                             Context.Current.ParentHostname.ForEach(parentHostname =>
                             {
-                                Log.Information($"Found parent hostname {parentHostname}");
+                                Log.Verbose($"Found parent hostname {parentHostname}");
                                 config.SetParentHostname(parentHostname);
                                 msgBuilder.AppendLine($", parent hostname '{parentHostname}'");
                                 props.Add(parentHostname);
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         private static void ResetConfigFile(string configFile, string defaultFile, string owner)
         {
             // Reset the config file to the default.
-            Log.Information($"Resetting {configFile} to {defaultFile}");
+            Log.Verbose($"Resetting {configFile} to {defaultFile}");
             File.Copy(defaultFile, configFile, true);
             OsPlatform.Current.SetOwner(configFile, owner, "644");
 
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
                 Directory.CreateDirectory(principalsPath);
                 OsPlatform.Current.SetOwner(principalsPath, owner, "755");
-                Log.Information($"Cleared {principalsPath}");
+                Log.Verbose($"Cleared {principalsPath}");
             }
         }
     }

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/SasManualProvisioningFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/SasManualProvisioningFixture.cs
@@ -31,7 +31,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                     AuthenticationType.Sas,
                     null,
                     token);
-                Log.Information($"Device ID {this.device.Id}");
 
                 Context.Current.DeleteList.TryAdd(this.device.Id, this.device);
 


### PR DESCRIPTION
Cherry pick bffddf69dc39efe9b2c0607752b7172f419568b2 and ca519d4e3929eaf8647fbcf40ef2e2e5a11f2a49 from release/1.2. See those commits for details. Note, however, that I had to revert the end-to-end pipeline to continue using MS-hosted and custom agents for now, because test results are inconsistent using our 1ES-hosted agents, and it's not yet clear why (these same agents work fine in release/1.2). We'll need to do more investigation.

I've confirmed that the Build Images, Edgelet Packages, and End-to-end Test pipelines all pass with these changes.