### PR TITLE
[main] Upgrade to latest Rust version

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -91,7 +91,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -100,7 +100,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "cert-renewal",
  "hex 0.4.3",
@@ -141,7 +141,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -165,7 +165,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -207,7 +207,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -220,7 +220,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "serde",
 ]
@@ -228,7 +228,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -238,7 +238,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -256,7 +256,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "http-common",
  "libc",
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "pkcs11",
  "serde",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "http-common",
  "serde",
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -417,10 +417,17 @@ checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
+ "async-trait",
+ "aziot-cert-client-async",
+ "aziot-key-client-async",
+ "chrono",
+ "futures-util",
+ "log",
  "openssl",
  "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -487,7 +494,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "serde",
  "toml",
@@ -1158,7 +1165,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "async-trait",
  "base64 0.13.0",
@@ -1437,7 +1444,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "env_logger",
  "log",
@@ -1608,7 +1615,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "cc",
 ]
@@ -1639,7 +1646,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1648,7 +1655,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1710,7 +1717,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1727,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 
 [[package]]
 name = "pkg-config"
@@ -2188,7 +2195,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#8f53f29c063c03529e508ee4111c7f1b1110c08f"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#df08bfaad7d2c2657ddc41cedc32fe0cc04561b1"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -62,7 +62,7 @@ pub fn version() -> &'static str {
 }
 
 pub fn version_with_source_version() -> String {
-    (&VERSION_WITH_SOURCE_VERSION).to_string()
+    VERSION_WITH_SOURCE_VERSION.to_string()
 }
 
 pub trait UrlExt {

--- a/edgelet/edgelet-http-mgmt/src/device_actions/reprovision.rs
+++ b/edgelet/edgelet-http-mgmt/src/device_actions/reprovision.rs
@@ -32,7 +32,7 @@ where
             return None;
         }
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-mgmt/src/identity/create_or_list.rs
+++ b/edgelet/edgelet-http-mgmt/src/identity/create_or_list.rs
@@ -58,7 +58,7 @@ where
             return None;
         }
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-mgmt/src/identity/delete_or_update.rs
+++ b/edgelet/edgelet-http-mgmt/src/identity/delete_or_update.rs
@@ -44,7 +44,7 @@ where
             .decode_utf8()
             .ok()?;
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-mgmt/src/module/create_or_list.rs
+++ b/edgelet/edgelet-http-mgmt/src/module/create_or_list.rs
@@ -35,7 +35,7 @@ where
             return None;
         }
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-mgmt/src/module/delete_or_get_or_update.rs
+++ b/edgelet/edgelet-http-mgmt/src/module/delete_or_get_or_update.rs
@@ -40,7 +40,7 @@ where
 
         let start = edgelet_http::find_query("start", query);
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-mgmt/src/module/prepare_update.rs
+++ b/edgelet/edgelet-http-mgmt/src/module/prepare_update.rs
@@ -36,7 +36,7 @@ where
             .decode_utf8()
             .ok()?;
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-workload/src/module/cert/identity.rs
+++ b/edgelet/edgelet-http-workload/src/module/cert/identity.rs
@@ -42,7 +42,7 @@ where
             service.config.hub_name, service.config.device_id, module_id
         );
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-workload/src/module/cert/server.rs
+++ b/edgelet/edgelet-http-workload/src/module/cert/server.rs
@@ -52,7 +52,7 @@ where
             .decode_utf8()
             .ok()?;
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-workload/src/module/data/decrypt.rs
+++ b/edgelet/edgelet-http-workload/src/module/data/decrypt.rs
@@ -63,7 +63,7 @@ where
             .decode_utf8()
             .ok()?;
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-workload/src/module/data/encrypt.rs
+++ b/edgelet/edgelet-http-workload/src/module/data/encrypt.rs
@@ -63,7 +63,7 @@ where
             .decode_utf8()
             .ok()?;
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/edgelet/edgelet-http-workload/src/module/data/sign.rs
+++ b/edgelet/edgelet-http-workload/src/module/data/sign.rs
@@ -59,7 +59,7 @@ where
             .decode_utf8()
             .ok()?;
 
-        let pid = match extensions.get::<Option<libc::pid_t>>().cloned().flatten() {
+        let pid = match extensions.get::<Option<libc::pid_t>>().copied().flatten() {
             Some(pid) => pid,
             None => return None,
         };

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.59"
+channel = "1.60"


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since iotedge/edgelet is a binary package, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- Change from `cloned()` to `copied()` since we can and to work around ICE: rust-lang/rust-clippy#8662

[^0]: https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes-11
  Namely, the point on `mem::uninitialized`.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [x] local testing done.  