### PR TITLE
Disable flaky CI and E2E tests

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -29,27 +29,29 @@ variables:
 
 jobs:
 
-################################################################################
-  - job: linux_arm32v7
-################################################################################
-    displayName: Linux arm32v7
+# Arm suite sometimes has a timeout problem where multiple tests fail.
+# Suspect this is an agent issue, but disabling until we fix.
+# ################################################################################
+#   - job: linux_arm32v7
+# ################################################################################
+#     displayName: Linux arm32v7
 
-    pool:
-      name: $(pool.custom.name)
-      demands: rpi3-e2e-tests
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: rpi3-e2e-tests
 
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactName: iotedged-debian9-arm32v7
+#     variables:
+#       os: linux
+#       arch: arm32v7
+#       artifactName: iotedged-debian9-arm32v7
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_1804_msmoby

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -169,46 +169,47 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: windows_10ent
-################################################################################
-    displayName: Windows 10 Enterprise (minimal)
+# Disabling until falkiness is fixed on this platform
+# ################################################################################
+#   - job: windows_10ent
+# ################################################################################
+#     displayName: Windows 10 Enterprise (minimal)
 
-    pool:
-      name: $(pool.windows.name)
-      demands:
-        - ImageOverride -equals agent-aziotedge-win10-entn2019-test
+#     pool:
+#       name: $(pool.windows.name)
+#       demands:
+#         - ImageOverride -equals agent-aziotedge-win10-entn2019-test
 
-    variables:
-      os: windows
-      arch: amd64
-      artifactName: iotedged-windows
-      minimal: true
+#     variables:
+#       os: windows
+#       arch: amd64
+#       artifactName: iotedged-windows
+#       minimal: true
 
-    steps:
-    - template: templates/e2e-setup.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
 
-    - pwsh: |
-        $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
-        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
-        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
-          -ArgumentList 'Root', 'LocalMachine'
-        $store.Open('ReadWrite')
-        $store.Add($cert)
-      displayName: Install CAB signing root cert
-      env:
-        PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
+#     - pwsh: |
+#         $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
+#         $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
+#         $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
+#           -ArgumentList 'Root', 'LocalMachine'
+#         $store.Open('ReadWrite')
+#         $store.Add($cert)
+#       displayName: Install CAB signing root cert
+#       env:
+#         PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
 
-    - pwsh: |
-        Write-Output '>>> BEFORE:'
-        netsh interface ipv6 show prefixpolicies
-        netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
-        Write-Output '>>> AFTER:'
-        netsh interface ipv6 show prefixpolicies
-      displayName: Prefer IPv4
+#     - pwsh: |
+#         Write-Output '>>> BEFORE:'
+#         netsh interface ipv6 show prefixpolicies
+#         netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
+#         Write-Output '>>> AFTER:'
+#         netsh interface ipv6 show prefixpolicies
+#       displayName: Prefer IPv4
 
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: centos7_amd64

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         static readonly IEntityStore<string, ModuleState> RestartStateStore = new Mock<IEntityStore<string, ModuleState>>().Object;
         static readonly IRestartPolicyManager RestartManager = new Mock<IRestartPolicyManager>().Object;
 
-        [Integration(Skip = "Flaky")]
+        [Integration]
         [Fact]
         public async Task TestEmptyEnvironment()
         {
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             }
         }
 
-        [Integration]
+        [Integration(Skip = "Flaky")]
         [Fact]
         public async Task TestEnvVars()
         {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
         static readonly IEntityStore<string, ModuleState> RestartStateStore = new Mock<IEntityStore<string, ModuleState>>().Object;
         static readonly IRestartPolicyManager RestartManager = new Mock<IRestartPolicyManager>().Object;
 
-        [Integration]
+        [Integration(Skip = "Flaky")]
         [Fact]
         public async Task TestEmptyEnvironment()
         {

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/RuntimeInfoProviderTest.cs
@@ -127,8 +127,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Docker.Test
             }
         }
 
