### PR TITLE
Add CI build as pipeline resource in E2E-Checkin pipeline

### DIFF
--- a/builds/checkin/e2e-checkin.yaml
+++ b/builds/checkin/e2e-checkin.yaml
@@ -16,6 +16,12 @@ pr:
 variables:
   DisableDockerDetector: true
 
+resources:
+  pipelines:
+  - pipeline: ci-build
+    source: 'Azure-IoT-Edge-Core CI Build'
+    branch: 'main'
+
 stages:
   
   - template: ../misc/templates/build-images.yaml


### PR DESCRIPTION
My recent update (96df97d) to unify the image and package builds introduced a regression. I removed the pipeline resources defined in e2e-checkin.yaml because I thought they were unused (my runs passed without them). But it turns out they _are_ needed in cases where either images or packages aren't built inline. This can happen when, for example, the PR that triggers the pipeline only made changes to one and not the other. The pipeline resources serve as the fallback source for either images or packages in this case.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.