### PR TITLE
[E2E] Content Trust E2E setup and testing

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -150,7 +150,7 @@ jobs:
     displayName: Ubuntu 20.04 with arm64v8
     pool:
       name: $(pool.custom.name)
-      demands:
+      demands: 
         - agent-group -equals rpi3-e2e-aarch64
 
     variables:

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -27,7 +27,7 @@ variables:
   # installation, or in running a very basic test. We don't need to repeat the entire test suite.
   # The 'minimal' variable defaults to 'false'; we override it in specific jobs as needed.
   minimal: false
-  verbose: false
+  verbose: true
 
 jobs:
 
@@ -142,30 +142,6 @@ jobs:
 
     steps:
     - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
-
-################################################################################
-  - job: ubuntu_2004_arm64v8
-################################################################################
-    displayName: Ubuntu 20.04 with arm64v8
-    pool:
-      name: $(pool.custom.name)
-      demands: 
-        - agent-group -equals rpi3-e2e-aarch64
-
-    variables:
-      os: linux
-      arch: arm64v8
-      artifactName: iotedged-ubuntu20.04-aarch64
-      identityServiceArtifactName: packages_ubuntu-20.04_aarch64
-      identityServicePackageFilter: aziot-identity-service_*_arm64.deb
-
-    timeoutInMinutes: 120
-
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
 ################################################################################

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -27,7 +27,7 @@ variables:
   # installation, or in running a very basic test. We don't need to repeat the entire test suite.
   # The 'minimal' variable defaults to 'false'; we override it in specific jobs as needed.
   minimal: false
-  verbose: true
+  verbose: false
 
 jobs:
 
@@ -142,6 +142,30 @@ jobs:
 
     steps:
     - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
+
+################################################################################
+  - job: ubuntu_2004_arm64v8
+################################################################################
+    displayName: Ubuntu 20.04 with arm64v8
+    pool:
+      name: $(pool.custom.name)
+      demands:
+        - agent-group -equals rpi3-e2e-aarch64
+
+    variables:
+      os: linux
+      arch: arm64v8
+      artifactName: iotedged-ubuntu20.04-aarch64
+      identityServiceArtifactName: packages_ubuntu-20.04_aarch64
+      identityServicePackageFilter: aziot-identity-service_*_arm64.deb
+
+    timeoutInMinutes: 120
+
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
 ################################################################################

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -19,7 +19,7 @@ steps:
     $test_type = '${{ parameters.test_type }}'
 
     # Filter out flaky tests.
