### PR TITLE
Update TempFilterFunc binding protocol to Amqp_Tcp_Only 

### DIFF
--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/ModuleClientCache.cs
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/ModuleClientCache.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EdgeHub
 
         async Task<ModuleClient> CreateModuleClient()
         {
-            ModuleClient moduleClient = await ModuleClient.CreateFromEnvironmentAsync(TransportType.Mqtt_Tcp_Only);
+            ModuleClient moduleClient = await ModuleClient.CreateFromEnvironmentAsync(TransportType.Amqp_Tcp_Only);
 
             moduleClient.ProductInfo = "Microsoft.Azure.WebJobs.Extensions.EdgeHub";
             return moduleClient;


### PR DESCRIPTION
Update TempFilterFunc binding protocol to Amqp_Tcp_Only to fix E2E test failure with DotNetty update.

Ref: (#5571)