### PR TITLE
Fix Document links for manifest trust that were broken

### DIFF
--- a/doc/IoTEdgeManifestTrust.md
+++ b/doc/IoTEdgeManifestTrust.md
@@ -4,17 +4,17 @@ IoT Edge Deployment Trust is a feature which provides data integrity of the depl
 To get started, follow the steps of the quick start guide of deploying modules to an IoT edge device as shown in this [link](https://docs.microsoft.com/en-us/azure/iot-edge/quickstart-linux?view=iotedge-2020-11). Follow the step where a review of the deployment of the module is done as shown in [this](https://docs.microsoft.com/en-us/azure/iot-edge/quickstart-linux?view=iotedge-2020-11#review-and-create) step. Do not click **Review + create** but note down the image URL of all the modules that needs to be deployed to the device. Now get another Linux device which is different from the IoT edge device where the images are signed and published by following the steps below.
 
 ### 1. Notary Content Trust to protect module images
-Get the container images downloaded into the machine which are configured in the deployment JSON by using  `docker pull`. First the module container image's data integrity must be protected by using Notary Content Trust as shown in the first three steps in [this](https://github.com/Azure/iotedge/blob/main/doc/NotaryContentTrust.md) document.
+Get the container images downloaded into the machine which are configured in the deployment JSON by using  `docker pull`. First the module container image's data integrity must be protected by using Notary Content Trust as shown in the first three steps in [this](https://github.com/Azure/iotedge/blob/feature/manifest-trust/doc/NotaryContentTrust.md) document.
 
 Once the module images are signed and published in the private Azure Container Registry, the registry server name and its credentials are updated in the deployment JSON as shown in the **Set modules** step in this [link](https://docs.microsoft.com/en-us/azure/iot-edge/quickstart-linux?view=iotedge-2020-11#modules). Again copy the Deployment JSON with the updated credentials of the Azure Container Registry which is used in the next step.
 
 ### 2. Sign the deployment Manifest
-Once the deployment JSON is updated with the registry credential details, now the Manifest Signer Client tool is used to sign the deployment manifest JSON. Follow the first three steps in [this](https://github.com/Azure/iotedge/blob/main/samples/dotnet/ManifestSignerClient/Readme.md). After this we have a signed deployment JSON ready to be deployed. 
+Once the deployment JSON is updated with the registry credential details, now the Manifest Signer Client tool is used to sign the deployment manifest JSON. Follow the first three steps in [this](https://github.com/Azure/iotedge/blob/feature/manifest-trust/samples/dotnet/ManifestSignerClient/Readme.md). After this we have a signed deployment JSON ready to be deployed. 
 
 ### 3. Configure the IoT edge Daemon in Edge device.
-Configure the IoT Edge Daemon to enable Notary Content Trust as shown in step 4 of [this](https://github.com/Azure/iotedge/blob/main/doc/NotaryContentTrust.md) document.
+Configure the IoT Edge Daemon to enable Notary Content Trust as shown in step 4 of [this](https://github.com/Azure/iotedge/blob/feature/manifest-trust/doc/NotaryContentTrust.md) document.
 
-Configure the IoT Edge Daemon to enable ManifestS Signing as shown in step 4 of [this](https://github.com/Azure/iotedge/blob/main/samples/dotnet/ManifestSignerClient/Readme.md) document.
+Configure the IoT Edge Daemon to enable ManifestS Signing as shown in step 4 of [this](https://github.com/Azure/iotedge/blob/feature/manifest-trust/samples/dotnet/ManifestSignerClient/Readme.md) document.
 
 ### 4. Deploy the Deployment JSON
 Once all the configurations are in place, deploy the signed deployment JSON from step 2 using Azure CLI tools. Example [here](https://docs.microsoft.com/en-us/cli/azure/iot/edge/deployment?view=azure-cli-latest). Now the modules status can be viewed by following the reminder of the quick start guide from this [link](https://docs.microsoft.com/en-us/azure/iot-edge/quickstart-linux?view=iotedge-2020-11#view-generated-data)

--- a/doc/NotaryContentTrust.md
+++ b/doc/NotaryContentTrust.md
@@ -28,7 +28,7 @@ To publish signed images, following tools must be installed in a publisher's env
 3. Docker client - to sign the image and publish to the Container Registry
 
 ##### b. Generate Certificates 
-Follow instructions in [iotedge repository]([https://github.com/Azure/iotedge/blob/main/edgelet/doc/devguide.md](https://github.com/Azure/iotedge/blob/main/edgelet/doc/devguide.md)) to install OpenSSL. There are two types of certificates to be generated.
+Follow instructions in [iotedge repository](https://github.com/Azure/iotedge/blob/main/edgelet/doc/devguide.md) to install OpenSSL. There are two types of certificates to be generated.
 1. root CA for each container registry
 2. root certificate for each container image
 
@@ -131,9 +131,9 @@ To check if the image is signed or not, `az` tools can be used. Before that logi
 
 The root CA of each Container Registry i.e `root_ca_exampleregistry.crt` must be copied out of band into the device in a specific location.
 
-In the `config.yaml`, in the Moby runtime section, content trust can be enabled by specifiying the registry server name and certificate ID of the root CA as shown in [sample](https://github.com/Azure/iotedge/blob/main/edgelet/iotedge/test-files/init/import/moby-runtime-content-trust/edged.yaml)
+In the `config.toml`, in the Moby runtime section, content trust can be enabled by specifiying the registry server name and certificate ID of the root CA as shown in [sample](https://github.com/Azure/iotedge/blob/feature/manifest-trust/edgelet/iotedge/test-files/config/moby-runtime-content-trust/edged.toml#L39)
 
-In the `super-config.toml`, under `moby_runtime.content_trust.ca_certs`, the mapping of the certificate ID and file path of the root CA must be configured as shown in [sample](https://github.com/Azure/iotedge/blob/main/edgelet/iotedge/test-files/config/moby-runtime-content-trust/super-config.toml#L56)
+In the `super-config.toml`, under `moby_runtime.content_trust.ca_certs`, the mapping of the certificate ID and file path of the root CA must be configured as shown in [sample](https://github.com/Azure/iotedge/blob/feature/manifest-trust/edgelet/iotedge/test-files/config/moby-runtime-content-trust/super-config.toml#L55)
 
 Recommendation is to create another Service Principal with Pull access for the edge device and ensure the login credentials are applied in the deployment manifest. 
 

--- a/samples/dotnet/ManifestSignerClient/Readme.md
+++ b/samples/dotnet/ManifestSignerClient/Readme.md
@@ -59,6 +59,6 @@ Once the `launchSettings.json` file is configured, the solution can be built and
 ### Step 4. Configure the IoT edge daemon to enable Manifest Signing
 The root CA of the device as mentioned in `MANIFEST_TRUST_DEVICE_ROOT_CA_PATH` must be configured in the IoT edge Daemon to enable Manifest Signing.
 
-In the `certd.toml`, under `preloaded_certs`, the mapping of the Manifest Trust Bundke and file path of the root CA must be configured as shown in [sample](https://github.com/Azure/iotedge/blob/main/edgelet/iotedge/test-files/config/manifest-trust-bundle/certd.toml#L11)
+In the `certd.toml`, under `preloaded_certs`, the mapping of the Manifest Trust Bundke and file path of the root CA must be configured as shown in [sample](https://github.com/Azure/iotedge/blob/feature/manifest-trust/edgelet/iotedge/test-files/config/manifest-trust-bundle/certd.toml#L11)
 
 Once configured in IoT edge daemon, the device is now capable of verifying the signed manifest contents. Once a signed deployment manifest is deployed and the signature verification is successful, then the modules are deployed. If the signature fails, then the modules are not deployed. This way we only deploy the verified twin data and thereby offer data integrity of deployment manifest JSON.


### PR DESCRIPTION
It was pointed to main branch instead of feature branch. 