### PR TITLE
Update dependency on vulnerable package

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Microsoft.Azure.Devices.Routing.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Routing.Core/Microsoft.Azure.Devices.Routing.Core.csproj
@@ -21,6 +21,13 @@
     <PackageReference Include="Antlr4" Version="4.6.1-beta002" />
     <PackageReference Include="App.Metrics" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <!--
+      Microsoft.Extensions.Logging.Console/5.0.0 takes a transitive dependency on
+      System.Text.Encodings.Web. Use an explicit reference here to override the
+      version and fix a security vulnerability.
+      See https://github.com/dotnet/runtime/issues/49377#issuecomment-804930299.
+    -->
+    <PackageReference Include="System.Text.Encodings.Web" Version="5.0.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Reflection.Extensions" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.5.1" />


### PR DESCRIPTION
We recently upgraded a dependency in one of our projects to Microsoft.Extensions.Logging.Console/5.0.0. That package has a transitive dependency on a vulnerable version of System.Text.Encodings.Web. There is no newer version of Microsoft.Extensions.Logging.Console yet, so the recommended approach is to make an explicit reference to the patched version of System.Text.Encodings.Web, to override the transitive version.

I used `dotnet list package --include-transitive` before and after the change to verify that the transitive dependency is replaced by the explicit dependency within the project.