### PR TITLE
Edge Agent: Stabilize upstream connection via manual timeouts

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentCloudSDKException.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/EdgeAgentCloudSDKException.cs
@@ -1,0 +1,22 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub
+{
+    using System;
+
+    public class EdgeAgentCloudSDKException : Exception
+    {
+        public EdgeAgentCloudSDKException()
+        {
+        }
+
+        public EdgeAgentCloudSDKException(string message)
+            : this(message, null)
+        {
+        }
+
+        public EdgeAgentCloudSDKException(string message, Exception innerException)
+            : base(message, innerException)
+        {
+        }
+    }
+}

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/ISdkModuleClientProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/ISdkModuleClientProvider.cs
@@ -1,13 +1,14 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient
 {
+    using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
 
     public interface ISdkModuleClientProvider
     {
-        ISdkModuleClient GetSdkModuleClient(string connectionString, ITransportSettings settings);
+        ISdkModuleClient GetSdkModuleClient(string connectionString, ITransportSettings settings, TimeSpan cloudConnectionHangingTimeout);
 
-        Task<ISdkModuleClient> GetSdkModuleClient(ITransportSettings settings);
+        Task<ISdkModuleClient> GetSdkModuleClient(ITransportSettings settings, TimeSpan cloudConnectionHangingTimeout);
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/SdkModuleClientProvider.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.IoTHub/sdkClient/SdkModuleClientProvider.cs
@@ -1,21 +1,22 @@
 // Copyright (c) Microsoft. All rights reserved.
 namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient
 {
+    using System;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
 
     public class SdkModuleClientProvider : ISdkModuleClientProvider
     {
-        public ISdkModuleClient GetSdkModuleClient(string connectionString, ITransportSettings settings)
+        public ISdkModuleClient GetSdkModuleClient(string connectionString, ITransportSettings settings, TimeSpan cloudConnectionHangingTimeout)
         {
             ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(connectionString, new[] { settings });
-            return new WrappingSdkModuleClient(moduleClient);
+            return new WrappingSdkModuleClient(moduleClient, cloudConnectionHangingTimeout);
         }
 
-        public async Task<ISdkModuleClient> GetSdkModuleClient(ITransportSettings settings)
+        public async Task<ISdkModuleClient> GetSdkModuleClient(ITransportSettings settings, TimeSpan cloudConnectionHangingTimeout)
         {
             ModuleClient moduleClient = await ModuleClient.CreateFromEnvironmentAsync(new[] { settings });
-            return new WrappingSdkModuleClient(moduleClient);
+            return new WrappingSdkModuleClient(moduleClient, cloudConnectionHangingTimeout);
         }
     }
 }

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/Program.cs
@@ -90,6 +90,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
             MetricsConfig metricsConfig;
             DiagnosticConfig diagnosticConfig;
             bool useServerHeartbeat;
+            TimeSpan cloudConnectionHangingTimeout;
 
             try
             {
@@ -101,6 +102,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                 coolOffTimeUnitInSeconds = configuration.GetValue("CoolOffTimeUnitInSeconds", 10);
                 usePersistentStorage = configuration.GetValue("UsePersistentStorage", true);
                 useServerHeartbeat = configuration.GetValue("UseServerHeartbeat", true);
+                cloudConnectionHangingTimeout = TimeSpan.FromSeconds(configuration.GetValue("CloudConnectionHangingTimeoutSecs", 600));
 
                 // Note: Keep in sync with iotedge-check's edge-agent-storage-mounted-from-host check (edgelet/iotedge/src/check/checks/storage_mounted_from_host.rs)
                 storagePath = GetOrCreateDirectoryPath(configuration.GetValue<string>("StorageFolder"), EdgeAgentStorageFolder);
@@ -154,7 +156,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         deviceId = connectionStringParser.DeviceId;
                         iothubHostname = connectionStringParser.HostName;
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize, storageMaxOpenFiles, storageLogLevel));
-                        builder.RegisterModule(new DockerModule(deviceConnectionString, edgeDeviceHostName, dockerUri, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, useServerHeartbeat, backupConfigFilePath));
+                        builder.RegisterModule(new DockerModule(deviceConnectionString, edgeDeviceHostName, dockerUri, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, useServerHeartbeat, backupConfigFilePath, cloudConnectionHangingTimeout));
                         break;
 
                     case Constants.IotedgedMode:
@@ -168,7 +170,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service
                         apiVersion = configuration.GetValue<string>(Constants.EdgeletApiVersionVariableName);
                         TimeSpan performanceMetricsUpdateFrequency = configuration.GetTimeSpan("PerformanceMetricsUpdateFrequency", TimeSpan.FromMinutes(5));
                         builder.RegisterModule(new AgentModule(maxRestartCount, intensiveCareTime, coolOffTimeUnitInSeconds, usePersistentStorage, storagePath, Option.Some(new Uri(workloadUri)), Option.Some(apiVersion), moduleId, Option.Some(moduleGenerationId), enableNonPersistentStorageBackup, storageBackupPath, storageTotalMaxWalSize, storageMaxOpenFiles, storageLogLevel));
-                        builder.RegisterModule(new EdgeletModule(iothubHostname, edgeDeviceHostName, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, performanceMetricsUpdateFrequency, useServerHeartbeat, backupConfigFilePath, checkImagePullBeforeModuleCreate));
+                        builder.RegisterModule(new EdgeletModule(iothubHostname, edgeDeviceHostName, deviceId, new Uri(managementUri), new Uri(workloadUri), apiVersion, dockerAuthConfig, upstreamProtocol, proxy, productInfo, closeOnIdleTimeout, idleTimeout, performanceMetricsUpdateFrequency, useServerHeartbeat, backupConfigFilePath, checkImagePullBeforeModuleCreate, cloudConnectionHangingTimeout));
 
                         trustBundle = await CertificateHelper.GetTrustBundleFromEdgelet(new Uri(workloadUri), apiVersion, Constants.WorkloadApiVersion, moduleId, moduleGenerationId);
                         CertificateHelper.InstallCertificates(trustBundle, logger);

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DockerModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/DockerModule.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly TimeSpan idleTimeout;
         readonly bool useServerHeartbeat;
         readonly string backupConfigFilePath;
+        readonly TimeSpan cloudConnectionHangingTimeout;
 
         public DockerModule(
             string edgeDeviceConnectionString,
@@ -49,7 +50,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             bool closeOnIdleTimeout,
             TimeSpan idleTimeout,
             bool useServerHeartbeat,
-            string backupConfigFilePath)
+            string backupConfigFilePath,
+            TimeSpan cloudConnectionHangingTimeout)
         {
             this.edgeDeviceConnectionString = Preconditions.CheckNonWhiteSpace(edgeDeviceConnectionString, nameof(edgeDeviceConnectionString));
             this.gatewayHostName = Preconditions.CheckNonWhiteSpace(gatewayHostName, nameof(gatewayHostName));
@@ -65,6 +67,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.idleTimeout = idleTimeout;
             this.useServerHeartbeat = useServerHeartbeat;
             this.backupConfigFilePath = Preconditions.CheckNonWhiteSpace(backupConfigFilePath, nameof(backupConfigFilePath));
+            this.cloudConnectionHangingTimeout = cloudConnectionHangingTimeout;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -81,7 +84,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                         this.productInfo,
                         this.closeOnIdleTimeout,
                         this.idleTimeout,
-                        this.useServerHeartbeat))
+                        this.useServerHeartbeat,
+                        this.cloudConnectionHangingTimeout))
                 .As<IModuleClientProvider>()
                 .SingleInstance();
 

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Service/modules/EdgeletModule.cs
@@ -46,6 +46,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
         readonly bool useServerHeartbeat;
         readonly string backupConfigFilePath;
         readonly bool checkImagePullBeforeModuleCreate;
