### PR TITLE
Update release/1.x references in pipelines

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 # Test agents are shared, so schedules must be coordinated to avoid conflicts:
-# - main and release/1.3 run daily except Sundays, but are offset from each other by 12 hours
+# - main and release/1.4 run daily except Sundays, but are offset from each other by 12 hours
 # - release/1.1 runs on Sundays
 schedules:
 - cron: "0 0 * * 1,2,3,4,5,6"
@@ -12,10 +12,10 @@ schedules:
     - main
   always: true
 - cron: "0 12 * * 1,2,3,4,5,6"
-  displayName: Daily run release/1.3
+  displayName: Daily run release/1.4
   branches:
     include:
-    - release/1.3
+    - release/1.4
   always: true
 - cron: "0 0 * * 0"
   displayName: Weekly run release/1.1

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 # Test agents are shared, so schedules must be coordinated to avoid conflicts:
-# - main and release/1.3 run daily, but are offset from each other by 12 hours
+# - main and release/1.4 run daily, but are offset from each other by 12 hours
 schedules:
 - cron: "0 0 * * *"
   displayName: Daily run main
@@ -11,10 +11,10 @@ schedules:
     - main
   always: true
 - cron: "0 12 * * *"
-  displayName: Daily run release/1.3
+  displayName: Daily run release/1.4
   branches:
     include:
-    - release/1.3
+    - release/1.4
   always: true
 
 variables:

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -5,7 +5,7 @@ schedules:
   displayName: Weekly run Thursday night
   branches:
     include:
-    - release/1.3
+    - release/1.4
   always: true
 
 variables:

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -2,7 +2,7 @@ trigger: none
 pr: none
 
 # Test agents are shared, so schedules must be coordinated to avoid conflicts:
-# - main and release/1.3 run daily, but are offset from each other by 12 hours
+# - main and release/1.4 run daily, but are offset from each other by 12 hours
 schedules:
 - cron: "0 0 * * *"
   displayName: Daily run main
@@ -11,10 +11,10 @@ schedules:
     - main
   always: true
 - cron: "0 12 * * *"
-  displayName: Daily run release/1.3
+  displayName: Daily run release/1.4
   branches:
     include:
-    - release/1.3
+    - release/1.4
   always: true
 
 variables:

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -5,7 +5,7 @@ schedules:
   displayName: Weekly run Thursday night
   branches:
     include:
-    - release/1.3
+    - release/1.4
   always: true
 
 variables:

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -15,8 +15,7 @@ resources:
     type: github
     endpoint: azure-iot-edge-iotedge1-github
     name: azure/iot-identity-service
-    ref: release/1.2
-    # TODO: Once release/1.3 is fork for IIS repo, we will need to update his parameter.
+    ref: release/1.4
 
 stages:
 ################################################################################

--- a/scripts/linux/github/updateLatestVersion.sh
+++ b/scripts/linux/github/updateLatestVersion.sh
@@ -176,7 +176,7 @@ update_latest_version_json()
         echo "Update $TARGET_IE_FILE:"
         cat $TARGET_IE_FILE | jq '.'
 
-    elif [ "$BRANCH_NAME" == "refs/heads/release/1.2" ]; then
+    elif [ "$BRANCH_NAME" == "refs/heads/release/1.4" ]; then
 
         [[ -z "$IIS_REPO_PATH" ]] && { echo "\$IIS_REPO_PATH is undefined"; exit 1; }
         # Set target version file to be updated


### PR DESCRIPTION
This change updates schedule triggers in various pipelines to include the upcoming `release/1.4` branch instead of `release/1.3`. Note that, given how [schedule triggers work](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#branch-considerations-for-scheduled-triggers) in Azure pipelines, these changes in `main` won't actually impact the schedules in `release/1.4` because the latter branch doesn't exist yet. But the schedules will light up as soon as the new branch is created.

This change also updates the Packages Release pipeline to point to the upcoming `release/1.4` branch of the Azure/iot-identity-service repo.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.