### PR TITLE
Lock cargo tarpaulin upstream dependences to a specific version

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -169,7 +169,7 @@ jobs:
       - script: edgelet/build/linux/install.sh
         displayName: Install Rust
       - script: |
-          $CARGO install cargo-tarpaulin --version '^0.20'
+          $CARGO install --locked cargo-tarpaulin
         workingDirectory: edgelet
         displayName: Install Cargo Tarpaulin
       - script: |

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -169,7 +169,7 @@ jobs:
       - script: edgelet/build/linux/install.sh
         displayName: Install Rust
       - script: |
-          $CARGO install --locked cargo-tarpaulin
+          $CARGO install --locked cargo-tarpaulin --version '^0.18'
         workingDirectory: edgelet
         displayName: Install Cargo Tarpaulin
       - script: |

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -169,7 +169,7 @@ jobs:
       - script: edgelet/build/linux/install.sh
         displayName: Install Rust
       - script: |
-          $CARGO install cargo-tarpaulin --version '^0.18'
+          $CARGO install cargo-tarpaulin --version '^0.20'
         workingDirectory: edgelet
         displayName: Install Cargo Tarpaulin
       - script: |

--- a/edgelet/build/linux/install.sh
+++ b/edgelet/build/linux/install.sh
@@ -77,7 +77,7 @@ sudo apt-get install -y \
     uuid-dev curl \
     libcurl4-openssl-dev \
     libssl-dev \
-    libssh2-1-dev \
+    librust-libgit2-sys+libssh2-sys-dev \
     debhelper \
     dh-systemd \
     valgrind

--- a/edgelet/build/linux/install.sh
+++ b/edgelet/build/linux/install.sh
@@ -77,7 +77,7 @@ sudo apt-get install -y \
     uuid-dev curl \
     libcurl4-openssl-dev \
     libssl-dev \
-    librust-libgit2-sys+libssh2-sys-dev \
+    libssh2-sys-dev \
     debhelper \
     dh-systemd \
     valgrind

--- a/edgelet/build/linux/install.sh
+++ b/edgelet/build/linux/install.sh
@@ -77,7 +77,6 @@ sudo apt-get install -y \
     uuid-dev curl \
     libcurl4-openssl-dev \
     libssl-dev \
-    libssh2-1 \
     debhelper \
     dh-systemd \
     valgrind

--- a/edgelet/build/linux/install.sh
+++ b/edgelet/build/linux/install.sh
@@ -77,7 +77,7 @@ sudo apt-get install -y \
     uuid-dev curl \
     libcurl4-openssl-dev \
     libssl-dev \
-    libssh2-sys-dev \
+    libssh2-1 \
     debhelper \
     dh-systemd \
     valgrind

--- a/edgelet/build/linux/install.sh
+++ b/edgelet/build/linux/install.sh
@@ -77,6 +77,7 @@ sudo apt-get install -y \
     uuid-dev curl \
     libcurl4-openssl-dev \
     libssl-dev \
+    libssh2-1-dev \
     debhelper \
     dh-systemd \
     valgrind


### PR DESCRIPTION
cargo tarpaulin is pinned to the latest 0.18.x version in release/1.1

However, it doesn't pin its upstream dependences to certain versions. 

What's currently happening is that a change to[ libz-sys ](https://crates.io/crates/libz-sys/versions)5 days ago, has caused that version (1.1.18) to be pulled in and break the cargo tarpaulin compile.

This PR ensures that only locked upstream dependences are pulled in for the cargo tarpaulin compile.

- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).