### PR TITLE
Upgrade to 1ES-hosted arm64 agents in test/release pipelines

### DIFF
--- a/builds/e2e/e2e-release.yaml
+++ b/builds/e2e/e2e-release.yaml
@@ -112,9 +112,9 @@ stages:
     ################################################################################
         displayName: Ubuntu 20.04 with arm64v8
         pool:
-          name: $(pool.custom.name)
-          demands: 
-            - agent-group -equals rpi3-e2e-aarch64
+          name: $(pool.linux.arm.name)
+          demands:
+          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
 
         variables:
           os: linux

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -160,9 +160,9 @@ jobs:
 ################################################################################
     displayName: Ubuntu 20.04 with arm64v8
     pool:
-      name: $(pool.custom.name)
-      demands: 
-        - agent-group -equals rpi3-e2e-aarch64
+      name: $(pool.linux.arm.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
 
     variables:
       os: linux

--- a/builds/misc/metrics-collector-images-release.yaml
+++ b/builds/misc/metrics-collector-images-release.yaml
@@ -292,9 +292,9 @@ stages:
   ################################################################################
       displayName: Ubuntu 20.04 with arm64v8
       pool:
-        name: $(pool.custom.name)
+        name: $(pool.linux.arm.name)
         demands:
-          - agent-group -equals rpi3-e2e-aarch64
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
 
       variables:
         os: linux


### PR DESCRIPTION
The arm64v8 jobs on pipelines in `main` were migrated from Raspberry Pi to 1ES-hosted agent VMs a while back, but the corresponding changes were never made in `release/1.1`, until now.

I verified that the end-to-end test pipeline passes with this change.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.