### PR TITLE
Don't stop the broker if unable to restore persisted state. (#6063)

### DIFF
--- a/mqtt/mqttd/src/app/generic.rs
+++ b/mqtt/mqttd/src/app/generic.rs
@@ -38,8 +38,16 @@ impl Bootstrap for GenericBootstrap {
 
         fs::create_dir_all(state_dir.clone())?;
         let mut persistor = FilePersistor::new(state_dir, VersionedFileFormat::default());
-        let state = persistor.load().await?;
-        info!("state loaded.");
+        let state = match persistor.load().await {
+            Ok(state) => {
+                info!("state loaded.");
+                state
+            }
+            Err(e) => {
+                error!("failed to load broker state, most likely the broker was forcefully shut down and state file is corrupted: {}", e);
+                None
+            }
+        };
 
         let broker = BrokerBuilder::default()
             .with_authorizer(AllowAll)


### PR DESCRIPTION
When broker is forcefully terminated, it is possible that the broker state file can be corrupted. Right now the corrupted state file prevents broker from restarting. This PR changes the behavior: now we log the error and ignore the corrupted state file. 

Even though the loss of up-to-date state happens in any circumstance with forced shutdown, the downside of this approach is that loss of state can happen unnoticeable. But it seems like it is preferable for a broker to continue to operate, rather that a user to go and cleanup state file(s).

This functionality is not covered by unit tests. The manual testing has been performed.

This fixes #6004

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.