### PR TITLE
Metrics Collector: Support for configurable transport type

### DIFF
--- a/edge-modules/metrics-collector/src/ModuleClientWrapper.cs
+++ b/edge-modules/metrics-collector/src/ModuleClientWrapper.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.Devices.Client;
+using Microsoft.Azure.Devices.Client.Transport.Mqtt;
 using Microsoft.Azure.Devices.Edge.Util;
 using Microsoft.Extensions.Logging;
 
@@ -11,25 +12,21 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
     public class ModuleClientWrapper : IDisposable
     {
         ModuleClient inner;
-        ITransportSettings[] transportSettings;
         SemaphoreSlim moduleClientLock;
+        TransportType transportType;
 
-        public ModuleClientWrapper(ModuleClient moduleClient, ITransportSettings[] transportSettings, SemaphoreSlim moduleClientLock)
+        public ModuleClientWrapper(ModuleClient moduleClient, TransportType transportType, SemaphoreSlim moduleClientLock)
         {
             this.inner = Preconditions.CheckNotNull(moduleClient);
-            this.transportSettings = Preconditions.CheckNotNull(transportSettings);
+            this.transportType = Preconditions.CheckNotNull(transportType);
             this.moduleClientLock = Preconditions.CheckNotNull(moduleClientLock);
         }
 
-        public static async Task<ModuleClientWrapper> BuildModuleClientWrapperAsync(ITransportSettings[] transportSettings)
+        public static async Task<ModuleClientWrapper> BuildModuleClientWrapperAsync(TransportType transportType)
         {
             SemaphoreSlim moduleClientLock = new SemaphoreSlim(1, 1);
-
-            ModuleClient moduleClient = await ModuleClient.CreateFromEnvironmentAsync(transportSettings);
-            moduleClient.ProductInfo = Constants.ProductInfo;
-            await moduleClient.OpenAsync();
-
-            return new ModuleClientWrapper(moduleClient, transportSettings, moduleClientLock);
+            ModuleClient moduleClient = await InitializeModuleClientAsync(transportType);
+            return new ModuleClientWrapper(moduleClient, transportType, moduleClientLock);
         }
 
         public async Task RecreateClientAsync()
@@ -39,10 +36,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             try
             {
                 this.inner.Dispose();
-                this.inner = await ModuleClient.CreateFromEnvironmentAsync(this.transportSettings);
-                this.inner.ProductInfo = Constants.ProductInfo;
-                await this.inner.OpenAsync();
-
+                this.inner = await InitializeModuleClientAsync(this.transportType);
                 LoggerUtil.Writer.LogInformation("Closed and re-established connection to IoT Hub");
             }
             catch (Exception e)
@@ -73,6 +67,36 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
         {
             this.inner.Dispose();
             this.moduleClientLock.Dispose();
+        }
+
+        static async Task<ModuleClient> InitializeModuleClientAsync(TransportType transportType)
+        {
+            LoggerUtil.Writer.LogInformation($"Trying to initialize module client using transport type [{transportType}]");
+
+            ITransportSettings[] GetTransportSettings()
+            {
+                switch (transportType)
+                {
+                    case TransportType.Mqtt:
+                    case TransportType.Mqtt_Tcp_Only:
+                        return new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_Tcp_Only) };
+                    case TransportType.Mqtt_WebSocket_Only:
+                        return new ITransportSettings[] { new MqttTransportSettings(TransportType.Mqtt_WebSocket_Only) };
+                    case TransportType.Amqp_WebSocket_Only:
+                        return new ITransportSettings[] { new AmqpTransportSettings(TransportType.Amqp_WebSocket_Only) };
+                    default:
+                        return new ITransportSettings[] { new AmqpTransportSettings(TransportType.Amqp_Tcp_Only) };
+                }
+            }
+
+            ITransportSettings[] settings = GetTransportSettings();
+            ModuleClient moduleClient = await ModuleClient.CreateFromEnvironmentAsync(settings);
+            moduleClient.ProductInfo = Constants.ProductInfo;
+            await moduleClient.OpenAsync();
+
+            LoggerUtil.Writer.LogInformation($"Successfully initialized module client of transport type [{transportType}]");
+
+            return moduleClient;
         }
     }
 }

--- a/edge-modules/metrics-collector/src/ModuleClientWrapper.cs
+++ b/edge-modules/metrics-collector/src/ModuleClientWrapper.cs
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             moduleClient.ProductInfo = Constants.ProductInfo;
             await moduleClient.OpenAsync();
 
