### PR TITLE
Rename dockersource to gnarly

### DIFF
--- a/scripts/linux/buildImage.sh
+++ b/scripts/linux/buildImage.sh
@@ -54,7 +54,7 @@ usage() {
     echo " -v, --image-version  Docker Image Version. Either use this option or set env variable BUILD_BUILDNUMBER"
     echo " -t, --target-arch    Target architecture (default: uname -m)"
     echo "--bin-dir             Directory containing the output binaries. Either use this option or set env variable BUILD_BINARIESDIRECTORY"
-    echo "--source-map          Path to the JSON file that maps Dockerfile image sources to their replacements. Assumes the tool 'dockersource' is in the PATH"
+    echo "--source-map          Path to the JSON file that maps Dockerfile image sources to their replacements. Assumes the tool 'gnarly' is in the PATH"
     echo "--skip-push           Build images, but don't push them"
     exit 1
 }
@@ -155,8 +155,8 @@ process_args() {
         print_help_and_exit
     fi
 
-    if [[ -n "$SOURCE_MAP" ]] && ! command -v dockersource > /dev/null; then
-        echo "--source-map specified, but required tool 'dockersource' not found in PATH"
+    if [[ -n "$SOURCE_MAP" ]] && ! command -v gnarly > /dev/null; then
+        echo "--source-map specified, but required tool 'gnarly' not found in PATH"
         print_help_and_exit
     fi
 
@@ -209,7 +209,7 @@ docker_build_and_tag_and_push() {
     fi
 
     if [[ -n "$SOURCE_MAP" ]]; then
-        build_context=$(dockersource --mod-config $SOURCE_MAP $dockerfile)
+        build_context=$(gnarly --mod-config $SOURCE_MAP $dockerfile)
     fi
 
     docker buildx build \

--- a/scripts/linux/buildRocksDb.sh
+++ b/scripts/linux/buildRocksDb.sh
@@ -30,7 +30,7 @@ function usage() {
     echo "--postfix             Options: amd64, armhf, arm64."
     echo "--build-number        Build number for which to tag image."
     echo "--arch                Options: amd64, arm32v7, arm64v8."
-    echo "--source-map          Path to the JSON file that maps Dockerfile image sources to their replacements. Assumes the tool 'dockersource' is in the PATH"
+    echo "--source-map          Path to the JSON file that maps Dockerfile image sources to their replacements. Assumes the tool 'gnarly' is in the PATH"
     echo " -h, --help           Print this help and exit."
     exit 1
 }
@@ -79,8 +79,8 @@ function process_args() {
         print_help_and_exit
     fi
 
-    if [[ -n "$SOURCE_MAP" ]] && ! command -v dockersource > /dev/null; then
-        echo "--source-map specified, but required tool 'dockersource' not found in PATH"
+    if [[ -n "$SOURCE_MAP" ]] && ! command -v gnarly > /dev/null; then
+        echo "--source-map specified, but required tool 'gnarly' not found in PATH"
         print_help_and_exit
     fi
 }
@@ -100,7 +100,7 @@ cd $BUILD_REPOSITORY_LOCALPATH/edge-util/docker/linux/$ARCH
 
 build_context=
 if [[ -n "$SOURCE_MAP" ]]; then
-    build_context=$(dockersource --mod-config $SOURCE_MAP ./Dockerfile)
+    build_context=$(gnarly --mod-config $SOURCE_MAP ./Dockerfile)
 fi
 
 docker buildx create --use --bootstrap


### PR DESCRIPTION
We recently started using the dockersource tool to generate the `--build-context` argument that gets passed to `docker buildx build` in our Docker image builds pipeline. Last week, it was moved to a new repo and renamed. This change updates our references to the tool. Without this change, image builds will fail because these scripts refer to a tool that no longer exists by the name 'dockersource'.

I ran the Build Images pipeline against these changes to exercise the script changes.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.