### PR TITLE
Removing moby check

### DIFF
--- a/edgelet/iotedge/src/check/checks/container_engine_is_moby.rs
+++ b/edgelet/iotedge/src/check/checks/container_engine_is_moby.rs
@@ -1,4 +1,4 @@
-use failure::{self, Context, Fail};
+use failure::{self, Context};
 
 use crate::check::{checker::Checker, Check, CheckResult};
 
@@ -30,55 +30,16 @@ impl ContainerEngineIsMoby {
             "Device is not using a production-supported container engine (moby-engine).\n\
              Please see https://aka.ms/iotedge-prod-checklist-moby for details.";
 
-        let docker_server_version =
-            if let Some(docker_server_version) = &check.docker_server_version {
-                self.docker_server_version = Some(docker_server_version.clone());
-                docker_server_version
-            } else {
-                return Ok(CheckResult::Skipped);
-            };
-
-        #[cfg(windows)]
-        {
-            let settings = if let Some(settings) = &check.settings {
-                settings
-            } else {
-                return Ok(CheckResult::Skipped);
-            };
-
-            let moby_runtime_uri = settings.moby_runtime().uri().to_string();
-            self.moby_runtime_uri = Some(moby_runtime_uri.clone());
-
-            if moby_runtime_uri != "npipe://./pipe/iotedge_moby_engine" {
-                return Ok(CheckResult::Warning(Context::new(MESSAGE).into()));
-            }
-        }
-
-        let docker_server_major_version = docker_server_version
-            .split('.')
-            .next()
-            .map(std::str::FromStr::from_str);
-        let docker_server_major_version: u32 = match docker_server_major_version {
-            Some(Ok(docker_server_major_version)) => docker_server_major_version,
-            Some(Err(_)) | None => {
-                return Ok(CheckResult::Warning(
-                    Context::new(format!(
-                        "Container engine returned malformed version string {:?}",
-                        docker_server_version,
-                    ))
-                    .context(MESSAGE)
-                    .into(),
-                ));
-            }
+        let settings = if let Some(settings) = &check.settings {
+            settings
+        } else {
+            return Ok(CheckResult::Skipped);
         };
 
-        // Older releases of Moby do not identify themselves in any unique way. Moby devs recommended assuming that anything less than version 10 is Moby,
-        // since these old releases are v3.x and regular Docker is in the high 10s.
-        //
-        // Newer releases of Moby follow Docker CE versioning, but have a "+azure" substring, eg "19.03.12+azure"
-        //
-        // Therefore Docker CE is anything with major version >= 10 but without a "+azure" substring.
-        if docker_server_major_version >= 10 && !docker_server_version.contains("+azure") {
+        let moby_runtime_uri = settings.moby_runtime().uri().to_string();
+        self.moby_runtime_uri = Some(moby_runtime_uri.clone());
+
+        if moby_runtime_uri != "npipe://./pipe/iotedge_moby_engine" {
             return Ok(CheckResult::Warning(Context::new(MESSAGE).into()));
         }
 

--- a/edgelet/iotedge/src/check/checks/mod.rs
+++ b/edgelet/iotedge/src/check/checks/mod.rs
@@ -24,6 +24,7 @@ pub(crate) use self::container_connect_iothub::get_host_container_iothub_tests;
 pub(crate) use self::container_engine_dns::ContainerEngineDns;
 pub(crate) use self::container_engine_installed::ContainerEngineInstalled;
 pub(crate) use self::container_engine_ipv6::ContainerEngineIPv6;
+#[cfg(windows)]
 pub(crate) use self::container_engine_is_moby::ContainerEngineIsMoby;
 pub(crate) use self::container_engine_logrotate::ContainerEngineLogrotate;
 pub(crate) use self::container_local_time::ContainerLocalTime;


### PR DESCRIPTION
As per discussion with moby team, we are removing the check for moby in iotedge because we won't be able to rely on "+azure" in the version forever.

That check however " if moby_runtime_uri != "npipe://./pipe/iotedge_moby_engine"" is still valid, but only for windows.
So the moby check was removed altogether for linux and just the check  if moby_runtime_uri != "npipe://./pipe/iotedge_moby_engine" was kept for windows.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
