### PR TITLE
Connectivity Tests: Make c2d tolerance protocol agnostic

### DIFF
--- a/test/modules/TestResultCoordinator/Reports/CountingReport.cs
+++ b/test/modules/TestResultCoordinator/Reports/CountingReport.cs
@@ -27,7 +27,7 @@ namespace TestResultCoordinator.Reports
     /// </summary>
     class CountingReport : TestResultReportBase
     {
-        const string C2dOverMqttTestDescription = "C2D | mqtt";
+        const string C2dTestDescription = "C2D";
         const string GenericMqttTelemetryTestDescription = "messages | local | mqtt | generic";
 
         public CountingReport(
@@ -117,7 +117,7 @@ namespace TestResultCoordinator.Reports
                 {
                     // Product issue for C2D messages connected to edgehub over mqtt.
                     // We should remove this failure tolerance when fixed.
-                    if (this.TestDescription.Equals(C2dOverMqttTestDescription))
+                    if (this.TestDescription.Contains(C2dTestDescription))
                     {
                         return ((double)this.TotalMatchCount / this.TotalExpectCount) > .8d;
                     }


### PR DESCRIPTION
Connectivity tests are failing due to amqp connected c2d test module failing the test. This is a legitimate failure. Previously we thought only mqtt connected modules were affected. We need to add a tolerance for amqp connected modules. So in this PR I make the existing tolerance protocol agnostic.

Waiting on this connectivity test for merge:
https://msazure.visualstudio.com/One/_build/results?buildId=48718095&view=results

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ x] Title of the pull request is clear and informative.
- [x ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ x] concise summary of tests added/modified
	- [ x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
