### PR TITLE
Make the GitHub API call creates a Draft github release page

### DIFF
--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -239,7 +239,7 @@ publish_to_github()
 
         #Create Release Page
         url="https://api.github.com/repos/Azure/azure-iotedge/releases"
-        body=$(jq -n --arg version "$VERSION" --arg body "$(cat $WDIR/content.txt)" '{tag_name: $version, name: $version, target_commitish:"main", body: $body}')
+        body=$(jq -n --arg version "$VERSION" --arg body "$(cat $WDIR/content.txt)" '{tag_name: $version, name: $version, target_commitish:"main", draft: true, body: $body}')
         sudo rm -rf $WDIR/content.txt
         
         echo "Body for Release is $body"

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -238,6 +238,8 @@ publish_to_github()
         sed -i "$ d" $WDIR/content.txt
 
         #Create Release Page
+        #  This unintentionally create a github tag associate with the latest commit which is an undesired behavior. 
+        #  We will need to update the tag to the proper commit once the /azure-iotege latest json are ready to go.
         url="https://api.github.com/repos/Azure/azure-iotedge/releases"
         body=$(jq -n --arg version "$VERSION" --arg body "$(cat $WDIR/content.txt)" '{tag_name: $version, name: $version, target_commitish:"main", draft: true, body: $body}')
         sudo rm -rf $WDIR/content.txt


### PR DESCRIPTION
Currently when we do GitHub release page to upload the artifact, we create the release page as an actual page. 
This is not a desire behavior as the release is not finalized. Hence, we are changing the step to only create a draft page.

Remark: The GitHub API has a side effect of tagging a new tag to the latest commit. That is not the commit we want as the correct commit is yet to create. There is a follow task to update the tag and publish release page from "draft" to official.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
