### PR TITLE
Update to 1.2.3 IIS components

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -99,7 +99,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -108,7 +108,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "hex 0.4.2",
  "http-common",
@@ -169,7 +169,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "aziot-identity-common",
  "http-common",
@@ -204,7 +204,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -219,7 +219,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "serde",
 ]
@@ -227,7 +227,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -237,7 +237,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -255,7 +255,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "http-common",
  "libc",
@@ -265,7 +265,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "pkcs11",
  "serde",
@@ -275,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "http-common",
  "serde",
@@ -284,7 +284,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -509,7 +509,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "serde",
  "toml",
@@ -1142,7 +1142,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1698,7 +1698,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "cc",
 ]
@@ -1735,7 +1735,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1744,7 +1744,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1807,7 +1807,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1824,7 +1824,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#7ce9a34cec7320b0f7a67d65dd443e48d0145ba1"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.2#55434733d5d3a73f67b9e70998c38da5b7190901"
 
 [[package]]
 name = "pkg-config"

--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -17,7 +17,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.2.2-1
+Requires:       aziot-identity-service = 1.2.3-1
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/contrib/debian/control
+++ b/edgelet/contrib/debian/control
@@ -9,7 +9,7 @@ Homepage: https://github.com/azure/iotedge
 
 Package: aziot-edge
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, aziot-identity-service (= 1.2.2-1), sed
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, aziot-identity-service (= 1.2.3-1), sed
 Description: Azure IoT Edge Module Runtime
  Azure IoT Edge is a fully managed service that delivers cloud intelligence
  locally by deploying and running artificial intelligence (AI), Azure services,

--- a/edgelet/iotedge/test-files/config/ca-quickstart/certd.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 30
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/certd.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-tpm/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-x509/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/imported-master-encryption-key/certd.toml
+++ b/edgelet/iotedge/test-files/config/imported-master-encryption-key/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manual-x509/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/moby-runtime-content-trust/certd.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-content-trust/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/nested-edge/certd.toml
+++ b/edgelet/iotedge/test-files/config/nested-edge/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/certd.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/certd.toml
@@ -3,9 +3,9 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-method = "self_signed"
 common_name = "iotedged workload ca my-device"
 expiry_days = 90
+method = "self_signed"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]


### PR DESCRIPTION
- Update aziotctl version to 1.2.3 & aziotd version to 1.2.3
Ref: https://github.com/Azure/iot-identity-service/commit/55434733d5d3a73f67b9e70998c38da5b7190901

- Update certd.toml config in tests to reflect the structure serialization changes in IIS 1.2.3 ( https://github.com/Azure/iot-identity-service/commit/3637eada145a720259c4e0744b0b551c8da04b10#diff-2988409407e7eb06011181dd65063f3c52c7201272be8c3af4b8479d65baebd3R228-R240 )
Note: This is a workaround in Rust TOML library where a complex structure needs to be resided last in the struct.