### PR TITLE
fix functions sample on centos

### DIFF
--- a/edge-modules/functions/samples/docker/linux/amd64/Dockerfile
+++ b/edge-modules/functions/samples/docker/linux/amd64/Dockerfile
@@ -1,7 +1,9 @@
 ﻿FROM mcr.microsoft.com/azure-functions/dotnet:3.0
 
+ARG EXE_DIR=.
+
 ENV AzureWebJobsScriptRoot=/app
 
-COPY . /app
+WORKDIR /app
 
-
+COPY $EXE_DIR/ ./

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -117,6 +117,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         [Test]
         [Category("FlakyOnArm")]
+        [Category("CentOsSafe")]
         // Test Temperature Filter Function: https://docs.microsoft.com/en-us/azure/iot-edge/tutorial-deploy-function
         public async Task TempFilterFunc()
         {


### PR DESCRIPTION
Functions runtime sample failed to start with exception: Unhandled exception. System.UnauthorizedAccessException: Access to the path '/proc/1/map_files' is denied.
 ---> System.IO.IOException: Operation not permitted
 
This started to happen after the upgrade of functions base image to 3.0 which has an updated dotnet core image. Fix adds WORKDIR /app to Dockerfile (to set the working directory for all the subsequent Dockerfile instructions).