### PR TITLE
[Tools] Package manager check and CA cert check

### DIFF
--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -560,7 +560,7 @@ check_package_manager() {
         wrap_debug "apt-get package manager is not present."
         result="$(need_cmd dpkg)"
         if [ $? != 0 ]; then
-            wrap_debug "dpkg package manager is present."
+            wrap_debug "dpkg package manager is not present."
             result="$(need_cmd yum)"
             if [ $? != 0 ]; then
                 wrap_debug "yum package manager is not present."
@@ -578,7 +578,7 @@ check_package_manager() {
             wrap_debug "dpkg package manager is present"
         fi
     else
-        wrap_debug "apt-get package manager is not present"   
+        wrap_debug "apt-get package manager is present"   
     fi
 
     if [ "$not_found" -eq 1 ]; then
@@ -593,51 +593,50 @@ check_package_manager() {
 aziotedge_check() {
 
     # Todo : As we add new versions, these checks will need to be changed. Keep a common check for now
-    # case $APP_VERSION in
-    # *) wrap_debug "Checking aziot-edge compatibility for Release 1.2" ;;
-    # esac
+    case $APP_VERSION in
+    *) wrap_debug "Checking aziot-edge compatibility for Release 1.2" ;;
+    esac
 
-    # SHARED_LIBRARIES="libssl.so.1.1 libcrypto.so.1.1 libdl.so.2 librt.so.1 libpthread.so.0 libc.so.6 libm.so.6 libgcc_s.so.1"
-    # MINIMUM_DOCKER_API_VERSION=1.34
-    # Required for resource allocation for containers
-    # check_cgroup_heirachy
+    SHARED_LIBRARIES="libssl.so.1.1 libcrypto.so.1.1 libdl.so.2 librt.so.1 libpthread.so.0 libc.so.6 libm.so.6 libgcc_s.so.1"
+    MINIMUM_DOCKER_API_VERSION=1.34
+    Required for resource allocation for containers
+    check_cgroup_heirachy
 
-    # Flags Required for setting elevated capabilities in a container. EdgeHub currently requires setting CAP_NET_BIND on dotnet binary.
-    # check_kernel_flags EXT4_FS_SECURITY
+    Flags Required for setting elevated capabilities in a container. EdgeHub currently requires setting CAP_NET_BIND on dotnet binary.
+    check_kernel_flags EXT4_FS_SECURITY
 
-    # The Following kernel flags are required for running a container engine. For description on each of the config flags : Visit -https://www.kernelconfig.io/
-    # Todo : Only check if docker engine is not present?
-    # Check for Required Container Engine Flags if docker is not present
-    # check_kernel_flags \
-    #     NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
-    #     CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG \
-    #     KEYS \
-    #     VETH BRIDGE BRIDGE_NETFILTER \
-    #     IP_NF_FILTER IP_NF_TARGET_MASQUERADE \
-    #     NETFILTER_XT_MATCH_ADDRTYPE \
-    #     NETFILTER_XT_MATCH_CONNTRACK \
-    #     NETFILTER_XT_MATCH_IPVS \
-    #     NETFILTER_XT_MARK \
-    #     IP_NF_NAT NF_NAT \
-    #     POSIX_MQUEUE
-    # (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
+    The Following kernel flags are required for running a container engine. For description on each of the config flags : Visit -https://www.kernelconfig.io/
+    Todo : Only check if docker engine is not present?
+    Check for Required Container Engine Flags if docker is not present
+    check_kernel_flags \
+        NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
+        CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG \
+        KEYS \
+        VETH BRIDGE BRIDGE_NETFILTER \
+        IP_NF_FILTER IP_NF_TARGET_MASQUERADE \
+        NETFILTER_XT_MATCH_ADDRTYPE \
+        NETFILTER_XT_MATCH_CONNTRACK \
+        NETFILTER_XT_MATCH_IPVS \
+        NETFILTER_XT_MARK \
+        IP_NF_NAT NF_NAT \
+        POSIX_MQUEUE
+    (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
 
-    # check_cgroup_heirachy
-    # check_systemd
-    # check_architecture
+    check_cgroup_heirachy
+    check_systemd
+    check_architecture
 
-    # check_docker_api_version $MINIMUM_DOCKER_API_VERSION
+    check_docker_api_version $MINIMUM_DOCKER_API_VERSION
 
-    # if [ $ARCH = x86_64 ]; then
-    #     SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-x86-64.so.2")"
-    # elif [ $ARCH = aarch64 ]; then
-    #     SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-aarch64.so.1")"
-    # elif [ $ARCH = armv7 ]; then
-    #     SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-armhf.so.3")"
-    # fi
-    # check_shared_library_dependency
+    if [ $ARCH = x86_64 ]; then
+        SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-x86-64.so.2")"
+    elif [ $ARCH = aarch64 ]; then
+        SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-aarch64.so.1")"
+    elif [ $ARCH = armv7 ]; then
+        SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-armhf.so.3")"
+    fi
+    check_shared_library_dependency
     check_package_manager
-    # check_free_memory
 
     echo "IoT Edge Compatibility Tool Check Complete"
 }

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -553,52 +553,91 @@ check_shared_library_dependency_display_util() {
     esac
 }
 
+check_package_manager() {
+    not_found=0
+    result="$(need_cmd apt-get)"
+    if [ $? != 0 ] ; then
+        wrap_debug "apt-get package manager is not present."
+        result="$(need_cmd dpkg)"
+        if [ $? != 0 ]; then
+            wrap_debug "dpkg package manager is present."
+            result="$(need_cmd yum)"
+            if [ $? != 0 ]; then
+                wrap_debug "yum package manager is not present."
+                result="$(need_cmd rpm)"
+                if [ $? != 0 ]; then
+                    wrap_debug "rpm package manager is not present."
+                    not_found=1
+                else
+                    wrap_debug "rpm package manager is present."
+                fi
+            else
+                wrap_debug "yum package manager is present."
+            fi
+        else
+            wrap_debug "dpkg package manager is present"
+        fi
+    else
+        wrap_debug "apt-get package manager is not present"   
+    fi
+
+    if [ "$not_found" -eq 1 ]; then
+        wrap_warning "Install a package manager for your distribution."
+        CA_CERT_PATH="/etc/ca-certificates"
+        if [ ! -d "/etc/ca-certificates" ]; then
+            wrap_warning "Install CA certificates package" 
+        fi
+    fi
+}
+
 aziotedge_check() {
 
     # Todo : As we add new versions, these checks will need to be changed. Keep a common check for now
-    case $APP_VERSION in
-    *) wrap_debug "Checking aziot-edge compatibility for Release 1.2" ;;
-    esac
+    # case $APP_VERSION in
+    # *) wrap_debug "Checking aziot-edge compatibility for Release 1.2" ;;
+    # esac
 
-    SHARED_LIBRARIES="libssl.so.1.1 libcrypto.so.1.1 libdl.so.2 librt.so.1 libpthread.so.0 libc.so.6 libm.so.6 libgcc_s.so.1"
-    MINIMUM_DOCKER_API_VERSION=1.34
-    #Required for resource allocation for containers
-    check_cgroup_heirachy
+    # SHARED_LIBRARIES="libssl.so.1.1 libcrypto.so.1.1 libdl.so.2 librt.so.1 libpthread.so.0 libc.so.6 libm.so.6 libgcc_s.so.1"
+    # MINIMUM_DOCKER_API_VERSION=1.34
+    # Required for resource allocation for containers
+    # check_cgroup_heirachy
 
-    #Flags Required for setting elevated capabilities in a container. EdgeHub currently requires setting CAP_NET_BIND on dotnet binary.
-    check_kernel_flags EXT4_FS_SECURITY
+    # Flags Required for setting elevated capabilities in a container. EdgeHub currently requires setting CAP_NET_BIND on dotnet binary.
+    # check_kernel_flags EXT4_FS_SECURITY
 
     # The Following kernel flags are required for running a container engine. For description on each of the config flags : Visit -https://www.kernelconfig.io/
-    #Todo : Only check if docker engine is not present?
-    #Check for Required Container Engine Flags if docker is not present
-    check_kernel_flags \
-        NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
-        CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG \
-        KEYS \
-        VETH BRIDGE BRIDGE_NETFILTER \
-        IP_NF_FILTER IP_NF_TARGET_MASQUERADE \
-        NETFILTER_XT_MATCH_ADDRTYPE \
-        NETFILTER_XT_MATCH_CONNTRACK \
-        NETFILTER_XT_MATCH_IPVS \
-        NETFILTER_XT_MARK \
-        IP_NF_NAT NF_NAT \
-        POSIX_MQUEUE
+    # Todo : Only check if docker engine is not present?
+    # Check for Required Container Engine Flags if docker is not present
+    # check_kernel_flags \
+    #     NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
+    #     CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG \
+    #     KEYS \
+    #     VETH BRIDGE BRIDGE_NETFILTER \
+    #     IP_NF_FILTER IP_NF_TARGET_MASQUERADE \
+    #     NETFILTER_XT_MATCH_ADDRTYPE \
+    #     NETFILTER_XT_MATCH_CONNTRACK \
+    #     NETFILTER_XT_MATCH_IPVS \
+    #     NETFILTER_XT_MARK \
+    #     IP_NF_NAT NF_NAT \
+    #     POSIX_MQUEUE
     # (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
 
-    check_cgroup_heirachy
-    check_systemd
-    check_architecture
+    # check_cgroup_heirachy
+    # check_systemd
+    # check_architecture
 
-    check_docker_api_version $MINIMUM_DOCKER_API_VERSION
+    # check_docker_api_version $MINIMUM_DOCKER_API_VERSION
 
-    if [ $ARCH = x86_64 ]; then
-        SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-x86-64.so.2")"
-    elif [ $ARCH = aarch64 ]; then
-        SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-aarch64.so.1")"
-    elif [ $ARCH = armv7 ]; then
-        SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-armhf.so.3")"
-    fi
-    check_shared_library_dependency
+    # if [ $ARCH = x86_64 ]; then
+    #     SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-x86-64.so.2")"
+    # elif [ $ARCH = aarch64 ]; then
+    #     SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-aarch64.so.1")"
+    # elif [ $ARCH = armv7 ]; then
+    #     SHARED_LIBRARIES="$(echo $SHARED_LIBRARIES "ld-linux-armhf.so.3")"
+    # fi
+    # check_shared_library_dependency
+    check_package_manager
+    # check_free_memory
 
     echo "IoT Edge Compatibility Tool Check Complete"
 }

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -561,7 +561,8 @@ check_package_manager() {
         res="$(need_cmd $package)"  
         if [ $? -eq 0 ] ; then
             not_found=0
-            wrap_pass "Current target platform supports $package package manager"
+            wrap_debug "Current target platform supports $package package manager"
+            wrap_pass "check_package_manager"
             if [ $package = "rpm" ] || [ $package = "dpkg" ]; then
                 check_ca_cert
             fi

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -573,6 +573,7 @@ check_package_manager() {
     }
     done
     if [ "$not_found" -eq 1 ]; then
+        wrap_warn "check_package_manager"
         wrap_warning "IoT Edge supports the following package types [*deb, *rpm] and following package managers [apt-get].We have identified that this device does not have support for the supported package type. Please head to aka.ms/iotedge for instructions on how to build the iotedge binaries from source"
         check_ca_cert
     fi

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -555,20 +555,20 @@ check_shared_library_dependency_display_util() {
 
 check_package_manager() {
     not_found=0
-    package_managers="apt-get dnf yum dpkg rpm"
+    package_managers="apt-get dnf yum dpkg dpkg"
     for package in $package_managers; do
     {
         res="$(need_cmd $package)"  
         if [ $? -eq 0 ] ; then
             not_found=0
-            wrap_debug "$package package manager is present."
-            if [ $package = "dpkg" || $package = "rpm" ]; then
+            wrap_pass "Current target platform supports $package package manager"
+            if [ $package = "rpm" ] || [ $package = "dpkg" ]; then
                 check_ca_cert
             fi
             break;
         else
             not_found=1
-            wrap_debug "$package package manager is not present."
+            wrap_debug "Current target platform does not support $package package manager"
         fi
     }
     done
@@ -579,8 +579,10 @@ check_package_manager() {
 }
 
 check_ca_cert() {
-    if [ ! -d "/etc/ca-certificate1s" ]; then
+    if [ ! -d "/etc/ca-certificates" ]; then
         wrap_warn "Install ca-certificates package"
+    else
+        wrap_pass "ca-certificates package is installed"
     fi
 }
 aziotedge_check() {

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -555,7 +555,7 @@ check_shared_library_dependency_display_util() {
 
 check_package_manager() {
     not_found=0
-    package_managers="apt-get dnf yum dpkg dpkg"
+    package_managers="apt-get dnf yum dpkg rpm"
     for package in $package_managers; do
     {
         res="$(need_cmd $package)"  

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -555,34 +555,24 @@ check_shared_library_dependency_display_util() {
 
 check_package_manager() {
     not_found=0
-    result="$(need_cmd apt-get)"
-    if [ $? != 0 ] ; then
-        wrap_debug "apt-get package manager is not present."
-        result="$(need_cmd dpkg)"
-        if [ $? != 0 ]; then
-            wrap_debug "dpkg package manager is not present."
-            result="$(need_cmd yum)"
-            if [ $? != 0 ]; then
-                wrap_debug "yum package manager is not present."
-                result="$(need_cmd rpm)"
-                if [ $? != 0 ]; then
-                    wrap_debug "rpm package manager is not present."
-                    not_found=1
-                else
-                    wrap_debug "rpm package manager is present."
-                fi
-            else
-                wrap_debug "yum package manager is present."
-            fi
+    package_managers="apt-get dpkg yum rpm"
+    for package in $package_managers; do
+    {
+        res="$(need_cmd $package)"
+        if [ $? -eq 0]; then
+            wrap_debug "$package package manager is present."
+            break;
         else
-            wrap_debug "dpkg package manager is present"
+            not_found=1
+            wrap_debug "$package package manager is not present."
         fi
-    else
-        wrap_debug "apt-get package manager is present"   
-    fi
-
+    }
+    done
     if [ "$not_found" -eq 1 ]; then
-        wrap_warning "Install a package manager for your distribution."
+        wrap_warning "IoT Edge supports the following package types [*deb, *rpm] and following package managers [apt-get].
+        We have identified that this device does not have support for the supported package type.
+        Please head to aka.ms/iotedge for instructions on how to build the iotedge binaries from source"
+
         if [ ! -d "/etc/ca-certificates" ]; then
             wrap_warning "Install CA certificates package" 
         fi
@@ -598,15 +588,15 @@ aziotedge_check() {
 
     SHARED_LIBRARIES="libssl.so.1.1 libcrypto.so.1.1 libdl.so.2 librt.so.1 libpthread.so.0 libc.so.6 libm.so.6 libgcc_s.so.1"
     MINIMUM_DOCKER_API_VERSION=1.34
-    # Required for resource allocation for containers
+    #Required for resource allocation for containers
     check_cgroup_heirachy
 
-    # Flags Required for setting elevated capabilities in a container. EdgeHub currently requires setting CAP_NET_BIND on dotnet binary.
+    #Flags Required for setting elevated capabilities in a container. EdgeHub currently requires setting CAP_NET_BIND on dotnet binary.
     check_kernel_flags EXT4_FS_SECURITY
 
     # The Following kernel flags are required for running a container engine. For description on each of the config flags : Visit -https://www.kernelconfig.io/
-    # Todo : Only check if docker engine is not present?
-    # Check for Required Container Engine Flags if docker is not present
+    #Todo : Only check if docker engine is not present?
+    #Check for Required Container Engine Flags if docker is not present
     check_kernel_flags \
         NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
         CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG \

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -582,7 +582,7 @@ check_ca_cert() {
     if [ ! -d "/etc/ca-certificates" ]; then
         wrap_warn "Install ca-certificates package"
     else
-        wrap_pass "ca-certificates package is installed"
+        wrap_pass "check_ca_cert"
     fi
 }
 aziotedge_check() {

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -583,7 +583,6 @@ check_package_manager() {
 
     if [ "$not_found" -eq 1 ]; then
         wrap_warning "Install a package manager for your distribution."
-        CA_CERT_PATH="/etc/ca-certificates"
         if [ ! -d "/etc/ca-certificates" ]; then
             wrap_warning "Install CA certificates package" 
         fi

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -555,13 +555,16 @@ check_shared_library_dependency_display_util() {
 
 check_package_manager() {
     not_found=0
-    package_managers="apt-get dpkg yum rpm"
+    package_managers="apt-get dnf yum dpkg rpm"
     for package in $package_managers; do
     {
         res="$(need_cmd $package)"  
         if [ $? -eq 0 ] ; then
             not_found=0
             wrap_debug "$package package manager is present."
+            if [ $package = "dpkg" || $package = "rpm" ]; then
+                check_ca_cert
+            fi
             break;
         else
             not_found=1
@@ -571,12 +574,15 @@ check_package_manager() {
     done
     if [ "$not_found" -eq 1 ]; then
         wrap_warning "IoT Edge supports the following package types [*deb, *rpm] and following package managers [apt-get].We have identified that this device does not have support for the supported package type. Please head to aka.ms/iotedge for instructions on how to build the iotedge binaries from source"
-        if [ ! -d "/etc/ca-certificates" ]; then
-            wrap_warning "Install CA certificates package" 
-        fi
+        check_ca_cert
     fi
 }
 
+check_ca_cert() {
+    if [ ! -d "/etc/ca-certificate1s" ]; then
+        wrap_warn "Install ca-certificates package"
+    fi
+}
 aziotedge_check() {
 
     # Todo : As we add new versions, these checks will need to be changed. Keep a common check for now

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -558,8 +558,9 @@ check_package_manager() {
     package_managers="apt-get dpkg yum rpm"
     for package in $package_managers; do
     {
-        res="$(need_cmd $package)"
-        if [ $? -eq 0]; then
+        res="$(need_cmd $package)"  
+        if [ $? -eq 0 ] ; then
+            not_found=0
             wrap_debug "$package package manager is present."
             break;
         else
@@ -569,10 +570,7 @@ check_package_manager() {
     }
     done
     if [ "$not_found" -eq 1 ]; then
-        wrap_warning "IoT Edge supports the following package types [*deb, *rpm] and following package managers [apt-get].
-        We have identified that this device does not have support for the supported package type.
-        Please head to aka.ms/iotedge for instructions on how to build the iotedge binaries from source"
-
+        wrap_warning "IoT Edge supports the following package types [*deb, *rpm] and following package managers [apt-get].We have identified that this device does not have support for the supported package type. Please head to aka.ms/iotedge for instructions on how to build the iotedge binaries from source"
         if [ ! -d "/etc/ca-certificates" ]; then
             wrap_warning "Install CA certificates package" 
         fi

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -599,15 +599,15 @@ aziotedge_check() {
 
     SHARED_LIBRARIES="libssl.so.1.1 libcrypto.so.1.1 libdl.so.2 librt.so.1 libpthread.so.0 libc.so.6 libm.so.6 libgcc_s.so.1"
     MINIMUM_DOCKER_API_VERSION=1.34
-    Required for resource allocation for containers
+    # Required for resource allocation for containers
     check_cgroup_heirachy
 
-    Flags Required for setting elevated capabilities in a container. EdgeHub currently requires setting CAP_NET_BIND on dotnet binary.
+    # Flags Required for setting elevated capabilities in a container. EdgeHub currently requires setting CAP_NET_BIND on dotnet binary.
     check_kernel_flags EXT4_FS_SECURITY
 
-    The Following kernel flags are required for running a container engine. For description on each of the config flags : Visit -https://www.kernelconfig.io/
-    Todo : Only check if docker engine is not present?
-    Check for Required Container Engine Flags if docker is not present
+    # The Following kernel flags are required for running a container engine. For description on each of the config flags : Visit -https://www.kernelconfig.io/
+    # Todo : Only check if docker engine is not present?
+    # Check for Required Container Engine Flags if docker is not present
     check_kernel_flags \
         NAMESPACES NET_NS PID_NS IPC_NS UTS_NS \
         CGROUPS CGROUP_CPUACCT CGROUP_DEVICE CGROUP_FREEZER CGROUP_SCHED CPUSETS MEMCG \
@@ -620,7 +620,7 @@ aziotedge_check() {
         NETFILTER_XT_MARK \
         IP_NF_NAT NF_NAT \
         POSIX_MQUEUE
-    (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
+    # (POSIX_MQUEUE is required for bind-mounting /dev/mqueue into containers)
 
     check_cgroup_heirachy
     check_systemd

--- a/scripts/linux/buildImage.sh
+++ b/scripts/linux/buildImage.sh
@@ -201,7 +201,8 @@ docker_build_and_tag_and_push()
     echo "Building and pushing Docker image $imagename for $arch"
 
     if [[ $DOCKER_USE_BUILDX = "true" ]]; then
-        sudo docker buildx ls
+        docker buildx ls
+        docker buildx prune --all --force
     
         docker_build_cmd="docker buildx build --no-cache"
 


### PR DESCRIPTION
Checking package managers like apt-get, yum, rpm, dpkg. 
apt-get installs the default dependencies like ca-certificates. When apt-get is not present, an additional check is also made. 