### PR TITLE
Github Release Page and Tagging Automation for /azure-iotedge

### DIFF
--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1011,7 +1011,7 @@ stages:
                 source $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
                 VERSION=$BASE_VERSION
                 # BEARWASHERE -- Disabled for testing
-                # github_update_and_push
+                github_update_and_push
               env:
                 GITHUB_PAT: "$(GitHubAccessToken)"
                 AZURE_IOTEDGE_REPO_PATH: "$(Build.SourcesDirectory)/azure-iotedge"

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1001,7 +1001,7 @@ stages:
 
                 #Create Release Page Before Publishing Artifacts in Parallel in the Next Job.
                 echo "Creating Release Page"
-                BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+                BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/iotedge/edgelet/version.txt`
                 # BEARWASHERE -- Testing
                 sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh 
                 $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh -p ubuntu20.04 -w $(Build.SourcesDirectory)/iotedge -d $(Build.SourcesDirectory)/iotedge -v "$BASE_VERSION" -s "github.com" -b  $(Build.SourceBranch) --skip-upload true

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1097,6 +1097,7 @@ stages:
             keyVaultName: $(kv.name)
             secretsFilter: >-
               GitHubAccessToken
+        - checkout: self
         - task: DownloadPipelineArtifact@2
           displayName: Download Pipeline Build Packages
           inputs:

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1077,9 +1077,10 @@ stages:
             os: ubuntu20.04
             artifactName: iotedged-ubuntu20.04-aarch64
 
-          Windows-amd64:
-            os: windows
-            artifactName: iotedged-windows-amd64
+          # BEARWASHERE -- Testing
+          # Windows-amd64:
+          #   os: windows
+          #   artifactName: iotedged-windows-amd64
 
       steps:
         - task: AzureKeyVault@1

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -817,157 +817,157 @@ stages:
         inputs:
           PathtoPublish: $(build.artifactstagingdirectory)
           ArtifactName: iotedged-debian11-aarch64
-    - job: Phase_3
-      displayName: Windows Amd64
-      cancelTimeoutInMinutes: 1
-      pool:
-        name: Azure-IoT-Edge-1ES-Hosted-Windows
-        demands:
-        - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
-      steps:
-      - checkout: self
-        submodules: recursive
-      - task: PowerShell@1
-        displayName: Install Rust
-        inputs:
-          scriptName: edgelet/build/windows/install.ps1
-          failOnStandardError: false
-      - task: PowerShell@1
-        displayName: Build
-        inputs:
-          scriptName: edgelet/build/windows/build.ps1
-          arguments: -Release
-          failOnStandardError: false
-      - task: CMake@1
-        displayName: Setup libiothsm
-        inputs:
-          cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
-          cmakeArgs: -G "Visual Studio 15 2017 Win64" -DBUILD_SHARED=ON -Duse_emulator=OFF ..
-      - task: CMake@1
-        displayName: Build libiothsm
-        inputs:
-          cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
-          cmakeArgs: --build . --config Release
-      - task: PowerShell@2
-        displayName: Override package version
-        inputs:
-          targetType: inline
-          script: >-
-            # Override the package version from WIN_PACKAGE_VERSION
+    # - job: Phase_3
+    #   displayName: Windows Amd64
+    #   cancelTimeoutInMinutes: 1
+    #   pool:
+    #     name: Azure-IoT-Edge-1ES-Hosted-Windows
+    #     demands:
+    #     - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
+    #   steps:
+    #   - checkout: self
+    #     submodules: recursive
+    #   - task: PowerShell@1
+    #     displayName: Install Rust
+    #     inputs:
+    #       scriptName: edgelet/build/windows/install.ps1
+    #       failOnStandardError: false
+    #   - task: PowerShell@1
+    #     displayName: Build
+    #     inputs:
+    #       scriptName: edgelet/build/windows/build.ps1
+    #       arguments: -Release
+    #       failOnStandardError: false
+    #   - task: CMake@1
+    #     displayName: Setup libiothsm
+    #     inputs:
+    #       cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
+    #       cmakeArgs: -G "Visual Studio 15 2017 Win64" -DBUILD_SHARED=ON -Duse_emulator=OFF ..
+    #   - task: CMake@1
+    #     displayName: Build libiothsm
+    #     inputs:
+    #       cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
+    #       cmakeArgs: --build . --config Release
+    #   - task: PowerShell@2
+    #     displayName: Override package version
+    #     inputs:
+    #       targetType: inline
+    #       script: >-
+    #         # Override the package version from WIN_PACKAGE_VERSION
 
-            # This is required because the cab file needs a different version than the global version number to support pre-releases
-
-
-            Write-Host "##vso[task.setvariable variable=VERSION]$(WIN_PACKAGE_VERSION)"
-      - task: EsrpCodeSigning@1
-        displayName: ESRP Binary CodeSigning
-        inputs:
-          ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
-          FolderPath: $(Build.SourcesDirectory)
-          Pattern: edgelet/hsm-sys/azure-iot-hsm-c/build/Release/iothsm.dll,edgelet/target/release/*.exe
-          CertificateId: 400
-          OpusName: Azure IoT Edge
-          OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
-          SessionTimeout: 20
-      - task: PowerShell@2
-        displayName: Prepare package template
-        inputs:
-          filePath: edgelet/build/windows/package.ps1
-          arguments: -CreateTemplate
-          script: >-
-            # Write your powershell commands here.
+    #         # This is required because the cab file needs a different version than the global version number to support pre-releases
 
 
-            Write-Host "Hello World"
+    #         Write-Host "##vso[task.setvariable variable=VERSION]$(WIN_PACKAGE_VERSION)"
+    #   - task: EsrpCodeSigning@1
+    #     displayName: ESRP Binary CodeSigning
+    #     inputs:
+    #       ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
+    #       FolderPath: $(Build.SourcesDirectory)
+    #       Pattern: edgelet/hsm-sys/azure-iot-hsm-c/build/Release/iothsm.dll,edgelet/target/release/*.exe
+    #       CertificateId: 400
+    #       OpusName: Azure IoT Edge
+    #       OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
+    #       SessionTimeout: 20
+    #   - task: PowerShell@2
+    #     displayName: Prepare package template
+    #     inputs:
+    #       filePath: edgelet/build/windows/package.ps1
+    #       arguments: -CreateTemplate
+    #       script: >-
+    #         # Write your powershell commands here.
 
 
-            # Use the environment variables input below to pass secret variables to this script.
-      - task: EsrpCodeSigning@1
-        displayName: ESRP Package Catalog and Setup Script CodeSigning
-        inputs:
-          ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
-          FolderPath: $(Build.SourcesDirectory)
-          Pattern: Package-Template/update.cat,scripts/windows/setup/IotEdgeSecurityDaemon.ps1
-          signConfigType: inlineSignParams
-          CertificateId: 401
-          OpusName: Azure IoT Edge
-          OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
-          inlineOperation: >-
-            [
-              {
-                "keyCode": "CP-229879",
-                "operationSetCode": "SigntoolSign",
-                "parameters": [
-                  {
-                    "parameterName": "OpusName",
-                    "parameterValue": "Microsoft Windows"
-                  },
-                  {
-                    "parameterName": "OpusInfo",
-                    "parameterValue": "http://www.microsoft.com/windows"
-                  },
-                  {
-                    "parameterName": "PageHash",
-                    "parameterValue": "/NPH"
-                  },
-                  {
-                    "parameterName": "FileDigest",
-                    "parameterValue": "/fd sha256"
-                  },
-                  {
-                    "parameterName": "TimeStamp",
-                    "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                  }
-                ],
-                "toolName": "signtool.exe",
-                "toolVersion": "6.2.9304.0"
-              }
-            ]
-          SessionTimeout: 20
-      - task: PowerShell@2
-        displayName: Generate CAB package
-        inputs:
-          filePath: edgelet/build/windows/package.ps1
-          arguments: -CreateCab
-          script: >-
-            # Write your powershell commands here.
+    #         Write-Host "Hello World"
 
 
-            Write-Host "Hello World"
+    #         # Use the environment variables input below to pass secret variables to this script.
+    #   - task: EsrpCodeSigning@1
+    #     displayName: ESRP Package Catalog and Setup Script CodeSigning
+    #     inputs:
+    #       ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
+    #       FolderPath: $(Build.SourcesDirectory)
+    #       Pattern: Package-Template/update.cat,scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+    #       signConfigType: inlineSignParams
+    #       CertificateId: 401
+    #       OpusName: Azure IoT Edge
+    #       OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
+    #       inlineOperation: >-
+    #         [
+    #           {
+    #             "keyCode": "CP-229879",
+    #             "operationSetCode": "SigntoolSign",
+    #             "parameters": [
+    #               {
+    #                 "parameterName": "OpusName",
+    #                 "parameterValue": "Microsoft Windows"
+    #               },
+    #               {
+    #                 "parameterName": "OpusInfo",
+    #                 "parameterValue": "http://www.microsoft.com/windows"
+    #               },
+    #               {
+    #                 "parameterName": "PageHash",
+    #                 "parameterValue": "/NPH"
+    #               },
+    #               {
+    #                 "parameterName": "FileDigest",
+    #                 "parameterValue": "/fd sha256"
+    #               },
+    #               {
+    #                 "parameterName": "TimeStamp",
+    #                 "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+    #               }
+    #             ],
+    #             "toolName": "signtool.exe",
+    #             "toolVersion": "6.2.9304.0"
+    #           }
+    #         ]
+    #       SessionTimeout: 20
+    #   - task: PowerShell@2
+    #     displayName: Generate CAB package
+    #     inputs:
+    #       filePath: edgelet/build/windows/package.ps1
+    #       arguments: -CreateCab
+    #       script: >-
+    #         # Write your powershell commands here.
 
 
-            # Use the environment variables input below to pass secret variables to this script.
-      - task: CopyFiles@2
-        displayName: Copy Package Artifact Staging
-        inputs:
-          SourceFolder: .
-          Contents: '*.cab'
-          TargetFolder: $(build.artifactstagingdirectory)
-      - task: CopyFiles@2
-        displayName: Copy Setup Script to Artifact Staging
-        inputs:
-          SourceFolder: scripts\windows\setup
-          Contents: IotEdgeSecurityDaemon.ps1
-          TargetFolder: $(build.artifactstagingdirectory)
-      - task: EsrpCodeSigning@1
-        displayName: ESRP Package CodeSigning
-        inputs:
-          ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
-          FolderPath: $(build.artifactstagingdirectory)
-          Pattern: '*.cab'
-          CertificateId: 400
-          OpusName: Azure IoT Edge
-          OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
-          SessionTimeout: 20
-      - task: ManifestGeneratorTask@0
-        displayName: SBOM Generation Task
-        inputs:
-          BuildDropPath: $(build.artifactstagingdirectory)
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifact: iotedged-windows-amd64'
-        inputs:
-          PathtoPublish: $(build.artifactstagingdirectory)
-          ArtifactName: iotedged-windows-amd64
+    #         Write-Host "Hello World"
+
+
+    #         # Use the environment variables input below to pass secret variables to this script.
+    #   - task: CopyFiles@2
+    #     displayName: Copy Package Artifact Staging
+    #     inputs:
+    #       SourceFolder: .
+    #       Contents: '*.cab'
+    #       TargetFolder: $(build.artifactstagingdirectory)
+    #   - task: CopyFiles@2
+    #     displayName: Copy Setup Script to Artifact Staging
+    #     inputs:
+    #       SourceFolder: scripts\windows\setup
+    #       Contents: IotEdgeSecurityDaemon.ps1
+    #       TargetFolder: $(build.artifactstagingdirectory)
+    #   - task: EsrpCodeSigning@1
+    #     displayName: ESRP Package CodeSigning
+    #     inputs:
+    #       ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
+    #       FolderPath: $(build.artifactstagingdirectory)
+    #       Pattern: '*.cab'
+    #       CertificateId: 400
+    #       OpusName: Azure IoT Edge
+    #       OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
+    #       SessionTimeout: 20
+    #   - task: ManifestGeneratorTask@0
+    #     displayName: SBOM Generation Task
+    #     inputs:
+    #       BuildDropPath: $(build.artifactstagingdirectory)
+    #   - task: PublishBuildArtifacts@1
+    #     displayName: 'Publish Artifact: iotedged-windows-amd64'
+    #     inputs:
+    #       PathtoPublish: $(build.artifactstagingdirectory)
+    #       ArtifactName: iotedged-windows-amd64
 
   ##############################################################################
   - stage: PublishPackagesGithub

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1098,7 +1098,6 @@ stages:
             keyVaultName: $(kv.name)
             secretsFilter: >-
               GitHubAccessToken
-        - checkout: self
         - task: DownloadPipelineArtifact@2
           displayName: Download Pipeline Build Packages
           inputs:
@@ -1111,8 +1110,8 @@ stages:
                 $(artifactName)/*.cab
         - bash: |
             BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
-            sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh
-            $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh -p $(os) -w $(System.ArtifactsDirectory) -d $(System.ArtifactsDirectory)/$(artifactName) -v "$BASE_VERSION" -s "github.com" -b $(Build.SourceBranch)
+            sudo chmod +x $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh
+            $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh -p $(os) -w $(System.ArtifactsDirectory) -d $(System.ArtifactsDirectory)/$(artifactName) -v "$BASE_VERSION" -s "github.com" -b $(Build.SourceBranch)
           env:
             GITHUB_PAT: "$(GitHubAccessToken)"    
           name: publish_artifacts 

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -993,6 +993,9 @@ stages:
                 #Create Release Page Before Publishing Artifacts in Parallel in the Next Job.
                 echo "Creating Release Page"
                 BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+                # BEARWASHERE -- 
+                #  1. Checkout other repos with a corresponding version
+                #  2. Update "$(Build.SourcesDirectory)" to be "$(Build.SourcesDirectory)/iotedge"
                 sudo chmod +x $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh 
                 $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh -p ubuntu20.04 -w $(Build.SourcesDirectory) -d $(Build.SourcesDirectory) -v "$BASE_VERSION" -s "github.com" -b  $(Build.SourceBranch) --skip-upload true
               env:

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -817,157 +817,157 @@ stages:
         inputs:
           PathtoPublish: $(build.artifactstagingdirectory)
           ArtifactName: iotedged-debian11-aarch64
-    # - job: Phase_3
-    #   displayName: Windows Amd64
-    #   cancelTimeoutInMinutes: 1
-    #   pool:
-    #     name: Azure-IoT-Edge-1ES-Hosted-Windows
-    #     demands:
-    #     - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
-    #   steps:
-    #   - checkout: self
-    #     submodules: recursive
-    #   - task: PowerShell@1
-    #     displayName: Install Rust
-    #     inputs:
-    #       scriptName: edgelet/build/windows/install.ps1
-    #       failOnStandardError: false
-    #   - task: PowerShell@1
-    #     displayName: Build
-    #     inputs:
-    #       scriptName: edgelet/build/windows/build.ps1
-    #       arguments: -Release
-    #       failOnStandardError: false
-    #   - task: CMake@1
-    #     displayName: Setup libiothsm
-    #     inputs:
-    #       cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
-    #       cmakeArgs: -G "Visual Studio 15 2017 Win64" -DBUILD_SHARED=ON -Duse_emulator=OFF ..
-    #   - task: CMake@1
-    #     displayName: Build libiothsm
-    #     inputs:
-    #       cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
-    #       cmakeArgs: --build . --config Release
-    #   - task: PowerShell@2
-    #     displayName: Override package version
-    #     inputs:
-    #       targetType: inline
-    #       script: >-
-    #         # Override the package version from WIN_PACKAGE_VERSION
+    - job: Phase_3
+      displayName: Windows Amd64
+      cancelTimeoutInMinutes: 1
+      pool:
+        name: Azure-IoT-Edge-1ES-Hosted-Windows
+        demands:
+        - ImageOverride -equals agent-aziotedge-winserver-2019dc-build
+      steps:
+      - checkout: self
+        submodules: recursive
+      - task: PowerShell@1
+        displayName: Install Rust
+        inputs:
+          scriptName: edgelet/build/windows/install.ps1
+          failOnStandardError: false
+      - task: PowerShell@1
+        displayName: Build
+        inputs:
+          scriptName: edgelet/build/windows/build.ps1
+          arguments: -Release
+          failOnStandardError: false
+      - task: CMake@1
+        displayName: Setup libiothsm
+        inputs:
+          cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
+          cmakeArgs: -G "Visual Studio 15 2017 Win64" -DBUILD_SHARED=ON -Duse_emulator=OFF ..
+      - task: CMake@1
+        displayName: Build libiothsm
+        inputs:
+          cwd: edgelet/hsm-sys/azure-iot-hsm-c/build
+          cmakeArgs: --build . --config Release
+      - task: PowerShell@2
+        displayName: Override package version
+        inputs:
+          targetType: inline
+          script: >-
+            # Override the package version from WIN_PACKAGE_VERSION
 
-    #         # This is required because the cab file needs a different version than the global version number to support pre-releases
-
-
-    #         Write-Host "##vso[task.setvariable variable=VERSION]$(WIN_PACKAGE_VERSION)"
-    #   - task: EsrpCodeSigning@1
-    #     displayName: ESRP Binary CodeSigning
-    #     inputs:
-    #       ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
-    #       FolderPath: $(Build.SourcesDirectory)
-    #       Pattern: edgelet/hsm-sys/azure-iot-hsm-c/build/Release/iothsm.dll,edgelet/target/release/*.exe
-    #       CertificateId: 400
-    #       OpusName: Azure IoT Edge
-    #       OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
-    #       SessionTimeout: 20
-    #   - task: PowerShell@2
-    #     displayName: Prepare package template
-    #     inputs:
-    #       filePath: edgelet/build/windows/package.ps1
-    #       arguments: -CreateTemplate
-    #       script: >-
-    #         # Write your powershell commands here.
+            # This is required because the cab file needs a different version than the global version number to support pre-releases
 
 
-    #         Write-Host "Hello World"
+            Write-Host "##vso[task.setvariable variable=VERSION]$(WIN_PACKAGE_VERSION)"
+      - task: EsrpCodeSigning@1
+        displayName: ESRP Binary CodeSigning
+        inputs:
+          ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
+          FolderPath: $(Build.SourcesDirectory)
+          Pattern: edgelet/hsm-sys/azure-iot-hsm-c/build/Release/iothsm.dll,edgelet/target/release/*.exe
+          CertificateId: 400
+          OpusName: Azure IoT Edge
+          OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
+          SessionTimeout: 20
+      - task: PowerShell@2
+        displayName: Prepare package template
+        inputs:
+          filePath: edgelet/build/windows/package.ps1
+          arguments: -CreateTemplate
+          script: >-
+            # Write your powershell commands here.
 
 
-    #         # Use the environment variables input below to pass secret variables to this script.
-    #   - task: EsrpCodeSigning@1
-    #     displayName: ESRP Package Catalog and Setup Script CodeSigning
-    #     inputs:
-    #       ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
-    #       FolderPath: $(Build.SourcesDirectory)
-    #       Pattern: Package-Template/update.cat,scripts/windows/setup/IotEdgeSecurityDaemon.ps1
-    #       signConfigType: inlineSignParams
-    #       CertificateId: 401
-    #       OpusName: Azure IoT Edge
-    #       OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
-    #       inlineOperation: >-
-    #         [
-    #           {
-    #             "keyCode": "CP-229879",
-    #             "operationSetCode": "SigntoolSign",
-    #             "parameters": [
-    #               {
-    #                 "parameterName": "OpusName",
-    #                 "parameterValue": "Microsoft Windows"
-    #               },
-    #               {
-    #                 "parameterName": "OpusInfo",
-    #                 "parameterValue": "http://www.microsoft.com/windows"
-    #               },
-    #               {
-    #                 "parameterName": "PageHash",
-    #                 "parameterValue": "/NPH"
-    #               },
-    #               {
-    #                 "parameterName": "FileDigest",
-    #                 "parameterValue": "/fd sha256"
-    #               },
-    #               {
-    #                 "parameterName": "TimeStamp",
-    #                 "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-    #               }
-    #             ],
-    #             "toolName": "signtool.exe",
-    #             "toolVersion": "6.2.9304.0"
-    #           }
-    #         ]
-    #       SessionTimeout: 20
-    #   - task: PowerShell@2
-    #     displayName: Generate CAB package
-    #     inputs:
-    #       filePath: edgelet/build/windows/package.ps1
-    #       arguments: -CreateCab
-    #       script: >-
-    #         # Write your powershell commands here.
+            Write-Host "Hello World"
 
 
-    #         Write-Host "Hello World"
+            # Use the environment variables input below to pass secret variables to this script.
+      - task: EsrpCodeSigning@1
+        displayName: ESRP Package Catalog and Setup Script CodeSigning
+        inputs:
+          ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
+          FolderPath: $(Build.SourcesDirectory)
+          Pattern: Package-Template/update.cat,scripts/windows/setup/IotEdgeSecurityDaemon.ps1
+          signConfigType: inlineSignParams
+          CertificateId: 401
+          OpusName: Azure IoT Edge
+          OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
+          inlineOperation: >-
+            [
+              {
+                "keyCode": "CP-229879",
+                "operationSetCode": "SigntoolSign",
+                "parameters": [
+                  {
+                    "parameterName": "OpusName",
+                    "parameterValue": "Microsoft Windows"
+                  },
+                  {
+                    "parameterName": "OpusInfo",
+                    "parameterValue": "http://www.microsoft.com/windows"
+                  },
+                  {
+                    "parameterName": "PageHash",
+                    "parameterValue": "/NPH"
+                  },
+                  {
+                    "parameterName": "FileDigest",
+                    "parameterValue": "/fd sha256"
+                  },
+                  {
+                    "parameterName": "TimeStamp",
+                    "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                  }
+                ],
+                "toolName": "signtool.exe",
+                "toolVersion": "6.2.9304.0"
+              }
+            ]
+          SessionTimeout: 20
+      - task: PowerShell@2
+        displayName: Generate CAB package
+        inputs:
+          filePath: edgelet/build/windows/package.ps1
+          arguments: -CreateCab
+          script: >-
+            # Write your powershell commands here.
 
 
-    #         # Use the environment variables input below to pass secret variables to this script.
-    #   - task: CopyFiles@2
-    #     displayName: Copy Package Artifact Staging
-    #     inputs:
-    #       SourceFolder: .
-    #       Contents: '*.cab'
-    #       TargetFolder: $(build.artifactstagingdirectory)
-    #   - task: CopyFiles@2
-    #     displayName: Copy Setup Script to Artifact Staging
-    #     inputs:
-    #       SourceFolder: scripts\windows\setup
-    #       Contents: IotEdgeSecurityDaemon.ps1
-    #       TargetFolder: $(build.artifactstagingdirectory)
-    #   - task: EsrpCodeSigning@1
-    #     displayName: ESRP Package CodeSigning
-    #     inputs:
-    #       ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
-    #       FolderPath: $(build.artifactstagingdirectory)
-    #       Pattern: '*.cab'
-    #       CertificateId: 400
-    #       OpusName: Azure IoT Edge
-    #       OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
-    #       SessionTimeout: 20
-    #   - task: ManifestGeneratorTask@0
-    #     displayName: SBOM Generation Task
-    #     inputs:
-    #       BuildDropPath: $(build.artifactstagingdirectory)
-    #   - task: PublishBuildArtifacts@1
-    #     displayName: 'Publish Artifact: iotedged-windows-amd64'
-    #     inputs:
-    #       PathtoPublish: $(build.artifactstagingdirectory)
-    #       ArtifactName: iotedged-windows-amd64
+            Write-Host "Hello World"
+
+
+            # Use the environment variables input below to pass secret variables to this script.
+      - task: CopyFiles@2
+        displayName: Copy Package Artifact Staging
+        inputs:
+          SourceFolder: .
+          Contents: '*.cab'
+          TargetFolder: $(build.artifactstagingdirectory)
+      - task: CopyFiles@2
+        displayName: Copy Setup Script to Artifact Staging
+        inputs:
+          SourceFolder: scripts\windows\setup
+          Contents: IotEdgeSecurityDaemon.ps1
+          TargetFolder: $(build.artifactstagingdirectory)
+      - task: EsrpCodeSigning@1
+        displayName: ESRP Package CodeSigning
+        inputs:
+          ConnectedServiceName: 6ee18517-6d66-4730-bffd-2858a151bf69
+          FolderPath: $(build.artifactstagingdirectory)
+          Pattern: '*.cab'
+          CertificateId: 400
+          OpusName: Azure IoT Edge
+          OpusInfo: https://azure.microsoft.com/en-us/services/iot-edge/
+          SessionTimeout: 20
+      - task: ManifestGeneratorTask@0
+        displayName: SBOM Generation Task
+        inputs:
+          BuildDropPath: $(build.artifactstagingdirectory)
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifact: iotedged-windows-amd64'
+        inputs:
+          PathtoPublish: $(build.artifactstagingdirectory)
+          ArtifactName: iotedged-windows-amd64
 
   ##############################################################################
   - stage: PublishPackagesGithub
@@ -1014,12 +1014,12 @@ stages:
                 sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh 
                 $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh -p ubuntu20.04 -w $(Build.SourcesDirectory)/iotedge -d $(Build.SourcesDirectory)/iotedge -v "$BASE_VERSION" -s "github.com" -b  $(Build.SourceBranch) --skip-upload true
 
-                # Update Github and tag
+                # Source the scripts & Update version files
                 sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
                 source $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
                 update_latest_version_json
 
-                # BEARWASHERE -- Disabled for testing
+                # Update Github and tag
                 github_update_and_push
               env:
                 GITHUB_PAT: "$(GitHubAccessToken)"
@@ -1085,10 +1085,9 @@ stages:
             os: ubuntu20.04
             artifactName: iotedged-ubuntu20.04-aarch64
 
-          # BEARWASHERE -- Testing
-          # Windows-amd64:
-          #   os: windows
-          #   artifactName: iotedged-windows-amd64
+          Windows-amd64:
+            os: windows
+            artifactName: iotedged-windows-amd64
 
       steps:
         - task: AzureKeyVault@1

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1010,7 +1010,7 @@ stages:
                 sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
                 source $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
                 VERSION=$BASE_VERSION
-                # BEARWASHERE -- Testing
+                # BEARWASHERE -- Disabled for testing
                 # github_update_and_push
               env:
                 GITHUB_PAT: "$(GitHubAccessToken)"

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -999,7 +999,7 @@ stages:
             - bash: |
                 echo "Approval Complete"
 
-                BASE_VERSION="cat $BUILD_SOURCESDIRECTORY/iotedge/edgelet/version.txt"
+                BASE_VERSION="$(cat $BUILD_SOURCESDIRECTORY/iotedge/edgelet/version.txt)"
                 VERSION="$BASE_VERSION"
                 AZURE_IOTEDGE_REPO_PATH="$(Build.SourcesDirectory)/azure-iotedge"
                 IOTEDGE_REPO_PATH="$(Build.SourcesDirectory)/iotedge"
@@ -1017,6 +1017,7 @@ stages:
                 # Update Github and tag
                 sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
                 source $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
+                update_latest_version_json
 
                 # BEARWASHERE -- Disabled for testing
                 github_update_and_push

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -999,22 +999,29 @@ stages:
             - bash: |
                 echo "Approval Complete"
 
+                BASE_VERSION="cat $BUILD_SOURCESDIRECTORY/iotedge/edgelet/version.txt"
+                VERSION="$BASE_VERSION"
+                AZURE_IOTEDGE_REPO_PATH="$(Build.SourcesDirectory)/azure-iotedge"
+                IOTEDGE_REPO_PATH="$(Build.SourcesDirectory)/iotedge"
+                BRANCH_NAME="$(Build.SourceBranch)"
+                echo "Version: $VERSION"
+                echo "Branch name: $BRANCH_NAME"
+                echo "azure-iotedge repo path: $AZURE_IOTEDGE_REPO_PATH"
+                echo "iotedge repo path: $IOTEDGE_REPO_PATH"
+
                 #Create Release Page Before Publishing Artifacts in Parallel in the Next Job.
                 echo "Creating Release Page"
-                BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/iotedge/edgelet/version.txt`
-                # BEARWASHERE -- Testing
                 sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh 
                 $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh -p ubuntu20.04 -w $(Build.SourcesDirectory)/iotedge -d $(Build.SourcesDirectory)/iotedge -v "$BASE_VERSION" -s "github.com" -b  $(Build.SourceBranch) --skip-upload true
 
                 # Update Github and tag
                 sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
                 source $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
