### PR TITLE
Use proper name for $rid parameter. (#5898)

### DIFF
--- a/mqtt/mqtt-bridge/src/upstream/rpc/remote.rs
+++ b/mqtt/mqtt-bridge/src/upstream/rpc/remote.rs
@@ -294,8 +294,8 @@ mod tests {
     #[tokio::test]
     async fn it_sends_publications_twin_response() {
         it_sends_publication_when_known_topic(
-            "$iothub/device_1/module_a/twin/res/?rid=1",
-            "$downstream/device_1/module_a/twin/res/?rid=1",
+            "$iothub/device_1/module_a/twin/res/?$rid=1",
+            "$downstream/device_1/module_a/twin/res/?$rid=1",
         )
         .await;
     }
@@ -303,8 +303,8 @@ mod tests {
     #[tokio::test]
     async fn it_sends_publications_twin_desired() {
         it_sends_publication_when_known_topic(
-            "$iothub/device_1/module_a/twin/desired/?rid=1",
-            "$downstream/device_1/module_a/twin/desired/?rid=1",
+            "$iothub/device_1/module_a/twin/desired/?$rid=1",
+            "$downstream/device_1/module_a/twin/desired/?$rid=1",
         )
         .await;
     }
@@ -312,8 +312,8 @@ mod tests {
     #[tokio::test]
     async fn it_sends_publications_direct_method() {
         it_sends_publication_when_known_topic(
-            "$iothub/device_1/module_a/methods/post/?rid=1",
-            "$downstream/device_1/module_a/methods/post/?rid=1",
+            "$iothub/device_1/module_a/methods/post/?$rid=1",
+            "$downstream/device_1/module_a/methods/post/?$rid=1",
         )
         .await;
     }
@@ -360,13 +360,13 @@ mod tests {
         assert_matches!(res, Ok(Handled::Skipped(_)));
     }
 
-    #[test_case("$iothub/device_1/module_a/twin/res/?rid=1", Some("$downstream/device_1/module_a/twin/res/?rid=1"); "twin module")]
-    #[test_case("$iothub/device_1/twin/res/?rid=1", Some("$downstream/device_1/twin/res/?rid=1"); "twin device")]
-    #[test_case("$iothub/device_1/module_a/twin/desired/?rid=1", Some("$downstream/device_1/module_a/twin/desired/?rid=1"); "desired twin module")]
-    #[test_case("$iothub/device_1/twin/desired/?rid=1", Some("$downstream/device_1/twin/desired/?rid=1"); "desired twin device")]
-    #[test_case("$iothub/device_1/module_a/methods/post/?rid=1", Some("$downstream/device_1/module_a/methods/post/?rid=1"); "direct method module")]
-    #[test_case("$iothub/device_1/methods/post/?rid=1", Some("$downstream/device_1/methods/post/?rid=1"); "direct method device")]
-    #[test_case("$edgehub/device_1/module_a/twin/res/?rid=1", None; "wrong prefix")]
+    #[test_case("$iothub/device_1/module_a/twin/res/?$rid=1", Some("$downstream/device_1/module_a/twin/res/?$rid=1"); "twin module")]
+    #[test_case("$iothub/device_1/twin/res/?$rid=1", Some("$downstream/device_1/twin/res/?$rid=1"); "twin device")]
+    #[test_case("$iothub/device_1/module_a/twin/desired/?$rid=1", Some("$downstream/device_1/module_a/twin/desired/?$rid=1"); "desired twin module")]
+    #[test_case("$iothub/device_1/twin/desired/?$rid=1", Some("$downstream/device_1/twin/desired/?$rid=1"); "desired twin device")]
+    #[test_case("$iothub/device_1/module_a/methods/post/?$rid=1", Some("$downstream/device_1/module_a/methods/post/?$rid=1"); "direct method module")]
+    #[test_case("$iothub/device_1/methods/post/?$rid=1", Some("$downstream/device_1/methods/post/?$rid=1"); "direct method device")]
+    #[test_case("$edgehub/device_1/module_a/twin/res/?$rid=1", None; "wrong prefix")]
     fn it_translates_upstream_topic(topic_name: &str, expected: Option<&str>) {
         assert_eq!(translate(topic_name).as_deref(), expected);
     }

--- a/mqtt/mqtt-bridge/tests/rpc.rs
+++ b/mqtt/mqtt-bridge/tests/rpc.rs
@@ -67,7 +67,7 @@ async fn get_twin_update_via_rpc() {
     // edgehub makes a request to get a twin for the leaf device
     let payload = command(
         "pub",
-        "$iothub/device-1/twin/get/?rid=1",
+        "$iothub/device-1/twin/get/?$rid=1",
         Some(Vec::default()),
     );
     edgehub
@@ -76,15 +76,15 @@ async fn get_twin_update_via_rpc() {
     assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/rpc/ack/2");
 
     // upstream client awaits on twin request and responds with twin message
-    assert_matches!(upstream.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$iothub/device-1/twin/get/?rid=1");
+    assert_matches!(upstream.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$iothub/device-1/twin/get/?$rid=1");
 
     let twin = "device-1 twin";
     upstream
-        .publish_qos1("$iothub/device-1/twin/res/200/?rid=1", twin, false)
+        .publish_qos1("$iothub/device-1/twin/res/200/?$rid=1", twin, false)
         .await;
 
     // edgehub verifies it received a twin response
-    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/device-1/twin/res/200/?rid=1");
+    assert_matches!(edgehub.publications().next().await, Some(ReceivedPublication {topic_name, ..}) if topic_name == "$downstream/device-1/twin/res/200/?$rid=1");
 
     // edgehub unsubscribes from twin response
     let payload = command("unsub", "$iothub/device-1/twin/res/#", None);

--- a/mqtt/mqtt-edgehub/src/topic/translation.rs
+++ b/mqtt/mqtt-edgehub/src/topic/translation.rs
@@ -351,22 +351,22 @@ mod tests {
 
         // Twin d2c
         assert_eq!(
-            d2c.to_internal("$iothub/twin/PATCH/properties/reported/?rid=1", &device_1),
-            Some("$edgehub/device_1/twin/reported/?rid=1".to_owned())
+            d2c.to_internal("$iothub/twin/PATCH/properties/reported/?$rid=1", &device_1),
+            Some("$edgehub/device_1/twin/reported/?$rid=1".to_owned())
         );
         assert_eq!(
-            d2c.to_internal("$iothub/twin/GET/?rid=2", &device_1),
-            Some("$edgehub/device_1/twin/get/?rid=2".to_owned())
+            d2c.to_internal("$iothub/twin/GET/?$rid=2", &device_1),
+            Some("$edgehub/device_1/twin/get/?$rid=2".to_owned())
         );
 
         // Twin c2d
         assert_eq!(
-            c2d.to_internal("$iothub/twin/PATCH/properties/desired/?rid=1", &device_1),
-            Some("$edgehub/device_1/twin/desired/?rid=1".to_owned())
+            c2d.to_internal("$iothub/twin/PATCH/properties/desired/?$rid=1", &device_1),
+            Some("$edgehub/device_1/twin/desired/?$rid=1".to_owned())
         );
         assert_eq!(
-            c2d.to_external("$edgehub/module_a/twin/desired/?rid=1"),
-            Some("$iothub/twin/PATCH/properties/desired/?rid=1".to_owned())
+            c2d.to_external("$edgehub/module_a/twin/desired/?$rid=1"),
+            Some("$iothub/twin/PATCH/properties/desired/?$rid=1".to_owned())
         );
 
         assert_eq!(
@@ -374,14 +374,14 @@ mod tests {
             Some("$edgehub/device_1/twin/res/#".to_owned())
         );
         assert_eq!(
-            c2d.to_external("$edgehub/module_a/twin/res/?rid=3"),
-            Some("$iothub/twin/res/?rid=3".to_owned())
+            c2d.to_external("$edgehub/module_a/twin/res/?$rid=3"),
+            Some("$iothub/twin/res/?$rid=3".to_owned())
         );
 
         // Direct Method d2c
         assert_eq!(
-            d2c.to_internal("$iothub/methods/res/200/?rid=4", &device_1),
-            Some("$edgehub/device_1/methods/res/200/?rid=4".to_owned())
+            d2c.to_internal("$iothub/methods/res/200/?$rid=4", &device_1),
+            Some("$edgehub/device_1/methods/res/200/?$rid=4".to_owned())
         );
 
         // Direct Method c2d
@@ -390,8 +390,8 @@ mod tests {
             Some("$edgehub/device_1/methods/post/#".to_owned())
         );
         assert_eq!(
-            c2d.to_external("$edgehub/device_1/methods/post/my_method/?rid=5"),
-            Some("$iothub/methods/POST/my_method/?rid=5".to_owned())
+            c2d.to_external("$edgehub/device_1/methods/post/my_method/?$rid=5"),
+            Some("$iothub/methods/POST/my_method/?$rid=5".to_owned())
         );
     }
 
@@ -462,22 +462,22 @@ mod tests {
 
         // Twin d2c
         assert_eq!(
-            d2c.to_internal("$iothub/twin/PATCH/properties/reported/?rid=1", &client_id),
-            Some("$edgehub/device_1/module_a/twin/reported/?rid=1".to_owned())
+            d2c.to_internal("$iothub/twin/PATCH/properties/reported/?$rid=1", &client_id),
+            Some("$edgehub/device_1/module_a/twin/reported/?$rid=1".to_owned())
         );
         assert_eq!(
-            d2c.to_internal("$iothub/twin/GET/?rid=2", &client_id),
-            Some("$edgehub/device_1/module_a/twin/get/?rid=2".to_owned())
+            d2c.to_internal("$iothub/twin/GET/?$rid=2", &client_id),
+            Some("$edgehub/device_1/module_a/twin/get/?$rid=2".to_owned())
         );
 
         // Twin c2d
         assert_eq!(
-            c2d.to_internal("$iothub/twin/PATCH/properties/desired/?rid=1", &client_id),
-            Some("$edgehub/device_1/module_a/twin/desired/?rid=1".to_owned())
+            c2d.to_internal("$iothub/twin/PATCH/properties/desired/?$rid=1", &client_id),
+            Some("$edgehub/device_1/module_a/twin/desired/?$rid=1".to_owned())
         );
         assert_eq!(
-            c2d.to_external("$edgehub/device_1/module_a/twin/desired/?rid=1"),
-            Some("$iothub/twin/PATCH/properties/desired/?rid=1".to_owned())
+            c2d.to_external("$edgehub/device_1/module_a/twin/desired/?$rid=1"),
+            Some("$iothub/twin/PATCH/properties/desired/?$rid=1".to_owned())
         );
 
         assert_eq!(
@@ -485,14 +485,14 @@ mod tests {
             Some("$edgehub/device_1/module_a/twin/res/#".to_owned())
         );
         assert_eq!(
-            c2d.to_external("$edgehub/device_1/module_a/twin/res/?rid=3"),
-            Some("$iothub/twin/res/?rid=3".to_owned())
+            c2d.to_external("$edgehub/device_1/module_a/twin/res/?$rid=3"),
+            Some("$iothub/twin/res/?$rid=3".to_owned())
         );
 
         // Direct Method d2c
         assert_eq!(
-            d2c.to_internal("$iothub/methods/res/200/?rid=4", &client_id),
-            Some("$edgehub/device_1/module_a/methods/res/200/?rid=4".to_owned())
+            d2c.to_internal("$iothub/methods/res/200/?$rid=4", &client_id),
+            Some("$edgehub/device_1/module_a/methods/res/200/?$rid=4".to_owned())
         );
 
         // Direct Method c2d
@@ -501,8 +501,8 @@ mod tests {
             Some("$edgehub/device_1/module_a/methods/post/#".to_owned())
         );
         assert_eq!(
-            c2d.to_external("$edgehub/device_1/module_a/methods/post/my_method/?rid=5"),
-            Some("$iothub/methods/POST/my_method/?rid=5".to_owned())
+            c2d.to_external("$edgehub/device_1/module_a/methods/post/my_method/?$rid=5"),
+            Some("$iothub/methods/POST/my_method/?$rid=5".to_owned())
         );
 
         // M2M subscription

--- a/mqtt/mqtt-edgehub/tests/edgehub_authorizer.rs
+++ b/mqtt/mqtt-edgehub/tests/edgehub_authorizer.rs
@@ -78,7 +78,7 @@ async fn pub_sub_not_allowed_identity_not_in_cache() {
                 false,
             ),
             retain: false,
-            topic_name: "$edgehub/device-1/twin/get?rid=42".into(),
+            topic_name: "$edgehub/device-1/twin/get?$rid=42".into(),
             payload: Bytes::from("qos 1"),
         })
         .await;

--- a/mqtt/mqtt-edgehub/tests/translation.rs
+++ b/mqtt/mqtt-edgehub/tests/translation.rs
@@ -44,17 +44,17 @@ async fn translation_twin_retrieve() {
         .subscribe("$iothub/twin/res/#", QoS::AtLeastOnce)
         .await;
     device_1
-        .publish_qos1("$iothub/twin/GET/?rid=10", "", false)
+        .publish_qos1("$iothub/twin/GET/?$rid=10", "", false)
         .await;
 
     // Core receives request
-    receive_with_topic(&mut edge_hub_core, "$edgehub/device_1/twin/get/?rid=10").await;
+    receive_with_topic(&mut edge_hub_core, "$edgehub/device_1/twin/get/?$rid=10").await;
     edge_hub_core
-        .publish_qos1("$edgehub/device_1/twin/res/200/?rid=10", "", false)
+        .publish_qos1("$edgehub/device_1/twin/res/200/?$rid=10", "", false)
         .await;
 
     // device receives response
-    receive_with_topic(&mut device_1, "$iothub/twin/res/200/?rid=10").await;
+    receive_with_topic(&mut device_1, "$iothub/twin/res/200/?$rid=10").await;
 
     edge_hub_core.shutdown().await;
     device_1.shutdown().await;
@@ -89,21 +89,21 @@ async fn translation_twin_update() {
         .subscribe("$iothub/twin/res/#", QoS::AtLeastOnce)
         .await;
     device_1
-        .publish_qos1("$iothub/twin/PATCH/properties/reported/?rid=20", "", false)
+        .publish_qos1("$iothub/twin/PATCH/properties/reported/?$rid=20", "", false)
         .await;
 
     // Core receives request
     receive_with_topic(
         &mut edge_hub_core,
-        "$edgehub/device_1/twin/reported/?rid=20",
+        "$edgehub/device_1/twin/reported/?$rid=20",
     )
     .await;
     edge_hub_core
-        .publish_qos1("$edgehub/device_1/twin/res/200/?rid=20", "", false)
+        .publish_qos1("$edgehub/device_1/twin/res/200/?$rid=20", "", false)
         .await;
 
     // device receives response
-    receive_with_topic(&mut device_1, "$iothub/twin/res/200/?rid=20").await;
+    receive_with_topic(&mut device_1, "$iothub/twin/res/200/?$rid=20").await;
 
     edge_hub_core.shutdown().await;
     device_1.shutdown().await;
@@ -183,22 +183,22 @@ async fn translation_direct_method_response() {
     // Core calls method
     edge_hub_core
         .publish_qos1(
-            "$edgehub/device_1/methods/post/my_cool_method/?rid=7",
+            "$edgehub/device_1/methods/post/my_cool_method/?$rid=7",
             "",
             false,
         )
         .await;
 
     // device receives call and responds
-    receive_with_topic(&mut device_1, "$iothub/methods/POST/my_cool_method/?rid=7").await;
+    receive_with_topic(&mut device_1, "$iothub/methods/POST/my_cool_method/?$rid=7").await;
     device_1
-        .publish_qos1("$iothub/methods/res/200/?rid=7", "", false)
+        .publish_qos1("$iothub/methods/res/200/?$rid=7", "", false)
         .await;
 
     // Core receives response
     receive_with_topic(
         &mut edge_hub_core,
-        "$edgehub/device_1/methods/res/200/?rid=7",
+        "$edgehub/device_1/methods/res/200/?$rid=7",
     )
     .await;
 
@@ -269,25 +269,25 @@ async fn test_twin_with_client_id(client_id: &str) {
     .await;
 
     device_1
-        .publish_qos1("$iothub/twin/GET/?rid=10", "", false)
+        .publish_qos1("$iothub/twin/GET/?$rid=10", "", false)
         .await;
 
     // Core receives request
     receive_with_topic(
         &mut edge_hub_core,
-        &format!("$edgehub/{}/twin/get/?rid=10", client_id),
+        &format!("$edgehub/{}/twin/get/?$rid=10", client_id),
     )
     .await;
     edge_hub_core
         .publish_qos1(
-            format!("$edgehub/{}/twin/res/200/?rid=10", client_id),
+            format!("$edgehub/{}/twin/res/200/?$rid=10", client_id),
             "",
             false,
         )
         .await;
 
     // device receives response
-    receive_with_topic(&mut device_1, "$iothub/twin/res/200/?rid=10").await;
+    receive_with_topic(&mut device_1, "$iothub/twin/res/200/?$rid=10").await;
 
     edge_hub_core.shutdown().await;
     device_1.shutdown().await;


### PR DESCRIPTION
It's been brought to our attention that we use incorrect parameter name. It should be `$rid`. 
**Note: this change only affect tests. The actual topic translation functionality works fine.**
I propose this test just to avoid confusion in the future where someone can look at the test and get the wrong impression about parameter name.

This PR does not require additional test coverage.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

