### PR TITLE
Remove unused secret from test pipeline

### DIFF
--- a/builds/e2e/templates/e2e-setup-base-image-update-release.yaml
+++ b/builds/e2e/templates/e2e-setup-base-image-update-release.yaml
@@ -15,7 +15,6 @@ steps:
         TestEventHubCompatibleEndpoint,
         TestGitHubAccessToken,
         TestPreviewEventHubCompatibleEndpoint,
-        TestIotedgedPackageRootSigningCert,
         TestIotHubConnectionString,
         TestRootCaCertificate,
         TestRootCaKey,

--- a/builds/e2e/templates/e2e-setup.yaml
+++ b/builds/e2e/templates/e2e-setup.yaml
@@ -15,7 +15,6 @@ steps:
         TestEventHubCompatibleEndpoint,
         TestGitHubAccessToken,
         TestPreviewEventHubCompatibleEndpoint,
-        TestIotedgedPackageRootSigningCert,
         TestIotHubConnectionString,
         TestRootCaCertificate,
         TestRootCaKey,


### PR DESCRIPTION
Our end-to-end test pipeline references a key vault secret that allows the test agent to trust the dev-signed IoT Edge Windows installer (CAB). Since we don't publish a Windows CAB file in v1.2+, we no longer need the secret.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.