### PR TITLE
Improve Windows service management in end-to-end tests

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/windows/EdgeDaemon.cs
@@ -116,6 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
                     {
                         sc.Stop();
                     }
+
                     return Task.FromResult(true);
                 },
                 _ => true,
@@ -136,7 +137,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Windows
                 TimeSpan.FromSeconds(2),
                 token);
             await WaitForStatusAsync(sc, ServiceControllerStatus.Stopped, token);
-            }
         }
 
         public async Task UninstallAsync(CancellationToken token)


### PR DESCRIPTION
A recent PR (#5608) added retry logic to the end-to-end tests on Windows when they try to stop the IoT Edge service but the service manager isn't ready. This PR expands that one to include another case: when the tests try to stop the IoT Edge service but the service is already stopped.

```
  X QuickstartCerts [7s 488ms]
  Error Message:
   System.InvalidOperationException : Cannot stop iotedge service on computer '.'.
  ----> System.ComponentModel.Win32Exception : The service has not been started.
```

The code path that stops the service first checks its status, and only issues the stop command if the service isn't already stopped. However, checking the service status + stopping the service is not an atomic operation, so there is a small window of opportunity to call "stop" on an already-stopped service. This change handles that window by checking the service status on every retry, not just the first time through. 

I was unable to get the condition to repro again after several runs in the pipeline, but I at least confirmed that these changes don't disrupt the happy path.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
