### PR TITLE
Connectivity Tests: Don't allow duplicates

### DIFF
--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/DirectMethodReportDataWithSenderAndReceiverSource.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/DirectMethodReportDataWithSenderAndReceiverSource.cs
@@ -217,26 +217,7 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
                     },
                     10, 6, 0, 0, 0, 0, 0, 1, 0, true,
                     NetworkControllerType.Satellite
-                },
-                new object[]
-                {
-                    // Duplicate receiver result test
-                    Enumerable.Range(1, 7).Select(v => (ulong)v),
-                    new[] { 1UL, 2UL, 3UL, 3UL, 4UL, 5UL, 6UL, 7UL },
-                    new List<HttpStatusCode> { HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK, HttpStatusCode.OK },
-                    new DateTime[]
-                    {
-                        new DateTime(2020, 1, 1, 9, 10, 12, 10),
-                        new DateTime(2020, 1, 1, 9, 10, 13, 10),
-                        new DateTime(2020, 1, 1, 9, 10, 21, 10),
-                        new DateTime(2020, 1, 1, 9, 10, 21, 10),
-                        new DateTime(2020, 1, 1, 9, 10, 22, 10),
-                        new DateTime(2020, 1, 1, 9, 10, 23, 10),
-                        new DateTime(2020, 1, 1, 9, 10, 24, 10),
-                        new DateTime(2020, 1, 1, 9, 10, 24, 15)
-                    },
-                    10, 7, 0, 0, 0, 0, 0, 0, 0, true
-                },
+                }
             };
     }
 }

--- a/test/modules/TestResultCoordinator/Reports/DirectMethod/DirectMethodReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/Reports/DirectMethod/DirectMethodReportGenerator.cs
@@ -156,24 +156,11 @@ namespace TestResultCoordinator.Reports.DirectMethod
                     $"{dmSenderTestResult.GetFormattedResult()}. ReceiverTestResult: {dmReceiverTestResult.GetFormattedResult()}");
             }
 
-            bool didFindMatch = false;
             if (dmSenderTestResult.SequenceNumber == dmReceiverTestResult.SequenceNumber)
             {
-                dmReceiverTestResult = JsonConvert.DeserializeObject<DirectMethodTestResult>(receiverTestResults.Current.Result);
-                didFindMatch = true;
-
-                ulong receiverSequenceNumber = dmReceiverTestResult.SequenceNumber;
-                while (hasReceiverResult && dmSenderTestResult.SequenceNumber == receiverSequenceNumber)
-                {
-                    hasReceiverResult = await receiverTestResults.MoveNextAsync();
-                    if (hasReceiverResult)
-                    {
-                        receiverSequenceNumber = JsonConvert.DeserializeObject<DirectMethodTestResult>(receiverTestResults.Current.Result).SequenceNumber;
-                    }
-                }
+                hasReceiverResult = await receiverTestResults.MoveNextAsync();
             }
-
-            if (!didFindMatch)
+            else
             {
                 if (dmSenderTestResult.SequenceNumber > dmReceiverTestResult.SequenceNumber)
                 {


### PR DESCRIPTION
In the earlier PR #5542, we started allowing duplicate results in connectivity. This was initially done to get around issues from the report becoming unreadable when the duplicates happen. But this case only happens in nested so we don't need this change in 1.1 branch.