### PR TITLE
Disable mariner arm64

### DIFF
--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -239,123 +239,123 @@ stages:
               ArtifactName: 'iotedged-$(os)$(os_version)-$(arch)'
             condition: succeededOrFailed()
 
-      ################################################################################
-      - job: mariner_linux_arm64
-      ################################################################################
-        displayName: Mariner_Linux on ARM64
-        pool:
-          name: $(pool.linux.arm.name)
-          demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-18.04-arm64
-        variables:
-          NugetSecurityAnalysisWarningLevel: warn
-        strategy:
-          matrix:
-            CBL-Mariner1.0-aarch64:
-              arch: aarch64
-              os: mariner
-              os_version: 1
-              mariner_release: 1.0-stable
-              target.iotedged: builds/mariner1/out/RPMS
-              target.logs: builds/mariner1/build/logs/pkggen/rpmbuilding/
-            CBL-Mariner2.0-aarch64:
-              arch: aarch64
-              os: mariner
-              os_version: 2
-              mariner_release: 2.0-stable
-              target.iotedged: builds/mariner2/out/RPMS
-              target.logs: builds/mariner2/build/logs/pkggen/rpmbuilding/
+      # ################################################################################
+      # - job: mariner_linux_arm64
+      # ################################################################################
+      #   displayName: Mariner_Linux on ARM64
+      #   pool:
+      #     name: $(pool.linux.arm.name)
+      #     demands:
+      #     - ImageOverride -equals agent-aziotedge-ubuntu-18.04-arm64
+      #   variables:
+      #     NugetSecurityAnalysisWarningLevel: warn
+      #   strategy:
+      #     matrix:
+      #       CBL-Mariner1.0-aarch64:
+      #         arch: aarch64
+      #         os: mariner
+      #         os_version: 1
+      #         mariner_release: 1.0-stable
+      #         target.iotedged: builds/mariner1/out/RPMS
+      #         target.logs: builds/mariner1/build/logs/pkggen/rpmbuilding/
+      #       CBL-Mariner2.0-aarch64:
+      #         arch: aarch64
+      #         os: mariner
+      #         os_version: 2
+      #         mariner_release: 2.0-stable
+      #         target.iotedged: builds/mariner2/out/RPMS
+      #         target.logs: builds/mariner2/build/logs/pkggen/rpmbuilding/
 
-        steps:
-          - bash: |
-              BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
-              VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
-              echo "##vso[task.setvariable variable=VERSION;]$VERSION"
-              echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
-              echo "PACKAGE_OS=$(os)"
-              echo "##vso[task.setvariable variable=MARINER_RELEASE;]$(mariner_release)"
-              echo "##vso[task.setvariable variable=OSVERSION;]$(os_version)"
-              mariner_arch=$(arch)
-              if [ $mariner_arch == "amd64" ]; then
-                mariner_arch="x86_64"
-              fi
-              echo "##vso[task.setvariable variable=MARINER_ARCH;]$mariner_arch"
-            displayName: Set Version
+      #   steps:
+      #     - bash: |
+      #         BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+      #         VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
+      #         echo "##vso[task.setvariable variable=VERSION;]$VERSION"
+      #         echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
+      #         echo "PACKAGE_OS=$(os)"
+      #         echo "##vso[task.setvariable variable=MARINER_RELEASE;]$(mariner_release)"
+      #         echo "##vso[task.setvariable variable=OSVERSION;]$(os_version)"
+      #         mariner_arch=$(arch)
+      #         if [ $mariner_arch == "amd64" ]; then
+      #           mariner_arch="x86_64"
+      #         fi
+      #         echo "##vso[task.setvariable variable=MARINER_ARCH;]$mariner_arch"
+      #       displayName: Set Version
 
-          # remove this one 1ES can prevent the daiy update from triggering
-          - bash: |
-              set -ex
-              ps aux | grep -i apt
-              waitAttempts=60
-              sleepDuration=10
-              for (( i=0; $i<$waitAttempts; i++ ))
-              do
-                if [[ $(ps aux | grep -c apt.systemd.daily) == 1 ]]; then
-                  break
-                fi
-                sleep $sleepDuration
-              done
-              ps aux | grep -i apt
-            displayName: Wait for 1ES agent update
+      #     # remove this one 1ES can prevent the daiy update from triggering
+      #     - bash: |
+      #         set -ex
+      #         ps aux | grep -i apt
+      #         waitAttempts=60
+      #         sleepDuration=10
+      #         for (( i=0; $i<$waitAttempts; i++ ))
+      #         do
+      #           if [[ $(ps aux | grep -c apt.systemd.daily) == 1 ]]; then
+      #             break
+      #           fi
+      #           sleep $sleepDuration
+      #         done
+      #         ps aux | grep -i apt
+      #       displayName: Wait for 1ES agent update
 
-          - bash: |
-              sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
-              curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-              sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu `lsb_release -cs` stable"
-              sudo apt update
-              sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
-              sudo systemctl restart docker
-            displayName: Install moby
+      #     - bash: |
+      #         sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
+      #         curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+      #         sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu `lsb_release -cs` stable"
+      #         sudo apt update
+      #         sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+      #         sudo systemctl restart docker
+      #       displayName: Install moby
 
