### PR TITLE
Patch a vulnerability in System.Text.Encodings.Web

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util.Metrics/Microsoft.Azure.Devices.Edge.Util.Metrics.csproj
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util.Metrics/Microsoft.Azure.Devices.Edge.Util.Metrics.csproj
@@ -19,6 +19,14 @@
     <PackageReference Include="prometheus-net" Version="4.2.0" />
     <PackageReference Include="prometheus-net.AspNetCore" Version="4.2.0" />
 
+    <!--
+      prometheus-net.AspNetCore takes a transitive dependency on
+      System.Test.Encodings.Web. Use an explicit reference here to override the
+      version and fix a security vulnerability.
+      See https://github.com/dotnet/runtime/issues/49377#issuecomment-804930299.
+    -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+
     <ProjectReference Include="..\Microsoft.Azure.Devices.Edge.Util\Microsoft.Azure.Devices.Edge.Util.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
One of our dependencies, prometheus-net.AspNetCore, has a transitive dependency on a vulnerable version of System.Text.Encodings.Web. Updating prometheus-net.AspNetCore wouldn't change anything, so the recommended approach is to make an explicit reference to the patched version of System.Text.Encodings.Web, to override the transitive version.

I used `dotnet list package --include-transitive` before and after the change to verify that the transitive dependency is replaced by the explicit dependency within the project.