### PR TITLE
Remove manifest trust from base image update release pipeline

### DIFF
--- a/builds/e2e/e2e-release.yaml
+++ b/builds/e2e/e2e-release.yaml
@@ -34,8 +34,6 @@ stages:
           identityServiceArtifactName: packages_debian-9-slim_arm32v7
           identityServicePackageFilter: aziot-identity-service_*_armhf.deb
           builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
-          # skip notary installation as it is not supported for ARM platforms
-          skip_notary: true
 
         timeoutInMinutes: 120
 
@@ -68,7 +66,6 @@ stages:
           identityServiceArtifactName: packages_ubuntu-18.04_amd64
           identityServicePackageFilter: aziot-identity-service_*_amd64.deb
           builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
-          skip_notary: false
 
         steps:
         - template: templates/e2e-setup-base-image-update-release.yaml
@@ -93,7 +90,6 @@ stages:
           identityServicePackageFilter: aziot-identity-service_*_amd64.deb
           builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
           minimal: true
-          skip_notary: false
 
         steps:
         - template: templates/e2e-setup-base-image-update-release.yaml
@@ -117,7 +113,6 @@ stages:
           identityServiceArtifactName: packages_ubuntu-20.04_amd64
           identityServicePackageFilter: aziot-identity-service_*_amd64.deb
           builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
-          skip_notary: false
 
         steps:
         - template: templates/e2e-setup-base-image-update-release.yaml
@@ -141,7 +136,6 @@ stages:
           identityServicePackageFilter: aziot-identity-service_*_amd64.deb
           builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
           minimal: true
-          skip_notary: false
 
         steps:
         - template: templates/e2e-setup-base-image-update-release.yaml
@@ -163,8 +157,6 @@ stages:
           identityServiceArtifactName: packages_ubuntu-20.04_aarch64
           identityServicePackageFilter: aziot-identity-service_*_arm64.deb
           builtImages: $[ stageDependencies.PublishManifests.PublishManifest.result ]
-          # skip notary installation as it is not supported for ARM platforms
-          skip_notary: true
 
         timeoutInMinutes: 120
 

--- a/builds/e2e/templates/e2e-run-base-image-update.yaml
+++ b/builds/e2e/templates/e2e-run-base-image-update.yaml
@@ -60,7 +60,7 @@ steps:
     elseif ($test_type -eq 'http_proxy')
     {
       #Disable tests that don't work in proxy environment. Renable post-investigation.
-      $filter += '&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~ValidateMetrics&FullyQualifiedName!~contenttrust'
+      $filter += '&FullyQualifiedName!~PlugAndPlay&FullyQualifiedName!~ValidateMetrics'
       #Disable nested edge tests
       $filter += '&Category!=NestedEdgeOnly'
     }
@@ -85,7 +85,6 @@ steps:
     E2E_EVENT_HUB_ENDPOINT: ${{ parameters['EventHubCompatibleEndpoint'] }}
     E2E_IOT_HUB_CONNECTION_STRING: ${{ parameters['IotHubConnectionString'] }}
     E2E_REGISTRIES__0__PASSWORD: $(ReleaseContainerRegistryPassword)
-    E2E_REGISTRIES__1__PASSWORD: $(TestContentTrustRegistryPassword)
     E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
     E2E_BLOB_STORE_SAS: $(TestBlobStoreSas)
     no_proxy: 'localhost'

--- a/builds/e2e/templates/e2e-setup-base-image-update-release.yaml
+++ b/builds/e2e/templates/e2e-setup-base-image-update-release.yaml
@@ -20,23 +20,7 @@ steps:
         TestRootCaCertificate,
         TestRootCaKey,
         TestRootCaPassword,
-        TestBlobStoreSas,
-        TestManifestSigningGoodRootCa,
-        TestManifestSigningIntermediateCa,
-        TestManifestSigningSignerCert,
-        TestManifestSigningSignerKey,
-        TestManifestSigningBadRootCa,
-        TestContentTrustRootCa,
-        TestContentTrustRegistryPassword
-
-  - bash: |
-      wget https://github.com/theupdateframework/notary/releases/download/v0.6.0/notary-Linux-amd64
-      chmod +x notary-Linux-amd64
-      sudo mv notary-Linux-amd64 /usr/bin/notary
-      ls -l /usr/bin
-    name: install_notary_for_content_trust
-    displayName: Install Notary for Content Trust
-    condition: eq(variables['skip_notary'], 'false')
+        TestBlobStoreSas
 
   - pwsh: |
       $certsDir = '$(System.ArtifactsDirectory)/certs'
