### PR TITLE
Fix queue len metric maths

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/storage/MessageStore.cs
@@ -134,6 +134,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
 
         public IMessageIterator GetMessageIterator(string endpointId) => this.GetMessageIterator(endpointId, DefaultStartingOffset);
 
+        public Task<ulong> GetMessageCountFromOffset(string endpointId, long offset)
+        {
+            if (!this.endpointSequentialStores.TryGetValue(Preconditions.CheckNonWhiteSpace(endpointId, nameof(endpointId)), out ISequentialStore<MessageRef> sequentialStore))
+            {
+                throw new InvalidOperationException($"Endpoint {nameof(endpointId)} not found");
+            }
+
+            return sequentialStore.GetCountFromOffset(offset);
+        }
+
         public void Dispose()
         {
             this.Dispose(true);
@@ -360,8 +370,10 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Storage
                                 }
                             }
 
-                            // update Metrics for message counts
-                            Checkpointer.Metrics.SetQueueLength(await sequentialStore.Count(), endpointId, priority.ToString());
+                            // Since we will have the total *true* count of messages in the store,
+                            // we need to set the counter here to the total count of messages in the store.
+                            Checkpointer.Metrics.SetQueueLength(await sequentialStore.Count(), endpointId, priority);
+
                             totalCleanupCount += cleanupCount;
                             totalCleanupStoreCount += cleanupEntityStoreCount;
                             Events.CleanupCompleted(messageQueueId, cleanupCount, cleanupEntityStoreCount, totalCleanupCount, totalCleanupStoreCount);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/IMessageStore.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Routing.Core/IMessageStore.cs
@@ -46,5 +46,10 @@ namespace Microsoft.Azure.Devices.Routing.Core
         /// Set the expiry time for messages in the store
         /// </summary>
         void SetTimeToLive(TimeSpan timeToLive);
+
+        /// <summary>
+        /// Returns the number of messages in the store from a offset
+        /// </summary>
+        Task<ulong> GetMessageCountFromOffset(string endpointId, long offset);
     }
 }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/StoringAsyncEndpointExecutorTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/StoringAsyncEndpointExecutorTest.cs
@@ -531,6 +531,8 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints
 
             public List<IMessage> GetReceivedMessagesForEndpoint(string endpointId) => this.GetQueue(endpointId).Queue;
 
+            public Task<ulong> GetMessageCountFromOffset(string endpointId, long offset) => Task.FromResult(0ul);
+
             TestMessageQueue GetQueue(string endpointId) => this.endpointQueues.GetOrAdd(endpointId, new TestMessageQueue());
 
             class TestMessageQueue : IMessageIterator

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/DbStoreDecorator.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/DbStoreDecorator.cs
@@ -104,5 +104,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         }
 
         public Task<ulong> Count() => this.dbStore.Count();
+
+        public Task<ulong> GetCountFromOffset(byte[] offset) => this.dbStore.GetCountFromOffset(offset);
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EncryptedStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EncryptedStore.cs
@@ -122,6 +122,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 
         public Task<ulong> Count() => this.entityStore.Count();
 
