### PR TITLE
Fix packages pipeline CI trigger

### DIFF
--- a/builds/misc/packages.yaml
+++ b/builds/misc/packages.yaml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - main
+      - release/*
 pr: none
 
 variables:


### PR DESCRIPTION
The edgelet packages pipeline runs every time a commit is merged to main. It should also run when commits are merged to release/1.4. This change updates the trigger spec to make that happen. Once this change is merged into main I'll also make sure it goes to release/1.4, since that's where the trigger will be evaluated.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.