### PR TITLE
Remove PR template body from commits

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -3,7 +3,7 @@ version = 1
 
 [update]
 # Update a PR whenever out of date with the base branch. The PR will be updated regardless of 
-# merge requirements (e.g. failing status checks, missing reviews, blacklist labels).
+# merge requirements (e.g. failing status checks, missing reviews).
 always = false # default: false
 
 # When enabled, Kodiak will only update PRs that have an automerge label. When disabled, any PR.
@@ -35,3 +35,6 @@ include_pull_request_author = false # default: false
 
 # remove html comments to auto remove PR templates.
 strip_html_comments = true # default: false
+
+# remove PR template from merge message body
+cut_body_after = "## Azure IoT Edge PR checklist:"


### PR DESCRIPTION
In the main branch, we've set up the kodiak tool to remove the PR template text from merge commits. This change brings the same behavior to the release/1.1 branch.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.