### PR TITLE
Upgrade service deployment pipeline to 1.4

### DIFF
--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -2,6 +2,13 @@
 
 pr: none
 trigger: none
+schedules:
+- cron: '0 3 * * *'
+  displayName: Nightly run 1.4 LTS
+  branches:
+    include:
+    - release/1.4
+  always: true
 
 variables:
   DisableDockerDetector: true

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -26,8 +26,8 @@ steps:
     azureSubscription: $(az.subscription)
     keyVaultName: $(az.keyVault)
     secretsFilter: >-
-      IotHubConnStr2,
-      EventHubConnStr2
+      TestIotHubConnectionString,
+      TestEventHubCompatibleEndpoint
 
 - pwsh: |
     $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
@@ -61,9 +61,9 @@ steps:
   displayName: Run tests
   env:
     EH_ARG: $(connstr.eventHub)
-    EH_KV: $(EventHubConnStr2)
+    EH_KV: $(TestEventHubCompatibleEndpoint)
     IH_ARG: $(connstr.iotHub)
-    IH_KV: $(IotHubConnStr2)
+    IH_KV: $(TestIotHubConnectionString)
 
 - task: PublishTestResults@2
   displayName: Publish test results

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -14,7 +14,9 @@ variables:
   DisableDockerDetector: true
 
 pool:
-  vmImage: ubuntu-18.04
+  name: $(pool.linux.name)
+  demands:
+  - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
 
 steps:
 - checkout: self

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -22,7 +22,21 @@ steps:
     keyVaultName: $(az.keyVault)
     secretsFilter: >-
       TestIotHubConnectionString,
-      TestEventHubCompatibleEndpoint
+      TestEventHubCompatibleEndpoint,
+      TestRootCaCertificate,
+      TestRootCaKey,
+      TestRootCaPassword
+
+- pwsh: |
+    $certsDir = '$(System.ArtifactsDirectory)/certs'
+    New-Item "$certsDir" -ItemType Directory -Force | Out-Null
+    $env:ROOT_CERT | Out-File -Encoding Utf8 "$certsDir/rsa_root_ca.cert.pem"
+    $env:ROOT_KEY | Out-File -Encoding Utf8 "$certsDir/rsa_root_ca.key.pem"
+    Write-Output "##vso[task.setvariable variable=certsDir]$certsDir"
+  displayName: Install CA keys
+  env:
+    ROOT_CERT: $(TestRootCaCertificate)
+    ROOT_KEY: $(TestRootCaKey)
 
 - pwsh: |
     $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
@@ -36,6 +50,8 @@ steps:
     $context = @{
       logFile = Join-Path '$(binDir)' 'testoutput.log';
       caCertScriptPath = Convert-Path '$(Build.SourcesDirectory)/tools/CACertificates';
+      rootCaCertificatePath = Convert-Path '$(certsDir)/rsa_root_ca.cert.pem';
+      rootCaPrivateKeyPath = Convert-Path '$(certsDir)/rsa_root_ca.key.pem';
     }
     $context | ConvertTo-Json | Out-File -Encoding Utf8 '$(binDir)/context.json'
   displayName: Create test arguments file (context.json)
@@ -60,6 +76,7 @@ steps:
     EH_KV: $(TestEventHubCompatibleEndpoint)
     IH_ARG: $(connstr.iotHub)
     IH_KV: $(TestIotHubConnectionString)
+    E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
 
 - task: PublishTestResults@2
   displayName: Publish test results

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -35,6 +35,7 @@ steps:
 - pwsh: |
     $context = @{
       logFile = Join-Path '$(binDir)' 'testoutput.log';
+      caCertScriptPath = Convert-Path '$(Build.SourcesDirectory)/tools/CACertificates';
     }
     $context | ConvertTo-Json | Out-File -Encoding Utf8 '$(binDir)/context.json'
   displayName: Create test arguments file (context.json)

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -18,7 +18,7 @@ pool:
 
 steps:
 - checkout: self
-  fetchDepth: 100
+  fetchDepth: 1
 
 - task: AzureKeyVault@1
   displayName: Get secrets

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -2,13 +2,6 @@
 
 pr: none
 trigger: none
-schedules:
-- cron: '0 3 * * *'
-  displayName: Nightly run 1.1 LTS
-  branches:
-    include:
-    - release/1.1
-  always: true
 
 variables:
   DisableDockerDetector: true


### PR DESCRIPTION
The service deployment pipeline runs an end-to-end scenario using released IoT Edge bits. Services like IoT Hub use it to test their latest releases against IoT Edge. Now that 1.4 has been released and will receive long-term support, this change updates the pipeline to use 1.4 bits instead of 1.1.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.