### PR TITLE
Use 1ES-hosted agent pool for arm64 end-to-end tests

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -31,167 +31,167 @@ variables:
 
 jobs:
 
-################################################################################
-  - job: debian_11_arm32v7
-################################################################################
-    displayName: Debian 11 arm32v7
+# ################################################################################
+#   - job: debian_11_arm32v7
+# ################################################################################
+#     displayName: Debian 11 arm32v7
 
-    pool:
-      name: $(pool.custom.name)
-      demands: deb11-e2e-tests
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: deb11-e2e-tests
 
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactName: iotedged-debian11-arm32v7
-      identityServiceArtifactName: packages_debian-11-slim_arm32v7
-      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+#     variables:
+#       os: linux
+#       arch: arm32v7
+#       artifactName: iotedged-debian11-arm32v7
+#       identityServiceArtifactName: packages_debian-11-slim_arm32v7
+#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: debian_10_arm32v7
-################################################################################
-    displayName: Debian 10 arm32v7 (minimal)
+# ################################################################################
+#   - job: debian_10_arm32v7
+# ################################################################################
+#     displayName: Debian 10 arm32v7 (minimal)
 
-    pool:
-      name: $(pool.custom.name)
-      demands: deb10-e2e-tests
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: deb10-e2e-tests
 
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactName: iotedged-debian10-arm32v7
-      identityServiceArtifactName: packages_debian-10-slim_arm32v7
-      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
-      minimal: true
+#     variables:
+#       os: linux
+#       arch: arm32v7
+#       artifactName: iotedged-debian10-arm32v7
+#       identityServiceArtifactName: packages_debian-10-slim_arm32v7
+#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+#       minimal: true
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: debian_9_arm32v7
-################################################################################
-    displayName: Debian 9 arm32v7 (minimal)
+# ################################################################################
+#   - job: debian_9_arm32v7
+# ################################################################################
+#     displayName: Debian 9 arm32v7 (minimal)
 
-    pool:
-      name: $(pool.custom.name)
-      demands: deb9-e2e-tests
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: deb9-e2e-tests
 
-    variables:
-      os: linux
-      arch: arm32v7
-      artifactName: iotedged-debian9-arm32v7
-      identityServiceArtifactName: packages_debian-9-slim_arm32v7
-      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
-      minimal: true
+#     variables:
+#       os: linux
+#       arch: arm32v7
+#       artifactName: iotedged-debian9-arm32v7
+#       identityServiceArtifactName: packages_debian-9-slim_arm32v7
+#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+#       minimal: true
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_1804_msmoby
-################################################################################
-    displayName: Ubuntu 18.04 with iotedge-moby
+# ################################################################################
+#   - job: ubuntu_1804_msmoby
+# ################################################################################
+#     displayName: Ubuntu 18.04 with iotedge-moby
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-      identityServiceArtifactName: packages_ubuntu-18.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu18.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_1804_docker
-################################################################################
-    displayName: Ubuntu 18.04 with Docker (minimal)
+# ################################################################################
+#   - job: ubuntu_1804_docker
+# ################################################################################
+#     displayName: Ubuntu 18.04 with Docker (minimal)
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-      identityServiceArtifactName: packages_ubuntu-18.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      minimal: true
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu18.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#       minimal: true
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_2004_msmoby
-################################################################################
-    displayName: Ubuntu 20.04 with iotedge-moby
+# ################################################################################
+#   - job: ubuntu_2004_msmoby
+# ################################################################################
+#     displayName: Ubuntu 20.04 with iotedge-moby
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu20.04-amd64
-      identityServiceArtifactName: packages_ubuntu-20.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu20.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: ubuntu_2004_docker
-################################################################################
-    displayName: Ubuntu 20.04 with Docker (minimal)
+# ################################################################################
+#   - job: ubuntu_2004_docker
+# ################################################################################
+#     displayName: Ubuntu 20.04 with Docker (minimal)
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu20.04-amd64
-      identityServiceArtifactName: packages_ubuntu-20.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      minimal: true
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu20.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#       minimal: true
 
-    timeoutInMinutes: 90
+#     timeoutInMinutes: 90
 
-    steps:
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_2004_arm64v8
@@ -278,58 +278,58 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: centos7_amd64
-################################################################################
-    displayName: CentOs7 amd64
+# ################################################################################
+#   - job: centos7_amd64
+# ################################################################################
+#     displayName: CentOs7 amd64
 
