### PR TITLE
Increase test timeout for Windows

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -163,6 +163,8 @@ jobs:
       arch: amd64
       artifactName: iotedged-windows
 
+    timeoutInMinutes: 120
+
     steps:
     - template: templates/e2e-setup.yaml
 

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -161,6 +161,7 @@ steps:
     if ($IsWindows)
     {
       $context['installerPath'] = Convert-Path '$(Build.SourcesDirectory)/scripts/windows/setup'
+      $context['testTimeoutMinutes'] = 8
     }
 
     if (('$(arch)' -eq 'arm32v7') -or ('$(arch)' -eq 'arm64v8'))
@@ -168,7 +169,7 @@ steps:
       $context['optimizeForPerformance'] = 'false'
       $context['setupTimeoutMinutes'] = 10
       $context['teardownTimeoutMinutes'] = 5
-      $context['testTimeoutMinutes'] = 8 
+      $context['testTimeoutMinutes'] = 8
     }
 
     Write-Host "Edge agent image: $imagePrefix-agent:$imageTag"


### PR DESCRIPTION
The TestGetModuleLogs test occasionally fails, not because it does something wrong but because it simply doesn't have time to finish all the stuff it's trying to do. This change increases the end-to-end test timeout to 8 minutes for Windows. It also increases the overall test time allotment to 120 minutes (default is 60). We really don't need to double the allotment, but arm32v7 will already take this long so it won't hurt to double (as opposed to picking some arbitrarily smaller value).

TestGetModuleLogs has only failed twice for this reason in the last couple of weeks, so it's hard to know whether this corrects the problem. But as long as this doesn't break anything, we'll make this change and see if flaky runs disappear over time.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.