-                VERSION=$BASE_VERSION
+
                 # BEARWASHERE -- Disabled for testing
                 github_update_and_push
               env:
                 GITHUB_PAT: "$(GitHubAccessToken)"
-                AZURE_IOTEDGE_REPO_PATH: "$(Build.SourcesDirectory)/azure-iotedge"
     - job: linux
       displayName: Linux
       dependsOn: safe_guard

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -5,6 +5,13 @@
 # Variable 'WIN_PACKAGE_VERSION' was defined in the Variables tab
 name: $(VERSION)
 
+resources:
+  repositories:
+  - repository: azure-iotedge
+    type: github
+    endpoint: azure-iot-edge-iotedge1-github
+    name: azure/azure-iotedge
+
 trigger: none
 pr: none
 stages:
@@ -987,19 +994,27 @@ stages:
                 secretsFilter: >-
                   GitHubAccessToken
             - checkout: self
+            - checkout: azure-iotedge
+              submodules: recursive
             - bash: |
                 echo "Approval Complete"
 
                 #Create Release Page Before Publishing Artifacts in Parallel in the Next Job.
                 echo "Creating Release Page"
                 BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
-                # BEARWASHERE -- 
-                #  1. Checkout other repos with a corresponding version
-                #  2. Update "$(Build.SourcesDirectory)" to be "$(Build.SourcesDirectory)/iotedge"
-                sudo chmod +x $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh 
-                $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh -p ubuntu20.04 -w $(Build.SourcesDirectory) -d $(Build.SourcesDirectory) -v "$BASE_VERSION" -s "github.com" -b  $(Build.SourceBranch) --skip-upload true
+                # BEARWASHERE -- Testing
+                sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh 
+                $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh -p ubuntu20.04 -w $(Build.SourcesDirectory)/iotedge -d $(Build.SourcesDirectory)/iotedge -v "$BASE_VERSION" -s "github.com" -b  $(Build.SourceBranch) --skip-upload true
+
+                # Update Github and tag
+                sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
+                source $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
+                VERSION=$BASE_VERSION
+                # BEARWASHERE -- Testing
+                # github_update_and_push
               env:
                 GITHUB_PAT: "$(GitHubAccessToken)"
