### PR TITLE
Fix reference to MetricsCollector end-to-end test

### DIFF
--- a/builds/e2e/templates/e2e-run-metrics-collector.yaml
+++ b/builds/e2e/templates/e2e-run-metrics-collector.yaml
@@ -2,7 +2,7 @@ steps:
 - pwsh: |
     $testFile = '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll'
 
-    $filter = 'TestMetricsCollector'
+    $filter = 'MetricsCollector'
 
     if ($IsWindows)
     {


### PR DESCRIPTION
In a recent change, the string that filters out a single end-to-end test to run in the metrics collector release pipeline was inadvertently changed, a victim of search and replace. ;)

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.