### PR TITLE
Update base image to alpine 3.14 (edge-agent/amd64)

### DIFF
--- a/edge-agent/docker/linux/amd64/Dockerfile
+++ b/edge-agent/docker/linux/amd64/Dockerfile
@@ -1,4 +1,4 @@
-﻿ARG base_tag=3.1.18-alpine3.13
+﻿ARG base_tag=3.1-alpine3.14
 FROM azureiotedge/azureiotedge-runtime-base:1.2-linux-amd64 as builder
 
 FROM mcr.microsoft.com/dotnet/aspnet:${base_tag}


### PR DESCRIPTION
The base image version in release/1.1 and release/1.2 is alpine 3.14. 

**Testing Notes:**

Built the image locally.

![image](https://user-images.githubusercontent.com/90283547/140586230-c0ba95a8-7927-4ab0-90c2-bc28b6a6a64b.png)


### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).