### PR TITLE
Edge Agent: Fix bug where Edge Agent is updated without backing image

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planner/HealthRestartPlanner.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/planner/HealthRestartPlanner.cs
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Planner
                 plan.AddRange(commands);
             }
 
-            // If we need to premept the constructured plan with image pull
+            // If we need to premept the constructed plan with image pull
             // commands, do so here.
             plan = upfrontImagePullPlan.Concat(plan).ToList();
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commandfactories/ExecutionPrerequisiteCommandFactory.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commandfactories/ExecutionPrerequisiteCommandFactory.cs
@@ -3,6 +3,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.CommandFactories
 {
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Agent.Core;
+    using Microsoft.Azure.Devices.Edge.Agent.Core.Commands;
     using Microsoft.Azure.Devices.Edge.Agent.Edgelet.Commands;
 
     // CommandFactory that will issue ExecutionPrerequisiteException on a
@@ -16,9 +17,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.CommandFactories
             this.commandFactory = commandFactory;
         }
 
-        public Task<ICommand> UpdateEdgeAgentAsync(IModuleWithIdentity module, IRuntimeInfo runtimeInfo)
+        public async Task<ICommand> UpdateEdgeAgentAsync(IModuleWithIdentity module, IRuntimeInfo runtimeInfo)
         {
-            return this.commandFactory.UpdateEdgeAgentAsync(module, runtimeInfo);
+            ICommand prepareUpdate = await this.commandFactory.PrepareUpdateAsync(module.Module, runtimeInfo);
+            ICommand updateEdgeAgent = await this.commandFactory.UpdateEdgeAgentAsync(module, runtimeInfo);
+            return new GroupCommand(new ExecutionPrerequisiteCommand(prepareUpdate), updateEdgeAgent);
         }
 
         public Task<ICommand> CreateAsync(IModuleWithIdentity module, IRuntimeInfo runtimeInfo)

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commandfactories/StandardCommandFactory.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/commandfactories/StandardCommandFactory.cs
@@ -27,9 +27,11 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.CommandFactories
             this.nullCommandFactory = NullCommandFactory.Instance;
         }
 
-        public Task<ICommand> UpdateEdgeAgentAsync(IModuleWithIdentity module, IRuntimeInfo runtimeInfo)
+        public async Task<ICommand> UpdateEdgeAgentAsync(IModuleWithIdentity module, IRuntimeInfo runtimeInfo)
         {
-            return this.commandFactory.UpdateEdgeAgentAsync(module, runtimeInfo);
+            ICommand prepareUpdate = await this.commandFactory.PrepareUpdateAsync(module.Module, runtimeInfo);
+            ICommand updateEdgeAgent = await this.commandFactory.UpdateEdgeAgentAsync(module, runtimeInfo);
+            return new GroupCommand(prepareUpdate, updateEdgeAgent);
         }
 
         public async Task<ICommand> CreateAsync(IModuleWithIdentity module, IRuntimeInfo runtimeInfo)

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/test-configs/module-priority-test-config.json
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/test-configs/module-priority-test-config.json
@@ -220,6 +220,10 @@
       "$type": "ModulePriorityValidator",
       "moduleCommands": [
         {
+          "command": "TestPrepareUpdate",
+          "moduleName": "edgeAgent"
+        },
+        {
           "command": "TestUpdateEdgeAgent",
           "moduleName": "edgeAgent"
         },
@@ -392,6 +396,163 @@
         {
           "command": "TestStart",
           "moduleName": "edgeHub"
+        }
+      ]
+    }
+  },
+  {
+    "deploymentConfig": {
+      "schemaVersion": "1.0",
+      "runtime": {
+        "type": "docker",
+        "settings": {
+          "minDockerVersion": "v1.25",
+          "loggingOptions": "",
+          "registryCredentials": {}
+        }
+      },
+      "systemModules": {
+        "edgeAgent": {
+          "type": "docker",
+          "settings": {
+            "image": "mcr.microsoft.com/azureiotedge-agent:1.0",
+            "createOptions": "{}"
+          },
+          "startupOrder": 2,
+          "env": {
+            "ModuleUpdateMode": {
+              "value": "WaitForAllPulls"
+            }
+          }
+        },
+        "edgeHub": {
+          "type": "docker",
+          "settings": {
+            "image": "mcr.microsoft.com/azureiotedge-hub:1.0",
+            "createOptions": "{\"HostConfig\":{\"PortBindings\":{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}],\"5671/tcp\":[{\"HostPort\":\"5671\"}]},\"StopTimeout\":60}}"
+          },
+          "env": {},
+          "startupOrder": 0,
+          "status": "running",
+          "restartPolicy": "always"
+        }
+      },
+      "modules": {
+        "tempSensor": {
+          "type": "docker",
+          "settings": {
+            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "createOptions": ""
+          },
+          "startupOrder": 1,
+          "status": "running",
+          "restartPolicy": "always"
+        },
+        "tempSensor2": {
+          "type": "docker",
+          "settings": {
+            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "createOptions": ""
+          },
+          "status": "running",
+          "restartPolicy": "always"
+        }
+      }
+    },
+    "runtimeInfo": {
+      "modules": {
+        "edgeAgent": {
+          "exitCode": 0,
+          "runtimeStatus": "running",
+          "status": "running",
+          "restartPolicy": "always",
+          "startupOrder": 2,
+          "type": "docker",
+          "settings": {
+            "image": "mcr.microsoft.com/azureiotedge-agent:2.0",
+            "createOptions": "{}"
+          }
+        },
+        "tempSensor": {
+          "exitCode": 0,
+          "runtimeStatus": "running",
+          "status": "running",
+          "restartPolicy": "always",
+          "startupOrder": 4,
+          "type": "docker",
+          "settings": {
+            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "createOptions": "{}"
+          }
+        },
+        "tempSensor1": {
+          "exitCode": 0,
+          "runtimeStatus": "running",
+          "status": "running",
+          "restartPolicy": "always",
+          "startupOrder": 3,
+          "type": "docker",
+          "settings": {
+            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.8-linux-amd64",
+            "createOptions": "{}"
+          }
+        }
+      }
+    },
+    "validator": {
+      "$type": "ModulePriorityValidator",
+      "moduleCommands": [
+        {
+          "command": "TestPrepareUpdate",
+          "moduleName": "edgeHub"
+        },
+        {
+          "command": "TestPrepareUpdate",
+          "moduleName": "tempSensor"
+        },
+        {
+          "command": "TestPrepareUpdate",
+          "moduleName": "tempSensor2"
+        },
+        {
+          "command": "TestPrepareUpdate",
+          "moduleName": "edgeAgent"
+        },
+        {
+          "command": "TestUpdateEdgeAgent",
+          "moduleName": "edgeAgent"
+        },
+        {
+          "command": "TestCreate",
+          "moduleName": "edgeHub"
+        },
+        {
+          "command": "TestStart",
+          "moduleName": "edgeHub"
+        },
+        {
+          "command": "TestUpdate",
+          "moduleName": "tempSensor"
+        },
+        {
+          "command": "TestStart",
+          "moduleName": "tempSensor"
+        },
+        {
+          "command": "TestStop",
+          "moduleName": "tempSensor1"
+        },
+        {
+          "command": "TestRemove",
+          "moduleName": "tempSensor1"
+        },
+        {
+          "command": "TestCreate",
+          "moduleName": "tempSensor2"
+        },
+        {
+          "command": "TestStart",
+          "moduleName": "tempSensor2"
         }
       ]
     }

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/test-configs/module-priority-test-config.json
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/test-configs/module-priority-test-config.json
@@ -34,7 +34,7 @@
         "tempSensor": {
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
             "createOptions": ""
           },
           "startupOrder": 2,
@@ -53,7 +53,7 @@
           "startupOrder": 2,
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.8-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.1",
             "createOptions": "{}"
           }
         },