+        readonly TimeSpan cloudConnectionHangingTimeout;
 
         public EdgeletModule(
             string iotHubHostname,
@@ -63,7 +64,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             TimeSpan performanceMetricsUpdateFrequency,
             bool useServerHeartbeat,
             string backupConfigFilePath,
-            bool checkImagePullBeforeModuleCreate)
+            bool checkImagePullBeforeModuleCreate,
+            TimeSpan cloudConnectionHangingTimeout)
         {
             this.iotHubHostName = Preconditions.CheckNonWhiteSpace(iotHubHostname, nameof(iotHubHostname));
             this.gatewayHostName = Preconditions.CheckNonWhiteSpace(gatewayHostName, nameof(gatewayHostName));
@@ -81,6 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
             this.useServerHeartbeat = useServerHeartbeat;
             this.backupConfigFilePath = Preconditions.CheckNonWhiteSpace(backupConfigFilePath, nameof(backupConfigFilePath));
             this.checkImagePullBeforeModuleCreate = checkImagePullBeforeModuleCreate;
+            this.cloudConnectionHangingTimeout = cloudConnectionHangingTimeout;
         }
 
         protected override void Load(ContainerBuilder builder)
@@ -94,7 +97,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Service.Modules
                         this.productInfo,
                         this.closeOnIdleTimeout,
                         this.idleTimeout,
