### PR TITLE
Fix creation and cleanup of edgeagentuser and edgehubuser

### DIFF
--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -97,12 +97,12 @@ fi
 
 # Create an edgeagentuser and add it to iotedge group
 if ! /usr/bin/getent passwd %{iotedge_agent_user} >/dev/null; then
-    %{_sbindir}/useradd -r -g %{iotedge_group} -c "edgeAgent user" -s /bin/sh -u %{iotedge_agent_uid} %{iotedge_agent_user}
+    %{_sbindir}/useradd -r -g %{iotedge_group} -c "edgeAgent user" -s /bin/sh -u %{iotedge_agent_uid} %{iotedge_agent_user} || true
 fi
 
 # Create an edgehubuser
 if ! getent passwd edgehubuser >/dev/null; then
-    %{_sbindir}/useradd -r -c "edgeHub user" -s /bin/sh -u %{iotedge_hub_uid} %{iotedge_hub_user}
+    %{_sbindir}/useradd -r -c "edgeHub user" -s /bin/sh -u %{iotedge_hub_uid} %{iotedge_hub_user} || true
 fi
 
 # Add iotedge user to aziot-identity-service groups

--- a/edgelet/contrib/debian/postrm
+++ b/edgelet/contrib/debian/postrm
@@ -18,8 +18,12 @@ case "$1" in
             gpasswd -d "$u" iotedge
         done
 
+        # Remove iotedge users.
         /usr/sbin/userdel iotedge
         rm -rf /var/lib/aziot/edged
+
+        /usr/sbin/userdel edgeagentuser
+        /usr/sbin/userdel edgehubuser
 
         if [ -d /var/lib/aziot ] && [ -z "$(ls -A /var/lib/aziot)" ]; then
             rm -rf /var/lib/aziot

--- a/edgelet/contrib/debian/preinst
+++ b/edgelet/contrib/debian/preinst
@@ -14,12 +14,12 @@ add_groups()
 
     # Create an edgeagentuser and add it to iotedge group
     if ! getent passwd edgeagentuser >/dev/null; then
-        useradd -r -g iotedge -c "edgeAgent user" -s /bin/sh -u 13622 edgeagentuser
+        useradd -r -g iotedge -c "edgeAgent user" -s /bin/sh -u 13622 edgeagentuser || true
     fi
 
     # Create an edgehubuser
     if ! getent passwd edgehubuser >/dev/null; then
-        useradd -r -c "edgeHub user" -s /bin/sh -u 13623 edgehubuser
+        useradd -r -c "edgeHub user" -s /bin/sh -u 13623 edgehubuser || true
     fi
 
     # add iotedge user to docker group so that it can talk to the docker socket

--- a/edgelet/contrib/enterprise-linux/aziot-edge.spec
+++ b/edgelet/contrib/enterprise-linux/aziot-edge.spec
@@ -97,12 +97,12 @@ fi
 
 # Create an edgeagentuser and add it to iotedge group
 if ! /usr/bin/getent passwd %{iotedge_agent_user} >/dev/null; then
-    %{_sbindir}/useradd -r -g %{iotedge_group} -c "edgeAgent user" -s /bin/sh -u %{iotedge_agent_uid} %{iotedge_agent_user}
+    %{_sbindir}/useradd -r -g %{iotedge_group} -c "edgeAgent user" -s /bin/sh -u %{iotedge_agent_uid} %{iotedge_agent_user} || true
 fi
 
 # Create an edgehubuser
 if ! getent passwd edgehubuser >/dev/null; then
-    %{_sbindir}/useradd -r -c "edgeHub user" -s /bin/sh -u %{iotedge_hub_uid} %{iotedge_hub_user}
+    %{_sbindir}/useradd -r -c "edgeHub user" -s /bin/sh -u %{iotedge_hub_uid} %{iotedge_hub_user} || true
 fi
 
 # Add iotedge user to aziot-identity-service groups


### PR DESCRIPTION
- Delete edgeagentuser and edgehubuser during package purge
- Allow creation of edgeagentuser and edgehub user to fail during package install. edgeHub and edgeAgent will still work if their users don't exist on the host. The host will misidentify files owned by edgeHub and edgeAgent, but the modules will still work.