### PR TITLE
Modify e2e checkin pipeline to exclude for k8s branch

### DIFF
--- a/builds/checkin/e2e-checkin.yaml
+++ b/builds/checkin/e2e-checkin.yaml
@@ -12,6 +12,7 @@ pr:
   paths:
     exclude:
       - platform-validation
+      - release/1.1-k8s-preview
 
 resources:
   pipelines:


### PR DESCRIPTION
The e2e checkin now runs on all release branch including k8s for which its not valid anymore so excluding it so other PRs don't get bogged down.