### PR TITLE
Update to CRD.yaml to version v1 and chart update

### DIFF
--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.28.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.4" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
+++ b/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
@@ -21,12 +21,14 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.26" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\binding\src\Microsoft.Azure.WebJobs.Extensions.EdgeHub\Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj" />

--- a/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
+++ b/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.3" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.6.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\binding\src\Microsoft.Azure.WebJobs.Extensions.EdgeHub\Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj" />

--- a/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes-crd/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for installing CRD for Azure IoT Edge on Kubernetes
 name: edge-kubernetes-crd
-version: 0.2.13
+version: 0.2.14

--- a/kubernetes/charts/edge-kubernetes-crd/templates/crd.yaml
+++ b/kubernetes/charts/edge-kubernetes-crd/templates/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: edgedeployments.microsoft.azure.devices.edge
@@ -10,7 +10,38 @@ spec:
     plural: edgedeployments
     singular: edgedeployment
   scope: Namespaced
-  subresources:
-    # status enables the status subresource.
-    status: {}
-  version: v1
+  versions:
+    - name: v1
+      storage: true
+      served: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  version:
+                    type: string
+                  type:
+                    type: string
+                  status:
+                    type: string
+                  restartPolicy:
+                    type: string
+                  imagePullPolicy:
+                    type: string
+                  settings:
+                    type: string
+                  env:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  owner:
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true

--- a/kubernetes/charts/edge-kubernetes/Chart.yaml
+++ b/kubernetes/charts/edge-kubernetes/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: '1.0'
 description: A Helm chart for running Azure IoT Edge on Kubernetes
 name: edge-kubernetes
-version: 0.2.13
+version: 0.2.14


### PR DESCRIPTION
For the k8s server 1.22 version update, the schema of CRD has changed. There is a mandatory field of OpenAPISchema and also taken care of preserving the fields has can get pruned while using the new schema
