### PR TITLE
add dotnetty.common reference to 0.7.1

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Diagnostics/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.28.2" />
+    <!-- We will need to keep this reference to DotNetty.Common until the next release of Microsoft.Azure.Devices.Client includes this dependency -->
+    <PackageReference Include="DotNetty.Common" Version="0.7.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/Microsoft.Azure.Devices.Edge.Agent.IoTHub.csproj
@@ -11,6 +11,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices" Version="1.22.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.28.2" />
+    <!-- We will need to keep this reference to DotNetty.Common until the next release of Microsoft.Azure.Devices.Client includes this dependency -->
+    <PackageReference Include="DotNetty.Common" Version="0.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.28.2" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <!-- We will need to keep this reference to DotNetty.Common until the next release of Microsoft.Azure.Devices.Client includes this dependency -->
+    <PackageReference Include="DotNetty.Common" Version="0.7.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -17,16 +17,18 @@ namespace Microsoft.Azure.Devices.Edge.Test
         const string SensorName = "tempSensor";
         const string DefaultSensorImage = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0";
 
-        [Test]
+        [TestCase(Protocol.Mqtt)]
+        [TestCase(Protocol.Amqp)]
         [Category("CentOsSafe")]
-        public async Task CertRenew()
+        public async Task CertRenew(Protocol protocol)
         {
             CancellationToken token = this.TestToken;
 
             EdgeDeployment deployment = await this.runtime.DeployConfigurationAsync(
                     builder =>
                     {
-                         builder.GetModule(ModuleName.EdgeHub).WithEnvironment(("ServerCertificateRenewAfterInMs", "6000"));
+                        builder.GetModule(ModuleName.EdgeHub).WithEnvironment(("ServerCertificateRenewAfterInMs", "6000"));
+                        builder.GetModule(ModuleName.EdgeHub).WithEnvironment(new[] { ("UpstreamProtocol", protocol.ToString()) });
                     },
                     token);
 


### PR DESCRIPTION
Reference dotnetty.common 0.7.1 to force using this version because it has a fix for bug introduced in 0.7.0 which client SDK uses. Bug causes edgeHub process to not be terminated for certificate renewal when UpstreamProtocol is Mqtt

Tested manually that edgeHub shutdown works when UpstreamProtocol is Mqtt and added e2e test for Mqtt.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  
