### PR TITLE
add allow_elevated_docker_permissions to config

### DIFF
--- a/edgelet/contrib/config/linux/config.yaml
+++ b/edgelet/contrib/config/linux/config.yaml
@@ -177,6 +177,19 @@ provisioning:
 #   endpoint: "http://localhost:9999"
 #   dynamic_reprovisioning: false
 
+# ==============================================================================
+# Elevated Docker Permissions Flag
+# ==============================================================================
+#
+# Some docker capabilities capabilities can be used to gain root access. 
+# By default, the --privileged flag and all capabilities listed in the CapAdd
+# field of the docker HostConfig are allowed.
+#
+# If no modules require privileged or additional capabilities, uncomment the following
+# line to improve the security of the device.
+#
+# allow_elevated_docker_permissions = false
+
 ###############################################################################
 # Certificate settings
 ###############################################################################

--- a/edgelet/contrib/config/linux/debian/config.yaml
+++ b/edgelet/contrib/config/linux/debian/config.yaml
@@ -177,6 +177,19 @@ provisioning:
 #   endpoint: "http://localhost:9999"
 #   dynamic_reprovisioning: false
 
+# ==============================================================================
+# Elevated Docker Permissions Flag
+# ==============================================================================
+#
+# Some docker capabilities capabilities can be used to gain root access. 
+# By default, the --privileged flag and all capabilities listed in the CapAdd
+# field of the docker HostConfig are allowed.
+#
+# If no modules require privileged or additional capabilities, uncomment the following
+# line to improve the security of the device.
+#
+# allow_elevated_docker_permissions = false
+
 ###############################################################################
 # Certificate settings
 ###############################################################################

--- a/edgelet/contrib/config/windows/config.yaml
+++ b/edgelet/contrib/config/windows/config.yaml
@@ -177,6 +177,19 @@ provisioning:
 #   endpoint: "http://localhost:9999"
 #   dynamic_reprovisioning: false
 
+# ==============================================================================
+# Elevated Docker Permissions Flag
+# ==============================================================================
+#
+# Some docker capabilities capabilities can be used to gain root access. 
+# By default, the --privileged flag and all capabilities listed in the CapAdd
+# field of the docker HostConfig are allowed.
+#
+# If no modules require privileged or additional capabilities, uncomment the following
+# line to improve the security of the device.
+#
+# allow_elevated_docker_permissions = false
+
 ###############################################################################
 # Certificate settings
 ###############################################################################


### PR DESCRIPTION
This adds a section for the allow_elevated_docker_permissions flag to the default config.yaml