### PR TITLE
Github Release Page and Tagging Automation for /azure-iotedge

### DIFF
--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -11,6 +11,7 @@ resources:
     type: github
     endpoint: azure-iot-edge-iotedge1-github
     name: azure/iot-identity-service
+    ref: release/1.2 # Warning: Update this ref as appropriate
 
 stages:
 ################################################################################

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1,3 +1,4 @@
+name: $(VERSION)
 trigger: none
 pr: none
 

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1,7 +1,18 @@
 trigger: none
 pr: none
 stages:
-  
+
+resources:
+  repositories:
+  - repository: azure-iotedge
+    type: github
+    endpoint: azure-iot-edge-iotedge1-github
+    name: azure/azure-iotedge
+  - repository: iot-identity-service
+    type: github
+    endpoint: azure-iot-edge-iotedge1-github
+    name: azure/iot-identity-service
+
 ################################################################################
   - stage: BuildPackages
 ################################################################################
@@ -231,10 +242,34 @@ stages:
                   secretsFilter: >-
                     GitHubAccessToken
               - checkout: self
+              - checkout: azure-iotedge
+                submodules: recursive
+              - checkout: iot-identity-service
+                submodules: recursive
               - bash: | #Create Release Page Before Publishing Artifacts in Parallel in the Next Job.
-                  echo "Approval Complete, Creating Release Page"
-                  BASE_VERSION=`cat $BUILD_SOURCESDIRECTORY/edgelet/version.txt`
-                  $(Build.SourcesDirectory)/scripts/linux/publishReleasePackages.sh -p ubuntu20.04 -w $(Build.SourcesDirectory) -d $(Build.SourcesDirectory) -v "$BASE_VERSION" -s "github.com" -b  $(Build.SourceBranch) --skip-upload true
+                  echo "Approval Complete"
+                  BASE_VERSION="$(cat $BUILD_SOURCESDIRECTORY/iotedge/edgelet/version.txt)"
+                  VERSION="$BASE_VERSION"
+                  AZURE_IOTEDGE_REPO_PATH="$(Build.SourcesDirectory)/azure-iotedge"
+                  IOTEDGE_REPO_PATH="$(Build.SourcesDirectory)/iotedge"
+                  IIS_REPO_PATH="$(Build.SourcesDirectory)/iot-identity-service"
+                  BRANCH_NAME="$(Build.SourceBranch)"
+                  echo "Version: $VERSION"
+                  echo "Branch name: $BRANCH_NAME"
+                  echo "azure-iotedge repo path: $AZURE_IOTEDGE_REPO_PATH"
+                  echo "iotedge repo path: $IOTEDGE_REPO_PATH"
+                  echo "iot-identity-service repo path: $IIS_REPO_PATH"
+
+                  sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh 
+                  $(Build.SourcesDirectory)/iotedge/scripts/linux/publishReleasePackages.sh -p ubuntu20.04 -w $(Build.SourcesDirectory)/iotedge -d $(Build.SourcesDirectory)/iotedge -v "$BASE_VERSION" -s "github.com" -b  $(Build.SourceBranch) --skip-upload true
+
+                  # Source the scripts & Update version files
+                  sudo chmod +x $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
+                  source $(Build.SourcesDirectory)/iotedge/scripts/linux/github/updateLatestVersion.sh
+                  update_latest_version_json
+
+                  # Update Github and tag
+                  github_update_and_push
                 env:
                   GITHUB_PAT: "$(GitHubAccessToken)"
     - job: linux
@@ -335,6 +370,7 @@ stages:
             keyVaultName: $(kv.name)
             secretsFilter: >-
               GitHubAccessToken
+        - checkout: self
         - task: DownloadPipelineArtifact@2
           displayName: Download Pipeline Build Packages
           inputs:

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -1,6 +1,5 @@
 trigger: none
 pr: none
-stages:
 
 resources:
   repositories:
@@ -13,6 +12,7 @@ resources:
     endpoint: azure-iot-edge-iotedge1-github
     name: azure/iot-identity-service
 
+stages:
 ################################################################################
   - stage: BuildPackages
 ################################################################################

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -257,6 +257,6 @@ github_update_and_push()
     lastCommitHash=$(git log -n 1 --pretty=format:"%H")
     git tag "$VERSION" $lastCommitHash
 
