### PR TITLE
[release/1.1] Unconditionally publish logs

### DIFF
--- a/builds/e2e/templates/e2e-run-base-image-update.yaml
+++ b/builds/e2e/templates/e2e-run-base-image-update.yaml
@@ -77,7 +77,7 @@ steps:
     searchFolder: $(Build.SourcesDirectory)/TestResults
     testRunTitle: End-to-end tests ($(Build.BuildNumber) $(System.JobDisplayName))
     buildPlatform: $(arch)
-  condition: succeededOrFailed()
+  condition: always()
 
 - pwsh: |
     $logDir = '$(Build.ArtifactStagingDirectory)/logs'
@@ -93,11 +93,11 @@ steps:
     $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
     Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
   displayName: Collect Logs
-  condition: succeededOrFailed()
+  condition: always()
 
 - task: PublishBuildArtifacts@1
   displayName: Publish logs
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/logs
     ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(artifactSuffix)
-  condition: succeededOrFailed()
+  condition: always()

--- a/builds/e2e/templates/e2e-run-metrics-collector.yaml
+++ b/builds/e2e/templates/e2e-run-metrics-collector.yaml
@@ -38,7 +38,7 @@ steps:
     searchFolder: $(Build.SourcesDirectory)/TestResults
     testRunTitle: End-to-end tests ($(Build.BuildNumber) $(System.JobDisplayName))
     buildPlatform: $(arch)
-  condition: succeededOrFailed()
+  condition: always()
 
 - pwsh: |
     $logDir = '$(Build.ArtifactStagingDirectory)/logs'
@@ -54,11 +54,11 @@ steps:
     $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
     Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
   displayName: Collect Logs
-  condition: succeededOrFailed()
+  condition: always()
 
 - task: PublishBuildArtifacts@1
   displayName: Publish logs
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/logs
     ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(artifactSuffix)
-  condition: succeededOrFailed()
+  condition: always()

--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -77,7 +77,7 @@ steps:
     searchFolder: $(Build.SourcesDirectory)/TestResults
     testRunTitle: End-to-end tests ($(Build.BuildNumber) $(System.JobDisplayName))
     buildPlatform: $(arch)
-  condition: succeededOrFailed()
+  condition: always()
 
 - pwsh: |
     $logDir = '$(Build.ArtifactStagingDirectory)/logs'
@@ -93,11 +93,11 @@ steps:
     $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
     Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
   displayName: Collect Logs
-  condition: succeededOrFailed()
+  condition: always()
 
 - task: PublishBuildArtifacts@1
   displayName: Publish logs
   inputs:
     PathtoPublish: $(Build.ArtifactStagingDirectory)/logs
     ArtifactName: logs-end-to-end-$(Build.BuildNumber)-$(artifactSuffix)
-  condition: succeededOrFailed()
+  condition: always()


### PR DESCRIPTION
It can sometimes be that builds succeed but the resulting artifacts lead
to test timeouts, for example if edgeHub crashes upon execution.
Unconditionally publishing logs would make it easier to debug these
cases.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  