@@ -65,7 +65,7 @@
           "startupOrder": 1,
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.8-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.1",
             "createOptions": "{}"
           }
         }
@@ -158,7 +158,7 @@
         "tempSensor": {
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
             "createOptions": ""
           },
           "startupOrder": 1,
@@ -168,7 +168,7 @@
         "tempSensor2": {
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
             "createOptions": ""
           },
           "status": "running",
@@ -198,7 +198,7 @@
           "startupOrder": 4,
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
             "createOptions": "{}"
           }
         },
@@ -210,7 +210,7 @@
           "startupOrder": 3,
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.8-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.1",
             "createOptions": "{}"
           }
         }
@@ -313,7 +313,7 @@
         "tempSensor": {
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
             "createOptions": ""
           },
           "startupOrder": 2,
@@ -332,7 +332,7 @@
           "startupOrder": 2,
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.8-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.1",
             "createOptions": "{}"
           }
         },
@@ -344,7 +344,7 @@
           "startupOrder": 1,
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.8-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.1",
             "createOptions": "{}"
           }
         }
@@ -441,7 +441,7 @@
         "tempSensor": {
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
             "createOptions": ""
           },
           "startupOrder": 1,
@@ -451,7 +451,7 @@
         "tempSensor2": {
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
             "createOptions": ""
           },
           "status": "running",
@@ -481,7 +481,7 @@
           "startupOrder": 4,
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.7-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0",
             "createOptions": "{}"
           }
         },
@@ -493,7 +493,7 @@
           "startupOrder": 3,
           "type": "docker",
           "settings": {
-            "image": "edgebuilds.azurecr.io/microsoft/azureiotedge-simulated-temperature-sensor:20191106.8-linux-amd64",
+            "image": "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.1",
             "createOptions": "{}"
           }
         }


### PR DESCRIPTION
I was doing some manual validation of my the Edge Agent feature I contributed in a prior PR:
https://github.com/Azure/iotedge/pull/6508

This validation turned up a bug relating to some side effects of how we restructured the command factories:
1. Update commands no longer are a GroupCommand with a PrepareUpdateCommand nested inside. This meant that on EdgeAgent update, new EdgeAgent image was not pulled before EdgeAgent went down.
2. Related to above, EdgeAgent needs dedicated PrepareUpdate command that will throw PrerequisiteException to block subsequent plan execution commands from running.

I have fixed both of these in this PR and added a test for when EdgeAgent container is updated with this feature flag on.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
