### PR TITLE
Update base image release pipeline

### DIFF
--- a/builds/misc/images-release-base-image-update.yaml
+++ b/builds/misc/images-release-base-image-update.yaml
@@ -15,18 +15,28 @@ stages:
     dependsOn: []
     jobs:
     - job: BuildDotnetComponents
-      # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).
       displayName: Build Dotnet Components
       steps:
-        - template: ../templates/dotnet3-globaljson.yaml # use dotnet 3 as primary install for build
         # Build
         - task: ShellScript@2
-          displayName: "Build (Release) dotnet artifacts"
+          displayName: "Build .NET artifacts"
           inputs:
             args: "-c Release"
             scriptPath: scripts/linux/buildBranch.sh
+        - task: DotNetCoreCLI@2
+          displayName: "Functions Binding nuget package"
+          inputs:
+            buildProperties: OutDir=$(Build.BinariesDirectory)/publish/Microsoft.Azure.WebJobs.Extensions.EdgeHub
+            command: pack
+            nobuild: true
+            packDirectory: $(Build.BinariesDirectory)/publish/
+            packagesToPack: "**/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj"
+            versionEnvVar: version
+            versioningScheme: byEnvVar
+        # The code sign task requires .NET Core 2.1.
+        # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).
+        - template: ../templates/force-dotnet21.yaml
         # Code Sign
-        - template: ../templates/dotnet2-globaljson.yaml # switch to dotnet 2 as primary install for code sign
         - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
           displayName: "Edge Agent Code Sign"
           inputs:
@@ -247,18 +257,6 @@ stages:
                   }
                 ]
             signConfigType: inlineSignParams
-        - template: ../templates/dotnet3-globaljson.yaml # switch to dotnet 3 as primary install for nuget package
-        - task: DotNetCoreCLI@2
-          displayName: "Functions Binding nuget package"
-          inputs:
-            buildProperties: OutDir=$(Build.BinariesDirectory)/publish/Microsoft.Azure.WebJobs.Extensions.EdgeHub
-            command: pack
-            nobuild: true
-            packDirectory: $(Build.BinariesDirectory)/publish/
-            packagesToPack: "**/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj"
-            versionEnvVar: version
-            versioningScheme: byEnvVar
-        - template: ../templates/dotnet2-globaljson.yaml # switch to dotnet 2 as primary install for code sign
         - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
           displayName: "Functions Binding nuget package Sign"
           inputs:
@@ -283,6 +281,8 @@ stages:
                   }
                 ]
             signConfigType: inlineSignParams
+        # We're done with code signing, so remove dotnet version override
+        - template: ../templates/restore-default-dotnet.yaml
         - bash: |
             mkdir $(Build.ArtifactStagingDirectory)/publish-linux && \
             mv $(Build.BinariesDirectory)/publish/{CACertificates,scripts} \


### PR DESCRIPTION
The standard Docker images release pipeline was updated in 37234e02b500e6930d389275ac09a5aee80f7445, but the corresponding parts of the base images release pipeline were not updated. This change brings the two back in sync:
- References to old templates `dotnet2-globaljson.yaml` and `dotnet3-globaljson.yaml` are replaced with `force-dotnet21.yaml` and `restore-default-dotnet.yaml`, respectively
- The nuget package task is reordered for clarity

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.