### PR TITLE
Nested E2E: Enhance lock/unlock logic

### DIFF
--- a/builds/e2e/templates/unlock-test-agents.yaml
+++ b/builds/e2e/templates/unlock-test-agents.yaml
@@ -31,10 +31,10 @@ steps:
         --request PUT "https://msazure.visualstudio.com/_apis/distributedtask/pools/$POOL_ID/agents/$agentId/usercapabilities" \
         -H "Content-Type:application/json" \
         -H "Accept: application/json;api-version=5.0;" \
-        --max-time 10 \
-        --retry 5 \
+        --max-time 15 \
+        --retry 10 \
         --retry-delay 0 \
-        --retry-max-time 40 \
+        --retry-max-time 80 \
         --retry-connrefused \
         --data @<(cat <<EOF
         $newAgentUserCapabilities

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -156,7 +156,7 @@ $newAgentUserCapabilities
 EOF
 ))
 
-    echo "$responseCapabilities"
+    echo "$responseCapabilities" | jq '.'
 
     # Validate the capability update was successful
     responseUserCapabilities=$(echo $responseCapabilities | jq '.userCapabilities')

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -156,6 +156,7 @@ $newAgentUserCapabilities
 EOF
 ))
 
+    echo "DEBUG statement:"
     echo "$responseCapabilities" | jq '.'
 
     # Validate the capability update was successful

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -156,7 +156,7 @@ $newAgentUserCapabilities
 EOF
 ))
 
-    echo $responseCapabilities
+    echo "$responseCapabilities"
 
     # Validate the capability update was successful
     responseUserCapabilities=$(echo $responseCapabilities | jq '.userCapabilities')

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -156,8 +156,6 @@ $newAgentUserCapabilities
 EOF
 ))
 
-    echo "$responseCapabilities" | jq '.'
-
     # Validate the capability update was successful
     responseUserCapabilities=$(echo $responseCapabilities | jq '.userCapabilities')
 

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -162,7 +162,7 @@ EOF
     if [ "$responseUserCapabilities" != "$newAgentUserCapabilities" ]
     then
         echo "Capabilities were not updated properly. Dumping response below." >&2
-        echo "$responseCapabilities" | jq '.' >&2
+        echo "$responseCapabilities" >&2
     fi
 }
 

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -155,6 +155,9 @@ function update_capabilities() {
 $newAgentUserCapabilities
 EOF
 ))
+
+    echo $responseCapabilities
+
     # Validate the capability update was successful
     responseUserCapabilities=$(echo $responseCapabilities | jq '.userCapabilities')
 

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -146,10 +146,10 @@ function update_capabilities() {
 --request PUT "https://msazure.visualstudio.com/_apis/distributedtask/pools/$POOL_ID/agents/$agentId/usercapabilities" \
 -H "Content-Type:application/json" \
 -H "Accept: application/json;api-version=5.0;" \
---max-time 10 \
---retry 5 \
+--max-time 15 \
+--retry 10 \
 --retry-delay 0 \
---retry-max-time 40 \
+--retry-max-time 80 \
 --retry-connrefused \
 --data @<(cat <<EOF
 $newAgentUserCapabilities
@@ -160,7 +160,7 @@ EOF
 
     if [ "$responseUserCapabilities" != "$newAgentUserCapabilities" ]
     then
-        echo "Capabilities were not updated properly. This will be retried."
+        echo "Capabilities were not updated properly."
     fi
 }
 

--- a/scripts/linux/nestedAgentLock.sh
+++ b/scripts/linux/nestedAgentLock.sh
@@ -156,7 +156,6 @@ $newAgentUserCapabilities
 EOF
 ))
 
-    echo "DEBUG statement:"
     echo "$responseCapabilities" | jq '.'
 
     # Validate the capability update was successful
@@ -164,7 +163,8 @@ EOF
 
     if [ "$responseUserCapabilities" != "$newAgentUserCapabilities" ]
     then
-        echo "Capabilities were not updated properly."
+        echo "Capabilities were not updated properly. Dumping response below." >&2
+        echo "$responseCapabilities" | jq '.' >&2
     fi
 }
 


### PR DESCRIPTION
Nested E2E Test had a one-off problem where it failed to unlock an agent, but succeeded in the subsequent unlock attempt. Enhancing this lock/unlock logic.
- Bump retries
- Log error in case of failed POST

Changes running:
https://dev.azure.com/msazure/One/_build/results?buildId=52735964&view=results

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
