### PR TITLE
Remove unused 'buildx_flag' from pipelines

### DIFF
--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -99,7 +99,6 @@ stages:
         name: API Proxy
         imageName: azureiotedge-api-proxy
         project: api-proxy-module
-        buildx_flag: false
         version: $(buildVersion)
         bin_dir: '$(Build.BinariesDirectory)'      
 

--- a/builds/misc/images-release-base-image-update.yaml
+++ b/builds/misc/images-release-base-image-update.yaml
@@ -372,7 +372,6 @@ stages:
           project: Microsoft.Azure.Devices.Edge.Hub.Service
           version: $(version)
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
     - job: BuildImageEdgeAgent
       steps:
@@ -383,7 +382,6 @@ stages:
           project: Microsoft.Azure.Devices.Edge.Agent.Service
           version: $(version)
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
     - job: BuildImageTemperatureSensor
       steps:
@@ -394,7 +392,6 @@ stages:
           project: SimulatedTemperatureSensor
           version: $(version)
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageDiagnostics
       steps:
       - template: templates/image-linux.yaml
@@ -404,7 +401,6 @@ stages:
           project: IotedgeDiagnosticsDotnet
           version: $(version)
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     # for E2E tests
     - job: BuildImageMetricsValidator
       steps:
@@ -414,7 +410,6 @@ stages:
           imageName: azureiotedge-metrics-validator
           project: MetricsValidator
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageDirectMethodSender
       steps:
       - template: templates/image-linux.yaml
@@ -423,7 +418,6 @@ stages:
           imageName: azureiotedge-direct-method-sender
           project: DirectMethodSender
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageDirectMethodReceiver
       steps:
       - template: templates/image-linux.yaml
@@ -432,7 +426,6 @@ stages:
           imageName: azureiotedge-direct-method-receiver
           project: DirectMethodReceiver
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageNumberLogger
       steps:
       - template: templates/image-linux.yaml
@@ -441,7 +434,6 @@ stages:
           imageName: azureiotedge-number-logger
           project: NumberLogger
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageTemperatureFilter
       steps:
       - template: templates/image-linux.yaml
@@ -450,7 +442,6 @@ stages:
           imageName: azureiotedge-temperature-filter
           project: TemperatureFilter
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageLoadGen
       steps:
       - template: templates/image-linux.yaml
@@ -459,7 +450,6 @@ stages:
           imageName: azureiotedge-load-gen
           project: load-gen
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageTestResultCoordinator
       steps:
       - template: templates/image-linux.yaml
@@ -468,7 +458,6 @@ stages:
           imageName: azureiotedge-test-result-coordinator
           project: TestResultCoordinator
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
     - job: BuildImageRelayer
       steps:
@@ -478,7 +467,6 @@ stages:
           imageName: azureiotedge-relayer
           project: Relayer
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     # Functions Sample - Not supported on linux arm64
     - job: BuildImageFunctionsSample
       steps:
@@ -488,7 +476,6 @@ stages:
           imageName: azureiotedge-functions-filter
           project: EdgeHubTriggerCSharp
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
 ################################################################################
   - stage: PublishManifests

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -369,7 +369,6 @@ stages:
           project: Microsoft.Azure.Devices.Edge.Hub.Service
           version: $(version)
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
     - job: BuildImageEdgeAgent
       steps:
@@ -380,7 +379,6 @@ stages:
           project: Microsoft.Azure.Devices.Edge.Agent.Service
           version: $(version)
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
     - job: BuildImageTemperatureSensor
       steps:
@@ -391,7 +389,6 @@ stages:
           project: SimulatedTemperatureSensor
           version: $(version)
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageDiagnostics
       steps:
       - template: templates/image-linux.yaml
@@ -401,7 +398,6 @@ stages:
           project: IotedgeDiagnosticsDotnet
           version: $(version)
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
 ################################################################################
   - stage: PublishManifests

--- a/builds/misc/templates/build-images.yaml
+++ b/builds/misc/templates/build-images.yaml
@@ -159,7 +159,6 @@ stages:
             imageName: azureiotedge-agent
             project: Microsoft.Azure.Devices.Edge.Agent.Service
             bin_dir: '$(Build.BinariesDirectory)'
-            buildx_flag: 'true'
             use_rocksdb: true
 
     - job: BuildImageEdgeHub
