### PR TITLE
Remove WebSocket Ping KeepAlives

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
@@ -56,7 +56,27 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             });
 
             app.UseHttpsRedirection();
-            app.UseWebSockets();
+            
+            /*
+             * The Java IoT SDK uses two libraries for connecting over WebSockets. Proton for AMQP
+             * and Paho for MQTT; respectively. Neither of these libraries can handle WebSocket pings
+             * correctly and they will cause the ModuleClient to get into a bad state. Both implementations
+             * expect some Application Data but Kestrel does not include this data. This is valid
+             * according to the WebSocket RFC.
+             * 
+             * Normally, the IoT hub instance will send a series of protocol dependent requests which
+             * are echoed back to the server from the client. This acts as a keep alive and will stop
+             * the hub from disconnecting the client.
+             * 
+             * When the ping request is sent from Kestrel the implementations do not know how to handle
+             * the ping and will stop echoing back the server keep alives. If the device does not send 
+             * any telemetry before the default timeout of 4 minutes the IoT hub will disconnect the client.
+             * 
+             */ 
+            app.UseWebSockets(new WebSocketOptions
+            {
+                KeepAliveInterval = TimeSpan.Zero
+            }); 
 
             var webSocketListenerRegistry = app.ApplicationServices.GetService(typeof(IWebSocketListenerRegistry)) as IWebSocketListenerRegistry;
             var httpProxiedCertificateExtractor = app.ApplicationServices.GetService(typeof(Task<IHttpProxiedCertificateExtractor>)) as Task<IHttpProxiedCertificateExtractor>;


### PR DESCRIPTION
The Java clients do not handle the Kestrel ping (KeepAlive) gracefully and can put the client into a bad state. This change sets the interval to Zero which disables the keep alive.