### PR TITLE
Fix aarch64 diagnostics module build

### DIFF
--- a/scripts/linux/buildImage.sh
+++ b/scripts/linux/buildImage.sh
@@ -202,6 +202,7 @@ docker_build_and_tag_and_push()
 
     if [[ $DOCKER_USE_BUILDX = "true" ]]; then
         docker buildx ls
+        docker buildx prune --all --force
     
         docker_build_cmd="docker buildx build --no-cache"
 


### PR DESCRIPTION
Our pipeline for building Docker images occasionally builds aarch64 images on top of arm32v7 base images. This behavior is intermittent, and we've only noticed it when building the diagnostics image (used by `iotedge check`).

I was able to reproduce this behavior locally. If I built the diagnostics image for arm32v7 first, then when I built for aarch64 it would be based on arm32v7. If I built for aarch64 first, then when I built for arm32v7 it would be based on aarch64.

I identified three ways to fix the problem:
1. Clear the buildx cache between each docker build with `docker buildx prune --all --force`
2. Create a new builder instance with `docker buildx create --name {name}; docker buildx use {name}`. Note that with this option, I could use the _single_ builder instance for both arm32v7 and aarch64--without clearing the cache between builds--and it built the images correctly
3. Remove `ARG base_tag=...` from the Dockerfile and hard-code the tag directly on the `FROM` line. This leads me to suspect that there's a bug in `docker buildx build` that causes it to (1) use build cache even when `--no-cache` is specified, and (2) decide it can use the previously cached Dockerfile if the only difference is the value of the `base_tag` ARG.

This PR uses the first approach to fix the problem, because it's a one-line change.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.