### PR TITLE
Define 'verbose' var in missed e2e-setup.yaml caller

### DIFF
--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -154,7 +154,8 @@ stages:
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       nestededge: true
       proxyAddress: $(otProxy)
-      test_type: nestededge_isa95      
+      test_type: nestededge_isa95
+      verbose: false
     pool:
      name: $(pool.name)
      demands:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -73,6 +73,7 @@ stages:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       nestededge: true
+      verbose: false
     pool:
       name: $(pool.name)
       demands:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -73,7 +73,6 @@ stages:
       identityServiceArtifactName: packages_ubuntu-18.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
       nestededge: true
-      verbose: false
     pool:
       name: $(pool.name)
       demands:


### PR DESCRIPTION
A recent change (1b4b446895824ef66e5947ef7872dd2fa8b09ea9) added a requirement that callers of the template `builds/e2e/templates/e2e-setup.yaml` need to define a default value for the variable 'verbose'. This value gets used when creating the context.json file that passes information to the end-to-end tests. The change added the definition of 'verbose' to `e2e.yaml`, but failed to add it to isa-95-smoke-test.yaml, which also calls the template.

This change updates isa-95-smoke-test.yaml with a default value for 'verbose'. I've confirmed the pipeline succeeds with this change.