### PR TITLE
[release/1.2] Flatten additional properties of metrics

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/SystemInfo.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/SystemInfo.cs
@@ -10,13 +10,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
     public class SystemInfo
     {
-        public SystemInfo(string operatingSystemType, string architecture, string version, IReadOnlyDictionary<string, object> additionalProperties)
+        public SystemInfo(string operatingSystemType, string architecture, string version, IDictionary<string, object> additionalProperties)
         {
             this.OperatingSystemType = operatingSystemType;
             this.Architecture = architecture;
             this.Version = version;
-
-            this.AdditionalProperties = additionalProperties?.ToDictionary(entry => entry.Key, entry => entry.Value?.ToString());
+            this.AdditionalProperties = additionalProperties;
         }
 
         public SystemInfo(string operatingSystemType, string architecture, string version)
@@ -24,13 +23,18 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
         {
         }
 
+        // NOTE: changed to snake-case to reflect edgelet
         public string OperatingSystemType { get; }
 
         public string Architecture { get; }
 
         public string Version { get; }
 
-        public IReadOnlyDictionary<string, string> AdditionalProperties { get; }
+        // NOTE: changed to IDictionary from IReadOnlyDictionary since the
+        // latter cannot be used as extension data.  Likewise for <string,
+        // object> from <string, string>.
+        [Newtonsoft.Json.JsonExtensionData]
+        public IDictionary<string, object> AdditionalProperties { get; }
 
         public string ToQueryString()
         {
@@ -41,11 +45,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core
 
             if (this.AdditionalProperties != null)
             {
-                foreach ((string k, string v) in this.AdditionalProperties)
+                foreach ((string k, object v) in this.AdditionalProperties)
                 {
                     if (!string.IsNullOrEmpty(k))
                     {
-                        b.Append($"{UrlEncode(k)}={UrlEncode(v ?? string.Empty)};");
+                        b.Append($"{UrlEncode(k)}={UrlEncode(v?.ToString() ?? string.Empty)};");
                     }
                 }
             }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/SystemInfoTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/SystemInfoTest.cs
@@ -113,8 +113,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
             SystemInfo systemInfo = new SystemInfo("A", "B", "C", new ReadOnlyDictionary<string, object>(properties));
             Assert.Equal(
                 @"{""OperatingSystemType"":""A"",""Architecture"":""B"",""Version"":""C"",""first"":""1"",""second"":""2"",""third"":""3""}",
-                Newtonsoft.Json.JsonConvert.SerializeObject(systemInfo)
-            );
+                Newtonsoft.Json.JsonConvert.SerializeObject(systemInfo));
         }
     }
 }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/SystemInfoTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/SystemInfoTest.cs
@@ -99,5 +99,22 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Test
                 + "first+first=1%2B1;second%2Bsecond=2+2;third+third=3%2B3;",
                 new SystemInfo("A", "B", "C", new ReadOnlyDictionary<string, object>(properties)).ToQueryString());
         }
+
+        [Fact]
+        [Unit]
+        public void FlattenedSerializationTest()
+        {
+            Dictionary<string, object> properties = new Dictionary<string, object>();
+
+            properties.Add("first", "1");
+            properties.Add("second", "2");
+            properties.Add("third", "3");
+
+            SystemInfo systemInfo = new SystemInfo("A", "B", "C", new ReadOnlyDictionary<string, object>(properties));
+            Assert.Equal(
+                @"{""OperatingSystemType"":""A"",""Architecture"":""B"",""Version"":""C"",""first"":""1"",""second"":""2"",""third"":""3""}",
+                Newtonsoft.Json.JsonConvert.SerializeObject(systemInfo)
+            );
+        }
     }
 }


### PR DESCRIPTION
The recent PR for adding arbitrary device product information (#6089) changed the structure of Microsoft.Azure.Devices.Edge.Agent.Core.SystemInfo, which in turn affected the metrics sent upstream.  While it is no longer feasible with the current regime of passing through extra properties to restore the old property names verbatim, we can at least flatten the additional properties to restore the general shape of the serialized information.  There is also a new test verifying that the flattening occurs as expected.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.