### PR TITLE
fix stopping module in 1.1.6

### DIFF
--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -33,7 +33,6 @@ pub enum ModuleStatus {
 pub enum ModuleAction {
     Start(String, Sender<()>),
     Stop(String),
-    Remove(String),
 }
 
 impl FromStr for ModuleStatus {

--- a/edgelet/edgelet-docker/tests/runtime.rs
+++ b/edgelet/edgelet-docker/tests/runtime.rs
@@ -918,7 +918,7 @@ fn container_create_succeeds() {
                 sender.send(()).unwrap();
                 Ok(())
             }
-            ModuleAction::Stop(_module_id) | ModuleAction::Remove(_module_id) => Ok(()),
+            ModuleAction::Stop(_module_id) => Ok(()),
         });
     runtime.spawn(simulate_workload_manager);
     runtime.spawn(server);

--- a/edgelet/iotedged/src/workload_manager.rs
+++ b/edgelet/iotedged/src/workload_manager.rs
@@ -228,23 +228,6 @@ where
     fn stop(&mut self, module_id: &str) -> Result<(), Error> {
         info!("Stopping listener for module {}", module_id);
 
-        let shutdown_sender = self.shutdown_senders.remove(module_id);
-
-        if let Some(shutdown_sender) = shutdown_sender {
-            if shutdown_sender.send(()).is_err() {
-                warn!("Received message that a module stopped, but was unable to close the socket server");
-                Err(Error::from(ErrorKind::WorkloadManager))
-            } else {
-                Ok(())
-            }
-        } else {
-            Ok(())
-        }
-    }
-
-    fn remove(&mut self, module_id: &str) -> Result<(), Error> {
-        info!("Removing listener for module {}", module_id);
-
         // If the container is removed, also remove the socket file to limit the leaking of socket file
         let workload_uri = self.get_listener_uri(module_id)?;
 
@@ -316,13 +299,6 @@ where
         }
         ModuleAction::Stop(module_id) => {
             if let Err(err) = workload_manager.stop(&module_id) {
-                log_failure(Level::Warn, &err);
-            }
-
-            Ok(())
-        }
-        ModuleAction::Remove(module_id) => {
-            if let Err(err) = workload_manager.remove(&module_id) {
                 log_failure(Level::Warn, &err);
             }
 


### PR DESCRIPTION
In 1.1.5 we fixed an issue with windows build. Windows would not create container if the socket doesn't exist.
However, the socket was created in "start" which comes after "create" of containers, so 1.1.5 would not work properly on windows if socket didn't exist beforehand.

The fix was to move the socket creation in "create" stage, this however creates another issue.
The server for the workload API starts in the create stage and get stopped when the container is stopped.
However, when a container is stopped, it is still "created" so it can be restarted without going through the "create" stage.
So stopping a module would kill the workload API server and restarting it, would make it running again but would not start the workload server because it is created in "create".

In the 1.1.5 fix, this was tested: https://github.com/Azure/iotedge/commit/382cf778bf061cf02ca893a68584e63eb6c6c878

> Tried stopping a module and checked listener would be stopped.
> Tried removing a module with and without stopping the module first

Removing a module and restarting it (without removing it) was not tried. Hence the issue went through the net.

The workaround the issue is simple:
- restart iotedge (this will create back the server)
- kill the container so it goes through the create state
- put a dummy variable in portal.

Test:
Linux
Create a module "registry" and check it responds to curl --unix-socket /var/lib/iotedge/mnt/registry.sock http://hello 
stop a module "registry" and check it still respond to curl --unix-socket /var/lib/iotedge/mnt/registry.sock http://hello 
start a module "registry" and check it still respond to curl --unix-socket /var/lib/iotedge/mnt/registry.sock http://hello

Tested on both linux and windows (no curl on windows)
Killed a container and check it restarts correctly. Check in the logs that listener is created
Put a dummy variable in edge Agent to force a restart. 
Simple iotedge restart.
Start/Stop/start a container.


