### PR TITLE
Remove nuget.config to address pipeline warnings

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-  </packageSources>
-</configuration>


### PR DESCRIPTION
We added a nuget.config file some time back because we needed to pull from multiple nuget feeds: the regular public feed and an internal feed needed occasionally/temporarily for special drops of the IoT SDK. When Microsoft began scanning for config files that might be subject to a substitution attack, we took a few different steps over time to ensure compliance.

Now we're beginning to see warnings in our pipeline because our config file points to the public feed, _even though its the only configured feed_. I suspect the scans are geared towards internal projects using OSS, rather than for public-facing projects which are themselves OSS.

Since we don't need any special feeds, I believe we can avoid the pipeline warnings by removing the config file altogether.

Cherry-pick 36fe1a9cc4ad90a54b425fa3529077a987ba53e6 from release/1.2.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.