@@ -59,39 +43,6 @@ steps:
       http_proxy: $(Agent.ProxyUrl)
       https_proxy: $(Agent.ProxyUrl)
     displayName: Build tests
-    
-  - pwsh: |
-      $manifestSignerClientDir = '$(Build.SourcesDirectory)/samples/dotnet/ManifestSignerClient'
-      dotnet build -c $(Build.Configuration) $manifestSignerClientDir
-      $manifestSignerClientBinDir = Convert-Path "$manifestSignerClientDir/bin/$(Build.Configuration)/net6.0"
-      Write-Output "##vso[task.setvariable variable=manifestSignerClientDir]$manifestSignerClientDir"
-      Write-Output "##vso[task.setvariable variable=manifestSignerClientBinDir]$manifestSignerClientBinDir"
-      $manifestSigningTestDir = '$(System.ArtifactsDirectory)/manifest_signing'
-      $manifestSigningDeploymentDir = '$(System.ArtifactsDirectory)/manifest_signing/deployment'
-      Write-Output "##vso[task.setvariable variable=manifestSigningDeploymentDir]$manifestSigningDeploymentDir"
-      $manifestSigningCertDir = '$(System.ArtifactsDirectory)/manifest_signing/certs'
-      $contentTrustCertDir = '$(System.ArtifactsDirectory)/content_trust/certs'
-      New-Item "$manifestSigningCertDir" -ItemType Directory -Force | Out-Null
-      New-Item "$contentTrustCertDir" -ItemType Directory -Force | Out-Null
-      New-Item "$manifestSigningDeploymentDir" -ItemType Directory -Force | Out-Null
-      New-Item -Path "$manifestSigningDeploymentDir/deployment.json" -ItemType File
-      New-Item -Path "$manifestSigningDeploymentDir/signed_deployment.json" -ItemType File
-      $env:GOOD_ROOT_CA_CERT | Out-File -Encoding Utf8 "$manifestSigningCertDir/good_root_ca.pem"
-      $env:BAD_ROOT_CA_CERT | Out-File -Encoding Utf8 "$manifestSigningCertDir/bad_root_ca.pem"
-      $env:INTERMEDIATE_CA_CERT | Out-File -Encoding Utf8 "$manifestSigningCertDir/intermediate_ca.pem"
-      $env:SIGNER_CERT | Out-File -Encoding Utf8 "$manifestSigningCertDir/signer_cert.pem"
-      $env:SIGNER_KEY | Out-File -Encoding Utf8 "$manifestSigningCertDir/signer_key.key"
-      $env:CONTENT_TRUST_ROOT_CA_CERT | Out-File -Encoding Utf8 "$contentTrustCertDir/content_trust_root_ca.pem"
-      Write-Output "##vso[task.setvariable variable=manifestSigningCertDir]$manifestSigningCertDir"
-      Write-Output "##vso[task.setvariable variable=contentTrustCertDir]$contentTrustCertDir"
-    displayName: Manifest Trust Setup
-    env:
-      GOOD_ROOT_CA_CERT: $(TestManifestSigningGoodRootCa)
-      BAD_ROOT_CA_CERT: $(TestManifestSigningBadRootCa)
-      INTERMEDIATE_CA_CERT: $(TestManifestSigningIntermediateCa)
-      SIGNER_CERT: $(TestManifestSigningSignerCert)
-      SIGNER_KEY: $(TestManifestSigningSignerKey)
-      CONTENT_TRUST_ROOT_CA_CERT : $(TestContentTrustRootCa)
   
   - pwsh: |
       if ('$(nestededge)' -eq 'true')
@@ -112,39 +63,6 @@ steps:
         $rootCaPrivateKeyPath = Convert-Path '$(certsDir)/rsa_root_ca.key.pem';
       }
 
