### PR TITLE
Prepare for release 1.4.0

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -162,7 +162,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "serde",
 ]
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "http-common",
  "libc",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "pkcs11",
  "serde",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "http-common",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -359,7 +359,7 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "async-trait",
  "aziot-cert-client-async",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "serde",
  "toml",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "async-trait",
  "base64",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "env_logger",
  "log",
@@ -1478,7 +1478,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "cc",
 ]
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1589,7 +1589,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 
 [[package]]
 name = "pkg-config"
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#d966a2227f3de42e5324db93786c572b203da605"
+source = "git+https://github.com/Azure/iot-identity-service?branch=release/1.4#c281b76772f16d7389fd6b25872c2119e539eab8"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/aziot-edged/Cargo.toml
+++ b/edgelet/aziot-edged/Cargo.toml
@@ -25,9 +25,9 @@ edgelet-http-workload = { path = "../edgelet-http-workload" }
 edgelet-image-cleanup = { path = "../edgelet-image-cleanup" }
 edgelet-settings = { path = "../edgelet-settings", features = ["settings-docker"] }
 
-aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-logger = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+logger = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }

--- a/edgelet/contrib/centos/aziot-edge.spec
+++ b/edgelet/contrib/centos/aziot-edge.spec
@@ -22,7 +22,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.4.0~dev-1%{?dist}
+Requires:       aziot-identity-service = 1.4.0~1%{?dist}
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/contrib/debian/control
+++ b/edgelet/contrib/debian/control
@@ -8,7 +8,7 @@ Homepage: https://github.com/azure/iotedge
 
 Package: aziot-edge
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, aziot-identity-service (= 1.4.0~dev-1), sed
+Depends: ${misc:Depends}, ${shlibs:Depends}, adduser, ca-certificates, hostname, aziot-identity-service (= 1.4.0-1), sed
 Description: Azure IoT Edge Module Runtime
  Azure IoT Edge is a fully managed service that delivers cloud intelligence
  locally by deploying and running artificial intelligence (AI), Azure services,

--- a/edgelet/contrib/enterprise-linux/aziot-edge.spec
+++ b/edgelet/contrib/enterprise-linux/aziot-edge.spec
@@ -22,7 +22,7 @@ URL:            https://github.com/azure/iotedge
 %{?systemd_requires}
 BuildRequires:  systemd
 Requires(pre):  shadow-utils
-Requires:       aziot-identity-service = 1.4.0~dev-1%{?dist}
+Requires:       aziot-identity-service = 1.4.0-1%{?dist}
 Source0:        aziot-edge-%{version}.tar.gz
 
 %description

--- a/edgelet/edgelet-core/Cargo.toml
+++ b/edgelet/edgelet-core/Cargo.toml
@@ -21,5 +21,5 @@ thiserror = "1"
 tokio = { version = "1", features = ["sync"] }
 url = "2"
 
-aziotctl-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziotctl-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 edgelet-settings = { path = "../edgelet-settings" }

--- a/edgelet/edgelet-docker/Cargo.toml
+++ b/edgelet/edgelet-docker/Cargo.toml
@@ -27,4 +27,4 @@ docker = { path = "../docker-rs" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-settings = { path = "../edgelet-settings", features = ["settings-docker"] }
 edgelet-utils = { path = "../edgelet-utils" }
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }

--- a/edgelet/edgelet-http-mgmt/Cargo.toml
+++ b/edgelet/edgelet-http-mgmt/Cargo.toml
@@ -24,14 +24,14 @@ edgelet-http = { path = "../edgelet-http" }
 edgelet-settings = { path = "../edgelet-settings" }
 support-bundle = { path = "../support-bundle" }
 
-aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
 [dev-dependencies]
 nix = "0.24"
 
 edgelet-test-utils = { path = "../edgelet-test-utils" }
-test-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+test-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }

