### PR TITLE
Handle Return Code From Get Module Logs Failure

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
@@ -111,7 +111,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
                         HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
                         if (!httpResponseMessage.IsSuccessStatusCode)
                         {
-                            throw new EdgeletCommunicationException(await httpResponseMessage.Content.ReadAsStringAsync(), (int)httpResponseMessage.StatusCode);
+                            switch (httpResponseMessage.StatusCode)
+                            {
+                                case HttpStatusCode.BadRequest:
+                                    throw new ArgumentException($"Request Returned Status Code {httpResponseMessage.StatusCode} with Message {await httpResponseMessage.Content.ReadAsStringAsync()}");
+                                default:
+                                    throw new InvalidOperationException($"Request Returned Status Code {httpResponseMessage.StatusCode} with Message {await httpResponseMessage.Content.ReadAsStringAsync()}");
+                            }
                         }
 
                         return await httpResponseMessage.Content.ReadAsStreamAsync();

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
@@ -109,15 +109,9 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
                     async () =>
                     {
                         HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
-                        if (httpResponseMessage != null && !httpResponseMessage.IsSuccessStatusCode)
+                        if (!httpResponseMessage.IsSuccessStatusCode)
                         {
-                            switch (httpResponseMessage.StatusCode)
-                            {
-                                case HttpStatusCode.BadRequest:
-                                    throw new ArgumentException($"Request Returned Status Code {httpResponseMessage.StatusCode} with Message {await httpResponseMessage.Content.ReadAsStringAsync()}");
-                                default:
-                                    throw new InvalidOperationException($"Request Returned Status Code {httpResponseMessage.StatusCode} with Message {await httpResponseMessage.Content.ReadAsStringAsync()}");
-                            }
+                            throw new EdgeletCommunicationException(await httpResponseMessage.Content.ReadAsStringAsync(), (int)httpResponseMessage.StatusCode);
                         }
 
                         return await httpResponseMessage.Content.ReadAsStreamAsync();

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
     using System.Collections.Generic;
     using System.Globalization;
     using System.IO;
+    using System.Net;
     using System.Net.Http;
     using System.Net.Sockets;
     using System.Runtime.InteropServices;
@@ -108,6 +109,17 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
                     async () =>
                     {
                         HttpResponseMessage httpResponseMessage = await httpClient.SendAsync(httpRequest, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+                        if (httpResponseMessage != null && !httpResponseMessage.IsSuccessStatusCode)
+                        {
+                            switch (httpResponseMessage.StatusCode)
+                            {
+                                case HttpStatusCode.BadRequest:
+                                    throw new ArgumentException($"Request Returned Status Code {httpResponseMessage.StatusCode} with Message {await httpResponseMessage.Content.ReadAsStringAsync()}");
+                                default:
+                                    throw new InvalidOperationException($"Request Returned Status Code {httpResponseMessage.StatusCode} with Message {await httpResponseMessage.Content.ReadAsStringAsync()}");
+                            }
+                        }
+
                         return await httpResponseMessage.Content.ReadAsStreamAsync();
                     },
                     $"Get logs for {module}");

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
                                 case HttpStatusCode.BadRequest:
                                     throw new ArgumentException($"Request Returned Status Code {httpResponseMessage.StatusCode} with Message {await httpResponseMessage.Content.ReadAsStringAsync()}");
                                 default:
-                                    throw new InvalidOperationException($"Request Returned Status Code {httpResponseMessage.StatusCode} with Message {await httpResponseMessage.Content.ReadAsStringAsync()}");
+                                    throw new EdgeletCommunicationException(await httpResponseMessage.Content.ReadAsStringAsync(), (int)httpResponseMessage.StatusCode);
                             }
                         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/IotHub.cs
@@ -92,17 +92,17 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 string parentDeviceScope = parentDevice == null ? string.Empty : parentDevice.Scope;
                 Log.Verbose($"Parent scope: {parentDeviceScope}");
                 var result = new Device(deviceId)
