### PR TITLE
Remove WebSocket Ping KeepAlives (#5623) (#5689)

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/Startup.cs
@@ -55,7 +55,14 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
             });
 
             app.UseHttpsRedirection();
-            app.UseWebSockets();
+
+            // We don't need to have server-initiated WebSocket ping requests,
+            // because the top level protocols (AMQT/MQTT) already do have
+            // keep-alive mechanisms implemented.
+            app.UseWebSockets(new WebSocketOptions
+            {
+                KeepAliveInterval = TimeSpan.Zero
+            });
 
             var webSocketListenerRegistry = app.ApplicationServices.GetService(typeof(IWebSocketListenerRegistry)) as IWebSocketListenerRegistry;
             app.UseWebSocketHandlingMiddleware(webSocketListenerRegistry);


### PR DESCRIPTION
The Java clients do not handle the Kestrel WebSocket Ping (KeepAlive) gracefully and can put the client into a bad state. This change sets the interval to Zero which disables the WebSocket Ping (KeepAlive).

This change should be safe because underlying AMQP and MQTT protocols have already built-in Keep Alive mechanisms. Also, IoT Hub does not support/send WebSocket Ping as well, that's why the issue is reproducible only with Edge Hub.

The plan will be to correctly support this in the Java clients going forward but the best remediation that will have the biggest impact is to turn these off and have the edge act similarly to the hub.

Cherry-pick #5689