-                        this.useServerHeartbeat))
+                        this.useServerHeartbeat,
+                        this.cloudConnectionHangingTimeout))
                 .As<IModuleClientProvider>()
                 .SingleInstance();
 

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/CombinedEdgeletConfigProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/CombinedEdgeletConfigProviderTest.cs
@@ -114,7 +114,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test
             {
                 Assert.Equal("/path/to/homedir/mnt/edgeAgent.sock:/path/to/workload.sock", config.CreateOptions.HostConfig.Binds[0]);
                 Assert.Equal("/path/to/mgmt.sock:/path/to/mgmt.sock", config.CreateOptions.HostConfig.Binds[1]);
-            }else
+            }
+            else
             {
                 Assert.Equal("C:\\path\\to\\homedir\\mnt\\edgeAgent:C:\\path\\to\\workload", config.CreateOptions.HostConfig.Binds[0]);
                 Assert.Equal("C:\\path\\to\\mgmt:C:\\path\\to\\mgmt", config.CreateOptions.HostConfig.Binds[1]);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentHangInitialConnectionTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/EdgeAgentHangInitialConnectionTest.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft. All rights reserved.
+namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.Devices.Edge.Agent.Core;
+    using Microsoft.Azure.Devices.Edge.Agent.IoTHub.SdkClient;
+    using Microsoft.Azure.Devices.Edge.Util;
+    using Microsoft.Azure.Devices.Edge.Util.Test.Common;
+    using Microsoft.Azure.Devices.Shared;
+    using Xunit;
+    using IotHubConnectionStringBuilder = Microsoft.Azure.Devices.IotHubConnectionStringBuilder;
+
+    class SdkModuleClientProviderHangFirstOpen : ISdkModuleClientProvider
+    {
+        FailingConnectionCounter failingConnectionCounter;
+
+        public SdkModuleClientProviderHangFirstOpen()
+        {
+            this.failingConnectionCounter = new FailingConnectionCounter();
+        }
+
+        public ISdkModuleClient GetSdkModuleClient(string connectionString, ITransportSettings settings, TimeSpan cloudConnectionHangingTimeout)
+        {
+            ModuleClient moduleClient = ModuleClient.CreateFromConnectionString(connectionString, new[] { settings });
+            WrappingSdkModuleClient wrappingSdkModuleClient = new WrappingSdkModuleClient(moduleClient, cloudConnectionHangingTimeout);
+            return new WrappingSdkModuleClientHangFirstOpen(wrappingSdkModuleClient, this.failingConnectionCounter);
+        }
+
+        public async Task<ISdkModuleClient> GetSdkModuleClient(ITransportSettings settings, TimeSpan cloudConnectionHangingTimeout)
+        {
+            ModuleClient moduleClient = await ModuleClient.CreateFromEnvironmentAsync(new[] { settings });
+            WrappingSdkModuleClient wrappingSdkModuleClient = new WrappingSdkModuleClient(moduleClient, cloudConnectionHangingTimeout);
+            return new WrappingSdkModuleClientHangFirstOpen(wrappingSdkModuleClient, this.failingConnectionCounter);
+        }
+    }
+
+    class FailingConnectionCounter
+    {
+        int failingConnectionCounter;
+
+        public void Increment()
+        {
+            this.failingConnectionCounter += 1;
+        }
+
+        public int Value()
+        {
+            return this.failingConnectionCounter;
+        }
+    }
+
+    class WrappingSdkModuleClientHangFirstOpen : ISdkModuleClient
+    {
+        readonly WrappingSdkModuleClient wrappingSdkModuleClient;
+        FailingConnectionCounter failingConnectionCounter;
+
+        public WrappingSdkModuleClientHangFirstOpen(WrappingSdkModuleClient wrappingSdkModuleClient, FailingConnectionCounter failingConnectionCounter)
+        {
+            this.wrappingSdkModuleClient = Preconditions.CheckNotNull(wrappingSdkModuleClient, nameof(wrappingSdkModuleClient));
+            this.failingConnectionCounter = failingConnectionCounter;
+        }
+
+        public Task OpenAsync()
+        {
+            if (this.failingConnectionCounter.Value() == 0)
+            {
+                this.failingConnectionCounter.Increment();
+                throw new EdgeAgentCloudSDKException("Operation timed out due to SDK hanging");
+            }
+            else
+            {
+                return this.wrappingSdkModuleClient.OpenAsync();
+            }
+        }
+
+        public void SetConnectionStatusChangesHandler(ConnectionStatusChangesHandler statusChangesHandler)
+            => this.wrappingSdkModuleClient.SetConnectionStatusChangesHandler(statusChangesHandler);
+
+        public void SetOperationTimeoutInMilliseconds(uint operationTimeoutInMilliseconds)
+            => this.wrappingSdkModuleClient.SetOperationTimeoutInMilliseconds(operationTimeoutInMilliseconds);
+
+        public void SetProductInfo(string productInfo) => this.wrappingSdkModuleClient.SetProductInfo(productInfo);
+
+        public Task SetDesiredPropertyUpdateCallbackAsync(DesiredPropertyUpdateCallback onDesiredPropertyChanged)
+            => this.wrappingSdkModuleClient.SetDesiredPropertyUpdateCallbackAsync(onDesiredPropertyChanged);
+
+        public Task SetMethodHandlerAsync(string methodName, MethodCallback callback)
+            => this.wrappingSdkModuleClient.SetMethodHandlerAsync(methodName, callback);
+
+        public Task SetDefaultMethodHandlerAsync(MethodCallback callback)
+            => this.wrappingSdkModuleClient.SetDefaultMethodHandlerAsync(callback);
+
+        public Task<Twin> GetTwinAsync()
+        {
+            return this.wrappingSdkModuleClient.GetTwinAsync();
+        }
+
+        public Task UpdateReportedPropertiesAsync(TwinCollection reportedProperties)
+            => this.wrappingSdkModuleClient.UpdateReportedPropertiesAsync(reportedProperties);
+
+        public Task SendEventAsync(Message message) => this.wrappingSdkModuleClient.SendEventAsync(message);
+
+        public Task CloseAsync()
+        {
+            return this.wrappingSdkModuleClient.CloseAsync();
+        }
+    }
+
+    public class EdgeAgentHangingConnectionTest
+    {
+        const string DockerType = "docker";
+        static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(60);
+
+        [Integration]
+        [Fact]
+        public async Task EdgeAgentConnectionHangInitialConnection()
+        {
+            string iotHubConnectionString = await SecretsHelper.GetSecretFromConfigKey("iotHubConnStrKey");
+            IotHubConnectionStringBuilder iotHubConnectionStringBuilder = IotHubConnectionStringBuilder.Create(iotHubConnectionString);
+            RegistryManager registryManager = RegistryManager.CreateFromConnectionString(iotHubConnectionString);
+            await registryManager.OpenAsync();
+
+            string edgeDeviceId = "testMmaEdgeDevice1" + Guid.NewGuid();
+
+            var edgeDevice = new Device(edgeDeviceId)
+            {
+                Capabilities = new DeviceCapabilities { IotEdge = true },
+                Authentication = new AuthenticationMechanism() { Type = AuthenticationType.Sas }
+            };
+
+            try
+            {
+                edgeDevice = await registryManager.AddDeviceAsync(edgeDevice);
+
+                await EdgeAgentConnectionTest.SetAgentDesiredProperties(registryManager, edgeDeviceId);
+
+                var moduleClientProvider = new SdkModuleClientProviderHangFirstOpen();
+                var edgeAgentConnection = EdgeAgentConnectionTest.CreateEdgeAgentConnection(iotHubConnectionStringBuilder, edgeDeviceId, edgeDevice, moduleClientProvider);
+
+                await Task.Delay(TimeSpan.FromSeconds(10));
+
+                Option<DeploymentConfigInfo> deploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
+
+                Assert.True(deploymentConfigInfo.HasValue);
+                DeploymentConfig deploymentConfig = deploymentConfigInfo.OrDefault().DeploymentConfig;
+                Assert.NotNull(deploymentConfig);
+                Assert.NotNull(deploymentConfig.Modules);
+                Assert.NotNull(deploymentConfig.Runtime);
+                Assert.NotNull(deploymentConfig.SystemModules);
+                Assert.Equal(EdgeAgentConnection.ExpectedSchemaVersion.ToString(), deploymentConfig.SchemaVersion);
+                Assert.Equal(1, deploymentConfig.Modules.Count);
+                Assert.NotNull(deploymentConfig.Modules["mongoserver"]);
+                EdgeAgentConnectionTest.ValidateRuntimeConfig(deploymentConfig.Runtime);
+                EdgeAgentConnectionTest.ValidateModules(deploymentConfig);
+
+                await EdgeAgentConnectionTest.UpdateAgentDesiredProperties(registryManager, edgeDeviceId);
+                await Task.Delay(TimeSpan.FromSeconds(10));
+
+                deploymentConfigInfo = await edgeAgentConnection.GetDeploymentConfigInfoAsync();
+
+                Assert.True(deploymentConfigInfo.HasValue);
+                deploymentConfig = deploymentConfigInfo.OrDefault().DeploymentConfig;
+                Assert.NotNull(deploymentConfig);
+                Assert.NotNull(deploymentConfig.Modules);
+                Assert.NotNull(deploymentConfig.Runtime);
+                Assert.NotNull(deploymentConfig.SystemModules);
+                Assert.Equal(EdgeAgentConnection.ExpectedSchemaVersion.ToString(), deploymentConfig.SchemaVersion);
+                Assert.Equal(2, deploymentConfig.Modules.Count);
+                Assert.NotNull(deploymentConfig.Modules["mongoserver"]);
+                Assert.NotNull(deploymentConfig.Modules["mlModule"]);
+                EdgeAgentConnectionTest.ValidateRuntimeConfig(deploymentConfig.Runtime);
+            }
+            finally
+            {
+                try
+                {
+                    await registryManager.RemoveDeviceAsync(edgeDevice);
+                }
+                catch (Exception)
+                {
+                    // ignored
+                }
+            }
+        }
+    }
+}

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/ModuleClientProviderTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/ModuleClientProviderTest.cs
@@ -26,12 +26,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         {
             // Arrange
             ITransportSettings receivedTransportSettings = null;
+            TimeSpan cloudConnectionHangingTimeout = TimeSpan.FromSeconds(60);
 
             var sdkModuleClient = new Mock<ISdkModuleClient>();
 
             var sdkModuleClientProvider = new Mock<ISdkModuleClientProvider>();
-            sdkModuleClientProvider.Setup(s => s.GetSdkModuleClient(It.IsAny<ITransportSettings>()))
-                .Callback<ITransportSettings>(t => receivedTransportSettings = t)
+            sdkModuleClientProvider.Setup(s => s.GetSdkModuleClient(It.IsAny<ITransportSettings>(), cloudConnectionHangingTimeout))
+                .Callback<ITransportSettings, TimeSpan>((t, cloudConnectionHangingTimeout) => receivedTransportSettings = t)
                 .ReturnsAsync(sdkModuleClient.Object);
 
             bool closeOnIdleTimeout = false;
@@ -46,12 +47,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 productInfo,
                 closeOnIdleTimeout,
                 idleTimeout,
-                false);
+                false,
+                cloudConnectionHangingTimeout);
             IModuleClient moduleClient = await moduleClientProvider.Create(handler);
 
             // Assert
             Assert.NotNull(moduleClient);
