### PR TITLE
[main] Include tpmd configuration section from IIS

### DIFF
--- a/edgelet/contrib/config/linux/template.toml
+++ b/edgelet/contrib/config/linux/template.toml
@@ -260,6 +260,35 @@
 
 
 # ==============================================================================
+# TPM
+# ==============================================================================
+#
+# If special configuration is required for the TPM when using DPS TPM
+# provisioning, uncomment any pertinent sections below.
+
+# [tpm]
+# # TCTI loader string; see "TCG TSS 2.0 TPM Command Transmission
+# # Interface (TCTI) API Specification" section 3.5 for an overview of
+# # acceptable TCTI loader strings. By default, this is "device". Setting
+# # this to the empty string will cause the TCTI loader library to try
+# # loading a predefined set of TCTI modules in order.
+# # Ref: https://github.com/tpm2-software/tpm2-tss/blob/3.1.1/src/tss2-tcti/tctildr-dl.c#L28-L59
+# tcti = "swtpm:port=2321"
+#
+# # The TPM index at which to persist the DPS authentication key. The index is
+# # taken as an offset from the base address for persistent objects
+# # (0x81000000), and must lie in the range 0x00_00_00--0x7F_FF_FF. The default
+# # value is 0x00_01_00.
+# auth_key_index = "0x00_01_00"
+
+# # Authorization values for use of the endorsement and owner hierarchies, if
+# # necessary. By default, these are empty strings.
+# [tpm.hierarchy_authorization]
+# endorsement = "hello"
+# owner = "world"
+
+
+# ==============================================================================
 # PKCS#11
 # ==============================================================================
 #


### PR DESCRIPTION
`aziot-tpmd` now has configuration options for TCTI loader string, DPS key storage index, and hierarchy authorization values. These are now included in the template configuration.

For technical discussion on the `aziot-tpmd` changes, see Azure/iot-identity-service#415.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  