### PR TITLE
Add nupkg as part of publish-linux

### DIFF
--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -289,7 +289,7 @@ stages:
         - bash: |
             mkdir $(Build.ArtifactStagingDirectory)/publish-linux && \
             mv $(Build.BinariesDirectory)/publish/{CACertificates,e2e_deployment_files,e2e_test_files,\
-            scripts,IotEdgeQuickstart*,LeafDevice*} $(Build.ArtifactStagingDirectory)/publish-linux
+            scripts,IotEdgeQuickstart*,LeafDevice*,*.nupkg} $(Build.ArtifactStagingDirectory)/publish-linux
           displayName: Move/stage test file artifacts
         - task: PublishBuildArtifacts@1
           displayName: 'Publish Artifacts to VSTS'


### PR DESCRIPTION
TL;DR -- Add Microsoft.Azure.WebJobs.Extensions*.nupkg to be part of the published artifact.

The artifact is used as part of the Azure Function dependency.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
