### PR TITLE
[master] Device product information

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string EdgeletApiVersionVariableName = "IOTEDGE_APIVERSION";
 
-        public const string EdgeletProductInfoVariableName = "IOTEDGE_PRODUCT_INFO";
+        public const string EdgeletProductInfoVariableName = "IOTEDGE_PRODUCTINFO";
 
         public const string ModeKey = "Mode";
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -71,6 +71,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string EdgeletApiVersionVariableName = "IOTEDGE_APIVERSION";
 
+        public const string EdgeletProductInfoVariableName = "IOTEDGE_PRODUCT_INFO";
+
         public const string ModeKey = "Mode";
 
         public const string IotedgedMode = "iotedged";

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
@@ -145,7 +145,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
 
             if (identity.ModuleId.Equals(Constants.EdgeAgentModuleIdentityName))
             {
-                string additionalProductInfo = configSource.Configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName);
+                string additionalProductInfo = configSource.Configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName, "");
                 if (!string.IsNullOrEmpty(additionalProductInfo) && !envVars.Exists(x => x.Key == Constants.EdgeletProductInfoVariableName))
                 {
                     envVars.Add(new EnvVar(Constants.EdgeletProductInfoVariableName, additionalProductInfo));

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
     using Microsoft.Azure.Devices.Edge.Agent.Edgelet.Models;
     using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
 
     public class CreateOrUpdateCommand : ICommand
@@ -18,6 +19,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
         readonly ModuleSpec moduleSpec;
         readonly Lazy<string> id;
         readonly Operation operation;
+
+        static readonly ILogger Log = Logger.Factory.CreateLogger<CreateOrUpdateCommand>();
 
         CreateOrUpdateCommand(IModuleManager moduleManager, ModuleSpec moduleSpec, Operation operation)
         {
@@ -142,16 +145,36 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
                 parentEdgeHostname.ForEach(value => envVars.Add(new EnvVar(Constants.ParentEdgeHostnameVariableName, value)));
             }
 
+            Log.LogInformation("### About to check PROD_INFO env variable");
+
             if (identity.ModuleId.Equals(Constants.EdgeAgentModuleIdentityName))
             {
+                Log.LogInformation("### Module name matched, so checking if PROD_INFO is defined");
+
                 var productInfo = configSource.Configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName);
                 if (!string.IsNullOrEmpty(productInfo))
                 {
+                    Log.LogInformation($"### PROD_INFO is defined in the environment, so putting there");
+
                     if (!envVars.Exists(e => e.Key == Constants.EdgeletProductInfoVariableName))
                     {
+                        Log.LogInformation($"### Adding PROD_INFO");
+
                         envVars.Add(new EnvVar(Constants.EdgeletProductInfoVariableName, productInfo));
                     }
+                    else
+                    {
+                        Log.LogInformation($"### NOT adding PROD_INFO, because it is added already");
+                    }
                 }
+                else
+                {
+                    Log.LogInformation($"### PROD_INFO is NOT defined in the environment");
+                }
+            }
+            else
+            {
+                Log.LogInformation($"### Module name did not matched, so PROD_INFO will not be put there ({identity.ModuleId})");
             }
 
             if (!string.IsNullOrWhiteSpace(identity.DeviceId))

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
@@ -142,6 +142,18 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
                 parentEdgeHostname.ForEach(value => envVars.Add(new EnvVar(Constants.ParentEdgeHostnameVariableName, value)));
             }
 
