### PR TITLE
Release/1.3

### DIFF
--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -20,7 +20,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.3.0-1
+Requires:       aziot-identity-service = 1.3.0-1%{?dist}
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/contrib/enterprise-linux/aziot-edge.spec
+++ b/edgelet/contrib/enterprise-linux/aziot-edge.spec
@@ -20,7 +20,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.3.0-1
+Requires:       aziot-identity-service = 1.3.0-1%{?dist}
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/docker-rs/src/apis/client.rs
+++ b/edgelet/docker-rs/src/apis/client.rs
@@ -13,7 +13,7 @@ use super::ApiError;
 
 use crate::models;
 
-type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
 
 #[derive(Clone)]
 pub struct DockerApiClient<C> {

--- a/edgelet/docker-rs/src/apis/configuration.rs
+++ b/edgelet/docker-rs/src/apis/configuration.rs
@@ -5,7 +5,9 @@ use std::error::Error;
 pub struct Configuration {
     pub base_path: String,
     pub user_agent: Option<String>,
-    pub uri_composer: Box<dyn Fn(&str, &str) -> Result<Uri, Box<dyn Error>> + Send + Sync>,
+    pub uri_composer: Box<
+        dyn Fn(&str, &str) -> Result<Uri, Box<dyn Error + Send + Sync + 'static>> + Send + Sync,
+    >,
 }
 
 impl Default for Configuration {

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -300,6 +300,7 @@ pub struct SystemInfo {
     pub system_vendor: Option<String>,
 
     pub version: String,
+    pub server_version: Option<String>,
 
     pub provisioning: ProvisioningInfo,
 
@@ -336,6 +337,8 @@ impl SystemInfo {
             system_vendor: dmi.vendor,
 
             version: crate::version_with_source_version(),
+            server_version: None,
+
             provisioning: ProvisioningInfo {
                 r#type: "ProvisioningType".into(),
                 dynamic_reprovisioning: false,
@@ -350,26 +353,28 @@ impl SystemInfo {
 
     pub fn merge_additional(&mut self, mut additional_info: BTreeMap<String, String>) -> &Self {
         macro_rules! remove_assign {
-            ($src:literal, $dest:ident) => {
-                if let Some((_, x)) = additional_info.remove_entry($src) {
-                    self.$dest = x.into();
+            ($key:ident) => {
+                if let Some((_, x)) = additional_info.remove_entry(stringify!($key)) {
+                    self.$key = x.into();
                 }
             };
         }
 
-        remove_assign!("kernel_name", kernel);
-        remove_assign!("kernel_release", kernel_release);
-        remove_assign!("kernel_version", kernel_version);
+        remove_assign!(kernel);
+        remove_assign!(kernel_release);
+        remove_assign!(kernel_version);
 
-        remove_assign!("os_name", operating_system);
-        remove_assign!("os_version", operating_system_version);
-        remove_assign!("os_variant", operating_system_variant);
-        remove_assign!("os_build", operating_system_build);
+        remove_assign!(operating_system);
+        remove_assign!(operating_system_version);
+        remove_assign!(operating_system_variant);
+        remove_assign!(operating_system_build);
 
-        remove_assign!("cpu_architecture", architecture);
+        remove_assign!(architecture);
 
-        remove_assign!("product_name", product_name);
-        remove_assign!("product_vendor", system_vendor);
+        remove_assign!(product_name);
+        remove_assign!(system_vendor);
+
+        remove_assign!(server_version);
 
         self.additional_properties
             .extend(additional_info.into_iter());
@@ -677,6 +682,8 @@ mod tests {
             system_vendor: None,
 
             version: crate::version_with_source_version(),
+            server_version: None,
+
             provisioning: ProvisioningInfo {
                 r#type: "ProvisioningType".into(),
                 dynamic_reprovisioning: false,
@@ -704,6 +711,8 @@ mod tests {
             system_vendor: None,
 
             version: crate::version_with_source_version(),
+            server_version: None,
+
             provisioning: ProvisioningInfo {
                 r#type: "ProvisioningType".into(),
                 dynamic_reprovisioning: false,
@@ -717,10 +726,10 @@ mod tests {
         };
 
         let additional = BTreeMap::from([
-            ("kernel_name".to_owned(), "linux".to_owned()),
+            ("kernel".to_owned(), "linux".to_owned()),
             ("kernel_release".to_owned(), "5.0".to_owned()),
             ("kernel_version".to_owned(), "1".to_owned()),
-            ("os_name".to_owned(), "OS".to_owned()),
+            ("operating_system".to_owned(), "OS".to_owned()),
             ("foo".to_owned(), "foofoo".to_owned()),
             ("bar".to_owned(), "barbar".to_owned()),
         ]);

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -654,6 +654,13 @@ where
         let mut system_info = CoreSystemInfo::from_system()
             .map_err(|_| Error::RuntimeOperation(RuntimeOperation::SystemInfo))?;
 
+        let docker_info = self
+            .client
+            .system_info()
+            .await
+            .map_err(|e| Error::DockerRuntime(e.to_string()))
+            .context(Error::RuntimeOperation(RuntimeOperation::SystemInfo))?;
+        system_info.server_version = docker_info.server_version().map(ToOwned::to_owned);
         system_info.merge_additional(self.additional_info.clone());
 
         info!("Successfully queried system info");


### PR DESCRIPTION
Installing aziot-edge 1.3 on either CentOS or RHEL will complain that 
```bash
Error:
Problem: conflicting requests
  - nothing provides aziot-identity-service = 1.3.0-1 needed by aziot-edge-1.3.0-1.el8.x86_64
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```
which is appears to be caused by my change a while back to add the %{?dist} to the aziot-identity-service's Release to differentiate between target platforms (e.g. el7 vs el8).