### PR TITLE
FIX: OnReconnectionClientsGetTwinsPulled() increased timeout

### DIFF
--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ConnectionEventTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test/ConnectionEventTest.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.MqttBrokerAdapter.Test
     {
         const int SafeProcessingDelayMs = 2000;
 
-        static readonly TimeSpan TotalProcessingTimeout = TimeSpan.FromSeconds(30);
+        static readonly TimeSpan TotalProcessingTimeout = TimeSpan.FromSeconds(60);
 
         static readonly string iotHubName = "testHub";
         static readonly string edgeModuleName = "$edgeHub";


### PR DESCRIPTION
The normal execution time (on a PC) was very close 30sec which was the defined timeout value - so in case of a hiccup the test timed out. Doubled the timeout value which no has more buffer for slower environments.