### PR TITLE
Fix: Workload socket issue for concurrent module create (#5876)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/Constants.cs
@@ -43,6 +43,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
         public const string EdgeModuleHubServerCertificateFileKey = "EdgeModuleHubServerCertificateFile";
 
+        public const string CheckImagePullBeforeModuleCreate = "CheckImagePullBeforeModuleCreate";
+
         public const string Unknown = "Unknown";
 
         public const string UpstreamProtocolKey = "UpstreamProtocol";

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/EdgeletCommandFactory.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/EdgeletCommandFactory.cs
@@ -16,11 +16,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
         readonly ICombinedConfigProvider<T> combinedConfigProvider;
         readonly string edgeDeviceHostname;
         readonly Option<string> parentEdgeHostname;
+        readonly bool checkImagePullBeforeModuleCreate;
 
         public EdgeletCommandFactory(
             IModuleManager moduleManager,
             IConfigSource configSource,
-            ICombinedConfigProvider<T> combinedConfigProvider)
+            ICombinedConfigProvider<T> combinedConfigProvider,
+            bool checkImagePullBeforeModuleCreate)
         {
             this.moduleManager = Preconditions.CheckNotNull(moduleManager, nameof(moduleManager));
             this.configSource = Preconditions.CheckNotNull(configSource, nameof(configSource));
@@ -32,19 +34,41 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet
             }
 
             this.parentEdgeHostname = Option.Maybe(this.configSource.Configuration.GetValue<string>(Constants.GatewayHostnameVariableName));
+            this.checkImagePullBeforeModuleCreate = checkImagePullBeforeModuleCreate;
         }
 
-        public Task<ICommand> CreateAsync(IModuleWithIdentity module, IRuntimeInfo runtimeInfo) =>
-            Task.FromResult(
-                CreateOrUpdateCommand.BuildCreate(
-                    this.moduleManager,
-                    module.Module,
-                    module.ModuleIdentity,
-                    this.configSource,
-                    this.combinedConfigProvider.GetCombinedConfig(module.Module, runtimeInfo),
-                    this.edgeDeviceHostname,
-                    this.parentEdgeHostname)
-                as ICommand);
+        public Task<ICommand> CreateAsync(IModuleWithIdentity module, IRuntimeInfo runtimeInfo)
+        {
+            if (this.checkImagePullBeforeModuleCreate)
+            {
+                T config = this.combinedConfigProvider.GetCombinedConfig(module.Module, runtimeInfo);
+                return Task.FromResult(
+                    new GroupCommand(
+                        new PrepareUpdateCommand(this.moduleManager, module.Module, config),
+                        CreateOrUpdateCommand.BuildCreate(
+                            this.moduleManager,
+                            module.Module,
+                            module.ModuleIdentity,
+                            this.configSource,
+                            config,
+                            this.edgeDeviceHostname,
+                            this.parentEdgeHostname)
+                        as ICommand) as ICommand);
+            }
+            else
+            {
+                return Task.FromResult(
+                    CreateOrUpdateCommand.BuildCreate(
+                        this.moduleManager,
+                        module.Module,
+                        module.ModuleIdentity,
+                        this.configSource,
+                        this.combinedConfigProvider.GetCombinedConfig(module.Module, runtimeInfo),
+                        this.edgeDeviceHostname,
+                        this.parentEdgeHostname)
+                    as ICommand);
+            }
+        }
 
         public Task<ICommand> UpdateAsync(IModule current, IModuleWithIdentity next, IRuntimeInfo runtimeInfo) =>
             this.UpdateAsync(Option.Some(current), next, runtimeInfo, false);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/PrepareUpdateCommand.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commands/PrepareUpdateCommand.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands
 
         public string Id => $"PrepareUpdateCommand({this.module.Name})";
 
