### PR TITLE
Enable Edge CA auto-renewal by default

### DIFF
--- a/edgelet/iotedge/src/config/apply.rs
+++ b/edgelet/iotedge/src/config/apply.rs
@@ -286,7 +286,7 @@ async fn execute_inner(
 
     let edge_ca = edge_ca.unwrap_or(super_config::EdgeCa::Quickstart {
         auto_generated_edge_ca_expiry_days: 90,
-        auto_renew: Some(cert_renewal::AutoRenewConfig::default()),
+        auto_renew: cert_renewal::AutoRenewConfig::default(),
         subject: None,
     });
 
@@ -431,8 +431,6 @@ async fn execute_inner(
                 Some(auto_generated_edge_ca_expiry_days),
                 subject,
             );
-
-            let auto_renew = auto_renew.unwrap_or_default();
 
             edgelet_settings::base::EdgeCa {
                 cert: None,

--- a/edgelet/iotedge/src/config/import/mod.rs
+++ b/edgelet/iotedge/src/config/import/mod.rs
@@ -350,7 +350,7 @@ fn execute_inner(
                 (
                     Some(super_config::EdgeCa::Quickstart {
                         auto_generated_edge_ca_expiry_days: auto_generated_ca_lifetime_days.into(),
-                        auto_renew: None,
+                        auto_renew: cert_renewal::AutoRenewConfig::default(),
                         subject: None,
                     }),
                     None,

--- a/edgelet/iotedge/src/config/super_config.rs
+++ b/edgelet/iotedge/src/config/super_config.rs
@@ -90,8 +90,11 @@ pub enum EdgeCa {
     Quickstart {
         auto_generated_edge_ca_expiry_days: u32,
 
-        #[serde(skip_serializing_if = "Option::is_none")]
-        auto_renew: Option<cert_renewal::AutoRenewConfig>,
+        #[serde(
+            default,
+            skip_serializing_if = "cert_renewal::AutoRenewConfig::is_default"
+        )]
+        auto_renew: cert_renewal::AutoRenewConfig,
 
         #[serde(flatten, skip_serializing_if = "Option::is_none")]
         subject: Option<aziot_certd_config::CertSubject>,

--- a/edgelet/iotedge/test-files/config/ca-quickstart/certd.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 30
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 30
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/ca-quickstart/edged.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/ca-quickstart/keyd.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/certd.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/edged.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/keyd.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/keyd.toml
+++ b/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/keyd.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/dps-tpm/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/certd.toml
@@ -6,9 +6,14 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/dps-tpm/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/dps-tpm/keyd.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/keyd.toml
@@ -12,8 +12,8 @@ keys = ["aziot_identityd_master_id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/dps-x509/certd.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/certd.toml
@@ -6,10 +6,14 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 device-id = "file:///var/secrets/device-id.pem"
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/dps-x509/edged.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/dps-x509/keyd.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/imported-master-encryption-key/certd.toml
+++ b/edgelet/iotedge/test-files/config/imported-master-encryption-key/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/imported-master-encryption-key/edged.toml
+++ b/edgelet/iotedge/test-files/config/imported-master-encryption-key/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/imported-master-encryption-key/keyd.toml
+++ b/edgelet/iotedge/test-files/config/imported-master-encryption-key/keyd.toml
@@ -14,8 +14,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/edged.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/keyd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/manual-connection-string/edged.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/manual-connection-string/keyd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/manual-x509/certd.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/certd.toml
@@ -6,10 +6,14 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 device-id = "file:///var/secrets/device-id.pem"
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/manual-x509/edged.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "Dynamic"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/manual-x509/keyd.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/nested-edge/certd.toml
+++ b/edgelet/iotedge/test-files/config/nested-edge/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/nested-edge/edged.toml
+++ b/edgelet/iotedge/test-files/config/nested-edge/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/nested-edge/keyd.toml
+++ b/edgelet/iotedge/test-files/config/nested-edge/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/edged.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/keyd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/edged.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/keyd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/certd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/edged.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/keyd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/certd.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/certd.toml
@@ -6,9 +6,13 @@ homedir_path = "/var/lib/aziot/certd"
 method = "self_signed"
 expiry_days = 90
 
+[cert_issuance.aziot-edged-ca-temp]
+method = "self_signed"
+expiry_days = 90
+
 [preloaded_certs]
 aziot-edged-trust-bundle = ["aziot-edged-ca"]
 
 [[principal]]
 uid = 5558
-certs = ["aziot-edged-ca", "aziot-edged/module/*"]
+certs = ["aziot-edged-ca", "aziot-edged/module/*", "aziot-edged-ca-temp"]

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/edged.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/edged.toml
@@ -7,6 +7,11 @@ auto_reprovisioning_mode = "OnErrorOnly"
 homedir = "/var/lib/aziot/edged"
 allow_elevated_docker_permissions = true
 
+[edge_ca.auto_renew]
+rotate_key = true
+threshold = "80%"
+retry = "4%"
+
 [agent]
 name = "edgeAgent"
 type = "docker"

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/keyd.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/keyd.toml
@@ -13,8 +13,8 @@ keys = ["aziot_identityd_master_id", "device-id"]
 
 [[principal]]
 uid = 5555
-keys = ["aziot-edged-ca"]
+keys = ["aziot-edged-ca", "aziot-edged-ca-temp"]
 
 [[principal]]
 uid = 5558
-keys = ["aziot-edged-ca", "iotedge_master_encryption_id"]
+keys = ["aziot-edged-ca", "iotedge_master_encryption_id", "aziot-edged-ca-temp"]


### PR DESCRIPTION
Updates the iotedge config apply tool to enable automatic renewal of the Edge CA by default.