### PR TITLE
CI: Disable flaky SendTelemetry test (#5945)

### DIFF
--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/TelemetryTest.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
     [Collection("Microsoft.Azure.Devices.Edge.Hub.E2E.Test")]
     public class TelemetryTest
     {
-        [Theory]
+        [Theory(Skip = "Flaky")]
         [MemberData(nameof(TestSettings.TransportSettings), MemberType = typeof(TestSettings))]
         async Task SendTelemetryTest(ITransportSettings[] transportSettings)
         {


### PR DESCRIPTION
Cherry pick: #5945

This CI test is flaky, but is also redundant as the scenario is also covered in our E2E suite. 

The root cause of the flake is that when the module client is disconnected, sometimes the amqp session is no longer there so the SDK will throw an exception when closing the ModuleClient. We could refactor this test to avoid this, but it seems less error-prone to rely on just the existing E2E test to cover this scenario.

Test run with changes:
https://dev.azure.com/msazure/One/_build/results?buildId=50188304&view=results

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
