### PR TITLE
Introduce the `%{?dist}` to the version string

### DIFF
--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -20,7 +20,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.3.0-1
+Requires:       aziot-identity-service = 1.3.0-1.%{?dist}
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -20,7 +20,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.3.0-1.%{?dist}
+Requires:       aziot-identity-service = 1.3.0-1%{?dist}
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/contrib/enterprise-linux/aziot-edge.spec
+++ b/edgelet/contrib/enterprise-linux/aziot-edge.spec
@@ -20,7 +20,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.3.0-1
+Requires:       aziot-identity-service = 1.3.0-1.%{?dist}
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/contrib/enterprise-linux/aziot-edge.spec
+++ b/edgelet/contrib/enterprise-linux/aziot-edge.spec
@@ -20,7 +20,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.3.0-1.%{?dist}
+Requires:       aziot-identity-service = 1.3.0-1%{?dist}
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description


### PR DESCRIPTION
It looks like yum rpmbuild now includes the `%{?dist}` to version string i.e. `1.3.0-1.el7`, `1.3.0-1.el8` instead of being `1.3.0-1`.
This change to update our edgelet spec to facilitate the version string difference.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
