### PR TITLE
Retry importing server certificate if private key is not accessible

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
@@ -12,11 +12,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class EdgeHubCertificates
     {
-        // The private-key import on windows randomly seems failing, however according to the tests, the second time
-        // after a failure it usually works. The number below is just a "big enough" number randomly chosen for
-        // self-healing, but gives a limit to avoid endless try.
-        const int MaxCertImportRetryCount = 10;
-
         EdgeHubCertificates(X509Certificate2 serverCertificate, IList<X509Certificate2> certificateChain, IList<X509Certificate2> trustBundle, Option<X509Certificate2> manifestTrustBundle)
         {
             this.ServerCertificate = Preconditions.CheckNotNull(serverCertificate, nameof(serverCertificate));
@@ -37,91 +32,65 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         {
             Preconditions.CheckNotNull(configuration, nameof(configuration));
 
-            bool isServerCertReady;
-            int retryCount = 0;
-
             EdgeHubCertificates result;
-            do
+
+            string edgeHubDevCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerCertificateFile);
+            string edgeHubDevPrivateKeyPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerPrivateKeyFile);
+            string edgeHubDevTrustBundlePath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevTrustBundleFile);
+            string edgeHubDockerCertPFXPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCertificateFile);
+            string edgeHubDockerCaChainCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCAChainCertificateFile);
+            string edgeHubConnectionString = configuration.GetValue<string>(Constants.ConfigKey.IotHubConnectionString);
+
+            if (string.IsNullOrEmpty(edgeHubConnectionString))
             {
-                string edgeHubDevCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerCertificateFile);
-                string edgeHubDevPrivateKeyPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerPrivateKeyFile);
-                string edgeHubDevTrustBundlePath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevTrustBundleFile);
-                string edgeHubDockerCertPFXPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCertificateFile);
-                string edgeHubDockerCaChainCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCAChainCertificateFile);
-                string edgeHubConnectionString = configuration.GetValue<string>(Constants.ConfigKey.IotHubConnectionString);
+                // When connection string is not set it is edged mode as iotedgd is expected to set this.
+                // In this case we reach out to the iotedged via the workload interface.
+                (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
 
-                if (string.IsNullOrEmpty(edgeHubConnectionString))
-                {
-                    // When connection string is not set it is edged mode as iotedgd is expected to set this.
-                    // In this case we reach out to the iotedged via the workload interface.
-                    (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
+                var workloadUri = new Uri(configuration.GetValue<string>(Constants.ConfigKey.WorkloadUri));
+                string edgeHubHostname = configuration.GetValue<string>(Constants.ConfigKey.EdgeDeviceHostName);
+                string moduleId = configuration.GetValue<string>(Constants.ConfigKey.ModuleId);
+                string generationId = configuration.GetValue<string>(Constants.ConfigKey.ModuleGenerationId);
+                string edgeletApiVersion = configuration.GetValue<string>(Constants.ConfigKey.WorkloadAPiVersion);
+                DateTime expiration = DateTime.UtcNow.AddDays(Constants.CertificateValidityDays);
 
-                    var workloadUri = new Uri(configuration.GetValue<string>(Constants.ConfigKey.WorkloadUri));
-                    string edgeHubHostname = configuration.GetValue<string>(Constants.ConfigKey.EdgeDeviceHostName);
-                    string moduleId = configuration.GetValue<string>(Constants.ConfigKey.ModuleId);
-                    string generationId = configuration.GetValue<string>(Constants.ConfigKey.ModuleGenerationId);
-                    string edgeletApiVersion = configuration.GetValue<string>(Constants.ConfigKey.WorkloadAPiVersion);
-                    DateTime expiration = DateTime.UtcNow.AddDays(Constants.CertificateValidityDays);
+                certificates = await CertificateHelper.GetServerCertificatesFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId, edgeHubHostname, expiration, logger);
+                IEnumerable<X509Certificate2> trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
+                Option<X509Certificate2> manifestTrustBundle = await CertificateHelper.GetManifestTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
 
-                    certificates = await CertificateHelper.GetServerCertificatesFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId, edgeHubHostname, expiration);
-                    IEnumerable<X509Certificate2> trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
-                    Option<X509Certificate2> manifestTrustBundle = await CertificateHelper.GetManifestTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
-
-                    result = new EdgeHubCertificates(
-                        certificates.ServerCertificate,
-                        certificates.CertificateChain?.ToList(),
-                        trustBundle?.ToList(),
-                        manifestTrustBundle);
-                }
-                else if (!string.IsNullOrEmpty(edgeHubDevCertPath) &&
-                         !string.IsNullOrEmpty(edgeHubDevPrivateKeyPath) &&
-                         !string.IsNullOrEmpty(edgeHubDevTrustBundlePath))
-                {
-                    // If no connection string was set and we use iotedged workload style certificates for development
-                    (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
-
-                    certificates = CertificateHelper.GetServerCertificateAndChainFromFile(edgeHubDevCertPath, edgeHubDevPrivateKeyPath);
-                    IEnumerable<X509Certificate2> trustBundle = CertificateHelper.ParseTrustedBundleFromFile(edgeHubDevTrustBundlePath);
-
-                    result = new EdgeHubCertificates(
-                        certificates.ServerCertificate,
-                        certificates.CertificateChain?.ToList(),
-                        trustBundle?.ToList(),
-                        Option.None<X509Certificate2>());
-                }
-                else if (!string.IsNullOrEmpty(edgeHubDockerCertPFXPath) &&
-                         !string.IsNullOrEmpty(edgeHubDockerCaChainCertPath))
-                {
-                    // If no connection string was set and we use iotedge devdiv style certificates for development
-                    List<X509Certificate2> certificateChain = CertificateHelper.GetServerCACertificatesFromFile(edgeHubDockerCaChainCertPath)?.ToList();
-                    result = new EdgeHubCertificates(new X509Certificate2(edgeHubDockerCertPFXPath), certificateChain, new List<X509Certificate2>(), Option.None<X509Certificate2>());
-                }
-                else
-                {
-                    throw new InvalidOperationException("Edge Hub certificate files incorrectly configured");
-                }
-
-                // On Windows, from time to time the private key cannot be accessed and kestrel fails accepting connections
-                // without the private key. Testing the private key here and if it fails, retry the entire cert import.
-                // The second try usually works.
-                try
-                {
-                    _ = result.ServerCertificate.PrivateKey;
-                    isServerCertReady = true;
-                }
-                catch
-                {
-                    if (++retryCount > MaxCertImportRetryCount)
-                    {
-                        throw new InvalidOperationException("Cannot import server certificate, giving up");
-                    }
-
-                    isServerCertReady = false;
-                    logger.LogWarning("Error importing server certificate, retrying");
-                    await Task.Delay(TimeSpan.FromSeconds(1)); // Do not spam the log
-                }
+                result = new EdgeHubCertificates(
+                    certificates.ServerCertificate,
+                    certificates.CertificateChain?.ToList(),
+                    trustBundle?.ToList(),
+                    manifestTrustBundle);
             }
