### PR TITLE
Update cargo dependencies

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "http-common",
  "libc",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "pkcs11",
  "serde",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "http-common",
  "serde",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "serde",
  "toml",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "cc",
 ]
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1744,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1807,7 +1807,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#15f59c8bd33b1fd8581a74ae6e5ea145c8cb1b9b"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/iotedge/src/config/import/mod.rs
+++ b/edgelet/iotedge/src/config/import/mod.rs
@@ -269,7 +269,7 @@ fn execute_inner(
                         global_endpoint,
                         id_scope: scope_id,
                         attestation: common_config::super_config::DpsAttestationMethod::X509 {
-                            registration_id: registration_id,
+                            registration_id,
                             identity: common_config::super_config::X509Identity::Preloaded {
                                 identity_cert,
                                 identity_pk: {

--- a/edgelet/iotedge/src/config/import/mod.rs
+++ b/edgelet/iotedge/src/config/import/mod.rs
@@ -269,9 +269,7 @@ fn execute_inner(
                         global_endpoint,
                         id_scope: scope_id,
                         attestation: common_config::super_config::DpsAttestationMethod::X509 {
-                            // TODO: Remove this when IS supports registration ID being optional for DPS-X509
-                            registration_id: registration_id
-                                .ok_or_else(|| "registration ID is currently required")?,
+                            registration_id: registration_id,
                             identity: common_config::super_config::X509Identity::Preloaded {
                                 identity_cert,
                                 identity_pk: {


### PR DESCRIPTION
https://github.com/Azure/iot-identity-service/pull/278 updated the common super config to allow registration ID to be optional. Update the cargo dependency to pull this change into `iotedge config apply`.

Also pull in the change to make registration ID optional for DPS-X509 provisioning.

Fixes #5488