### PR TITLE
Mitigate ModuleToModuleDirectMethod e2e test failures

### DIFF
--- a/test/modules/DirectMethodSender/DirectMethodLocalSender.cs
+++ b/test/modules/DirectMethodSender/DirectMethodLocalSender.cs
@@ -54,7 +54,7 @@ namespace DirectMethodSender
             ulong directMethodCount,
             CancellationToken none)
         {
-            MethodRequest request = new MethodRequest(methodName, Encoding.UTF8.GetBytes($"{{ \"Message\": \"Hello\", \"DirectMethodCount\": \"{directMethodCount.ToString()}\" }}"));
+            MethodRequest request = new MethodRequest(methodName, Encoding.UTF8.GetBytes($"{{ \"Message\": \"Hello\", \"DirectMethodCount\": \"{directMethodCount.ToString()}\" }}"), TimeSpan.FromSeconds(300), TimeSpan.FromSeconds(300));
             MethodResponse result = await this.moduleClient.InvokeMethodAsync(deviceId, targetModuleId, request);
             return result.Status;
         }


### PR DESCRIPTION
Cherry-pick from PR #6716

Set Connection Timeout and Response Timeout to max values of 5 minutes in DirectMethodSender test module used by the ModuleToModuleDirectMethod method. This should reduce the failure rate of the test on ARM32v7 platforms where direct methods can take a long time to complete.

To test this change a CI Build pipeline was run from this branch and then an E2E pipeline was run using the resulting artifacts.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
