### PR TITLE
Update CRD to v1 version to support 1.22 K8s 

### DIFF
--- a/kubernetes/charts/edge-kubernetes-crd/templates/crd.yaml
+++ b/kubernetes/charts/edge-kubernetes-crd/templates/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: edgedeployments.microsoft.azure.devices.edge


### PR DESCRIPTION
Kubernetes 1.22 does not support CRD v1beta1 anymore. This PR aims to remove the deprecation. 