### PR TITLE
Make iotedge check respect journald as valid log rotation setting

### DIFF
--- a/edgelet/iotedge/src/check/checks/container_engine_logrotate.rs
+++ b/edgelet/iotedge/src/check/checks/container_engine_logrotate.rs
@@ -55,8 +55,10 @@ impl ContainerEngineLogrotate {
             .context(MESSAGE)?;
         self.daemon_config = Some(daemon_config.clone());
 
-        if daemon_config.log_driver.is_none() {
-            return Ok(CheckResult::Warning(anyhow!(MESSAGE)));
+        match daemon_config.log_driver.as_deref() {
+            Some("journald") => return Ok(CheckResult::Ok),
+            None => return Ok(CheckResult::Warning(anyhow!(MESSAGE))),
+            _ => (),
         }
 
         if let Some(log_opts) = &daemon_config.log_opts {


### PR DESCRIPTION
Cherry-pick PR #6734

This PR will make iotedge check respect docker's journald logdriver as a valid log rotation setting.

See issue #6728

## Azure IoT Edge PR checklist:

***Please replace this line with your PR description and read PR checklist below***

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [ ] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [ ] Title of the pull request is clear and informative.
- [ ] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