-            while (!isServerCertReady);
+            else if (!string.IsNullOrEmpty(edgeHubDevCertPath) &&
+                        !string.IsNullOrEmpty(edgeHubDevPrivateKeyPath) &&
+                        !string.IsNullOrEmpty(edgeHubDevTrustBundlePath))
+            {
+                // If no connection string was set and we use iotedged workload style certificates for development
+                (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
+
+                certificates = CertificateHelper.GetServerCertificateAndChainFromFile(edgeHubDevCertPath, edgeHubDevPrivateKeyPath, logger);
+                IEnumerable<X509Certificate2> trustBundle = CertificateHelper.ParseTrustedBundleFromFile(edgeHubDevTrustBundlePath);
+
+                result = new EdgeHubCertificates(
+                    certificates.ServerCertificate,
+                    certificates.CertificateChain?.ToList(),
+                    trustBundle?.ToList(),
+                    Option.None<X509Certificate2>());
+            }
+            else if (!string.IsNullOrEmpty(edgeHubDockerCertPFXPath) &&
+                        !string.IsNullOrEmpty(edgeHubDockerCaChainCertPath))
+            {
+                // If no connection string was set and we use iotedge devdiv style certificates for development
+                List<X509Certificate2> certificateChain = CertificateHelper.GetServerCACertificatesFromFile(edgeHubDockerCaChainCertPath)?.ToList();
+                result = new EdgeHubCertificates(new X509Certificate2(edgeHubDockerCertPFXPath), certificateChain, new List<X509Certificate2>(), Option.None<X509Certificate2>());
+            }
+            else
+            {
+                throw new InvalidOperationException("Edge Hub certificate files incorrectly configured");
+            }
 
             CertificateHelper.InstallCertificates(result.CertificateChain, logger);
             CertificateHelper.InstallCertificates(result.TrustBundle, logger);

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
@@ -3,9 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
-    using System.Runtime.InteropServices;
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -14,6 +12,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 
     public class EdgeHubCertificates
     {
+        // The private-key import on windows randomly seems failing, however according to the tests, the second time
+        // after a failure it usually works. The number below is just a "big enough" number randomly chosen for
+        // self-healing, but gives a limit to avoid endless try.
+        const int MaxCertImportRetryCount = 10;
+
         EdgeHubCertificates(X509Certificate2 serverCertificate, IList<X509Certificate2> certificateChain, IList<X509Certificate2> trustBundle, Option<X509Certificate2> manifestTrustBundle)
         {
             this.ServerCertificate = Preconditions.CheckNotNull(serverCertificate, nameof(serverCertificate));
@@ -33,64 +36,92 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
         public static async Task<EdgeHubCertificates> LoadAsync(IConfigurationRoot configuration, ILogger logger)
         {
             Preconditions.CheckNotNull(configuration, nameof(configuration));
+
+            bool isServerCertReady;
+            int retryCount = 0;
+
             EdgeHubCertificates result;
-            string edgeHubDevCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerCertificateFile);
-            string edgeHubDevPrivateKeyPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerPrivateKeyFile);
-            string edgeHubDevTrustBundlePath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevTrustBundleFile);
-            string edgeHubDockerCertPFXPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCertificateFile);
-            string edgeHubDockerCaChainCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCAChainCertificateFile);
-            string edgeHubConnectionString = configuration.GetValue<string>(Constants.ConfigKey.IotHubConnectionString);
-
-            if (string.IsNullOrEmpty(edgeHubConnectionString))
+            do
             {
-                // When connection string is not set it is edged mode as iotedgd is expected to set this.
-                // In this case we reach out to the iotedged via the workload interface.
-                (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
+                string edgeHubDevCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerCertificateFile);
+                string edgeHubDevPrivateKeyPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevServerPrivateKeyFile);
+                string edgeHubDevTrustBundlePath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubDevTrustBundleFile);
+                string edgeHubDockerCertPFXPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCertificateFile);
+                string edgeHubDockerCaChainCertPath = configuration.GetValue<string>(Constants.ConfigKey.EdgeHubServerCAChainCertificateFile);
+                string edgeHubConnectionString = configuration.GetValue<string>(Constants.ConfigKey.IotHubConnectionString);
 
