### PR TITLE
E2E: Fix proxy Manifest Trust Setup build step

### DIFF
--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -168,6 +168,8 @@ steps:
       SIGNER_CERT: $(TestManifestSigningSignerCert)
       SIGNER_KEY: $(TestManifestSigningSignerKey)
       CONTENT_TRUST_ROOT_CA_CERT : $(TestContentTrustRootCa)
+      http_proxy: $(Agent.ProxyUrl)
+      https_proxy: $(Agent.ProxyUrl)
 
   - pwsh: |
       $imageId = Get-Content -Encoding Utf8 `

--- a/mqtt/policy/src/core/builder.rs
+++ b/mqtt/policy/src/core/builder.rs
@@ -101,7 +101,6 @@ where
 
     /// Specifies the default decision that `Policy` will return if
     /// no rules match the request.
-    #[must_use]
     pub fn with_default_decision(mut self, decision: Decision) -> Self {
         self.default_decision = decision;
         self

--- a/mqtt/policy/src/core/builder.rs
+++ b/mqtt/policy/src/core/builder.rs
@@ -101,6 +101,7 @@ where
 
     /// Specifies the default decision that `Policy` will return if
     /// no rules match the request.
+    #[must_use]
     pub fn with_default_decision(mut self, decision: Decision) -> Self {
         self.default_decision = decision;
         self


### PR DESCRIPTION
Manifest Trust Setup build step isn't using proxy env vars. Fixing.


## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
