### PR TITLE
Update dependency to fix OOM bug

### DIFF
--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -20,6 +20,13 @@
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.6" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+    <!--
+      We have a transitive dependency on Dotnetty via Microsoft.Azure.Devices.Client. Use an
+      explicit reference here to override the version and fix a known OOM bug. See
+      https://github.com/Azure/DotNetty/pull/583. If ProtocolGateway updates its dependency,
+      we can remove this reference.
+    -->
+    <PackageReference Include="DotNetty.Common" Version="0.7.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Core/Microsoft.Azure.Devices.Edge.Hub.Core.csproj
@@ -21,12 +21,18 @@
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.6" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <!--
-      We have a transitive dependency on Dotnetty via Microsoft.Azure.Devices.Client. Use an
-      explicit reference here to override the version and fix a known OOM bug. See
-      https://github.com/Azure/DotNetty/pull/583. If ProtocolGateway updates its dependency,
-      we can remove this reference.
+      We have a transitive dependency on Dotnetty via Microsoft.Azure.Devices.Client. Use
+      explicit references here to override the version and fix a known OOM bug. See
+      https://github.com/Azure/DotNetty/pull/583. If Microsoft.Azure.Devices.Client updates
+      its dependency, we can remove the Dotnetty references.
     -->
+    <PackageReference Include="DotNetty.Buffers" Version="0.7.5" />
+    <PackageReference Include="DotNetty.Codecs" Version="0.7.5" />
+    <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.7.5" />
     <PackageReference Include="DotNetty.Common" Version="0.7.5" />
+    <PackageReference Include="DotNetty.Handlers" Version="0.7.5" />
+    <PackageReference Include="DotNetty.Transport" Version="0.7.5" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
@@ -13,11 +13,17 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <!--
       We have a transitive dependency on Dotnetty via Microsoft.Azure.Devices.ProtocolGateway.Core.
-      Use an explicit reference here to override the version and fix a known OOM bug. See
+      Use explicit references here to override the version and fix a known OOM bug. See
       https://github.com/Azure/DotNetty/pull/583. If ProtocolGateway updates its dependency,
-      we can remove this reference.
+      we can remove the Dotnetty references.
     -->
+    <PackageReference Include="DotNetty.Buffers" Version="0.7.5" />
+    <PackageReference Include="DotNetty.Codecs" Version="0.7.5" />
+    <PackageReference Include="DotNetty.Codecs.Mqtt" Version="0.7.5" />
     <PackageReference Include="DotNetty.Common" Version="0.7.5" />
+    <PackageReference Include="DotNetty.Handlers" Version="0.7.5" />
+    <PackageReference Include="DotNetty.Transport" Version="0.7.5" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
+++ b/edge-hub/core/src/Microsoft.Azure.Devices.Edge.Hub.Mqtt/Microsoft.Azure.Devices.Edge.Hub.Mqtt.csproj
@@ -11,6 +11,13 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.ProtocolGateway.Core" Version="2.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
+    <!--
+      We have a transitive dependency on Dotnetty via Microsoft.Azure.Devices.ProtocolGateway.Core.
+      Use an explicit reference here to override the version and fix a known OOM bug. See
+      https://github.com/Azure/DotNetty/pull/583. If ProtocolGateway updates its dependency,
+      we can remove this reference.
+    -->
+    <PackageReference Include="DotNetty.Common" Version="0.7.5" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixes #6630.

DotNetty has an OOM bug that is fixed in v0.7.5. Two components in Edge Hub have a transitive dependency on DotNetty:
* Microsoft.Azure.Devices.Edge.Hub.Core via Microsoft.Azure.Devices.Client
* Microsoft.Azure.Devices.Edge.Hub.Mqtt via Microsoft.Azure.Devices.ProtocolGateway.Core.

The best approach is for our dependencies to update their reference to DotNetty, then we update our dependencies. In the meantime, we'll make explicit references to override the transitive versions.

I used `dotnet list package --include-transitive` before and after the change to verify that the transitive dependency is replaced by the explicit dependency in the two updated projects, and that transitive packages are at 0.7.5 throughout the rest of Edge Hub. It would work to _only_ add explicit references in Microsoft.Azure.Devices.Edge.Hub.Core since Microsoft.Azure.Devices.Edge.Hub.Mqtt depends on Core but adding explicit references at the site of each dependency should help avoid surprises.

Changes to Edge Hub connectivity can have far-reaching impacts, so I'm running end-to-end, nested end-to-end, connectivity, and long-haul pipelines to test this change.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.