-                var workloadUri = new Uri(configuration.GetValue<string>(Constants.ConfigKey.WorkloadUri));
-                string edgeHubHostname = configuration.GetValue<string>(Constants.ConfigKey.EdgeDeviceHostName);
-                string moduleId = configuration.GetValue<string>(Constants.ConfigKey.ModuleId);
-                string generationId = configuration.GetValue<string>(Constants.ConfigKey.ModuleGenerationId);
-                string edgeletApiVersion = configuration.GetValue<string>(Constants.ConfigKey.WorkloadAPiVersion);
-                DateTime expiration = DateTime.UtcNow.AddDays(Constants.CertificateValidityDays);
+                if (string.IsNullOrEmpty(edgeHubConnectionString))
+                {
+                    // When connection string is not set it is edged mode as iotedgd is expected to set this.
+                    // In this case we reach out to the iotedged via the workload interface.
+                    (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
 
-                certificates = await CertificateHelper.GetServerCertificatesFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId, edgeHubHostname, expiration);
-                IEnumerable<X509Certificate2> trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
-                Option<X509Certificate2> manifestTrustBundle = await CertificateHelper.GetManifestTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
+                    var workloadUri = new Uri(configuration.GetValue<string>(Constants.ConfigKey.WorkloadUri));
+                    string edgeHubHostname = configuration.GetValue<string>(Constants.ConfigKey.EdgeDeviceHostName);
+                    string moduleId = configuration.GetValue<string>(Constants.ConfigKey.ModuleId);
+                    string generationId = configuration.GetValue<string>(Constants.ConfigKey.ModuleGenerationId);
+                    string edgeletApiVersion = configuration.GetValue<string>(Constants.ConfigKey.WorkloadAPiVersion);
+                    DateTime expiration = DateTime.UtcNow.AddDays(Constants.CertificateValidityDays);
 
-                result = new EdgeHubCertificates(
-                    certificates.ServerCertificate,
-                    certificates.CertificateChain?.ToList(),
-                    trustBundle?.ToList(),
-                    manifestTrustBundle);
+                    certificates = await CertificateHelper.GetServerCertificatesFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId, edgeHubHostname, expiration);
+                    IEnumerable<X509Certificate2> trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
+                    Option<X509Certificate2> manifestTrustBundle = await CertificateHelper.GetManifestTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
+
+                    result = new EdgeHubCertificates(
+                        certificates.ServerCertificate,
+                        certificates.CertificateChain?.ToList(),
+                        trustBundle?.ToList(),
+                        manifestTrustBundle);
+                }
+                else if (!string.IsNullOrEmpty(edgeHubDevCertPath) &&
+                         !string.IsNullOrEmpty(edgeHubDevPrivateKeyPath) &&
+                         !string.IsNullOrEmpty(edgeHubDevTrustBundlePath))
+                {
+                    // If no connection string was set and we use iotedged workload style certificates for development
+                    (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
+
+                    certificates = CertificateHelper.GetServerCertificateAndChainFromFile(edgeHubDevCertPath, edgeHubDevPrivateKeyPath);
+                    IEnumerable<X509Certificate2> trustBundle = CertificateHelper.ParseTrustedBundleFromFile(edgeHubDevTrustBundlePath);
+
+                    result = new EdgeHubCertificates(
+                        certificates.ServerCertificate,
+                        certificates.CertificateChain?.ToList(),
+                        trustBundle?.ToList(),
+                        Option.None<X509Certificate2>());
+                }
+                else if (!string.IsNullOrEmpty(edgeHubDockerCertPFXPath) &&
+                         !string.IsNullOrEmpty(edgeHubDockerCaChainCertPath))
+                {
+                    // If no connection string was set and we use iotedge devdiv style certificates for development
+                    List<X509Certificate2> certificateChain = CertificateHelper.GetServerCACertificatesFromFile(edgeHubDockerCaChainCertPath)?.ToList();
+                    result = new EdgeHubCertificates(new X509Certificate2(edgeHubDockerCertPFXPath), certificateChain, new List<X509Certificate2>(), Option.None<X509Certificate2>());
+                }
+                else
+                {
+                    throw new InvalidOperationException("Edge Hub certificate files incorrectly configured");
+                }
+
+                // On Windows, from time to time the private key cannot be accessed and kestrel fails accepting connections
+                // without the private key. Testing the private key here and if it fails, retry the entire cert import.
+                // The second try usually works.
+                try
+                {
+                    _ = result.ServerCertificate.PrivateKey;
+                    isServerCertReady = true;
+                }
+                catch
+                {
+                    if (++retryCount > MaxCertImportRetryCount)
+                    {
+                        throw new InvalidOperationException("Cannot import server certificate, giving up");
+                    }
+
+                    isServerCertReady = false;
+                    logger.LogWarning("Error importing server certificate, retrying");
+                    await Task.Delay(TimeSpan.FromSeconds(1)); // Do not spam the log
+                }
             }
