### PR TITLE
Add Instructions to Run Azure IoT Edge Daemon Locally

### DIFF
--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -173,7 +173,8 @@ In order to locally run aziot-edged, there is a dependency on running Azure IoT 
 4. Copy Provisioning File and Fill out the provisioning parameters. Example : For Provisioning via Symmetric Keys Use [these instructions](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-symmetric?view=iotedge-2020-11&tabs=azure-portal%2Cubuntu)
 
     ```sh
-      cp edgelet/contrib/config/linux/template.toml /etc/aziot/config.toml
+      cd <iot-edge-path>/edgelet
+      cp contrib/config/linux/template.toml /etc/aziot/config.toml
     ```
 5. Modify the Daemon configuration section in /etc/aziot/config.toml to match this
     ```toml
@@ -191,7 +192,7 @@ In order to locally run aziot-edged, there is a dependency on running Azure IoT 
 
 6. Apply Config.
     ```sh
-        cd edgelet
+        cd <iot-edge-path>/edgelet
         cargo run -p iotedge -- config apply
     ```
 7. Run keyd service in a separate shell
@@ -211,7 +212,7 @@ In order to locally run aziot-edged, there is a dependency on running Azure IoT 
     ```
 10. Finally, Run aziot-edged in a separate shell
     ```sh
-       cd edgelet
+       cd <iot-edge-path>/edgelet
        cargo run -p aziot-edged
     ```
 11. When stopping the service, stop aziot-edged, identityd, keyd and certd, in that order.

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -161,12 +161,14 @@ This will create `aziot-edged` and `iotedge` binaries under `edgelet/target/debu
 
 ### Run
 
-In order to locally run aziot-edged, there is a dependency on running azure identity service.The following instruction can be used to run aziot-edged locally:
-1. Clone the [aziot-iis repo](https://github.com/Azure/iot-identity-service)
-2. Build IIS Binaries using [these build steps](https://github.com/Azure/iot-identity-service/blob/main/docs-dev/building.md)
+In order to locally run aziot-edged, there is a dependency on running Azure IoT Identity Service.The following instruction can be used to run aziot-edged locally:
+1. Clone the [identity service repo](https://github.com/Azure/iot-identity-service)
+2. Build Binaries using [these build steps](https://github.com/Azure/iot-identity-service/blob/main/docs-dev/building.md)
 3. Make directories and chown them to your user
     ```sh
-    mkdir -p /run/aziot /var/lib/aziot/{keyd,certd,identityd,edged} /var/lib/iotedge /etc/aziot/{keyd,certd,identityd,tpm,edged}/config.d
+    mkdir -p /run/aziot /var/lib/aziot/{keyd,certd,identityd,edged} /var/lib/iotedge /etc/aziot/{keyd,certd,identityd,tpmd,edged}/config.d
+    
+    chown -hR $USER /run/aziot /var/lib/aziot/ /var/lib/iotedge /etc/aziot/
     ```
 4. Copy Provisioning File and Fill out the provisioning parameters. Example : For Provisioning via Symmetric Keys Use [these instructions](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-symmetric?view=iotedge-2020-11&tabs=azure-portal%2Cubuntu)
 
@@ -187,40 +189,32 @@ In order to locally run aziot-edged, there is a dependency on running azure iden
     ```
    This is because when running locally or without systemd, LISTEN_FDNAMES environment variable is not passed to aziot-edged and hence we explicitly need to specify the listen sockets.
 
-6. Create Users for IIS Components
-    ```sh
-     <IISRepoPath>/contrib/debian/preinst install
-    ```
-7. Create Users for aziot-edge Components
-     ```sh
-     edgelet/contrib/debian/preinst install
-    ```
-8. Apply Config.
+6. Apply Config.
     ```sh
         cd edgelet
         cargo run -p iotedge -- config apply
     ```
-9. Run keyd service in a separate shell
+7. Run keyd service in a separate shell
     ```sh
-       cd <IISRepoPath>
+       cd <iot-identity-service-path>
        cargo run --target x86_64-unknown-linux-gnu -p aziotd -- aziot-keyd
     ```
