### PR TITLE
[release/1.1] Revert EdgeHub configuration waiting

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/ConfigUpdater.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/ConfigUpdater.cs
@@ -56,13 +56,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
                     {
                         Events.GettingConfig();
                         await pullTask;
-
-                        this.currentConfig.Expect<InvalidOperationException>(() => throw new InvalidOperationException(
-                                        "Could not obtain twin neither from local store nor from cloud. " +
-                                        "This happens when there is no upstream connection and this is the first EdgeHub startup, " +
-                                        "or there is no persistent store to save a previous twin configuration. " +
-                                        "EdgeHub cannot start without basic configuration stored in twin. Stopping now."));
-
                         return this.currentConfig;
                     });
 


### PR DESCRIPTION
There is still an interdependency between the configuration fetch task and the protocol heads in the nested case. The pertinent PR is #5515.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.
