### PR TITLE
Cherry-pick: Default connectivity tests to debug level logs (#5540)

### DIFF
--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -32,6 +32,9 @@
               },
               "ExperimentalFeatures__EnableUploadLogs": {
                 "value": "true"
+              },
+              "RuntimeLogLevel" : {
+                "value": "debug"
               }
             },
             "settings": {

--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -282,10 +282,10 @@ function clean_up() {
 
 function print_deployment_logs() {
     print_highlighted_message '========== Logs from docker =========='
-    journalctl -u docker --no-pager || true
+    journalctl -u docker --since "$test_start_time" --no-pager || true
 
     print_highlighted_message '========== Logs from iotedge system =========='
-    iotedge system logs
+    iotedge system logs -- --since "$test_start_time" --no-pager || true
 
     print_highlighted_message '========== Logs from edgeAgent =========='
     docker logs edgeAgent || true

--- a/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
+++ b/smoke/IotEdgeQuickstart/details/IotedgedLinux.cs
@@ -459,13 +459,20 @@ namespace IotEdgeQuickstart.Details
                 SetOwner(path, service.Value.Owner, "644");
                 Console.WriteLine($"Created config {path}");
             }
+
+            using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
+            {
+                Console.WriteLine($"Calling iotedge system set-log-level {runtimeLogLevel.ToString().ToLower()}");
+                string[] output = await Process.RunAsync("iotedge", $"system set-log-level {runtimeLogLevel.ToString().ToLower()}", cts.Token);
+                Console.WriteLine($"{output.ToString()}");
+            }
         }
 
         public async Task Start()
         {
             using (var cts = new CancellationTokenSource(TimeSpan.FromMinutes(2)))
             {
-                await Process.RunAsync("systemctl", "restart aziot-keyd aziot-certd aziot-identityd aziot-edged", cts.Token);
+                await Process.RunAsync("iotedge", "system restart", cts.Token);
                 Console.WriteLine("Waiting for aziot-edged to start up.");
 
                 // Waiting for the processes to enter the "Running" state doesn't guarantee that


### PR DESCRIPTION
Default to debug level logs during Single-node and Nested Connectivity tests. This change applies to edgeAgent and aziot system services (i.e. aziot-edged, aziot-keyd, aziot-certd, and aziot-identityd).

Also, start docker and aziot* logs at the test start time. Previously docker logs from previous runs would show up and most of the aziot* logs would be missing from the start of the run.