### PR TITLE
Fix bug where Edge CA is always self-signed

### DIFF
--- a/edgelet/edgelet-http-workload/src/module/cert/mod.rs
+++ b/edgelet/edgelet-http-workload/src/module/cert/mod.rs
@@ -274,7 +274,7 @@ pub(crate) async fn check_edge_ca(
             .map_err(|_| edgelet_http::error::server_error("failed to generate edge ca csr"))?;
 
         cert_client
-            .create_cert(edge_ca_cert, &csr, Some((edge_ca_cert, key_handle)))
+            .create_cert(edge_ca_cert, &csr, None)
             .await
             .map_err(|_| edgelet_http::error::server_error("failed to create edge ca cert"))?;
 


### PR DESCRIPTION
Accidentally passed handle of Edge CA as its own issuer, which caused aziot-certd to always issue it as self-signed. Change to None so aziot-certd checks cert_issuance options instead.