### PR TITLE
Make tests resilient to Windows service manager errors

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -29,6 +29,106 @@ variables:
 
 jobs:
 ################################################################################
+  - job: linux_arm32v7
+################################################################################
+    displayName: Linux arm32v7
+
+    pool:
+      name: $(pool.custom.name)
+      demands: rpi3-e2e-tests-1.1
+
+    variables:
+      os: linux
+      arch: arm32v7
+      artifactName: iotedged-debian9-arm32v7
+
+    timeoutInMinutes: 120
+
+    steps:
+      - template: templates/e2e-clean-directory.yaml
+      - template: templates/e2e-setup.yaml
+      - template: templates/e2e-clear-docker-cached-images.yaml
+      - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_1804_msmoby
+################################################################################
+    displayName: Ubuntu 18.04 with iotedge-moby
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_1804_docker
+################################################################################
+    displayName: Ubuntu 18.04 with Docker (minimal)
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      minimal: true
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_2004_msmoby
+################################################################################
+    displayName: Ubuntu 20.04 with iotedge-moby
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_2004_docker
+################################################################################
+    displayName: Ubuntu 20.04 with Docker (minimal)
+
+    pool:
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      minimal: true
+
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
   - job: windows_server
 ################################################################################
     displayName: Windows Server 2019
@@ -68,43 +168,93 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
+# Disabling until falkiness is fixed on this platform
+# ################################################################################
+#   - job: windows_10ent
+# ################################################################################
+#     displayName: Windows 10 Enterprise (minimal)
+
+#     pool:
+#       name: $(pool.windows.name)
+#       demands:
+#         - ImageOverride -equals agent-aziotedge-win10-entn2019-test
+
+#     variables:
+#       os: windows
+#       arch: amd64
+#       artifactName: iotedged-windows
+#       minimal: true
+
+#     steps:
+#     - template: templates/e2e-setup.yaml
+
+#     - pwsh: |
+#         $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
+#         $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
+#         $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
+#           -ArgumentList 'Root', 'LocalMachine'
+#         $store.Open('ReadWrite')
+#         $store.Add($cert)
+#       displayName: Install CAB signing root cert
+#       env:
+#         PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
+
+#     - pwsh: |
+#         Write-Output '>>> BEFORE:'
+#         netsh interface ipv6 show prefixpolicies
+#         netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
+#         Write-Output '>>> AFTER:'
+#         netsh interface ipv6 show prefixpolicies
+#       displayName: Prefer IPv4
+
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
+
 ################################################################################
-  - job: windows_10ent
+  - job: centos7_amd64
 ################################################################################
-    displayName: Windows 10 Enterprise (minimal)
+    displayName: CentOs7 amd64
 
     pool:
-      name: $(pool.windows.name)
+      name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-win10-entn2019-test
+        - ImageOverride -equals agent-aziotedge-centos-7-msmoby
 
     variables:
-      os: windows
+      os: linux
       arch: amd64
-      artifactName: iotedged-windows
-      minimal: true
+      artifactName: iotedged-centos7-amd64
 
     steps:
+    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
-
-    - pwsh: |
-        $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
-        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
-        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
-          -ArgumentList 'Root', 'LocalMachine'
-        $store.Open('ReadWrite')
-        $store.Add($cert)
-      displayName: Install CAB signing root cert
-      env:
-        PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
-
-    - pwsh: |
-        Write-Output '>>> BEFORE:'
-        netsh interface ipv6 show prefixpolicies
-        netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
-        Write-Output '>>> AFTER:'
-        netsh interface ipv6 show prefixpolicies
-      displayName: Prefer IPv4
-
     - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+    - template: templates/e2e-run.yaml 
+
+# Disabling until EFLOW agent hardware issues are resolved
+# ################################################################################
+#   - job: EFLOW_amd64
+# ################################################################################
+#     displayName: EFLOW amd64
+
+#     pool:
+#       name: $(pool.custom.name)
+#       demands:
+#         - Agent.OS -equals Linux
+#         - Agent.OSArchitecture -equals X64
+#         - run-new-e2e-tests -equals true
+#         - eflow -equals true
+
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-mariner-amd64
+#       NUGET_HTTP_CACHE_PATH: /var/tmp/NuGet/v3-cache
+#       NUGET_PACKAGES: /var/tmp/NuGet/packages
+#       NUGET_PLUGINS_CACHE_PATH: /var/tmp/NuGet/plugins-cache
+
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -29,106 +29,6 @@ variables:
 
 jobs:
 ################################################################################
