### PR TITLE
Modify How Dotnet is Accessed during E2E Run

### DIFF
--- a/builds/checkin/e2e-checkin.yaml
+++ b/builds/checkin/e2e-checkin.yaml
@@ -46,9 +46,8 @@ stages:
     condition: |
       and
       ( 
-        succeededOrFailed(),
-        in(dependencies.BuildExecutables.result, 'Succeeded','Skipped'),
-        in(dependencies.BuildPackages.result, 'Succeeded','Skipped')
+        in(dependencies.BuildExecutables.result, 'Succeeded','Skipped','SucceededWithIssues'),
+        in(dependencies.BuildPackages.result, 'Succeeded','Skipped','SucceededWithIssues')
       )     
     jobs:
       - job: ubuntu_2004_msmoby

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -46,8 +46,16 @@ steps:
       {
         $filter += '&Name~TempSensor'
       }
-
-      sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
+      
+      #Dotnet SDK 3.1.415 package on Centos doesn't allow dotnet to be accessed via sudo command due to Path issues. Use the below workaround for centos only.
+      if ('$(artifactName)'.Contains('centos'))
+      {
+        sudo --preserve-env $(command -v dotnet) test $testFile --no-build --logger 'trx' --filter "$filter"
+      }
+      else
+      {
+        sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
+      }
     }
   displayName: Run tests
   env:

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -29,7 +29,7 @@ steps:
       Write-Host "Built Packages Result is $(builtPackages)"
       $buildImages = "$(builtImages)"
       $buildPackages = "$(builtPackages)"
-      if ($buildImages -eq 'Succeeded')
+      if ($buildImages -eq 'Succeeded' -or $buildImages -eq 'SucceededWithIssues')
       {
         Write-Host "Use Pipeline Image Artifacts"
         Write-Host "##vso[task.setvariable variable=UsePipelineImageArtifacts;isOutput=true]TRUE"
@@ -39,7 +39,7 @@ steps:
         Write-Host "Use Build Image Artifacts"
         Write-Host "##vso[task.setvariable variable=UsePipelineImageArtifacts;isOutput=true]FALSE"
       }
-      if ($buildPackages -eq 'Succeeded')
+      if ($buildPackages -eq 'Succeeded' -or $buildPackages -eq 'SucceededWithIssues')
       {
         Write-Host "Use Pipeline Package Artifacts"
         Write-Host "##vso[task.setvariable variable=UsePipelinePackageArtifacts;isOutput=true]TRUE"


### PR DESCRIPTION
Changes Had to be ported manually from #5826. The location of the changes are the same 
1. 1.1 Uses powershell instead of bash for running E2E Setup (Because of Windows Environment)
2.  Difference in Build Images Process in 1.1 as compared to master

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
