### PR TITLE
[E2E]: Enable aziot-edge install from Microsoft prod (#4881)

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -62,7 +62,35 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
 
         public string[] GetInstallCommandsFromMicrosoftProd(Option<Uri> proxy)
         {
-            throw new NotImplementedException("aziot-edge and aziot-identity-service currently aren't available in package repos");
+            // we really support only two options for now.
+            string repository = this.os.ToLower() switch
+            {
+                "ubuntu" => $"https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list",
+                "debian" => $"https://packages.microsoft.com/config/debian/stretch/multiarch/prod.list",
+                _ => throw new NotImplementedException($"Don't know how to install daemon for '{this.os}'"),
+            };
+
+            return this.packageExtension switch
+            {
+                SupportedPackageExtension.Deb => new[]
+                {
+                    $"curl {repository} > /etc/apt/sources.list.d/microsoft-prod.list",
+                    "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
+                    $"apt-get update",
+                    $"apt-get install --yes aziot-edge"
+                },
+                SupportedPackageExtension.Rpm => new[]
+                {
+                    $"rpm -iv --replacepkgs https://packages.microsoft.com/config/{this.os}/{this.version}/packages-microsoft-prod.rpm",
+                    $"yum updateinfo",
+                    $"yum install --yes aziot-edge",
+                    "pathToSystemdConfig=$(systemctl cat aziot-edge | head -n 1)",
+                    "sed 's/=on-failure/=no/g' ${pathToSystemdConfig#?} > ~/override.conf",
+                    "sudo mv -f ~/override.conf ${pathToSystemdConfig#?}",
+                    "sudo systemctl daemon-reload"
+                },
+                _ => throw new NotImplementedException($"Don't know how to install daemon on for '.{this.packageExtension}'"),
+            };
         }
 
         public string[] GetUninstallCommands() => this.packageExtension switch


### PR DESCRIPTION
Straight cherry-pick:  This change will enable aziot-edge install from Microsoft prod. This is useful for scenarios where we don't care about specific version of runtime, but are fine with the latest officially published.

The use case for 1.2 is to make the release process simpler, when it comes to base images updates. 

- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).