### PR TITLE
Default connectivity tests to debug level logs

### DIFF
--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -32,6 +32,9 @@
               },
               "ExperimentalFeatures__EnableUploadLogs": {
                 "value": "true"
+              },
+              "RuntimeLogLevel" : {
+                "value": "debug"
               }
             },
             "settings": {

--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -757,6 +757,12 @@ function run_connectivity_test() {
             fi
 
             sleep "${sleep_frequency_secs}s"
+
+            #### DO NOT MREGE- Temporarily added for quicker debugging
+            iotedge system logs
+            iotedge logs edgeAgent
+            #### End DO NOT MERGE
+
             total_wait=$((total_wait+sleep_frequency_secs))
             echo "total wait time=$(TZ=UTC0 printf '%(%H:%M:%S)T\n' "$total_wait")"
         done

--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -655,6 +655,12 @@ function run_connectivity_test() {
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run connectivity test with -d '$device_id' started at $test_start_time"
 
+    iotedge system set-log-level $TEST_RUNTIME_LOG_LEVEL || funcRet=$?
+    if [ $funcRet -ne 0 ]; then
+        print_error "Failed setting iotedge system log level to $TEST_RUNTIME_LOG_LEVEL"
+        return $funcRet; 
+    fi
+
     SECONDS=0
 
     NESTED_EDGE_TEST=$(printenv E2E_nestedEdgeTest)

--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -282,10 +282,10 @@ function clean_up() {
 
 function print_deployment_logs() {
     print_highlighted_message '========== Logs from docker =========='
-    journalctl -u docker --no-pager || true
+    journalctl -u docker --since "$test_start_time" --no-pager || true
 
     print_highlighted_message '========== Logs from iotedge system =========='
-    iotedge system logs
+    iotedge system logs -- --since "$test_start_time" --no-pager || true
 
     print_highlighted_message '========== Logs from edgeAgent =========='
     docker logs edgeAgent || true

--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -757,12 +757,6 @@ function run_connectivity_test() {
             fi
 
             sleep "${sleep_frequency_secs}s"
-
-            #### DO NOT MREGE- Temporarily added for quicker debugging
-            iotedge system logs
-            iotedge logs edgeAgent
-            #### End DO NOT MERGE
-
             total_wait=$((total_wait+sleep_frequency_secs))
             echo "total wait time=$(TZ=UTC0 printf '%(%H:%M:%S)T\n' "$total_wait")"
         done

--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -655,12 +655,6 @@ function run_connectivity_test() {
     test_start_time="$(date '+%Y-%m-%d %H:%M:%S')"
     print_highlighted_message "Run connectivity test with -d '$device_id' started at $test_start_time"
 
-    iotedge system set-log-level $TEST_RUNTIME_LOG_LEVEL || funcRet=$?
-    if [ $funcRet -ne 0 ]; then
-        print_error "Failed setting iotedge system log level to $TEST_RUNTIME_LOG_LEVEL"
-        return $funcRet; 
-    fi
-
     SECONDS=0
 
     NESTED_EDGE_TEST=$(printenv E2E_nestedEdgeTest)

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -462,8 +462,8 @@ namespace IotEdgeQuickstart.Details
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
             {
-                Console.WriteLine($"Calling iotedge system set-log-level {runtimeLogLevel.ToString()}");
-                string[] output = await Process.RunAsync("iotedge", $"system set-log-level {runtimeLogLevel.ToString()}", cts.Token);
+                Console.WriteLine($"Calling iotedge system set-log-level {runtimeLogLevel.ToString().ToLower()}");
+                string[] output = await Process.RunAsync("iotedge", $"system set-log-level {runtimeLogLevel.ToString().ToLower()}", cts.Token);
                 Console.WriteLine($"{output.ToString()}");
             }
         }

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -463,8 +463,8 @@ namespace IotEdgeQuickstart.Details
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
             {
                 Console.WriteLine($"Calling iotedge system set-log-level {runtimeLogLevel.ToString()}");
-                string output = await Process.RunAsync("iotedge", $"system set-log-level {runtimeLogLevel.ToString()}", cts.Token, true);
-                Console.WriteLine($"{output}");
+                string[] output = await Process.RunAsync("iotedge", $"system set-log-level {runtimeLogLevel.ToString()}", cts.Token);
+                Console.WriteLine($"{output.ToString()}");
             }
         }
 

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -462,7 +462,9 @@ namespace IotEdgeQuickstart.Details
 
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
             {
-                await Process.RunAsync("iotedge", $"system set-log-level {runtimeLogLevel.ToString()}", cts.Token);
+                Console.WriteLine($"Calling iotedge system set-log-level {runtimeLogLevel.ToString()}");
+                string output = await Process.RunAsync("iotedge", $"system set-log-level {runtimeLogLevel.ToString()}", cts.Token, true);
+                Console.WriteLine($"{output}");
             }
         }
 
@@ -470,7 +472,7 @@ namespace IotEdgeQuickstart.Details
         {
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
             {
-                await Process.RunAsync("systemctl", "restart aziot-keyd aziot-certd aziot-identityd aziot-edged", cts.Token);
+                await Process.RunAsync("iotedge", "system restart", cts.Token);
                 Console.WriteLine("Waiting for aziot-edged to start up.");
 
                 // Waiting for the processes to enter the "Running" state doesn't guarantee that

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -459,6 +459,11 @@ namespace IotEdgeQuickstart.Details
                 SetOwner(path, service.Value.Owner, "644");
                 Console.WriteLine($"Created config {path}");
             }
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
+            {
+                await Process.RunAsync("iotedge", $"system set-log-level {runtimeLogLevel.ToString()}", cts.Token);
+            }
         }
 
         public async Task Start()


### PR DESCRIPTION
Default to debug level logs during Single-node and Nested Connectivity tests. This change applies to edgeAgent and aziot system services (i.e. aziot-edged, aziot-keyd, aziot-certd, and aziot-identityd).

Also, start docker and aziot* logs at the test start time. Previously docker logs from previous runs would show up and most of the aziot* logs would be missing from the start of the run.