### PR TITLE
[DRAFT] Enable 1ES-hosted agents for end-to-end tests

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -31,29 +31,29 @@ variables:
 
 jobs:
 
-################################################################################
-  - job: linux_arm32v7
-################################################################################
-    displayName: Linux arm32v7
+# ################################################################################
+#   - job: linux_arm32v7
+# ################################################################################
+#     displayName: Linux arm32v7
 
-    pool:
-      name: $(pool.custom.name)
-      demands: rpi3-e2e-tests
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: rpi3-e2e-tests
 
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactName: iotedged-debian9-arm32v7
-      identityServiceArtifactName: packages_debian-9-slim_arm32v7
-      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+#     variables:
+#       os: linux
+#       arch: arm32v7
+#       artifactName: iotedged-debian9-arm32v7
+#       identityServiceArtifactName: packages_debian-9-slim_arm32v7
+#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_1804_msmoby
@@ -164,35 +164,35 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: linux_amd64_proxy
-################################################################################
-    displayName: Linux amd64 behind a proxy
+# ################################################################################
+#   - job: linux_amd64_proxy
+# ################################################################################
+#     displayName: Linux amd64 behind a proxy
 
-    pool:
-      name: $(pool.custom.name)
-      demands: new-e2e-proxy
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: new-e2e-proxy
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-      identityServiceArtifactName: packages_ubuntu-18.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
-      'agent.disablelogplugin.testfilepublisherplugin': true
-      'agent.disablelogplugin.testresultlogplugin': true
-      # because we aren't publishing test artifacts for this job, turn on verbose logging instead
-      verbose: true
-      # skip component governance detection to avoid proxy issues. It is checked in the other jobs.
-      skipComponentGovernanceDetection: true
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu18.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#       # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
+#       'agent.disablelogplugin.testfilepublisherplugin': true
+#       'agent.disablelogplugin.testresultlogplugin': true
+#       # because we aren't publishing test artifacts for this job, turn on verbose logging instead
+#       verbose: true
+#       # skip component governance detection to avoid proxy issues. It is checked in the other jobs.
+#       skipComponentGovernanceDetection: true
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
-      parameters:
-        test_type: http_proxy
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
+#       parameters:
+#         test_type: http_proxy


### PR DESCRIPTION
We switched from custom- and MS-hosted agents to 1ES-hosted agents in the end-to-end pipeline for the 1.1 and 1.2 release branches, but didn't do the same in master because of test failures. I'm enabling them again to see if the failures are still happening...

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
