### PR TITLE
Enable MQTT Code Coverage and Documentation for Running Code Coverage Locally

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -118,12 +118,6 @@ jobs:
       - bash: edgelet/build/linux/clippy.sh
         displayName: Clippy
 
-# The CI VMs encounter
-#
-# >ld returned 1 exit status
-#
-# ... when running this job for no obvious reason.
-#
 ################################################################################
   - job: code_coverage
 ################################################################################
@@ -131,7 +125,6 @@ jobs:
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     variables:
-      coverage.excludes: "docker-rs*"
       coverage.goal: 44
     pool:
       vmImage: "ubuntu-18.04"
@@ -148,11 +141,9 @@ jobs:
         workingDirectory: edgelet
         displayName: Install Cargo Tarpaulin
       - script: |
-          $CARGO tarpaulin --out Xml --exclude-files $COVERAGE_EXCLUDES --output-dir .
+          $CARGO tarpaulin --out Xml --output-dir .
         displayName: Test
         workingDirectory: edgelet
-        env:
-          COVERAGE_EXCLUDES: $(coverage.excludes)
       - task: PublishCodeCoverageResults@1
         displayName: Publish code coverage results
         inputs:

--- a/builds/checkin/mqtt.yaml
+++ b/builds/checkin/mqtt.yaml
@@ -73,3 +73,42 @@ jobs:
         displayName: Format Code
       - bash: mqtt/build/linux/clippy.sh
         displayName: Clippy
+
+################################################################################
+  - job: code_coverage
+################################################################################
+    displayName: Code Coverage
+    dependsOn: check_run_pipeline
+    condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
+    variables:
+      coverage.goal: 44
+    pool:
+      vmImage: "ubuntu-18.04"
+    steps:
+      - script: |
+          echo "##vso[task.setvariable variable=IOTEDGE_HOMEDIR;]/tmp"
+          echo "##vso[task.setvariable variable=CARGO;]${CARGO_HOME:-"$HOME/.cargo"}/bin/cargo"
+        displayName: Set env variables
+        workingDirectory: mqtt
+      - script: scripts/linux/generic-rust/install.sh --project-root "mqtt"
+        displayName: Install Rust
+      - script: |
+          $CARGO install cargo-tarpaulin
+        workingDirectory: mqtt
+        displayName: Install Cargo Tarpaulin
+      - script: |
+          $CARGO tarpaulin --out Xml --output-dir .
+        displayName: Test
+        workingDirectory: mqtt
+      - task: PublishCodeCoverageResults@1
+        displayName: Publish code coverage results
+        inputs:
+          codeCoverageTool: cobertura
+          summaryFileLocation: "mqtt/cobertura.xml"
+      - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@5
+        displayName: "Check build quality"
+        inputs:
+          checkCoverage: true
+          coverageFailOption: fixed
+          coverageType: lines
+          coverageThreshold: $(coverage.goal)

--- a/builds/checkin/mqtt.yaml
+++ b/builds/checkin/mqtt.yaml
@@ -81,7 +81,7 @@ jobs:
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     variables:
-      coverage.goal: 44
+      coverage.goal: 84
     pool:
       vmImage: "ubuntu-18.04"
     steps:

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -194,6 +194,48 @@ To run `aziot-edged` locally:
 cargo test --all
 ```
 
+### Run Code Coverage Checks
+
+In order to run Code Coverage Checks locally do the following 
+```sh
+
+#Run From the Edgelet Directory
+cd edgelet 
+
+#One Time Setup Only.
+cargo install cargo-tarpaulin
+
+
+#Run Unit Test with Code Coverage
+cargo tarpaulin --out Xml --output-dir .
+```
+
+You should see an output like this
+
+```sh
+.
+.
+.
+|| support-bundle/src/error.rs: 0/9
+|| support-bundle/src/runtime_util.rs: 0/18
+|| support-bundle/src/shell_util.rs: 0/117
+|| support-bundle/src/support_bundle.rs: 0/50
+|| 
+46.28% coverage, 2993/6467 lines covered
+```
+
+Additionally, You can also view a HTML Report highlighting code sections covered using the following
+
+```sh
+
+#One Time Setup Only.
+pip install pycobertura
+
+#Create an HTML Report for viewing using pycobertura
+pycobertura show --format html --output coverage.html cobertura.xml
+
+```
+
 
 ### Additional Tools
 

--- a/edgelet/docker-rs/src/lib.rs
+++ b/edgelet/docker-rs/src/lib.rs
@@ -9,7 +9,7 @@
     unused_mut
 )]
 #![allow(clippy::all, clippy::pedantic)]
-
+#![cfg(not(tarpaulin_include))]
 pub mod apis;
 pub mod models;
 pub mod utils;


### PR DESCRIPTION
1. Enable Code Coverage Checks for MQTT with initial check-in gate of 84%
2. cargo-tarpaulin was updated recently to fix the bug I had opened (https://github.com/xd009642/tarpaulin/issues/846). Set exclude at lib.rs instead of at yaml. This allows to manage excludes in the code instead of yaml.
3. Added documentation for running Rust Code Coverage Check locally

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
