### PR TITLE
Update README with instructions to run end-to-end tests on localmachine for release/1.1

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -2,91 +2,332 @@
 
 ## Test code structure
 
-There are three directories under `test/`:
+There are three directories under the `test/` directory:
 
 1. `test/Microsoft.Azure.Devices.Edge.Test/`: The actual tests live here, as do "fixtures" (setup and tear-down code that runs before/after/between tests) and the `Context` class (exposes the test arguments to tests).
-2. `test/Microsoft.Azure.Devices.Edge.Test.Common/`: The helper library tests use to do interesting things--like deploy modules or wait for a message to arrive in IoT Hub--lives here.
-3. `test/modules`: All test modules live here. The common pattern for an end-to-end test is to deploy some modules that run through a scenario (i.e., the thing you actually want to test, like sending messages between modules), then wait for them to report some result.
+2. `test/Microsoft.Azure.Devices.Edge.Test.Common/`: The helper library tests use to do interesting things--like deploy modules or wait for a message to arrive in IoT hub--lives here.
+3. `test/modules`: All custom modules used by the tests live here. The common pattern for an end-to-end test is to deploy some modules that run through a scenario (i.e., the thing you actually want to test, like sending messages between modules), then wait for them to report the results.
 
-## How to run the tests
+## One time setup
+*Note: The steps mentioned here have been run and validated on an ubuntu18.04/amd64 machine. If you are running a different os/arch, your steps may differ.*
 
-### Software Requirements
+## One time setup for your local machine
+To run the end-to-end tests, we will be building the required binaries from the code, build container images and push them to a local container registry. The tests will install the IoT Edge runtime from the binaries on your machine and run the containers using your local registry.
 
