### PR TITLE
Fix: detect fail-over from iot hub/sdk behavior and disconnect from hub

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/CloudProxy.cs
@@ -306,6 +306,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                     Events.HandleNre(ex, this);
                     return this.CloseAsync();
                 }
+                else if (ex.IsFailOver())
+                {
+                    Events.FailOverDetected(ex, this);
+                    return this.CloseAsync();
+                }
             }
             catch (Exception e)
             {
@@ -491,7 +496,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 ErrorUpdatingReportedProperties,
                 ErrorSendingFeedbackMessageAsync,
                 ErrorGettingTwin,
-                HandleNre
+                HandleNre,
+                FailOverDetected
             }
 
             public static void Closed(CloudProxy cloudProxy)
@@ -602,6 +608,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             public static void HandleNre(Exception ex, CloudProxy cloudProxy)
             {
                 Log.LogDebug((int)EventIds.HandleNre, ex, Invariant($"Got a non-recoverable error from client for {cloudProxy.clientId}. Closing the cloud proxy since it may be in a bad state."));
+            }
+
+            public static void FailOverDetected(Exception ex, CloudProxy cloudProxy)
+            {
+                Log.LogInformation((int)EventIds.FailOverDetected, ex, Invariant($"Fail-over detected, closing cloud proxy for {cloudProxy.clientId}."));
             }
 
             internal static void ExceptionInHandleException(CloudProxy cloudProxy, Exception handlingException, Exception caughtException)

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ConnectivityAwareClient.cs
@@ -163,6 +163,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                         await this.deviceConnectivityManager.CallTimedOut();
                     }
                 }
+                else if (ex.IsFailOver())
+                {
+                    Events.FailOverDetected(this.identity, operation, mappedException);
+                    if (useForConnectivityCheck)
+                    {
+                        await this.deviceConnectivityManager.CallTimedOut();
+                    }
+                }
                 else
                 {
                     Events.OperationFailed(this.identity, operation, mappedException);
@@ -199,7 +207,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
                 OperationTimedOut,
                 OperationFailed,
                 OperationSucceeded,
-                ChangingStatus
+                ChangingStatus,
+                FailOverDetected
             }
 
             public static void ReceivedDeviceSdkCallback(IIdentity identity, ConnectionStatus status, ConnectionStatusChangeReason reason)
@@ -225,6 +234,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             public static void ChangingStatus(AtomicBoolean isConnected, IIdentity identity)
             {
                 Log.LogInformation((int)EventIds.ChangingStatus, $"Cloud connection for {identity.Id} is {isConnected.Get()}");
+            }
+
+            public static void FailOverDetected(IIdentity identity, string operation, Exception ex)
+            {
+                Log.LogInformation((int)EventIds.FailOverDetected, ex, $"Operation {operation} failed for {identity.Id} because of fail-over");
             }
         }
     }

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ExceptionMapper.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.CloudProxy/ExceptionMapper.cs
@@ -3,10 +3,13 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
 {
     using System;
     using DotNetty.Transport.Channels;
+    using Microsoft.Azure.Devices.Client.Exceptions;
     using Microsoft.Azure.Devices.Edge.Util;
 
     public static class ExceptionMapper
     {
+        const string FailOverMessage = "(condition='com.microsoft:iot-hub-not-found-error')";
+
         public static Exception GetEdgeException(this Exception sdkException, string operation)
         {
             Preconditions.CheckNonWhiteSpace(operation, nameof(operation));
@@ -19,6 +22,16 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy
             }
 
             return sdkException;
+        }
+
+        public static bool IsFailOver(this Exception ex)
+        {
+            var isFailOver = ex is IotHubException
+                          && ex.InnerException != null
+                          && !string.IsNullOrEmpty(ex.InnerException.Message)
+                          && ex.InnerException.Message.Contains(FailOverMessage);
+
+            return isFailOver;
         }
     }
 }


### PR DESCRIPTION
Iot-hub does not disconnect in case of fail over and edgeHub keeps sending messages/operations. These operations fail with a specific error and never recover.
Added some logic to filter exceptions, so when the error message arrives that is thrown by the "old" server (the server serving before fail-over), EdgeHub disconnect and the new connection attempt will find the new server.

cherry pick of #5669 