### PR TITLE
Only publishing the Diagnostics image

### DIFF
--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -364,35 +364,35 @@ stages:
         - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
     dependsOn: ConsolidateAndPubishArtifacts
     jobs:
-    - job: BuildImageEdgeHub
-      steps:
-      - template: templates/image-linux.yaml
-        parameters:
-          imageName: azureiotedge-hub
-          name: "Edge Hub"
-          project: Microsoft.Azure.Devices.Edge.Hub.Service
-          version: $(version)
-          bin_dir: '$(Build.BinariesDirectory)'
-          use_rocksdb: true
-    - job: BuildImageEdgeAgent
-      steps:
-      - template: templates/image-linux.yaml
-        parameters:
-          imageName: azureiotedge-agent
-          name: "Edge Agent"
-          project: Microsoft.Azure.Devices.Edge.Agent.Service
-          version: $(version)
-          bin_dir: '$(Build.BinariesDirectory)'
-          use_rocksdb: true
-    - job: BuildImageTemperatureSensor
-      steps:
-      - template: templates/image-linux.yaml
-        parameters:
-          imageName: azureiotedge-simulated-temperature-sensor
-          name: "Temperature Sensor"
-          project: SimulatedTemperatureSensor
-          version: $(version)
-          bin_dir: '$(Build.BinariesDirectory)'
+    # - job: BuildImageEdgeHub
+    #   steps:
+    #   - template: templates/image-linux.yaml
+    #     parameters:
+    #       imageName: azureiotedge-hub
+    #       name: "Edge Hub"
+    #       project: Microsoft.Azure.Devices.Edge.Hub.Service
+    #       version: $(version)
+    #       bin_dir: '$(Build.BinariesDirectory)'
+    #       use_rocksdb: true
+    # - job: BuildImageEdgeAgent
+    #   steps:
+    #   - template: templates/image-linux.yaml
+    #     parameters:
+    #       imageName: azureiotedge-agent
+    #       name: "Edge Agent"
+    #       project: Microsoft.Azure.Devices.Edge.Agent.Service
+    #       version: $(version)
+    #       bin_dir: '$(Build.BinariesDirectory)'
+    #       use_rocksdb: true
+    # - job: BuildImageTemperatureSensor
+    #   steps:
+    #   - template: templates/image-linux.yaml
+    #     parameters:
+    #       imageName: azureiotedge-simulated-temperature-sensor
+    #       name: "Temperature Sensor"
+    #       project: SimulatedTemperatureSensor
+    #       version: $(version)
+    #       bin_dir: '$(Build.BinariesDirectory)'
     - job: BuildImageDiagnostics
       steps:
       - template: templates/image-linux.yaml
@@ -417,12 +417,12 @@ stages:
       displayName: Publish Manifest
       strategy:
         matrix:
-          EdgeAgent:
-            manifestFilePath: '$(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template'
-          EdgeHub:
-            manifestFilePath: '$(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template'
-          SimulatedTemperatureSensor:
-            manifestFilePath: '$(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template'
+          # EdgeAgent:
+          #   manifestFilePath: '$(System.DefaultWorkingDirectory)/edge-agent/docker/manifest.yaml.template'
+          # EdgeHub:
+          #   manifestFilePath: '$(System.DefaultWorkingDirectory)/edge-hub/docker/manifest.yaml.template'
+          # SimulatedTemperatureSensor:
+          #   manifestFilePath: '$(System.DefaultWorkingDirectory)/edge-modules/SimulatedTemperatureSensor/docker/manifest.yaml.template'
           Diagnostics:
             manifestFilePath: '$(System.DefaultWorkingDirectory)/edge-modules/iotedge-diagnostics-dotnet/docker/manifest.yaml.template'
       steps:


### PR DESCRIPTION
We need to publish Diagnostics module for release 1.4.1 as the module is highly coupled with edgelet artifacts and self-help. 
The images were not part of the release 1.4.1; hence, the Diagonostic module was not updated causing a failure in the use cases.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
