### PR TITLE
Fix openssl build on windows

### DIFF
--- a/edgelet/build/windows/openssl.ps1
+++ b/edgelet/build/windows/openssl.ps1
@@ -16,11 +16,16 @@ function Get-OpenSSL
     if (!((Test-Path -Path $env:HOMEDRIVE\vcpkg) -and ((Test-Path -Path $env:HOMEDRIVE\vcpkg\vcpkg.exe))))
     {
         Write-Host "Installing vcpkg from github..."
-        git clone https://github.com/Microsoft/vcpkg $env:HOMEDRIVE\vcpkg
+        git init "$env:HOMEDRIVE\vcpkg"
+        git -C "$env:HOMEDRIVE\vcpkg" remote add origin 'https://github.com/microsoft/vcpkg'
+        # pin to OpenSSL 1.1.1n
+        git -C "$env:HOMEDRIVE\vcpkg" fetch origin '3b3bd424827a1f7f4813216f6b32b6c61e386b2e'
         if ($LastExitCode)
         {
             Throw "Failed to clone vcpkg repo with exit code $LastExitCode"
         }
+        git -C "$env:HOMEDRIVE\vcpkg" reset --hard FETCH_HEAD
+
         Write-Host "Bootstrapping vcpkg..."
         & "$env:HOMEDRIVE\vcpkg\bootstrap-vcpkg.bat"
         if ($LastExitCode)
@@ -35,7 +40,6 @@ function Get-OpenSSL
         }
     }
 
-    Write-Host "Downloading strawberry perl"
     if (!(Test-Path -Path $env:HOMEDRIVE\vcpkg\Downloads))
     {
         New-Item -Type Directory "$env:HOMEDRIVE\vcpkg\Downloads" | Out-Null


### PR DESCRIPTION
When building edgelet, the HSM components need a local installation of OpenSSL to link against. In our "iotedged Checkin" pipeline (and probably elsewhere) we build OpenSSL from source using vcpkg. A couple weeks ago, vcpkg updated their OpenSSL scripts to build 3.0 instead of 1.1.1. We see build errors in our pipelines when attempting to link against OpenSSL 3.0.

This change pins the vcpkg port of openssl to a specific commit (1.1.1n). The approach is recommended [here](https://vcpkg.io/en/docs/about/faq.html#how-do-i-use-different-versions-of-a-library-on-one-machine). This allows us to continue building edgelet the way we were before. We only need to do this in `release/1.1` as our architecture is quite different in 1.2.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.