### PR TITLE
Modify How Dotnet is Accessed during E2E Run

### DIFF
--- a/builds/checkin/e2e-checkin.yaml
+++ b/builds/checkin/e2e-checkin.yaml
@@ -41,9 +41,8 @@ stages:
     condition: |
       and
       ( 
-        succeededOrFailed(),
-        in(dependencies.PublishManifests.result, 'Succeeded','Skipped'),
-        in(dependencies.BuildPackages.result, 'Succeeded','Skipped')
+        in(dependencies.PublishManifests.result, 'Succeeded','Skipped', 'SucceededWithIssues'),
+        in(dependencies.BuildPackages.result, 'Succeeded','Skipped', 'SucceededWithIssues')
       )     
     jobs:
       - job: ubuntu_2004_msmoby

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -69,8 +69,16 @@ steps:
     {
       $filter += '&Category!=NestedEdgeOnly'
     }
-
-    sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
+    
+    #Dotnet SDK 3.1.415 package on Centos doesn't allow dotnet to be accessed via sudo command due to Path issues. Use the below workaround for centos only.
+    if ('$(artifactName)'.Contains('centos'))
+    {
+      sudo --preserve-env $(command -v dotnet) test $testFile --no-build --logger 'trx' --filter "$filter"
+    }
+    else
+    {
+      sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
+    }
 
   displayName: Run tests ${{ parameters.test_type }}
   env:

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -31,7 +31,7 @@ steps:
   - bash: | 
       echo "Built Images Result is $(builtImages)"
       echo "Built Packages Result is $(builtPackages)"
-      if [[ ! -z $(builtImages) && $(builtImages) == 'Succeeded' ]]
+      if [[ ! -z $(builtImages) && ( $(builtImages) == 'Succeeded' || $(builtImages) == 'SucceededWithIssues') ]]
       then
         echo "Use Pipeline Image Artifacts"
         echo "##vso[task.setvariable variable=UsePipelineImageArtifacts;isOutput=true]TRUE"
@@ -39,7 +39,7 @@ steps:
         echo "Use Build Image Artifacts"
         echo "##vso[task.setvariable variable=UsePipelineImageArtifacts;isOutput=true]FALSE"
       fi
-      if [[ ! -z $(builtPackages) && $(builtPackages) == 'Succeeded' ]]
+      if [[ ! -z $(builtPackages) && ( $(builtPackages) == 'Succeeded' || $(builtPackages) == 'SucceededWithIssues') ]]
       then
         echo "Use Pipeline Package Artifacts"
         echo "##vso[task.setvariable variable=UsePipelinePackageArtifacts;isOutput=true]TRUE"


### PR DESCRIPTION
This is a Cherry-Pick of #5826

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
