### PR TITLE
Fixing connectivity flakiness

### DIFF
--- a/e2e_deployment_files/connectivity_deployment.template.json
+++ b/e2e_deployment_files/connectivity_deployment.template.json
@@ -897,20 +897,20 @@
             "TestReportType": "DirectMethodConnectivityReport",
             "SenderSource": "directMethodSender1.send",
             "ReceiverSource": "directMethodReceiver1.receive",
-            "TolerancePeriod": "00:01:00",
+            "TolerancePeriod": "00:03:00",
             "TestDescription": "direct method | cloud | amqp"
           },
           "reportMetadata11": {
             "TestReportType": "DirectMethodConnectivityReport",
             "SenderSource": "directMethodSender2.send",
             "ReceiverSource": "directMethodReceiver2.receive",
-            "TolerancePeriod": "00:01:00",
+            "TolerancePeriod": "00:03:00",
             "TestDescription": "direct method | cloud | mqtt"
           },
           "reportMetadata12": {
             "TestReportType": "DirectMethodConnectivityReport",
             "SenderSource": "directMethodSender3.send",
-            "TolerancePeriod": "00:01:00",
+            "TolerancePeriod": "00:03:00",
             "TestDescription": "edge agent ping"
           },
           "reportMetadata13": {

--- a/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/NetworkStatusTimelineTest.cs
+++ b/test/modules/Modules.Test/TestResultCoordinator/Reports/DirectMethod/NetworkStatusTimelineTest.cs
@@ -92,19 +92,19 @@ namespace Modules.Test.TestResultCoordinator.Reports.DirectMethod
             IAsyncEnumerable<TestOperationResult> resultCollection = this.GetStoreTestResultCollection(networkControllerResultValues, networkControllerResultDates, networkControllerResultOperations);
             NetworkStatusTimeline timeline = await NetworkStatusTimeline.CreateAsync(resultCollection.GetAsyncEnumerator(), new TimeSpan(0, 0, 0, 0, 5));
 
-            (NetworkControllerStatus status, bool inTolerance) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 11, 10));
+            (NetworkControllerStatus status, bool inTolerance, _) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 11, 10));
             Assert.Equal(NetworkControllerStatus.Disabled, status);
             Assert.False(inTolerance);
-            (status, inTolerance) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 16, 10));
+            (status, inTolerance, _) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 16, 10));
             Assert.Equal(NetworkControllerStatus.Enabled, status);
             Assert.False(inTolerance);
-            (status, inTolerance) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 20, 15));
+            (status, inTolerance, _) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 20, 15));
             Assert.Equal(NetworkControllerStatus.Disabled, status);
             Assert.True(inTolerance);
-            (status, inTolerance) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 25, 11));
+            (status, inTolerance, _) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 25, 11));
             Assert.Equal(NetworkControllerStatus.Enabled, status);
             Assert.True(inTolerance);
-            (status, inTolerance) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 25, 12));
+            (status, inTolerance, _) = timeline.GetNetworkControllerStatusAndWithinToleranceAt(new DateTime(2020, 1, 1, 9, 10, 25, 12));
             Assert.Equal(NetworkControllerStatus.Enabled, status);
             Assert.True(inTolerance);
         }

--- a/test/modules/TestResultCoordinator/Reports/DirectMethod/Connectivity/DirectMethodConnectivityReportGenerator.cs
+++ b/test/modules/TestResultCoordinator/Reports/DirectMethod/Connectivity/DirectMethodConnectivityReportGenerator.cs
@@ -89,7 +89,7 @@ namespace TestResultCoordinator.Reports.DirectMethod.Connectivity
             while (hasSenderResult)
             {
                 this.ValidateDataSource(this.SenderTestResults.Current, this.SenderSource);
-                (NetworkControllerStatus networkControllerStatus, bool isWithinTolerancePeriod) =
+                (NetworkControllerStatus networkControllerStatus, bool isWithinTolerancePeriod, TimeSpan delay) =
                     this.NetworkStatusTimeline.GetNetworkControllerStatusAndWithinToleranceAt(this.SenderTestResults.Current.CreatedAt);
                 this.ValidateNetworkControllerStatus(networkControllerStatus);
                 DirectMethodTestResult dmSenderTestResult = JsonConvert.DeserializeObject<DirectMethodTestResult>(this.SenderTestResults.Current.Result);
@@ -108,7 +108,7 @@ namespace TestResultCoordinator.Reports.DirectMethod.Connectivity
                     }
                 }
 
