### PR TITLE
Add "Warnings" section to doc/devguide.md

### DIFF
--- a/doc/devguide.md
+++ b/doc/devguide.md
@@ -5,6 +5,10 @@ The C# development setup is described below. The Rust development setup is descr
 
 If you want to run tests outside of the pipelines, you will need to be running linux.
 
+## Warnings
+
+- If you have upgraded the most recent API version and have backported to 1.2, make sure PR for main is merged before the PR to 1.2. This is because the pipelines for main rely on images built from 1.2.
+
 ## Setup
 
 Make sure the following dependencies are installed in your environment before you build IoT Edge code:
@@ -68,7 +72,6 @@ The syntax of the "filter" argument is described [here](https://docs.microsoft.c
 
 The end-to-end tests are documented [here](../test/README.md).
 
-
 ## Running Code Coverage Checks for Unit Tests Locally (Windows Only)
 
 Currently, Code Coverage Local Checks are supported only in a Windows Environment due to dependency on Microsoft Code Coverage Tools
@@ -92,8 +95,6 @@ dotnet-coverageconverter --CoverageFilesFolder TestResults
 dotnet tool install -g dotnet-reportgenerator-globaltool
 reportgenerator "-reports:TestResults\*\*.coveragexml" "-targetdir:report"
 ```
-
-
 
 ## Build Edge Hub Container Locally
 

--- a/doc/devguide.md
+++ b/doc/devguide.md
@@ -7,7 +7,7 @@ If you want to run tests outside of the pipelines, you will need to be running l
 
 ## Warnings
 
-- If you have upgraded the most recent API version and have backported to 1.2, make sure PR for main is merged before the PR to 1.2. This is because the pipelines for main rely on images built from 1.2.
+- If you have upgraded the most recent API version and have backported to 1.2, make sure PR for main is merged before the PR to 1.2. This is because there are Microsoft-internal teams that use edgelet from main and images from 1.2.9.
 
 ## Setup
 


### PR DESCRIPTION
A recent PR of mine caused a pipeline break due to the backported PR being merged before the main PR. The breakage was due to the pipelines for the main branch utilizing images built from 1.2, something which I was not aware of. This PR adds a "Warnings" section to the developer guide initially starting with this note. Similar unexpected failure modes can be added as they are found by others.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  
