### PR TITLE
E2E tests: Allow apt-get to wait up to 5 minutes on lock.

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 SupportedPackageExtension.Deb => new[]
                 {
                     "set -e",
-                    $"apt-get install -y {string.Join(' ', packages)}",
-                    $"apt-get install -f"
+                    $"apt-get install -y --option DPkg::Lock::Timeout=600 {string.Join(' ', packages)}",
+                    $"apt-get install -f --option DPkg::Lock::Timeout=600"
                 },
                 SupportedPackageExtension.Rpm => new[]
                 {
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     $"curl {repository} > /etc/apt/sources.list.d/microsoft-prod.list",
                     "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
                     $"apt-get update",
-                    $"apt-get install --yes aziot-edge"
+                    $"apt-get install --option DPkg::Lock::Timeout=600 --yes aziot-edge"
                 },
                 SupportedPackageExtension.Rpm => new[]
                 {


### PR DESCRIPTION
Some E2E tests are failing for "Network is down" error - @damonbarry pointed out that this is apt-get returning error 100.

The logs say apt-get is failing because another process has the lock, and it appears to be `unattended-upgr`- automatic updates.

There's an apt option (`DPkg::Lock::Timeout`) that lets us wait on the lock. This option should work on apt-get versions 1.9.11 or later, but experimentation shows this only works for "install" and not "update."  So it may not fix all problems.
I also (manually) confirmed this option is ignored for apt-get versions lower than this, so this won't fix test failures on 18.04, but I don't think we have `unattended-upgr` running on our 18.04 systems.

A successful E2E test run will show this doesn't break E2E tests.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [] local testing done.  