-    git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git
-    git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git "$VERSION"
+    git push --force https://$GITHUB_PAT@github.com/yophilav/azure-iotedge.git
+    git push --force https://$GITHUB_PAT@github.com/yophilav/azure-iotedge.git "$VERSION"
 }

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -243,15 +243,20 @@ update_latest_version_json()
 #######################################
 github_update_and_push()
 {
-    [[ -z "$AZURE_IOTEDGE_REPO_PATH" ]] && { echo "\$IOTEDGE_REPO_PATH is undefined"; exit 1; }
+    [[ -z "$AZURE_IOTEDGE_REPO_PATH" ]] && { echo "\$AZURE_IOTEDGE_REPO_PATH is undefined"; exit 1; }
     [[ -z "$VERSION" ]] && { echo "\$VERSION is undefined"; exit 1; }
     [[ -z "$GITHUB_PAT" ]] && { echo "\$GITHUB_PAT is undefined"; exit 1; }
 
     cd $AZURE_IOTEDGE_REPO_PATH
     git config user.name iotedge1
+
+    git checkout main
+    git pull
+
     git commit -am "Prepare for Release $VERSION"
     lastCommitHash=$(git log -n 1 --pretty=format:"%H")
     git tag "$VERSION" $lastCommitHash
+
     git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git
     git push https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git "$VERSION"
 }

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -257,6 +257,6 @@ github_update_and_push()
     lastCommitHash=$(git log -n 1 --pretty=format:"%H")
     git tag "$VERSION" $lastCommitHash
 
-    git push --force https://$GITHUB_PAT@github.com/yophilav/azure-iotedge.git
-    git push --force https://$GITHUB_PAT@github.com/yophilav/azure-iotedge.git "$VERSION"
+    git push --force https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git
+    git push --force https://$GITHUB_PAT@github.com/Azure/azure-iotedge.git "$VERSION"
 }

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -221,22 +221,22 @@ fi
 # DESCRIPTION:
 #    The function has two operating mode depending the value of $SKIP_UPLOAD
 #
-#    If SKIP_UPLOAD=true, the script creates a github release page on /azure-iotedge 
+#    If SKIP_UPLOAD=false, the script creates a github release page on /azure-iotedge 
 #    repository with a VERSION tag to the latest commit. The release page comprises of
 #      - Change log as a description which is parsed from CHANGELOG.MD
 #      - Renamed production artifacts from the build pipeline in the format of
 #        <component>_<version>_<os>_<architecture>.<fileExtension> 
 #        i.e. iotedge_1.1.13-1_debian11_arm64.deb
 #
-#    If SKIP_UPLOAD=false, the script creates a DRAFT github release page on /azure-iotedge
+#    If SKIP_UPLOAD=true, the script creates a DRAFT github release page on /azure-iotedge
 #    without a github tag AND no production artifacts are uploaded to draft.
 #    
 # GLOBALS:
 #    BRANCH_NAME ________________ Source Branch name            (string)
 #    GITHUB_PAT _________________ Github Personal Access Token  (string)
 #    SKIP_UPLOAD ________________ Skip Github artifact upload   (bool)
-#      if true, upload artifacts to github release page
-#      if false, create the release page in draft mode without artifacts uploaded.
+#      if false, upload artifacts to github release page
+#      if true, create the release page in draft mode without artifacts uploaded.
 #    VERSION ____________________ Current release version       (string)
 #    WDIR _______________________ Current work directory        (string)
 #

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -122,6 +122,31 @@ process_args() {
     done
 }
 
+
+#######################################
+# NAME: 
+#    publish_to_microsoft_repo
+#
+# DESCRIPTION:
+#    The function upload artifacts to Microsoft Linux Package Repository which is multiarch 
+#    repository at packages.microsoft.com (PMC). The upload of the artifacts is done via RepoClient
+#    app (which now avaiable as a docker image)
+#
+#    The script simply does the follow:
+#    1. Pull clean docker image for RepoClient app
+#    2. To upload the artifacts, the function runs the RepoClient image against 
+#       the config file an the uploading artifacts.
+#    3. Validate if the artifacts are readily available on PMC.
+# GLOBALS:
+#    BRANCH_NAME ________________ Source Branch name            (string)
+#    CONFIG_DIR _________________ Path to RepoClient config file(string)
+#    OS_NAME ____________________ Operating System name         (string)
+#    OS_VERSION _________________ Operating System version      (string)
+#    PACKAGE_DIR ________________ Path to artifact directory    (string)
+#
+# OUTPUTS:
+#    Uploaded linux artifacts in packages.microsoft.com
+#######################################
 publish_to_microsoft_repo()
 {
 #Cleanup
@@ -188,6 +213,36 @@ fi
 
 }
 
