### PR TITLE
change so nginx doesn't start as root by mistake (#5634)

### DIFF
--- a/edge-modules/api-proxy-module/docker/linux/amd64/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/amd64/Dockerfile
@@ -3,13 +3,35 @@
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
 
-FROM alpine:3.13.1
+FROM alpine:3.13.6
 WORKDIR /app
+
+RUN	apk update && \
+    apk add --no-cache libcap
+
+ENV NGINXUSER_ID ${NGINXUSER_ID:-13624}
+RUN adduser -Ds /bin/sh -u ${NGINXUSER_ID} nginx 
+
+RUN chown -R nginx:nginx /app   
+
 COPY ./docker/linux/amd64/api-proxy-module .
 COPY ./docker/linux/amd64/templates .
+
 RUN	apk update && \
-    apk add nginx && \
+    apk add --no-cache nginx && \
 	mkdir /run/nginx
+RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx
+
+RUN chown -R nginx:nginx /app && \
+    mkdir /var/cache/nginx && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    chown -R nginx:nginx /etc/nginx/conf.d
+RUN touch /var/run/nginx/nginx.pid && \
+        chown -R nginx:nginx /var/run/nginx/nginx.pid 
+        
+
+USER nginx    
 
 #expose ports
 EXPOSE 443/tcp	
@@ -18,6 +40,6 @@ EXPOSE 80/tcp
 EXPOSE 5000/tcp
 #used by blob storage
 EXPOSE 11002/tcp
-#use for custom defining ports
-EXPOSE 7000-8000/tcp
+#default
+EXPOSE 8000/tcp
 ENTRYPOINT ["/app/api-proxy-module"]

--- a/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm32v7/Dockerfile
@@ -2,11 +2,28 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-
-FROM arm32v7/nginx:1.19.9
+FROM arm32v7/nginx:1.21.1
 WORKDIR /app
+
+RUN apt-get update && \	
+    apt-get install -y libcap2-bin && \
+    rm -rf /var/lib/apt/lists/*	
+RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx
+
+ENV NGINXUSER_ID ${NGINXUSER_ID:-13624}
+RUN usermod -u ${NGINXUSER_ID} nginx
+
+RUN chown -R nginx:nginx /app && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    chown -R nginx:nginx /etc/nginx/conf.d
+RUN touch /var/run/nginx.pid && \
+        chown -R nginx:nginx /var/run/nginx.pid 
+        
 COPY ./docker/linux/arm32v7/api-proxy-module .
 COPY ./docker/linux/arm32v7/templates .
+
+USER nginx  
 
 #expose ports
 EXPOSE 443/tcp	
@@ -15,7 +32,6 @@ EXPOSE 80/tcp
 EXPOSE 5000/tcp
 #used by blob storage
 EXPOSE 11002/tcp
-#use for custom defining ports
-EXPOSE 7000-8000/tcp
+#default
+EXPOSE 8000/tcp
 ENTRYPOINT ["/app/api-proxy-module"]
- 

--- a/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
+++ b/edge-modules/api-proxy-module/docker/linux/arm64v8/Dockerfile
@@ -2,10 +2,28 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
 #-------------------------------------------------------------------------------------------------------------
-FROM arm64v8/nginx:1.19.9
+FROM arm64v8/nginx:1.21.1
 WORKDIR /app
+
+RUN apt-get update && \	
+    apt-get install -y libcap2-bin && \
+    rm -rf /var/lib/apt/lists/*	
+RUN setcap 'cap_net_bind_service=+ep' /usr/sbin/nginx
+
+ENV NGINXUSER_ID ${NGINXUSER_ID:-13624}
+RUN usermod -u ${NGINXUSER_ID} nginx
+
+RUN chown -R nginx:nginx /app && \
+    chown -R nginx:nginx /var/cache/nginx && \
+    chown -R nginx:nginx /var/log/nginx && \
+    chown -R nginx:nginx /etc/nginx/conf.d
+RUN touch /var/run/nginx.pid && \
+        chown -R nginx:nginx /var/run/nginx.pid 
+
 COPY ./docker/linux/arm64v8/api-proxy-module .
 COPY ./docker/linux/arm64v8/templates .
+
+USER nginx  
 
 #expose ports
 EXPOSE 443/tcp	
@@ -14,7 +32,6 @@ EXPOSE 80/tcp
 EXPOSE 5000/tcp
 #used by blob storage
 EXPOSE 11002/tcp
-#use for custom defining ports
-EXPOSE 7000-8000/tcp
+#default
+EXPOSE 8000/tcp
 ENTRYPOINT ["/app/api-proxy-module"]
- 


### PR DESCRIPTION
assigning 13624 as nginx uid so it doesn't run on 1000.
Adding setcap binding so it can bin to 443.

Test (both on amd&arm):
Check API proxy runs
PS aux inside container to check nginx user is used
cat /etc/passwd to check uid