-      $testManifestSigningGoodRootCaPath = Convert-Path "$(manifestSigningCertDir)/good_root_ca.pem";
-      $testManifestSigningBadRootCaPath = Convert-Path "$(manifestSigningCertDir)/bad_root_ca.pem";
-      $testManifestSigningIntermediateCaPath = Convert-Path "$(manifestSigningCertDir)/intermediate_ca.pem";
-      $testManifestSigningSignerCertPath = Convert-Path "$(manifestSigningCertDir)/signer_cert.pem";
-      $testManifestSigningSignerKeyPath = Convert-Path "$(manifestSigningCertDir)/signer_key.key";
-      $testManifestSigningDeploymentPath = Convert-Path "$(manifestSigningDeploymentDir)/deployment.json";
-      $testManifestSigningSignedDeploymentPath = Convert-Path "$(manifestSigningDeploymentDir)/signed_deployment.json";
-      $testManifestSignerClientDirectory = Convert-Path "$(manifestSignerClientDir)";
-      $testManifestSignerClientProjectPath = Convert-Path "$(manifestSignerClientDir)/ManifestSignerClient.csproj";
-      $testManifestSigningLaunchSettingsPath = Convert-Path "$(manifestSignerClientDir)/Properties/launchSettings.json";
-      $testContentTrustRootCaPath = Convert-Path "$(contentTrustCertDir)/content_trust_root_ca.pem";
-
-      $testManifestSigningDefaultLaunchSettings = @{
-        profiles = @{
-          ManifestSignerClient = @{
-            commandName = "Project";
-            environmentVariables = @{  
-              USE_TESTING_CA = "true";
-              DEPLOYMENT_MANIFEST_FILE_PATH = "$testManifestSigningDeploymentPath";
-              SIGNED_DEPLOYMENT_MANIFEST_FILE_PATH = "$testManifestSigningSignedDeploymentPath";
-              MANIFEST_TRUST_INTERMEDIATE_CA_PATH = "$testManifestSigningIntermediateCaPath";
-              MANIFEST_TRUST_SIGNER_PRIVATE_KEY_PATH = "$testManifestSigningSignerKeyPath";
-              MANIFEST_TRUST_SIGNER_CERT_PATH = "$testManifestSigningSignerCertPath";
-              DSA_ALGORITHM = "ES256";
-            }
-          }
-        }
-      };
-
-      $testManifestSigningDefaultLaunchSettings = $testManifestSigningDefaultLaunchSettings | ConvertTo-Json -Depth 3 
-      $testManifestSigningDefaultLaunchSettings | Out-File -Encoding Utf8 "$testManifestSigningLaunchSettingsPath"
-      Get-Content -Path "$testManifestSigningLaunchSettingsPath"
-      
       $versionInfo = "$(version)-$(os)-$(arch)"
       $edgeAgentImage = "$imagePrefix-agent:$versionInfo";
       $edgeHubImage = "$imagePrefix-hub:$versionInfo";
@@ -177,10 +95,6 @@ steps:
             address = '$(registry.address)';
             username = '$(registry.username)';
           },
-          @{
-            address = '$(contenttrust.address)';
-            username = '$(contenttrust.username)';
-          }
         );
         caCertScriptPath = "$caCertScriptPath";
         rootCaCertificatePath = "$rootCaCertificatePath";
@@ -188,18 +102,6 @@ steps:
         logFile = Join-Path '$(binDir)' 'testoutput.log';
         verbose = '$(verbose)';
         getSupportBundle = 'true';
-        manifestSigningDeploymentPath = "$testManifestSigningDeploymentPath";
-        manifestSigningSignedDeploymentPath = "$testManifestSigningSignedDeploymentPath";
-        manifestSigningGoodRootCaPath = "$testManifestSigningGoodRootCaPath";
-        manifestSigningBadRootCaPath = "$testManifestSigningBadRootCaPath";
-        manifestSigningDefaultLaunchSettings = "$testManifestSigningDefaultLaunchSettings";
-        manifestSigningLaunchSettingsPath = "$testManifestSigningLaunchSettingsPath";
-        manifestSignerClientDirectory = "$testManifestSignerClientDirectory";
-        manifestSignerClientProjectPath = "$testManifestSignerClientProjectPath";
-        contentTrustRootCaPath = "$testContentTrustRootCaPath";
-        contentTrustRegistryName = "${env:CONTENTTRUST_ADDRESS}";
-        contentTrustSignedImage = "${env:CONTENTTRUST_SIGNEDIMAGE}";
-        contentTrustUnsignedImage = "${env:CONTENTTRUST_UNSIGNEDIMAGE}";
       }
   
       if ('$(nestededge)' -eq 'true')

--- a/builds/e2e/templates/e2e-setup-base-image-update-release.yaml
+++ b/builds/e2e/templates/e2e-setup-base-image-update-release.yaml
@@ -94,7 +94,7 @@ steps:
           @{
             address = '$(registry.address)';
             username = '$(registry.username)';
-          },
+          }
         );
         caCertScriptPath = "$caCertScriptPath";
         rootCaCertificatePath = "$rootCaCertificatePath";


### PR DESCRIPTION
This PR removes the Manifest trust feature from the Base image update release pipeline.

- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).