### PR TITLE
Add device ID to edge CA common name

### DIFF
--- a/edgelet/edgelet-http-workload/src/server/cert/identity.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/identity.rs
@@ -76,6 +76,7 @@ where
                     super::EdgeCaCertificate {
                         cert_id: cfg.edge_ca_cert().to_string(),
                         key_id: cfg.edge_ca_key().to_string(),
+                        device_id: cfg.device_id().to_string(),
                     },
                     ErrorKind::CertOperation(CertOperation::CreateIdentityCert),
                 )

--- a/edgelet/edgelet-http-workload/src/server/cert/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/mod.rs
@@ -33,13 +33,11 @@ pub use self::server::ServerCertHandler;
 // 5 mins
 const AZIOT_EDGE_CA_CERT_MIN_DURATION_SECS: i64 = 5 * 60;
 
-// Workload CA CN
-const IOTEDGED_COMMONNAME_PREFIX: &str = "iotedged workload ca";
-
 #[derive(Clone)]
 pub(crate) struct EdgeCaCertificate {
     pub(crate) cert_id: String,
     pub(crate) key_id: String,
+    pub(crate) device_id: String,
 }
 
 fn cert_to_response<T: CoreCertificate>(
@@ -339,7 +337,7 @@ fn create_edge_ca_certificate(
     context: ErrorKind,
 ) -> Box<dyn Future<Item = (), Error = Error> + Send> {
     let edgelet_ca_props = CertificateProperties::new(
-        IOTEDGED_COMMONNAME_PREFIX.to_string(),
+        format!("iotedged workload ca {}", ca.device_id),
         CertificateType::Ca,
         ca.cert_id.to_string(),
     );

--- a/edgelet/edgelet-http-workload/src/server/cert/server.rs
+++ b/edgelet/edgelet-http-workload/src/server/cert/server.rs
@@ -118,6 +118,7 @@ where
                     super::EdgeCaCertificate {
                         cert_id: cfg.edge_ca_cert().to_string(),
                         key_id: cfg.edge_ca_key().to_string(),
+                        device_id: cfg.device_id().to_string(),
                     },
                     ErrorKind::CertOperation(CertOperation::GetServerCert),
                 )

--- a/edgelet/edgelet-http-workload/src/server/mod.rs
+++ b/edgelet/edgelet-http-workload/src/server/mod.rs
@@ -60,6 +60,7 @@ impl WorkloadService {
             cert::EdgeCaCertificate {
                 cert_id: config.edge_ca_cert().to_string(),
                 key_id: config.edge_ca_key().to_string(),
+                device_id: config.device_id().to_string(),
             },
             ErrorKind::StartService,
         );


### PR DESCRIPTION
Since `certd` cannot override the DN of EST-issued certificates, EST-issued edge CAs have the same DN for every device (`/CN=iotedged workload ca`). This quickly becomes problematic in scenarios with larger numbers of devices. This PR is an approximate backport of the edge CA DN parameterization in master, which appends the device ID to the common name. For example, a device with ID `my_device` would request an edge CA certificate with DN `/CN=iotedged workload ca my_device`.

Motivated by #5782.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.