### PR TITLE
Fix aziot-edged startup when mnt is missing

### DIFF
--- a/edgelet/aziot-edged/src/main.rs
+++ b/edgelet/aziot-edged/src/main.rs
@@ -55,6 +55,17 @@ async fn run() -> Result<(), EdgedError> {
         )
     })?;
 
+    let mnt_dir = std::path::Path::new(&settings.homedir()).join("mnt");
+    std::fs::create_dir_all(&mnt_dir).map_err(|err| {
+        EdgedError::from_err(
+            format!(
+                "Failed to create mnt directory {}",
+                mnt_dir.as_path().display()
+            ),
+            err,
+        )
+    })?;
+
     let identity_client = provision::identity_client(&settings)?;
 
     let device_info = provision::get_device_info(

--- a/edgelet/aziot-edged/src/workload_manager.rs
+++ b/edgelet/aziot-edged/src/workload_manager.rs
@@ -41,10 +41,7 @@ where
         let service = edgelet_http_workload::Service::new(settings, runtime, device_info)
             .map_err(|err| EdgedError::from_err("Invalid service endpoint", err))?;
 
-        service
-            .check_edge_ca()
-            .await
-            .map_err(|message| EdgedError::new(message))?;
+        service.check_edge_ca().await.map_err(EdgedError::new)?;
 
         let home_dir = settings.homedir().to_path_buf();
 


### PR DESCRIPTION
If /var/lib/aziot/edged/mnt is missing, aziot-edged fails to start because of a `No such file or directory` error. It is fine to just create this directory on startup.

Since the directory is now created on startup, it's no longer necessary to create it in the watchdog.