### PR TITLE
Retry importing server certificate if private key is not accessible

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Service/EdgeHubCertificates.cs
@@ -3,9 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
 {
     using System;
     using System.Collections.Generic;
-    using System.Globalization;
     using System.Linq;
-    using System.Runtime.InteropServices;
     using System.Security.Cryptography.X509Certificates;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util;
@@ -51,7 +49,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 string edgeletApiVersion = configuration.GetValue<string>(Constants.ConfigKey.WorkloadAPiVersion);
                 DateTime expiration = DateTime.UtcNow.AddDays(Constants.CertificateValidityDays);
 
-                certificates = await CertificateHelper.GetServerCertificatesFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId, edgeHubHostname, expiration);
+                certificates = await CertificateHelper.GetServerCertificatesFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId, edgeHubHostname, expiration, logger);
                 IEnumerable<X509Certificate2> trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(workloadUri, edgeletApiVersion, Constants.WorkloadApiVersion, moduleId, generationId);
 
                 result = new EdgeHubCertificates(
@@ -66,7 +64,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Service
                 // If no connection string was set and we use iotedged workload style certificates for development
                 (X509Certificate2 ServerCertificate, IEnumerable<X509Certificate2> CertificateChain) certificates;
 
-                certificates = CertificateHelper.GetServerCertificateAndChainFromFile(edgeHubDevCertPath, edgeHubDevPrivateKeyPath);
+                certificates = CertificateHelper.GetServerCertificateAndChainFromFile(edgeHubDevCertPath, edgeHubDevPrivateKeyPath, logger);
                 IEnumerable<X509Certificate2> trustBundle = CertificateHelper.ParseTrustedBundleFromFile(edgeHubDevTrustBundlePath);
 
                 result = new EdgeHubCertificates(


### PR DESCRIPTION
This is a workaround for #5087

When EdgeHub starts up and imports the certificates with their private keys, sometimes the private key does not get associated with the certificate. As a result, using the certificate object and accessing the private key throws an exception.
Because this certificate is handed over to Kestrel to provide a TLS connection, Kestrel tries to access the private key and throws an exception every time a client tries to connect. As a result, no client can connect to EdgeHub and it never recovers from this error.

We could not find the root cause that why the import fails sometimes and other times not, also it is not clear why only on windows. However, what we found is that retrying the import (with the same certificate and key files) usually works (always worked in the tests, but we cannot claim that it always will).

As a workaround, during startup, edge hub tries to access the private key to see if the association between the certificate and the key is working. If an error occurs, it re-imports the certificate, and it tries at max 10 times before stopping. Stop is needed because it is possible that the certificate files themself not correct and we want to avoid endless tries.

The diff tool shows excessive change, however only a few lines was added at the beginning of the file and around line 100.