### PR TITLE
Use preloadable temporary module in ValidateMetrics

### DIFF
--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -178,8 +178,8 @@ namespace Microsoft.Azure.Devices.Edge.Test
         public static void AddTemporaryModule(this EdgeConfigBuilder builder)
         {
             const string Name = "stopMe";
-            const string Image = "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0";
-            builder.AddModule(Name, Image).WithEnvironment(new[] { ("MessageCount", "0") });
+            string image = Context.Current.TempSensorImage.Expect(() => new InvalidOperationException("Missing Temp Sensor image"));
+            builder.AddModule(Name, image).WithEnvironment(new[] { ("MessageCount", "0") });
         }
 
         public static void AddMetricsValidatorConfig(this EdgeConfigBuilder builder, string image)


### PR DESCRIPTION
The `ValidateMetrics` end-to-end test deploys a module to the test device then removes it in order to bump a particular metric. It doesn't matter which module is used; we just need to add something then remove it. Currently, we've hardcoded `mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.0`. Because that isn't one of the images listed in context.json, our test pipeline doesn't preload it on slow test devices, which means it has to be downloaded during the test, which eats into the test's timeout duration.

The `ValidateMetrics` test is consistently timing out on Raspberry Pi. Changing the test to use the tempSensor image from context.json _should_ speed up the test and prevent the timeouts.

I ran the end-to-end pipeline against these changes and `ValidateMetrics` passed on Raspberry Pi.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.