### PR TITLE
Revert Changes to Handle Validation of Since and Until Time

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
@@ -92,26 +92,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
                 string baseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri).TrimEnd('/');
                 var logsUrl = new StringBuilder();
                 logsUrl.AppendFormat(CultureInfo.InvariantCulture, LogsUrlTemplate, baseUrl, module, this.Version.Name, follow.ToString().ToLowerInvariant());
-                List<(string Name, string Value)> timeCollection = new List<(string, string)>();
-                since.ForEach(s =>
-                {
-                    timeCollection.Add((LogsUrlSinceParameter, s));
-                    logsUrl.AppendFormat($"&{LogsUrlSinceParameter}={Uri.EscapeUriString(s)}");
-                });
-                until.ForEach(u =>
-                {
-                    timeCollection.Add((LogsUrlUntilParameter, u));
-                    logsUrl.AppendFormat($"&{LogsUrlUntilParameter}={Uri.EscapeUriString(u)}");
-                });
-
-                timeCollection.ForEach(t =>
-                {
-                    if (!DateTime.TryParseExact(t.Value, "yyyy-MM-dd'T'HH:mm:ssZ", CultureInfo.InvariantCulture, DateTimeStyles.None, out var time))
-                    {
-                        throw new ArgumentException($"{t.Name} Time with value : {t.Value} is not in the correct format. The correct format should be yyyy-MM-dd'T'HH:mm:ssZ");
-                    }
-                });
-
+                since.ForEach(s => logsUrl.AppendFormat($"&{LogsUrlSinceParameter}={Uri.EscapeUriString(s)}"));
+                until.ForEach(u => logsUrl.AppendFormat($"&{LogsUrlUntilParameter}={Uri.EscapeUriString(u)}"));
                 includeTimestamp.ForEach(b => logsUrl.AppendFormat($"&{LogsIncludeTimestampParameter}={b.ToString().ToLower()}"));
 
                 if (!(tail.HasValue && since.HasValue && until.HasValue))

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleManagementHttpClientTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleManagementHttpClientTest.cs
@@ -27,8 +27,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
 
         public static IEnumerable<object[]> VersionMap => GetVersionMap();
 
-        public static IEnumerable<object[]> InvalidVersionDateTimeMap => GetInvalidDateTime();
-
         public ModuleManagementHttpClientTest(EdgeletFixture edgeletFixture)
         {
             this.serverUrl = new Uri(edgeletFixture.ServiceUrl);
@@ -264,40 +262,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
             IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
 
             // Act
-            Stream logsStream = await client.GetModuleLogs("edgeHub", false, Option.None<int>(), Option.None<string>(), Option.None<string>(), Option.Some(false), CancellationToken.None);
+            Stream logsStream = await client.GetModuleLogs("edgeHub", false, Option.None<int>(), Option.None<string>(), Option.None<string>(),  Option.Some(false), CancellationToken.None);
 
             // Assert
             Assert.NotNull(logsStream);
             byte[] buffer = new byte[1024];
             int bytesRead = await logsStream.ReadAsync(buffer, 0, buffer.Length);
             Assert.Equal(buffer.Length, bytesRead);
-        }
-
-        [Theory]
-        [MemberData(nameof(InvalidVersionDateTimeMap))]
-        public async Task ModuleLogsTestInvalidDateTime(string serverApiVersion, string clientApiVersion, string since, string until)
-        {
-            // Arrange
-            IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
-            // Act and Assert
-            var ex = await Assert.ThrowsAsync<ArgumentException>(async () =>
-            {
-                await client.GetModuleLogs("edgeHub", false, Option.Some<int>(10), Option.Some<string>(since), Option.Some<string>(until), Option.Some(true), CancellationToken.None);
-            });
-            Assert.Contains("The correct format should be yyyy-MM-dd'T'HH:mm:ssZ", ex.Message);
-        }
-
-        [Theory]
-        [MemberData(nameof(VersionMap))]
-        public async Task ModuleLogsTestValidDateTime(string serverApiVersion, string clientApiVersion)
-        {
-            // Arrange
-            IModuleManager client = new ModuleManagementHttpClient(this.serverUrl, serverApiVersion, clientApiVersion);
-
-            // Act and Assert
-            string since = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd'T'HH:mm:ssZ");
-            string until = DateTime.Now.AddDays(+1).ToString("yyyy-MM-dd'T'HH:mm:ssZ");
-            await client.GetModuleLogs("edgeHub", false, Option.Some<int>(10), Option.Some<string>(since), Option.Some<string>(until), Option.Some(true), CancellationToken.None);
         }
 
         [Theory]
@@ -376,19 +347,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
         {
             List<object[]> versionMap = Versions.SelectMany(x => Versions.Select(y => new object[] { x, y })).ToList();
             return versionMap;
-        }
-
-        public static IEnumerable<object[]> GetInvalidDateTime()
-        {
-            var invalidDateTimes = new List<(string Since, string Until)>()
-            {
-                ($"2021-11-01T12:07:0Z", "2021-11-01T12:07:44Z"),
-                ("2021-11-01T12:07:32Z", "2021-11-01T12:07:0Z"),
-                ("random1", "random2"),
-            };
-
-            var incorrect = GetVersionMap().SelectMany(x => invalidDateTimes.Select(y => new object[] { x[0], x[1], y.Since, y.Until }));
-            return incorrect;
         }
     }
 }


### PR DESCRIPTION
Revert Changes by PR #5801, Time Stamp handling needs to be handled in the edgelet code. This change broke the Portal Log Viewing since since and until time can take unix as well as simple language time

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
