### PR TITLE
CI / E2E: Disable flaky tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
         [Test]
         [Category("CentOsSafe")]
+        [Category("Flaky")]
         public async Task TempFilter()
         {
             const string filterName = "tempFilter";

--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string LoadGenModuleName = "loadGenModule";
 
         [Test]
+        [Category("Flaky")]
         public async Task DeviceClient()
         {
             CancellationToken token = this.TestToken;
@@ -68,6 +69,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         }
 
         [Test]
+        [Category("Flaky")]
         public async Task ModuleClient()
         {
             CancellationToken token = this.TestToken;


### PR DESCRIPTION
Disabling these flaky tests in CI / E2E. They cannot be failing due to a product bug as the commit they fail for is behind a commit where all the tests pass.