-  - job: linux_arm32v7
-################################################################################
-    displayName: Linux arm32v7
-
-    pool:
-      name: $(pool.custom.name)
-      demands: rpi3-e2e-tests-1.1
-
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactName: iotedged-debian9-arm32v7
-
-    timeoutInMinutes: 120
-
-    steps:
-      - template: templates/e2e-clean-directory.yaml
-      - template: templates/e2e-setup.yaml
-      - template: templates/e2e-clear-docker-cached-images.yaml
-      - template: templates/e2e-run.yaml
-
-################################################################################
-  - job: ubuntu_1804_msmoby
-################################################################################
-    displayName: Ubuntu 18.04 with iotedge-moby
-
-    pool:
-      name: $(pool.linux.name)
-      demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
-
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
-
-################################################################################
-  - job: ubuntu_1804_docker
-################################################################################
-    displayName: Ubuntu 18.04 with Docker (minimal)
-
-    pool:
-      name: $(pool.linux.name)
-      demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
-
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-      minimal: true
-
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
-
-################################################################################
-  - job: ubuntu_2004_msmoby
-################################################################################
-    displayName: Ubuntu 20.04 with iotedge-moby
-
-    pool:
-      name: $(pool.linux.name)
-      demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
-
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
-
-################################################################################
-  - job: ubuntu_2004_docker
-################################################################################
-    displayName: Ubuntu 20.04 with Docker (minimal)
-
-    pool:
-      name: $(pool.linux.name)
-      demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
-
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-      minimal: true
-
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
-
-################################################################################
   - job: windows_server
 ################################################################################
     displayName: Windows Server 2019
@@ -168,93 +68,43 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-# Disabling until falkiness is fixed on this platform
-# ################################################################################
-#   - job: windows_10ent
-# ################################################################################
-#     displayName: Windows 10 Enterprise (minimal)
-
-#     pool:
-#       name: $(pool.windows.name)
-#       demands:
-#         - ImageOverride -equals agent-aziotedge-win10-entn2019-test
-
-#     variables:
-#       os: windows
-#       arch: amd64
-#       artifactName: iotedged-windows
-#       minimal: true
-
-#     steps:
-#     - template: templates/e2e-setup.yaml
-
-#     - pwsh: |
-#         $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
-#         $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
-#         $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
-#           -ArgumentList 'Root', 'LocalMachine'
-#         $store.Open('ReadWrite')
-#         $store.Add($cert)
-#       displayName: Install CAB signing root cert
-#       env:
-#         PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
-
-#     - pwsh: |
-#         Write-Output '>>> BEFORE:'
-#         netsh interface ipv6 show prefixpolicies
-#         netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
-#         Write-Output '>>> AFTER:'
-#         netsh interface ipv6 show prefixpolicies
-#       displayName: Prefer IPv4
-
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
-
 ################################################################################
-  - job: centos7_amd64
+  - job: windows_10ent
 ################################################################################
-    displayName: CentOs7 amd64
+    displayName: Windows 10 Enterprise (minimal)
 
     pool:
-      name: $(pool.linux.name)
+      name: $(pool.windows.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-centos-7-msmoby
+        - ImageOverride -equals agent-aziotedge-win10-entn2019-test
 
     variables:
-      os: linux
+      os: windows
       arch: amd64
-      artifactName: iotedged-centos7-amd64
+      artifactName: iotedged-windows
+      minimal: true
 
     steps:
-    - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
+
+    - pwsh: |
+        $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
+        $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
+        $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
+          -ArgumentList 'Root', 'LocalMachine'
+        $store.Open('ReadWrite')
+        $store.Add($cert)
+      displayName: Install CAB signing root cert
+      env:
+        PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
+
+    - pwsh: |
+        Write-Output '>>> BEFORE:'
+        netsh interface ipv6 show prefixpolicies
+        netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
+        Write-Output '>>> AFTER:'
+        netsh interface ipv6 show prefixpolicies
+      displayName: Prefer IPv4
+
     - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml 
-
-# Disabling until EFLOW agent hardware issues are resolved
-# ################################################################################
-#   - job: EFLOW_amd64
-# ################################################################################
-#     displayName: EFLOW amd64
-
-#     pool:
-#       name: $(pool.custom.name)
-#       demands:
-#         - Agent.OS -equals Linux
-#         - Agent.OSArchitecture -equals X64
-#         - run-new-e2e-tests -equals true
-#         - eflow -equals true
-
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-mariner-amd64
-#       NUGET_HTTP_CACHE_PATH: /var/tmp/NuGet/v3-cache
-#       NUGET_PACKAGES: /var/tmp/NuGet/packages
-#       NUGET_PLUGINS_CACHE_PATH: /var/tmp/NuGet/plugins-cache
-
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    - template: templates/e2e-run.yaml

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
@@ -115,7 +115,19 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
                         return Task.FromResult(true);
                     },
                     _ => true,
