### PR TITLE
Download artifacts based on pipeline 'resources'

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -20,7 +20,6 @@ schedules:
 variables:
   NugetSecurityAnalysisWarningLevel: warn
   images.artifact.name.linux: 'core-linux'
-  vsts.project: $(System.TeamProjectId)
 
 resources:
   pipelines:
@@ -142,8 +141,8 @@ jobs:
         displayName: 'Download Edgelet Artifacts'
         inputs:
           buildType: specific
-          project: $(vsts.project)
-          pipeline: $(edgelet.package.build)
+          project: $(resources.pipeline.packages.projectID)
+          pipeline: $(resources.pipeline.packages.pipelineName)
           branchName: $(resources.pipeline.packages.sourceBranch)
           buildVersionToDownload: latestFromBranch
           downloadPath: '$(Build.StagingDirectory)'
@@ -154,8 +153,8 @@ jobs:
         displayName: 'Download Images Artifacts'
         inputs:
           buildType: specific
-          project: $(vsts.project)
-          pipeline: $(images.build)
+          project: $(resources.pipeline.images.projectID)
+          pipeline: $(resources.pipeline.images.pipelineName)
           branchName: $(resources.pipeline.images.sourceBranch)
           buildVersionToDownload: latestFromBranch
           downloadPath: '$(Build.StagingDirectory)'

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -144,7 +144,7 @@ jobs:
           buildType: specific
           project: $(vsts.project)
           pipeline: $(edgelet.package.build)
-          branchName: $(edgelet.package.branchName)
+          branchName: $(resources.pipeline.packages.sourceBranch)
           buildVersionToDownload: latestFromBranch
           downloadPath: '$(Build.StagingDirectory)'
           artifactName: $(edgelet.artifact.name)
@@ -156,7 +156,7 @@ jobs:
           buildType: specific
           project: $(vsts.project)
           pipeline: $(images.build)
-          branchName: $(images.branchName)
+          branchName: $(resources.pipeline.images.sourceBranch)
           buildVersionToDownload: latestFromBranch
           downloadPath: '$(Build.StagingDirectory)'
           artifactName: $(images.artifact.name.linux)


### PR DESCRIPTION
The 'Download Edge Artifacts' and 'Download Image Artifacts' tasks used the
edgelet.package.branchName and images.branchName variables, respectively but
instead needed to use the appropriate resource variables (which were being specified
in the resources sectin of the YAML but not used at all)