+            if (identity.ModuleId.Equals(Constants.EdgeAgentModuleIdentityName))
+            {
+                var productInfo = configSource.Configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName);
+                if (!string.IsNullOrEmpty(productInfo))
+                {
+                    if (!envVars.Exists(e => e.Key == Constants.EdgeletProductInfoVariableName))
+                    {
+                        envVars.Add(new EnvVar(Constants.EdgeletProductInfoVariableName, productInfo));
+                    }
+                }
+            }
+
             if (!string.IsNullOrWhiteSpace(identity.DeviceId))
             {
                 envVars.Add(new EnvVar(Constants.DeviceIdVariableName, identity.DeviceId));

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
@@ -20,8 +20,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
         readonly Lazy<string> id;
         readonly Operation operation;
 
-        static readonly ILogger Log = Logger.Factory.CreateLogger<CreateOrUpdateCommand>();
-
         CreateOrUpdateCommand(IModuleManager moduleManager, ModuleSpec moduleSpec, Operation operation)
         {
             this.moduleManager = Preconditions.CheckNotNull(moduleManager, nameof(moduleManager));

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/CreateOrUpdateCommand.cs
@@ -145,36 +145,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
                 parentEdgeHostname.ForEach(value => envVars.Add(new EnvVar(Constants.ParentEdgeHostnameVariableName, value)));
             }
 
-            Log.LogInformation("### About to check PROD_INFO env variable");
-
             if (identity.ModuleId.Equals(Constants.EdgeAgentModuleIdentityName))
             {
-                Log.LogInformation("### Module name matched, so checking if PROD_INFO is defined");
-
-                var productInfo = configSource.Configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName);
-                if (!string.IsNullOrEmpty(productInfo))
+                string additionalProductInfo = configSource.Configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName);
+                if (!string.IsNullOrEmpty(additionalProductInfo) && !envVars.Exists(x => x.Key == Constants.EdgeletProductInfoVariableName))
                 {
-                    Log.LogInformation($"### PROD_INFO is defined in the environment, so putting there");
-
-                    if (!envVars.Exists(e => e.Key == Constants.EdgeletProductInfoVariableName))
-                    {
-                        Log.LogInformation($"### Adding PROD_INFO");
-
-                        envVars.Add(new EnvVar(Constants.EdgeletProductInfoVariableName, productInfo));
-                    }
-                    else
-                    {
-                        Log.LogInformation($"### NOT adding PROD_INFO, because it is added already");
-                    }
+                    envVars.Add(new EnvVar(Constants.EdgeletProductInfoVariableName, additionalProductInfo));
                 }
-                else
-                {
-                    Log.LogInformation($"### PROD_INFO is NOT defined in the environment");
-                }
-            }
-            else
-            {
-                Log.LogInformation($"### Module name did not matched, so PROD_INFO will not be put there ({identity.ModuleId})");
             }
 
             if (!string.IsNullOrWhiteSpace(identity.DeviceId))

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -149,11 +149,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 {
                     productInfo += $"/{versionInfo}";
                 }
+
                 string additionalProductInfo = configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName);
                 if (!string.IsNullOrEmpty(additionalProductInfo))
                 {
                     productInfo += $" {additionalProductInfo}";
                 }
+
                 Option<UpstreamProtocol> upstreamProtocol = configuration.GetValue<string>(Constants.UpstreamProtocolKey).ToUpstreamProtocol();
                 Option<IWebProxy> proxy = Proxy.Parse(configuration.GetValue<string>("https_proxy"), logger);
                 bool closeOnIdleTimeout = configuration.GetValue(Constants.CloseOnIdleTimeout, false);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -144,10 +144,16 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             {
                 var builder = new ContainerBuilder();
                 builder.RegisterModule(new LoggingModule(dockerLoggingDriver, dockerLoggingOptions));
-                string productInfo =
-                    versionInfo != VersionInfo.Empty ?
-                    $"{Constants.IoTEdgeAgentProductInfoIdentifier}/{versionInfo}" :
-                    Constants.IoTEdgeAgentProductInfoIdentifier;
+                string productInfo = Constants.IoTEdgeAgentProductInfoIdentifier;
+                if (versionInfo != VersionInfo.Empty)
+                {
+                    productInfo += $"/{versionInfo}";
+                }
+                string additionalProductInfo = configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName);
+                if (!string.IsNullOrEmpty(additionalProductInfo))
+                {
+                    productInfo += $" {additionalProductInfo}";
+                }
                 Option<UpstreamProtocol> upstreamProtocol = configuration.GetValue<string>(Constants.UpstreamProtocolKey).ToUpstreamProtocol();
                 Option<IWebProxy> proxy = Proxy.Parse(configuration.GetValue<string>("https_proxy"), logger);
                 bool closeOnIdleTimeout = configuration.GetValue(Constants.CloseOnIdleTimeout, false);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                     productInfo += $"/{versionInfo}";
                 }
 