-          # build iot-identity-service here since they cannot build native aarch64 packages
-          - bash: |
-              set -ex
-              git clone --recurse-submodules https://github.com/Azure/iot-identity-service.git -b release/1.2
-              pushd iot-identity-service
-              packageVersion=$(git tag | grep 1.2.[0-9]*$ | tail -1)
-              sudo docker run --rm \
-                -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
-                -e "ARCH=$PACKAGE_ARCH" \
-                -e "OS=$OS:$OSVERSION" \
-                -e "PACKAGE_VERSION=$packageVersion" \
-                -e "PACKAGE_RELEASE=1" \
-                --privileged \
-                "ubuntu:18.04" \
-                '/src/ci/package.sh'
-              popd
-              sudo cp iot-identity-service/packages/mariner$(os_version)/$(arch)/*.rpm .
-              sudo rm -rf iot-identity-service
+      #     # build iot-identity-service here since they cannot build native aarch64 packages
+      #     - bash: |
+      #         set -ex
+      #         git clone --recurse-submodules https://github.com/Azure/iot-identity-service.git -b release/1.2
+      #         pushd iot-identity-service
+      #         packageVersion=$(git tag | grep 1.2.[0-9]*$ | tail -1)
+      #         sudo docker run --rm \
+      #           -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
+      #           -e "ARCH=$PACKAGE_ARCH" \
+      #           -e "OS=$OS:$OSVERSION" \
+      #           -e "PACKAGE_VERSION=$packageVersion" \
+      #           -e "PACKAGE_RELEASE=1" \
+      #           --privileged \
+      #           "ubuntu:18.04" \
+      #           '/src/ci/package.sh'
+      #         popd
+      #         sudo cp iot-identity-service/packages/mariner$(os_version)/$(arch)/*.rpm .
+      #         sudo rm -rf iot-identity-service
           
-          - bash: |
-              sudo docker run --rm \
-                -v "$(Build.SourcesDirectory):/src" \
-                -e "ARCH=$arch" \
-                -e "OS=$OS" \
-                -e "MARINER_RELEASE=$MARINER_RELEASE" \
-                -e "MARINER_ARCH=$MARINER_ARCH" \
-                -e "VERSION=$VERSION" \
-                --privileged \
-                "ubuntu:18.04" \
-                '/src/edgelet/build/linux/package-mariner.sh'
-          - task: CopyFiles@2
-            displayName: Copy iotedged build logs to artifact staging
-            inputs:
-              SourceFolder: $(target.logs)
-              Contents: |
-                **/*.rpm.log
-              TargetFolder: '$(build.artifactstagingdirectory)'
-            condition: succeededOrFailed()
-          - task: CopyFiles@2
-            displayName: Copy iotedged Files to Artifact Staging
-            inputs:
-              SourceFolder: $(target.iotedged)/$(mariner_arch)
-              Contents: |
-                *.rpm
-              TargetFolder: '$(build.artifactstagingdirectory)'
-            condition: succeededOrFailed()
-          - task: PublishBuildArtifacts@1
-            displayName: Publish Artifacts
-            inputs:
-              PathtoPublish: '$(build.artifactstagingdirectory)'
-              ArtifactName: 'iotedged-$(os)$(os_version)-$(arch)'
-            condition: succeededOrFailed()
+      #     - bash: |
+      #         sudo docker run --rm \
+      #           -v "$(Build.SourcesDirectory):/src" \
+      #           -e "ARCH=$arch" \
+      #           -e "OS=$OS" \
+      #           -e "MARINER_RELEASE=$MARINER_RELEASE" \
+      #           -e "MARINER_ARCH=$MARINER_ARCH" \
+      #           -e "VERSION=$VERSION" \
+      #           --privileged \
+      #           "ubuntu:18.04" \
+      #           '/src/edgelet/build/linux/package-mariner.sh'
+      #     - task: CopyFiles@2
+      #       displayName: Copy iotedged build logs to artifact staging
+      #       inputs:
+      #         SourceFolder: $(target.logs)
+      #         Contents: |
+      #           **/*.rpm.log
+      #         TargetFolder: '$(build.artifactstagingdirectory)'
+      #       condition: succeededOrFailed()
+      #     - task: CopyFiles@2
+      #       displayName: Copy iotedged Files to Artifact Staging
+      #       inputs:
+      #         SourceFolder: $(target.iotedged)/$(mariner_arch)
+      #         Contents: |
+      #           *.rpm
+      #         TargetFolder: '$(build.artifactstagingdirectory)'
+      #       condition: succeededOrFailed()
+      #     - task: PublishBuildArtifacts@1
+      #       displayName: Publish Artifacts
+      #       inputs:
+      #         PathtoPublish: '$(build.artifactstagingdirectory)'
+      #         ArtifactName: 'iotedged-$(os)$(os_version)-$(arch)'
+      #       condition: succeededOrFailed()


### PR DESCRIPTION
PR https://github.com/Azure/iotedge/pull/6356 has introduced failures in E2E tests. It looks as if the Mariner on ARM64 doesn't get triggered.

Disabling testing against Mariner ARM 64 for now.

- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
