### PR TITLE
added workaround for windows-certificate import problem

### DIFF
--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/CertificateHelper.cs
@@ -452,6 +452,13 @@ namespace Microsoft.Azure.Devices.Edge.Util
                 throw new InvalidOperationException(errorMessage);
             }
 
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // On Windows the certificate in 'result' gives an error when used with kestrel: "No credentials are available in the security"
+                // This is a suggested workaround that seems working (https://github.com/dotnet/runtime/issues/45680)
+                result = new X509Certificate2(result.Export(X509ContentType.Pkcs12));
+            }
+
             return result;
         }
 


### PR DESCRIPTION
(cherry picked from commit 56f2d77e31188381252411b260cab92eaefbcfda)

