### PR TITLE
Disable throttling of edged sockets

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -82,7 +82,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -91,7 +91,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -132,7 +132,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -146,7 +146,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -157,7 +157,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -171,7 +171,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -185,7 +185,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -213,7 +213,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "serde",
 ]
@@ -221,7 +221,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -231,7 +231,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -249,7 +249,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "http-common",
  "libc",
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "pkcs11",
  "serde",
@@ -269,7 +269,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "http-common",
  "serde",
@@ -278,7 +278,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -366,7 +366,7 @@ checksum = "79c2681d6594606957bbb8631c4b90a7fcaaa72cdb714743a437b156d6a7eedd"
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "async-trait",
  "aziot-cert-client-async",
@@ -437,7 +437,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "serde",
  "toml",
@@ -1028,7 +1028,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "async-trait",
  "base64",
@@ -1279,7 +1279,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "env_logger",
  "log",
@@ -1435,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "cc",
 ]
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1529,7 +1529,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1546,7 +1546,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 
 [[package]]
 name = "pkg-config"
@@ -1928,7 +1928,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#4315c31fde7514a662f2d882650556784af6623a"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#3ce096b5b42b953a9fbac6857d78d3a4c6021c68"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/aziot-edged/Cargo.toml
+++ b/edgelet/aziot-edged/Cargo.toml
@@ -27,5 +27,5 @@ aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-ser
 aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
 aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
 
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main", features = ["no-socket-throttle"] }
 logger = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }


### PR DESCRIPTION
Fix a bug where consolidating the Edge daemon server code with the server in aziot-identity-service unintentionally introduced the identity service throttling mechanisms to Edge daemon. Edge daemon has its own throttling mechanism, so the identity service mechanism is not needed.

Fixes https://github.com/Azure/iot-identity-service/issues/433