### PR TITLE
Update Microsoft.Azure.Devices.Client from 1.36.3 to 1.36.4 (#6115)

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="App.Metrics" Version="3.0.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 

--- a/edge-modules/MetricsCollector/MetricsCollector.csproj
+++ b/edge-modules/MetricsCollector/MetricsCollector.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
+++ b/edge-modules/SimulatedTemperatureSensor/SimulatedTemperatureSensor.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.27" />
   </ItemGroup>
 

--- a/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
+++ b/samples/dotnet/EdgeDownstreamDevice/EdgeDownstreamDevice.csproj
@@ -9,6 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
   </ItemGroup>
 </Project>

--- a/samples/dotnet/EdgeX509AuthDownstreamDevice/EdgeX509AuthDownstreamDevice.csproj
+++ b/samples/dotnet/EdgeX509AuthDownstreamDevice/EdgeX509AuthDownstreamDevice.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/smoke/LeafDevice/LeafDevice.csproj
+++ b/smoke/LeafDevice/LeafDevice.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.2" />
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="RunProcessAsTask" Version="1.2.4" />
     <PackageReference Include="YamlDotNet" Version="6.0.0" />

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/Microsoft.Azure.Devices.Edge.Test.Common.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.5.0" />

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -17,16 +17,18 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string SensorName = "tempSensor";
         const string DefaultSensorImage = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0";
 
-        [Test]
+        [TestCase(Protocol.Mqtt)]
+        [TestCase(Protocol.Amqp)]
         [Category("CentOsSafe")]
-        public async Task CertRenew()
+        public async Task CertRenew(Protocol protocol)
         {
             CancellationToken token = this.TestToken;
 
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(
                     builder =>
                     {
-                         builder.GetModule("$edgeHub").WithEnvironment(("ServerCertificateRenewAfterInMs", "6000"));
+                         builder.GetModule(ModuleName.EdgeHub).WithEnvironment(("ServerCertificateRenewAfterInMs", "6000"));
+                         builder.GetModule(ModuleName.EdgeHub).WithEnvironment(new[] { ("UpstreamProtocol", protocol.ToString()) });
                     },
                     token,
                     Context.Current.NestedEdge);

--- a/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageTester.csproj
+++ b/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageTester.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/test/modules/DirectMethodReceiver/DirectMethodReceiver.csproj
+++ b/test/modules/DirectMethodReceiver/DirectMethodReceiver.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/test/modules/DirectMethodSender/DirectMethodSender.csproj
+++ b/test/modules/DirectMethodSender/DirectMethodSender.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/test/modules/EdgeHubRestartTester/EdgeHubRestartTester.csproj
+++ b/test/modules/EdgeHubRestartTester/EdgeHubRestartTester.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/test/modules/MetricsValidator/MetricsValidator.csproj
+++ b/test/modules/MetricsValidator/MetricsValidator.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/test/modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
+++ b/test/modules/ModuleLib/Microsoft.Azure.Devices.Edge.ModuleUtil.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\..\..\netcoreappVersion.props" />
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/modules/ModuleRestarter/ModuleRestarter.csproj
+++ b/test/modules/ModuleRestarter/ModuleRestarter.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/test/modules/Relayer/Relayer.csproj
+++ b/test/modules/Relayer/Relayer.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/test/modules/TemperatureFilter/TemperatureFilter.csproj
+++ b/test/modules/TemperatureFilter/TemperatureFilter.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />

--- a/test/modules/TwinTester/TwinTester.csproj
+++ b/test/modules/TwinTester/TwinTester.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.31.1" />
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />

--- a/test/modules/load-gen/load-gen.csproj
+++ b/test/modules/load-gen/load-gen.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.3" />
+    <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />


### PR DESCRIPTION
Update Microsoft.Azure.Devices.Client version to 1.36.4 which includes fix for dotnetty bug where it created threads in foreground instead of background. The bug in dotnetty caused issue with certificate renewal in edgeHub because the process is not terminated when UpstreamProtocol is Mqtt.
Tested manually that certificate renewal works.

## Azure IoT Edge PR checklist:


## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  


