### PR TITLE
Use 1ES hosted agent for amd64 single-node connectivity tests

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -87,12 +87,9 @@ jobs:
           testrun.network.runProfile: "Cellular3G"
           testrun.duration: "01:00:00"
     pool:
-      name: $(pool.name)
+      name: $(pool.linux.name)
       demands:
-        - agent-group -equals $(agent.group)
-        - Agent.OS -equals Linux
-        - Agent.OSArchitecture -equals X64
-        - run-connectivity -equals true
+        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu18.04-amd64'
       aziotis.artifact.name: 'packages_ubuntu-18.04_amd64'

--- a/builds/e2e/templates/connectivity-deploy.yaml
+++ b/builds/e2e/templates/connectivity-deploy.yaml
@@ -171,7 +171,7 @@ steps:
   - task: PublishBuildArtifacts@1
     displayName: "Publish Support Bundle"
     inputs:
-      PathtoPublish: $(Agent.HomeDirectory)/../working/support
+      PathtoPublish: $(Agent.BuildDirectory)/../working/support
       ArtifactName: logs-$(artifactSuffix)
     condition: succeededOrFailed()
     

--- a/builds/e2e/templates/connectivity-deploy.yaml
+++ b/builds/e2e/templates/connectivity-deploy.yaml
@@ -38,27 +38,27 @@ steps:
     displayName: 'Copy Edgelet Artifact'
     inputs:
       SourceFolder: "$(Build.StagingDirectory)/${{ parameters['edgelet.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/"
+      TargetFolder: "$(Agent.BuildDirectory)/../artifacts/"
       CleanTargetFolder: true
   - task: CopyFiles@2
     condition: and(succeeded(), eq(variables['run.flag'], 1))
     displayName: 'Copy Images Artifact'
     inputs:
       SourceFolder: "$(Build.StagingDirectory)/${{ parameters['images.artifact.name'] }}"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
+      TargetFolder: "$(Agent.BuildDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}"
   - task: CopyFiles@2
     condition: and(succeeded(), eq(variables['run.flag'], 1))
     displayName: 'Copy aziot-identity-service'
     inputs:
       SourceFolder: "$(Build.StagingDirectory)"
       Contents: "$(aziotis.package.filter)"
-      TargetFolder: "$(Agent.HomeDirectory)/../artifacts/"
+      TargetFolder: "$(Agent.BuildDirectory)/../artifacts/"
   - task: Bash@3
     condition: and(succeeded(), eq(variables['run.flag'], 1))
     displayName: 'Generate device certificates'
     inputs:
       ${{ if eq(parameters['connectivity.nested'], 'false') }}:
-        workingDirectory: "$(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/CACertificates"
+        workingDirectory: "$(Agent.BuildDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/CACertificates"
       ${{ if eq(parameters['connectivity.nested'], 'true') }}:
         workingDirectory: "/certs"
       targetType: inline
@@ -93,7 +93,7 @@ steps:
       targetType: inline
       script: |
         declare -a cnreg=( ${{ parameters['container.registry.credential'] }} )
-        . $(Agent.HomeDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
+        . $(Agent.BuildDirectory)/../artifacts/${{ parameters['images.artifact.name'] }}/artifactInfo.txt
         chmod +x ${{ parameters['build.repo.path'] }}/scripts/linux/trcE2ETest.sh
         testName="Connectivity"
 
@@ -111,7 +111,7 @@ steps:
 
         sudo --preserve-env ${{ parameters['build.repo.path'] }}/scripts/linux/trcE2ETest.sh \
           -testName 'Connectivity' \
-          -testDir "$(Agent.HomeDirectory)/.." \
+          -testDir "$(Agent.BuildDirectory)/.." \
           -releaseLabel "${{ parameters['release.label'] }}" \
           -artifactImageBuildNumber "$BuildNumber" \
           -containerRegistry "${{ parameters['container.registry'] }}" \
@@ -150,7 +150,7 @@ steps:
         echo "script exit code=$scriptExitCode"
         exit $scriptExitCode
 
-      workingDirectory: "$(Agent.HomeDirectory)/.."
+      workingDirectory: "$(Agent.BuildDirectory)/.."
   
     env:
       E2E_nestedEdgeTest: $(nestededge)


### PR DESCRIPTION
This reverts commit 4852689781ca3e9d912accbd1921ec7a59ca18f2.

Fix to use 1ES Agent was made in #5798 

Waiting for this run to complete before merging the change in

Pipeline Run : https://msazure.visualstudio.com/One/_build/results?buildId=48819597&view=results

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