-            sdkModuleClientProvider.Verify(s => s.GetSdkModuleClient(It.IsAny<ITransportSettings>()), Times.Once);
+            sdkModuleClientProvider.Verify(s => s.GetSdkModuleClient(It.IsAny<ITransportSettings>(), cloudConnectionHangingTimeout), Times.Once);
 
             sdkModuleClient.Verify(s => s.SetProductInfo(productInfo), Times.Once);
 
@@ -93,12 +95,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
         {
             // Arrange
             ITransportSettings receivedTransportSettings = null;
+            TimeSpan cloudConnectionHangingTimeout = TimeSpan.FromSeconds(60);
 
             var sdkModuleClient = new Mock<ISdkModuleClient>();
 
             var sdkModuleClientProvider = new Mock<ISdkModuleClientProvider>();
-            sdkModuleClientProvider.Setup(s => s.GetSdkModuleClient(It.IsAny<ITransportSettings>()))
-                .Callback<ITransportSettings>(t => receivedTransportSettings = t)
+            sdkModuleClientProvider.Setup(s => s.GetSdkModuleClient(It.IsAny<ITransportSettings>(), cloudConnectionHangingTimeout))
+                .Callback<ITransportSettings, TimeSpan>((t, cloudConnectionHangingTimeout) => receivedTransportSettings = t)
                 .ReturnsAsync(sdkModuleClient.Object);
 
             bool closeOnIdleTimeout = false;
@@ -113,7 +116,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 null,
                 closeOnIdleTimeout,
                 idleTimeout,
-                false));
+                false,
+                cloudConnectionHangingTimeout));
         }
 
         [Theory]