-                string additionalProductInfo = configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName);
+                string additionalProductInfo = configuration.GetValue<string>(Constants.EdgeletProductInfoVariableName, "");
                 if (!string.IsNullOrEmpty(additionalProductInfo))
                 {
                     productInfo += $" {additionalProductInfo}";

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/commands/CreateOrUpdateCommandTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/commands/CreateOrUpdateCommandTest.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.Commands
     {
         [Theory]
         [MemberData(nameof(TestDataCollection))]
-        public void VerfiyCreateOrUpdateCommand(CreateOrUpdateCommandTestData testData)
+        public void VerifyCreateOrUpdateCommand(CreateOrUpdateCommandTestData testData)
         {
             var mocks = new CreateOrUpdateCommandMocks(testData);
 

--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -143,6 +143,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tokio 1.12.0",
+ "toml",
  "url 2.2.2",
 ]
 

--- a/edgelet/aziot-edged/Cargo.toml
+++ b/edgelet/aziot-edged/Cargo.toml
@@ -12,8 +12,9 @@ futures-util = "0.3"
 log = "0.4"
 serde_json = "1"
 sha2 = "0.9"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "sync", "time"] }
+toml = "0.5"
 url = "2"
 
 edgelet-core = { path = "../edgelet-core" }

--- a/edgelet/aziot-edged/src/main.rs
+++ b/edgelet/aziot-edged/src/main.rs
@@ -5,6 +5,7 @@
 
 mod error;
 mod management;
+mod product_info;
 mod provision;
 mod watchdog;
 mod workload_manager;