--- a/edgelet/edgelet-http-workload/Cargo.toml
+++ b/edgelet/edgelet-http-workload/Cargo.toml
@@ -26,25 +26,25 @@ edgelet-core = { path = "../edgelet-core" }
 edgelet-http = { path = "../edgelet-http" }
 edgelet-settings = { path = "../edgelet-settings" }
 
-aziot-key-client = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-key-openssl-engine = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-key-client = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-key-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-key-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-key-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-key-openssl-engine = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
-aziot-cert-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-cert-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-cert-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-cert-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
-aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
-cert-renewal = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+cert-renewal = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
 [dev-dependencies]
 nix = "0.24"
 
 edgelet-test-utils = { path = "../edgelet-test-utils" }
-test-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+test-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }

--- a/edgelet/edgelet-http/Cargo.toml
+++ b/edgelet/edgelet-http/Cargo.toml
@@ -19,7 +19,7 @@ serde_json = "1"
 edgelet-core = { path = "../edgelet-core" }
 edgelet-settings = { path = "../edgelet-settings" }
 
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }

--- a/edgelet/edgelet-image-cleanup/Cargo.toml
+++ b/edgelet/edgelet-image-cleanup/Cargo.toml
@@ -16,4 +16,4 @@ edgelet-docker = { path = "../edgelet-docker" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-settings = { path = "../edgelet-settings" }
 
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }

--- a/edgelet/edgelet-settings/Cargo.toml
+++ b/edgelet/edgelet-settings/Cargo.toml
@@ -11,11 +11,11 @@ serde = { version = "1", features = ["derive"] }
 humantime-serde = "1.0"
 url = { version = "2", features = ["serde"] }
 
-aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-cert-renewal = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-config-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main", optional = true }
+aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+cert-renewal = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+config-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4", optional = true }
 docker = { path = "../docker-rs", optional = true }
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
 [dev-dependencies]
 lazy_static = "1"

--- a/edgelet/edgelet-test-utils/Cargo.toml
+++ b/edgelet/edgelet-test-utils/Cargo.toml
@@ -17,6 +17,6 @@ tokio = "1"
 edgelet-core = { path = "../edgelet-core" }
 edgelet-settings = { path = "../edgelet-settings" }
 
-aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 
-cert-renewal = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+cert-renewal = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }

--- a/edgelet/iotedge/Cargo.toml
+++ b/edgelet/iotedge/Cargo.toml
@@ -36,23 +36,23 @@ tokio = { version = "1", features = ["macros", "process"] }
 toml = "0.5"
 url = "2"
 
-aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-identityd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-keyd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-keys-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziot-tpmd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-aziotctl-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-cert-renewal = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
-config-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+aziot-certd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-client-async = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identity-common-http = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-identityd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-keyd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-keys-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziot-tpmd-config = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+aziotctl-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+cert-renewal = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
+config-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 docker = { path = "../docker-rs" }
 edgelet-core = { path = "../edgelet-core" }
 edgelet-http = { path = "../edgelet-http" }
 edgelet-settings = { path = "../edgelet-settings", features = ["settings-docker"] }
 edgelet-utils = { path = "../edgelet-utils" }
-http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "main" }
+http-common = { git = "https://github.com/Azure/iot-identity-service", branch = "release/1.4" }
 support-bundle = { path = "../support-bundle" }
 
 [dev-dependencies]

--- a/edgelet/iotedge/src/config/import/old_config/mod.rs
+++ b/edgelet/iotedge/src/config/import/old_config/mod.rs
@@ -192,7 +192,7 @@ agent:
   type: 'docker'
   env: {}
   config:
-    image: 'mcr.microsoft.com/azureiotedge-agent:1.0'
+    image: 'mcr.microsoft.com/azureiotedge-agent:1.4'
     auth: {}
 
 hostname: 'localhost'

