### PR TITLE
E2E: Skip component governance on proxy test suite

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -206,8 +206,8 @@ jobs:
       'agent.disablelogplugin.testresultlogplugin': true
       # because we aren't publishing test artifacts for this job, turn on verbose logging instead
       verbose: true
-      # don't error on component governance here, as this task doesn't have proxy support
-      NugetSecurityAnalysisWarningLevel: warn
+      # skip component governance detection to avoid proxy issues. It is checked in the other jobs.
+      skipComponentGovernanceDetection: true
 
     timeoutInMinutes: 120
 


### PR DESCRIPTION
In #5694 I tried to make the CG give a warning rather than an error. However the specific failure in master branch CG is installing dotnet, which is not treated as a warning by `NugetSecurityAnalysisWarningLevel: warn`.

Instead we will skip the check as instructed by the docs.
https://docs.opensource.microsoft.com/tools/cg/index.html

Waiting for this e2e run before merge:



# Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
