### PR TITLE
[1.3] Lock cargo tarpaulin upstream dependences to a specific version

### DIFF
--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -137,7 +137,7 @@ jobs:
       - script: scripts/linux/generic-rust/install.sh --project-root "edgelet"
         displayName: Install Rust
       - script: |
-          $CARGO install cargo-tarpaulin
+          $CARGO install --locked cargo-tarpaulin
         workingDirectory: edgelet
         displayName: Install Cargo Tarpaulin
       - script: |


### PR DESCRIPTION
cargo tarpaulin doesn't pin its upstream dependences to certain versions.

This runs the risk that a change/update to an upstream dependency might be pulled in and end up breaking the cargo tarpaulin compile. This isn't a problem right now, but with 1.3 being cut, this is likely to be a problem down the line.

This PR ensures that only locked upstream dependences are pulled in for the cargo tarpaulin compile.

- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
