### PR TITLE
E2E: Reenable validate metrics

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -22,8 +22,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
         public const string ModuleName = "metricsValidator";
 
         [Test]
-        // [9/27/2021] Disabling the test because of the bug - https://github.com/Azure/iotedge/issues/5438
-        [Category("Flaky")]
         [Category("FlakyOnArm")]
         public async Task ValidateMetrics()
         {


### PR DESCRIPTION
Validate metrics was disabled due to a github issue. The issue is now resolved so I am reenabling the test.

Waiting on this run before merge:
https://dev.azure.com/msazure/One/_build/results?buildId=48470933&view=ms.vss-test-web.build-test-results-tab

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