-            else if (!string.IsNullOrEmpty(edgeHubDevCertPath) &&
-                     !string.IsNullOrEmpty(edgeHubDevPrivateKeyPath) &&
-                     !string.IsNullOrEmpty(edgeHubDevTrustBundlePath))
-            {
-                // If no connection string was set and we use iotedged workload style certificates for development
-                (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
-
-                certificates = CertificateHelper.GetServerCertificateAndChainFromFile(edgeHubDevCertPath, edgeHubDevPrivateKeyPath);
-                IEnumerable<X509Certificate2> trustBundle = CertificateHelper.ParseTrustedBundleFromFile(edgeHubDevTrustBundlePath);
-
-                result = new EdgeHubCertificates(
-                    certificates.ServerCertificate,
-                    certificates.CertificateChain?.ToList(),
-                    trustBundle?.ToList(),
-                    Option.None<X509Certificate2>());
-            }
-            else if (!string.IsNullOrEmpty(edgeHubDockerCertPFXPath) &&
-                     !string.IsNullOrEmpty(edgeHubDockerCaChainCertPath))
-            {
-                // If no connection string was set and we use iotedge devdiv style certificates for development
-                List<X509Certificate2> certificateChain = CertificateHelper.GetServerCACertificatesFromFile(edgeHubDockerCaChainCertPath)?.ToList();
-                result = new EdgeHubCertificates(new X509Certificate2(edgeHubDockerCertPFXPath), certificateChain, new List<X509Certificate2>(), Option.None<X509Certificate2>());
-            }
-            else
-            {
-                throw new InvalidOperationException("Edge Hub certificate files incorrectly configured");
-            }
+            while (!isServerCertReady);
 
             CertificateHelper.InstallCertificates(result.CertificateChain, logger);
             CertificateHelper.InstallCertificates(result.TrustBundle, logger);

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -388,6 +388,8 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
             while (retryCount++ < MaxCertImportRetryCount)
             {
+                bool isEcKey = false;
+
                 IEnumerable<string> pemCerts = ParsePemCerts(certificateWithChain);
 
                 if (pemCerts.FirstOrDefault() == null)
@@ -425,6 +427,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
                     }
                     else if (certObject is ECPrivateKeyParameters ecParameters)
                     {
+                        isEcKey = true;
                         keyParams = ecParameters;
                     }
 
@@ -450,6 +453,15 @@ namespace Microsoft.Azure.Devices.Edge.Util
                     {
                         if (cert.HasPrivateKey)
                         {
+                            if (isEcKey)
+                            {
+                                _ = cert.GetECDsaPrivateKey();
+                            }
+                            else
+                            {
+                                _ = cert.GetRSAPrivateKey();
+                            }
+
                             return (cert, certsChain);
                         }
                     }

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
     using System.Security.Cryptography;
     using System.Security.Cryptography.X509Certificates;
     using System.Text;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util.Edged;
     using Microsoft.Extensions.Logging;
@@ -21,6 +22,11 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
     public static class CertificateHelper
     {
+        // The private-key import on windows randomly seems failing, however according to the tests, the second time
+        // after a failure it usually works. The number below is just a "big enough" number randomly chosen for
+        // self-healing, but gives a limit to avoid endless try.
+        const int MaxCertImportRetryCount = 10;
+
         public static string GetSha256Thumbprint(X509Certificate2 cert)
         {
             Preconditions.CheckNotNull(cert);
@@ -249,7 +255,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 .Select(c => new X509Certificate2(c))
                 .ToList();
 
-        public static async Task<(X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain)> GetServerCertificatesFromEdgelet(Uri workloadUri, string workloadApiVersion, string workloadClientApiVersion, string moduleId, string moduleGenerationId, string edgeHubHostname, DateTime expiration)
+        public static async Task<(X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain)> GetServerCertificatesFromEdgelet(Uri workloadUri, string workloadApiVersion, string workloadClientApiVersion, string moduleId, string moduleGenerationId, string edgeHubHostname, DateTime expiration, ILogger logger)
         {
             if (string.IsNullOrEmpty(edgeHubHostname))
             {
@@ -257,7 +263,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
             }
 
             ServerCertificateResponse response = await new WorkloadClient(workloadUri, workloadApiVersion, workloadClientApiVersion, moduleId, moduleGenerationId).CreateServerCertificateAsync(edgeHubHostname, expiration);
-            return ParseCertificateResponse(response);
+            return ParseCertificateResponse(response, logger);
         }
 
         public static async Task<IEnumerable<X509Certificate2>> GetTrustBundleFromEdgelet(Uri workloadUri, string workloadApiVersion, string workloadClientApiVersion, string moduleId, string moduleGenerationId)
@@ -294,7 +300,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
             return chain.Build(signerCertificate);
         }
 
-        public static (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) GetServerCertificateAndChainFromFile(string serverWithChainFilePath, string serverPrivateKeyFilePath)
+        public static (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) GetServerCertificateAndChainFromFile(string serverWithChainFilePath, string serverPrivateKeyFilePath, ILogger logger = null)
         {
             string cert, privateKey;
 
@@ -318,7 +324,7 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 privateKey = sr.ReadToEnd();
             }
 
-            return ParseCertificateAndKey(cert, privateKey);
+            return ParseCertificateAndKey(cert, privateKey, logger);
         }
 
         public static IEnumerable<X509Certificate2> GetServerCACertificatesFromFile(string chainPath)
@@ -373,67 +379,87 @@ namespace Microsoft.Azure.Devices.Edge.Util
             return GetCertificatesFromPem(ParsePemCerts(manifestTrustedCACerts)).FirstOrDefault();
         }
 
