### PR TITLE
Rocksdb build for arm needs Ubuntu 18

### DIFF
--- a/edge-util/docker/linux/arm32v7/Dockerfile
+++ b/edge-util/docker/linux/arm32v7/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# docker file for azureiotedge/azureiotedge-runtime-base:1.2-linux-arm32v7
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 ARG num_procs=4
 

--- a/edge-util/docker/linux/arm64v8/Dockerfile
+++ b/edge-util/docker/linux/arm64v8/Dockerfile
@@ -1,5 +1,5 @@
 ﻿# docker file for azureiotedge/azureiotedge-runtime-base:1.2-linux-arm64v8
-FROM ubuntu:20.04
+FROM ubuntu:18.04
 
 ARG num_procs=4
 


### PR DESCRIPTION
It looks like if I use ubuntu 20.04 as a base for the RocksDB build,
it pulls in the incorrect version of glibc. The dotnet containers are 
based on bionic, so dropping down to 18.04 should
allow the libsrocksdb to be loaded.

Ran E2E test again, and checked for the exception I saw earlier. The storage is created cleanly.


## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  


