### PR TITLE
Prefix userid's with snap_ when used in a snap.

### DIFF
--- a/edgelet/iotedge/src/config/apply.rs
+++ b/edgelet/iotedge/src/config/apply.rs
@@ -25,35 +25,67 @@ pub async fn execute(config: &Path) -> Result<(), std::borrow::Cow<'static, str>
     // So when running as root, get the four users appropriately.
     // Otherwise, if this is a debug build, fall back to using the current user.
     // Otherwise, tell the user to re-run as root.
+    // When run in a snap expect the four users to be prefixed with `snap_`.
     let (aziotks_user, aziotcs_user, aziotid_user, aziottpm_user, iotedge_user) =
         if nix::unistd::Uid::current().is_root() {
-            let aziotks_user = nix::unistd::User::from_name("aziotks")
-                .map_err(|err| format!("could not query aziotks user information: {}", err))?
-                .ok_or("could not query aziotks user information")?;
+            if std::env::var("SNAP").is_ok() {
+                println!("Running in SNAP confinement");
+                let aziotks_user = nix::unistd::User::from_name("snap_aziotks")
+                    .map_err(|err| format!("could not query snap_aziotks user information: {}", err))?
+                    .ok_or("could not query aziotks user information")?;
 
-            let aziotcs_user = nix::unistd::User::from_name("aziotcs")
-                .map_err(|err| format!("could not query aziotcs user information: {}", err))?
-                .ok_or("could not query aziotcs user information")?;
+                let aziotcs_user = nix::unistd::User::from_name("snap_aziotcs")
+                    .map_err(|err| format!("could not query snap_aziotcs user information: {}", err))?
+                    .ok_or("could not query aziotcs user information")?;
 
-            let aziotid_user = nix::unistd::User::from_name("aziotid")
-                .map_err(|err| format!("could not query aziotid user information: {}", err))?
-                .ok_or("could not query aziotid user information")?;
+                let aziotid_user = nix::unistd::User::from_name("snap_aziotid")
+                    .map_err(|err| format!("could not query snap_aziotid user information: {}", err))?
+                    .ok_or("could not query aziotid user information")?;
 
-            let aziottpm_user = nix::unistd::User::from_name("aziottpm")
-                .map_err(|err| format!("could not query aziottpm user information: {}", err))?
-                .ok_or("could not query aziottpm user information")?;
+                let aziottpm_user = nix::unistd::User::from_name("snap_aziottpm")
+                    .map_err(|err| format!("could not query snap_aziottpm user information: {}", err))?
+                    .ok_or("could not query aziottpm user information")?;
 
-            let iotedge_user = nix::unistd::User::from_name("iotedge")
-                .map_err(|err| format!("could not query iotedge user information: {}", err))?
-                .ok_or("could not query iotedge user information")?;
+                let iotedge_user = nix::unistd::User::from_name("snap_iotedge")
+                    .map_err(|err| format!("could not query snap_iotedge user information: {}", err))?
+                    .ok_or("could not query iotedge user information")?;
 
-            (
-                aziotks_user,
-                aziotcs_user,
-                aziotid_user,
-                aziottpm_user,
-                iotedge_user,
-            )
+                (
+                    aziotks_user,
+                    aziotcs_user,
+                    aziotid_user,
+                    aziottpm_user,
+                    iotedge_user,
+                )
+            } else {
+                let aziotks_user = nix::unistd::User::from_name("aziotks")
+                    .map_err(|err| format!("could not query aziotks user information: {}", err))?
+                    .ok_or("could not query aziotks user information")?;
+
+                let aziotcs_user = nix::unistd::User::from_name("aziotcs")
+                    .map_err(|err| format!("could not query aziotcs user information: {}", err))?
+                    .ok_or("could not query aziotcs user information")?;
+
+                let aziotid_user = nix::unistd::User::from_name("aziotid")
+                    .map_err(|err| format!("could not query aziotid user information: {}", err))?
+                    .ok_or("could not query aziotid user information")?;
+
+                let aziottpm_user = nix::unistd::User::from_name("aziottpm")
+                    .map_err(|err| format!("could not query aziottpm user information: {}", err))?
+                    .ok_or("could not query aziottpm user information")?;
+
+                let iotedge_user = nix::unistd::User::from_name("iotedge")
+                    .map_err(|err| format!("could not query iotedge user information: {}", err))?
+                    .ok_or("could not query iotedge user information")?;
+
+                (
+                    aziotks_user,
+                    aziotcs_user,
+                    aziotid_user,
+                    aziottpm_user,
+                    iotedge_user,
+                )
+            }
         } else if cfg!(debug_assertions) {
             let current_user = nix::unistd::User::from_uid(nix::unistd::Uid::current())
                 .map_err(|err| format!("could not query current user information: {}", err))?


### PR DESCRIPTION
This change is to unblock potential development of a snap package for IoT Edge. A pre-requisite is to detect when running in snap confinement (e.g. looking at [env vars injected by snapd](https://github.com/snapcore/snapd/wiki/Environment-Variables)) and then expect the OS userid's to be prefixed with _`snap_`_

Tested by installing a build of IoT Edge, creating the snap_* users, reassigning ownership of the various files/directories to the snap_ users, copying over the built 'iotedge' binary with this change, and using it to perform actions such as:
* `sudo SNAP=1 ./iotedge config mp -c ...`
* `sudo SNAP=1 ./iotedge config apply`

And then I manually inspected the generated config files and the user ID's registered.  For example, here's the output from one:
```bash
micahl@fooD:~$ sudo cat /etc/aziot/identityd/config.d/00-super.toml
# This file is auto-generated by `iotedge config apply`
# Do not edit it manually; any edits will be lost when the command is run again.

hostname = "fooD"
homedir = "/var/lib/aziot/identityd"

[provisioning]
source = "manual"
iothub_hostname = "micahl-test-hub.azure-devices.net"
device_id = "doctest"

[provisioning.authentication]
method = "sas"
device_id_pk = "device-id"

[[principal]]
uid = 988
name = "aziot-edge"

micahl@fooD:~$ id 988
uid=988(snap_iotedge) gid=994(snap_iotedge) groups=994(snap_iotedge),101(systemd-journal),121(docker),998(snap_aziotks),996(snap_aziotcs),995(snap_aziotid)
```

