### PR TITLE
EdgeHubTriggerAttribute resolve InputName param

### DIFF
--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/EdgeHubTriggerBindingProvider.cs
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/EdgeHubTriggerBindingProvider.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.WebJobs.Extensions.EdgeHub
     using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Client;
+    using Microsoft.Azure.WebJobs.Host;
     using Microsoft.Azure.WebJobs.Host.Triggers;
 
     /// <summary>
@@ -14,10 +15,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.EdgeHub
     /// It's TryCreateAsync method is called by the runtime for all job parameters, giving it a chance to return a binding.
     /// Please see <see href="https://github.com/Azure/azure-webjobs-sdk-extensions/wiki/Trigger-Binding-Extensions#binding-provider">Trigger Binding Extensions</see>
     /// </summary>
-    class EdgeHubTriggerBindingProvider : ITriggerBindingProvider
+    public class EdgeHubTriggerBindingProvider : ITriggerBindingProvider
     {
         readonly ConcurrentDictionary<string, IList<EdgeHubMessageProcessor>> receivers = new ConcurrentDictionary<string, IList<EdgeHubMessageProcessor>>();
         ModuleClient moduleClient;
+        readonly INameResolver nameResolver;
+
+        public EdgeHubTriggerBindingProvider(INameResolver nameResolver)
+        {
+            this.nameResolver = nameResolver;
+        }
 
         public async Task<ITriggerBinding> TryCreateAsync(TriggerBindingProviderContext context)
         {
@@ -33,13 +40,16 @@ namespace Microsoft.Azure.WebJobs.Extensions.EdgeHub
                 return null;
             }
 
+            var inputName = nameResolver?.ResolveWholeString(attribute.InputName) ?? attribute.InputName;
+            inputName = inputName.ToLowerInvariant();
+
             await this.TrySetEventDefaultHandlerAsync();
 
             var messageProcessor = new EdgeHubMessageProcessor();
             var triggerBinding = new EdgeHubTriggerBinding(context.Parameter, messageProcessor);
 
             this.receivers.AddOrUpdate(
-                attribute.InputName.ToLowerInvariant(),
+                inputName,
                 // The function used to generate a value for an absent.
                 // Creates a new List and adds the message processor
                 (k) => new List<EdgeHubMessageProcessor>()
@@ -70,8 +80,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.EdgeHub
 
         async Task<MessageResponse> FunctionsMessageHandler(Message message, object userContext)
         {
+            var inputName = message.InputName.ToLowerInvariant();
             byte[] payload = message.GetBytes();
-            if (this.receivers.TryGetValue(message.InputName.ToLowerInvariant(), out IList<EdgeHubMessageProcessor> functionReceivers))
+
+            if (this.receivers.TryGetValue(inputName, out IList<EdgeHubMessageProcessor> functionReceivers))
             {
                 foreach (EdgeHubMessageProcessor edgeHubTriggerBinding in functionReceivers)
                 {

--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj
@@ -28,13 +28,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="..\..\..\..\..\LICENSE" Pack="true" PackagePath=""/>
-    <None Include="images\icon.png" Pack="true" PackagePath=""/>
+    <None Include="..\..\..\..\..\LICENSE" Pack="true" PackagePath="" />
+    <None Include="images\icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.6" />
-    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.27" />
+    <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.33" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 

--- a/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/config/EdgeHubExtensionConfigProvider.cs
+++ b/edge-modules/functions/binding/src/Microsoft.Azure.WebJobs.Extensions.EdgeHub/config/EdgeHubExtensionConfigProvider.cs
@@ -15,8 +15,15 @@ namespace Microsoft.Azure.WebJobs.Extensions.EdgeHub.Config
     /// Extension configuration provider used to register EdgeHub triggers and binders
     /// </summary>
     [Extension("EdgeHub")]
-    class EdgeHubExtensionConfigProvider : IExtensionConfigProvider
+    public class EdgeHubExtensionConfigProvider : IExtensionConfigProvider
     {
+        readonly INameResolver nameResolver;
+
+        public EdgeHubExtensionConfigProvider(INameResolver nameResolver)
+        {
+            this.nameResolver = nameResolver;
+        }
+
         public void Initialize(ExtensionConfigContext context)
         {
             if (context == null)
@@ -24,11 +31,10 @@ namespace Microsoft.Azure.WebJobs.Extensions.EdgeHub.Config
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var bindingProvider = new EdgeHubTriggerBindingProvider();
             var rule = context.AddBindingRule<EdgeHubTriggerAttribute>();
             rule.AddConverter<Message, string>(ConvertMessageToString);
             rule.AddConverter<Message, byte[]>(ConvertMessageToBytes);
-            rule.BindToTrigger<Message>(bindingProvider);
+            rule.BindToTrigger<Message>(new EdgeHubTriggerBindingProvider(nameResolver));
 
             var rule2 = context.AddBindingRule<EdgeHubAttribute>();
             rule2.BindToCollector<Message>(typeof(EdgeHubCollectorBuilder));


### PR DESCRIPTION
Implement param resolve in EdgeHubTriggerAttribute's InputName (resolution of {} and %% binding expressions applied)

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
