### PR TITLE
Revert usage of arsing/cross to upstream cross 0.2 and 0.1

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -65,8 +65,8 @@ jobs:
         displayName: Set Version
       - script: edgelet/build/linux/install.sh
         displayName: Install Rust
-      - script: "cargo install --git https://github.com/arsing/cross.git --branch set-path"
-        displayName: "Install cross (fork with docker fix)"
+      - script: "cargo install cross --version ^0.2"
+        displayName: "Install cross"
       - script: "cross build --target armv7-unknown-linux-gnueabihf"
         displayName: armv7-unknown-linux-gnueabihf build
         workingDirectory: $(Build.SourcesDirectory)/edgelet
@@ -94,8 +94,8 @@ jobs:
         displayName: Set Version
       - script: edgelet/build/linux/install.sh
         displayName: Install Rust
-      - script: "cargo install --git https://github.com/arsing/cross.git --branch set-path"
-        displayName: "Install cross (fork with docker fix)"
+      - script: "cargo install cross --version ^0.2"
+        displayName: "Install cross"
       - script: "cross build --target aarch64-unknown-linux-gnu"
         displayName: aarch64-unknown-linux-gnu build
         workingDirectory: $(Build.SourcesDirectory)/edgelet

--- a/builds/ci/edgelet.yaml
+++ b/builds/ci/edgelet.yaml
@@ -51,8 +51,8 @@ jobs:
         displayName: Install Rust
         inputs:
           filePath: edgelet/build/linux/install.sh
-      - script: cargo install --git https://github.com/arsing/cross.git --branch set-path
-        displayName: Install cross (fork with docker fix)
+      - script: cargo install cross --version ^0.2
+        displayName: Install cross
       - task: Bash@3
         displayName: armv7-unknown-linux-gnueabihf build
         inputs:

--- a/builds/misc/templates/image-linux-rust-jobs.yaml
+++ b/builds/misc/templates/image-linux-rust-jobs.yaml
@@ -23,8 +23,10 @@ jobs:
       - bash: 'echo "##vso[task.setvariable variable=PATH;]${CARGO_HOME:-"$HOME/.cargo"}/bin:$PATH"'
         displayName: Modify path
 
-      - bash: 'cargo install --git https://github.com/arsing/cross.git --branch set-path'
-        displayName: 'Install cross (fork with docker fix)'
+      # TODO: Update this to cross 0.2 when a solution for using openssl
+      # in cross 0.2's builder image is found.
+      - bash: 'cargo install cross --version ^0.1'
+        displayName: 'Install cross'
       
       - template: build-edgelet-linux.yaml
         parameters:


### PR DESCRIPTION
The fix we needed was merged into upstream a long time ago.

Ref: https://github.com/cross-rs/cross/issues/52
Ref: https://github.com/cross-rs/cross/commit/249500e9a1f953d7eeca8a8b744e3aa1a10f64e6

The image-linux-rust job uses cross 0.1 and not 0.2. This is because
this job builds iotedge-proxy for x86_64-unknown-linux-musl, to make
an iotedge-proxy Docker image for Kubernetes. We do not have
a custom builder image for this target, so cross 0.2 would use upstream's image,
which does not have openssl. We *could* use cross 0.2 with a custom image,
like we do for the ARM targets (see Cross.toml), but for now this change just
sticks with cross 0.1. The openssl in 0.1's image is still ancient
(the image hasn't been updated in 4 years), but Dave said that can be tackled
later, as part of updating openssl across this branch in general.