--- a/edgelet/aziot-edged/src/product_info.rs
+++ b/edgelet/aziot-edged/src/product_info.rs
@@ -1,0 +1,194 @@
+use std::convert::AsRef;
+use std::fmt;
+use std::fs;
+use std::io::{self, BufRead};
+use std::path::Path;
+use std::process::{Command, Output};
+
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize, PartialEq)]
+pub(crate) struct ProductInfo {
+    product: Vec<Product>,
+}
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct Product {
+    name: String,
+    version: String,
+    comment: Option<String>,
+}
+
+#[inline]
+fn read_utf8(v: Vec<u8>) -> io::Result<String> {
+    Ok(String::from_utf8(v)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?
+        .trim()
+        .to_owned())
+}
+
+#[inline]
+fn read_output(out: Output) -> io::Result<String> {
+    match out.status.code() {
+        Some(0) => read_utf8(out.stdout),
+        Some(code) => Err(io::Error::from_raw_os_error(code)),
+        _ => Err(io::Error::from(io::ErrorKind::Other)),
+    }
+}
+
+#[inline]
+fn strip_quotes(s: &str) -> io::Result<&str> {
+    s.strip_prefix('\"')
+        .and_then(|s| s.strip_suffix('\"'))
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "mismatched quotes"))
+}
+
+impl ProductInfo {
+    pub fn try_load(p: impl AsRef<Path>) -> io::Result<Self> {
+        let bytes = fs::read(p)?;
+
+        toml::de::from_slice(&bytes).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+    }
+
+    pub fn from_system() -> io::Result<Self> {
+        let mut product = vec![];
+
+        // NOTE: operating system
+        product.push({
+            let b = io::BufReader::new(
+                fs::File::open("/etc/os-release")
+                    .or_else(|_| fs::File::open("/usr/lib/os-release"))?,
+            );
+
+            let mut name = None;
+            let mut version = None;
+            let mut comment = None;
+
+            for line in b.lines() {
+                match line?.trim().split_once("=") {
+                    Some(("ID", value)) => name = Some(strip_quotes(value)?.to_owned()),
+                    Some(("VERSION_ID", value)) => version = Some(strip_quotes(value)?.to_owned()),
+                    Some(("PRETTY_NAME", value)) => comment = Some(strip_quotes(value)?.to_owned()),
+                    _ => (),
+                }
+            }
+
+            Product {
+                name: name
+                    .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "os-release: ID"))?,
+                version: version.ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "os-release: VERSION_ID")
+                })?,
+                comment,
+            }
+        });
+
+        // NOTE: kernel
+        product.push(Product {
+            name: Command::new("uname")
+                .arg("-s")
+                .output()
+                .and_then(read_output)?,
+            version: Command::new("uname")
+                .arg("-r")
+                .output()
+                .and_then(read_output)?,
+            comment: Some(
+                Command::new("uname")
+                    .arg("-v")
+                    .output()
+                    .and_then(read_output)?,
+            ),
+        });
+
+        // NOTE: device
+        product.push(Product {
+            name: read_utf8(fs::read("/sys/devices/virtual/dmi/id/product_name")?)?,
+            version: read_utf8(fs::read("/sys/devices/virtual/dmi/id/product_version")?)?,
+            comment: Some(read_utf8(fs::read(
+                "/sys/devices/virtual/dmi/id/sys_vendor",
+            )?)?),
+        });
+
+        Ok(Self { product })
+    }
+}
+
+impl fmt::Display for Product {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.name, self.version)?;
+
+        if let Some(comment) = &self.comment {
+            write!(f, " ({})", comment)?;
+        };
+
+        Ok(())
+    }
+}
+
+impl fmt::Display for ProductInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(first) = self.product.first() {
+            write!(f, "{}", first)?;
+
+            // NOTE: will not panic
+            for product in &self.product[1..] {
+                write!(f, " {}", product)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    impl From<(&str, &str)> for Product {
+        fn from(value: (&str, &str)) -> Self {
+            Product {
+                name: value.0.to_owned(),
+                version: value.1.to_owned(),
+                comment: None,
+            }
+        }
+    }
+
+    impl From<(&str, &str, &str)> for Product {
+        fn from(value: (&str, &str, &str)) -> Self {
+            Product {
+                name: value.0.to_owned(),
+                version: value.1.to_owned(),
+                comment: Some(value.2.to_owned()),
+            }
+        }
+    }
+
+    #[test]
+    fn product_string_no_comment() {
+        let p: Product = ("FOO", "BAR").into();
+
+        assert_eq!("FOO/BAR", p.to_string());
+    }
+
+    #[test]
+    fn product_string_with_comment() {
+        let p: Product = ("FOO", "BAR", "BAZ").into();
+
+        assert_eq!("FOO/BAR (BAZ)", p.to_string());
+    }
+
+    #[test]
+    fn multiple_products() {
+        let pinfo = ProductInfo {
+            product: vec![
+                ("FOO", "BAR").into(),
+                ("A", "B", "C").into(),
+                ("name", "version", "comment").into(),
+            ],
+        };
+
+        assert_eq!("FOO/BAR A/B (C) name/version (comment)", pinfo.to_string());
+    }
+}

--- a/edgelet/edgelet-settings/src/base/mod.rs
+++ b/edgelet/edgelet-settings/src/base/mod.rs
@@ -22,6 +22,7 @@ pub trait RuntimeSettings {
 
     fn agent(&self) -> &module::Settings<Self::ModuleConfig>;
     fn agent_mut(&mut self) -> &mut module::Settings<Self::ModuleConfig>;
+    fn product_info(&self) -> Option<&std::path::Path>;
 
     fn connect(&self) -> &uri::Connect;
     fn listen(&self) -> &uri::Listen;
@@ -56,6 +57,9 @@ pub struct Settings<ModuleConfig> {
     pub allow_elevated_docker_permissions: bool,
 
     pub agent: module::Settings<ModuleConfig>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub product_info: Option<std::path::PathBuf>,
+
     pub connect: uri::Connect,
     pub listen: uri::Listen,
 
@@ -112,6 +116,10 @@ impl<T: Clone> RuntimeSettings for Settings<T> {
 
     fn agent_mut(&mut self) -> &mut module::Settings<Self::ModuleConfig> {
         &mut self.agent
+    }
+
+    fn product_info(&self) -> Option<&std::path::Path> {
+        self.product_info.as_deref()
     }
 
     fn connect(&self) -> &uri::Connect {

--- a/edgelet/edgelet-settings/src/docker/mod.rs
+++ b/edgelet/edgelet-settings/src/docker/mod.rs
@@ -90,6 +90,10 @@ impl crate::RuntimeSettings for Settings {
         self.base.agent_mut()
     }
 
+    fn product_info(&self) -> Option<&std::path::Path> {
+        self.base.product_info()
+    }
+
     fn connect(&self) -> &crate::uri::Connect {
         self.base.connect()
     }

--- a/edgelet/edgelet-test-utils/src/settings.rs
+++ b/edgelet/edgelet-test-utils/src/settings.rs
@@ -50,6 +50,10 @@ impl edgelet_settings::RuntimeSettings for Settings {
         unimplemented!()
     }
 
+    fn product_info(&self) -> Option<&std::path::Path> {
+        unimplemented!()
+    }
+
     fn connect(&self) -> &edgelet_settings::uri::Connect {
         unimplemented!()
     }

--- a/edgelet/iotedge/src/config/import/mod.rs
+++ b/edgelet/iotedge/src/config/import/mod.rs
@@ -439,6 +439,7 @@ fn execute_inner(
                 },
             )?
         },
+        product_info: Default::default(),
 
         connect: {
             let old_config::Connect {

--- a/edgelet/iotedge/src/config/mp.rs
+++ b/edgelet/iotedge/src/config/mp.rs
@@ -77,6 +77,7 @@ To reconfigure IoT Edge, run:
         },
 
         agent: super_config::default_agent(),
+        product_info: Default::default(),
 
         connect: Default::default(),
         listen: Default::default(),

--- a/edgelet/iotedge/src/config/super_config.rs
+++ b/edgelet/iotedge/src/config/super_config.rs
@@ -39,6 +39,9 @@ pub struct Config {
     pub agent: edgelet_settings::ModuleSpec<edgelet_settings::DockerConfig>,
 
     #[serde(default)]
+    pub product_info: Option<ProductInfo>,
+
+    #[serde(default)]
     pub connect: edgelet_settings::uri::Connect,
     #[serde(default)]
     pub listen: edgelet_settings::uri::Listen,
@@ -70,6 +73,13 @@ pub fn default_agent() -> edgelet_settings::ModuleSpec<edgelet_settings::DockerC
         /* image pull policy */ Default::default(),
     )
     .expect("name and type are never empty")
+}
+
+#[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]
+#[serde(rename_all = "snake_case", tag = "source", content = "value")]
+pub enum ProductInfo {
+    System,
+    Custom(String),
 }
 
 #[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]

--- a/edgelet/iotedge/src/config/super_config.rs
+++ b/edgelet/iotedge/src/config/super_config.rs
@@ -38,8 +38,8 @@ pub struct Config {
     #[serde(default = "default_agent")]
     pub agent: edgelet_settings::ModuleSpec<edgelet_settings::DockerConfig>,
 
-    #[serde(default)]
-    pub product_info: Option<ProductInfo>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub product_info: Option<std::path::PathBuf>,
 
     #[serde(default)]
     pub connect: edgelet_settings::uri::Connect,
@@ -73,13 +73,6 @@ pub fn default_agent() -> edgelet_settings::ModuleSpec<edgelet_settings::DockerC
         /* image pull policy */ Default::default(),
     )
     .expect("name and type are never empty")
-}
-
-#[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]
-#[serde(rename_all = "snake_case", tag = "source", content = "value")]
-pub enum ProductInfo {
-    System,
-    Custom(String),
 }
 
 #[derive(Debug, serde_derive::Deserialize, serde_derive::Serialize)]


### PR DESCRIPTION
Currently, the edge agent encodes some runtime information (e.g. EdgeAgent and .NET versions) as part of the product information connection parameter, which can then be used to examine device characteristics from management interfaces. Some users desire the ability to add system-level properties--such as kernel version--to the product information. This PR adds a configuration option for custom product information strings as well as an automated option which augments the existing runtime information with the following system parameters:
- kernel name, release, architecture
- OS name, release
- system name, version, vendor

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  