-                    e => e is Win32Exception ex && ex.ErrorCode == 1061, // ERROR_SERVICE_CANNOT_ACCEPT_CTRL
+                    e =>
+                    {
+                        // ERROR_SERVICE_CANNOT_ACCEPT_CTRL
+                        if (e is Win32Exception ex && ex.ErrorCode == 1061)
+                        {
+                            Log.Verbose(
+                                "While attempting to stop IoT Edge, Windows returned an error ({Error}). Retrying...",
+                                e.Message);
+                            return true;
+                        }
+
+                        return false;
+                    },
                     TimeSpan.FromSeconds(2),
                     token
                 );

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
@@ -129,8 +129,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
                         return false;
                     },
                     TimeSpan.FromSeconds(2),
-                    token
-                );
+                    token);
                 await WaitForStatusAsync(sc, ServiceControllerStatus.Stopped, token);
             }
         }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
@@ -104,7 +104,21 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
             var sc = new ServiceController("iotedge");
             if (sc.Status != ServiceControllerStatus.Stopped)
             {
-                sc.Stop();
+                // Sometimes Windows will throw ERROR_SERVICE_CANNOT_ACCEPT_CTRL ("The service
+                // cannot accept control messages at this time.") when we try to stop a service.
+                // When that happens, wait a couple seconds and try again.
+                await Retry.Do(
+                    () =>
+                    {
+                        sc.Refresh();
+                        sc.Stop();
+                        return Task.FromResult(true);
+                    },
+                    _ => true,
+                    e => e is Win32Exception ex && ex.ErrorCode == 1061, // ERROR_SERVICE_CANNOT_ACCEPT_CTRL
+                    TimeSpan.FromSeconds(2),
+                    token
+                );
                 await WaitForStatusAsync(sc, ServiceControllerStatus.Stopped, token);
             }
         }


### PR DESCRIPTION
In a failed end-to-end test run on Windows earlier today, I noticed that all test failures looked like this:

```
  Error Message:
   System.InvalidOperationException : Cannot stop iotedge service on computer '.'.
  ----> System.ComponentModel.Win32Exception : The service cannot accept control messages at this time.
  Stack Trace:
     at System.ServiceProcess.ServiceController.Stop()
   at Microsoft.Azure.Devices.Edge.Test.Common.Windows.EdgeDaemon.InternalStopAsync(CancellationToken token) in D:\a\_work\1\s\test\Microsoft.Azure.Devices.Edge.Test.Common\windows\EdgeDaemon.cs:line 107
   at Microsoft.Azure.Devices.Edge.Test.Common.Windows.EdgeDaemon.ConfigureAsync(Func`2 config, CancellationToken token, Boolean restart) in D:\a\_work\1\s\test\Microsoft.Azure.Devices.Edge.Test.Common\windows\EdgeDaemon.cs:line 65
   ...
```

I've noticed this before as well. Sometimes, the service manager in Windows isn't ready when you stop a service, but waiting a little while and trying again tends to solve it (e.g., see [this](https://docs.microsoft.com/en-us/previous-versions/ms833805(v=msdn.10)?redirectedfrom=MSDN)). I noticed we weren't retrying when we get this exception, so this change adds the retry logic.

The error is not very common, so I was unable to confirm that my change works around it. But I ran the Windows jobs in the pipeline 7 times (with several jobs running in parallel too), and the stop logic still works, so at least generally I know I didn't make it worse. I added a verbose log so that we can gather more data if we still see this error in the future.