### PR TITLE
Increase the validation timeout for PMC package upload 

### DIFF
--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -152,8 +152,8 @@ if [[ $status != "202" ]]; then
     exit 1
 fi
 
-#Wait upto 10 Minutes to see if package uploaded
-end_time=$((SECONDS + 600))
+#Wait upto 30 Minutes to see if package uploaded
+end_time=$((SECONDS + 1800))
 uploaded=false
 
 while [[ $SECONDS -lt $end_time ]]; do
@@ -172,7 +172,7 @@ while [[ $SECONDS -lt $end_time ]]; do
     done
     if [[ $uploaded == false ]]; then
         echo "Retrying.."
-        sleep 10
+        sleep 30
     else
         break
     fi


### PR DESCRIPTION
- `packages.microsoft.com` can take up to 30 minutes to show up in GA. We should increase the validation to pass up until then. If it continues to fail after 30 minutes, we have a bigger issue and should contact Linux Repo team.

Cherry-picked: https://github.com/Azure/iotedge/commit/5f9a1eb9acc944076ec3f7bb9fd4862092bda2c6

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
