### PR TITLE
Connectivity Tests: Change retry approach in C2D receiver

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/LeafDevice.cs
@@ -389,10 +389,10 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common
         }
 
         // This error detection strategy is intended for SDK clients connecting
-        // to EdgeHub encountering a variety of issues.
+        // to EdgeHub encountering a variety of issues related to dotnet 6.
         //
         // Can be removed when the below are fixed:
-        // 1 (AuthenticationException) - Sometimes tls auth error occurs because EdgeHub sends an unexpected message (work item 14057676).
+        // 1 (AuthenticationException) - Sometimes tls auth error occurs because EdgeHub sends an unexpected message (https://github.com/Azure/azure-iot-sdk-csharp/issues/2370).
         // 2 (ObjectDisposedException) - Devices SDK Issue: ObjectDisposed exception (https://github.com/Azure/azure-iot-sdk-csharp/issues/2337)
         // 3 (InvalidOperationException) - Devices SDK Issue: No authenticated context (https://github.com/Azure/azure-iot-sdk-csharp/issues/2353)
         class FailingConnectionErrorDetectionStrategy : ITransientErrorDetectionStrategy

--- a/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageReceiver.cs
+++ b/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageReceiver.cs
@@ -140,11 +140,16 @@ namespace CloudToDeviceMessageTester
         }
     }
 
+    // This error detection strategy is intended for SDK clients connecting
+    // to EdgeHub encountering auth issue related to dotnet 6.
+    //
+    // Can be removed when the below is fixed:
+    // (InvalidOperationException) - Devices SDK Issue: No authenticated context (https://github.com/Azure/azure-iot-sdk-csharp/issues/2353)
     class FailingConnectionErrorDetectionStrategy : ITransientErrorDetectionStrategy
     {
         public bool IsTransient(Exception ex)
         {
-            return ex is IotHubCommunicationException;
+            return ex is InvalidOperationException && ex.Message.Contains("This operation is only allowed using a successfully authenticated context.");
         }
     }
 }

--- a/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageReceiver.cs
+++ b/test/modules/CloudToDeviceMessageTester/CloudToDeviceMessageReceiver.cs
@@ -93,7 +93,15 @@ namespace CloudToDeviceMessageTester
                 await retryPolicy.ExecuteAsync(
                     async () =>
                 {
-                    await this.deviceClient.OpenAsync(ct);
+                    try
+                    {
+                        await this.deviceClient.OpenAsync(ct);
+                    }
+                    catch (Exception e)
+                    {
+                        this.logger.LogInformation("Device client encountered exception on connection attempt: {0}", e);
+                        throw;
+                    }
                 }, ct);
 
                 while (!ct.IsCancellationRequested)


### PR DESCRIPTION
We want to change our approach with retries for these reasons:
1. We stopped seeing IoTHubCommunicationException in the last four runs off of main, when previously this was very unstable for a long time. Did not expect this so we should remove this retry to be sure it is absolutely needed. We can add it back later (with ideally some more specific exception message catching) if needed.
2. We want to catch the known dotnet 6 SDK issues we have bugs logged for on them. I'd rather take a conservative approach here though and only catch the ones that directly affect connectivity tests for sure.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