@@ -170,7 +169,6 @@ stages:
           imageName: azureiotedge-hub
           project: Microsoft.Azure.Devices.Edge.Hub.Service
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
 
     - job: BuildImageTemperatureSensor
@@ -181,7 +179,6 @@ stages:
           imageName: azureiotedge-simulated-temperature-sensor
           project: SimulatedTemperatureSensor
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageDiagnostics
       steps:
@@ -191,7 +188,6 @@ stages:
           imageName: azureiotedge-diagnostics
           project: IotedgeDiagnosticsDotnet
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageTemperatureFilter
       steps:
@@ -201,7 +197,6 @@ stages:
           imageName: azureiotedge-temperature-filter
           project: TemperatureFilter
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageLoadGen
       steps:
@@ -211,7 +206,6 @@ stages:
           imageName: azureiotedge-load-gen
           project: load-gen
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
     - job: BuildImageTestAnalyzer
       steps:
       - template: image-linux.yaml
@@ -221,7 +215,6 @@ stages:
           project: TestAnalyzer
           bin_dir: '$(Build.BinariesDirectory)'
           use_rocksdb: true
-          buildx_flag: 'true'
 
       # Functions Sample - Not supported on linux arm64
     - job: BuildImageFunctionsSample
@@ -241,7 +234,6 @@ stages:
           imageName: azureiotedge-direct-method-sender
           project: DirectMethodSender
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageDirectMethodReceiver
       steps:
@@ -251,7 +243,6 @@ stages:
           imageName: azureiotedge-direct-method-receiver
           project: DirectMethodReceiver
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageMetricsValidator
       steps:
@@ -261,7 +252,6 @@ stages:
           imageName: azureiotedge-metrics-validator
           project: MetricsValidator
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageNumberLogger
       steps:
@@ -271,7 +261,6 @@ stages:
           imageName: azureiotedge-number-logger
           project: NumberLogger
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageModuleRestarter
       steps:
@@ -281,7 +270,6 @@ stages:
           imageName: azureiotedge-module-restarter
           project: ModuleRestarter
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageTwinTester
       steps:
@@ -291,7 +279,6 @@ stages:
           imageName: azureiotedge-twin-tester
           project: TwinTester
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
     - job: BuildImageRelayer
       steps:
@@ -301,7 +288,6 @@ stages:
           imageName: azureiotedge-relayer
           project: Relayer
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageNetworkController
       steps:
@@ -311,7 +297,6 @@ stages:
           imageName: azureiotedge-network-controller
           project: NetworkController
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
 
     - job: BuildImageTestResultCoordinator
@@ -322,7 +307,6 @@ stages:
           imageName: azureiotedge-test-result-coordinator
           project: TestResultCoordinator
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
           use_rocksdb: true
 
     - job: BuildImageTestMetricsCollector
@@ -333,7 +317,6 @@ stages:
           imageName: azureiotedge-test-metrics-collector
           project: TestMetricsCollector
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
 
     - job: BuildImageDeploymentTester
@@ -344,7 +327,6 @@ stages:
           imageName: azureiotedge-deployment-tester
           project: DeploymentTester
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
 
     - job: BuildImageEdgeHubRestartTester
@@ -355,7 +337,6 @@ stages:
           imageName: azureiotedge-edgehub-restart-tester
           project: EdgeHubRestartTester
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageCloudToDeviceMessageTester
       steps:
@@ -365,7 +346,6 @@ stages:
           imageName: azureiotedge-c2dmessage-tester
           project: CloudToDeviceMessageTester
           bin_dir: '$(Build.BinariesDirectory)'
-          buildx_flag: 'true'
 
     - job: BuildImageApiProxy
       steps:
@@ -377,7 +357,6 @@ stages:
           name: API Proxy
           imageName: azureiotedge-api-proxy
           project: api-proxy-module
-          buildx_flag: false
           bin_dir: '$(Build.BinariesDirectory)'
 
 ################################################################################

--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -4,7 +4,6 @@ parameters:
   namespace: 'microsoft'
   project: ''
   version: ''
-  buildx_flag: ''
   bin_dir: ''
   use_rocksdb: false
 


### PR DESCRIPTION
The script argument 'buildx_flag' was removed a458af376177adacb25349cc8f59df8aae9e1a15 but references weren't removed from the build pipelines. This change updates the pipelines.

I ran the Build Images pipeline to confirm that nothing bad happens.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.