### PR TITLE
[Draft] moduleClient.dispose() hanging on 1.1.8

### DIFF
--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttProtocolHead.cs
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/MqttProtocolHead.cs
@@ -82,6 +82,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt
         {
             try
             {
+                Thread.Sleep(120000);
                 this.logger.LogInformation("Starting MQTT head");
 
                 ServerBootstrap bootstrap = this.SetupServerBootstrap();


### PR DESCRIPTION
In LH for release 1.1.8, the DirectMethodReceiver2 module came up before MQTT head was ready on the edgeHub which causes the initial connection to fail. Instead of exiting the program, the module hanged on moduleClient.dispose() for about 24hr until manually restarting the module which prompted it work correctly.


## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ x] Title of the pull request is clear and informative.