-        internal static (X509Certificate2, IEnumerable<X509Certificate2>) ParseCertificateResponse(ServerCertificateResponse response) =>
-            ParseCertificateAndKey(response.Certificate, response.PrivateKey);
+        internal static (X509Certificate2, IEnumerable<X509Certificate2>) ParseCertificateResponse(ServerCertificateResponse response, ILogger logger = null) =>
+            ParseCertificateAndKey(response.Certificate, response.PrivateKey, logger);
 
-        internal static (X509Certificate2, IEnumerable<X509Certificate2>) ParseCertificateAndKey(string certificateWithChain, string privateKey)
+        internal static (X509Certificate2, IEnumerable<X509Certificate2>) ParseCertificateAndKey(string certificateWithChain, string privateKey, ILogger logger = null)
         {
-            IEnumerable<string> pemCerts = ParsePemCerts(certificateWithChain);
+            int retryCount = 0;
 
-            if (pemCerts.FirstOrDefault() == null)
+            while (retryCount++ < MaxCertImportRetryCount)
             {
-                throw new InvalidOperationException("Certificate is required");
-            }
+                IEnumerable<string> pemCerts = ParsePemCerts(certificateWithChain);
 
-            IEnumerable<X509Certificate2> certsChain = GetCertificatesFromPem(pemCerts.Skip(1));
-
-            Pkcs12Store store = new Pkcs12StoreBuilder().Build();
-            IList<X509CertificateEntry> chain = new List<X509CertificateEntry>();
-
-            // note: the seperator between the certificate and private key is added for safety to delinate the cert and key boundary
-            var sr = new StringReader(pemCerts.First() + "\r\n" + privateKey);
-            var pemReader = new PemReader(sr);
-
-            AsymmetricKeyParameter keyParams = null;
-            object certObject = pemReader.ReadObject();
-            while (certObject != null)
-            {
-                if (certObject is X509Certificate x509Cert)
+                if (pemCerts.FirstOrDefault() == null)
                 {
-                    chain.Add(new X509CertificateEntry(x509Cert));
+                    throw new InvalidOperationException("Certificate is required");
                 }
 
-                // when processing certificates generated via openssl certObject type is of AsymmetricCipherKeyPair
-                if (certObject is AsymmetricCipherKeyPair keyPair)
+                IEnumerable<X509Certificate2> certsChain = GetCertificatesFromPem(pemCerts.Skip(1));
+
+                Pkcs12Store store = new Pkcs12StoreBuilder().Build();
+                IList<X509CertificateEntry> chain = new List<X509CertificateEntry>();
+
+                // note: the seperator between the certificate and private key is added for safety to delinate the cert and key boundary
+                var sr = new StringReader(pemCerts.First() + "\r\n" + privateKey);
+                var pemReader = new PemReader(sr);
+
+                AsymmetricKeyParameter keyParams = null;
+                object certObject = pemReader.ReadObject();
+                while (certObject != null)
                 {
-                    certObject = keyPair.Private;
+                    if (certObject is X509Certificate x509Cert)
+                    {
+                        chain.Add(new X509CertificateEntry(x509Cert));
+                    }
+
+                    // when processing certificates generated via openssl certObject type is of AsymmetricCipherKeyPair
+                    if (certObject is AsymmetricCipherKeyPair keyPair)
+                    {
+                        certObject = keyPair.Private;
+                    }
+
+                    if (certObject is RsaPrivateCrtKeyParameters rsaParameters)
+                    {
+                        keyParams = rsaParameters;
+                    }
+                    else if (certObject is ECPrivateKeyParameters ecParameters)
+                    {
+                        keyParams = ecParameters;
+                    }
+
+                    certObject = pemReader.ReadObject();
                 }
 
-                if (certObject is RsaPrivateCrtKeyParameters rsaParameters)
+                if (keyParams == null)
                 {
-                    keyParams = rsaParameters;
-                }
-                else if (certObject is ECPrivateKeyParameters ecParameters)
-                {
-                    keyParams = ecParameters;
+                    throw new InvalidOperationException("Private key is required");
                 }
 
-                certObject = pemReader.ReadObject();
+                store.SetKeyEntry("Edge", new AsymmetricKeyEntry(keyParams), chain.ToArray());
+                using (var p12File = new MemoryStream())
+                {
+                    store.Save(p12File, new char[] { }, new SecureRandom());
+
+                    var cert = new X509Certificate2(p12File.ToArray());
+
+                    // On Windows, from time to time the private key cannot be accessed and kestrel fails accepting connections
+                    // without the private key. Testing the private key here and if it fails, retry the entire cert import.
+                    // The second try usually works.
+                    try
+                    {
+                        _ = cert.PrivateKey;
+                        return (cert, certsChain);
+                    }
+                    catch
+                    {
+                        logger?.LogWarning("Error importing certificate, retrying");
+                        Thread.Sleep(TimeSpan.FromSeconds(1)); // Do not spam the log
+                    }
+                }
             }
 
-            if (keyParams == null)
-            {
-                throw new InvalidOperationException("Private key is required");
-            }
-
-            store.SetKeyEntry("Edge", new AsymmetricKeyEntry(keyParams), chain.ToArray());
-            using (var p12File = new MemoryStream())
-            {
-                store.Save(p12File, new char[] { }, new SecureRandom());
-
-                var cert = new X509Certificate2(p12File.ToArray());
-                return (cert, certsChain);
-            }
+            throw new InvalidOperationException("Cannot import server certificate, giving up");
         }
 
         static string ToHexString(byte[] bytes)

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -448,14 +448,18 @@ namespace Microsoft.Azure.Devices.Edge.Util
                     // The second try usually works.
                     try
                     {
-                        _ = cert.PrivateKey;
-                        return (cert, certsChain);
+                        if (cert.HasPrivateKey)
+                        {
+                            return (cert, certsChain);
+                        }
                     }
                     catch
                     {
-                        logger?.LogWarning("Error importing certificate, retrying");
-                        Thread.Sleep(TimeSpan.FromSeconds(1)); // Do not spam the log
+                        // swallow
                     }
+
+                    logger?.LogWarning("Error importing certificate, retrying");
+                    Thread.Sleep(TimeSpan.FromSeconds(1)); // Do not spam the log
                 }
             }
 


### PR DESCRIPTION
This is a workaround for https://github.com/Azure/iotedge/issues/5087

When EdgeHub starts up and imports the certificates with their private keys, sometimes the private key does not get associated with the certificate. As a result, using the certificate object and accessing the private key throws an exception.
Because this certificate is handed over to Kestrel to provide a TLS connection, Kestrel tries to access the private key and throws an exception every time a client tries to connect. As a result, no client can connect to EdgeHub and it never recovers from this error.

We could not find the root cause that why the import fails sometimes and other times not, also it is not clear why only on windows. However, what we found is that retrying the import (with the same certificate and key files) usually works (always worked in the tests, but we cannot claim that it always will).

As a workaround, during startup, edge hub tries to access the private key to see if the association between the certificate and the key is working. If an error occurs, it re-imports the certificate, and it tries at max 10 times before stopping. Stop is needed because it is possible that the certificate files themself not correct and we want to avoid endless tries.

The diff tool shows excessive change, however only a few lines was added at the beginning of the file and around line 100.