-                reportGeneratorMetadata = await this.ProcessSenderTestResults(dmSenderTestResult, networkControllerStatus, isWithinTolerancePeriod, this.SenderTestResults);
+                reportGeneratorMetadata = await this.ProcessSenderTestResults(dmSenderTestResult, networkControllerStatus, isWithinTolerancePeriod, this.SenderTestResults, delay);
                 networkOnSuccess += reportGeneratorMetadata.NetworkOnSuccess;
                 networkOffSuccess += reportGeneratorMetadata.NetworkOffSuccess;
                 networkOnToleratedSuccess += reportGeneratorMetadata.NetworkOnToleratedSuccess;
@@ -241,7 +241,8 @@ namespace TestResultCoordinator.Reports.DirectMethod.Connectivity
             DirectMethodTestResult dmSenderTestResult,
             NetworkControllerStatus networkControllerStatus,
             bool isWithinTolerancePeriod,
-            IAsyncEnumerator<TestOperationResult> senderTestResults)
+            IAsyncEnumerator<TestOperationResult> senderTestResults,
+            TimeSpan delay)
         {
             ulong networkOnSuccess = 0;
             ulong networkOffSuccess = 0;
@@ -258,6 +259,8 @@ namespace TestResultCoordinator.Reports.DirectMethod.Connectivity
                 }
                 else
                 {
+                    Logger.LogError($"Error: Type {this.NetworkControllerType}, statusCode {statusCode}, " +
+                    $"Controller Status {networkControllerStatus}, iswithin tol {isWithinTolerancePeriod}, delay {delay}");
                     networkOnFailure++;
                 }
             }
@@ -275,6 +278,8 @@ namespace TestResultCoordinator.Reports.DirectMethod.Connectivity
                     }
                     else
                     {
+                        Logger.LogError($"Error: Type {this.NetworkControllerType}, statusCode {statusCode}, " +
+                        $"Controller Status {networkControllerStatus}, iswithin tol {isWithinTolerancePeriod}, delay {delay}");
                         networkOnFailure++;
                     }
                 }
@@ -293,11 +298,15 @@ namespace TestResultCoordinator.Reports.DirectMethod.Connectivity
                     }
                     else
                     {
+                        Logger.LogError($"Error: Type {this.NetworkControllerType}, statusCode {statusCode}, " +
+                        $"Controller Status {networkControllerStatus}, iswithin tol {isWithinTolerancePeriod}, delay {delay}");
                         networkOffFailure++;
                     }
                 }
                 else
                 {
+                    Logger.LogError($"Error: Type {this.NetworkControllerType}, statusCode {statusCode}, " +
+                    $"Controller Status {networkControllerStatus}, iswithin tol {isWithinTolerancePeriod}, delay {delay}");
                     networkOffFailure++;
                 }
             }

--- a/test/modules/TestResultCoordinator/Reports/DirectMethod/Connectivity/NetworkStatusTimeline.cs
+++ b/test/modules/TestResultCoordinator/Reports/DirectMethod/Connectivity/NetworkStatusTimeline.cs
@@ -89,9 +89,11 @@ namespace TestResultCoordinator.Reports.DirectMethod.Connectivity
             this.testResultsValidated = true;
         }
 
-        public (NetworkControllerStatus networkControllerStatus, bool isWithinTolerancePeriod) GetNetworkControllerStatusAndWithinToleranceAt(DateTime statusTime)
+        public (NetworkControllerStatus networkControllerStatus, bool isWithinTolerancePeriod, TimeSpan delay) GetNetworkControllerStatusAndWithinToleranceAt(DateTime statusTime)
         {
             this.ValidateNetworkControllerTestResults();
+
+            var delay = TimeSpan.Zero;
 
             // Return network controller status at given time
             NetworkControllerStatus networkControllerStatus = this.initialNetworkControllerStatus;
@@ -107,9 +109,13 @@ namespace TestResultCoordinator.Reports.DirectMethod.Connectivity
                 networkControllerStatus = curr.NetworkControllerStatus;
                 NetworkControllerTestResult next = this.networkControllerTestResults[i + 1];
                 isWithinTolerancePeriod = statusTime > curr.CreatedAt && statusTime <= next.CreatedAt.Add(this.tolerancePeriod);
+                if (statusTime > curr.CreatedAt)
+                {
+                    delay = statusTime.Subtract(curr.CreatedAt);
+                }
             }
 
-            return (networkControllerStatus, isWithinTolerancePeriod);
+            return (networkControllerStatus, isWithinTolerancePeriod, delay);
         }
 
         static Option<NetworkControllerTestResult> GetNetworkControllerTestOperationResult(TestOperationResult current)


### PR DESCRIPTION
This issue should fix most of the flakiness oberserved in connectivity test. Discounting recent issues with event hub and pulling identities.
This aims to help the issue as to why we had to set such a high level of tolerance on failures.
Ticket with details:https://msazure.visualstudio.com/One/_queries/edit/11005697/?action=new&triage=true