### PR TITLE
Upgrade to Rust 1.64

### DIFF
--- a/edge-modules/api-proxy-module/src/main.rs
+++ b/edge-modules/api-proxy-module/src/main.rs
@@ -73,10 +73,10 @@ async fn main() -> Result<()> {
         .await
         .context("Fatal, could not shut down SDK")?;
 
-    cert_monitor_shutdown_handle.shutdown().await;
-    config_monitor_shutdown_handle.shutdown().await;
-    nginx_controller_shutdown_handle.shutdown().await;
-    token_server_shutdown_handle.shutdown().await;
+    cert_monitor_shutdown_handle.shutdown();
+    config_monitor_shutdown_handle.shutdown();
+    nginx_controller_shutdown_handle.shutdown();
+    token_server_shutdown_handle.shutdown();
 
     if let Err(e) = cert_monitor_handle.await {
         error!("error on finishing cert monitor: {}", e);

--- a/edge-modules/api-proxy-module/src/utils/shutdown_handle.rs
+++ b/edge-modules/api-proxy-module/src/utils/shutdown_handle.rs
@@ -6,7 +6,7 @@ use tokio::sync::Notify;
 pub struct ShutdownHandle(pub Arc<Notify>);
 
 impl ShutdownHandle {
-    pub async fn shutdown(self) {
+    pub fn shutdown(self) {
         self.0.notify_one();
     }
 }

--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -72,7 +72,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -94,7 +94,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -137,7 +137,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -162,7 +162,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -205,7 +205,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -218,7 +218,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "serde",
 ]
@@ -226,7 +226,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -254,7 +254,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "http-common",
  "libc",
@@ -264,7 +264,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "pkcs11",
  "serde",
@@ -274,7 +274,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "http-common",
  "serde",
@@ -283,7 +283,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -359,7 +359,7 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "async-trait",
  "aziot-cert-client-async",
@@ -434,7 +434,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "serde",
  "toml",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "async-trait",
  "base64",
@@ -1325,7 +1325,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "env_logger",
  "log",
@@ -1478,7 +1478,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "cc",
 ]
@@ -1520,7 +1520,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1589,7 +1589,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1606,7 +1606,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 
 [[package]]
 name = "pkg-config"
@@ -1986,7 +1986,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#2d4a9ffc023c8d189fccd04a5d056215315d72df"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#34b5e707de334d4047ee55613c950a6eda42fa9f"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/edgelet-docker/src/runtime.rs
+++ b/edgelet/edgelet-docker/src/runtime.rs
@@ -120,17 +120,10 @@ where
             Ok(image_name_to_id) => {
                 if image_name_to_id.is_empty() {
                     log::error!("No docker images present on device: {} was just pulled, but not found on device", image);
+                } else if let Some(image_id) = image_name_to_id.get(config.image()) {
+                    self.image_use_data.record_image_use_timestamp(image_id)?;
                 } else {
-                    let image_id = match image_name_to_id.get(config.image()) {
-                        Some(imageid) => imageid,
-                        None => {
-                            log::warn!("Could not retrieve image id. {} was not added to image garbage collection list and will not be garbage collected", image);
-                            ""
-                        }
-                    };
-                    if !image_id.is_empty() {
-                        self.image_use_data.record_image_use_timestamp(image_id)?;
-                    }
+                    log::warn!("Could not retrieve image id. {} was not added to image garbage collection list and will not be garbage collected", image);
                 }
             }
             Err(e) => log::error!("Could not get list of docker images: {}", e),

--- a/edgelet/edgelet-http/src/modules.rs
+++ b/edgelet/edgelet-http/src/modules.rs
@@ -40,7 +40,7 @@ pub struct EnvVar {
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 #[serde(rename_all = "camelCase")]
 pub struct ModuleStatus {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -53,7 +53,7 @@ pub struct ModuleStatus {
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 #[serde(rename_all = "camelCase")]
 pub struct ExitStatus {
     pub exit_time: String,
@@ -61,7 +61,7 @@ pub struct ExitStatus {
 }
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
-#[cfg_attr(test, derive(PartialEq))]
+#[cfg_attr(test, derive(Eq, PartialEq))]
 pub struct RuntimeStatus {
     pub status: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/edgelet/iotedge/src/check/checks/proxy_settings.rs
+++ b/edgelet/iotedge/src/check/checks/proxy_settings.rs
@@ -14,18 +14,16 @@ impl Checker for ProxySettings {
     }
 
     async fn execute(&mut self, check: &mut Check) -> CheckResult {
-        self.inner_execute(check)
-            .await
-            .unwrap_or_else(CheckResult::Failed)
+        Self::inner_execute(check)
     }
 }
 
 impl ProxySettings {
-    async fn inner_execute(&mut self, check: &mut Check) -> anyhow::Result<CheckResult> {
+    fn inner_execute(check: &mut Check) -> CheckResult {
         let settings = if let Some(settings) = &mut check.settings {
             settings
         } else {
-            return Ok(CheckResult::Skipped);
+            return CheckResult::Skipped;
         };
 
         // Pull the proxy address from the aziot-edged settings
@@ -55,16 +53,16 @@ impl ProxySettings {
             && edge_agent_proxy_uri.eq(&edge_daemon_proxy_uri)
             && edge_agent_proxy_uri.eq(&identity_daemon_proxy_uri)
         {
-            Ok(CheckResult::Ok)
+            CheckResult::Ok
         } else {
-            Ok(CheckResult::Warning(anyhow::anyhow!(
+            CheckResult::Warning(anyhow::anyhow!(
                     "The proxy setting for IoT Edge Agent {:?}, IoT Edge Daemon {:?}, IoT Identity Daemon {:?}, and Moby {:?} may need to be identical.",
                     edge_agent_proxy_uri,
                     edge_daemon_proxy_uri,
                     identity_daemon_proxy_uri,
                     moby_proxy_uri
                 )
-            ))
+            )
         }
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.63"
+channel = "1.64"


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- `clippy::derive_partial_eq_without_eq`: derive `Eq` where possible
- `clippy::single_match_else`: replace `match` with `if let`
- `clippy::unused_async`: remove `async`
- `clippy::unused_self`: make function associated
- `clippy::unnecessary_wraps`: remove unnecessary wrapping `Result`

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

[^0]: https://github.com/rust-lang/rust/blob/1.48.0/RELEASES.md#compatibility-notes
  Namely, the point on `mem::uninitialized`.