### PR TITLE
Allow apt-get to wait up to 5 minutes on lock. (#6259)

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/linux/PackageManagement.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                 SupportedPackageExtension.Deb => new[]
                 {
                     "set -e",
-                    $"apt-get install -y {string.Join(' ', packages)}",
-                    $"apt-get install -f"
+                    $"apt-get install -y --option DPkg::Lock::Timeout=600 {string.Join(' ', packages)}",
+                    $"apt-get install -f --option DPkg::Lock::Timeout=600"
                 },
                 SupportedPackageExtension.Rpm => new[]
                 {
@@ -77,7 +77,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Linux
                     $"curl {repository} > /etc/apt/sources.list.d/microsoft-prod.list",
                     "curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/microsoft.gpg",
                     $"apt-get update",
-                    $"apt-get install --yes aziot-edge"
+                    $"apt-get install --option DPkg::Lock::Timeout=600 --yes aziot-edge"
                 },
                 SupportedPackageExtension.Rpm => new[]
                 {


### PR DESCRIPTION
Allow apt-get to wait up to 5 minutes on lock. 
This option should work on apt-get Version 1.9.11 or later,
but experimentation shows this only works for "install" and not "update" so it may not fix all problems

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