--- a/edgelet/iotedge/src/config/super_config.rs
+++ b/edgelet/iotedge/src/config/super_config.rs
@@ -73,7 +73,7 @@ pub fn default_agent() -> edgelet_settings::ModuleSpec<edgelet_settings::DockerC
         /* type */ "docker".to_owned(),
         /* config */
         edgelet_settings::DockerConfig::new(
-            /* image */ "mcr.microsoft.com/azureiotedge-agent:1.2".to_owned(),
+            /* image */ "mcr.microsoft.com/azureiotedge-agent:1.4".to_owned(),
             /* create_options */ docker::models::ContainerCreateBody::new(),
             /* digest */ None,
             /* auth */ None,

--- a/platform-validation/scripts/aziot-compatibility.sh
+++ b/platform-validation/scripts/aziot-compatibility.sh
@@ -850,7 +850,7 @@ aziotedge_check() {
 
     #Todo : As we add new versions, these checks will need to be changed. Keep a common check for now
     case $APP_VERSION in
-    *) wrap_debug_message "Checking aziot-edge compatibility for Release 1.2" ;;
+    *) wrap_debug_message "Checking aziot-edge compatibility for Release 1.4" ;;
     esac
 
     # Keep the ordering of checks consistent, Add new checks towards the end, Since outputs of

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/AgentModuleConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/AgentModuleConfigBuilder.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
 
     public class AgentModuleConfigBuilder : BaseModuleConfigBuilder
     {
-        const string DefaultImage = "mcr.microsoft.com/azureiotedge-agent:1.0";
+        const string DefaultImage = "mcr.microsoft.com/azureiotedge-agent:1.4";
 
         public AgentModuleConfigBuilder(Option<string> image)
             : base(ModuleName.EdgeAgent, image.GetOrElse(DefaultImage))

--- a/test/Microsoft.Azure.Devices.Edge.Test.Common/config/HubModuleConfigBuilder.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test.Common/config/HubModuleConfigBuilder.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Devices.Edge.Test.Common.Config
 
     public class HubModuleConfigBuilder : ModuleConfigBuilder
     {
-        const string DefaultImage = "mcr.microsoft.com/azureiotedge-hub:1.0";
+        const string DefaultImage = "mcr.microsoft.com/azureiotedge-hub:1.4";
         const string DefaultSchemaVersion = "1.2";
         const string HubCreateOptions = "{\"HostConfig\":{\"PortBindings\":{\"8883/tcp\":[{\"HostPort\":\"8883\"}],\"443/tcp\":[{\"HostPort\":\"443\"}],\"5671/tcp\":[{\"HostPort\":\"5671\"}]}}}";
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/Image.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Image.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     public class Image : SasManualProvisioningFixture
     {
         const string SensorName = "tempSensor";
-        const string DefaultSensorImage = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0";
+        const string DefaultSensorImage = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.4";
 
         [Test]
         [Category("CentOsSafe")]

--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
         public static void AddTemporaryModule(this EdgeConfigBuilder builder)
         {
             const string Name = "stopMe";
-            const string Image = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0";
+            const string Image = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.1";
             builder.AddModule(Name, Image).WithEnvironment(new[] { ("MessageCount", "0") });
         }
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
     public class Module : SasManualProvisioningFixture
     {
         const string SensorName = "tempSensor";
-        const string DefaultSensorImage = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0";
+        const string DefaultSensorImage = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.4";
 
         [TestCase(Protocol.Mqtt)]
         [TestCase(Protocol.Amqp)]

--- a/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/SetupFixture.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Azure.Devices.Edge.Test
                             msgBuilder.Append("with hostname '{hostname}'");
                             props.Add(hostname);
 
-                            string edgeAgent = Context.Current.EdgeAgentImage.GetOrElse("mcr.microsoft.com/azureiotedge-agent:1.2");
+                            string edgeAgent = Context.Current.EdgeAgentImage.GetOrElse("mcr.microsoft.com/azureiotedge-agent:1.4");
 
                             Log.Verbose("Search parents");
                             Context.Current.ParentHostname.ForEach(parentHostname =>

--- a/test/doc/e2e.md
+++ b/test/doc/e2e.md
@@ -24,8 +24,8 @@ The end-to-end tests take several parameters, which they expect to find in a fil
 |------|----------|-------------|
 | `caCertScriptPath` | * | Path to the folder containing `certGen.sh` (Linux) or `ca-certs.ps1` (Windows). Required when running the test 'TransparentGateway', ignored otherwise. |
 | `dpsIdScope` | * | The [ID Scope](https://docs.microsoft.com/azure/iot-dps/concepts-device#id-scope) assigned to a Device Provisioning Service. Required when running any DPS tests, ignored otherwise. |
-| `edgeAgentImage` || Docker image to pull/use for Edge Agent. If not given, the default value `mcr.microsoft.com/azureiotedge-agent:1.0` is used. This setting only applies to any configurations deployed by the tests. Note also that the default value is ALWAYS used in config.yaml to start IoT Edge; this setting only applies to any configurations deployed by the tests. |
-| `edgeHubImage` || Docker image to pull/use for Edge Hub. If not given, `mcr.microsoft.com/azureiotedge-hub:1.0` is used. |
+| `edgeAgentImage` || Docker image to pull/use for Edge Agent. If not given, the default value `mcr.microsoft.com/azureiotedge-agent:1.4` is used. This setting only applies to any configurations deployed by the tests. Note also that the default value is ALWAYS used in config.toml to start IoT Edge; this setting only applies to any configurations deployed by the tests. |
+| `edgeHubImage` || Docker image to pull/use for Edge Hub. If not given, `mcr.microsoft.com/azureiotedge-hub:1.4` is used. |
 | `edgeHubSchemaVersion` || The schema version used for EdgeHub. |
 | `installerPath` || Path to the Windows installer script `IotEdgeSecurityDaemon.ps1`. This parameter is ignored on Linux, and optional on Windows. If not given on Windows, the default script will be downloaded from https://aka.ms/iotedge-win to a temporary location. |
 | `loadGenImage` | * | LoadGen image to be used. Required when running PriorityQueue tests, ignored otherwise.|
@@ -45,7 +45,7 @@ The end-to-end tests take several parameters, which they expect to find in a fil
 | `teardownTimeoutMinutes` || The maximum amount of time, in minutes, test teardown should take. This includes teardown for all tests, for the tests in a fixture, or for a single test. If this time is exceeded, the associated test(s) will fail with a timeout error. If not given, the default value is `2`. |
 | `tempFilterFuncImage` | * | Azure temperature filter function to be used. Required when running the test 'TempFilterFunc', ignored otherwise.|
 | `tempFilterImage` | * | Docker image to pull/use for the temperature filter module. Required when running the test 'TempFilter', ignored otherwise.|
-| `tempSensorImage` || Docker image to pull/use for the temperature sensor module (see the test 'TempSensor'). If not given, `mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0` is used.|
+| `tempSensorImage` || Docker image to pull/use for the temperature sensor module (see the test 'TempSensor'). If not given, `mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.4` is used.|
 | `numberLoggerImage` || Docker image to pull/use for the Edge agent direct method tests. Used to generate predictable logs. |
 | `testResultCoordinatorImage` | * | TestResultCoordinator image to be used. Required when running PriorityQueue or GenericMqtt tests, ignored otherwise.|
 | `testTimeoutMinutes` || The maximum amount of time, in minutes, a single test should take. If this time is exceeded, the associated test will fail with a timeout error. If not given, the default value is `5`. |

--- a/versionInfo.json
+++ b/versionInfo.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0-dev",
+  "version": "1.4.0",
   "build": "BUILDNUMBER",
   "commit": "COMMITID"
 }


### PR DESCRIPTION
Updating edgelet refs for release/1.4. Referenced Arnav's PR:
https://github.com/Azure/iotedge/pull/6460

Also contains changes from this PR, which we needed to combine PRs to avoid long checkin times for a time sensitive release:
https://github.com/Azure/iotedge/pull/6623


