### PR TITLE
Use buildx for building API Proxy on ARM

### DIFF
--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -360,8 +360,15 @@ stages:
         project: CloudToDeviceMessageTester     
         bin_dir: '$(Build.BinariesDirectory)'
         
-  - job: BuildImageApiProxy 
+  - job: BuildImageApiProxy
     steps:
+    - bash: |
+        sudo apt-get update && sudo apt-get -y install qemu binfmt-support qemu-user-static && \
+        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes && \
+        docker buildx rm  mbuilder || true  && \
+        docker buildx create --name mbuilder  || true  && \
+        docker buildx use mbuilder
+        docker -v
     - template: templates/image-linux.yaml
       parameters:
         name: API Proxy


### PR DESCRIPTION
This is to correct the accidental removal of this when the following PR was merged:

Parallelize build-images pipeline (#5547)