### PR TITLE
Lock cargo tarpaulin upstream dependences to a specific version (#6392)

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -139,7 +139,7 @@ jobs:
       - script: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
       - script: |
-          $CARGO install cargo-tarpaulin --version '^0.18'
+          $CARGO install --locked cargo-tarpaulin --version '^0.18'
         workingDirectory: edgelet
         displayName: Install Cargo Tarpaulin
       - script: |


### PR DESCRIPTION
Straight cherry-pick of https://github.com/Azure/iotedge/pull/6392


cargo tarpaulin is pinned to the latest 0.18.x version in release/1.1

However, it doesn't pin its upstream dependences to certain versions. 

What's currently happening is that a change to[ libz-sys ](https://crates.io/crates/libz-sys/versions)5 days ago, has caused that version (1.1.18) to be pulled in and break the cargo tarpaulin compile.

This PR ensures that only locked upstream dependences are pulled in for the cargo tarpaulin compile.

- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).