-            LoggerUtil.Writer.LogInformation($"Successfully initialized module client of transport type [{transportType}]");
+            LoggerUtil.Writer.LogInformation($"Successfully initialized module client using transport type [{transportType}]");
 
             return moduleClient;
         }

--- a/edge-modules/metrics-collector/src/Program.cs
+++ b/edge-modules/metrics-collector/src/Program.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                 }
                 catch (Exception e)
                 {
-                    String msg = String.Format("Error connecting to EdgeHub. Is EdgeHub up and running with settings for clients connecting over {0}?. Exception: {1}", Settings.Current.TransportType, e);
+                    String msg = String.Format("Error connecting to EdgeHub. Is EdgeHub up and running with settings for clients connecting over {0}? Exception: {1}", Settings.Current.TransportType, e);
                     if (Settings.Current.UploadTarget == UploadTarget.IotMessage)
                     {
                         LoggerUtil.Writer.LogError(msg);

--- a/edge-modules/metrics-collector/src/Program.cs
+++ b/edge-modules/metrics-collector/src/Program.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             ModuleClientWrapper moduleClientWrapper = null;
             try
             {
-                moduleClientWrapper = await ModuleClientWrapper.BuildModuleClientWrapperAsync(transportSettings);
+                moduleClientWrapper = await ModuleClientWrapper.BuildModuleClientWrapperAsync(Settings.Current.TransportType);
 
                 PeriodicTask periodicIothubConnect = new PeriodicTask(moduleClientWrapper.RecreateClientAsync, Settings.Current.IotHubConnectFrequency, TimeSpan.FromMinutes(1), LoggerUtil.Writer, "Reconnect to IoT Hub", true);
 

--- a/edge-modules/metrics-collector/src/Program.cs
+++ b/edge-modules/metrics-collector/src/Program.cs
@@ -45,9 +45,6 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
 #endif
 
             LoggerUtil.Writer.LogInformation($"Metrics collector initialized with the following settings:\r\n{Settings.Information}");
-            var transportSetting = new AmqpTransportSettings(TransportType.Amqp_Tcp_Only);
-
-            ITransportSettings[] transportSettings = { transportSetting };
             ModuleClientWrapper moduleClientWrapper = null;
             try
             {

--- a/edge-modules/metrics-collector/src/Program.cs
+++ b/edge-modules/metrics-collector/src/Program.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                 }
                 catch (Exception e)
                 {
-                    String msg = String.Format("Error connecting to EdgeHub. Is EdgeHub up and running with settings for clients connecting over {0}? Exception: {1}", Settings.Current.TransportType, e);
+                    String msg = String.Format("Error connecting to Edge Hub. Is Edge Hub up and running with settings for clients connecting over {0}? Exception: {1}", Settings.Current.TransportType, e);
                     if (Settings.Current.UploadTarget == UploadTarget.IotMessage)
                     {
                         LoggerUtil.Writer.LogError(msg);

--- a/edge-modules/metrics-collector/src/Program.cs
+++ b/edge-modules/metrics-collector/src/Program.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                 try
                 {
                     moduleClientWrapper = await ModuleClientWrapper.BuildModuleClientWrapperAsync(Settings.Current.TransportType);
+                    PeriodicTask periodicIothubConnect = new PeriodicTask(moduleClientWrapper.RecreateClientAsync, Settings.Current.IotHubConnectFrequency, TimeSpan.FromMinutes(1), LoggerUtil.Writer, "Reconnect to IoT Hub", true);
                 }
                 catch (Exception e)
                 {
@@ -65,8 +66,6 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                         LoggerUtil.Writer.LogWarning(msg);
                     }
                 }
-
-                PeriodicTask periodicIothubConnect = new PeriodicTask(moduleClientWrapper.RecreateClientAsync, Settings.Current.IotHubConnectFrequency, TimeSpan.FromMinutes(1), LoggerUtil.Writer, "Reconnect to IoT Hub", true);
 
                 MetricsScraper scraper = new MetricsScraper(Settings.Current.Endpoints);
                 IMetricsPublisher publisher;

--- a/edge-modules/metrics-collector/src/Program.cs
+++ b/edge-modules/metrics-collector/src/Program.cs
@@ -48,7 +48,23 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             ModuleClientWrapper moduleClientWrapper = null;
             try
             {
-                moduleClientWrapper = await ModuleClientWrapper.BuildModuleClientWrapperAsync(Settings.Current.TransportType);
+                try
+                {
+                    moduleClientWrapper = await ModuleClientWrapper.BuildModuleClientWrapperAsync(Settings.Current.TransportType);
+                }
+                catch (Exception e)
+                {
+                    String msg = String.Format("Error connecting to EdgeHub. Is EdgeHub up and running with settings for clients connecting over {0}?. Exception: {1}", Settings.Current.TransportType, e);
+                    if (Settings.Current.UploadTarget == UploadTarget.IotMessage)
+                    {
+                        LoggerUtil.Writer.LogError(msg);
+                        throw;
+                    }
+                    else
+                    {
+                        LoggerUtil.Writer.LogWarning(msg);
+                    }
+                }
 
                 PeriodicTask periodicIothubConnect = new PeriodicTask(moduleClientWrapper.RecreateClientAsync, Settings.Current.IotHubConnectFrequency, TimeSpan.FromMinutes(1), LoggerUtil.Writer, "Reconnect to IoT Hub", true);
 

--- a/edge-modules/metrics-collector/src/Settings.cs
+++ b/edge-modules/metrics-collector/src/Settings.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
     using Microsoft.Extensions.Logging;
     using Newtonsoft.Json;
     using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Client;
 
     internal class Settings
     {
@@ -32,7 +33,8 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             string resourceId,
             string version,
             TimeSpan iotHubConnectFrequency,
-            string azureDomain)
+            string azureDomain,
+            TransportType transportType)
         {
             this.UploadTarget = uploadTarget;
             this.ResourceId = Preconditions.CheckNonWhiteSpace(resourceId, nameof(resourceId));
@@ -70,6 +72,8 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
             this.Version = version;
             this.IotHubConnectFrequency = iotHubConnectFrequency;
             this.AzureDomain = azureDomain;
+
+            this.TransportType = transportType;
         }
 
         private static Settings Create()
@@ -96,7 +100,8 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                     configuration.GetValue<string>("ResourceID", ""),
                     configuration.GetValue<string>("version", ""),
                     configuration.GetValue<TimeSpan>("IotHubConnectFrequency", TimeSpan.FromDays(1)),
-                    configuration.GetValue<String>("AzureDomain", "azure.com")
+                    configuration.GetValue<String>("AzureDomain", "azure.com"),
+                    configuration.GetValue("transportType", TransportType.Amqp_Tcp_Only)
                     );
             }
             catch (ArgumentException e)
@@ -128,7 +133,8 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                 regex.Replace(settings.ResourceId, "$1" + "XXX" + "$3" + "XXX" + "$5"),
                 settings.Version,
                 settings.IotHubConnectFrequency,
-                settings.AzureDomain);
+                settings.AzureDomain,
+                settings.TransportType);
         }
 
         public string LogAnalyticsWorkspaceId { get; }
