### PR TITLE
Disable SCCA task

### DIFF
--- a/builds/checkin/e2e-checkin.yaml
+++ b/builds/checkin/e2e-checkin.yaml
@@ -14,6 +14,9 @@ pr:
       - platform-validation
       - release/1.1-k8s-preview
 
+variables:
+  DisableDockerDetector: true
+
 resources:
   pipelines:
   - pipeline: images

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -6,6 +6,7 @@ trigger:
       - release/*
 pr: none
 variables:
+  DisableDockerDetector: true
   build.configuration: Release
   test.filter: Category=Integration&Category!=Stress
 jobs:

--- a/builds/e2e/compare-compatibility.yaml
+++ b/builds/e2e/compare-compatibility.yaml
@@ -2,6 +2,9 @@
 trigger: none
 pr: none
 
+variables:
+  DisableDockerDetector: true
+
 resources:
   pipelines:
   - pipeline: images

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -18,6 +18,7 @@ schedules:
   always: true
 
 variables:
+  DisableDockerDetector: true
   images.artifact.name.linux: 'core-linux'
 
 resources:

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -19,6 +19,7 @@ resources:
       - release/*
 
 variables:
+  DisableDockerDetector: true
   # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
   # environments that are very similar to other platforms/environments in our matrix, Ubuntu 18.04
   # with the 'docker-ce' package vs. Ubuntu 18.04 with the 'iotedge-moby' package vs. the same

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -17,6 +17,7 @@ schedules:
   always: true
 
 variables:
+  DisableDockerDetector: true
   itProxy: http://10.16.8.4:3128
   otProxy: http://10.16.5.4:3128 
   ressourceGroup: nested-edge-isa95 

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -21,6 +21,7 @@ schedules:
   always: true
 
 variables:
+  DisableDockerDetector: true
   # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
   # environments that are very similar to other platforms/environments in our matrix, Ubuntu 18.04
   # with the 'docker-ce' package vs. Ubuntu 18.04 with the 'iotedge-moby' package vs. the same

--- a/builds/misc/images.yaml
+++ b/builds/misc/images.yaml
@@ -8,6 +8,7 @@ pr: none
 
 variables:
   NugetSecurityAnalysisWarningLevel: warn
+  DisableDockerDetector: true
   
 stages:
   - template: templates/build-images.yaml

--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -5,5 +5,8 @@ trigger:
       - main
 pr: none
 
+variables:
+  DisableDockerDetector: true
+
 stages:
   - template: templates/build-packages.yaml

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -10,6 +10,9 @@ schedules:
     - main
   always: true
 
+variables:
+  DisableDockerDetector: true
+
 pool:
   vmImage: ubuntu-18.04
 


### PR DESCRIPTION
The SCCA task can fail the builds if it detects Dockerfiles in our repo that reference external images. We're working on a solution with the SCCA team that will meet the needs of our open-source project. In the meantime, we're disabling this task on their recommendation.

I used the Build Images pipeline to confirm that the SCCA task passes when the `DisableDockerDetector` variable is set in the pipeline.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.