### PR TITLE
Custom Release pipeline for simplifying Release process on Base image updates for release/1.1

### DIFF
--- a/builds/e2e/e2e-release.yaml
+++ b/builds/e2e/e2e-release.yaml
@@ -1,0 +1,288 @@
+parameters:
+  dependency: []
+stages:
+################################################################################
+  - stage: RunE2ETest
+################################################################################
+    dependsOn: PublishManifests
+    condition: in(dependencies.PublishManifests.result, 'Succeeded', 'SucceededWithIssues')
+    variables:
+      # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
+      # environments that are very similar to other platforms/environments in our matrix, Ubuntu 18.04
+      # with the 'docker-ce' package vs. Ubuntu 18.04 with the 'iotedge-moby' package vs. the same
+      # variations in Ubuntu 20.04. In these instances the platforms/environments are so similar that we
+      # don't reasonably expect to encounter differences--if we do, it would likely manifest during
+      # installation, or in running a very basic test. We don't need to repeat the entire test suite.
+      # The 'minimal' variable defaults to 'false'; we override it in specific jobs as needed.
+      minimal: false
+      verbose: false
+    jobs:
+    ################################################################################
+      - job: linux_arm32v7
+    ################################################################################
+        displayName: Linux arm32v7
+
+        pool:
+          name: $(pool.custom.name)
+          demands: rpi3-e2e-tests
+
+        variables:
+          os: linux
+          arch: arm32v7
+          artifactName: iotedged-debian9-arm32v7
+          builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+
+        timeoutInMinutes: 120
+
+        steps:
+        - task: Docker@2
+          displayName: Docker login edgerelease
+          inputs:
+            command: login
+            containerRegistry: iotedge-release-acr
+        - template: templates/e2e-clean-directory.yaml
+        - template: templates/e2e-setup-base-image-update-release.yaml
+        - template: templates/e2e-clear-docker-cached-images.yaml
+        - template: templates/e2e-run-base-image-update.yaml
+
+    ################################################################################
+      - job: ubuntu_1804_msmoby
+    ################################################################################
+        displayName: Ubuntu 18.04 with iotedge-moby
+
+        pool:
+          name: $(pool.linux.name)
+          demands:
+            - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
+
+        variables:
+          os: linux
+          arch: amd64
+          artifactName: iotedged-ubuntu18.04-amd64
+          builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+
+        steps:
+        - template: templates/e2e-setup-base-image-update-release.yaml
+        - template: templates/e2e-run-base-image-update.yaml
+
+    ################################################################################
+      - job: ubuntu_1804_docker
+    ################################################################################
+        displayName: Ubuntu 18.04 with Docker (minimal)
+
+        pool:
+          name: $(pool.linux.name)
+          demands:
+            - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+
+        variables:
+          os: linux
+          arch: amd64
+          artifactName: iotedged-ubuntu18.04-amd64
+          builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+          minimal: true
+
+        steps:
+        - template: templates/e2e-setup-base-image-update-release.yaml
+        - template: templates/e2e-run-base-image-update.yaml
+
+    ################################################################################
+      - job: ubuntu_2004_msmoby
+    ################################################################################
+        displayName: Ubuntu 20.04 with iotedge-moby
+
+        pool:
+          name: $(pool.linux.name)
+          demands:
+            - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+
+        variables:
+          os: linux
+          arch: amd64
+          artifactName: iotedged-ubuntu20.04-amd64
+          builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+
+        steps:
+        - template: templates/e2e-setup-base-image-update-release.yaml
+        - template: templates/e2e-run-base-image-update.yaml
+
+    ################################################################################
+      - job: ubuntu_2004_arm64v8
+    ################################################################################
+        displayName: Ubuntu 20.04 with arm64v8
+        pool:
+          name: $(pool.custom.name)
+          demands: 
+            - agent-group -equals rpi3-e2e-aarch64
+
+        variables:
+          os: linux
+          arch: arm64v8
+          artifactName: iotedged-ubuntu20.04-aarch64
+          builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+
+        steps:
+        - task: Docker@2
+          displayName: Docker login edgerelease
+          inputs:
+            command: login
+            containerRegistry: iotedge-release-acr
+        - template: templates/e2e-clean-directory.yaml
+        - template: templates/e2e-setup-base-image-update-release.yaml
+        - template: templates/e2e-clear-docker-cached-images.yaml
+        - template: templates/e2e-run-base-image-update.yaml
+
+    ################################################################################
+      - job: ubuntu_2004_docker
+    ################################################################################
+        displayName: Ubuntu 20.04 with Docker (minimal)
+
+        pool:
+          name: $(pool.linux.name)
+          demands:
+            - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+
+        variables:
+          os: linux
+          arch: amd64
+          artifactName: iotedged-ubuntu20.04-amd64
+          builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+          minimal: true
+
+        steps:
+        - template: templates/e2e-setup-base-image-update-release.yaml
+        - template: templates/e2e-run-base-image-update.yaml
+
+    ################################################################################
+      - job: windows_server
+    ################################################################################
+        displayName: Windows Server 2019
+
+        pool:
+          name: $(pool.windows.name)
+          demands:
+            - ImageOverride -equals agent-aziotedge-winserver-2019dc-test
+
+        variables:
+          os: windows
+          arch: amd64
+          artifactName: iotedged-windows
+          builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+
+        steps:
+        - template: templates/e2e-setup-base-image-update-release.yaml
+
+        - pwsh: |
+            $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
+            $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
+            $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
+              -ArgumentList 'Root', 'LocalMachine'
+            $store.Open('ReadWrite')
+            $store.Add($cert)
+          displayName: Install CAB signing root cert
+          env:
+            PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
+
+        - pwsh: |
+            Write-Output '>>> BEFORE:'
+            netsh interface ipv6 show prefixpolicies
+            netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
+            Write-Output '>>> AFTER:'
+            netsh interface ipv6 show prefixpolicies
+          displayName: Prefer IPv4
+
+        - template: templates/e2e-clear-docker-cached-images.yaml
+        - template: templates/e2e-run-base-image-update.yaml
+
+    ################################################################################
+      - job: windows_10ent
+    ################################################################################
+        displayName: Windows 10 Enterprise (minimal)
+
+        pool:
+          name: $(pool.windows.name)
+          demands:
+            - ImageOverride -equals agent-aziotedge-win10-entn2019-test
+
+        variables:
+          os: windows
+          arch: amd64
+          artifactName: iotedged-windows
+          builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+          minimal: true
+
+        steps:
+        - template: templates/e2e-setup-base-image-update-release.yaml
+
+        - pwsh: |
+            $certBytes = [system.Text.Encoding]::UTF8.GetBytes($env:PACKAGE_SIGNING_CERT)
+            $cert = [System.Security.Cryptography.X509Certificates.X509Certificate]::new($certBytes)
+            $store = New-Object System.Security.Cryptography.X509Certificates.X509Store `
+              -ArgumentList 'Root', 'LocalMachine'
+            $store.Open('ReadWrite')
+            $store.Add($cert)
+          displayName: Install CAB signing root cert
+          env:
+            PACKAGE_SIGNING_CERT: $(TestIotedgedPackageRootSigningCert)
+
+        - pwsh: |
+            Write-Output '>>> BEFORE:'
+            netsh interface ipv6 show prefixpolicies
+            netsh interface ipv6 set prefixpolicy ::ffff:0:0/96 45 4
+            Write-Output '>>> AFTER:'
+            netsh interface ipv6 show prefixpolicies
+          displayName: Prefer IPv4
+
+        - template: templates/e2e-clear-docker-cached-images.yaml
+        - template: templates/e2e-run-base-image-update.yaml
+
+    # CentOS 7 is tier 2
+    # ################################################################################
+    #   - job: centos7_amd64
+    # ################################################################################
+    #     displayName: CentOs7 amd64
+
+    #     pool:
+    #       name: $(pool.linux.name)
+    #       demands:
+    #         - ImageOverride -equals agent-aziotedge-centos-7-msmoby
+
+    #     variables:
+    #       os: linux
+    #       arch: amd64
+    #       artifactName: iotedged-centos7-amd64
+    #       builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
+
+    #     steps:
+    #     - template: templates/e2e-clean-directory.yaml
+    #     - template: templates/e2e-setup-base-image-update-release.yaml
+    #     - template: templates/e2e-clear-docker-cached-images.yaml
+    #     - template: templates/e2e-run-base-image-update.yaml
+
+    # Disabling until EFLOW agent hardware issues are resolved
+    # ################################################################################
+    #   - job: EFLOW_amd64
+    # ################################################################################
+    #     displayName: EFLOW amd64
+
+    #     pool:
+    #       name: $(pool.custom.name)
+    #       demands:
+    #         - Agent.OS -equals Linux
+    #         - Agent.OSArchitecture -equals X64
+    #         - run-new-e2e-tests -equals true
+    #         - eflow -equals true
+
+    #     variables:
+    #       os: linux
+    #       arch: amd64
+    #       artifactName: iotedged-mariner-amd64
+    #       NUGET_HTTP_CACHE_PATH: /var/tmp/NuGet/v3-cache
+    #       NUGET_PACKAGES: /var/tmp/NuGet/packages
+    #       NUGET_PLUGINS_CACHE_PATH: /var/tmp/NuGet/plugins-cache
+
+    #     steps:
+    #     - template: templates/e2e-clean-directory.yaml
+    #     - template: templates/e2e-setup-base-image-update-release.yaml
+    #     - template: templates/e2e-clear-docker-cached-images.yaml
+    #     - template: templates/e2e-run-base-image-update.yaml

--- a/builds/e2e/templates/e2e-run-base-image-update.yaml
+++ b/builds/e2e/templates/e2e-run-base-image-update.yaml
@@ -1,0 +1,103 @@
+# This E2E test pipeline uses the following filters in order to skip certain tests:
+#   Flaky: Flaky on multiple platforms
+#   FlakyOnArm: Flaky only on arm
+#   FlakyOnWindows: Flaky only on windows
+#   CentOsSafe: Can be run on CentOs
+steps:
+- pwsh: |
+    $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
+
+    # Filter out flaky tests.
+    $filter = 'Category!=Flaky'
+
+    if ('$(arch)' -eq 'arm32v7' -Or '$(arch)' -eq 'arm64v8')
+    {
+      $filter += '&Category!=FlakyOnArm'
+    }
+
+    if ($IsWindows)
+    {
+      $filter += '&Category!=FlakyOnWindows'
+
+      # The windows installer script doesn't update the PATH in the current
+      # terminal session, so add `iotedge` and `docker` CLIs manually
+      $env:Path =
+        $env:Path,
+        $(Join-Path $env:ProgramFiles 'iotedge'),
+        $(Join-Path $env:ProgramFiles 'iotedge-moby') -join ';'
+      if ('$(minimal)' -eq 'true')
+      {
+        # The minimal test suite on windows cannot use TempSensor test.
+        # Using another test for now until this issue is resolved:
+        # https://github.com/Azure/azure-iot-sdk-csharp/issues/2223
+        $filter += '&Name~TestPing'
+      }
+
+      dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
+    }
+    else
+    {
+      # Unfortunately CentOs has some failing test that need to be worked on.
+      if ('$(artifactName)'.Contains('centos'))
+      {
+        $filter += '&TestCategory=CentOsSafe'
+      }
+      elseif ('$(minimal)' -eq 'true')
+      {
+        $filter += '&Name~TempSensor'
+      }
+      
+      #Dotnet SDK 3.1.415 package on Centos doesn't allow dotnet to be accessed via sudo command due to Path issues. Use the below workaround for centos only.
+      if ('$(artifactName)'.Contains('centos'))
+      {
+        sudo --preserve-env $(command -v dotnet) test $testFile --no-build --logger 'trx' --filter "$filter"
+      }
+      else
+      {
+        sudo --preserve-env dotnet test $testFile --no-build --logger 'trx' --filter "$filter"
+      }
+    }
+  displayName: Run tests
+  env:
+    E2E_DPS_GROUP_KEY: $(TestDpsGroupKeySymmetric)
+    E2E_EVENT_HUB_ENDPOINT: $(TestEventHubCompatibleEndpoint)
+    E2E_PREVIEW_EVENT_HUB_ENDPOINT: $(TestPreviewEventHubCompatibleEndpoint)
+    E2E_IOT_HUB_CONNECTION_STRING: $(TestIotHubConnectionString)
+    E2E_IOT_HUB_RESOURCE_ID: $(TestIotHubResourceId)
+    E2E_PREVIEW_IOT_HUB_CONNECTION_STRING: $(TestPreviewIotHubConnectionString)
+    E2E_REGISTRIES__0__PASSWORD: $(ReleaseContainerRegistryPassword)
+    E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
+    E2E_BLOB_STORE_SAS: $(TestBlobStoreSas)
+
+- task: PublishTestResults@2
+  displayName: Publish test results
+  inputs:
+    testResultsFormat: vstest
+    testResultsFiles: '**/*.trx'
+    searchFolder: $(Build.SourcesDirectory)/TestResults
+    testRunTitle: End-to-end tests ($(Build.BuildNumber) $(System.JobDisplayName))
+    buildPlatform: $(arch)
+  condition: succeededOrFailed()
+
+- pwsh: |
+    $logDir = '$(Build.ArtifactStagingDirectory)/logs'
+    New-Item $logDir -ItemType Directory -Force | Out-Null
+    Out-File "$logDir/$(Build.DefinitionName)-$(Build.BuildNumber)"
+    Copy-Item "$(Build.SourcesDirectory)/TestResults" "$logDir/" -Recurse
+    # The setup fixtures run outside the scope of any test, so their logs (*-[test|device]-*.log)
+    # aren't included in the TRX. Copy them manually here.
+    Copy-Item "$(binDir)/*-test-*.log" "$logDir/"
+    Copy-Item "$(binDir)/*-device-*.log" "$logDir/"
+    Copy-Item "$(binDir)/testoutput.log" "$logDir/"
+    Copy-Item "$(binDir)/supportbundle*" "$logDir/"
+    $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
+    Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
+  displayName: Collect Logs
+  condition: succeededOrFailed()
+
+- task: PublishBuildArtifacts@1
+  displayName: Publish logs
+  inputs:
+    PathtoPublish: $(Build.ArtifactStagingDirectory)/logs
+    ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(artifactSuffix)
+  condition: succeededOrFailed()

--- a/builds/e2e/templates/e2e-setup-base-image-update-release.yaml
+++ b/builds/e2e/templates/e2e-setup-base-image-update-release.yaml
@@ -1,0 +1,95 @@
+steps:
+- checkout: self
+  clean: true
+  fetchDepth: 100
+
+- task: AzureKeyVault@1
+  displayName: Get secrets
+  inputs:
+    azureSubscription: $(az.subscription)
+    keyVaultName: $(kv.name)
+    secretsFilter: >-
+      ReleaseContainerRegistryPassword,
+      TestDpsGroupKeySymmetric,
+      TestEventHubCompatibleEndpoint,
+      TestPreviewEventHubCompatibleEndpoint,
+      TestIotedgedPackageRootSigningCert,
+      TestIotHubConnectionString,
+      TestIotHubResourceId,
+      TestPreviewIotHubConnectionString,
+      TestRootCaCertificate,
+      TestRootCaKey,
+      TestRootCaPassword,
+      TestBlobStoreSas
+
+- pwsh: |
+    $certsDir = '$(System.ArtifactsDirectory)/certs'
+    New-Item "$certsDir" -ItemType Directory -Force | Out-Null
+    $env:ROOT_CERT | Out-File -Encoding Utf8 "$certsDir/rsa_root_ca.cert.pem"
+    $env:ROOT_KEY | Out-File -Encoding Utf8 "$certsDir/rsa_root_ca.key.pem"
+    Write-Output "##vso[task.setvariable variable=certsDir]$certsDir"
+  displayName: Install CA keys
+  env:
+    ROOT_CERT: $(TestRootCaCertificate)
+    ROOT_KEY: $(TestRootCaKey)
+
+- pwsh: |
+    $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
+    dotnet build $testDir
+
+    $binDir = Convert-Path "$testDir/bin/Release/netcoreapp3.1"
+    Write-Output "##vso[task.setvariable variable=binDir]$binDir"
+  displayName: Build tests
+
+- pwsh: |
+    $imagePrefix = '$(registry.address)/microsoft/azureiotedge'
+    $versionInfo = "$(version)-$(os)-$(arch)"
+    
+    $context = @{
+      dpsIdScope = '$(dps.idScope)'
+      edgeAgentImage = "$imagePrefix-agent:$versionInfo";
+      edgeHubImage = "$imagePrefix-hub:$versionInfo";
+      tempFilterFuncImage = "$imagePrefix-functions-filter:$versionInfo";
+      tempFilterImage = "$imagePrefix-temperature-filter:$versionInfo";
+      tempSensorImage = "$imagePrefix-simulated-temperature-sensor:$versionInfo";
+      methodSenderImage = "$imagePrefix-direct-method-sender:$versionInfo";
+      methodReceiverImage = "$imagePrefix-direct-method-receiver:$versionInfo";
+      loadGenImage = "$imagePrefix-load-gen:$versionInfo";
+      relayerImage = "$imagePrefix-relayer:$versionInfo";
+      networkControllerImage = "$imagePrefix-network-controller:$versionInfo";
+      testResultCoordinatorImage = "$imagePrefix-test-result-coordinator:$versionInfo";
+      metricsValidatorImage = "$imagePrefix-metrics-validator:$versionInfo";
+      metricsCollectorImage = "$imagePrefix-metrics-collector:$versionInfo"
+      numberLoggerImage = "$imagePrefix-number-logger:$versionInfo";
+      edgeAgentBootstrapImage = "$imagePrefix-agent-bootstrap-e2e-$(os)-$(arch)";
+      registries = @(
+        @{
+          address = '$(registry.address)';
+          username = '$(registry.username)';
+        }
+      );
+      caCertScriptPath = Convert-Path '$(Build.SourcesDirectory)/tools/CACertificates';
+      rootCaCertificatePath = Convert-Path '$(certsDir)/rsa_root_ca.cert.pem';
+      rootCaPrivateKeyPath = Convert-Path '$(certsDir)/rsa_root_ca.key.pem';
+      logFile = Join-Path '$(binDir)' 'testoutput.log';
+      getSupportBundle = 'true'
+    }
+
+    if ($IsWindows)
+    {
+      $context['installerPath'] = Convert-Path '$(Build.SourcesDirectory)/scripts/windows/setup'
+    }
+
+    if (('$(arch)' -eq 'arm32v7') -or ('$(arch)' -eq 'arm64v8'))
+    {
+      $context['optimizeForPerformance'] = 'false'
+      $context['setupTimeoutMinutes'] = 10
+      $context['teardownTimeoutMinutes'] = 5
+      $context['testTimeoutMinutes'] = 6
+    }
+
+    Write-Host "Edge agent image: $imagePrefix-agent:$versionInfo"
+    Write-Host "Edge hub image: $imagePrefix-hub:$versionInfo"
+    $context | ConvertTo-Json | Out-File -Encoding Utf8 '$(binDir)/context.json'
+    Get-Content -Path '$(binDir)/context.json'
+  displayName: Create test arguments file (context.json)

--- a/builds/misc/images-release-base-image-update.yaml
+++ b/builds/misc/images-release-base-image-update.yaml
@@ -1,0 +1,770 @@
+trigger: none
+pr: none
+
+name: $(version)
+
+stages:
+# This stage builds Rocks DB and adds the files to staging directory
+################################################################################
+- template: templates/build-rocksdb.yaml
+################################################################################
+
+- stage: BuildReleaseImages
+  dependsOn: [ BuildRocksDB ]
+
+  jobs: 
+################################################################################
+  - job: linux_dotnet_projects
+################################################################################
+    # The code sign steps will fail unless we explicitly say to use dotnet 2 before.
+    # This means we have to toggle back and forth between primary dotnet installations for the sign and build.
+    # TODO: Investigate why we have to toggle primary installs on linux, but not on windows.
+    displayName: LinuxDotnet
+    pool:
+        name: $(pool.linux.name)
+        demands:
+          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+    steps:
+      - task: Docker@2
+        displayName: Docker login edgerelease
+        inputs:
+          command: login
+          containerRegistry: iotedge-release-acr
+      - template: ../templates/dotnet3-globaljson.yaml # use dotnet 3 as primary install for build
+      - task: ShellScript@2
+        displayName: "Build Azure-IoT-Edge-Core"
+        inputs: 
+          args: "-c Release"
+          scriptPath: scripts/linux/buildBranch.sh
+      - template: ../templates/dotnet2-globaljson.yaml # switch to dotnet 2 as primary install for code sign
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "Edge Agent Code Sign"
+        inputs: 
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Agent.Service
+          Pattern: Microsoft.Azure.Devices.Edge.*.dll
+          SessionTimeout: 20
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "Append",
+                        "parameterValue": "/as"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [
+                    {
+                        "parameterName": "VerifyAll",
+                        "parameterValue": "/all"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "Edge Hub Code Sign"
+        inputs: 
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Hub.Service
+          Pattern: "Microsoft.Azure.Devices.Edge.*.dll,Microsoft.Azure.Devices.Routing.*.dll"
+          SessionTimeout: 20
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "Append",
+                        "parameterValue": "/as"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [
+                    {
+                        "parameterName": "VerifyAll",
+                        "parameterValue": "/all"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "Temp Sensor Code Sign"
+        inputs: 
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)/publish/SimulatedTemperatureSensor
+          Pattern: "Microsoft.Azure.Devices.Edge.*.dll,SimulatedTemperatureSensor.dll"
+          SessionTimeout: 20
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "Append",
+                        "parameterValue": "/as"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [
+                    {
+                        "parameterName": "VerifyAll",
+                        "parameterValue": "/all"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "Functions Binding Code Sign"
+        inputs: 
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)/publish/Microsoft.Azure.WebJobs.Extensions.EdgeHub
+          Pattern: Microsoft.Azure.WebJobs.Extensions*.dll
+          SessionTimeout: 20
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "Append",
+                        "parameterValue": "/as"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [
+                    {
+                        "parameterName": "VerifyAll",
+                        "parameterValue": "/all"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams       
+      - template: ../templates/dotnet3-globaljson.yaml # switch to dotnet 3 as primary install for nuget package
+      - task: DotNetCoreCLI@2
+        displayName: "Functions Binding nuget package"
+        inputs:
+          buildProperties: OutDir=$(Build.BinariesDirectory)/publish/Microsoft.Azure.WebJobs.Extensions.EdgeHub
+          command: pack
+          nobuild: true
+          packDirectory: $(Build.BinariesDirectory)/publish/
+          packagesToPack: "**/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj"
+          versionEnvVar: version
+          versioningScheme: byEnvVar
+      - template: ../templates/dotnet2-globaljson.yaml # switch to dotnet 2 as primary install for code sign
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "Functions Binding nuget package Sign"
+        inputs:
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)/publish
+          Pattern: Microsoft.Azure.WebJobs.Extensions*.nupkg
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-401405",
+                    "operationSetCode": "NuGetSign",
+                    "parameters": [],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-401405",
+                    "operationSetCode": "NuGetVerify",
+                    "parameters": [],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams
+
+      - task: DownloadPipelineArtifact@2
+        inputs:
+          artifact: 'librocksdb'
+          # place in '$(Pipeline.Workspace)/librocksdb'
+          path: '$(Pipeline.Workspace)/librocksdb'
+
+      - task: CopyFiles@2
+        displayName: Copy rocksdb libs
+        inputs:
+          sourceFolder: '$(Pipeline.Workspace)/librocksdb'
+          contents: '**'
+          targetFolder: '$(Build.BinariesDirectory)/publish/librocksdb'
+
+      - template: templates/image-linux.yaml
+        parameters: 
+          imageName: azureiotedge-agent
+          name: "Edge Agent"
+          project: Microsoft.Azure.Devices.Edge.Agent.Service
+          version: $(version)
+          buildx_flag: 'true'
+          use_rocksdb: true
+      - template: templates/image-linux.yaml
+        parameters: 
+          imageName: azureiotedge-hub
+          name: "Edge Hub"
+          project: Microsoft.Azure.Devices.Edge.Hub.Service
+          version: $(version)
+          buildx_flag: 'true'
+          use_rocksdb: true
+      - template: templates/image-linux.yaml
+        parameters: 
+          imageName: azureiotedge-simulated-temperature-sensor
+          name: "Temperature Sensor"
+          project: SimulatedTemperatureSensor
+          version: $(version)
+          buildx_flag: 'true'
+      - template: templates/image-linux.yaml
+        parameters:
+          imageName: azureiotedge-diagnostics
+          name: "Diagnostics Module"
+          project: IotedgeDiagnosticsDotnet
+          version: $(version)
+          buildx_flag: 'true'
+
+      # for E2E tests
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "Metrics Validator"
+          imageName: azureiotedge-metrics-validator
+          project: MetricsValidator
+          bin_dir: '$(Build.BinariesDirectory)'
+          buildx_flag: 'true'
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "Metrics Collector"
+          imageName: azureiotedge-metrics-collector
+          project: Microsoft.Azure.Devices.Edge.Azure.Monitor
+          buildx_flag: 'true'
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "Direct Method Sender"
+          imageName: azureiotedge-direct-method-sender
+          project: DirectMethodSender
+          bin_dir: '$(Build.BinariesDirectory)'
+          buildx_flag: 'true'
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "Direct Method Receiver"
+          imageName: azureiotedge-direct-method-receiver
+          project: DirectMethodReceiver
+          bin_dir: '$(Build.BinariesDirectory)'
+          buildx_flag: 'true'
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "Number Logger"
+          imageName: azureiotedge-number-logger
+          project: NumberLogger
+          bin_dir: '$(Build.BinariesDirectory)'
+          buildx_flag: 'true'
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "Temperature Filter"
+          imageName: azureiotedge-temperature-filter
+          project: TemperatureFilter
+          bin_dir: '$(Build.BinariesDirectory)'
+          buildx_flag: 'true'
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "Load Gen"
+          imageName: azureiotedge-load-gen
+          project: load-gen
+          bin_dir: '$(Build.BinariesDirectory)'
+          buildx_flag: 'true'
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "TestResultCoordinator"
+          imageName: azureiotedge-test-result-coordinator
+          project: TestResultCoordinator
+          bin_dir: '$(Build.BinariesDirectory)'
+          buildx_flag: 'true'
+          use_rocksdb: true
+      - template: templates/image-linux.yaml
+        parameters:
+          name: "Relayer"
+          imageName: azureiotedge-relayer
+          project: Relayer
+          bin_dir: '$(Build.BinariesDirectory)'
+          buildx_flag: 'true'
+
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 'SBOM Generation Task'
+        inputs:
+            BuildDropPath: '$(Build.BinariesDirectory)/publish'             
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts to VSTS'
+        inputs:
+          PathtoPublish: '$(Build.BinariesDirectory)/publish'
+          ArtifactName: 'publish-linux'          
+
+################################################################################
+  - job: windows
+################################################################################
+    displayName: Windows
+    pool:
+      name: $(pool.windows.name)
+      demands: 
+       - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
+    steps:
+      - task: Docker@2
+        displayName: Docker login edgerelease
+        inputs:
+          command: login
+          containerRegistry: iotedge-release-acr
+      - powershell: "scripts/windows/build/Publish-Branch.ps1 -Configuration:\"$(configuration)\" -PublishTests:$False -UpdateVersion"
+        displayName: "Build ($(configuration))"
+        name: build
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "Edge Agent Code Sign"
+        inputs: 
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)\publish\Microsoft.Azure.Devices.Edge.Agent.Service
+          Pattern: Microsoft.Azure.Devices.Edge.*.dll
+          SessionTimeout: 20
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "Append",
+                        "parameterValue": "/as"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [
+                    {
+                        "parameterName": "VerifyAll",
+                        "parameterValue": "/all"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "Edge Hub Code Sign"
+        inputs: 
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)\publish\Microsoft.Azure.Devices.Edge.Hub.Service
+          Pattern: "Microsoft.Azure.Devices.Edge.*.dll,Microsoft.Azure.Devices.Routing.*.dll"
+          SessionTimeout: 20
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "Append",
+                        "parameterValue": "/as"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [
+                    {
+                        "parameterName": "VerifyAll",
+                        "parameterValue": "/all"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "Temp Sensor Code Sign"
+        inputs: 
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)\publish\SimulatedTemperatureSensor
+          Pattern: "Microsoft.Azure.Devices.Edge.*.dll,SimulatedTemperatureSensor.dll"
+          SessionTimeout: 20
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "Append",
+                        "parameterValue": "/as"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [
+                    {
+                        "parameterName": "VerifyAll",
+                        "parameterValue": "/all"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams
+      - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        displayName: "azureiotedge-diagnostics Code Sign"
+        inputs:
+          ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+          FolderPath: $(Build.BinariesDirectory)\publish\IotedgeDiagnosticsDotnet
+          Pattern: "Microsoft.Azure.Devices.Edge.*.dll,IotedgeDiagnosticsDotnet.dll"
+          SessionTimeout: 20
+          inlineOperation: |
+              [
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolSign",
+                    "parameters": [
+                    {
+                        "parameterName": "OpusName",
+                        "parameterValue": "Microsoft"
+                    },
+                    {
+                        "parameterName": "OpusInfo",
+                        "parameterValue": "http://www.microsoft.com"
+                    },
+                    {
+                        "parameterName": "Append",
+                        "parameterValue": "/as"
+                    },
+                    {
+                        "parameterName": "FileDigest",
+                        "parameterValue": "/fd \"SHA256\""
+                    },
+                    {
+                        "parameterName": "PageHash",
+                        "parameterValue": "/NPH"
+                    },
+                    {
+                        "parameterName": "TimeStamp",
+                        "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                },
+                {
+                    "keyCode": "CP-230012",
+                    "operationSetCode": "SigntoolVerify",
+                    "parameters": [
+                    {
+                        "parameterName": "VerifyAll",
+                        "parameterValue": "/all"
+                    }
+                    ],
+                    "toolName": "sign",
+                    "toolVersion": "1.0"
+                }
+              ]
+          signConfigType: inlineSignParams
+      - task: PowerShell@2
+        displayName: "Build Image - Edge Agent - amd64"
+        inputs: 
+          arguments: "-Name 'azureiotedge-agent' -Project 'Microsoft.Azure.Devices.Edge.Agent.Service' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Edge Hub - amd64"
+        inputs: 
+          arguments: "-Name 'azureiotedge-hub' -Project 'Microsoft.Azure.Devices.Edge.Hub.Service' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Temp Sensor - amd64"
+        inputs: 
+          arguments: "-Name 'azureiotedge-simulated-temperature-sensor' -Project 'SimulatedTemperatureSensor' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Diagnostics Module- amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-diagnostics' -Project 'IotedgeDiagnosticsDotnet' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      # for E2E tests
+      - task: PowerShell@2
+        displayName: "Build Image - Metrics Validator - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-metrics-validator' -Project 'MetricsValidator' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Metrics Collector - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-metrics-collector' -Project 'Microsoft.Azure.Devices.Edge.Azure.Monitor' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Direct Method Sender - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-direct-method-sender' -Project 'DirectMethodSender' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Direct Method Receiver - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-direct-method-receiver' -Project 'DirectMethodReceiver' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Number Logger - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-number-logger' -Project 'NumberLogger' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Temperature Filter - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-temperature-filter' -Project 'TemperatureFilter' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Load Gen - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-load-gen' -Project 'load-gen' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - TestResultCoordinator - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-test-result-coordinator' -Project 'TestResultCoordinator' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+      - task: PowerShell@2
+        displayName: "Build Image - Relayer - amd64"
+        inputs:
+          arguments: "-Name 'azureiotedge-relayer' -Project 'Relayer' -Version '$(version)' -Registry '$(registry.address)' -Namespace '$(namespace)' -Push"
+          filePath: ./scripts/windows/build/Publish-DockerImage.ps1
+          targetType: filePath
+
+      - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+        displayName: 'SBOM Generation Task'
+        inputs:
+            BuildDropPath: '$(Build.BinariesDirectory)/publish'            
+      - task: PublishBuildArtifacts@1
+        displayName: "Publish Artifacts to VSTS"
+        inputs: 
+          ArtifactName: publish-win
+          PathtoPublish: $(Build.BinariesDirectory)\publish           
+################################################################################
+- stage: PublishManifests
+################################################################################
+  displayName: Publish Manifest Images
+  pool:
+    name: $(pool.linux.name)
+    demands:
+          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+  dependsOn: BuildReleaseImages
+  jobs:
+  - job:
+    steps:
+    - task: Docker@2
+      displayName: Docker login edgerelease
+      inputs:
+        command: login
+        containerRegistry: iotedge-release-acr
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish azureiotedge-diagnostics Manifest'
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish Edge Agent Manifest'
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish Edge Hub Manifest'
+    - script: scripts/linux/buildManifest.sh -r '$(registry.address)' -v '$(version)' -t '$(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template' -n '$(namespace)' --tags '$(tags)'
+      displayName: 'Publish Temperature Sensor Manifest'
+
+################################################################################
+- template: ../e2e/e2e-release.yaml
+################################################################################

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -79,30 +79,40 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
             };
         }
 
-        public string[] GetInstallCommandsFromMicrosoftProd() => this.packageExtension switch
+        public string[] GetInstallCommandsFromMicrosoftProd()
         {
-            SupportedPackageExtension.Deb => new[]
+            // we really support only two options for now.
+            string repository = this.os.ToLower() switch
             {
-                // Based on instructions at:
-                // https://github.com/MicrosoftDocs/azure-docs/blob/058084949656b7df518b64bfc5728402c730536a/articles/iot-edge/how-to-install-iot-edge-linux.md
-                // TODO: 8/30/2019 support curl behind a proxy
-                $"curl https://packages.microsoft.com/config/{this.os}/{this.version}/multiarch/prod.list > /etc/apt/sources.list.d/microsoft-prod.list",
-                "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
-                $"apt-get update",
-                $"apt-get install --yes iotedge"
-            },
-            SupportedPackageExtension.RpmCentOS => new[]
-            {
-                $"rpm -iv --replacepkgs https://packages.microsoft.com/config/{this.os}/{this.version}/packages-microsoft-prod.rpm",
-                $"yum updateinfo",
-                $"yum install --yes iotedge",
-                "pathToSystemdConfig=$(systemctl cat iotedge | head -n 1)",
-                "sed 's/=on-failure/=no/g' ${pathToSystemdConfig#?} > ~/override.conf",
-                "sudo mv -f ~/override.conf ${pathToSystemdConfig#?}",
-                "sudo systemctl daemon-reload"
-            },
-            _ => throw new NotImplementedException($"Don't know how to install daemon on for '.{this.packageExtension}'"),
-        };
+                "ubuntu" => this.version == "18.04" ? "https://packages.microsoft.com/config/ubuntu/18.04/multiarch/prod.list" : "https://packages.microsoft.com/config/ubuntu/20.04/prod.list",
+                "debian" => $"https://packages.microsoft.com/config/debian/stretch/multiarch/prod.list",
+                _ => throw new NotImplementedException($"Don't know how to install daemon for '{this.os}'"),
+            };
+
+            return this.packageExtension switch {
+                SupportedPackageExtension.Deb => new[]
+                {
+                    // Based on instructions at:
+                    // https://github.com/MicrosoftDocs/azure-docs/blob/058084949656b7df518b64bfc5728402c730536a/articles/iot-edge/how-to-install-iot-edge-linux.md
+                    // TODO: 8/30/2019 support curl behind a proxy
+                    $"curl {repository} > /etc/apt/sources.list.d/microsoft-prod.list",
+                    "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
+                    $"apt-get update",
+                    $"apt-get install --yes iotedge"
+                },
+                SupportedPackageExtension.RpmCentOS => new[]
+                {
+                    $"rpm -iv --replacepkgs https://packages.microsoft.com/config/{this.os}/{this.version}/packages-microsoft-prod.rpm",
+                    $"yum updateinfo",
+                    $"yum install --yes iotedge",
+                    "pathToSystemdConfig=$(systemctl cat iotedge | head -n 1)",
+                    "sed 's/=on-failure/=no/g' ${pathToSystemdConfig#?} > ~/override.conf",
+                    "sudo mv -f ~/override.conf ${pathToSystemdConfig#?}",
+                    "sudo systemctl daemon-reload"
+                },
+                _ => throw new NotImplementedException($"Don't know how to install daemon on for '.{this.packageExtension}'"),
+            };
+        }
 
         public string[] GetUninstallCommands() => this.packageExtension switch
         {


### PR DESCRIPTION
This is a standalone Release pipeline, intended to simplify the existing internal release process.

To wit:

- It eliminates the need to run a separate pipeline to build test images by removing external dependences,
- It only builds images that are needed, either for the release or for testing purposes, and
- It obviates the need for running manual checks/smoke tests by running E2E tests on the Release bits (which isn't something we were doing before).

This change also adds Ubuntu 20.04 support (to account for a change in directory structure).

**Testing Notes:**

![image](https://user-images.githubusercontent.com/90283547/151478992-3b39fb6b-43de-43ce-a611-9bf1d9e4b958.png)


### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).