### PR TITLE
Test arm64 using 1ES agent in image release pipeline

### DIFF
--- a/builds/e2e/e2e-release.yaml
+++ b/builds/e2e/e2e-release.yaml
@@ -148,11 +148,11 @@ stages:
     ################################################################################
       - job: ubuntu_2004_arm64v8
     ################################################################################
-        displayName: Ubuntu 20.04 with arm64v8
+        displayName: Ubuntu 20.04 on arm64v8
         pool:
-          name: $(pool.custom.name)
-          demands: 
-            - agent-group -equals rpi3-e2e-aarch64
+          name: $(pool.linux.arm.name)
+          demands:
+          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
 
         variables:
           os: linux


### PR DESCRIPTION
When we migrated test pipelines over to use 1ES agents for arm64, we missed one in the `main` branch: the base image update  pipeline. This PR updates it to use a 1ES-hosted agent (Azure VM) instead of a Raspberry Pi from our lab.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.