### PR TITLE
Added connection-check for direct method test

### DIFF
--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeToDeviceMethodTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/EdgeToDeviceMethodTest.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             this.logger.Dispose();
         }
 
-        [Theory(Skip = "Flaky")]
+        [Theory]
         [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
         public async Task InvokeMethodOnModuleTest(ITransportSettings[] transportSettings)
         {
@@ -65,6 +65,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 receiver = ModuleClient.CreateFromConnectionString(receiverModuleConnectionString, transportSettings);
                 await receiver.OpenAsync();
                 await receiver.SetMethodHandlerAsync("poke", MethodHandler, null);
+
+                var waitStart = DateTime.Now;
+                var isConnected = false;
+
+                while (!isConnected && (DateTime.Now - waitStart) < TimeSpan.FromSeconds(30))
+                {
+                    var connectedDevice = await rm.GetModuleAsync(edgeDeviceId, receiverModuleName);
+                    isConnected = connectedDevice.ConnectionState == DeviceConnectionState.Connected;
+                }
+
+                Assert.True(isConnected);
 
                 // Need longer sleep to ensure receiver is completely initialized
                 await Task.Delay(TimeSpan.FromSeconds(10));
@@ -146,6 +157,17 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
                 receiver = DeviceClient.CreateFromConnectionString(receiverModuleConnectionString, transportSettings);
                 await receiver.OpenAsync();
                 await receiver.SetMethodHandlerAsync("poke", MethodHandler, null);
+
+                var waitStart = DateTime.Now;
+                var isConnected = false;
+
+                while (!isConnected && (DateTime.Now - waitStart) < TimeSpan.FromSeconds(30))
+                {
+                    var connectedDevice = await rm.GetDeviceAsync(deviceId);
+                    isConnected = connectedDevice.ConnectionState == DeviceConnectionState.Connected;
+                }
+
+                Assert.True(isConnected);
 
                 // Need longer sleep to ensure receiver is completely initialized
                 await Task.Delay(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
these tests sometimes did not see the device/module, probably because the fix-timed delay was not always enough