-    $filter = 'Category!=Flaky&Category=contenttrust'
+    $filter = 'Category!=Flaky'
     if ('$(minimal)' -eq 'true')
     {
       $filter += '&Name~TempSensor'

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -19,7 +19,7 @@ steps:
     $test_type = '${{ parameters.test_type }}'
 
     # Filter out flaky tests.
-    $filter = 'Category!=Flaky'
+    $filter = 'Category!=Flaky&Category=contenttrust'
     if ('$(minimal)' -eq 'true')
     {
       $filter += '&Name~TempSensor'
@@ -58,7 +58,7 @@ steps:
     elseif ($test_type -eq 'http_proxy')
     {
       #Disable tests that don't work in proxy environment. Renable post-investigation.
-      $filter += '&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~ValidateMetrics'
+      $filter += '&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~ValidateMetrics&FullyQualifiedName!~contenttrust'
       #Disable nested edge tests
       $filter += '&Category!=NestedEdgeOnly'
     }
@@ -83,6 +83,7 @@ steps:
     E2E_EVENT_HUB_ENDPOINT: ${{ parameters['EventHubCompatibleEndpoint'] }}
     E2E_IOT_HUB_CONNECTION_STRING: ${{ parameters['IotHubConnectionString'] }}
     E2E_REGISTRIES__0__PASSWORD: $(TestContainerRegistryPassword)
+    E2E_REGISTRIES__1__PASSWORD: $(TestContentTrustRegistryPassword)
     E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
     E2E_BLOB_STORE_SAS: $(TestBlobStoreSas)
     no_proxy: 'localhost'

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -25,9 +25,10 @@ steps:
         TestManifestSigningIntermediateCa,
         TestManifestSigningSignerCert,
         TestManifestSigningSignerKey,
-        TestManifestSigningBadRootCa
+        TestManifestSigningBadRootCa,
+        TestContentTrustRootCa,
+        TestContentTrustRegistryPassword,
 
-  
   - bash: | 
       echo "Built Images Result is $(builtImages)"
       echo "Built Packages Result is $(builtPackages)"
@@ -49,7 +50,15 @@ steps:
       fi
     name: check_use_artifacts
     displayName: Check Use Pipeline Image Artifacts
-  
+
+  - bash: |
+      wget https://github.com/theupdateframework/notary/releases/download/v0.6.0/notary-Linux-amd64
+      chmod +x notary-Linux-amd64
+      sudo mv notary-Linux-amd64 /usr/bin/notary
+      ls -l /usr/bin
+    name: install_notary_for_content_trust
+    displayName: Install Notary for Content Trust
+
   - task: DownloadPipelineArtifact@2
     displayName: Download Pipeline Build Images
     condition: eq(variables['check_use_artifacts.UsePipelineImageArtifacts'],'true')
@@ -136,7 +145,9 @@ steps:
       $manifestSigningDeploymentDir = '$(System.ArtifactsDirectory)/manifest_signing/deployment'
       Write-Output "##vso[task.setvariable variable=manifestSigningDeploymentDir]$manifestSigningDeploymentDir"
       $manifestSigningCertDir = '$(System.ArtifactsDirectory)/manifest_signing/certs'
+      $contentTrustCertDir = '$(System.ArtifactsDirectory)/content_trust/certs'
       New-Item "$manifestSigningCertDir" -ItemType Directory -Force | Out-Null
+      New-Item "$contentTrustCertDir" -ItemType Directory -Force | Out-Null
       New-Item "$manifestSigningDeploymentDir" -ItemType Directory -Force | Out-Null
       New-Item -Path "$manifestSigningDeploymentDir/deployment.json" -ItemType File
       New-Item -Path "$manifestSigningDeploymentDir/signed_deployment.json" -ItemType File
@@ -145,15 +156,18 @@ steps:
       $env:INTERMEDIATE_CA_CERT | Out-File -Encoding Utf8 "$manifestSigningCertDir/intermediate_ca.pem"
       $env:SIGNER_CERT | Out-File -Encoding Utf8 "$manifestSigningCertDir/signer_cert.pem"
       $env:SIGNER_KEY | Out-File -Encoding Utf8 "$manifestSigningCertDir/signer_key.key"
+      $env:CONTENT_TRUST_ROOT_CA_CERT | Out-File -Encoding Utf8 "$contentTrustCertDir/content_trust_root_ca.pem"
       Write-Output "##vso[task.setvariable variable=manifestSigningCertDir]$manifestSigningCertDir"
-    displayName: Build Manifest Signer Client and set up certificates
+      Write-Output "##vso[task.setvariable variable=contentTrustCertDir]$contentTrustCertDir"
+    displayName: Manifest Trust Setup 
     env:
       GOOD_ROOT_CA_CERT: $(TestManifestSigningGoodRootCa)
       BAD_ROOT_CA_CERT: $(TestManifestSigningBadRootCa)
       INTERMEDIATE_CA_CERT: $(TestManifestSigningIntermediateCa)
       SIGNER_CERT: $(TestManifestSigningSignerCert)
       SIGNER_KEY: $(TestManifestSigningSignerKey)
-  
+      CONTENT_TRUST_ROOT_CA_CERT : $(TestContentTrustRootCa)
+
   - pwsh: |
       $imageId = Get-Content -Encoding Utf8 `
         '$(System.ArtifactsDirectory)/$(az.pipeline.images.artifacts)/artifactInfo.txt'
@@ -204,6 +218,7 @@ steps:
       $testManifestSignerClientDirectory = Convert-Path "$(manifestSignerClientDir)";
       $testManifestSignerClientProjectPath = Convert-Path "$(manifestSignerClientDir)/ManifestSignerClient.csproj";
       $testManifestSigningLaunchSettingsPath = Convert-Path "$(manifestSignerClientDir)/Properties/launchSettings.json";
+      $testContentTrustRootCaPath = Convert-Path "$(contentTrustCertDir)/content_trust_root_ca.pem";
 
       $testManifestSigningDefaultLaunchSettings = @{
         profiles = @{
@@ -253,6 +268,10 @@ steps:
           @{
             address = '$(cr.address)';
             username = '$(cr.username)';
+          },
+          @{
+            address = '$(contenttrust.address)';
+            username = '$(contenttrust.username)';
           }
         );
         packagePath = Convert-Path '$(System.ArtifactsDirectory)/$(artifactName)';
@@ -261,7 +280,19 @@ steps:
         rootCaPrivateKeyPath = "$rootCaPrivateKeyPath";
         logFile = Join-Path '$(binDir)' 'testoutput.log';
         verbose = '$(verbose)';
-        getSupportBundle = 'true'
+        getSupportBundle = 'true';
+        manifestSigningDeploymentPath = "$testManifestSigningDeploymentPath";
+        manifestSigningSignedDeploymentPath = "$testManifestSigningSignedDeploymentPath";
+        manifestSigningGoodRootCaPath = "$testManifestSigningGoodRootCaPath";
+        manifestSigningBadRootCaPath = "$testManifestSigningBadRootCaPath";
+        manifestSigningDefaultLaunchSettings = "$testManifestSigningDefaultLaunchSettings";
+        manifestSigningLaunchSettingsPath = "$testManifestSigningLaunchSettingsPath";
+        manifestSignerClientDirectory = "$testManifestSignerClientDirectory";
+        manifestSignerClientProjectPath = "$testManifestSignerClientProjectPath";
+        contentTrustRootCaPath = "$testContentTrustRootCaPath";
+        contentTrustRegistryName = "${env:CONTENTTRUST_ADDRESS}";
+        contentTrustSignedImage = "${env:CONTENTTRUST_SIGNEDIMAGE}";
+        contentTrustUnsignedImage = "${env:CONTENTTRUST_UNSIGNEDIMAGE}";
       }
   
       if ('$(nestededge)' -eq 'true')
@@ -292,14 +323,5 @@ steps:
         $context['edgeProxy'] = $env:AGENT_PROXYURL
       }
 
-      $context['manifestSigningDeploymentPath'] = "$testManifestSigningDeploymentPath"
-      $context['manifestSigningSignedDeploymentPath'] = "$testManifestSigningSignedDeploymentPath"
-      $context['manifestSigningGoodRootCaPath'] = "$testManifestSigningGoodRootCaPath"
-      $context['manifestSigningBadRootCaPath'] = "$testManifestSigningBadRootCaPath"
-      $context['manifestSigningDefaultLaunchSettings'] = "$testManifestSigningDefaultLaunchSettings"
-      $context['manifestSigningLaunchSettingsPath'] = "$testManifestSigningLaunchSettingsPath"
-      $context['manifestSignerClientDirectory'] = "$testManifestSignerClientDirectory"
-      $context['manifestSignerClientProjectPath'] = "$testManifestSignerClientProjectPath"
-      
       $context | ConvertTo-Json | Out-File -Encoding Utf8 '$(binDir)/context.json'
     displayName: Create test arguments file (context.json)

--- a/doc/NotaryContentTrust.md
+++ b/doc/NotaryContentTrust.md
@@ -71,9 +71,9 @@ Important Note:
 Notary initializes the TUF trust collection for each image in the Container Registry. 
 
 ##### a. Notary Installation
-Notary client can be installed with `wget` command for `amd64` target platform and avoid installing using `sudo apt-get install notary`
+Notary client can be installed with `wget` command for `amd64` target platform and avoid installing using `sudo apt-get install notary` as it installs the latest version which has known bugs.
 
-`wget https://github.com/theupdateframework/notary/releases/download/v0.6.1/notary-Linux-amd64`
+`wget https://github.com/theupdateframework/notary/releases/download/v0.6.0/notary-Linux-amd64` (Note: 0.6.1 version has bugs on `notary lookup` operation. so please install the version specified.)
 
 Rename `notary-Linux-amd64` to `notary` and change the permissions by `chmod +x notary` and place the binary in `/usr/bin/notary`
 
@@ -133,7 +133,7 @@ The root CA of each Container Registry i.e `root_ca_exampleregistry.crt` must be
 
 In the `config.yaml`, in the Moby runtime section, content trust can be enabled by specifiying the registry server name and certificate ID of the root CA as shown in [sample](https://github.com/Azure/iotedge/blob/master/edgelet/iotedge/test-files/init/import/moby-runtime-content-trust/edged.yaml)
 
-In the `certd.toml`, under `preloaded_certs`, the mapping of the certificate ID and file path of the root CA must be configured as shown in [sample](https://github.com/Azure/iotedge/blob/master/edgelet/iotedge/test-files/config/moby-runtime-content-trust/certd.toml)
+In the `super-config.toml`, under `moby_runtime.content_trust.ca_certs`, the mapping of the certificate ID and file path of the root CA must be configured as shown in [sample](https://github.com/Azure/iotedge/blob/master/edgelet/iotedge/test-files/config/moby-runtime-content-trust/super-config.toml#L56)
 
 Recommendation is to create another Service Principal with Pull access for the edge device and ensure the login credentials are applied in the deployment manifest. 
 

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -285,11 +285,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         }
 
         public void RemoveManifestTrustBundle() => this.config[Service.Certd].Document.RemoveIfExists("preloaded_certs.aziot-edged-manifest-trust-bundle");
-        public void RemoveContentTrustCerts()
-        {
-            this.config[Service.Edged].Document.RemoveIfExists("moby_runtime.content_trust.ca_certs");
-            this.config[Service.Certd].Document.RemoveIfExists("preloaded_certs");
-        }
 
         public void AddIdentityPrincipal(string name, uint uid, string[] type = null, Dictionary<string, string> opts = null)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/DaemonConfiguration.cs
@@ -258,6 +258,20 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 this.config[Service.Certd].Document.ReplaceOrAdd("preloaded_certs.aziot-edged-manifest-trust-bundle", "file://" + certs.ManifestTrustedCertificatesPath.OrDefault());
             }
 
+            if (certs.ContentTrustInputs.HasValue)
+            {
+                // Content trust config is a part of super-config.toml. Currently, We don't have a way to set up super config in E2E test.
+                // To enable content trust in E2E, both certd and edged needs to be configured with right mapping.
+                foreach (var kvp in certs.ContentTrustInputs.OrDefault())
+                {
+                    string quoted_hostname = $"\"{kvp.Key}\"";
+                    string prefix_hostname = $"content-trust-{kvp.Key}";
+                    string prefix_quoted_hostname = $"\"content-trust-{kvp.Key}\"";
+                    this.config[Service.Edged].Document.AddTable("moby_runtime.content_trust.ca_certs", quoted_hostname, prefix_hostname);
+                    this.config[Service.Certd].Document.AddToTableWithExistingEntry("preloaded_certs", prefix_quoted_hostname, $"file://{kvp.Value}");
+                }
+            }
+
             this.config[Service.Certd].Document.ReplaceOrAdd("preloaded_certs.aziot-edged-ca", "file://" + certs.CertificatePath);
             this.config[Service.Keyd].Document.ReplaceOrAdd("preloaded_keys.aziot-edged-ca", "file://" + certs.KeyPath);
             this.config[Service.Certd].Document.ReplaceOrAdd("preloaded_certs.aziot-edged-trust-bundle", "file://" + certs.TrustedCertificatesPath);
@@ -271,6 +285,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         }
 
         public void RemoveManifestTrustBundle() => this.config[Service.Certd].Document.RemoveIfExists("preloaded_certs.aziot-edged-manifest-trust-bundle");
+        public void RemoveContentTrustCerts()
+        {
+            this.config[Service.Edged].Document.RemoveIfExists("moby_runtime.content_trust.ca_certs");
+            this.config[Service.Certd].Document.RemoveIfExists("preloaded_certs");
+        }
 
         public void AddIdentityPrincipal(string name, uint uid, string[] type = null, Dictionary<string, string> opts = null)
         {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/EdgeRuntime.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Util;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Linq;
 
     public class EdgeRuntime
     {

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/TomlDocument.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/TomlDocument.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
             return this.document.ToString();
         }
 
-        void AddTable<T>(string tableName, string key, T value)
+        public void AddTable<T>(string tableName, string key, T value)
         {
             string v = value is string ? $"\"{value}\"" : value.ToString().ToLower();
 
@@ -85,6 +85,24 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
                 this.document.ToString() + "\n" +
                 $"[{tableName}]\n" +
                 $"{key} = {v}\n");
+        }
+
+        public void AddToTableWithExistingEntry<T>(string tableName, string key, T value)
+        {
+            // Split the TOML table contents on tablename to check for an already existing entry.
+            string bracketTableName = "[" + tableName + "]";
+            string[] segments = this.document.ToString().Split(bracketTableName);
+            if (segments.Length > 1)
+            {
+                string v = value is string ? $"\"{value}\"" : value.ToString().ToLower();
+                string addedString = $"[{tableName}]\n" + $"{key} = {v}";
+                string finalString = "\n" + segments[0] + addedString + segments[1];
+                this.document = Toml.ReadString(finalString);
+            }
+            else
+            {
+                this.AddTable(tableName, key, value);
+            }
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/CaCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/certs/CaCertificates.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
     {
         public string TrustedCertificatesPath { get; }
         public Option<string> ManifestTrustedCertificatesPath { get; }
+        public Option<Dictionary<string, string>> ContentTrustInputs { get; }
 
         public IEnumerable<X509Certificate2> TrustedCertificates =>
             new[]
@@ -46,10 +47,11 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Certs
             this.TrustedCertificatesPath = trustedCertsPath;
         }
 
-        public CaCertificates(string certificatePath, string keyPath, string trustedCertsPath, string manifestSigningTrustBundlePath)
+        public CaCertificates(string certificatePath, string keyPath, string trustedCertsPath, string manifestSigningTrustBundlePath, Dictionary<string, string> contentTrustInputs)
             : this(certificatePath, keyPath, trustedCertsPath)
         {
             this.ManifestTrustedCertificatesPath = Option.Maybe(manifestSigningTrustBundlePath);
+            this.ContentTrustInputs = Option.Maybe(contentTrustInputs);
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/ContentTrust.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/ContentTrust.cs
@@ -1,0 +1,114 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Test
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Edge.Test.Common;
+    using Microsoft.Azure.Devices.Edge.Test.Helpers;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
+    using NUnit.Framework;
+
+    [EndToEnd]
+    public class ContentTrust : ManifestTrustSetupFixture
+    {
+        const string SignedImageModuleName = "signedImage";
+        const string UnsignedImageModuleName = "unsignedImage";
+        string signedImage = Context.Current.ContentTrustSignedImage.OrDefault();
+        string unsignedImage = Context.Current.ContentTrustUnsignedImage.OrDefault();
+        EdgeModule signedImageModule;
+        DateTime startTime;
+
+        async Task SetConfigToEdgeDaemon(Option<Dictionary<string, string>> contentTrustInputs, CancellationToken token)
+        {
+            // This is a temporary solution see ticket: 9288683
+            if (!Context.Current.ISA95Tag)
+            {
+                TestCertificates testCerts;
+                (testCerts, this.ca) = await TestCertificates.GenerateCertsAsync(this.device.Id, token);
+                this.startTime = DateTime.Now;
+
+                await this.ConfigureDaemonAsync(
+                    config =>
+                    {
+                        testCerts.AddCertsToConfigForManifestTrust(config, Option.None<string>(), contentTrustInputs);
+
+                        config.SetManualSasProvisioning(this.IotHub.Hostname, Context.Current.ParentHostname, this.device.Id, this.device.SharedAccessKey);
+
+                        config.Update();
+
+                        return Task.FromResult((
+                            "with connection string for device '{Identity}'",
+                            new object[] { this.device.Id }));
+                    },
+                    this.device,
+                    this.startTime,
+                    token);
+            }
+        }
+
+        // Content trust is not supported as of now on ARM platforms
+        [Category("contenttrust")]
+        [Category("FlakyOnArm")]
+        [Test]
+        public async Task TestContentTrustDeployment()
+        {
+            // Create the input dictionary of the mapping of container registry name and its corresponding root CA
+            var contentTrustInput = new Dictionary<string, string>();
+            contentTrustInput.Add(Context.Current.ContentTrustRegistryName.OrDefault(), Context.Current.ContentTrustRootCaPath.OrDefault());
+
+            // Edge Daemon is configured with a content trust root CA
+            await this.SetConfigToEdgeDaemon(Option.Some(contentTrustInput), this.TestToken);
+
+            // This is a temporary solution see ticket: 9288683
+            if (!Context.Current.ISA95Tag)
+            {
+                EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(
+                    builder =>
+                    {
+                        builder.AddModule(SignedImageModuleName, this.signedImage)
+                            .WithEnvironment(new[] { ("MessageCount", "-1") });
+                    },
+                    this.TestToken,
+                    Context.Current.NestedEdge,
+                    null);
+                this.signedImageModule = deployment.Modules[SignedImageModuleName];
+                this.startTime = deployment.StartTime;
+            }
+            else
+            {
+                this.signedImageModule = new EdgeModule(SignedImageModuleName, this.runtime.DeviceId, this.IotHub);
+                this.startTime = DateTime.Now;
+            }
+
+            await this.signedImageModule.WaitForEventsReceivedAsync(this.startTime, this.TestToken);
+
+            // This is a temporary solution see ticket: 9288683
+            if (!Context.Current.ISA95Tag)
+            {
+                bool isCancelled = false;
+                CancellationTokenSource unsignedImageToken = new CancellationTokenSource(TimeSpan.FromMinutes(2));
+                try
+                {
+                    EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(
+                        builder =>
+                        {
+                            builder.AddModule(UnsignedImageModuleName, this.unsignedImage)
+                                .WithEnvironment(new[] { ("MessageCount", "-1") });
+                        },
+                        unsignedImageToken.Token,
+                        Context.Current.NestedEdge,
+                        null);
+                }
+                catch (TaskCanceledException)
+                {
+                    isCancelled = true;
+                }
+
+                Assert.IsTrue(isCancelled);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Azure.Devices.Edge.Test/ManifestSigning.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/ManifestSigning.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Test
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
@@ -14,7 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using NUnit.Framework;
 
     [EndToEnd]
-    public class ManifestSigning : ManifestSigningSetupFixture
+    public class ManifestSigning : ManifestTrustSetupFixture
     {
         const string SensorName = "tempSensor";
         const string DefaultSensorImage = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0";
@@ -22,7 +23,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         EdgeModule sensor;
         DateTime startTime;
 
-        async Task SetConfigToEdgeDaemon(Option<string> rootCaPath, CancellationToken token)
+        async Task SetConfigToEdgeDaemon(Option<string> manifestTrustBundle, CancellationToken token)
         {
             // This is a temporary solution see ticket: 9288683
             if (!Context.Current.ISA95Tag)
@@ -34,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 await this.ConfigureDaemonAsync(
                     config =>
                     {
-                        testCerts.AddCertsToConfigForManifestSigning(config, rootCaPath);
+                        testCerts.AddCertsToConfigForManifestTrust(config, manifestTrustBundle, Option.None<Dictionary<string, string>>());
 
                         config.SetManualSasProvisioning(this.IotHub.Hostname, Context.Current.ParentHostname, this.device.Id, this.device.SharedAccessKey);
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 {
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Net;
     using System.Text;
     using System.Text.RegularExpressions;
@@ -114,7 +115,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
                                 edgeAgent = Regex.Replace(edgeAgent, @"\$upstream", parentHostname);
                             });
 
-                            config.SetEdgeAgentImage(edgeAgent, Context.Current.Registries);
+                            // The first element corresponds to the registry credentials for edge agent image
+                            config.SetEdgeAgentImage(edgeAgent, Context.Current.Registries.Take(1));
 
                             Context.Current.EdgeProxy.ForEach(proxy =>
                             {
@@ -229,7 +231,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             config.SetCertificates(new CaCertificates(certPath, keyPath, trustBundlePath));
         }
 
-        public void AddCertsToConfigForManifestSigning(DaemonConfiguration config, Option<string> inputManifestSigningTrustBundlePath)
+        public void AddCertsToConfigForManifestTrust(DaemonConfiguration config, Option<string> inputManifestSigningTrustBundlePath, Option<Dictionary<string, string>> contentTrustInputs)
         {
             string path = Path.Combine(FixedPaths.E2E_TEST_DIR, this.deviceId);
             string certPath = Path.Combine(path, "device_ca_cert.pem");
@@ -251,7 +253,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                 OsPlatform.Current.SetOwner(manifestSigningTrustBundlePath, "aziotcs", "644");
             }
 
-            config.SetCertificates(new CaCertificates(certPath, keyPath, trustBundlePath, manifestSigningTrustBundlePath));
+            config.SetCertificates(new CaCertificates(certPath, keyPath, trustBundlePath, manifestSigningTrustBundlePath, contentTrustInputs.OrDefault()));
         }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/Context.cs
@@ -129,6 +129,10 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
             this.ManifestSigningLaunchSettingsPath = Option.Maybe(Get("manifestSigningLaunchSettingsPath"));
             this.ManifestSignerClientDirectory = Option.Maybe(Get("manifestSignerClientDirectory"));
             this.ManifestSignerClientProjectPath = Option.Maybe(Get("manifestSignerClientProjectPath"));
+            this.ContentTrustRootCaPath = Option.Maybe(Get("contentTrustRootCaPath"));
+            this.ContentTrustRegistryName = Option.Maybe(Get("contentTrustRegistryName"));
+            this.ContentTrustSignedImage = Option.Maybe(Get("contentTrustSignedImage"));
+            this.ContentTrustUnsignedImage = Option.Maybe(Get("contentTrustUnsignedImage"));
             this.GetSupportBundle = context.GetValue("getSupportBundle", false);
         }
 
@@ -233,6 +237,15 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
         public Option<string> ManifestSignerClientDirectory { get; }
 
         public Option<string> ManifestSignerClientProjectPath { get; }
+
+        public Option<string> ContentTrustRootCaPath { get; }
+
+        public Option<string> ContentTrustRegistryName { get; }
+
+        public Option<string> ContentTrustSignedImage { get; }
+
+        public Option<string> ContentTrustUnsignedImage { get; }
+
         public bool GetSupportBundle { get; }
     }
 }

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManifestTrustSetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/ManifestTrustSetupFixture.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Helpers
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Serilog;
 
-    public class ManifestSigningSetupFixture : SasManualProvisioningFixture
+    public class ManifestTrustSetupFixture : SasManualProvisioningFixture
     {
         protected override Task BeforeTestTimerStarts() => this.SasProvisionEdgeAsync();
 


### PR DESCRIPTION
E2E content trust setup contains the following changes for enablement
1. Set up of content trust registry containing a notary signed image and an unsigned image
2. Enable Edge Daemon with content trust feature by configuring the edged and certd toml files with its certificates
3. Addition of content trust azure container registry and its credentials are updated to both E2E checkin and E2E core test pipelines along with the registry Root CA
4. Notary installation in /usr/bin in the pipeline infrastructure
5. Deploy the signed and unsigned container images modules
6. Update in the document to use the right Notary version and also configuring in the super-config.toml