### PR TITLE
Fix API proxy for special characters

### DIFF
--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -89,7 +89,7 @@ http {
         location ~^/registry/(.*) {
             proxy_http_version 1.1;
             resolver 127.0.0.11;
-            set $endpoint http://${DOCKER_REQUEST_ROUTE_ADDRESS}/$1$is_args$args;
+            set $endpoint http://${DOCKER_REQUEST_ROUTE_ADDRESS}$request_uri;
             proxy_pass $endpoint;
         }
         #endif_tag ${DOCKER_REQUEST_ROUTE_ADDRESS}
@@ -98,7 +98,7 @@ http {
         location ~^/storage/(.*){
             resolver 127.0.0.11;
             proxy_http_version 1.1;
-            set $endpoint http://${BLOB_UPLOAD_ROUTE_ADDRESS}/$1$is_args$args;
+            set $endpoint http://${BLOB_UPLOAD_ROUTE_ADDRESS}$request_uri;
             proxy_pass $endpoint;
         }
         #endif_tag ${BLOB_UPLOAD_ROUTE_ADDRESS}        
@@ -114,7 +114,7 @@ http {
             proxy_ssl_trusted_certificate trustedCA.crt;
             proxy_ssl_verify_depth 7;
             proxy_ssl_verify       on;
-            proxy_pass          https://${IOTEDGE_PARENTHOSTNAME}:${NGINX_DEFAULT_PORT}/$1$is_args$args;
+            proxy_pass          https://${IOTEDGE_PARENTHOSTNAME}:${NGINX_DEFAULT_PORT}$request_uri;
         }
         #endif_tag ${IOTEDGE_PARENTHOSTNAME}
 


### PR DESCRIPTION
This PR fix an issue where API proxy uses the URI instead of Request URI.

URI is the normalization of Request URI. Request URI is the un-changed URI received.

When doing a proxy pass, using the URI lead to issue because of the normalization operation that occured.
