### PR TITLE
Trim leading '$' from server cert SANs (#6577)

### DIFF
--- a/edgelet/edgelet-http-workload/src/module/cert/server.rs
+++ b/edgelet/edgelet-http-workload/src/module/cert/server.rs
@@ -83,10 +83,11 @@ where
             None => return Err(edgelet_http::error::bad_request("missing request body")),
         };
 
-        let cert_id = format!(
-            "aziot-edged/module/{}:{}:server",
-            &self.module_id, &self.gen_id
-        );
+        // Remove any leading '$' from modules like '$edgeAgent' and '$edgeHub' for consistency
+        // with previous versions.
+        let module_id = self.module_id.trim_start_matches('$');
+
+        let cert_id = format!("aziot-edged/module/{}:{}:server", &module_id, &self.gen_id);
 
         // SANs take precedence over CN. The CN must be in the SAN list to be considered.
         let common_name_san = common_name.clone();
@@ -98,7 +99,7 @@ where
         };
 
         // Server certificates have the module ID and certificate CN as the SANs.
-        let module_id_san = super::SubjectAltName::Dns(self.module_id);
+        let module_id_san = super::SubjectAltName::Dns(module_id.to_string());
 
         let subject_alt_names = vec![common_name_san, module_id_san];
 

--- a/edgelet/edgelet-utils/src/lib.rs
+++ b/edgelet/edgelet-utils/src/lib.rs
@@ -17,7 +17,7 @@ mod logging;
 mod ser_de;
 mod yaml_file_source;
 
-use std::{collections::HashMap, net::IpAddr, str::FromStr};
+use std::collections::HashMap;
 
 pub use crate::error::Error;
 pub use crate::logging::log_failure;
@@ -55,54 +55,4 @@ pub fn prepare_cert_uri_module(hub_name: &str, device_id: &str, module_id: &str)
         "URI: azureiot://{}/devices/{}/modules/{}",
         hub_name, device_id, module_id
     )
-}
-
-const ALLOWED_CHAR_DNS: char = '-';
-const DNS_MAX_SIZE: usize = 63;
-
-/// The name returned from here must conform to following rules (as per RFC 1035):
-///  - length must be <= 63 characters
-///  - must be all lower case alphanumeric characters or '-'
-///  - must start with an alphabet
-///  - must end with an alphanumeric character
-pub fn sanitize_dns_label(name: &str) -> String {
-    name.trim_start_matches(|c: char| !c.is_ascii_alphabetic())
-        .trim_end_matches(|c: char| !c.is_ascii_alphanumeric())
-        .to_lowercase()
-        .chars()
-        .filter(|c| c.is_ascii_alphanumeric() || c == &ALLOWED_CHAR_DNS)
-        .take(DNS_MAX_SIZE)
-        .collect::<String>()
-}
-
-pub fn prepare_dns_san_entries<'a>(
-    names: impl Iterator<Item = &'a str> + 'a,
-) -> impl Iterator<Item = String> + 'a {
-    names.filter_map(|name| {
-        let dns = sanitize_dns_label(name);
-        if dns.is_empty() {
-            None
-        } else {
-            Some(dns)
-        }
-    })
-}
-
-pub fn append_dns_san_entries(sans: &str, names: &[&str]) -> String {
-    let mut dns_ip_sans = names
-        .iter()
-        .filter_map(|name| {
-            if IpAddr::from_str(name).is_ok() {
-                Some(format!("IP:{}", name))
-            } else if name.trim().is_empty() {
-                None
-            } else {
-                Some(name.to_lowercase())
-            }
-        })
-        .collect::<Vec<String>>()
-        .join(", ");
-    dns_ip_sans.push_str(", ");
-    dns_ip_sans.push_str(sans);
-    dns_ip_sans
 }


### PR DESCRIPTION
In 1.2, the workload API removed the '$' from module names like '$edgeAgent' and '$edgeHub' before issuing the server certs with the module name SANs. Restore that behavior in 1.3.

In response to #6540 