### PR TITLE
Use pre-installed certs on agents to build Windows packages

### DIFF
--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -864,7 +864,7 @@ stages:
         displayName: Prepare package template
         inputs:
           filePath: edgelet/build/windows/package.ps1
-          arguments: -CreateTemplate
+          arguments: -CreateTemplate -SkipInstallCerts
           script: >-
             # Write your powershell commands here.
 

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -5,43 +5,43 @@ parameters:
 
 stages:
 
-################################################################################
-  - stage: CheckBuildPackages
-################################################################################
-    displayName: Check For Source Code Changes
-    pool:
-        name: $(pool.linux.name)
-        demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
-    dependsOn: []
-    jobs:
-      - job: check_source_change_edgelet
-        displayName: Check Source Changes Edgelet (changes ARE in builds or edgelet)
-        steps:
-          - bash: |
-              git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|edgelet)'
-              if [[ $? == 0 ]]; then
-                echo "Detected changes inside builds or edgelet folders"
-                echo "##vso[task.setvariable variable=EDGELETCHANGES;isOutput=true]TRUE"
-              fi
-            displayName: Check changes in edgelet sources
-            name: check_files
+# ################################################################################
+#   - stage: CheckBuildPackages
+# ################################################################################
+#     displayName: Check For Source Code Changes
+#     pool:
+#         name: $(pool.linux.name)
+#         demands:
+#           - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+#     dependsOn: []
+#     jobs:
+#       - job: check_source_change_edgelet
+#         displayName: Check Source Changes Edgelet (changes ARE in builds or edgelet)
+#         steps:
+#           - bash: |
+#               git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(builds|edgelet)'
+#               if [[ $? == 0 ]]; then
+#                 echo "Detected changes inside builds or edgelet folders"
+#                 echo "##vso[task.setvariable variable=EDGELETCHANGES;isOutput=true]TRUE"
+#               fi
+#             displayName: Check changes in edgelet sources
+#             name: check_files
   
 ################################################################################
   - stage: BuildPackages
 ################################################################################
     displayName: Build Packages
-    condition: |
-      or
-      (
-        eq(${{ parameters['E2EBuild'] }}, false), 
-        eq(dependencies.CheckBuildPackages.outputs['check_source_change_edgelet.check_files.EDGELETCHANGES'], 'true')
-      )
+    # condition: |
+    #   or
+    #   (
+    #     eq(${{ parameters['E2EBuild'] }}, false), 
+    #     eq(dependencies.CheckBuildPackages.outputs['check_source_change_edgelet.check_files.EDGELETCHANGES'], 'true')
+    #   )
     pool:
       name: $(pool.linux.name)
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
-    dependsOn: CheckBuildPackages
+    # dependsOn: CheckBuildPackages
     jobs:
 # ################################################################################
 #     - job: linux

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -223,6 +223,13 @@ stages:
           - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
       steps:
         - powershell: |
