### PR TITLE
Fix E2E pipeline artifact name collision

### DIFF
--- a/builds/e2e/templates/e2e-run.yaml
+++ b/builds/e2e/templates/e2e-run.yaml
@@ -101,6 +101,7 @@ steps:
   condition: not(variables['Agent.ProxyUrl'])
 
 - pwsh: |
+    $test_type = '${{ parameters.test_type }}'
     $logDir = '$(Build.ArtifactStagingDirectory)/logs${{ parameters.test_type }}'
     New-Item $logDir -ItemType Directory -Force | Out-Null
     Out-File "$logDir/$(Build.DefinitionName)-$(Build.BuildNumber)"
@@ -111,7 +112,12 @@ steps:
     Copy-Item "$(binDir)/*-device-*.log" "$logDir/"
     Copy-Item "$(binDir)/testoutput.log" "$logDir/"
     Copy-Item "$(binDir)/supportbundle*" "$logDir/"
-    $artifactSuffix = '$(Build.BuildNumber)-$(System.JobName)' -replace '_','-'
+    if ($test_type -eq 'upgrade_scenarios')
+    {
+      $artifactSuffix = '$(Build.BuildNumber)-$(System.JobName)' -replace '_','-'
+    } else {
+      $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
+    }
     Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
   displayName: Collect Logs
   condition: always()

--- a/builds/e2e/upgrade-scenarios.yaml
+++ b/builds/e2e/upgrade-scenarios.yaml
@@ -233,4 +233,6 @@ jobs:
       displayName: Update schemaVersion in context.json
 
     - template: templates/e2e-run.yaml
+      parameters:
+          test_type: upgrade_scenarios
 


### PR DESCRIPTION
Fixes the artifact suffix so that System.JobName is only used when upgrade scenario tests are run. Otherwise, it goes back to using System.PhaseName.

Changes have been tested by running E2E and upgrade scenario pipelines.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
