### PR TITLE
Update Base Images for a Security Patch

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}

--- a/edge-agent/docker/linux/arm32v7/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-agent/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-agent/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-bionic-arm32v7
+﻿ARG base_tag=3.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/edge-agent/docker/linux/arm64v8/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 
 FROM azureiotedge/azureiotedge-agent-base:${base_tag}
  

--- a/edge-agent/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-agent/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-bionic-arm64v8
+﻿ARG base_tag=3.1.19-bionic-arm64v8
 ARG num_procs=4
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}

--- a/edge-hub/docker/linux/amd64/Dockerfile
+++ b/edge-hub/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}

--- a/edge-hub/docker/linux/arm32v7/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./watchdog/armv7-unknown-linux-gnueabihf/release/watchdog /usr/local/bin/watchdog

--- a/edge-hub/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-hub/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-bionic-arm32v7
+﻿ARG base_tag=3.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-hub/docker/linux/arm64v8/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./watchdog/aarch64-unknown-linux-gnu/release/watchdog /usr/local/bin/watchdog

--- a/edge-hub/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-hub/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-bionic-arm64v8
+﻿ARG base_tag=3.1.19-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 # Add an unprivileged user account for running Edge Hub

--- a/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/MetricsCollector/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-bionic-arm32v7
+﻿ARG base_tag=3.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
+++ b/edge-modules/SimulatedTemperatureSensor/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-bionic-arm64v8
+﻿ARG base_tag=3.1.19-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 # Add an unprivileged user account for running the module

--- a/edge-modules/api-proxy-module/docker/linux/amd64/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/amd64/Dockerfile
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM alpine:3.13.1
+FROM alpine:3.14.1
 WORKDIR /app
 COPY ./docker/linux/amd64/api-proxy-module .
 COPY ./docker/linux/amd64/templates .

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/iotedge-diagnostics-dotnet/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/edge-util/docker/linux/amd64/Dockerfile
+++ b/edge-util/docker/linux/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# docker file for azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64
-FROM alpine:3.13
+FROM alpine:3.14
 
 ARG num_procs=4
 

--- a/mqtt/docker/linux/amd64/Dockerfile
+++ b/mqtt/docker/linux/amd64/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# Use the same base image as prod edgehub images
-ARG base_tag=3.1.18-alpine3.13
+ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 ADD ./x86_64-unknown-linux-musl/release/mqttd /usr/local/bin/mqttd

--- a/mqtt/docker/linux/arm32v7/Dockerfile
+++ b/mqtt/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 # Use the same base image as prod edgehub images
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-hub-base:${base_tag}
 
 ADD ./armv7-unknown-linux-gnueabihf/release/mqttd /usr/local/bin/mqttd

--- a/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
+++ b/test/connectivity/modules/NetworkController/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/CloudToDeviceMessageTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DeploymentTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodReceiver/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/DirectMethodSender/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/EdgeHubRestartTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/MetricsValidator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/ModuleRestarter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/NumberLogger/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/amd64/Dockerfile
+++ b/test/modules/Relayer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/Relayer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TemperatureFilter/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm32v7/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-bionic-arm32v7
+﻿ARG base_tag=3.1.19-bionic-arm32v7
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && apt-get install -y libcap2-bin libsnappy1v5 && \

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
+++ b/test/modules/TestAnalyzer/docker/linux/arm64v8/base/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-bionic-arm64v8
+﻿ARG base_tag=3.1.19-bionic-arm64v8
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}
 
 RUN apt-get update && \

--- a/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}

--- a/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TestResultCoordinator/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/amd64/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM azureiotedge/azureiotedge-runtime-base:1.1-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}

--- a/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/TwinTester/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base-full:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/amd64/Dockerfile
+++ b/test/modules/load-gen/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1.19-alpine3.14
 FROM mcr.microsoft.com/dotnet/runtime:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm32v7/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm32v7
+ARG base_tag=1.0.6.15-linux-arm32v7
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.

--- a/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
+++ b/test/modules/load-gen/docker/linux/arm64v8/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_tag=1.0.6.14-linux-arm64v8
+ARG base_tag=1.0.6.15-linux-arm64v8
 FROM azureiotedge/azureiotedge-module-base:${base_tag}
 
 ARG EXE_DIR=.


### PR DESCRIPTION
Update Base Images for Security Patch

ARM32/64 🠘 3.1.19-bionic-arm*
Linux AMD64 🠘 3.1.19-alpine3.14
Winwods AMD64 🠘 3.1.19-nanoserver-1809