### PR TITLE
Change Metrics Collector release pipeline name

### DIFF
--- a/builds/release/metrics-collector-images-publish.yaml
+++ b/builds/release/metrics-collector-images-publish.yaml
@@ -8,7 +8,7 @@ variables:
 resources:
   pipelines:
   - pipeline: stage-metrics-collector
-    source: 'Stage Metrics Collector Images'
+    source: 'Metrics Collector - Stage Images'
     trigger: true
 
 pool:


### PR DESCRIPTION
The new Metrics Collector release pipelines are named:
- Stage Metrics Collector Images
- Publish Metrics Collector Images

The pipelines will be updated to:
- Metrics Collector - Stage Images
- Metrics Collector - Publish Images

...to make it easier to find them in the list of release pipelines. This change updates the pipeline resource in the publish pipeline to refer to the new name.