+            #Thumbprint                                Subject
+            #----------                                -------
+            #3ec2a996bd5319d0f6137917a1678e785e69e350  CN=Windows OEM Test Cert 2017 (TEST ONLY), O=Microsoft Partner, OU=Windows, L=Redmond, S=Washington, C=US
+            $signcerts = Get-ChildItem -Path cert: -CodeSigningCert -Recurse | where-object { $_.Thumbprint -ieq "3ec2a996bd5319d0f6137917a1678e785e69e350" }
+            Write-Host $signcerts
+          displayName: Validate the test signing cert
+        - powershell: |
             $base_version = Get-Content -Path "$(Build.SourcesDirectory)\edgelet\version.txt"
             if ($base_version -like '*~*') {
               $version = ("{0}{1}" -f $base_version, $(Build.BuildNumber))

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -223,10 +223,12 @@ stages:
           - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
       steps:
         - powershell: |
+            Write-Host "Looking for test signing cert..."
             #Thumbprint                                Subject
             #----------                                -------
             #3ec2a996bd5319d0f6137917a1678e785e69e350  CN=Windows OEM Test Cert 2017 (TEST ONLY), O=Microsoft Partner, OU=Windows, L=Redmond, S=Washington, C=US
             $signcerts = Get-ChildItem -Path cert: -CodeSigningCert -Recurse | where-object { $_.Thumbprint -ieq "3ec2a996bd5319d0f6137917a1678e785e69e350" }
+            Write-Host "Found cert? $($signcerts -ne $null)"
             Write-Host $signcerts
           displayName: Validate the test signing cert
         - powershell: |

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -248,7 +248,7 @@ stages:
           inputs:
             workingDirectory: 'edgelet/hsm-sys/azure-iot-hsm-c/build'
             cmakeArgs: '--build . --config Release'
-        - powershell: edgelet/build/windows/package.ps1 -CreateTemplate
+        - powershell: edgelet/build/windows/package.ps1 -CreateTemplate -SkipInstallCerts
           displayName: Prepare package template
         - powershell: edgelet/build/windows/package.ps1 -CreateCab
           displayName: Generate CAB package

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -43,174 +43,174 @@ stages:
         - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
     dependsOn: CheckBuildPackages
     jobs:
-################################################################################
-    - job: linux
-################################################################################
-      displayName: Linux
-      pool:
-        name: $(pool.linux.name)
-        demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
-      strategy:
-        matrix:
-          Centos75-amd64:
-            arch: amd64
-            os: centos7
-            target.iotedged: edgelet/target/rpmbuild/RPMS/x86_64
-          # Centos75-arm32v7 and Centos75-aarch64 are built in packages.slow.yaml 
-          Debian9-amd64:
-            os: debian9
-            arch: amd64
-            target.iotedged: edgelet/target/release
-          Debian9-arm32v7:
-            os: debian9
-            arch: arm32v7
-            target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
-          Debian9-aarch64:
-            os: debian9
-            arch: aarch64
-            target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+# ################################################################################
+#     - job: linux
+# ################################################################################
+#       displayName: Linux
+#       pool:
+#         name: $(pool.linux.name)
+#         demands:
+#           - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+#       strategy:
+#         matrix:
+#           Centos75-amd64:
+#             arch: amd64
+#             os: centos7
+#             target.iotedged: edgelet/target/rpmbuild/RPMS/x86_64
+#           # Centos75-arm32v7 and Centos75-aarch64 are built in packages.slow.yaml 
+#           Debian9-amd64:
+#             os: debian9
+#             arch: amd64
+#             target.iotedged: edgelet/target/release
+#           Debian9-arm32v7:
+#             os: debian9
+#             arch: arm32v7
+#             target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+#           Debian9-aarch64:
+#             os: debian9
+#             arch: aarch64
+#             target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
   
-          Debian10-amd64:
-            os: debian10
-            arch: amd64
-            target.iotedged: edgelet/target/release
-          Debian10-arm32v7:
-            os: debian10
-            arch: arm32v7
-            target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
-          Debian10-aarch64:
-            os: debian10
-            arch: aarch64
-            target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+#           Debian10-amd64:
+#             os: debian10
+#             arch: amd64
+#             target.iotedged: edgelet/target/release
+#           Debian10-arm32v7:
+#             os: debian10
+#             arch: arm32v7
+#             target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+#           Debian10-aarch64:
+#             os: debian10
+#             arch: aarch64
+#             target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
   
-          Debian11-amd64:
-            os: debian11
-            arch: amd64
-            target.iotedged: edgelet/target/release
-          Debian11-arm32v7:
-            os: debian11
-            arch: arm32v7
-            target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
-          Debian11-aarch64:
-            os: debian11
-            arch: aarch64
-            target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+#           Debian11-amd64:
+#             os: debian11
+#             arch: amd64
+#             target.iotedged: edgelet/target/release
+#           Debian11-arm32v7:
+#             os: debian11
+#             arch: arm32v7
+#             target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+#           Debian11-aarch64:
+#             os: debian11
+#             arch: aarch64
+#             target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
   
-          Ubuntu1804-amd64:
-            os: ubuntu18.04
-            arch: amd64
-            target.iotedged: edgelet/target/release
-          Ubuntu1804-arm32v7:
-            os: ubuntu18.04
-            arch: arm32v7
-            target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
-          Ubuntu1804-aarch64:
-            os: ubuntu18.04
-            arch: aarch64
-            target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+#           Ubuntu1804-amd64:
+#             os: ubuntu18.04
+#             arch: amd64
+#             target.iotedged: edgelet/target/release
+#           Ubuntu1804-arm32v7:
+#             os: ubuntu18.04
+#             arch: arm32v7
+#             target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+#           Ubuntu1804-aarch64:
+#             os: ubuntu18.04
+#             arch: aarch64
+#             target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
 
-          Ubuntu2004-amd64:
-              arch: amd64
-              os: ubuntu20.04
-              target.iotedged: edgelet/target/release
-          Ubuntu2004-arm32v7:
-              arch: arm32v7
-              os: ubuntu20.04
-              target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
-          Ubuntu2004-aarch64:
-              arch: aarch64
-              os: ubuntu20.04
-              target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
-      steps:
-        # Ensure any changes here are replicated in packages.slow.yaml
-        - bash: |
-            BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
-            VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
-            echo "##vso[task.setvariable variable=VERSION;]$VERSION"
+#           Ubuntu2004-amd64:
+#               arch: amd64
+#               os: ubuntu20.04
+#               target.iotedged: edgelet/target/release
+#           Ubuntu2004-arm32v7:
+#               arch: arm32v7
+#               os: ubuntu20.04
+#               target.iotedged: edgelet/target/armv7-unknown-linux-gnueabihf/release
+#           Ubuntu2004-aarch64:
+#               arch: aarch64
+#               os: ubuntu20.04
+#               target.iotedged: edgelet/target/aarch64-unknown-linux-gnu/release
+#       steps:
+#         # Ensure any changes here are replicated in packages.slow.yaml
+#         - bash: |
+#             BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+#             VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
+#             echo "##vso[task.setvariable variable=VERSION;]$VERSION"
   
-            echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
-            echo "##vso[task.setvariable variable=PACKAGE_OS;]$(os)"
-          displayName: Set Version
-          condition: or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64'))
-        - script: edgelet/build/linux/package.sh
-          displayName: Create libiothsm and iotedged packages
-          condition: or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64'))
-        - task: CopyFiles@2
-          displayName: Copy libiothsm Files to Artifact Staging
-          condition: or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64'))
-          inputs:
-            SourceFolder: edgelet/target/hsm
-            Contents: |
-              *.deb
-              *.rpm
-            TargetFolder: '$(build.artifactstagingdirectory)'
-        - task: CopyFiles@2
-          displayName: Copy iotedged Files to Artifact Staging
-          condition: or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64'))
-          inputs:
-            SourceFolder: $(target.iotedged)
-            Contents: |
-              *.deb
-              *.rpm
-              *.tar.gz
-            TargetFolder: '$(build.artifactstagingdirectory)'
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Artifacts
-          inputs:
-            PathtoPublish: '$(build.artifactstagingdirectory)'
-            ArtifactName: 'iotedged-$(os)-$(arch)'
-          condition: and(succeededOrFailed(),or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64')))
+#             echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
+#             echo "##vso[task.setvariable variable=PACKAGE_OS;]$(os)"
+#           displayName: Set Version
+#           condition: or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64'))
+#         - script: edgelet/build/linux/package.sh
+#           displayName: Create libiothsm and iotedged packages
+#           condition: or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64'))
+#         - task: CopyFiles@2
+#           displayName: Copy libiothsm Files to Artifact Staging
+#           condition: or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64'))
+#           inputs:
+#             SourceFolder: edgelet/target/hsm
+#             Contents: |
+#               *.deb
+#               *.rpm
+#             TargetFolder: '$(build.artifactstagingdirectory)'
+#         - task: CopyFiles@2
+#           displayName: Copy iotedged Files to Artifact Staging
+#           condition: or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64'))
+#           inputs:
+#             SourceFolder: $(target.iotedged)
+#             Contents: |
+#               *.deb
+#               *.rpm
+#               *.tar.gz
+#             TargetFolder: '$(build.artifactstagingdirectory)'
+#         - task: PublishBuildArtifacts@1
+#           displayName: Publish Artifacts
+#           inputs:
+#             PathtoPublish: '$(build.artifactstagingdirectory)'
+#             ArtifactName: 'iotedged-$(os)-$(arch)'
+#           condition: and(succeededOrFailed(),or(eq(${{ parameters['E2EBuild'] }}, false), eq(variables.arch,'amd64')))
   
-################################################################################
-    - job: mariner_linux
-################################################################################
-      displayName: Mariner_Linux
-      condition: eq(${{ parameters['E2EBuild'] }}, false)
-      pool:
-        vmImage: 'ubuntu-18.04'
-      strategy:
-        matrix:
-          CBL-Mariner1.0-amd64:
-            arch: amd64
-            os: mariner
-            release: tags/1.0-stable
-            target.iotedged: builds/mariner/out/RPMS/x86_64/
-      steps:
-        - bash: |
-            BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
-            VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
-            echo "##vso[task.setvariable variable=VERSION;]$VERSION"
+# ################################################################################
+#     - job: mariner_linux
+# ################################################################################
+#       displayName: Mariner_Linux
+#       condition: eq(${{ parameters['E2EBuild'] }}, false)
+#       pool:
+#         vmImage: 'ubuntu-18.04'
+#       strategy:
+#         matrix:
+#           CBL-Mariner1.0-amd64:
+#             arch: amd64
+#             os: mariner
+#             release: tags/1.0-stable
+#             target.iotedged: builds/mariner/out/RPMS/x86_64/
+#       steps:
+#         - bash: |
+#             BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+#             VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
+#             echo "##vso[task.setvariable variable=VERSION;]$VERSION"
   
-            echo "PACKAGE_ARCH=$(arch)"
-            echo "PACKAGE_OS=$(os)"
-            echo "##vso[task.setvariable variable=MARINER_RELEASE;]$(release)"
-          displayName: Set Version
-        - script: edgelet/build/linux/package-mariner.sh
-          displayName: Create libiothsm and iotedged packages
-        - task: CopyFiles@2
-          displayName: Copy iotedged and libiothsm build logs to artifact staging
-          inputs:
-            SourceFolder: builds/mariner/build/logs/pkggen/rpmbuilding/
-            Contents: |
-              **/*.rpm.log
-            TargetFolder: '$(build.artifactstagingdirectory)'
-          condition: succeededOrFailed()
-        - task: CopyFiles@2
-          displayName: Copy iotedged and libiothsm Files to Artifact Staging
-          inputs:
-            SourceFolder: $(target.iotedged)
-            Contents: |
-              *.rpm
-            TargetFolder: '$(build.artifactstagingdirectory)'
-          condition: succeededOrFailed()
-        - task: PublishBuildArtifacts@1
-          displayName: Publish Artifacts
-          inputs:
-            PathtoPublish: '$(build.artifactstagingdirectory)'
-            ArtifactName: 'iotedged-$(os)-$(arch)'
-          condition: succeededOrFailed()
-  
+#             echo "PACKAGE_ARCH=$(arch)"
+#             echo "PACKAGE_OS=$(os)"
+#             echo "##vso[task.setvariable variable=MARINER_RELEASE;]$(release)"
+#           displayName: Set Version
+#         - script: edgelet/build/linux/package-mariner.sh
+#           displayName: Create libiothsm and iotedged packages
+#         - task: CopyFiles@2
+#           displayName: Copy iotedged and libiothsm build logs to artifact staging
+#           inputs:
+#             SourceFolder: builds/mariner/build/logs/pkggen/rpmbuilding/
+#             Contents: |
+#               **/*.rpm.log
+#             TargetFolder: '$(build.artifactstagingdirectory)'
+#           condition: succeededOrFailed()
+#         - task: CopyFiles@2
+#           displayName: Copy iotedged and libiothsm Files to Artifact Staging
+#           inputs:
+#             SourceFolder: $(target.iotedged)
+#             Contents: |
+#               *.rpm
+#             TargetFolder: '$(build.artifactstagingdirectory)'
+#           condition: succeededOrFailed()
+#         - task: PublishBuildArtifacts@1
+#           displayName: Publish Artifacts
+#           inputs:
+#             PathtoPublish: '$(build.artifactstagingdirectory)'
+#             ArtifactName: 'iotedged-$(os)-$(arch)'
+#           condition: succeededOrFailed()
+
 ################################################################################
     - job: windows_amd64
 ################################################################################


### PR DESCRIPTION
We use OEM test certs from the Windows Driver Kit (WDK) to sign our CAB installer. The certs expired on Feb 1, 2022. Updated certs are available on https://github.com/ms-iot/iot-adk-addonkit. We've updated our Windows build agents so they spin up with the new certs already installed. The only change needed in this repo is to skip installing the (old) certs during the pipeline run.

I ran the edgelet packages pipeline to confirm that we can still build the CAB. Then I ran the end-to-end tests pipeline to confirm that the resulting package is installable and functional on Windows.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.