### PR TITLE
Enable e2e test: TestUploadModuleLogs

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -131,7 +131,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
         [Test]
         public async Task TestUploadModuleLogs()
         {
-
             string moduleName = "NumberLogger";
             int count = 10;
             string sasUrl = Context.Current.BlobSasUrl.Expect(() => new InvalidOperationException("Missing Blob SAS url"));

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -131,7 +131,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
         [Test]
         public async Task TestUploadModuleLogs()
         {
-            Assert.Ignore("This test currently does not run automatically. To manually run, replace the sas url below with one pointing to a valid blob store");
 
             string moduleName = "NumberLogger";
             int count = 10;


### PR DESCRIPTION
This test was fixed to lookup the sas key from kv in PR https://github.com/Azure/iotedge/pull/3868.
However, the test was not enabled.