### PR TITLE
[master] Unconditionally publish logs

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -98,7 +98,7 @@ steps:
     buildPlatform: $(arch)
   # This task takes 15 min when behind a proxy, so disable it
   # see https://github.com/microsoft/azure-pipelines-tasks/issues/11831
-  condition: and(succeededOrFailed(), not(variables['Agent.ProxyUrl']))
+  condition: not(variables['Agent.ProxyUrl'])
 
 - pwsh: |
     $logDir = '$(Build.ArtifactStagingDirectory)/logs${{ parameters.test_type }}'
@@ -114,11 +114,11 @@ steps:
     $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
     Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
   displayName: Collect Logs
-  condition: succeededOrFailed()
+  condition: always()
 
 - task: PublishBuildArtifacts@1
   displayName: Publish logs
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/logs${{ parameters.test_type }}
     ArtifactName: logs-end-to-end-$(artifactSuffix)
-  condition: succeededOrFailed()
+  condition: always()


### PR DESCRIPTION
It can sometimes be that builds succeed but the resulting artifacts lead
to test timeouts, for example if edgeHub crashes upon execution.
Unconditionally publishing logs would make it easier to debug these
cases.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  