-                                 {
-                                     Authentication = new AuthenticationMechanism()
-                                     {
-                                         Type = authType,
-                                         X509Thumbprint = x509Thumbprint
-                                     },
-                                     Capabilities = new DeviceCapabilities()
-                                     {
-                                         IotEdge = true
-                                     }
-                                 };
+                {
+                    Authentication = new AuthenticationMechanism()
+                    {
+                        Type = authType,
+                        X509Thumbprint = x509Thumbprint
+                    },
+                    Capabilities = new DeviceCapabilities()
+                    {
+                        IotEdge = true
+                    }
+                };
                 result.ParentScopes.Add(parentDeviceScope);
                 return result;
             },
@@ -184,7 +184,9 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 {
                     Log.Verbose($"Method '{method.MethodName}' on '{deviceId}/{moduleId}' returned: " +
                         $"{result.Status}\n{result.GetPayloadAsJson()}");
-                    return result.Status == 200;
+
+                    // No Need to retry when server returns Bad Request.
+                    return result.Status == 200 || result.Status == 400;
                 },
                 e =>
                     {

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -56,6 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 Context.Current.NestedEdge);
             await Task.Delay(30000);
 
+            // Verify RFC3339 Operation
             string since = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd'T'HH:mm:ssZ");
             string until = DateTime.Now.AddDays(+1).ToString("yyyy-MM-dd'T'HH:mm:ssZ");
 
@@ -68,6 +69,43 @@ namespace Microsoft.Azure.Devices.Edge.Test
             string expected = string.Join('\n', Enumerable.Range(0, count)) + "\n";
             LogResponse response = JsonConvert.DeserializeObject<LogResponse[]>(result.GetPayloadAsJson()).Single();
             Assert.AreEqual(expected, response.Payload);
+
+            // Verify Unix Time Operation
+            since = DateTime.Now.AddDays(-1).ToUnixTimestamp().ToString();
+            until = DateTime.Now.AddDays(+1).ToUnixTimestamp().ToString();
+
+            request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.Some(10), Option.Some(since), Option.Some(until), Option.None<int>(), Option.None<bool>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
+
+            result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
+
+            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+
+            expected = string.Join('\n', Enumerable.Range(0, count)) + "\n";
+            response = JsonConvert.DeserializeObject<LogResponse[]>(result.GetPayloadAsJson()).Single();
+            Assert.AreEqual(expected, response.Payload);
+
+            // Verify Human Readable Time Operation
+            since = "1 hour".ToString();
+            until = "1 second".ToString();
+
+            request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.Some(10), Option.Some(since), Option.Some(until), Option.None<int>(), Option.None<bool>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
+
+            result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
+
+            Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
+
+            expected = string.Join('\n', Enumerable.Range(0, count)) + "\n";
+            response = JsonConvert.DeserializeObject<LogResponse[]>(result.GetPayloadAsJson()).Single();
+            Assert.AreEqual(expected, response.Payload);
+
+            // Verify Incorrect Timestamp gives correct error
+            since = DateTime.Now.AddDays(-1).ToString("yyyy-MM-dd'T'HH:mm");
+            until = DateTime.Now.AddDays(+1).ToString("yyyy-MM-dd'T'HH:mm");
+
+            request = new ModuleLogsRequest("1.0", new List<LogRequestItem> { new LogRequestItem(moduleName, new ModuleLogFilter(Option.Some(10), Option.Some(since), Option.Some(until), Option.None<int>(), Option.None<bool>(), Option.None<string>())) }, LogsContentEncoding.None, LogsContentType.Text);
+
+            result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetModuleLogs", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
+            Assert.AreEqual((int)HttpStatusCode.BadRequest, result.Status);
         }
 
         [Test]


### PR DESCRIPTION
The goal of this PR is to handle return code correctly when calling get module logs. 

Earlier Behavior
1. A Request to Edgelet component with an incorrect argument, returned a Bad Request but was never handled and lead to Stream Parsing failure when trying to parse module logs , giving a cryptic error

New Behavior
1. Edge-Agent checks the correct HTTP Status code before trying to parse the Module Log Response

Testing
1. Added Test Case for both Happy-Path and Bad-Path in TestGetModuleLogs Test in E2E Test

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