@@ -126,12 +130,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
             // Arrange
             string connectionString = "DummyConnectionString";
             ITransportSettings receivedTransportSettings = null;
+            TimeSpan cloudConnectionHangingTimeout = TimeSpan.FromSeconds(60);
 
             var sdkModuleClient = new Mock<ISdkModuleClient>();
 
             var sdkModuleClientProvider = new Mock<ISdkModuleClientProvider>();
-            sdkModuleClientProvider.Setup(s => s.GetSdkModuleClient(connectionString, It.IsAny<ITransportSettings>()))
-                .Callback<string, ITransportSettings>((c, t) => receivedTransportSettings = t)
+            sdkModuleClientProvider.Setup(s => s.GetSdkModuleClient(connectionString, It.IsAny<ITransportSettings>(), cloudConnectionHangingTimeout))
+                .Callback<string, ITransportSettings, TimeSpan>((c, t, cloudConnectionHangingTimeout) => receivedTransportSettings = t)
                 .Returns(sdkModuleClient.Object);
 
             bool closeOnIdleTimeout = false;
@@ -147,12 +152,13 @@ namespace Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test
                 productInfo,
                 closeOnIdleTimeout,
                 idleTimeout,
-                false);
+                false,
+                cloudConnectionHangingTimeout);
             IModuleClient moduleClient = await moduleClientProvider.Create(handler);
 
             // Assert
             Assert.NotNull(moduleClient);
