### PR TITLE
Fix ValidateMetrics e2e test by increasing timeout

### DIFF
--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -168,7 +168,7 @@ steps:
       $context['optimizeForPerformance'] = 'false'
       $context['setupTimeoutMinutes'] = 10
       $context['teardownTimeoutMinutes'] = 5
-      $context['testTimeoutMinutes'] = 6
+      $context['testTimeoutMinutes'] = 8 
     }
 
     Write-Host "Edge agent image: $imagePrefix-agent:$imageTag"


### PR DESCRIPTION
Based on two recent pipeline failures on ARM32 Raspberry Pis, the ValidateMetrics test needs more time to complete. Kusto logs were examined and they indicated that the ValidateMetrics direct method call succeeded within 30 seconds of the test timing out and failing.  Therefore, extending the timeout by 2 minutes should be more than enough time to fix this issue.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
