### PR TITLE
Update i-i-s dependency for EST fixes.

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "http-common",
  "libc",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "pkcs11",
  "serde",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "http-common",
  "serde",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "serde",
  "toml",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "cc",
 ]
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1744,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1807,7 +1807,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#18d8ece9a4079c0df31d2a29c107dfc6eb967e3d"
 
 [[package]]
 name = "pkg-config"


### PR DESCRIPTION
---

commit 18d8ece9a4079c0df31d2a29c107dfc6eb967e3d
Author: Arnav Singh <arsing@microsoft.com>
Date:   Thu Sep 16 11:52:46 2021 -0700

Fix `MaybeProxyConnector` to use the trusted certs even when a client identity is not being used. (#280)

Cherry-pick from main of aa62e9cc61b907f886c2317a3784bf08187564ea

---

commit 9355f866045046e088a7e70791c91af1c1d70585
Author: Gordon Wang <36049150+gordonwang0@users.noreply.github.com>
Date:   Wed Sep 15 15:30:09 2021 -0700

Fixes for EST cert issuance (#200) (#276)

- Allow the trusted_certs to be empty. Makes using servers with publicly-rooted TLS certs easier.
- Treat HTTP 201 (Created) as Ok.