-    pool:
-      name: $(pool.linux.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-centos-7-msmoby
+#     pool:
+#       name: $(pool.linux.name)
+#       demands:
+#       - ImageOverride -equals agent-aziotedge-centos-7-msmoby
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-centos7-amd64
-      identityServiceArtifactName: packages_centos-7_amd64
-      identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-centos7-amd64
+#       identityServiceArtifactName: packages_centos-7_amd64
+#       identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
 
-    timeoutInMinutes: 90
+#     timeoutInMinutes: 90
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
 
-################################################################################
-  - job: linux_amd64_proxy
-################################################################################
-    displayName: Linux amd64 behind a proxy
+# ################################################################################
+#   - job: linux_amd64_proxy
+# ################################################################################
+#     displayName: Linux amd64 behind a proxy
 
-    pool:
-      name: $(pool.custom.name)
-      demands: new-e2e-proxy
+#     pool:
+#       name: $(pool.custom.name)
+#       demands: new-e2e-proxy
 
-    variables:
-      os: linux
-      arch: amd64
-      artifactName: iotedged-ubuntu18.04-amd64
-      identityServiceArtifactName: packages_ubuntu-18.04_amd64
-      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
-      'agent.disablelogplugin.testfilepublisherplugin': true
-      'agent.disablelogplugin.testresultlogplugin': true
-      # because we aren't publishing test artifacts for this job, turn on verbose logging instead
-      verbose: true
+#     variables:
+#       os: linux
+#       arch: amd64
+#       artifactName: iotedged-ubuntu18.04-amd64
+#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
+#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+#       # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
+#       'agent.disablelogplugin.testfilepublisherplugin': true
+#       'agent.disablelogplugin.testresultlogplugin': true
+#       # because we aren't publishing test artifacts for this job, turn on verbose logging instead
+#       verbose: true
 
-    timeoutInMinutes: 120
+#     timeoutInMinutes: 120
 
-    steps:
-    - template: templates/e2e-clean-directory.yaml
-    - template: templates/e2e-setup.yaml
-    - template: templates/e2e-clear-docker-cached-images.yaml
-    - template: templates/e2e-run.yaml
-      parameters:
-        test_type: http_proxy
+#     steps:
+#     - template: templates/e2e-clean-directory.yaml
+#     - template: templates/e2e-setup.yaml
+#     - template: templates/e2e-clear-docker-cached-images.yaml
+#     - template: templates/e2e-run.yaml
+#       parameters:
+#         test_type: http_proxy

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -31,167 +31,167 @@ variables:
 
 jobs:
 
-# ################################################################################
-#   - job: debian_11_arm32v7
-# ################################################################################
-#     displayName: Debian 11 arm32v7
+################################################################################
+  - job: debian_11_arm32v7
+################################################################################
+    displayName: Debian 11 arm32v7
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands: deb11-e2e-tests
+    pool:
+      name: $(pool.custom.name)
+      demands: deb11-e2e-tests
 
-#     variables:
-#       os: linux
-#       arch: arm32v7
-#       artifactName: iotedged-debian11-arm32v7
-#       identityServiceArtifactName: packages_debian-11-slim_arm32v7
-#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+    variables:
+      os: linux
+      arch: arm32v7
+      artifactName: iotedged-debian11-arm32v7
+      identityServiceArtifactName: packages_debian-11-slim_arm32v7
+      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: debian_10_arm32v7
-# ################################################################################
-#     displayName: Debian 10 arm32v7 (minimal)
+################################################################################
+  - job: debian_10_arm32v7
+################################################################################
+    displayName: Debian 10 arm32v7 (minimal)
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands: deb10-e2e-tests
+    pool:
+      name: $(pool.custom.name)
+      demands: deb10-e2e-tests
 
-#     variables:
-#       os: linux
-#       arch: arm32v7
-#       artifactName: iotedged-debian10-arm32v7
-#       identityServiceArtifactName: packages_debian-10-slim_arm32v7
-#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
-#       minimal: true
+    variables:
+      os: linux
+      arch: arm32v7
+      artifactName: iotedged-debian10-arm32v7
+      identityServiceArtifactName: packages_debian-10-slim_arm32v7
+      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+      minimal: true
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: debian_9_arm32v7
-# ################################################################################
-#     displayName: Debian 9 arm32v7 (minimal)
+################################################################################
+  - job: debian_9_arm32v7
+################################################################################
+    displayName: Debian 9 arm32v7 (minimal)
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands: deb9-e2e-tests
+    pool:
+      name: $(pool.custom.name)
+      demands: deb9-e2e-tests
 
-#     variables:
-#       os: linux
-#       arch: arm32v7
-#       artifactName: iotedged-debian9-arm32v7
-#       identityServiceArtifactName: packages_debian-9-slim_arm32v7
-#       identityServicePackageFilter: aziot-identity-service_*_armhf.deb
-#       minimal: true
+    variables:
+      os: linux
+      arch: arm32v7
+      artifactName: iotedged-debian9-arm32v7
+      identityServiceArtifactName: packages_debian-9-slim_arm32v7
+      identityServicePackageFilter: aziot-identity-service_*_armhf.deb
+      minimal: true
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: ubuntu_1804_msmoby
-# ################################################################################
-#     displayName: Ubuntu 18.04 with iotedge-moby
+################################################################################
+  - job: ubuntu_1804_msmoby
+################################################################################
+    displayName: Ubuntu 18.04 with iotedge-moby
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu18.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      identityServiceArtifactName: packages_ubuntu-18.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: ubuntu_1804_docker
-# ################################################################################
-#     displayName: Ubuntu 18.04 with Docker (minimal)
+################################################################################
+  - job: ubuntu_1804_docker
+################################################################################
+    displayName: Ubuntu 18.04 with Docker (minimal)
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu18.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-#       minimal: true
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      identityServiceArtifactName: packages_ubuntu-18.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      minimal: true
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: ubuntu_2004_msmoby
-# ################################################################################
-#     displayName: Ubuntu 20.04 with iotedge-moby
+################################################################################
+  - job: ubuntu_2004_msmoby
+################################################################################
+    displayName: Ubuntu 20.04 with iotedge-moby
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu20.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu20.04-amd64
+      identityServiceArtifactName: packages_ubuntu-20.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: ubuntu_2004_docker
-# ################################################################################
-#     displayName: Ubuntu 20.04 with Docker (minimal)
+################################################################################
+  - job: ubuntu_2004_docker
+################################################################################
+    displayName: Ubuntu 20.04 with Docker (minimal)
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu20.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-20.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-#       minimal: true
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu20.04-amd64
+      identityServiceArtifactName: packages_ubuntu-20.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      minimal: true
 
-#     timeoutInMinutes: 90
+    timeoutInMinutes: 90
 
-#     steps:
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-run.yaml
 
 ################################################################################
   - job: ubuntu_2004_arm64v8
@@ -278,58 +278,58 @@ jobs:
     - template: templates/e2e-clear-docker-cached-images.yaml
     - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: centos7_amd64
-# ################################################################################
-#     displayName: CentOs7 amd64
+################################################################################
+  - job: centos7_amd64
+################################################################################
+    displayName: CentOs7 amd64
 
-#     pool:
-#       name: $(pool.linux.name)
-#       demands:
-#       - ImageOverride -equals agent-aziotedge-centos-7-msmoby
+    pool:
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-centos-7-msmoby
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-centos7-amd64
-#       identityServiceArtifactName: packages_centos-7_amd64
-#       identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-centos7-amd64
+      identityServiceArtifactName: packages_centos-7_amd64
+      identityServicePackageFilter: aziot-identity-service-*.x86_64.rpm
 
-#     timeoutInMinutes: 90
+    timeoutInMinutes: 90
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
 
-# ################################################################################
-#   - job: linux_amd64_proxy
-# ################################################################################
-#     displayName: Linux amd64 behind a proxy
+################################################################################
+  - job: linux_amd64_proxy
+################################################################################
+    displayName: Linux amd64 behind a proxy
 
-#     pool:
-#       name: $(pool.custom.name)
-#       demands: new-e2e-proxy
+    pool:
+      name: $(pool.custom.name)
+      demands: new-e2e-proxy
 
-#     variables:
-#       os: linux
-#       arch: amd64
-#       artifactName: iotedged-ubuntu18.04-amd64
-#       identityServiceArtifactName: packages_ubuntu-18.04_amd64
-#       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-#       # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
-#       'agent.disablelogplugin.testfilepublisherplugin': true
-#       'agent.disablelogplugin.testresultlogplugin': true
-#       # because we aren't publishing test artifacts for this job, turn on verbose logging instead
-#       verbose: true
+    variables:
+      os: linux
+      arch: amd64
+      artifactName: iotedged-ubuntu18.04-amd64
+      identityServiceArtifactName: packages_ubuntu-18.04_amd64
+      identityServicePackageFilter: aziot-identity-service_*_amd64.deb
+      # workaround, see https://github.com/Microsoft/azure-pipelines-agent/issues/2138#issuecomment-470166671
+      'agent.disablelogplugin.testfilepublisherplugin': true
+      'agent.disablelogplugin.testresultlogplugin': true
+      # because we aren't publishing test artifacts for this job, turn on verbose logging instead
+      verbose: true
 
-#     timeoutInMinutes: 120
+    timeoutInMinutes: 120
 
-#     steps:
-#     - template: templates/e2e-clean-directory.yaml
-#     - template: templates/e2e-setup.yaml
-#     - template: templates/e2e-clear-docker-cached-images.yaml
-#     - template: templates/e2e-run.yaml
-#       parameters:
-#         test_type: http_proxy
+    steps:
+    - template: templates/e2e-clean-directory.yaml
+    - template: templates/e2e-setup.yaml
+    - template: templates/e2e-clear-docker-cached-images.yaml
+    - template: templates/e2e-run.yaml
+      parameters:
+        test_type: http_proxy

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -196,11 +196,11 @@ jobs:
 ################################################################################
   - job: ubuntu_2004_arm64v8
 ################################################################################
-    displayName: Ubuntu 20.04 with arm64v8
+    displayName: Ubuntu 20.04 on arm64v8
     pool:
-      name: $(pool.custom.name)
-      demands: 
-        - agent-group -equals rpi3-e2e-aarch64
+      name: 'Azure-IoT-Edge-1ES-Hosted-Linux-Arm64'
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64
 
     variables:
       os: linux
@@ -212,6 +212,67 @@ jobs:
     timeoutInMinutes: 120
 
     steps:
+    - bash: |
+        set -e
+
+        # Install PowerShell dependencies
+        sudo apt-get update
+        sudo apt-get install -y liblttng-ust0 jq
+
+        # Get the PowerShell tarball
+        release_id=$(curl -sSH 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/powershell/powershell/releases/latest | jq '.id')
+        url=$(curl -sSH 'Accept: application/vnd.github.v3+json' https://api.github.com/repos/powershell/powershell/releases/$release_id/assets | jq -r ".[] | select(.name | contains(\"linux-arm64.tar.gz\")) | .browser_download_url")
+        echo "$release_id"
+        echo "$url"
+        file=$(basename $url)
+        curl -sSL $url -o /tmp/$file
+
+        # Install PowerShell
+        sudo mkdir -p /opt/microsoft/powershell/7
+        sudo tar zxf /tmp/$file -C /opt/microsoft/powershell/7
+        sudo chmod +x /opt/microsoft/powershell/7/pwsh
+        sudo ln -s /opt/microsoft/powershell/7/pwsh /usr/bin/pwsh
+      displayName: Install pwsh
+
+    - bash: |
+        set -e
+
+        # Install .NET Core dependencies
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            libc6 libgcc1 libgssapi-krb5-2 libicu66 libssl1.1 libstdc++6 zlib1g
+
+        # Install .NET Core
+        curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin --channel 3.1
+        sudo ln -s $HOME/.dotnet/dotnet /usr/bin/dotnet
+      displayName: Install .NET Core
+
+    - task: DownloadBuildArtifacts@0
+      displayName: Download Resource Build Images
+      inputs:  
+        buildType: specific
+        project: $(resources.pipeline.images.projectID)
+        pipeline: $(resources.pipeline.images.pipelineName)
+        buildVersionToDownload: specific
+        buildId: $(resources.pipeline.images.runID)
+        downloadType: single
+        artifactName: $(az.pipeline.images.artifacts)
+        allowPartiallySucceededBuilds: true
+        itemPattern: $(az.pipeline.images.artifacts)/artifactInfo.txt
+
+    - bash: |
+        set -e
+
+        # Install Moby
+        curl https://packages.microsoft.com/config/ubuntu/20.04/prod.list > ./microsoft-prod.list
+        sudo cp ./microsoft-prod.list /etc/apt/sources.list.d/
+        curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.gpg
+        sudo cp ./microsoft.gpg /etc/apt/trusted.gpg.d/
+        rm microsoft-prod.list microsoft.gpg
+        sudo apt-get update
+        sudo apt-get install -y moby-engine
+      displayName: Install moby
+
     - template: templates/e2e-clean-directory.yaml
     - template: templates/e2e-setup.yaml
     - template: templates/e2e-clear-docker-cached-images.yaml


### PR DESCRIPTION
This change moves our arm64 end-to-end tests to use preview 1ES-hosted agent pools instead of Raspberry Pis. The job runs a lot faster, and it reduces the physical hardware we have to maintain. The tradeoff is that, while arm64 agents are in preview, there are limitations we have to work around by adding ugly script directly into the job yaml. We should be able to remove it soon, when arm64 agents become generally available.

I ran the end-to-end test pipeline a few times and made sure it passed.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.