### PR TITLE
E2E: Avoid flakiness in custom mqtt tests (#5467)

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/GenericMqtt.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string NetworkControllerModuleName = "networkController";
         const string GenericMqttInitiatorModuleName = "GenericMqttInitiator";
         const string GenericMqttRelayerModuleName = "GenericMqttRelayer";
-        const string GenericMqttTesterMaxMessages = "5";
+        const int GenericMqttTesterMaxMessages = 5;
         const string GenericMqttTesterTestStartDelay = "10s";
-        const int SecondsBeforeVerification = 45;
+        const int VerificationTolerance = 90;
 
         /// <summary>
         /// Scenario:
@@ -52,9 +52,26 @@ namespace Microsoft.Azure.Devices.Edge.Test
             Action<EdgeConfigBuilder> config = addMqttBrokerConfig + addNetworkControllerConfig + addTestResultCoordinatorConfig + addGenericMqttTesterConfig;
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(config, token, Context.Current.NestedEdge);
 
-            await Task.Delay(TimeSpan.FromSeconds(SecondsBeforeVerification));
+            await ValidateScenarioAsync(TimeSpan.FromSeconds(VerificationTolerance), GenericMqttTesterMaxMessages);
+        }
 
-            await TestResultCoordinatorUtil.ValidateResultsAsync();
+        static async Task ValidateScenarioAsync(TimeSpan verificationTolerance, int numResultsExpected)
+        {
+            DateTime end = DateTime.UtcNow + verificationTolerance;
+
+            bool scenarioPassed = false;
+            while (DateTime.UtcNow < end)
+            {
+                await Task.Delay(TimeSpan.FromSeconds(5));
+
+                if (await TestResultCoordinatorUtil.IsCountingReportResultValidAsync(numResultsExpected))
+                {
+                    scenarioPassed = true;
+                    break;
+                }
+            }
+
+            Assert.True(scenarioPassed);
         }
 
         private Action<EdgeConfigBuilder> BuildAddGenericMqttTesterConfig(string trackingId, string trcImage, string genericMqttTesterImage)
@@ -68,7 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                             ("TEST_SCENARIO", "InitiateAndReceiveRelayed"),
                             ("TRACKING_ID", trackingId),
                             ("TEST_START_DELAY", GenericMqttTesterTestStartDelay),
-                            ("MESSAGES_TO_SEND", GenericMqttTesterMaxMessages),
+                            ("MESSAGES_TO_SEND", GenericMqttTesterMaxMessages.ToString()),
                         });
 
                     builder.AddModule(GenericMqttRelayerModuleName, genericMqttTesterImage, false)

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             Action<EdgeConfigBuilder> addRelayerConfig = this.BuildAddRelayerConfig(relayerImage, loadGenTestStatus);
             deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig + addRelayerConfig, token, Context.Current.NestedEdge);
             await this.PollUntilFinishedAsync(RelayerModuleName, token);
-            await TestResultCoordinatorUtil.ValidateResultsAsync();
+            Assert.True(await TestResultCoordinatorUtil.IsResultValidAsync());
         }
 
         [Test]
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 await testResultReportingClient.ReportResultAsync(messageTestResult.ToTestOperationResultDto());
             }
 
-            await TestResultCoordinatorUtil.ValidateResultsAsync();
+            Assert.True(await TestResultCoordinatorUtil.IsResultValidAsync());
         }
 
         [Test]
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             Action<EdgeConfigBuilder> addRelayerConfig = this.BuildAddRelayerConfig(relayerImage, loadGenTestStatus);
             deployment = await this.runtime.DeployConfigurationAsync(addLoadGenConfig + addTrcConfig + addRelayerConfig, token, Context.Current.NestedEdge);
             await this.PollUntilFinishedAsync(RelayerModuleName, token);
-            await TestResultCoordinatorUtil.ValidateResultsAsync();
+            Assert.True(await TestResultCoordinatorUtil.IsResultValidAsync());
         }
 
         async Task ReceiveEventsFromIotHub(DateTime startTime, ConcurrentQueue<MessageTestResult> messages, PriorityQueueTestStatus loadGenTestStatus, string trackingId, CancellationToken token)

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/TestResultCoordinatorUtil.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                 });
         }
 
-        public static async Task ValidateResultsAsync()
+        public static async Task<bool> IsResultValidAsync()
         {
             HttpClient client = new HttpClient();
             HttpResponseMessage response = await client.GetAsync(TestResultCoordinatorUrl);
@@ -109,7 +109,40 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
                 Log.Information("Test Result Coordinator response: {Response}", jsonstring);
             }
 
-            Assert.IsTrue(isPassed);
+            return isPassed;
+        }
+
+        public static async Task<bool> IsCountingReportResultValidAsync(int numResultsExpected)
+        {
+            HttpClient client = new HttpClient();
+            HttpResponseMessage response = await client.GetAsync(TestResultCoordinatorUrl);
+            var jsonstring = await response.Content.ReadAsStringAsync();
+            bool isTestReportValid;
+            int expected;
+            int matched;
+            try
+            {
+                isTestReportValid = (bool)JArray.Parse(jsonstring)[0]["IsPassed"];
+
+                expected = (int)JArray.Parse(jsonstring)[0]["TotalExpectCount"];
+                matched = (int)JArray.Parse(jsonstring)[0]["TotalMatchCount"];
+
+                if (expected != numResultsExpected || matched != numResultsExpected)
+                {
+                    isTestReportValid = false;
+                }
+            }
+            catch
+            {
+                isTestReportValid = false;
+            }
+
+            if (!isTestReportValid)
+            {
+                Log.Verbose("Test Result Coordinator response: {Response}", jsonstring);
+            }
+
+            return isTestReportValid;
         }
     }
 }

--- a/test/modules/generic-mqtt-tester/src/message_initiator.rs
+++ b/test/modules/generic-mqtt-tester/src/message_initiator.rs
@@ -81,7 +81,7 @@ impl MessageInitiator {
         loop {
             if Some(seq_num) == self.messages_to_send {
                 info!("stopping test as we have sent max messages",);
-                time::delay_for(POST_MESSAGE_WAIT).await;
+                time::sleep(POST_MESSAGE_WAIT).await;
                 break;
             }
 

--- a/test/modules/generic-mqtt-tester/src/message_initiator.rs
+++ b/test/modules/generic-mqtt-tester/src/message_initiator.rs
@@ -22,6 +22,8 @@ use trc_client::{MessageTestResult, TrcClient};
 
 use crate::{settings::Settings, ExitedWork, MessageTesterError, ShutdownHandle};
 
+const POST_MESSAGE_WAIT: Duration = Duration::from_secs(60);
+
 /// Responsible for starting to send the messages that will be relayed and
 /// tracked by the test module.
 pub struct MessageInitiator {
@@ -79,6 +81,7 @@ impl MessageInitiator {
         loop {
             if Some(seq_num) == self.messages_to_send {
                 info!("stopping test as we have sent max messages",);
+                time::delay_for(POST_MESSAGE_WAIT).await;
                 break;
             }
 


### PR DESCRIPTION
Two issues fixed with custom mqtt tests in E2E pipeline:
1. The custom mqtt test module would stop a bit too early in the case where it was sending fixed number of messages. Fixed by adding a wait of 60 seconds for any slow telemetry to come back.
2. On arm the test modules take a bit too long to come up. This causes the test to exceed time threshold. Changing the TRC validation logic to periodically poll the endpoint.