### PR TITLE
Fix permission denied on workload socket

### DIFF
--- a/edgelet/edgelet-http/Cargo.toml
+++ b/edgelet/edgelet-http/Cargo.toml
@@ -34,7 +34,6 @@ systemd = { path = "../systemd" }
 hyperlocal = "0.6"
 libc = "0.2"
 nix = "0.14"
-scopeguard = "0.3.3"
 tokio-uds = "0.2"
 
 [target.'cfg(windows)'.dependencies]

--- a/edgelet/edgelet-http/src/unix.rs
+++ b/edgelet/edgelet-http/src/unix.rs
@@ -2,17 +2,11 @@
 
 use std::fs;
 #[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
-#[cfg(unix)]
 use std::os::unix::prelude::PermissionsExt;
 use std::path::Path;
 
 use failure::ResultExt;
 use log::{debug, error};
-#[cfg(unix)]
-use nix::sys::stat::{umask, Mode};
-#[cfg(unix)]
-use scopeguard::defer;
 #[cfg(unix)]
 use tokio_uds::UnixListener;
 #[cfg(windows)]
@@ -22,56 +16,36 @@ use crate::error::{Error, ErrorKind};
 use crate::util::{incoming::Incoming, socket_file_exists};
 
 pub fn listener<P: AsRef<Path>>(path: P, unix_socket_permission: u32) -> Result<Incoming, Error> {
-    let listener = if socket_file_exists(path.as_ref()) {
-        // get the previous file's metadata
-        #[cfg(unix)]
-        let metadata = get_metadata(path.as_ref())?;
+    let path = path.as_ref();
+    let path_display = path.display();
 
-        debug!("unlinking {}...", path.as_ref().display());
-        fs::remove_file(&path)
-            .with_context(|_| ErrorKind::Path(path.as_ref().display().to_string()))?;
-        debug!("unlinked {}", path.as_ref().display());
+    if socket_file_exists(path) {
+        debug!("unlinking {}...", path_display);
 
-        #[cfg(unix)]
-        let prev = set_umask(&metadata, path.as_ref());
-        #[cfg(unix)]
-        defer! {{ umask(prev); }}
-
-        debug!("binding {}...", path.as_ref().display());
-
-        let listener = UnixListener::bind(&path)
-            .with_context(|_| ErrorKind::Path(path.as_ref().display().to_string()))?;
-        debug!("bound {}", path.as_ref().display());
-
-        Incoming::Unix(listener)
-    } else {
-        // If parent doesn't exist, create it and socket will be created inside.
-        if let Some(parent) = path.as_ref().parent() {
-            if !parent.exists() {
-                fs::create_dir_all(parent).with_context(|err| {
-                    error!("Cannot create directory, error: {}", err);
-                    ErrorKind::Path(path.as_ref().display().to_string())
-                })?;
-            }
+        let err1 = fs::remove_file(path).err();
+        let err2 = fs::remove_dir_all(path).err();
+        if let Some((err1, err2)) = err1.zip(err2) {
+            error!("Could not unlink existing socket: [{}] [{}]", err1, err2);
+            return Err(ErrorKind::Path(path_display.to_string()).into());
         }
+        debug!("unlinked {}", path_display);
+    }
 
-        let listener = UnixListener::bind(&path)
-            .with_context(|_| ErrorKind::Path(path.as_ref().display().to_string()))?;
+    // If parent doesn't exist, create it and socket will be created inside.
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).with_context(|err| {
+            error!("Cannot create directory, error: {}", err);
+            ErrorKind::Path(path_display.to_string())
+        })?;
+    }
 
-        set_permissions(path.as_ref(), unix_socket_permission)?;
+    let listener =
+        UnixListener::bind(&path).with_context(|_| ErrorKind::Path(path_display.to_string()))?;
+    debug!("bound {}", path_display);
 
-        Incoming::Unix(listener)
-    };
+    set_permissions(path, unix_socket_permission)?;
 
-    Ok(listener)
-}
-
-#[cfg(unix)]
-fn get_metadata(path: &Path) -> Result<fs::Metadata, Error> {
-    let metadata =
-        fs::metadata(path).with_context(|_| ErrorKind::Path(path.display().to_string()))?;
-    debug!("read metadata {:?} for {}", metadata, path.display());
-    Ok(metadata)
+    Ok(Incoming::Unix(listener))
 }
 
 #[cfg(unix)]
@@ -91,29 +65,12 @@ fn set_permissions(_path: &Path, _unix_socket_permission: u32) -> Result<(), Err
     Ok(())
 }
 