+
+#######################################
+# NAME: 
+#    publish_to_github
+#
+# DESCRIPTION:
+#    The function has two operating mode depending the value of $SKIP_UPLOAD
+#
+#    If SKIP_UPLOAD=true, the script creates a github release page on /azure-iotedge 
+#    repository with a VERSION tag to the latest commit. The release page comprises of
+#      - Change log as a description which is parsed from CHANGELOG.MD
+#      - Renamed production artifacts from the build pipeline in the format of
+#        <component>_<version>_<os>_<architecture>.<fileExtension> 
+#        i.e. iotedge_1.1.13-1_debian11_arm64.deb
+#
+#    If SKIP_UPLOAD=false, the script creates a DRAFT github release page on /azure-iotedge
+#    without a github tag AND no production artifacts are uploaded to draft.
+#    
+# GLOBALS:
+#    BRANCH_NAME ________________ Source Branch name            (string)
+#    GITHUB_PAT _________________ Github Personal Access Token  (string)
+#    SKIP_UPLOAD ________________ Skip Github artifact upload   (bool)
+#      if true, upload artifacts to github release page
+#      if false, create the release page in draft mode without artifacts uploaded.
+#    VERSION ____________________ Current release version       (string)
+#    WDIR _______________________ Current work directory        (string)
+#
+# OUTPUTS:
+#    Github release page on /azure-iotedge repository
+#######################################
 publish_to_github()
 {
     # Investigate if this can be derived from a commit, Hardcode for now.
@@ -195,17 +250,13 @@ publish_to_github()
         echo "No Branch Name Provided"
         exit 1
     fi
-    
+
     branch_name=${BRANCH_NAME/"refs/heads/"/""}
     echo "Branch Name is $branch_name"
-    
-    # Get the latest release from a given branch
-    echo "Fetch the latest release: "
-    url="https://api.github.com/repos/Azure/iotedge/releases"
-    header_content="Accept:application/vnd.github.v3+json"
-    header_auth="Authorization:token $GITHUB_PAT"
-    content=$(curl -X GET -H "$header_content" -H "$header_auth" "$url")
-    latest_release=$(echo $content | jq --arg branch "$branch_name" '[.[] | select(.target_commitish==$branch)][0]' | jq '.name' | tr -d '"')
+
+    # Note: $(pwd) is the $(Build.SourcesDirectory)
+    source ./iotedge/scripts/linux/github/updateLatestVersion.sh
+    latest_release=$(get_latest_release_per_branch_name)
     echo "Latest Release is $latest_release"
 
     if [[ -z $latest_release || $latest_release == null ]];then
@@ -214,9 +265,9 @@ publish_to_github()
     fi
     
     url="https://api.github.com/repos/Azure/azure-iotedge/releases"
+    header_content="Accept:application/vnd.github.v3+json"
+    header_auth="Authorization:token $GITHUB_PAT"
     content=$(curl -X GET -H "$header_content" -H "$header_auth" "$url")
-    
-    # TODO: Check if the repository is tagged with a given version. Otherwise, tag the commit with the releasing version
 
     # Check if Release Page has already been created
     release_created=$(echo $content | jq --arg version $VERSION '.[] | select(.name==$version)')
@@ -241,7 +292,11 @@ publish_to_github()
 
         #Create Release Page
         url="https://api.github.com/repos/Azure/azure-iotedge/releases"
-        body=$(jq -n --arg version "$VERSION" --arg body "$(cat $WDIR/content.txt)" '{tag_name: $version, name: $version, target_commitish:"main", body: $body}')
+        reqBody='{tag_name: $version, name: $version, target_commitish:"main", draft: true, body: $body}'
+        if [[ $SKIP_UPLOAD == "false" ]]; then
+            reqBody='{tag_name: $version, name: $version, target_commitish:"main", body: $body}'
+        fi
+        body=$(jq -n --arg version "$VERSION" --arg body "$(cat $WDIR/content.txt)" "$reqBody")
         sudo rm -rf $WDIR/content.txt
         
         echo "Body for Release is $body"
@@ -280,7 +335,7 @@ publish_to_github()
                     mimetype="application/octet-stream"
                     ;;
             esac
-            
+
             upload_url="https://uploads.github.com/repos/Azure/azure-iotedge/releases/$release_id/assets?name=$name"
             echo "Upload URL is $upload_url"
             echo "Mime Type is $mimetype"

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -254,8 +254,8 @@ publish_to_github()
     branch_name=${BRANCH_NAME/"refs/heads/"/""}
     echo "Branch Name is $branch_name"
 
-    # Note: $(pwd) is the $(Build.SourcesDirectory)
-    source ./iotedge/scripts/linux/github/updateLatestVersion.sh
+    # Using relative path from this script to source the helper script
+    source "$(dirname "$(realpath "$0")")/github/updateLatestVersion.sh"
     latest_release=$(get_latest_release_per_branch_name)
     echo "Latest Release is $latest_release"
 


### PR DESCRIPTION
- Integrate the script from (https://github.com/Azure/iotedge/pull/6343) with the pipeline to automagically increment & tag the github branch for /azure-iotedge repository
- Fix the bug when the release page uses a whole changelog instead of parsing correctly.
- Use the version string as a name of the release run.
- Update the dependency to be of 1.2

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
