### PR TITLE
Remove WebSocket Ping KeepAlives (#5623)

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
@@ -56,7 +56,27 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             });
 
             app.UseHttpsRedirection();
-            app.UseWebSockets();
+
+            /*
+             * The Java IoT SDK uses two libraries for connecting over WebSockets. Proton for AMQP
+             * and Paho for MQTT; respectively. Neither of these libraries can handle WebSocket pings
+             * correctly and they will cause the ModuleClient to get into a bad state. Both implementations
+             * expect some Application Data but Kestrel does not include this data. This is valid
+             * according to the WebSocket RFC.
+             *
+             * Normally, the IoT hub instance will send a series of protocol dependent requests which
+             * are echoed back to the server from the client. This acts as a keep alive and will stop
+             * the hub from disconnecting the client.
+             *
+             * When the ping request is sent from Kestrel the implementations do not know how to handle
+             * the ping and will stop echoing back the server keep alives. If the device does not send
+             * any telemetry before the default timeout of 4 minutes the IoT hub will disconnect the client.
+             *
+             */
+            app.UseWebSockets(new WebSocketOptions
+            {
+                KeepAliveInterval = TimeSpan.Zero
+            });
 
             var webSocketListenerRegistry = app.ApplicationServices.GetService(typeof(IWebSocketListenerRegistry)) as IWebSocketListenerRegistry;
             var httpProxiedCertificateExtractor = app.ApplicationServices.GetService(typeof(Task<IHttpProxiedCertificateExtractor>)) as Task<IHttpProxiedCertificateExtractor>;


### PR DESCRIPTION
The Java clients do not handle the Kestrel WebSocket Ping (KeepAlive) gracefully and can put the client into a bad state. This change sets the interval to Zero which disables the WebSocket Ping (KeepAlive).

This change should be safe because underlying AMQP and MQTT protocols have already built-in Keep Alive mechanisms. Also, IoT Hub does not support/send WebSocket Ping as well, that's why the issue is reproducible only with Edge Hub.

The plan will be to correctly support this in the Java clients going forward but the best remediation that will have the biggest impact is to turn these off and have the edge act similarly to the hub.

Cherry-pick #5623