-#[cfg(unix)]
-fn set_umask(metadata: &fs::Metadata, path: &Path) -> Mode {
-    #[cfg(target_os = "macos")]
-    #[allow(clippy::cast_possible_truncation)]
-    let mode = Mode::from_bits_truncate(metadata.mode() as u16);
-
-    #[cfg(not(target_os = "macos"))]
-    let mode = Mode::from_bits_truncate(metadata.mode());
-
-    let mut mask = Mode::all();
-    mask.toggle(mode);
-
-    debug!("settings permissions {:#o} for {}...", mode, path.display());
-
-    umask(mask)
-}
-
 #[cfg(test)]
 #[cfg(unix)]
 mod tests {
-    use super::{listener, MetadataExt};
-
+    use super::listener;
     use std::fs::OpenOptions;
+    use std::os::unix::fs::MetadataExt;
     use std::os::unix::fs::OpenOptionsExt;
 
     use futures::Stream;
@@ -139,7 +96,21 @@ mod tests {
         let _srv = listener.for_each(move |(_socket, _addr)| Ok(()));
 
         let file_stat = stat(&path).unwrap();
-        assert_eq!(0o600, file_stat.st_mode & 0o777);
+        assert_eq!(0o666, file_stat.st_mode & 0o777);
+
+        dir.close().unwrap();
+    }
+
+    #[test]
+    fn test_socket_not_created() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("dummy_socket.sock");
+
+        let listener = listener(&path, 0o666).unwrap();
+        let _srv = listener.for_each(move |(_socket, _addr)| Ok(()));
+
+        let file_stat = stat(&path).unwrap();
+        assert_eq!(0o666, file_stat.st_mode & 0o777);
 
         dir.close().unwrap();
     }

--- a/edgelet/iotedged/src/workload_manager.rs
+++ b/edgelet/iotedged/src/workload_manager.rs
@@ -133,13 +133,32 @@ where
     ) -> Result<(), Error> {
         let label = "work".to_string();
 
-        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
+        // If a listener has already been created, remove previous listener.
+        // This avoid the launch of 2 listeners.
+        // We chose to remove instead and create a new one instead of
+        // just return and say, one listener has already been created:
+        // We chose to remove because a listener could crash without getting removed correctly.
+        // That could make the module crash. Then that module would be restarted without ever going to
+        // "stop"
+        // There is still a chance that 2 concurrent servers are launch with concurrence,
+        // But it is extremely unlikely and anyway doesn't have any side effect expect memory footprint.
+        if let Some(shutdown_sender) = self.shutdown_senders.remove(module_id) {
+            info!(
+                "Listener  {} already started, removing old listener",
+                module_id
+            );
+            shutdown_sender
+                .send(())
+                .map_err(|()| Error::from(ErrorKind::WorkloadService))?;
+        }
 
-        let cert_manager = self.cert_manager.clone();
-        let min_protocol_version = self.min_protocol_version;
+        let (shutdown_sender, shutdown_receiver) = oneshot::channel();
 
         self.shutdown_senders
             .insert(module_id.to_string(), shutdown_sender);
+
+        let cert_manager = self.cert_manager.clone();
+        let min_protocol_version = self.min_protocol_version;
 
         let future = WorkloadService::new(
             &self.key_store,


### PR DESCRIPTION
Porting of : https://github.com/Azure/iotedge/pull/5698

Restarting iotedge many time lead to permission issues

This doesn't seem to happen in 1.1.6. I tried many times but could not get it to fail however some customer experienced the same symptoms so this is most likely an issue across version.
The fact that it seems to fail more on some setup is something we could not explain.

Tests:
Tried all of those. A few times manually (3-5 times), a cycle of hundreds time each with a script (Ubuntu + Centos).
For each test we check that all module are up and running, that permissions and user are correct and that there is a listener on the socket:
1.1 sudo iotedge system restart
1.2 sudo iotedge system stop + delete all containers + sudo iotedge system restart
1.3 sudo iotedge system stop + delete /var/lib/aziot/edged/mnt/ folder + sudo iotedge system restart
1.4 sudo iotedge system stop + delete all container + delete /var/lib/aziot/edged/mnt/ folder + sudo iotedge system restart
1.5 sudo iotedge system stop + delete workloads inside /var/lib/aziot/edged/mnt + create a sudo dir inside with the name of the sockets + sudo iotedge system restart (NOT on Windows, since socket are dir and without the folder docker refuses to create the container and won't create a default one)

Script ubuntu: [script_ubuntu.txt](https://github.com/Azure/iotedge/files/7367236/script_ubuntu.txt)
Test result: [ubuntu18.txt_release1_1.txt](https://github.com/Azure/iotedge/files/7367243/ubuntu18.txt_release1_1.txt)

Script windows:[script_windows.txt](https://github.com/Azure/iotedge/files/7367310/script_windows.txt)
Test result:[windows_result.txt](https://github.com/Azure/iotedge/files/7367305/windows_result.txt)
Note: edgeHub container is missing in one of the restart. However it is not in failed state (so no issue with socket). From experience, sometimes edgeAgent takes a while to get the deployment config on windows.

E2E test: https://dev.azure.com/msazure/One/_build/results?buildId=47950182&view=results
package#:https://dev.azure.com/msazure/One/_build/results?buildId=47915899&view=results

# Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
