### PR TITLE
Add EST server conf into the API proxy nginx default configuration, 

### DIFF
--- a/edge-modules/api-proxy-module/templates/nginx_default_config.conf
+++ b/edge-modules/api-proxy-module/templates/nginx_default_config.conf
@@ -115,6 +115,17 @@ http {
             proxy_pass          https://${IOTEDGE_PARENTHOSTNAME}:${NGINX_DEFAULT_PORT}$request_uri;
         }
         #endif_tag ${IOTEDGE_PARENTHOSTNAME}
+        
+        #if_tag ${EST_URL}
+        location ~^/.estproxy/(.*) {
+           resolver 127.0.0.11;
+           proxy_http_version  1.1;
+           proxy_ssl_verify    off;
+           set $est ${EST_URL}/$1$is_args$args;
+           proxy_set_header   X-Forwarded-Host $http_host;
+           proxy_pass $est;
+        }
+        #endif_tag ${EST_URL}
 
         location ~^/devices|twins/ {
             auth_request /auth;


### PR DESCRIPTION
To allow for easier configuration for EST URL via the twin env variable (similar to `DOCKER_REQUEST_ROUTE_ADDRESS` and `NGINX_DEFAULT_PORT`), and solves part of this issue https://github.com/Azure/iotedge/issues/5269

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
