### PR TITLE
Nested Tests: Agent lock resiliency (#5836)

### DIFF
--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -45,7 +45,7 @@ stages:
       - template: templates/nested-get-secrets.yaml
       - script: scripts/linux/nestedAgentLock.sh -a "$(agent.group)" -b "$(Build.BuildId)" -n 1 -u "amqp"
         env:
-          PAT: "$(edgebuild-1-PAT)"
+          PAT: "$(IotEdge1-PAT-msazure)"
         displayName: Lock agents for nested topology
         name: lock_test_agent
       

--- a/builds/e2e/templates/lock-test-agents.yaml
+++ b/builds/e2e/templates/lock-test-agents.yaml
@@ -14,6 +14,6 @@ jobs:
       - template: nested-get-secrets.yaml
       - script: scripts/linux/nestedAgentLock.sh -a "$(agent.group)" -b "$(Build.BuildId)" -n ${{ parameters['testRunnerCount'] }} -u ${{ parameters['upstream.protocol'] }}
         env:
-          PAT: "$(edgebuild-1-PAT)"
+          PAT: "$(IotEdge1-PAT-msazure)"
         displayName: Lock agents for nested topology
         name: lock_test_agent

--- a/builds/e2e/templates/nested-get-secrets.yaml
+++ b/builds/e2e/templates/nested-get-secrets.yaml
@@ -15,7 +15,7 @@ steps:
         GitHubAccessToken,
         edgebuild-blob-core-connection-string,
         edgebuild-service-principal-secret,
-        edgebuild-1-PAT
+        IotEdge1-PAT-msazure
 
   - task: AzureKeyVault@1
     displayName: 'Azure Key Vault: $(azure.keyVault)'

--- a/builds/e2e/templates/unlock-test-agents.yaml
+++ b/builds/e2e/templates/unlock-test-agents.yaml
@@ -5,7 +5,7 @@ steps:
     env:
       POOL_ID: 123
       API_VER: 6.0
-      PAT: "$(edgebuild-1-PAT)"
+      PAT: "$(IotEdge1-PAT-msazure)"
       BUILD_ID: $(Build.BuildId)
     inputs:
       targetType: inline

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -116,6 +116,7 @@ process_args()
     fi
 
     echo "Curl version: $(curl --version)"
+    echo
 }
 
 ###############################################################################
@@ -232,6 +233,21 @@ if ! command -v $CMD &>/dev/null; then
     sudo apt-get install -y $CMD
 fi
 echo "Done validating jq"
+echo
+
+echo "Validating devops API interface"
+echo "Checking for agents from the agent group $AGENT_GROUP..."
+agentsInfo=$(curl -s -u :$PAT --request GET "https://dev.azure.com/msazure/_apis/distributedtask/pools/$POOL_ID/agents?includeCapabilities=true&api-version=$API_VER")
+agents=($(echo $agentsInfo | jq '.value | .[] | select(.userCapabilities."agent-group"=='\"$AGENT_GROUP\"') | .id' | tr -d '[], "'))
+echo ${#agents[@]}
+if [ ${#agents[@]} -eq 0 ]; then
+    echo "Problem interfacing with Devops API to retrieve agent data. Recommend checking PAT expiry."
+    exit 1
+else
+    echo "Successfully interfaced with Devops API to retrieve agent data."
+fi
+echo "Done validating devops API interface"
+echo
 
 startSeconds=$((SECONDS))
 endSeconds=$((SECONDS + $TIMEOUT_SECONDS))


### PR DESCRIPTION
Cherry-pick #5836

This PR changes the PAT secret to be the one used elsewhere in the repository. It also adds an initial check that the script can retrieve agent data from the devops api, so the root cause will be more obvious if it happens again. 

I tested the fail path locally and the success path in the pipeline:
https://dev.azure.com/msazure/One/_build/results?buildId=49243483&view=results

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