+                AZURE_IOTEDGE_REPO_PATH: "$(Build.SourcesDirectory)/azure-iotedge"
     - job: linux
       displayName: Linux
       dependsOn: safe_guard
@@ -1086,8 +1101,8 @@ stages:
                 $(artifactName)/*.cab
         - bash: |
             BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
-            sudo chmod +x $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh
-            $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh -p $(os) -w $(System.ArtifactsDirectory) -d $(System.ArtifactsDirectory)/$(artifactName) -v "$BASE_VERSION" -s "github.com" -b $(Build.SourceBranch)
+            sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh
+            $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh -p $(os) -w $(System.ArtifactsDirectory) -d $(System.ArtifactsDirectory)/$(artifactName) -v "$BASE_VERSION" -s "github.com" -b $(Build.SourceBranch)
           env:
             GITHUB_PAT: "$(GitHubAccessToken)"    
           name: publish_artifacts 

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -256,7 +256,7 @@ github_update_and_push()
     git commit -am "Prepare for Release $VERSION"
     lastCommitHash=$(git log -n 1 --pretty=format:"%H")
     git tag "$VERSION" $lastCommitHash
-    # BEARWASHERE -- Testing
+
     git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git
     git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git "$VERSION"
 }

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -269,7 +269,7 @@ update_latest_version_json()
 #######################################
 github_update_and_push()
 {
-    [[ -z "$AZURE_IOTEDGE_REPO_PATH" ]] && { echo "\$IOTEDGE_REPO_PATH is undefined"; exit 1; }
+    [[ -z "$AZURE_IOTEDGE_REPO_PATH" ]] && { echo "\$AZURE_IOTEDGE_REPO_PATH is undefined"; exit 1; }
     [[ -z "$VERSION" ]] && { echo "\$VERSION is undefined"; exit 1; }
     [[ -z "$GITHUB_PAT" ]] && { echo "\$GITHUB_PAT is undefined"; exit 1; }
 

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -275,6 +275,10 @@ github_update_and_push()
 
     cd $AZURE_IOTEDGE_REPO_PATH
     git config user.name iotedge1
+
+    # BEARWASHERE -- Testing
+    git checkout -b "yophilav/testing$(date +%s)"
+
     git commit -am "Prepare for Release $VERSION"
     lastCommitHash=$(git log -n 1 --pretty=format:"%H")
     git tag "$VERSION" $lastCommitHash

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -218,35 +218,9 @@ update_latest_version_json()
         echo "I'm pretty sure you don't want to release from the main branch."
         exit 1;
     else
-        # echo "Oh dear, how did you get here?!?"
-        # echo "Let me not let you do the release from your pull request branch"
-        # exit 1;
-
-        # BEARWASHERE -- Testing
-        # Set target version file to be updated
-        TARGET_IE_FILE="$AZURE_IOTEDGE_REPO_PATH/latest-iotedge-lts.json"
-
-        # Get all the relevant version to be verified
-        proposedEdgeletVersion=$(cat $IOTEDGE_REPO_PATH/edgelet/version.txt)
-        proposedImageVersion=$(cat $IOTEDGE_REPO_PATH/versionInfo.json | jq ".version" | tr -d '"')
-
-        content=$(cat $AZURE_IOTEDGE_REPO_PATH/latest-iotedge-lts.json)
-        latestEdgeletVersion=$(echo $content | jq ".iotedged" | tr -d '"')
-        latestImageVersion=$(echo $content | jq '."azureiotedge-agent"' | tr -d '"')
-
-        # Verify
-        echo "Sanity check iotedge version"
-        version_sanity_check $proposedEdgeletVersion $latestEdgeletVersion
-        echo "Sanity check docker image version"
-        version_sanity_check $proposedImageVersion $latestImageVersion
-
-        # Rewriting the latest-iotedge-lts.json
-        jqQuery=".iotedged = \"$proposedEdgeletVersion\" | .\"azureiotedge-agent\" = \"$proposedImageVersion\" | .\"azureiotedge-hub\" = \"$proposedImageVersion\""
-        echo $content | jq "$jqQuery" > $TARGET_IE_FILE
-
-        # Pring log for debugging
-        echo "Update $TARGET_IE_FILE:"
-        cat $TARGET_IE_FILE | jq '.'
+        echo "Oh dear, how did you get here?!?"
+        echo "Let me not let you do the release from your pull request branch"
+        exit 1;
     fi
 }
 
@@ -276,13 +250,13 @@ github_update_and_push()
     cd $AZURE_IOTEDGE_REPO_PATH
     git config user.name iotedge1
 
-    # BEARWASHERE -- Testing
-    git checkout -b "yophilav/testing$(date +%s)"
+    git checkout main
+    git pull
 
     git commit -am "Prepare for Release $VERSION"
     lastCommitHash=$(git log -n 1 --pretty=format:"%H")
     git tag "$VERSION" $lastCommitHash
     # BEARWASHERE -- Testing
-    git push https://$GITHUB_PAT@github.com/yophilav/azure-iotedge.git
-    git push https://$GITHUB_PAT@github.com/yophilav/azure-iotedge.git "$VERSION"
+    git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git
+    git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git "$VERSION"
 }

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -218,9 +218,35 @@ update_latest_version_json()
         echo "I'm pretty sure you don't want to release from the main branch."
         exit 1;
     else
-        echo "Oh dear, how did you get here?!?"
-        echo "Let me not let you do the release from your pull request branch"
-        exit 1;
+        # echo "Oh dear, how did you get here?!?"
+        # echo "Let me not let you do the release from your pull request branch"
+        # exit 1;
+
+        # BEARWASHERE -- Testing
+        # Set target version file to be updated
+        TARGET_IE_FILE="$AZURE_IOTEDGE_REPO_PATH/latest-iotedge-lts.json"
+
+        # Get all the relevant version to be verified
+        proposedEdgeletVersion=$(cat $IOTEDGE_REPO_PATH/edgelet/version.txt)
+        proposedImageVersion=$(cat $IOTEDGE_REPO_PATH/versionInfo.json | jq ".version" | tr -d '"')
+
+        content=$(cat $AZURE_IOTEDGE_REPO_PATH/latest-iotedge-lts.json)
+        latestEdgeletVersion=$(echo $content | jq ".iotedged" | tr -d '"')
+        latestImageVersion=$(echo $content | jq '."azureiotedge-agent"' | tr -d '"')
+
+        # Verify
+        echo "Sanity check iotedge version"
+        version_sanity_check $proposedEdgeletVersion $latestEdgeletVersion
+        echo "Sanity check docker image version"
+        version_sanity_check $proposedImageVersion $latestImageVersion
+
+        # Rewriting the latest-iotedge-lts.json
+        jqQuery=".iotedged = \"$proposedEdgeletVersion\" | .\"azureiotedge-agent\" = \"$proposedImageVersion\" | .\"azureiotedge-hub\" = \"$proposedImageVersion\""
+        echo $content | jq "$jqQuery" > $TARGET_IE_FILE
+
+        # Pring log for debugging
+        echo "Update $TARGET_IE_FILE:"
+        cat $TARGET_IE_FILE | jq '.'
     fi
 }
 

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -252,6 +252,7 @@ github_update_and_push()
     git commit -am "Prepare for Release $VERSION"
     lastCommitHash=$(git log -n 1 --pretty=format:"%H")
     git tag "$VERSION" $lastCommitHash
-    git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git
-    git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git "$VERSION"
+    # BEARWASHERE -- Testing
+    git push https://$GITHUB_PAT@github.com/yophilav/azure-iotedge.git
+    git push https://$GITHUB_PAT@github.com/yophilav/azure-iotedge.git "$VERSION"
 }

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -239,7 +239,7 @@ publish_to_github()
 
         #Create Release Page
         url="https://api.github.com/repos/Azure/azure-iotedge/releases"
-        body=$(jq -n --arg version "$VERSION" --arg body "$(cat $WDIR/content.txt)" '{tag_name: $version, name: $version, target_commitish:"main", body: $body}')
+        body=$(jq -n --arg version "$VERSION" --arg body "$(cat $WDIR/content.txt)" '{tag_name: $version, name: $version, target_commitish:"main", draft: true, body: $body}')
         sudo rm -rf $WDIR/content.txt
         
         echo "Body for Release is $body"

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -234,7 +234,8 @@ publish_to_github()
         sed -i "$ d" $WDIR/content.txt
 
         #Create Release Page
-        url="https://api.github.com/repos/Azure/azure-iotedge/releases"
+        # BEARWASHERE -- Disabled for testing
+        url="https://api.github.com/repos/yophilav/azure-iotedge/releases"
         reqBody='{tag_name: $version, name: $version, target_commitish:"main", draft: true, body: $body}'
         if [[ $SKIP_UPLOAD == "false" ]]; then
             reqBody='{tag_name: $version, name: $version, target_commitish:"main", body: $body}'

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -234,8 +234,7 @@ publish_to_github()
         sed -i "$ d" $WDIR/content.txt
 
         #Create Release Page
-        # BEARWASHERE -- Testing
-        url="https://api.github.com/repos/yophilav/azure-iotedge/releases"
+        url="https://api.github.com/repos/Azure/azure-iotedge/releases"
         reqBody='{tag_name: $version, name: $version, target_commitish:"main", draft: true, body: $body}'
         if [[ $SKIP_UPLOAD == "false" ]]; then
             reqBody='{tag_name: $version, name: $version, target_commitish:"main", body: $body}'
@@ -279,9 +278,8 @@ publish_to_github()
                     mimetype="application/octet-stream"
                     ;;
             esac
-            # BEARWASHERE -- Testing
-            upload_url="https://uploads.github.com/repos/yophilav/azure-iotedge/releases/$release_id/assets?name=$name"
-            #upload_url="https://uploads.github.com/repos/Azure/azure-iotedge/releases/$release_id/assets?name=$name"
+
+            upload_url="https://uploads.github.com/repos/Azure/azure-iotedge/releases/$release_id/assets?name=$name"
             echo "Upload URL is $upload_url"
             echo "Mime Type is $mimetype"
 

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -234,7 +234,7 @@ publish_to_github()
         sed -i "$ d" $WDIR/content.txt
 
         #Create Release Page
-        # BEARWASHERE -- Disabled for testing
+        # BEARWASHERE -- Testing
         url="https://api.github.com/repos/yophilav/azure-iotedge/releases"
         reqBody='{tag_name: $version, name: $version, target_commitish:"main", draft: true, body: $body}'
         if [[ $SKIP_UPLOAD == "false" ]]; then
@@ -279,8 +279,9 @@ publish_to_github()
                     mimetype="application/octet-stream"
                     ;;
             esac
-            
-            upload_url="https://uploads.github.com/repos/Azure/azure-iotedge/releases/$release_id/assets?name=$name"
+            # BEARWASHERE -- Testing
+            upload_url="https://uploads.github.com/repos/yophilav/azure-iotedge/releases/$release_id/assets?name=$name"
+            #upload_url="https://uploads.github.com/repos/Azure/azure-iotedge/releases/$release_id/assets?name=$name"
             echo "Upload URL is $upload_url"
             echo "Mime Type is $mimetype"
 

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -122,6 +122,31 @@ process_args() {
     done
 }
 
+
+#######################################
+# NAME: 
+#    publish_to_microsoft_repo
+#
+# DESCRIPTION:
+#    The function upload artifacts to Microsoft Linux Package Repository which is multiarch 
+#    repository at packages.microsoft.com (PMC). The upload of the artifacts is done via RepoClient
+#    app (which now avaiable as a docker image)
+#
+#    The script simply does the follow:
+#    1. Pull clean docker image for RepoClient app
+#    2. To upload the artifacts, the function runs the RepoClient image against 
+#       the config file an the uploading artifacts.
+#    3. Validate if the artifacts are readily available on PMC.
+# GLOBALS:
+#    BRANCH_NAME ________________ Source Branch name            (string)
+#    CONFIG_DIR _________________ Path to RepoClient config file(string)
+#    OS_NAME ____________________ Operating System name         (string)
+#    OS_VERSION _________________ Operating System version      (string)
+#    PACKAGE_DIR ________________ Path to artifact directory    (string)
+#
+# OUTPUTS:
+#    Uploaded linux artifacts in packages.microsoft.com
+#######################################
 publish_to_microsoft_repo()
 {
 #Cleanup
@@ -187,6 +212,36 @@ fi
 
 }
 
+
+#######################################
+# NAME: 
+#    publish_to_github
+#
+# DESCRIPTION:
+#    The function has two operating mode depending the value of $SKIP_UPLOAD
+#
+#    If SKIP_UPLOAD=true, the script creates a github release page on /azure-iotedge 
+#    repository with a VERSION tag to the latest commit. The release page comprises of
+#      - Change log as a description which is parsed from CHANGELOG.MD
+#      - Renamed production artifacts from the build pipeline in the format of
+#        <component>_<version>_<os>_<architecture>.<fileExtension> 
+#        i.e. iotedge_1.1.13-1_debian11_arm64.deb
+#
+#    If SKIP_UPLOAD=false, the script creates a DRAFT github release page on /azure-iotedge
+#    without a github tag AND no production artifacts are uploaded to draft.
+#    
+# GLOBALS:
+#    BRANCH_NAME ________________ Source Branch name            (string)
+#    GITHUB_PAT _________________ Github Personal Access Token  (string)
+#    SKIP_UPLOAD ________________ Skip Github artifact upload   (bool)
+#      if true, upload artifacts to github release page
+#      if false, create the release page in draft mode without artifacts uploaded.
+#    VERSION ____________________ Current release version       (string)
+#    WDIR _______________________ Current work directory        (string)
+#
+# OUTPUTS:
+#    Github release page on /azure-iotedge repository
+#######################################
 publish_to_github()
 {
     # Investigate if this can be derived from a commit, Hardcode for now.

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -238,6 +238,8 @@ publish_to_github()
         sed -i "$ d" $WDIR/content.txt
 
         #Create Release Page
+        #  This unintentionally create a github tag associate with the latest commit which is an undesired behavior. 
+        #  We will need to update the tag to the proper commit once the /azure-iotege latest json are ready to go.
         url="https://api.github.com/repos/Azure/azure-iotedge/releases"
         body=$(jq -n --arg version "$VERSION" --arg body "$(cat $WDIR/content.txt)" '{tag_name: $version, name: $version, target_commitish:"main", draft: true, body: $body}')
         sudo rm -rf $WDIR/content.txt


### PR DESCRIPTION
- Integrate the script from (https://github.com/Azure/iotedge/pull/6343) with the pipeline to automagically increment & tag the github branch for /azure-iotedge repository
- Fix the bug when the release page uses a whole changelog instead of parsing correctly.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
