### PR TITLE
dumping pkcs

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -398,6 +398,20 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 store.Save(p12File, new char[] { }, new SecureRandom());
 
                 var cert = new X509Certificate2(p12File.ToArray());
+
+                try
+                {
+                    _ = cert.PrivateKey;
+                }
+                catch
+                {
+                    using (var file = File.Create("pkcsdump.bin"))
+                    {
+                        var content = p12File.ToArray();
+                        file.Write(content, 0, content.Length);
+                    }
+                }
+
                 return (cert, certsChain);
             }
         }


### PR DESCRIPTION
dumping the pkcs file when the private key of a certificate cannot be accessed