### PR TITLE
Disable connection pooling for docker client.

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -87,7 +87,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -100,7 +100,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -109,7 +109,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "hex 0.4.3",
  "http-common",
@@ -148,7 +148,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -162,7 +162,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -185,7 +185,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -197,7 +197,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -212,7 +212,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -225,7 +225,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "serde",
 ]
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -243,7 +243,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -261,7 +261,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "http-common",
  "libc",
@@ -271,7 +271,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "pkcs11",
  "serde",
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "http-common",
  "serde",
@@ -290,7 +290,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -491,7 +491,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "serde",
  "toml",
@@ -1241,7 +1241,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1594,7 +1594,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "env_logger",
  "log",
@@ -1852,7 +1852,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "cc",
 ]
@@ -1889,7 +1889,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1986,7 +1986,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -2003,7 +2003,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f6294bdd027284a27a03d83b4c5dc736d98e0a32"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#b59977078be65a4cc5d981cc036ced13f69b5f18"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -295,10 +295,9 @@ impl MakeModuleRuntime for DockerModuleRuntime {
 
 pub fn init_client(docker_url: &Url) -> Result<DockerApiClient> {
     // build the hyper client
-    let client: Client<_, Body> = Client::builder().pool_max_idle_per_host(0).build(
-        Connector::new(docker_url)
-            .map_err(|e| Error::from(ErrorKind::Initialization(e.to_string())))?,
-    );
+    let client: Client<_, Body> = Connector::new(docker_url)
+        .map_err(|e| Error::from(ErrorKind::Initialization(e.to_string())))?
+        .into_client();
 
     // extract base path - the bit that comes after the scheme
     let base_path = docker_url

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -295,7 +295,7 @@ impl MakeModuleRuntime for DockerModuleRuntime {
 
 pub fn init_client(docker_url: &Url) -> Result<DockerApiClient> {
     // build the hyper client
-    let client: Client<_, Body> = Client::builder().build(
+    let client: Client<_, Body> = Client::builder().pool_max_idle_per_host(0).build(
         Connector::new(docker_url)
             .map_err(|e| Error::from(ErrorKind::Initialization(e.to_string())))?,
     );

--- a/edgelet/iotedge/src/client.rs
+++ b/edgelet/iotedge/src/client.rs
@@ -32,8 +32,9 @@ pub struct MgmtClient {
 
 impl MgmtClient {
     pub fn new(url: &Url) -> Result<Self> {
-        let client: Client<_, Body> = Client::builder()
-            .build(Connector::new(url).map_err(|e| Error::from(ErrorKind::Misc(e.to_string())))?);
+        let client: Client<_, Body> = Connector::new(url)
+            .map_err(|e| Error::from(ErrorKind::Misc(e.to_string())))?
+            .into_client();
 
         let base_path = url
             .to_base_path()


### PR DESCRIPTION
By default, `hyper` uses connection pool that can grow till `usize::MAX`. This, we believe, could cause some issues when heavy [GetModuleLogs](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-retrieve-iot-edge-logs?view=iotedge-2020-11) are frequently executed.

Also, connection pool does not have benefits for local UDS connections anyways.
