### PR TITLE
 add back"Mariner ARM64 Build [Squashed]"

### DIFF
--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -238,3 +238,124 @@ stages:
               PathtoPublish: '$(build.artifactstagingdirectory)'
               ArtifactName: 'iotedged-$(os)$(os_version)-$(arch)'
             condition: succeededOrFailed()
+
+      ################################################################################
+      - job: mariner_linux_arm64
+      ################################################################################
+        displayName: Mariner_Linux on ARM64
+        pool:
+          name: $(pool.linux.arm.name)
+          demands:
+          - ImageOverride -equals agent-aziotedge-ubuntu-18.04-arm64
+        variables:
+          NugetSecurityAnalysisWarningLevel: warn
+        strategy:
+          matrix:
+            CBL-Mariner1.0-aarch64:
+              arch: aarch64
+              os: mariner
+              os_version: 1
+              mariner_release: 1.0-stable
+              target.iotedged: builds/mariner1/out/RPMS
+              target.logs: builds/mariner1/build/logs/pkggen/rpmbuilding/
+            CBL-Mariner2.0-aarch64:
+              arch: aarch64
+              os: mariner
+              os_version: 2
+              mariner_release: 2.0-stable
+              target.iotedged: builds/mariner2/out/RPMS
+              target.logs: builds/mariner2/build/logs/pkggen/rpmbuilding/
+
+        steps:
+          - bash: |
+              BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
+              VERSION="$BASE_VERSION$BUILD_BUILDNUMBER"
+              echo "##vso[task.setvariable variable=VERSION;]$VERSION"
+              echo "##vso[task.setvariable variable=PACKAGE_ARCH;]$(arch)"
+              echo "PACKAGE_OS=$(os)"
+              echo "##vso[task.setvariable variable=MARINER_RELEASE;]$(mariner_release)"
+              echo "##vso[task.setvariable variable=OSVERSION;]$(os_version)"
+              mariner_arch=$(arch)
+              if [ $mariner_arch == "amd64" ]; then
+                mariner_arch="x86_64"
+              fi
+              echo "##vso[task.setvariable variable=MARINER_ARCH;]$mariner_arch"
+            displayName: Set Version
+
+          # remove this one 1ES can prevent the daiy update from triggering
+          - bash: |
+              set -ex
+              ps aux | grep -i apt
+              waitAttempts=60
+              sleepDuration=10
+              for (( i=0; $i<$waitAttempts; i++ ))
+              do
+                if [[ $(ps aux | grep -c apt.systemd.daily) == 1 ]]; then
+                  break
+                fi
+                sleep $sleepDuration
+              done
+              ps aux | grep -i apt
+            displayName: Wait for 1ES agent update
+
+          - bash: |
+              sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
+              curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+              sudo add-apt-repository "deb [arch=arm64] https://download.docker.com/linux/ubuntu `lsb_release -cs` stable"
+              sudo apt update
+              sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
+              sudo systemctl restart docker
+            displayName: Install moby
+
+          # build iot-identity-service here since they cannot build native aarch64 packages
+          - bash: |
+              set -ex
+              git clone --recurse-submodules https://github.com/Azure/iot-identity-service.git -b release/1.2
+              pushd iot-identity-service
+              packageVersion=$(git tag | grep 1.2.[0-9]*$ | tail -1)
+              sudo docker run --rm \
+                -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
+                -e "ARCH=$PACKAGE_ARCH" \
+                -e "OS=$OS:$OSVERSION" \
+                -e "PACKAGE_VERSION=$packageVersion" \
+                -e "PACKAGE_RELEASE=1" \
+                --privileged \
+                "ubuntu:18.04" \
+                '/src/ci/package.sh'
+              popd
+              sudo cp iot-identity-service/packages/mariner$(os_version)/$(arch)/*.rpm .
+              sudo rm -rf iot-identity-service
+          
+          - bash: |
+              sudo docker run --rm \
+                -v "$(Build.SourcesDirectory):/src" \
+                -e "ARCH=$arch" \
+                -e "OS=$OS" \
+                -e "MARINER_RELEASE=$MARINER_RELEASE" \
+                -e "MARINER_ARCH=$MARINER_ARCH" \
+                -e "VERSION=$VERSION" \
+                --privileged \
+                "ubuntu:18.04" \
+                '/src/edgelet/build/linux/package-mariner.sh'
+          - task: CopyFiles@2
+            displayName: Copy iotedged build logs to artifact staging
+            inputs:
+              SourceFolder: $(target.logs)
+              Contents: |
+                **/*.rpm.log
+              TargetFolder: '$(build.artifactstagingdirectory)'
+            condition: succeededOrFailed()
+          - task: CopyFiles@2
+            displayName: Copy iotedged Files to Artifact Staging
+            inputs:
+              SourceFolder: $(target.iotedged)/$(mariner_arch)
+              Contents: |
+                *.rpm
+              TargetFolder: '$(build.artifactstagingdirectory)'
+            condition: succeededOrFailed()
+          - task: PublishBuildArtifacts@1
+            displayName: Publish Artifacts
+            inputs:
+              PathtoPublish: '$(build.artifactstagingdirectory)'
+              ArtifactName: 'iotedged-$(os)$(os_version)-$(arch)'
+            condition: succeededOrFailed()

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -17,7 +17,7 @@ case "${MARINER_RELEASE}" in
         PackageExtension="cm1"
         ;;
     '2.0-stable')
