### PR TITLE
Fix env vars when running script locally

### DIFF
--- a/scripts/linux/consolidate-build-artifacts.sh
+++ b/scripts/linux/consolidate-build-artifacts.sh
@@ -17,10 +17,10 @@
 # Get directory of running script
 DIR=$(cd "$(dirname "$0")" && pwd)
 
-BUILD_REPOSITORY_LOCALPATH=${BUILD_REPOSITORY_LOCALPATH:-$DIR/../..}
+BUILD_REPOSITORY_LOCALPATH=$(realpath ${BUILD_REPOSITORY_LOCALPATH:-$DIR/../..})
 DESTINATION_DIRECTORY=${BUILD_BINARIESDIRECTORY:-$BUILD_REPOSITORY_LOCALPATH/target}/publish
-DOTNET_ARTIFACTS_SOURCE_DIRECTORY=${BUILD_BINARIESDIRECTORY}/publish
-RUST_ARTIFACTS_SOURCE_DIRECTORY="./"
+DOTNET_ARTIFACTS_SOURCE_DIRECTORY=$DESTINATION_DIRECTORY
+RUST_ARTIFACTS_SOURCE_DIRECTORY=$BUILD_REPOSITORY_LOCALPATH
 SCRIPT_NAME=$(basename "$0")
 
 ###############################################################################
@@ -92,12 +92,9 @@ edge-hub)
     ARTIFACTS_DEST="${DESTINATION_DIRECTORY}/$ARTIFACT_NAME"
 
     # make build context structure
-    mkdir -p "$ARTIFACTS_DEST"
-    mkdir -p "$ARTIFACTS_DEST/mqtt"
     mkdir -p "$ARTIFACTS_DEST/mqtt/$TARGET_AMD64_MUSL/release"
     mkdir -p "$ARTIFACTS_DEST/mqtt/$TARGET_ARM32V7/release"
     mkdir -p "$ARTIFACTS_DEST/mqtt/$TARGET_ARM64V8/release"
-    mkdir "$ARTIFACTS_DEST/watchdog"
     mkdir -p "$ARTIFACTS_DEST/watchdog/$TARGET_AMD64_MUSL/release"
     mkdir -p "$ARTIFACTS_DEST/watchdog/$TARGET_ARM32V7/release"
     mkdir -p "$ARTIFACTS_DEST/watchdog/$TARGET_ARM64V8/release"
@@ -123,7 +120,6 @@ mqttd)
     ARTIFACTS_DEST="mqtt/build-context"
 
     # make build context structure
-    mkdir "$ARTIFACTS_DEST"
     mkdir -p "$ARTIFACTS_DEST/$TARGET_AMD64_MUSL/release"
     mkdir -p "$ARTIFACTS_DEST/$TARGET_ARM32V7/release"
     mkdir -p "$ARTIFACTS_DEST/$TARGET_ARM64V8/release"


### PR DESCRIPTION
Cherry-pick 04314fad3b68e3bdf84f340f2f2b48224de3806d to master.

To test, I ran end-to-end tests locally and in the official pipeline.

# Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

<!--
### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
-->