-10. Run Identityd service in a separate shell
+8. Run Identityd service in a separate shell
      ```sh
-       cd <IISRepoPath>
+       cd <iot-identity-service-path>
        cargo run --target x86_64-unknown-linux-gnu -p aziotd -- aziot-identityd
     ```
-11. Run Certd Service in a separate shell
+9. Run Certd Service in a separate shell
     ```sh
-       cd <IISRepoPath>
+       cd <iot-identity-service-path>
        cargo run --target x86_64-unknown-linux-gnu -p aziotd -- aziot-certd
     ```
-12. Finally, Run aziot-edged in a separate shell
+10. Finally, Run aziot-edged in a separate shell
     ```sh
        cd edgelet
        cargo run -p aziot-edged
     ```
-13. When stopping the service, stop aziot-edged, identityd, keyd and certd, in that order.
+11. When stopping the service, stop aziot-edged, identityd, keyd and certd, in that order.
 ### Run tests
 
 ```sh

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -177,15 +177,15 @@ In order to locally run aziot-edged, there is a dependency on running Azure IoT 
     ```
 5. Modify the Daemon configuration section in /etc/aziot/config.toml to match this
     ```toml
-      [connect]
-      workload_uri = "unix:///var/run/iotedge/workload.sock"
-      management_uri = "unix:///var/run/iotedge/management.sock"
+    [connect]
+    workload_uri = "unix:///var/run/iotedge/workload.sock"
+    management_uri = "unix:///var/run/iotedge/management.sock"
 
-    
-      [listen]
-      workload_uri = "unix:///var/run/iotedge/workload.sock"
-      management_uri = "unix:///var/run/iotedge/management.sock"
-      min_tls_version = "tls1.0"
+
+    [listen]
+    workload_uri = "unix:///var/run/iotedge/workload.sock"
+    management_uri = "unix:///var/run/iotedge/management.sock"
+    min_tls_version = "tls1.0"
     ```
    This is because when running locally or without systemd, LISTEN_FDNAMES environment variable is not passed to aziot-edged and hence we explicitly need to specify the listen sockets.
 

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -166,7 +166,7 @@ In order to locally run aziot-edged, there is a dependency on running azure iden
 2. Build IIS Binaries using [these build steps](https://github.com/Azure/iot-identity-service/blob/main/docs-dev/building.md)
 3. Make directories and chown them to your user
     ```sh
-    mkdir -p /run/aziot /var/lib/aziot/{keyd,certd,identityd,edged} /var/lib/iotedge /etc/aziot/{keyd,certd,identityd,edged}/config.d
+    mkdir -p /run/aziot /var/lib/aziot/{keyd,certd,identityd,edged} /var/lib/iotedge /etc/aziot/{keyd,certd,identityd,tpm,edged}/config.d
     ```
 4. Copy Provisioning File and Fill out the provisioning parameters. Example : For Provisioning via Symmetric Keys Use [these instructions](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-symmetric?view=iotedge-2020-11&tabs=azure-portal%2Cubuntu)
 
@@ -208,7 +208,7 @@ In order to locally run aziot-edged, there is a dependency on running azure iden
 10. Run Identityd service in a separate shell
      ```sh
        cd <IISRepoPath>
-       cargo run --target x86_64-unknown-linux-gnu -p aziotd -- aziot-keyd
+       cargo run --target x86_64-unknown-linux-gnu -p aziotd -- aziot-identityd
     ```
 11. Run Certd Service in a separate shell
     ```sh

--- a/edgelet/doc/devguide.md
+++ b/edgelet/doc/devguide.md
@@ -161,33 +161,66 @@ This will create `aziot-edged` and `iotedge` binaries under `edgelet/target/debu
 
 ### Run
 
-To run `aziot-edged` locally:
-
-1. Create a directory that it will use as its home directory, such as `~/iotedge`
-
-    - Linux / macOS
-
-        ```sh
-        export AZIOT_EDGED_CONFIG_DIR=~/iotedge
-        mkdir -p "$AZIOT_EDGED_CONFIG_DIR"
-        ```
-
-    - Windows
-
-        ```powershell
-        $env:AZIOT_EDGED_CONFIG_DIR = Resolve-Path ~/iotedge
-        New-Item -Type Directory -Force $env:AZIOT_EDGED_CONFIG_DIR
-        ```
-
-1. Create a `config.toml`. It's okay to create this under the `AZIOT_EDGED_CONFIG_DIR` directory.
-
-1. Run the daemon with the `AZIOT_EDGED_CONFIG_DIR` environment variable set and with the path to the `config.toml`
+In order to locally run aziot-edged, there is a dependency on running azure identity service.The following instruction can be used to run aziot-edged locally:
+1. Clone the [aziot-iis repo](https://github.com/Azure/iot-identity-service)
+2. Build IIS Binaries using [these build steps](https://github.com/Azure/iot-identity-service/blob/main/docs-dev/building.md)
+3. Make directories and chown them to your user
+    ```sh
+    mkdir -p /run/aziot /var/lib/aziot/{keyd,certd,identityd,edged} /var/lib/iotedge /etc/aziot/{keyd,certd,identityd,edged}/config.d
+    ```
+4. Copy Provisioning File and Fill out the provisioning parameters. Example : For Provisioning via Symmetric Keys Use [these instructions](https://docs.microsoft.com/en-us/azure/iot-edge/how-to-provision-single-device-linux-symmetric?view=iotedge-2020-11&tabs=azure-portal%2Cubuntu)
 
     ```sh
-    cargo run -p aziot-edged -- -c /absolute/path/to/config.toml
+      cp edgelet/contrib/config/linux/template.toml /etc/aziot/config.toml
     ```
+5. Modify the Daemon configuration section in /etc/aziot/config.toml to match this
+    ```toml
+      [connect]
+      workload_uri = "unix:///var/run/iotedge/workload.sock"
+      management_uri = "unix:///var/run/iotedge/management.sock"
 
+    
+      [listen]
+      workload_uri = "unix:///var/run/iotedge/workload.sock"
+      management_uri = "unix:///var/run/iotedge/management.sock"
+      min_tls_version = "tls1.0"
+    ```
+   This is because when running locally or without systemd, LISTEN_FDNAMES environment variable is not passed to aziot-edged and hence we explicitly need to specify the listen sockets.
 
+6. Create Users for IIS Components
+    ```sh
+     <IISRepoPath>/contrib/debian/preinst install
+    ```
+7. Create Users for aziot-edge Components
+     ```sh
+     edgelet/contrib/debian/preinst install
+    ```
+8. Apply Config.
+    ```sh
+        cd edgelet
+        cargo run -p iotedge -- config apply
+    ```
+9. Run keyd service in a separate shell
+    ```sh
+       cd <IISRepoPath>
+       cargo run --target x86_64-unknown-linux-gnu -p aziotd -- aziot-keyd
+    ```
+10. Run Identityd service in a separate shell
+     ```sh
+       cd <IISRepoPath>
+       cargo run --target x86_64-unknown-linux-gnu -p aziotd -- aziot-keyd
+    ```
+11. Run Certd Service in a separate shell
+    ```sh
+       cd <IISRepoPath>
+       cargo run --target x86_64-unknown-linux-gnu -p aziotd -- aziot-certd
+    ```
+12. Finally, Run aziot-edged in a separate shell
+    ```sh
+       cd edgelet
+       cargo run -p aziot-edged
+    ```
+13. When stopping the service, stop aziot-edged, identityd, keyd and certd, in that order.
 ### Run tests
 
 ```sh


### PR DESCRIPTION
The PR adds Instructions on how to run edge daemon locally. The goal is to provide these instructions as part of compatibility check tool in case the target OS is missing systemd support

I tested this on an ubuntu 20.04 VM without systemd support


## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