-        UsePreview=y
+        UsePreview=n
         MarinerIdentity=mariner2
         PackageExtension="cm2"
         ;;

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -8,26 +8,6 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 export DEBIAN_FRONTEND=noninteractive
 export TZ=UTC
 
-apt-get update -y
-apt-get upgrade -y
-apt-get install -y software-properties-common
-add-apt-repository -y ppa:longsleep/golang-backports
-apt-get update -y
-apt-get install -y \
-    cmake curl gcc g++ git jq make pkg-config \
-    libclang1 libssl-dev llvm-dev \
-    cpio genisoimage golang-1.13-go qemu-utils pigz python-pip python3-distutils rpm tar wget
-
-rm -f /usr/bin/go
-ln -vs /usr/lib/go-1.13/bin/go /usr/bin/go
-if [ -f /.dockerenv ]; then
-    mv /.dockerenv /.dockerenv.old
-fi
-
-echo 'Installing rustup'
-curl -sSLf https://sh.rustup.rs | sh -s -- -y
-. ~/.cargo/env
-
 
 # need to use preview repo for the next 2 weeks untill mariner 2.0 gets moved to prod
 case "${MARINER_RELEASE}" in
@@ -48,12 +28,45 @@ EDGELET_ROOT="${BUILD_REPOSITORY_LOCALPATH}/edgelet"
 MARINER_BUILD_ROOT="${BUILD_REPOSITORY_LOCALPATH}/builds/${MarinerIdentity}"
 REVISION="${REVISION:-1}"
 
+apt-get update -y
+apt-get upgrade -y
+apt-get install -y software-properties-common
+add-apt-repository -y ppa:longsleep/golang-backports
+apt-get update -y
+apt-get install -y \
+    cmake curl gcc g++ git jq make pkg-config \
+    libclang1 libssl-dev llvm-dev \
+    cpio genisoimage golang-1.13-go qemu-utils pigz python-pip python3-distutils rpm tar wget
+
+rm -f /usr/bin/go
+ln -vs /usr/lib/go-1.13/bin/go /usr/bin/go
+if [ -f /.dockerenv ]; then
+    mv /.dockerenv /.dockerenv.old
+fi
+
+# Download Mariner repo and build toolkit
+mkdir -p ${MARINER_BUILD_ROOT}
+MarinerToolkitDir='/tmp/CBL-Mariner'
+if ! [ -f "$MarinerToolkitDir/toolkit.tar.gz" ]; then
+    rm -rf "$MarinerToolkitDir"
+    git clone 'https://github.com/microsoft/CBL-Mariner.git' --branch "$MARINER_RELEASE" --depth 1 "$MarinerToolkitDir"
+    pushd "$MarinerToolkitDir/toolkit/"
+    make package-toolkit REBUILD_TOOLS=y
+    popd
+    cp "$MarinerToolkitDir"/out/toolkit-*.tar.gz "${MARINER_BUILD_ROOT}/toolkit.tar.gz"
+    rm -rf MarinerToolkitDir
+fi
+
+echo 'Installing rustup'
+curl -sSLf https://sh.rustup.rs | sh -s -- -y
+. ~/.cargo/env
+
 pushd $EDGELET_ROOT
 case "${MARINER_ARCH}" in
     'x86_64')
         rustup target add x86_64-unknown-linux-gnu
         ;;
-    'arm64')
+    'aarch64')
         rustup target add aarch64-unknown-linux-gnu
         ;;
 esac
@@ -122,19 +135,6 @@ cp -r ~/.cargo "rust"
 cp -r ~/.rustup "rust"
 tar cf "${MARINER_BUILD_ROOT}/SPECS/aziot-edge/SOURCES/rust.tar.gz" "rust"
 popd
-
-# Download Mariner repo and build toolkit
-echo "Cloning the \"${MARINER_RELEASE}\" tag of the CBL-Mariner repo."
-git clone https://github.com/microsoft/CBL-Mariner.git
-pushd CBL-Mariner
-git checkout ${MARINER_RELEASE}
-pushd toolkit
-make package-toolkit REBUILD_TOOLS=y
-popd
-mv out/toolkit-*.tar.gz "${MARINER_BUILD_ROOT}/toolkit.tar.gz"
-popd
-
-rm -rf CBL-Mariner
 
 # copy over IIS RPM
 mkdir -p ${MARINER_BUILD_ROOT}/out/RPMS/${MARINER_ARCH}


### PR DESCRIPTION
Reverts Azure/iotedge#6375. This change should be fixed in the pipelines now, so we can add this back. This also makes the Mariner 2.0 use prod since there appears to be an issue in the preview repo right now.