-            sdkModuleClientProvider.Verify(s => s.GetSdkModuleClient(connectionString, It.IsAny<ITransportSettings>()), Times.Once);
+            sdkModuleClientProvider.Verify(s => s.GetSdkModuleClient(connectionString, It.IsAny<ITransportSettings>(), cloudConnectionHangingTimeout), Times.Once);
 
             sdkModuleClient.Verify(s => s.SetProductInfo(productInfo), Times.Once);
 


### PR DESCRIPTION
Customer was complaining about their amqp connection hanging and not recovering. This is caused by their EdgeAgent's fallback connection to IoTHub hanging and never timing out. We have never seen this behavior before, and believe it is due to customer running large number of devices in the field (1000+).

This PR implements manual timeout on EdgeAgent upstream connection , since SDK timeouts are not reliable. The manual timeout only applies to `ModuleClient.OpenAsync()` and defaults to 600 seconds. Default timeout for SDK alone is 300 seconds. Inspired by Bilal's change to EdgeHub for similar hanging SDK connections linked below. Similar to Bilal's PR we are technically making this manual timeout configurable but not documenting it to customers.
https://github.com/Azure/iotedge/pull/6269 (description pasted below)

I synced with Bilal who worked on the above linked PR. We decided it was best to only apply this manual timeout to the customer's affected case (i.e. `ModuleClient.OpenAsync()`), rather than all other async ModuleClient methods. We are doing this for a few reasons:
1. IoT Edge (1.1 in particular) has been out for a long time with no sign of this happening, so it is wise to limit the affected code with this fix.
2. 1.1 goes out of LTS this November. 1.4 comes with both a new dotnet version and new SDK version (which I know has multiple amqp related fixes). It is possible (not sure how likely) 1.4 fixes this issue for customers.
3. This is really a problem in the underlying SDK, so we should ask them to get a fix out rather than patching this problem up everywhere in our codebase.


---------------------------------------------------------------------------------
Description from linked PR:
> PR to implement a workaround for the ongoing SDK issue where sending messages upstream hangs until edgehub is restarted. Customers noticed the SendEventAsync call would hang and edgehub would get stuck until restarted. This logic adds a configurable timer task that will cancel any upstream calls that go over the configured time (default at 50 seconds)