-End-to-end tests are written in .NET Core and run with the `dotnet test` command, so you need to [install .NET Core SDK](https://docs.microsoft.com/en-us/dotnet/core/install/sdk).
+##### Prerequisites
 
-The tests install the IoT Edge runtime _on the local host_, so your machine must support IoT Edge. Check out our installation docs ([Linux](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-windows), [Windows](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-linux)) to see what steps the test fixtures take to install IoT Edge, and to ensure your machine meets any prerequisites. **Note that on Linux, the fixtures do not install Moby engine**; you need to install Moby engine (or Docker) before you run the tests.
+It is important that your machine meets the requirements to run IoT Edge. See our installation docs ([Linux](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-linux), [Windows](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge-windows)) for more information on prerequisites
 
-### Test parameters
+##### Install java
+The build scripts use Java for code generation tasks, so you will need a jdk on your machine. Here is how you can install a jdk (if you don't already have one).
+~~~ sh
+ubuntu_release=`lsb_release -rs`
+wget https://packages.microsoft.com/config/ubuntu/${ubuntu_release}/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+sudo dpkg -i packages-microsoft-prod.deb
 
-The end-to-end tests take several parameters, which they expect to find in a file named `context.json` in the same directory as the test binaries (e.g., `test/Microsoft.Azure.Devices.Edge.Test/bin/Debug/netcoreapp2.1/context.json`). Parameter names are case-insensitive. The parameters are:
+sudo apt-get install apt-transport-https
+sudo apt-get update
+sudo apt-get install msopenjdk-11
+~~~
 
-| Name | Required | Description |
-|------|----------|-------------|
-| `caCertScriptPath` | * | Path to the folder containing `certGen.sh` (Linux) or `ca-certs.ps1` (Windows). Required when running the test 'TransparentGateway', ignored otherwise. |
-| `dpsIdScope` | * | The [ID Scope](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-device#id-scope) assigned to a Device Provisioning Service. Required when running any DPS tests, ignored otherwise. |
-| `edgeAgentImage` || Docker image to pull/use for Edge Agent. If not given, the default value `mcr.microsoft.com/azureiotedge-agent:1.0` is used. This setting only applies to any configurations deployed by the tests. Note also that the default value is ALWAYS used in config.yaml to start IoT Edge; this setting only applies to any configurations deployed by the tests. |
-| `edgeHubImage` || Docker image to pull/use for Edge Hub. If not given, `mcr.microsoft.com/azureiotedge-hub:1.0` is used. |
-| `installerPath` || Path to the Windows installer script `IotEdgeSecurityDaemon.ps1`. This parameter is ignored on Linux, and optional on Windows. If not given on Windows, the default script will be downloaded from https://aka.ms/iotedge-win to a temporary location. |
-| `logFile` || Path to which all test output will be written, including verbose output. This setting allows the user to capture all the details of a test pass while keeping the shell window output free of visual clutter. Note that daemon logs and module logs are always written to the same directory as the test binaries (e.g., `test/Microsoft.Azure.Devices.Edge.Test/bin/Debug/netcoreapp2.1/*.log`), independent of this parameter. |
-| `methodReceiverImage` | * | Docker image to pull/use for the 'DirectMethodReceiver' module. Required when running the test 'ModuleToModuleDirectMethod', ignored otherwise. |
-| `methodSenderImage` | * | Docker image to pull/use for the 'DirectMethodSender' module. Required when running the test 'ModuleToModuleDirectMethod', ignored otherwise. |
-| `optimizeForPerformance` || Boolean value passed to Edge Hub. Usually set to 'false' when running on more constrained platforms like Raspberry Pi. If not given, it defaults to 'true'. |
-| `packagePath` || Path to the folder containing IoT Edge installation packages (e.g., .deb files on Linux, .cab file on Windows). If not given, the latest stable release packages are downloaded and used. |
-| `proxy` || URL of an HTTPS proxy server to use for all communication to IoT Hub. |
-| `registries` || JSON array of container registries to be used by the tests. This information will be added to configurations deployed to the edge device under test. If not given, IoT Edge will attempt anonymous access to container registries. The format of each JSON object in the array is: `{ "address": "{server hostname}", "username": "{username}" }`. Note that each object must also have a value `"password": "{password}"`, but you are encouraged to use an environment variable to meet this requirement (see _Secret test parameters_ below). |
-| `rootCaCertificatePath` | * | Full path to a root certificate given to leaf test devices so they can verify the authenticity of Edge Hub during the TLS handshake. Required when running the test 'TransparentGateway', ignored otherwise. |
-| `rootCaPrivateKeyPath` | * | Full path to a file containing the private key associated with `rootCaCertificatePath`. Required when running the test 'TransparentGateway', ignored otherwise. |
-| `setupTimeoutMinutes` || The maximum amount of time, in minutes, test setup should take. This includes setup for all tests, for the tests in a fixture, or for a single test. If this time is exceeded, the associated test(s) will fail with a timeout error. If not given, the default value is `5`. |
-| `teardownTimeoutMinutes` || The maximum amount of time, in minutes, test teardown should take. This includes teardown for all tests, for the tests in a fixture, or for a single test. If this time is exceeded, the associated test(s) will fail with a timeout error. If not given, the default value is `2`. |
-| `testResultCoordinatorImage` | * | TestResultCoordinator image to be used. Required when running PriorityQueue tests, ignored otherwise.|
-| `networkControllerImage` | * | NetworkControllerImage image to be used. Required when running PriorityQueue tests, ignored otherwise.|
-| `loadGenImage` | * | LoadGen image to be used. Required when running PriorityQueue tests, ignored otherwise.|
-| `relayerImage` | * | Relayer image to be used. Required when running PriorityQueue tests, ignored otherwise.|
-| `tempFilterFuncImage` | * | Azure temperature filter function to be used. Required when running the test 'TempFilterFunc', ignored otherwise.|
-| `tempFilterImage` | * | Docker image to pull/use for the temperature filter module. Required when running the test 'TempFilter', ignored otherwise.|
-| `metricsCollectorImage` | * | Docker image to pull/use for the Metrics Collector module. Required when running the test 'MetricsCollector', ignored otherwise.|
-| `tempSensorImage` || Docker image to pull/use for the temperature sensor module (see the test 'TempSensor'). If not given, `mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0` is used.|
-| `edgeAgentBootstrapImage` || Docker image to pull/use for the initial startup of edgeAgent. It is the EdgeAgent image used in config.yaml. This is a temporary parameter - only here now because the 1.0 version is incompatible with the way this test framework verifies deployments in the master branch. If you want to specify your own, the container registry used is the first registry in the list of registries given by the 'registries' parameter|'
-| `numberLoggerImage` || Docker image to pull/use for the Edge agent direct method tests. Used to generate predictable logs. |
-| `testTimeoutMinutes` || The maximum amount of time, in minutes, a single test should take. If this time is exceeded, the associated test will fail with a timeout error. If not given, the default value is `5`. |
-| `hubResourceId` | * | Full path to Iot Hub that will receive the metrics messages in the following format - `/resource/subscriptions/<Azure subscription GUID>/resourceGroups/<resource group name>/providers/Microsoft.Devices/IotHubs/<Iot Hub name>`. Required when running the test 'MetricsCollector', ignored otherwise.|
-| `verbose` || Boolean value indicating whether to output more verbose logging information to standard output during a test run. If not given, the default is `false`. |
+The steps above are for ubuntu 18.04. See [Install the Microsoft Build of the OpenJDK](https://docs.microsoft.com/en-us/java/openjdk/install) for information on how to install on other platforms.
 
-### Test secrets
+##### Setup access to Microsoft installation packages
+Prepare your machine to access the Microsoft installation packages. The steps to do this are listed below for your convenience. *Again, please look at the section in the linked document for your os/arch combination if it is different from ubuntu18.04/amd64*
 
-The tests also expect to find several _secret_ parameters. While these can technically be added to `context.json`, it is recommended that you create environment variables and make them available to the test framework in a way that avoids committing them to your shell's command history or saving them in clear text on your filesystem. When set as environment variables, all secret parameters must be prefixed with `E2E_`. Parameter names are case-**in**sensitive; they're only shown in uppercase here to follow the common convention for environment variables, and to stand out as secrets.
+~~~sh
+# Setup the repository information
+curl https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list > ./microsoft-prod.list
 
-| Name | Required | Description |
-|------|----------|-------------|
-| `[E2E_]DPS_GROUP_KEY` | * | The symmetric key of the DPS [enrollment group](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-service#enrollment-group) to use. Required when running any DPS tests, ignored otherwise. |
-| `[E2E_]IOT_HUB_CONNECTION_STRING` | ✔ | Hub-scoped IoT Hub connection string that can be used to get/add/remove devices, deploy edge configurations, and get/update module twins. |
-| `[E2E_]EVENT_HUB_ENDPOINT` | ✔ | Connection string used to connect to the Event Hub-compatible endpoint of your IoT Hub, to listen for D2C events sent by devices or modules. |
-| `[E2E_]REGISTRIES__{n}__PASSWORD` || Password associated with a container registry entry in the `registries` array of `context.json`. `{n}` is the number corresponding to the (zero-based) array entry. For example, if you specified a single container registry in the `registries` array, the corresponding parameter would be `[E2E_]REGISTRIES__0__PASSWORD`. |
-| `[E2E_]ROOT_CA_PASSWORD` || The password associated with the root certificate specified in `rootCaCertificatePath`. |
-| `[E2E_]BLOB_STORE_SAS` || The sas token used to upload module logs and support bundle in the tests. |
+# Setup the Microsoft GPG pulic key in the apt's trusted list.
+sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/
+curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
 
-_Note: the definitive source for information about test parameters is `test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs`._
+# Run update to update the package lists on your machine
+sudo apt-get update
+~~~
 
-### Running the tests
+##### Create Root CA Certificate for your machine
+Create a Root CA certificate for your machine *(See [Create Certs](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-create-test-certificates?view=iotedge-2020-11#create-root-ca-certificate) for more details)*. Navigate to the directory where the certificate generation scripts are found (typically iotedge/tools/CACertificates) and run
+~~~ sh
+./certGen.sh create_root_and_intermediate
+# This will create root and intermediate CA certs. The Root CA cert will be located in the 
+# certs sub directory and will be needed to run the tests.
+~~~
 
-With the test parameters and secrets in place, you can run all the end-to-end tests from the command line
+##### Configure your local container registry
+We will be building the container images from the codebase and pushing them to a local container registry. To prepare, we will install the moby engine and configure the container registry using the steps below. 
 
-_In Windows Command Prompt (Admin),_
+###### Install moby engine
+See [Install a container engine](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-install-iot-edge?view=iotedge-2020-11#install-a-container-engine) for details
 
-```cmd
-cd {repo root}
-dotnet test test/Microsoft.Azure.Devices.Edge.Test
-```
-_For Linux,_
+~~~ sh
+sudo apt-get install moby-engine
+~~~
+###### Create TLS certificates
+We will be running the container registry with TLS and authentication turned on. If you already have certs for TLS, feel free to use those and skip the cert creation steps listed below. 
+In a convenient directory, create a folder called `auth` to store your keys and certs (*I have used /home/azureuser/auth*)
+~~~sh
+mkdir auth
+cd auth
+# Create a private key
+openssl genrsa -out server.key  2048
+# Create a csr
+openssl req -new -key server.key -out server.csr
+# Create a cert from the csr
+openssl x509 -req -days 365 -in server.csr -signkey server.key -out server.crt
+
+# At the end of these steps, you have 3 files in your auth directory - server.key (the  
+# key), server.csr (the certificate signing request) and, server.crt (the certificate)
+~~~
+
+###### Setup native basic auth
+Next, we will setup basic username/password authentication for the registry using [htpasswd](http://httpd.apache.org/docs/current/programs/htpasswd.html).
+~~~ sh
+sudo apt-get install apache2-utils
+# Create password file
+: | sudo tee htpasswd
+# Create username and password. Replace the username and password strings 
+# below with a user/password combo that you like
+echo "password" | sudo htpasswd -iB htpasswd username
+~~~
+
+###### Configure and run the local container registry
+~~~ sh
+# Set up the container registry to listen on port 5000 and to restart automatically.
+# Mount the auth folder into the container and point to the TLS and Basic auth files
+# Restart is set to always - This will ensure that the registry is always up.
+sudo docker run -d  -p 5000:5000 \
+  --name registry  \
+  -v /home/azureuser/auth/:/etc/security \
+  -e REGISTRY_HTTP_TLS_CERTIFICATE=/etc/security/server.crt  \
+  -e REGISTRY_HTTP_TLS_KEY=/etc/security/server.key \
+  -e REGISTRY_AUTH=htpasswd   \
+  -e REGISTRY_AUTH_HTPASSWD_PATH=/etc/security/htpasswd   \
+  -e REGISTRY_AUTH_HTPASSWD_REALM="Registry Realm"  \
+  --restart always  \
+  registry:2
+
+# Run docker ps to validate that the registry came up successfully
+# If all goes well, you will see the something like below when you run docker ps.
+# 59867fe47a5b   registry:2   "/entrypoint.sh /etc…"   6 seconds ago   Up 6 seconds   0.0.0.0:5000->5000/tcp, :::5000->5000/tcp   registry
+sudo docker ps
+
+# Run docker login to validate your setup and verify that your login/password works. 
+# The login step will cache your credentials on your machine and will be required later 
+# when you build and push docker images
+
+sudo docker login localhost:5000
+~~~
+
+##### Install .NET
+The end-to-end tests are written in .NET Core and run with the `dotnet test` command, and you need to install .NET Core SDK. See [Install the .NET SDK](https://docs.microsoft.com/en-us/dotnet/core/install/sdk) for further information. *Note: You will have to install .NET version 3.1.*
+
+Here is a convenient way to install the SDK.
+~~~ sh
+curl -sL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+chmod u+x dotnet-install.sh
+./dotnet-install.sh -c Current
+~~~
+
+## One time cloud resources setup for the tests
+The end-to-end tests require a number of azure cloud side resources i.e., IoTHub, Device Provisioning Service, and a Storage Container to be setup. This next section will walk you through how to setup the cloud resources.
+
+##### Create a resource group
+If you don't already have a resource group, create one.
+Here is how you can create one using the CLI
+~~~ sh
+az group create --name {resource group name} --location {region}
+~~~
+
+##### IoT Hub
+If you don't already have an existing IoT hub, create one. There is no special configuration required, except for making sure that your IoTHub is enabled for public access.
+Here is how you can create one using the CLI
+
+~~~sh
+# Create a free tier Iot hub
+az iot hub create --resource-group {resource group name} --name {IoT hub name} --sku F1 --partition-count 2
+~~~
+
+Note down the `event hub compatible endpoint` and the primary connection string of the `iothubowner` policy. These will need to be set in the `E2E_EVENT_HUB_ENDPOINT` and `E2E_IOT_HUB_CONNECTION_STRING` environment variables later to run the tests.
+
+You can get these via the CLI by running 
+~~~sh
+# Primary Connection string
+az iot hub connection-string show --hub-name {IoT hub name} --key-type primary
+
+#Default eventhub compatible end point
+az iot hub connection-string show --hub-name {IoT hub name} --default-eventhub
+
+~~~
+##### Device Provisioning Service (DPS)
+Create a DPS instance. A subset of the end-to-end tests will use DPS for testing device provisioning scenarios. Note down the `ID Scope` of this DPS instance. You will need to set it in the `dpsIdScope` configuration variable later to run the tests.
+
+Using the CLI,
+~~~sh
+az iot dps create --name {dps group name} --resource-group {resource group name} --location {region}
+~~~
+
+###### Create enrollment group for symmetric key based enrollment
+In your DPS instance, create a new enrollment group for symmetric key based enrollment. For this enrollment group, set the attestation type to be symmetric key, set the IoTEdge Device setting to true, and link the group to your IoThub with the access policy of `iotHubOwner`. 
+
+Using the CLI,
+~~~sh
+#Link the DPS group to your Iot hub
+az iot dps linked-hub create --dps-name {dps group name} --resource-group {resource group name} \
+  --connection-string "{Iothub ConnectionString}" --location westus2
+
+#Create enrollment group for symmetric key based enrollment
+ az iot dps enrollment-group create -g {resource group name} --dps-name {dps group name} \
+  --enrollment-id {symkey enrollment group name } --edge-enabled
+~~~
+You do not have to create the symmetric key. The system will auto generate it for you when the enrollment group is created. After the enrollment group is created, note down the Primary Key. You will need to set this in the `E2E_DPS_GROUP_KEY` environment variable later to run the tests.
+
+See [Symmetric key attestation](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-auto-provision-symmetric-keys?view=iotedge-2020-11&tabs=windows) for further details.
+
+###### Create enrollment group for X.509 certificate based enrollment
+In your DPS instance, create another enrollment group for X.509 certificate based enrollment. For this enrollment group, set the attestation type to be certificate and upload the root CA certificate that you had created earlier, set the IoTEdge Device setting to true, and link the group to your IotHub with the access policy of `iotHubOwner`.
+
+~~~sh
+# Upload the root ca cert and set it to be verified
+az iot dps certificate create --certificate-name {dps root ca name}  --resource-group {resource group name} \
+  --dps-name {dps group name} --path {path to ca cert .pem file}  --verified true
+
+# Create enrollment group for X.509 based enrollment
+az iot dps enrollment-group create -g {resource group name} --dps-name {dps group name} \
+  --enrollment-id {cert enrollment group name} --ca-name {dps root ca name} --edge-enabled
+~~~
+See [X.509 certificate attestation](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-auto-provision-x509-certs?view=iotedge-2020-11&tabs=windows) for further details.
+
+##### Create a storage account/container
+Create a storage account and storage container, with access level set to private. A subset of the tests will use the storage container to test log/diagnostics upload scenarios. To securely acesss the storage container, create a SAS token URL ( allow https only, permissions set to "write" only). Note down this URL as you will need it to set the `E2E_BLOB_STORE_SAS` environment variable later to run the tests.
+~~~ sh
+# Create storage account
+az storage account create --name {storage account name} --resource-group {resource group name } \
+  --location {region} --sku Standard_RAGRS --kind StorageV2
+
+# Get the connection string from the Storage account. This will be needed to create the storage container
+az storage account show-connection-string --name {storage account name} \
+  --resource-group {resource group name} -o tsv
+
+# Create the storage container
+ az storage container create --name {container name} --resource-group {resource group name} \
+   --account-name {storage account name} --connection-string "{connection string}"
+
+# TODO: Currently, the SAS URL has to created using the Azure portal. Add instructions
+# here to do it using the CLI
+~~~
+
+## Build
+#### Building the binaries
+From the top folder of the codebase ( i.e., the iotedge folder), run the following(*Note: Some of these steps will require to be run as sudo*)
+~~~ sh
+./scripts/linux/buildBranch.sh
+
+# setup environment variables
+export PACKAGE_OS="ubuntu18.04"
+export PACKAGE_ARCH="amd64"
+
+# update sub modules [DOUBLE CHECK THIS]
+git submodule update --init --recursive
+
+# Create the installable packages. It will typically be located
+# in the ./edgelet/target/release/ and the ./edgelet/target/hsm/ folders 
+# and named something like aziot-edge*amd64.deb and libiothsm-std*.deb 
+
+./edgelet/build/linux/package.sh
+
+# copy the libiothsm*.deb file into the edgelet release directory, so that the
+# tests can pickup both deb files from the same folder.
+cp edgelet/target/hsm/libiothsm*.deb edgelet/target/release
+
+~~~
+
+#### Building the container images and pushing them to the local container registry
+From the top folder of the codebase, run the following. 
+~~~ sh
+
+# Build and push images to local container registry
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "edge-hub" -P "Microsoft.Azure.Devices.Edge.Hub.Service"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "edge-agent" -P "Microsoft.Azure.Devices.Edge.Agent.Service"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "load-gen" -P "load-gen"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "direct-method-sender" -P "DirectMethodSender"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "direct-method-receiver" -P "DirectMethodReceiver"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "network-controller" -P "NetworkController"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "relayer" -P "Relayer"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "temperature-filter" -P "TemperatureFilter"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "simulated-temperature-sensor" -P "SimulatedTemperatureSensor"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "test-result-coordinator" -P "TestResultCoordinator"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "number-logger" -P "NumberLogger"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "diagnostics" -P "IotedgeDiagnosticsDotnet"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "metrics-collector" -P "MetricsCollector"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "metrics-validator" -P "MetricsValidator"  -v "latest" --bin-dir target
+sudo scripts/linux/buildImage.sh -r localhost:5000  -i "temperature-filter-function" -P "EdgeHubTriggerCSharp"  -v "latest" --bin-dir target
+
+~~~
+
+## Test
+
+#### Test parameters
+
+The end-to-end tests take several parameters, which they expect to find in a file named `context.json` in the same directory as the test binaries (e.g., `test/Microsoft.Azure.Devices.Edge.Test/bin/Debug/netcoreapp3.1/context.json`). Parameter names are case-insensitive. See [end-to-end test parameters](./doc/end-to-end-test-config.md) for details. 
+
+#### Sample context.json
+~~~ json
+{
+    "packagePath": "/home/azureuser/iotedge/edgelet/target/release/",
+    "edgeAgentImage": "localhost:5000/microsoft/edge-agent:latest-linux-amd64",
+    "edgeHubImage": "localhost:5000/microsoft/edge-hub:latest-linux-amd64",
+    "loadGenImage": "localhost:5000/microsoft/load-gen:latest-linux-amd64",
+    "methodSenderImage": "localhost:5000/microsoft/direct-method-sender:latest-linux-amd64",
+    "methodReceiverImage": "localhost:5000/microsoft/direct-method-receiver:latest-linux-amd64",
+    "networkControllerImage": "localhost:5000/microsoft/network-controller:latest-linux-amd64",
+    "relayerImage": "localhost:5000/microsoft/relayer:latest-linux-amd64",
+    "tempFilterFuncImage": "localhost:5000/microsoft/temperature-filter-function:latest-linux-amd64",
+    "tempFilterImage": "localhost:5000/microsoft/temperature-filter:latest-linux-amd64",
+    "tempSensorImage": "localhost:5000/microsoft/simulated-temperature-sensor:latest-linux-amd64",
+    "testResultCoordinatorImage": "localhost:5000/microsoft/test-result-coordinator:latest-linux-amd64",
+    "numberLoggerImage": "localhost:5000/microsoft/number-logger:latest-linux-amd64",
+    "diagnosticsImage": "localhost:5000/microsoft/diagnostics:latest-linux-amd64",
+    "metricsCollectorImage": "localhost:5000/microsoft/metrics-collector:latest-linux-amd64",
+    "metricsValidatorImage": "localhost:5000/microsoft/metrics-validator:latest-linux-amd64",
+    "caCertScriptPath": "/home/azureuser/iotedge/test/certs",
+    "dpsIdScope": "0ne01F35169",
+    "rootCaCertificatePath": "/home/azureuser/iotedge/test/certs/certs/azure-iot-test-only.root.ca.cert.pem",
+    "rootCaPrivateKeyPath": "/home/azureuser/iotedge/test/certs/private/azure-iot-test-only.root.ca.key.pem",
+    "verbose": "true",
+    "logFile": "/home/azureuser/iotedge/logs/logfile",
+    "registries":
+    [    
+        {
+            "address": "localhost:5000",
+            "username": "username"
+        }
+    ]
+}
+~~~
+
+#### Test secrets
+
+The tests also expect to find several _secret_ parameters. It is recommended that you create environment variables and make them available to the test framework in a way that avoids committing them to your shell's command history or saving them in clear text on your filesystem.
+
+See [environment variables](./doc/end-to-end-test-config.md#environment-variables) for details.
+
+#### Run the tests
+
+With the test parameters and secrets in place, you can run all the end-to-end tests from the command line. From the top folder of the codebase,
+
 ```bash
-cd {repo root}
-sudo --preserve-env dotnet test ./test/Microsoft.Azure.Devices.Edge.Test
+cd test
+sudo --preserve-env dotnet test ./Microsoft.Azure.Devices.Edge.Test \
+     --filter "TestCategory=EndToEnd&TestCategory!=NestedEdgeOnly"
 ```
 
-To learn about other ways to run the tests (e.g., to run only certain tests), see
+To learn about other ways to run the tests (e.g., to run only certain tests), see 
 [Running selective unit tests](https://docs.microsoft.com/en-us/dotnet/core/testing/selective-unit-tests#nunit)
 
-### Troubleshooting
+#### Troubleshooting
 
 #### File handle limit in VS Code
 

--- a/test/README.md
+++ b/test/README.md
@@ -67,7 +67,7 @@ sudo apt-get install moby-engine
 ~~~
 ###### Create TLS certificates
 We will be running the container registry with TLS and authentication turned on. If you already have certs for TLS, feel free to use those and skip the cert creation steps listed below. 
-In a convenient directory, create a folder called `auth` to store your keys and certs (*I have used /home/azureuser/auth*)
+In a convenient directory, create a folder called `auth` to store your keys and certs (*The snippets below use /home/azureuser/auth*)
 ~~~sh
 mkdir auth
 cd auth
@@ -147,7 +147,7 @@ Here is how you can create one using the CLI
 
 ~~~sh
 # Create a free tier Iot hub
-az iot hub create --resource-group {resource group name} --name {IoT hub name} --sku F1 --partition-count 2
+az iot hub create --resource-group {resource group name} --name {IoT hub name} 
 ~~~
 
 Note down the `event hub compatible endpoint` and the primary connection string of the `iothubowner` policy. These will need to be set in the `E2E_EVENT_HUB_ENDPOINT` and `E2E_IOT_HUB_CONNECTION_STRING` environment variables later to run the tests.
@@ -239,7 +239,7 @@ git submodule update --init --recursive
 ./edgelet/build/linux/package.sh
 
 # copy the libiothsm*.deb file into the edgelet release directory, so that the
-# tests can pickup both deb files from the same folder.
+# tests can pickup both .deb files from the same folder.
 cp edgelet/target/hsm/libiothsm*.deb edgelet/target/release
 
 ~~~

--- a/test/doc/end-to-end-test-config.md
+++ b/test/doc/end-to-end-test-config.md
@@ -31,7 +31,6 @@ _Note: A ✔ in the required column indicates that it is required for all the te
 | `edgeAgentBootstrapImage` || Docker image to pull/use for the initial startup of edgeAgent. It is the EdgeAgent image used in config.yaml. This is a temporary parameter - only here now because the 1.0 version is incompatible with the way this test framework verifies deployments in the master branch. If you want to specify your own, the container registry used is the first registry in the list of registries given by the 'registries' parameter|'
 | `numberLoggerImage` || Docker image to pull/use for the Edge agent direct method tests. Used to generate predictable logs. |
 | `testTimeoutMinutes` || The maximum amount of time, in minutes, a single test should take. If this time is exceeded, the associated test will fail with a timeout error. If not given, the default value is `5`. |
-| `hubResourceId` | * | Full path to Iot Hub that will receive the metrics messages in the following format - `/resource/subscriptions/<Azure subscription GUID>/resourceGroups/<resource group name>/providers/Microsoft.Devices/IotHubs/<Iot Hub name>`. Required when running the test 'MetricsCollector', ignored otherwise.|
 | `verbose` || Boolean value indicating whether to output more verbose logging information to standard output during a test run. If not given, the default is `false`. |
 
 # [Environment Variables](#environment-variables)
@@ -44,5 +43,6 @@ _Note: A ✔ in the required column indicates that it is required for all the te
 | `E2E_REGISTRIES__{n}__PASSWORD` || Password associated with a container registry entry in the `registries` array of `context.json`. `{n}` is the number corresponding to the (zero-based) array entry. For example, if you specified a single container registry in the `registries` array, the corresponding parameter would be `E2E_REGISTRIES__0__PASSWORD`. |
 | `E2E_ROOT_CA_PASSWORD` || The password associated with the root certificate specified in `rootCaCertificatePath`. |
 | `E2E_BLOB_STORE_SAS` || The sas token used to upload module logs and support bundle in the tests. |
+| `E2E_IOT_HUB_RESOURCE_ID` || Full path to Iot hub that will receive the metrics messages in the following format - `/resource/subscriptions/<Azure subscription GUID>/resourceGroups/<resource group name>/providers/Microsoft.Devices/IotHubs/<Iot Hub name>`. Required when running the test 'MetricsCollector', ignored otherwise.|
 
 _Note: the definitive source for information about test parameters is `test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs`._

--- a/test/doc/end-to-end-test-config.md
+++ b/test/doc/end-to-end-test-config.md
@@ -1,0 +1,48 @@
+# End to End Test Parameters
+
+_Note: A ✔ in the required column indicates that it is required for all the tests, where as * indicates that the attribute is only required for a subset of the tests_ 
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `caCertScriptPath` | * | Path to the folder containing `certGen.sh` (Linux) or `ca-certs.ps1` (Windows). Required when running the test 'TransparentGateway', ignored otherwise. |
+| `dpsIdScope` | * | The [ID Scope](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-device#id-scope) assigned to a Device Provisioning Service. Required when running any DPS tests, ignored otherwise. |
+| `edgeAgentImage` || Docker image to pull/use for Edge Agent. If not given, the default value `mcr.microsoft.com/azureiotedge-agent:1.0` is used. This setting only applies to any configurations deployed by the tests. Note also that the default value is ALWAYS used in config.yaml to start IoT Edge; this setting only applies to any configurations deployed by the tests. |
+| `edgeHubImage` || Docker image to pull/use for Edge Hub. If not given, `mcr.microsoft.com/azureiotedge-hub:1.0` is used. |
+| `installerPath` || Path to the Windows installer script `IotEdgeSecurityDaemon.ps1`. This parameter is ignored on Linux, and optional on Windows. If not given on Windows, the default script will be downloaded from https://aka.ms/iotedge-win to a temporary location. |
+| `logFile` || Path to which all test output will be written, including verbose output. This setting allows the user to capture all the details of a test pass while keeping the shell window output free of visual clutter. Note that daemon logs and module logs are always written to the same directory as the test binaries (e.g., `test/Microsoft.Azure.Devices.Edge.Test/bin/Debug/netcoreapp2.1/*.log`), independent of this parameter. |
+| `methodReceiverImage` | * | Docker image to pull/use for the 'DirectMethodReceiver' module. Required when running the test 'ModuleToModuleDirectMethod', ignored otherwise. |
+| `methodSenderImage` | * | Docker image to pull/use for the 'DirectMethodSender' module. Required when running the test 'ModuleToModuleDirectMethod', ignored otherwise. |
+| `optimizeForPerformance` || Boolean value passed to Edge Hub. Usually set to 'false' when running on more constrained platforms like Raspberry Pi. If not given, it defaults to 'true'. |
+| `packagePath` || Path to the folder containing IoT Edge installation packages (e.g., .deb files on Linux, .cab file on Windows). If not given, the latest stable release packages are downloaded and used. |
+| `proxy` || URL of an HTTPS proxy server to use for all communication to IoT Hub. |
+| `registries` || JSON array of container registries to be used by the tests. This information will be added to configurations deployed to the edge device under test. If not given, IoT Edge will attempt anonymous access to container registries. The format of each JSON object in the array is: `{ "address": "{server hostname}", "username": "{username}" }`. Note that each object must also have a value `"password": "{password}"`, but you are encouraged to use an environment variable to meet this requirement (see _Secret test parameters_ below). |
+| `rootCaCertificatePath` | * | Full path to a root certificate given to leaf test devices so they can verify the authenticity of Edge Hub during the TLS handshake. Required when running the test 'TransparentGateway', ignored otherwise. |
+| `rootCaPrivateKeyPath` | * | Full path to a file containing the private key associated with `rootCaCertificatePath`. Required when running the test 'TransparentGateway', ignored otherwise. |
+| `setupTimeoutMinutes` || The maximum amount of time, in minutes, test setup should take. This includes setup for all tests, for the tests in a fixture, or for a single test. If this time is exceeded, the associated test(s) will fail with a timeout error. If not given, the default value is `5`. |
+| `teardownTimeoutMinutes` || The maximum amount of time, in minutes, test teardown should take. This includes teardown for all tests, for the tests in a fixture, or for a single test. If this time is exceeded, the associated test(s) will fail with a timeout error. If not given, the default value is `2`. |
+| `testResultCoordinatorImage` | * | TestResultCoordinator image to be used. Required when running PriorityQueue tests, ignored otherwise.|
+| `networkControllerImage` | * | NetworkControllerImage image to be used. Required when running PriorityQueue tests, ignored otherwise.|
+| `loadGenImage` | * | LoadGen image to be used. Required when running PriorityQueue tests, ignored otherwise.|
+| `relayerImage` | * | Relayer image to be used. Required when running PriorityQueue tests, ignored otherwise.|
+| `tempFilterFuncImage` | * | Azure temperature filter function to be used. Required when running the test 'TempFilterFunc', ignored otherwise.|
+| `tempFilterImage` | * | Docker image to pull/use for the temperature filter module. Required when running the test 'TempFilter', ignored otherwise.|
+| `metricsCollectorImage` | * | Docker image to pull/use for the Metrics Collector module. Required when running the test 'MetricsCollector', ignored otherwise.|
+| `tempSensorImage` || Docker image to pull/use for the temperature sensor module (see the test 'TempSensor'). If not given, `mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0` is used.|
+| `edgeAgentBootstrapImage` || Docker image to pull/use for the initial startup of edgeAgent. It is the EdgeAgent image used in config.yaml. This is a temporary parameter - only here now because the 1.0 version is incompatible with the way this test framework verifies deployments in the master branch. If you want to specify your own, the container registry used is the first registry in the list of registries given by the 'registries' parameter|'
+| `numberLoggerImage` || Docker image to pull/use for the Edge agent direct method tests. Used to generate predictable logs. |
+| `testTimeoutMinutes` || The maximum amount of time, in minutes, a single test should take. If this time is exceeded, the associated test will fail with a timeout error. If not given, the default value is `5`. |
+| `hubResourceId` | * | Full path to Iot Hub that will receive the metrics messages in the following format - `/resource/subscriptions/<Azure subscription GUID>/resourceGroups/<resource group name>/providers/Microsoft.Devices/IotHubs/<Iot Hub name>`. Required when running the test 'MetricsCollector', ignored otherwise.|
+| `verbose` || Boolean value indicating whether to output more verbose logging information to standard output during a test run. If not given, the default is `false`. |
+
+# [Environment Variables](#environment-variables)
+
+| Name | Required | Description |
+|------|----------|-------------|
+| `E2E_DPS_GROUP_KEY` | * | The symmetric key of the DPS [enrollment group](https://docs.microsoft.com/en-us/azure/iot-dps/concepts-service#enrollment-group) to use. Required when running any DPS tests, ignored otherwise. |
+| `E2E_IOT_HUB_CONNECTION_STRING` | ✔ | Hub-scoped IoT Hub connection string that can be used to get/add/remove devices, deploy edge configurations, and get/update module twins. |
+| `E2E_EVENT_HUB_ENDPOINT` | ✔ | Connection string used to connect to the Event Hub-compatible endpoint of your IoT Hub, to listen for D2C events sent by devices or modules. |
+| `E2E_REGISTRIES__{n}__PASSWORD` || Password associated with a container registry entry in the `registries` array of `context.json`. `{n}` is the number corresponding to the (zero-based) array entry. For example, if you specified a single container registry in the `registries` array, the corresponding parameter would be `E2E_REGISTRIES__0__PASSWORD`. |
+| `E2E_ROOT_CA_PASSWORD` || The password associated with the root certificate specified in `rootCaCertificatePath`. |
+| `E2E_BLOB_STORE_SAS` || The sas token used to upload module logs and support bundle in the tests. |
+
+_Note: the definitive source for information about test parameters is `test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs`._


### PR DESCRIPTION
The steps to setup the local machine and the cloud side resources are the same as detailed out in the PR for 1.1.
There are changes in how the code is built, what container images are needed, context.json and environment settings.