### PR TITLE
Update Windows crate dependencies following branch rename

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "hyperlocal-windows"
 version = "0.1.0"
-source = "git+https://github.com/Azure/hyperlocal-windows#2bd432bbbfb5b1cf38429733dd9a593c7b97a850"
+source = "git+https://github.com/Azure/hyperlocal-windows?branch=main#bb68309f77bd6c821d6ff371d4b0f73a39059a93"
 dependencies = [
  "futures",
  "hex",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "mio-uds-windows"
 version = "0.1.0"
-source = "git+https://github.com/Azure/mio-uds-windows.git#87a4a9970e668fdbe9205f4039967e175182c70e"
+source = "git+https://github.com/Azure/mio-uds-windows.git?branch=main#87a4a9970e668fdbe9205f4039967e175182c70e"
 dependencies = [
  "iovec",
  "kernel32-sys",
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "tokio-uds-windows"
 version = "0.1.0"
-source = "git+https://github.com/Azure/tokio-uds-windows.git#b689a914dbaa905f359f89200c01fed7a6c8df3f"
+source = "git+https://github.com/Azure/tokio-uds-windows.git?branch=main#e652c8425785448316b1b930bdc3c22226342da7"
 dependencies = [
  "bytes 0.4.12",
  "futures",

--- a/edgelet/edgelet-http/Cargo.toml
+++ b/edgelet/edgelet-http/Cargo.toml
@@ -38,10 +38,10 @@ tokio-uds = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 hyper-named-pipe = { path = "../hyper-named-pipe" }
-hyperlocal-windows = { git = "https://github.com/Azure/hyperlocal-windows" }
-mio-uds-windows = { git = "https://github.com/Azure/mio-uds-windows.git" }
+hyperlocal-windows = { git = "https://github.com/Azure/hyperlocal-windows", branch = "main" }
+mio-uds-windows = { git = "https://github.com/Azure/mio-uds-windows.git", branch = "main" }
 tokio-named-pipe = { path = "../tokio-named-pipe" }
-tokio-uds-windows = { git = "https://github.com/Azure/tokio-uds-windows.git" }
+tokio-uds-windows = { git = "https://github.com/Azure/tokio-uds-windows.git", branch = "main" }
 winapi = { version = "0.3.6", features = ["bcrypt", "errhandlingapi", "minwindef", "ncrypt", "wincrypt", "winnt", "winsock2"] }
 
 [dev-dependencies]

--- a/edgelet/edgelet-test-utils/Cargo.toml
+++ b/edgelet/edgelet-test-utils/Cargo.toml
@@ -22,8 +22,8 @@ edgelet-core = { path = "../edgelet-core" }
 hyperlocal = "0.6"
 
 [target.'cfg(windows)'.dependencies]
-hyperlocal-windows = { git = "https://github.com/Azure/hyperlocal-windows" }
+hyperlocal-windows = { git = "https://github.com/Azure/hyperlocal-windows", branch = "main" }
 mio = "0.6"
 mio-named-pipes = "0.1"
-mio-uds-windows = { git = "https://github.com/Azure/mio-uds-windows.git" }
+mio-uds-windows = { git = "https://github.com/Azure/mio-uds-windows.git", branch = "main" }
 miow = "0.3"

--- a/tools/snitch/snitcher/Cargo.toml
+++ b/tools/snitch/snitcher/Cargo.toml
@@ -35,4 +35,4 @@ url_serde = "0.2"
 tokio-uds = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-tokio-uds-windows = { git = "https://github.com/Azure/tokio-uds-windows.git" }
+tokio-uds-windows = { git = "https://github.com/Azure/tokio-uds-windows.git", branch = "main" }


### PR DESCRIPTION
For Windows, or edgelet code depends on three repositories whose default branches were renamed:
Azure/hyperlocal-windows
Azure/mio-uds-windows
Azure/tokio-uds-windows

In various Cargo.toml files, we weren't specifying the crate's branch, so cargo was assuming "master". In the case of mariner builds, the rename caused build failures because the vendored crate no longer matches the patched crate. This change updates all Cargo.toml references to explicitly name the branch.

I confirmed that the edgelet packages build passes with these changes.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.