-        public string Show() => $"Prepare update module {this.module.Name}";
+        public string Show() => $"Prepare module {this.module.Name}";
 
         public Task ExecuteAsync(CancellationToken token)
         {

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -176,6 +176,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                     case Constants.IotedgedMode:
                         string managementUri = configuration.GetValue<string>(Constants.EdgeletManagementUriVariableName);
                         string workloadUri = configuration.GetValue<string>(Constants.EdgeletWorkloadUriVariableName);
+                        bool checkImagePullBeforeModuleCreate = configuration.GetValue<bool>(Constants.CheckImagePullBeforeModuleCreate, true);
                         iothubHostname = configuration.GetValue<string>(Constants.IotHubHostnameVariableName);
                         deviceId = configuration.GetValue<string>(Constants.DeviceIdVariableName);
                         string moduleId = configuration.GetValue(Constants.ModuleIdVariableName, Constants.EdgeAgentModuleIdentityName);
@@ -183,7 +184,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         apiVersion = configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
                         TimeSpan performanceMetricsUpdateFrequency = configuration.GetTimeSpan("PerformanceMetricsUpdateFrequency", TimeSpan.FromMinutes(5));
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize, storageMaxManifestFileSize, storageMaxOpenFiles, storageLogLevel));
-                        builder.RegisterModule(new EdgeletModule(iothubHostname, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, performanceMetricsUpdateFrequency, useServerHeartbeat, backupConfigFilePath));
+                        builder.RegisterModule(new EdgeletModule(iothubHostname, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, performanceMetricsUpdateFrequency, useServerHeartbeat, backupConfigFilePath, checkImagePullBeforeModuleCreate));
                         IEnumerable<X509Certificate2> trustBundle =
                             await CertificateHelper.GetTrustBundleFromEdgelet(new Uri(workloadUri), apiVersion, Constants.WorkloadApiVersion, moduleId, moduleGenerationId);
                         CertificateHelper.InstallCertificates(trustBundle, logger);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly TimeSpan performanceMetricsUpdateFrequency;
         readonly bool useServerHeartbeat;
         readonly string backupConfigFilePath;
+        readonly bool checkImagePullBeforeModuleCreate;
 
         public EdgeletModule(
             string iotHubHostname,
@@ -59,7 +60,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             TimeSpan idleTimeout,
             TimeSpan performanceMetricsUpdateFrequency,
             bool useServerHeartbeat,
-            string backupConfigFilePath)
+            string backupConfigFilePath,
+            bool checkImagePullBeforeModuleCreate)
         {
             this.iotHubHostName = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
             this.deviceId = Preconditions.CheckNonWhiteSpace(deviceId, nameof(deviceId));
@@ -75,6 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.performanceMetricsUpdateFrequency = performanceMetricsUpdateFrequency;
             this.useServerHeartbeat = useServerHeartbeat;
             this.backupConfigFilePath = Preconditions.CheckNonWhiteSpace(backupConfigFilePath, nameof(backupConfigFilePath));
+            this.checkImagePullBeforeModuleCreate = checkImagePullBeforeModuleCreate;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -129,7 +132,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                         ICommandFactory factory = new EdgeletCommandFactory<CombinedDockerConfig>(
                             moduleManager,
                             configSource,
-                            combinedDockerConfigProvider);
+                            combinedDockerConfigProvider,
+                            this.checkImagePullBeforeModuleCreate);
                         factory = new MetricsCommandFactory(factory, metricsProvider);
                         return new LoggingCommandFactory(factory, loggerFactory) as ICommandFactory;
                     })


### PR DESCRIPTION
Cherry pick: https://github.com/Azure/iotedge/pull/5876

* Workload socket fix


TEST:
Used the script to perform the test:
[test_new_flag.txt](https://github.com/Azure/iotedge/files/7651550/test_new_flag.txt)
Without flag
[prepare_module_on.txt](https://github.com/Azure/iotedge/files/7651556/prepare_module_on.txt)
With flag disabling prepare module on
[prepare_module_off.txt](https://github.com/Azure/iotedge/files/7651557/prepare_module_off.txt)

Both works.

So I checked in the journal logs to verify that the script is correctly reproducing the issue. It does, we see the "conflict" with current operation. However, since in 1.2 we create the socket in start, so it doesn't matter if socket was removed in create.
```
Pulling image via tag mcr.microsoft.com/media/video-analyzer:1...
Successfully pulled image mcr.microsoft.com/media/video-analyzer:1
Creating module AzureVideoAnalyzerEdge...
Creating image via tag mcr.microsoft.com/media/video-analyzer:1...
Successfully pulled image mcr.microsoft.com/media/video-analyzer:1
Creating module AzureVideoAnalyzerEdge...
Creating image via tag mcr.microsoft.com/media/video-analyzer:1...
Could not create module AzureVideoAnalyzerEdge
        caused by: Conflict with current operation
[mgmt] - - - [2021-12-03 17:53:52.519321102 UTC] "POST /modules?api-version=2020-07-07 HTTP/1.1" 409 Conflict 167 "-" "-" auth_id(-)
Successfully created module AzureVideoAnalyzerEdge
[mgmt] - - - [2021-12-03 17:53:52.574579949 UTC] "POST /modules?api-version=2020-07-07 HTTP/1.1" 201 Created 1016 "-" "-" auth_id(-)
Starting module AzureVideoAnalyzerEdge...
Starting new listener for module AzureVideoAnalyzerEdge
Listening on unix:///var/lib/aziot/edged/mnt/AzureVideoAnalyzerEdge.sock with 1 thread for workload API.


```


Co-authored-by: Ubuntu <azureuser@debug.wciqoipclkaejnvszvrhsyebkf.bx.internal.cloudapp.net>

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
