### PR TITLE
Disable chaining verification in EA and EH

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -568,14 +568,6 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 bool signatureVerified = false;
                 using (IDisposable verificationTimer = this.deploymentMetrics.StartTwinSignatureTimer())
                 {
-                    // Currently not verifying the chaining as Manifest signer client already does that.
-                    // There is known bug in which the certs are not processed correctly which breaks the chaining verification.
-                    /* if (!CertificateHelper.VerifyManifestTrustBunldeCertificateChaining(signerCert, intermediatecacert, manifestTrustBundleRootCertificate))
-                    {
-                        throw new ManifestTrustBundleChainingFailedException("The signer cert with or without the intermediate CA cert in the twin does not chain up to the Manifest Trust Bundle Root CA configured in the device");
-                    }
-                    */
-
                     signatureVerified = SignatureValidator.VerifySignature(desiredProperties.ToString(), header.ToString(), signatureBytes, signerCert, algoResult.Key, algoResult.Value);
                 }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -568,6 +568,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 bool signatureVerified = false;
                 using (IDisposable verificationTimer = this.deploymentMetrics.StartTwinSignatureTimer())
                 {
+                    // Currently not verifying the chaining as Manifest signer client already does that.
+                    // There is known bug in which the certs are not processed correctly which breaks the chaining verification.
                     signatureVerified = SignatureValidator.VerifySignature(desiredProperties.ToString(), header.ToString(), signatureBytes, signerCert, algoResult.Key, algoResult.Value);
                 }
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -568,10 +568,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                 bool signatureVerified = false;
                 using (IDisposable verificationTimer = this.deploymentMetrics.StartTwinSignatureTimer())
                 {
-                    if (!CertificateHelper.VerifyManifestTrustBunldeCertificateChaining(signerCert, intermediatecacert, manifestTrustBundleRootCertificate))
+                    // Currently not verifying the chaining as Manifest signer client already does that.
+                    // There is known bug in which the certs are not processed correctly which breaks the chaining verification.
+                    /* if (!CertificateHelper.VerifyManifestTrustBunldeCertificateChaining(signerCert, intermediatecacert, manifestTrustBundleRootCertificate))
                     {
                         throw new ManifestTrustBundleChainingFailedException("The signer cert with or without the intermediate CA cert in the twin does not chain up to the Manifest Trust Bundle Root CA configured in the device");
                     }
+                    */
 
                     signatureVerified = SignatureValidator.VerifySignature(desiredProperties.ToString(), header.ToString(), signatureBytes, signerCert, algoResult.Key, algoResult.Value);
                 }

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/TwinConfigSource.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/TwinConfigSource.cs
@@ -306,13 +306,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
                 bool signatureVerified = false;
                 using (IDisposable verificationTimer = Metrics.StartTwinSignatureTimer())
                 {
-                    // Currently not verifying the chaining as Manifest signer client already does that.
-                    // There is known bug in which the certs are not processed correctly which breaks the chaining verification.
-                    /* if (!CertificateHelper.VerifyManifestTrustBunldeCertificateChaining(signerCert, intermediatecacert, manifestTrustBundleRootCertificate))
-                    {
-                        throw new ManifestTrustBundleChainingFailedException("The signer cert with or without the intermediate CA cert in the twin does not chain up to the Manifest Trust Bundle Root CA configured in the device");
-                    }*/
-
                     signatureVerified = SignatureValidator.VerifySignature(desiredProperties.ToString(), header.ToString(), signatureBytes, signerCert, algoResult.Key, algoResult.Value);
                 }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/TwinConfigSource.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/TwinConfigSource.cs
@@ -306,6 +306,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
                 bool signatureVerified = false;
                 using (IDisposable verificationTimer = Metrics.StartTwinSignatureTimer())
                 {
+                    // Currently not verifying the chaining as Manifest signer client already does that.
+                    // There is known bug in which the certs are not processed correctly which breaks the chaining verification.
                     signatureVerified = SignatureValidator.VerifySignature(desiredProperties.ToString(), header.ToString(), signatureBytes, signerCert, algoResult.Key, algoResult.Value);
                 }
 

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/TwinConfigSource.cs
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/config/TwinConfigSource.cs
@@ -306,10 +306,12 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Core.Config
                 bool signatureVerified = false;
                 using (IDisposable verificationTimer = Metrics.StartTwinSignatureTimer())
                 {
-                    if (!CertificateHelper.VerifyManifestTrustBunldeCertificateChaining(signerCert, intermediatecacert, manifestTrustBundleRootCertificate))
+                    // Currently not verifying the chaining as Manifest signer client already does that.
+                    // There is known bug in which the certs are not processed correctly which breaks the chaining verification.
+                    /* if (!CertificateHelper.VerifyManifestTrustBunldeCertificateChaining(signerCert, intermediatecacert, manifestTrustBundleRootCertificate))
                     {
                         throw new ManifestTrustBundleChainingFailedException("The signer cert with or without the intermediate CA cert in the twin does not chain up to the Manifest Trust Bundle Root CA configured in the device");
-                    }
+                    }*/
 
                     signatureVerified = SignatureValidator.VerifySignature(desiredProperties.ToString(), header.ToString(), signatureBytes, signerCert, algoResult.Key, algoResult.Value);
                 }


### PR DESCRIPTION
Disable chaining verification in EA and EH as there is known bug in the way the certs are processed after a deployment is set. Util a fix is made, disabling it for now. Also the chaining verification is done already in the Manifest signer client so it doesn't needed for now. 