### PR TITLE
Workaround for `docker buildx` using in correct ARM arch for image build

### DIFF
--- a/scripts/linux/buildImage.sh
+++ b/scripts/linux/buildImage.sh
@@ -206,15 +206,15 @@ docker_build_and_tag_and_push()
         docker_build_cmd="docker buildx build --no-cache"
 
         if [[ $arch = "amd64" ]]; then
-            docker_build_cmd+=" --platform linux/amd64"
+            docker_build_cmd+=" --platform=linux/amd64"
         fi
         
         if [[ $arch = "arm32v7" ]]; then
-            docker_build_cmd+=" --platform linux/arm/v7"
+            docker_build_cmd+=" --platform=linux/arm/v7"
         fi
 
         if [[ $arch = "arm64v8" ]]; then
-            docker_build_cmd+=" --platform linux/arm64"
+            docker_build_cmd+=" --platform=linux/arm64"
         fi
 
         docker_build_cmd+=" -t $DOCKER_REGISTRY/$DOCKER_NAMESPACE/$imagename:$DOCKER_IMAGEVERSION-linux-$arch"


### PR DESCRIPTION
Workaround for `docker buildx` using in correct ARM arch for image build

I have manually run the image build and verify that all the arch images are correctly built.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