+        public Task<ulong> GetCountFromOffset(TK offset) => this.entityStore.GetCountFromOffset(offset);
+
         public void Dispose()
         {
             this.Dispose(true);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EntityStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/EntityStore.cs
@@ -152,6 +152,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 
         public Task<ulong> Count() => this.dbStore.Count();
 
+        public Task<ulong> GetCountFromOffset(TK offset) => this.dbStore.GetCountFromOffset(offset);
+
         public void Dispose()
         {
             this.Dispose(true);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/IKeyValueStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/IKeyValueStore.cs
@@ -44,5 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         Task IterateBatch(TK startKey, int batchSize, Func<TK, TV, Task> perEntityCallback, CancellationToken cancellationToken);
 
         Task<ulong> Count();
+
+        Task<ulong> GetCountFromOffset(TK offset);
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/ISequentialStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/ISequentialStore.cs
@@ -34,5 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         Task<IEnumerable<(long, T)>> GetBatch(long startingOffset, int batchSize, CancellationToken cancellationToken);
 
         Task<ulong> Count();
+
+        Task<ulong> GetCountFromOffset(long offset);
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/InMemoryDbStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/InMemoryDbStore.cs
@@ -122,6 +122,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 
         public Task<ulong> Count() => Task.FromResult((ulong)this.keyValues.Count);
 
+        public Task<ulong> GetCountFromOffset(byte[] offset) => throw new NotImplementedException();
+
         public void Dispose()
         {
             // No-op

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/KeyValueStoreMapper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/KeyValueStoreMapper.cs
@@ -76,6 +76,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 
         public Task<ulong> Count() => this.underlyingStore.Count();
 
+        public Task<ulong> GetCountFromOffset(TK offset) => this.underlyingStore.GetCountFromOffset(this.keyMapper.From(offset));
+
         Task IterateBatch(Option<TK> startKey, int batchSize, Func<TK, TV, Task> callback, CancellationToken cancellationToken)
         {
             Preconditions.CheckRange(batchSize, 1, nameof(batchSize));

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/NullKeyValueStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/NullKeyValueStore.cs
@@ -45,5 +45,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         public Task IterateBatch(TK startKey, int batchSize, Func<TK, TV, Task> perEntityCallback, CancellationToken cancellationToken) => Task.CompletedTask;
 
         public Task<ulong> Count() => Task.FromResult(0UL);
+
+        public Task<ulong> GetCountFromOffset(TK offset) => Task.FromResult(0UL);
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/SequentialStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/SequentialStore.cs
@@ -190,6 +190,8 @@ namespace Microsoft.Azure.Devices.Edge.Storage
 
         public Task<ulong> Count() => this.entityStore.Count();
 
+        public Task<ulong> GetCountFromOffset(long offset) => this.entityStore.GetCountFromOffset(StoreUtils.GetKeyFromOffset(offset));
+
         public void Dispose()
         {
             this.Dispose(true);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/TimedEntityStore.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Storage/TimedEntityStore.cs
@@ -131,5 +131,7 @@ namespace Microsoft.Azure.Devices.Edge.Storage
         }
 
         public Task<ulong> Count() => this.underlyingKeyValueStore.Count();
+
+        public Task<ulong> GetCountFromOffset(TK offset) => this.underlyingKeyValueStore.GetCountFromOffset(offset);
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/IMetricsGauge.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/IMetricsGauge.cs
@@ -3,6 +3,12 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics
 {
     public interface IMetricsGauge
     {
+        double Get(string[] labelValues);
+
         void Set(double value, string[] labelValues);
+
+        void Increment(string[] labelValues);
+
+        void Decrement(string[] labelValues);
     }
 }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/appMetrics/MetricsGauge.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/appMetrics/MetricsGauge.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.AppMetrics
     using App.Metrics;
     using App.Metrics.Gauge;
 
+    // NOTE: AppMetrics is not used and doesn't support inc/dec on gauge natively.
+    // We currently only use the prometheus version of gauage.
     public class MetricsGauge : BaseMetric, IMetricsGauge
     {
         readonly IMeasureGaugeMetrics gaugeMetrics;
@@ -21,6 +23,12 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.AppMetrics
                 MeasurementUnit = Unit.Items
             };
         }
+
+        public void Decrement(string[] labelValues) => throw new System.NotImplementedException();
+
+        public double Get(string[] labelValues) => throw new System.NotImplementedException();
+
+        public void Increment(string[] labelValues) => throw new System.NotImplementedException();
 
         public void Set(double value, string[] labelValues)
         {

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/nullMetrics/NullMetricsGauge.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/nullMetrics/NullMetricsGauge.cs
@@ -3,7 +3,17 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.NullMetrics
 {
     public class NullMetricsGauge : IMetricsGauge
     {
+        public double Get(string[] labelValues) => 0;
+
         public void Set(double value, string[] labelValues)
+        {
+        }
+
+        public void Increment(string[] labelValues)
+        {
+        }
+
+        public void Decrement(string[] labelValues)
         {
         }
     }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsGauge.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/metrics/prometheus.net/MetricsGauge.cs
@@ -14,9 +14,15 @@ namespace Microsoft.Azure.Devices.Edge.Util.Metrics.Prometheus.Net
             this.gauge = Metrics.CreateGauge(name, description, labelNames.ToArray());
         }
 
+        public double Get(string[] labelValues) => this.gauge.WithLabels(this.GetLabelValues(labelValues)).Value;
+
         public void Set(double value, string[] labelValues)
             => this.gauge
                 .WithLabels(this.GetLabelValues(labelValues))
                 .Set(value);
+
+        public void Increment(string[] labelValues) => this.gauge.WithLabels(this.GetLabelValues(labelValues)).Inc();
+
+        public void Decrement(string[] labelValues) => this.gauge.WithLabels(this.GetLabelValues(labelValues)).Dec();
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/ColumnFamilyStoreTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/ColumnFamilyStoreTest.cs
@@ -72,5 +72,36 @@ namespace Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test
             Assert.Equal(lastKey, lastEntry.key.FromBytes());
             Assert.Equal(lastValue, lastEntry.value.FromBytes());
         }
+
+        [Fact]
+        public async Task MessageCountTest()
+        {
+            using (IDbStore columnFamilyDbStore = this.rocksDbStoreProvider.GetDbStore("test"))
+            {
+                Assert.Equal(0ul, await columnFamilyDbStore.Count());
+
+                for (int i = 0; i < 10; i++)
+                {
+                    string key = $"key{i}";
+                    string value = "$value{i}";
+                    await columnFamilyDbStore.Put(key.ToBytes(), value.ToBytes());
+                }
+
+                Assert.Equal(10ul, await columnFamilyDbStore.Count());
+            }
+
+            using (IDbStore columnFamilyDbStore = this.rocksDbStoreProvider.GetDbStore("test"))
+            {
+                Assert.Equal(10ul, await columnFamilyDbStore.Count());
+
+                for (int i = 0; i < 10; i++)
+                {
+                    string key = $"key{i}";
+                    await columnFamilyDbStore.Remove(key.ToBytes());
+                }
+
+                Assert.Equal(0ul, await columnFamilyDbStore.Count());
+            }
+        }
     }
 }


### PR DESCRIPTION
After doing some testing, I have found this type of approach should work. We will pass into propose the total number of messages that store is aware of, this way we can adjust in the event of TTL.

Imagine there are 100 messages being processed and half of them expire leaving 50. The checkpointer would still have its' two pointers for propose and offset remain the same, showing a difference of 100 (100 - 0). But in reality, we should show 50. To do this we can say that if (proposed - offset) > total_messages, move offset closer to proposed. To accommodate this change the propose method for checkpointers has been updated.

Changes:
- Propose signature for checkpointers
- update columnFamilyDbStore for correct count and make count operations atomic
- use endpoint executor to pass info that MessageStore knows about to Checkpointer