### PR TITLE
[TESTING] "Use 1ES hosted agent for amd64 single-node connectivty tests …

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -88,9 +88,12 @@ jobs:
           testrun.network.runProfile: "Cellular3G"
           testrun.duration: "01:00:00"
     pool:
-      name: $(pool.linux.name)
+      name: $(pool.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
+        - agent-group -equals $(agent.group)
+        - Agent.OS -equals Linux
+        - Agent.OSArchitecture -equals X64
+        - run-connectivity -equals true
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu18.04-amd64'
       aziotis.artifact.name: 'packages_ubuntu-18.04_amd64'

--- a/builds/e2e/templates/connectivity-deploy.yaml
+++ b/builds/e2e/templates/connectivity-deploy.yaml
@@ -38,27 +38,27 @@ steps:
     displayName: 'Copy Edgelet Artifact'
     inputs:
       SourceFolder: "$(Build.StagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
-      TargetFolder: "$(Agent.BuildDirectory)/../artifacts/"
+      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/"
       CleanTargetFolder: true
   - task: CopyFiles@2
     condition: and(succeeded(), eq(variables['run.flag'], 1))
     displayName: 'Copy Images Artifact'
     inputs:
       SourceFolder: "$(Build.StagingDirectory)/${{ parameters['images.artifact.name'] }}"
-      TargetFolder: "$(Agent.BuildDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
+      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
   - task: CopyFiles@2
     condition: and(succeeded(), eq(variables['run.flag'], 1))
     displayName: 'Copy aziot-identity-service'
     inputs:
       SourceFolder: "$(Build.StagingDirectory)"
       Contents: "$(aziotis.package.filter)"
-      TargetFolder: "$(Agent.BuildDirectory)/../artifacts/"
+      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/"
   - task: Bash@3
     condition: and(succeeded(), eq(variables['run.flag'], 1))
     displayName: 'Generate device certificates'
     inputs:
       ${{ if eq(parameters['connectivity.nested'], 'false') }}:
-        workingDirectory: "$(Agent.BuildDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/CACertificates"
+        workingDirectory: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/CACertificates"
       ${{ if eq(parameters['connectivity.nested'], 'true') }}:
         workingDirectory: "/certs"
       targetType: inline
@@ -93,7 +93,7 @@ steps:
       targetType: inline
       script: |
         declare -a cnreg=( ${{ parameters['container.registry.credential'] }} )
-        . $(Agent.BuildDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
+        . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x ${{ parameters['build.repo.path'] }}/scripts/linux/trcE2ETest.sh
         testName="Connectivity"
 
@@ -111,7 +111,7 @@ steps:
 
         sudo --preserve-env ${{ parameters['build.repo.path'] }}/scripts/linux/trcE2ETest.sh \
           -testName 'Connectivity' \
-          -testDir "$(Agent.BuildDirectory)/.." \
+          -testDir "$(Agent.HomeDirectory)/.." \
           -releaseLabel "${{ parameters['release.label'] }}" \
           -artifactImageBuildNumber "$BuildNumber" \
           -containerRegistry "${{ parameters['container.registry'] }}" \
@@ -150,7 +150,7 @@ steps:
         echo "script exit code=$scriptExitCode"
         exit $scriptExitCode
 
-      workingDirectory: "$(Agent.BuildDirectory)/.."
+      workingDirectory: "$(Agent.HomeDirectory)/.."
     env:
       E2E_nestedEdgeTest: $(nestededge)
       E2E_trustedCaCerts: $(TrustBundle)


### PR DESCRIPTION
…(#5456)" (#5551)

This PR is needed as it seems 1ES is a likely reason the connectivity tests are transiently failing with a hard-to-debug error. Custom agents will assist in debugging, while also surfacing whether 1ES itself might be at play.