### PR TITLE
Default to release/1.1 branch for conn test pipeline resources

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -9,10 +9,10 @@ resources:
   pipelines:
   - pipeline: images
     source: 'Azure-IoT-Edge-Core Build Images'
-    branch: 'master'
+    branch: 'release/1.1'
   - pipeline: packages
     source: 'Azure-IoT-Edge-Core Edgelet Packages'
-    branch: 'master'
+    branch: 'release/1.1'
 
 jobs:
 ################################################################################


### PR DESCRIPTION
Manually triggered connectivity test pipeline runs on release/1.1 are defaulting to artifacts from the master branch for Build Images and Edgelet Packages. This is a mistake and they should be using artifacts from release/1.1 by default.