### PR TITLE
Revert usage of arsing/cross to upstream cross 0.2

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -63,7 +63,7 @@ jobs:
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
       - script: "cargo install cross --version ^0.2"
-        displayName: "Install cross (fork with docker fix)"
+        displayName: "Install cross"
       - script: "cross build --target armv7-unknown-linux-gnueabihf"
         displayName: armv7-unknown-linux-gnueabihf build
         workingDirectory: $(Build.SourcesDirectory)/edgelet
@@ -92,7 +92,7 @@ jobs:
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
       - script: "cargo install cross --version ^0.2"
-        displayName: "Install cross (fork with docker fix)"
+        displayName: "Install cross"
       - script: "cross build --target aarch64-unknown-linux-gnu"
         displayName: aarch64-unknown-linux-gnu build
         workingDirectory: $(Build.SourcesDirectory)/edgelet

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -62,7 +62,7 @@ jobs:
         displayName: Set Version
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
-      - script: "cargo install --git https://github.com/arsing/cross.git --branch set-path"
+      - script: "cargo install cross --version ^0.2"
         displayName: "Install cross (fork with docker fix)"
       - script: "cross build --target armv7-unknown-linux-gnueabihf"
         displayName: armv7-unknown-linux-gnueabihf build
@@ -91,7 +91,7 @@ jobs:
         displayName: Set Version
       - bash: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
-      - script: "cargo install --git https://github.com/arsing/cross.git --branch set-path"
+      - script: "cargo install cross --version ^0.2"
         displayName: "Install cross (fork with docker fix)"
       - script: "cross build --target aarch64-unknown-linux-gnu"
         displayName: aarch64-unknown-linux-gnu build

--- a/builds/ci/edgelet.yaml
+++ b/builds/ci/edgelet.yaml
@@ -55,7 +55,7 @@ jobs:
           filePath: scripts/linux/generic-rust/install.sh
           arguments: --project-root "edgelet"
       - script: cargo install cross --version ^0.2
-        displayName: Install cross (fork with docker fix)
+        displayName: Install cross
       - task: Bash@3
         displayName: armv7-unknown-linux-gnueabihf build
         inputs:

--- a/builds/ci/edgelet.yaml
+++ b/builds/ci/edgelet.yaml
@@ -54,7 +54,7 @@ jobs:
         inputs:
           filePath: scripts/linux/generic-rust/install.sh
           arguments: --project-root "edgelet"
-      - script: cargo install --git https://github.com/arsing/cross.git --branch set-path
+      - script: cargo install cross --version ^0.2
         displayName: Install cross (fork with docker fix)
       - task: Bash@3
         displayName: armv7-unknown-linux-gnueabihf build


### PR DESCRIPTION
The fix we needed was merged into upstream a long time ago.

Ref: https://github.com/cross-rs/cross/issues/52
Ref: https://github.com/cross-rs/cross/commit/249500e9a1f953d7eeca8a8b744e3aa1a10f64e6