### PR TITLE
Cherry-pick: Add script and documentation for attaching VSCode debugger to a container/module

### DIFF
--- a/doc/devguide.md
+++ b/doc/devguide.md
@@ -123,3 +123,52 @@ options
  -v, --image-version  Docker Image Version.
  -t, --template       Yaml file template for manifest definition.
 ```
+## Attach the VSCode Debugger to EdgeAgent
+There is a script in the repo to setup a docker container with the Visual Studio Debugger (vsdbg).  After running the script in a container, you can connect the VSCode debugger to a process running in the container. The following example shows how to run the setup script on a Linux IoT Edge device to setup the debugger in the Edge Agent container:
+
+```
+$ scripts/linux/setupContainerDebugger.sh -c edgeAgent -u edgeagentuser
+```
+After running the debugger setup script, create a launch.json file in the edgeAgent/.vscode directory. The launch.json file should have the following contents (Note: replace the value in `sourceFileMap` before running):
+```
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Remote Debug IoT Edge Module (.NET Core)",
+            "type": "coreclr",
+            "request": "attach",
+            "processId": "${command:pickRemoteProcess}",
+            "pipeTransport": {
+                "pipeProgram": "docker",
+                "pipeArgs": [
+                    "exec",
+                    "-i",
+                    "-u",
+                    "edgeagentuser"
+                    "edgeAgent",
+                    "sh",
+                    "-c"
+                ],
+                "debuggerPath": "/root/vsdbg/vsdbg",
+                "pipeCwd": "${workspaceFolder}",
+                "quoteArgs": true
+            },
+            "sourceFileMap": {
+                "<replace-with-compile-time-path-to-edge-agent-source>": "${workspaceRoot}"
+            },
+            "symbolOptions": {
+                "searchPaths": ["/app"],
+                "searchMicrosoftSymbolServer": false,
+                "searchNuGetOrgSymbolServer": false
+            },
+            "justMyCode": true,
+            "requireExactSource": true
+        }
+    ]
+}
+```
+Start debugging by selecting the configuration defined above from the 'Run and Debug' tab (Ctrl+Shift+D) and selecting the 'Start Debugging' button (F5). 

--- a/scripts/linux/setupContainerDebugger.sh
+++ b/scripts/linux/setupContainerDebugger.sh
@@ -1,0 +1,64 @@
+###############################################################################
+# This script installs and configures vsdbg in a specified container module.
+# After running this script, Visual Studio or VSCode can be attached locally
+# or remotely to debug processes running in the container.
+###############################################################################
+
+###############################################################################
+# Define Environment Variables
+###############################################################################
+CONTAINER_NAME="edgeAgent"
+USERNAME="edgeagentuser"
+SCRIPT_NAME=$(basename "$0")
+
+###############################################################################
+# Print usage information pertaining to this script and exit
+###############################################################################
+function usage() {
+    echo "$SCRIPT_NAME [options]"
+    echo ""
+    echo "options"
+    echo " -c, --container-name             The name of the container in which to setup the debugger."
+    echo " -u, --username                   The username associated with the process to be debugged."
+    echo " -h, --help                       Print this help and exit."
+    exit 1
+}
+
+function print_help_and_exit() {
+    echo "Run $SCRIPT_NAME --help for more information."
+    exit 1
+}
+
+###############################################################################
+# Obtain and validate the options supported by this script
+###############################################################################
+function process_args() {
+    save_next_arg=0
+    for arg in "$@"; do
+        if [ ${save_next_arg} -eq 1 ]; then
+            CONTAINER_NAME=$arg
+            save_next_arg=0
+        elif [ ${save_next_arg} -eq 2 ]; then
+            USERNAME=$arg
+            save_next_arg=0          
+        else
+            case "$arg" in
+            "-h" | "--help") usage ;;
+            "-c" | "--container-name") save_next_arg=1 ;;
+            "-u" | "--username") save_next_arg=2 ;;
+            *) usage ;;
+            esac
+        fi
+    done
+}
+
+process_args "$@"
+
+sudo docker exec -it $CONTAINER_NAME apk add curl icu procps shadow sudo
+sudo docker exec -it $CONTAINER_NAME curl -sSL https://aka.ms/getvsdbgsh  -o /root/GetVsDbg.sh
+sudo docker exec -it $CONTAINER_NAME sh -C /root/GetVsDbg.sh -v latest -l /root/vsdbg
+sudo docker exec -it $CONTAINER_NAME chmod 770 /root 
+sudo docker exec -it $CONTAINER_NAME chmod 770 /root/vsdbg
+sudo docker exec -it $CONTAINER_NAME chmod 770 /root/vsdbg/vsdbg
+sudo docker exec -it $CONTAINER_NAME usermod $USERNAME -G root
+


### PR DESCRIPTION
Add a script for setting up the Visual Studio debugger in an Edge container/module. Also, update the Dev Guide to document how to use the script and VSCode to attach a debugger to the edgeAgent container/module.

This script and documented steps have been tested on an Ubuntu18.04 dev machine running a local build of aziot-edge v1.2. In this test, VSCode was running on the dev machine and was able to successfully attach its debugger to the Edge Agent container. 

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_