### PR TITLE
Fix bug causing Edge Agent 1-hour delay in sending reported properties to IoT Hub

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentConnection.cs
@@ -339,8 +339,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
                         if (this.CheckIfTwinSignatureIsValid(twin.Properties.Desired))
                         {
                             this.desiredProperties = Option.Some(twin.Properties.Desired);
-                            await this.UpdateDeploymentConfig(twin.Properties.Desired);
                             this.reportedProperties = Option.Some(twin.Properties.Reported);
+                            await this.UpdateDeploymentConfig(twin.Properties.Desired);
                             Events.TwinRefreshSuccess();
                         }
                     }


### PR DESCRIPTION
Cherry-pick from #6709

Fixes a bug causing newly provisioned devices to delay uploading reported properties to IoT Hub for an hour, resulting in "NA" and "Error" status in Azure Portal.

These changes have been tested by building an EdgeAgent image from this branch and specifying the image as the Default Edge Agent image in config.toml.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