@@ -159,6 +165,8 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
 
         public string AzureDomain { get; }
 
+        public TransportType TransportType { get; }
+
         // Used to eliminate secrets when logging the settings
         public override string ToString()
         {
@@ -175,7 +183,8 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
                 { nameof(this.BlockedMetrics), string.Join(",", this.BlockedMetrics.ToString()) },
                 { nameof(this.ResourceId), this.ResourceId ?? string.Empty },
                 { nameof(this.IotHubConnectFrequency), this.IotHubConnectFrequency.ToString() ?? string.Empty },
-                { nameof(this.AzureDomain), this.AzureDomain ?? string.Empty }
+                { nameof(this.AzureDomain), this.AzureDomain ?? string.Empty },
+                { nameof(this.TransportType), this.TransportType.ToString() }
             };
 
             return $"Settings:{Environment.NewLine}{string.Join(Environment.NewLine, fields.Select(f => $"{f.Key}={f.Value}"))}";


### PR DESCRIPTION
This PR:
1. Makes transport type configurable
2. Fixes bug where metrics collector will restart if cannot connect to EdgeHub when using AzureMonitor upload target. Now it will log a warning and continue in case of failed connection to EdgeHub. This connection is only used for internal diagnostics so it can be treated as recoverable.

Manually tested:
- Case where can switch between transport types
- Case where can work when opposite protocol head disabled in EdgeHub
- Case where can work when used protocol head disabled in EdgeHub and upload target is log analytics
- Case where won't work when used protocol head disabled in EdgeHub and upload target is iot message

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
