### PR TITLE
Add delay between nginx crashes

### DIFF
--- a/edge-modules/api-proxy-module/src/main.rs
+++ b/edge-modules/api-proxy-module/src/main.rs
@@ -19,6 +19,7 @@ use tokio::{
     process::{Child, Command},
     sync::Notify,
     task::JoinHandle,
+    time,
 };
 
 use api_proxy_module::{
@@ -27,6 +28,8 @@ use api_proxy_module::{
     utils::{shutdown, shutdown_handle},
 };
 use shutdown_handle::ShutdownHandle;
+
+const MAX_LOOP_INTERVAL_SECONDS: tokio::time::Duration = tokio::time::Duration::from_secs(1);
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -188,6 +191,10 @@ pub fn nginx_controller_start(
                         return Ok(());
                     }
                 }
+
+                // This delay controls how fast the main loop can reconnect once nginx crashed.
+                // Without this, nginx crashes and restart continuously. Rapidly increasing the size of the logs.
+                time::sleep(MAX_LOOP_INTERVAL_SECONDS);
             }
         }
     });


### PR DESCRIPTION
Added a delay between nginx restarts to avoid spamming the log file.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