-        [Integration(Skip = "Flaky")]
-        [Fact]
+        [Integration]
+        [Fact(Skip = "Flaky")]
         public async Task TestEnvVars()
         {
             const string Image = "hello-world:latest";

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentConnectionTest.cs
@@ -341,7 +341,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         }
 
         [Integration]
-        [Fact]
+        [Fact(Skip = "Flaky")]
         public async Task EdgeAgentConnectionConfigurationTest()
         {
             string edgeDeviceId = "testMmaEdgeDevice1" + Guid.NewGuid();

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudProxyTest.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
             await CheckMessageInEventHub(sentMessagesByDevice, startTime);
         }
 
-        [Fact]
+        [Fact(Skip = "Flaky")]
         [TestPriority(403)]
         public async Task SendMessageBatchTest()
         {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
     using IotHubConnectionStringBuilder = Microsoft.Azure.Devices.IotHubConnectionStringBuilder;
     using Message = Microsoft.Azure.Devices.Client.Message;
 
-    [Integration]
+    [Integration(Skip = "Flaky")]
     [Collection("Microsoft.Azure.Devices.Edge.Hub.E2E.Test")]
     public class EdgeHubConnectionTest
     {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeHubConnectionTest.cs
@@ -27,13 +27,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
     using IotHubConnectionStringBuilder = Microsoft.Azure.Devices.IotHubConnectionStringBuilder;
     using Message = Microsoft.Azure.Devices.Client.Message;
 
-    [Integration(Skip = "Flaky")]
+    [Integration]
     [Collection("Microsoft.Azure.Devices.Edge.Hub.E2E.Test")]
     public class EdgeHubConnectionTest
     {
         const string EdgeHubModuleId = "$edgeHub";
 
-        [Theory]
+        [Theory(Skip = "Flaky")]
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeToDeviceMethodTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeToDeviceMethodTest.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             await Task.Delay(TimeSpan.FromSeconds(10));
         }
 
-        [Theory]
+        [Theory(Skip = "Flaky")]
         [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
         public async Task InvokeMethodOnDeviceTest(ITransportSettings[] transportSettings)
         {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
     [Collection("Microsoft.Azure.Devices.Edge.Hub.E2E.Test")]
     public class TelemetryTest
     {
-        [Theory]
+        [Theory(Skip = "Flaky")]
         [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
         async Task SendTelemetryTest(ITransportSettings[] transportSettings)
         {

--- a/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TwinDiffE2ETest.cs
+++ b/edge-hub/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TwinDiffE2ETest.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 });
         }
 
-        [Theory]
+        [Theory(Skip = "Flaky")]
         [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
         public async Task RemovePropertySuccess(ITransportSettings[] transportSettings)
         {
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 });
         }
 
-        [Theory]
+        [Theory(Skip = "Flaky")]
         [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
         public async Task NonexistantRemovePropertySuccess(ITransportSettings[] transportSettings)
         {
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 });
         }
 
-        [Theory]
+        [Theory(Skip = "Flaky")]
         [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
         public async Task OverwriteObjectWithValueSuccess(ITransportSettings[] transportSettings)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -130,6 +130,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("Flaky")]
         public async Task TestUploadModuleLogs()
         {
             string moduleName = "NumberLogger";

--- a/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
@@ -15,7 +15,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
     [EndToEnd]
     class X509Device : X509ManualProvisioningFixture
     {
-        [Test(Skip = "Flaky")]
+        [Test]
+        [Category("Flaky")]
         public async Task X509ManualProvision()
         {
             CancellationToken token = this.TestToken;

--- a/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     [EndToEnd]
     class X509Device : X509ManualProvisioningFixture
     {
-        [Test]
+        [Test(Skip = "Flaky")]
         public async Task X509ManualProvision()
         {
             CancellationToken token = this.TestToken;


### PR DESCRIPTION
These tests are flaky so disabling. Some of these are redundant given coverage in other areas. So we can honestly delete them when needed. (Thinking the `RemovePropertySuccess` and `SendMessageBatchTest` tests)