### PR TITLE
Change default common name of Edge CA cert to "aziot-edge CA"

### DIFF
--- a/edgelet/contrib/config/linux/template.toml
+++ b/edgelet/contrib/config/linux/template.toml
@@ -340,7 +340,7 @@
 # # Optional EST configuration for issuing the Edge CA certificate below.
 # # If not set, the defaults in [cert_issuance.est] will be used.
 #
-# common_name = "iotedged workload ca"
+# common_name = "aziot-edge CA"
 # expiry_days = 90
 # url = "https://example.org/.well-known/est"
 #
@@ -368,7 +368,7 @@
 #
 # # Optional configuration below.
 #
-# common_name = "iotedged workload ca"
+# common_name = "aziot-edge CA"
 # expiry_days = 90
 
 # ==============================================================================

--- a/edgelet/edgelet-http-workload/src/module/cert/mod.rs
+++ b/edgelet/edgelet-http-workload/src/module/cert/mod.rs
@@ -247,7 +247,7 @@ pub(crate) async fn check_edge_ca(
     if should_renew(&cert_client, edge_ca_cert).await? {
         log::info!("Requesting new Edge CA certificate...");
 
-        let common_name = format!("iotedged workload ca {}", device_id);
+        let common_name = format!("aziot-edge CA {}", device_id);
         let keys = edge_ca_keys(key_connector, key_handle)?;
 
         let extensions = edge_ca_extensions().map_err(|_| {

--- a/edgelet/iotedge/src/check/mod.rs
+++ b/edgelet/iotedge/src/check/mod.rs
@@ -681,7 +681,7 @@ fn get_local_service_proxy_setting(svc_name: &str) -> Option<String> {
     const PROXY_KEY: &str = "https_proxy";
     let output = Command::new("sh")
         .arg("-c")
-        .arg("sudo systemctl show --property=Environment ".to_owned() + svc_name)
+        .arg("systemctl show --property=Environment ".to_owned() + svc_name)
         .output()
         .expect("failed to execute process");
     let stdout = String::from_utf8_lossy(&output.stdout);

--- a/edgelet/iotedge/src/config/apply.rs
+++ b/edgelet/iotedge/src/config/apply.rs
@@ -14,7 +14,7 @@ const AZIOT_EDGED_HOMEDIR_PATH: &str = "/var/lib/aziot/edged";
 const TRUST_BUNDLE_USER_ALIAS: &str = "trust-bundle-user";
 
 // TODO: Dedupe this with edgelet-http-workload
-const IOTEDGED_COMMONNAME_PREFIX: &str = "iotedged workload ca";
+const IOTEDGED_COMMONNAME_PREFIX: &str = "aziot-edge CA";
 
 pub fn execute(config: &Path) -> Result<(), std::borrow::Cow<'static, str>> {
     // In production, running as root is the easiest way to guarantee the tool has write access to every service's config file.

--- a/edgelet/iotedge/test-files/config/ca-certs-est/certd.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs-est/certd.toml
@@ -11,7 +11,7 @@ identity_cert = "est-id-aziot-edged-ca"
 identity_pk = "est-id-aziot-edged-ca"
 bootstrap_identity_cert = "est-bootstrap-id-aziot-edged-ca"
 bootstrap_identity_pk = "est-bootstrap-id-aziot-edged-ca"
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca", "trust-bundle-user"]

--- a/edgelet/iotedge/test-files/config/ca-quickstart/certd.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 30
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/certd.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-tpm/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/dps-x509/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/imported-master-encryption-key/certd.toml
+++ b/edgelet/iotedge/test-files/config/imported-master-encryption-key/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manifest-trust-bundle/certd.toml
+++ b/edgelet/iotedge/test-files/config/manifest-trust-bundle/certd.toml
@@ -3,7 +3,7 @@
 
 homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 expiry_days = 90
 method = "self_signed"
 

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/manual-x509/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/moby-runtime-content-trust/certd.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-content-trust/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/nested-edge/certd.toml
+++ b/edgelet/iotedge/test-files/config/nested-edge/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/certd.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/certd.toml
@@ -5,7 +5,7 @@ homedir_path = "/var/lib/aziot/certd"
 [cert_issuance.aziot-edged-ca]
 method = "self_signed"
 expiry_days = 90
-common_name = "iotedged workload ca my-device"
+common_name = "aziot-edge CA my-device"
 
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]


### PR DESCRIPTION
This affects the certd config generated by running `iotedge config apply`,
as well as a new Edge CA cert issued when the current one expires *and*
the common name has not been set explicitly in certd config already.

Fixes #5937
Ref #4740

Also fix iotedge-check tests to not require sudo access.

Ref https://github.com/Azure/iotedge/pull/5927#issuecomment-1007806386