### PR TITLE
Mitigate upload support bundle test issues

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -237,7 +237,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
             var request = new
             {
                 schemaVersion = "1.0",
-                since = "2d",
+                since = "5m",
                 edgeRuntimeOnly = false,
                 sasUrl,
             };

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -244,7 +244,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
 
             var payload = JsonConvert.SerializeObject(request);
 
-            CloudToDeviceMethodResult result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("UploadSupportBundle", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(180)).SetPayloadJson(payload), token);
+            CloudToDeviceMethodResult result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("UploadSupportBundle", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(payload), token);
 
             var response = JsonConvert.DeserializeObject<TaskStatusResponse>(result.GetPayloadAsJson());
             await this.WaitForTaskCompletion(response.CorrelationId, token);
@@ -260,7 +260,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                     correlationId
                 };
 
-                var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetTaskStatus", TimeSpan.FromSeconds(120), TimeSpan.FromSeconds(60)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
+                var result = await this.IotHub.InvokeMethodAsync(this.runtime.DeviceId, ConfigModuleName.EdgeAgent, new CloudToDeviceMethod("GetTaskStatus", TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300)).SetPayloadJson(JsonConvert.SerializeObject(request)), token);
 
                 Assert.AreEqual((int)HttpStatusCode.OK, result.Status);
                 var response = JsonConvert.DeserializeObject<TaskStatusResponse>(result.GetPayloadAsJson());


### PR DESCRIPTION
Mitigates the failure likelihood for the UploadSupportBundle E2E test by reducing the amount of data being uploaded. This should reduce the likelihood of timeout on resource constrained agents such as 32-bit Raspberry Pis. 

Also, the response and connection timeouts for both the UploadSupportBundle and GetTaskStatus direct methods have been set to the max allowed value of 300 seconds. This aligns with the values on the 1.2 branch.

These changes build on top of #6424, which allowed the tests to get farther (i.e. edgelet now gets the supportbundle GET request that it was not getting previously in observed failure scenarios).

I've run the pipeline 3 times and it succeeded each time.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
