### PR TITLE
Upgrade to Rust 1.63

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -162,7 +162,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "serde",
 ]
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "http-common",
  "libc",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "pkcs11",
  "serde",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "http-common",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -359,7 +359,7 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "async-trait",
  "aziot-cert-client-async",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "serde",
  "toml",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "async-trait",
  "base64",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "env_logger",
  "log",
@@ -1478,7 +1478,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "cc",
 ]
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1589,7 +1589,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 
 [[package]]
 name = "pkg-config"
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#846fb12157f06d1f8f4ff2c102264744be045e3d"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/edgelet-core/src/lib.rs
+++ b/edgelet/edgelet-core/src/lib.rs
@@ -70,7 +70,7 @@ impl UrlExt for Url {
 
 pub const UNIX_SCHEME: &str = "unix";
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum WatchdogAction {
     EdgeCaRenewal,
     Reprovision,

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -15,7 +15,7 @@ use edgelet_settings::module::Settings as ModuleSpec;
 
 use crate::error::Error;
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ModuleStatus {
     Unknown,
@@ -57,7 +57,7 @@ pub enum ModuleAction {
     Remove(String),
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ModuleRuntimeState {
     status: ModuleStatus,
     exit_code: Option<i64>,
@@ -129,7 +129,7 @@ impl ModuleRuntimeState {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum LogTail {
     All,
     Num(u64),
@@ -255,7 +255,7 @@ pub trait ModuleRegistry {
     async fn remove(&self, name: &str) -> anyhow::Result<()>;
 }
 
-#[derive(Debug, PartialEq, Serialize)]
+#[derive(Debug, Eq, PartialEq, Serialize)]
 pub struct SystemInfo {
     #[serde(rename = "osType")]
     pub kernel: String,
@@ -389,7 +389,7 @@ impl Default for SystemInfo {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ProvisioningInfo {
     /// IoT Edge provisioning type, examples: manual.device_connection_string, dps.x509
     pub r#type: String,
@@ -528,7 +528,7 @@ impl fmt::Display for RegistryOperation {
 }
 
 // Useful for error contexts
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum RuntimeOperation {
     CreateModule(String),
     GetModule(String),

--- a/edgelet/edgelet-settings/src/base/aziot.rs
+++ b/edgelet/edgelet-settings/src/base/aziot.rs
@@ -13,7 +13,7 @@ impl Default for AutoReprovisioningMode {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Endpoints {
     aziot_certd_url: url::Url,
     aziot_keyd_url: url::Url,

--- a/edgelet/edgelet-settings/src/base/image.rs
+++ b/edgelet/edgelet-settings/src/base/image.rs
@@ -111,6 +111,8 @@ mod hhmm_as_minutes {
         Ok((time.hour() * 60 + time.minute()).into())
     }
 
+    // NOTE: Reference required by serde
+    #[allow(clippy::trivially_copy_pass_by_ref)]
     pub fn serialize<S>(cleanup_time: &u64, ser: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/edgelet/edgelet-settings/src/base/mod.rs
+++ b/edgelet/edgelet-settings/src/base/mod.rs
@@ -42,7 +42,7 @@ pub trait RuntimeSettings {
     fn image_garbage_collection(&self) -> &image::ImagePruneSettings;
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct EdgeCa {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cert: Option<String>,
@@ -64,7 +64,7 @@ impl EdgeCa {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IotedgeMaxRequests {
     pub management: usize,
     pub workload: usize,

--- a/edgelet/edgelet-settings/src/base/module.rs
+++ b/edgelet/edgelet-settings/src/base/module.rs
@@ -118,7 +118,7 @@ impl<ModuleConfig> Settings<ModuleConfig> {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum ImagePullPolicy {
     #[serde(rename = "on-create")]

--- a/edgelet/edgelet-settings/src/base/uri.rs
+++ b/edgelet/edgelet-settings/src/base/uri.rs
@@ -87,7 +87,7 @@ impl Default for Listen {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MinTlsVersion {
     Tls10,
     Tls11,

--- a/edgelet/edgelet-settings/src/docker/network.rs
+++ b/edgelet/edgelet-settings/src/docker/network.rs
@@ -73,7 +73,7 @@ impl Network {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct Ipam {
     #[serde(rename = "config", skip_serializing_if = "Option::is_none")]
     pub config: Option<Vec<IpamConfig>>,
@@ -91,7 +91,7 @@ impl Ipam {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
 pub struct IpamConfig {
     #[serde(rename = "gateway", skip_serializing_if = "Option::is_none")]
     pub gateway: Option<String>,

--- a/edgelet/iotedge/src/check/checks/proxy_settings.rs
+++ b/edgelet/iotedge/src/check/checks/proxy_settings.rs
@@ -57,14 +57,14 @@ impl ProxySettings {
         {
             Ok(CheckResult::Ok)
         } else {
-            return Ok(CheckResult::Warning(anyhow::anyhow!(
+            Ok(CheckResult::Warning(anyhow::anyhow!(
                     "The proxy setting for IoT Edge Agent {:?}, IoT Edge Daemon {:?}, IoT Identity Daemon {:?}, and Moby {:?} may need to be identical.",
                     edge_agent_proxy_uri,
                     edge_daemon_proxy_uri,
                     identity_daemon_proxy_uri,
                     moby_proxy_uri
                 )
-            ));
+            ))
         }
     }
 }

--- a/edgelet/iotedge/src/check/checks/storage_mounted_from_host.rs
+++ b/edgelet/iotedge/src/check/checks/storage_mounted_from_host.rs
@@ -99,7 +99,7 @@ async fn storage_mounted_from_host<'a>(
         // and needs to be in the context of the container user instead of the host running `iotedge check`.
         .unwrap_or("/tmp");
 
-    let storage_directory = Path::new(&*temp_dir).join(storage_directory_name);
+    let storage_directory = Path::new(temp_dir).join(storage_directory_name);
     *storage_directory_out = Some(storage_directory.clone());
 
     let mounted_directories = inspect_result

--- a/edgelet/iotedge/src/check/mod.rs
+++ b/edgelet/iotedge/src/check/mod.rs
@@ -55,7 +55,7 @@ pub struct Check {
     docker_server_version: Option<String>,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum OutputFormat {
     Json,
     Text,

--- a/edgelet/support-bundle/src/support_bundle.rs
+++ b/edgelet/support-bundle/src/support_bundle.rs
@@ -125,7 +125,7 @@ where
     Ok(result)
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub enum OutputLocation {
     File(OsString),
     Memory,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.62"
+channel = "1.63"

--- a/test/rust-test-util/test-result-reporting-client/src/models/message_result.rs
+++ b/test/rust-test-util/test-result-reporting-client/src/models/message_result.rs
@@ -1,6 +1,6 @@
 use serde::{Serialize, Serializer};
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct MessageTestResult {
     tracking_id: String,
     batch_id: String,


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- `clippy::borrow_deref_ref`: remove unnecessary uses of `&*`
- `clippy::derive_partial_eq_without_eq`: derive `Eq` where possible

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

[^0]: https://github.com/rust-lang/rust/blob/1.48.0/RELEASES.md#compatibility-notes
  Namely, the point on `mem::uninitialized`.