### PR TITLE
Set timeout to http client

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2018_06_28/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2018_06_28/ModuleManagementHttpClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task<Identity> CreateIdentityAsync(string name, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task<Identity> UpdateIdentityAsync(string name, string generationId, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task DeleteIdentityAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteIdentityAsync(this.Version.Name, name), $"Delete identity for {name}");
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task<IEnumerable<Identity>> GetIdentities()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 IdentityList identityList = await this.Execute(() => edgeletHttpClient.ListIdentitiesAsync(this.Version.Name), $"List identities");
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task CreateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.CreateModuleAsync(this.Version.Name, this.MapToModuleSpec(moduleSpec)), $"Create module {moduleSpec.Name}");
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task DeleteModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteModuleAsync(this.Version.Name, name), $"Delete module {name}");
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task RestartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task<SystemInfo> GetSystemInfoAsync(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemInfo systemInfo = await this.Execute(
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task<IEnumerable<ModuleRuntimeInfo>> GetModules<T>(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 ModuleList moduleList = await this.Execute(
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task StartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StartModuleAsync(this.Version.Name, name), $"start module {name}");
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task StopModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StopModuleAsync(this.Version.Name, name), $"stop module {name}");
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task UpdateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, null, this.MapToModuleSpec(moduleSpec)), $"update module {moduleSpec.Name}");
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2018_06_28
 
         public override async Task UpdateAndStartModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, true, this.MapToModuleSpec(moduleSpec)), $"update and start module {moduleSpec.Name}");

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2019_01_30/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2019_01_30/ModuleManagementHttpClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task<Identity> CreateIdentityAsync(string name, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task<Identity> UpdateIdentityAsync(string name, string generationId, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task DeleteIdentityAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteIdentityAsync(this.Version.Name, name), $"Delete identity for {name}");
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task<IEnumerable<Identity>> GetIdentities()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 IdentityList identityList = await this.Execute(() => edgeletHttpClient.ListIdentitiesAsync(this.Version.Name), $"List identities");
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task CreateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.CreateModuleAsync(this.Version.Name, MapToModuleSpec(moduleSpec)), $"Create module {moduleSpec.Name}");
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task DeleteModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteModuleAsync(this.Version.Name, name), $"Delete module {name}");
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task RestartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task<SystemInfo> GetSystemInfoAsync(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemInfo systemInfo = await this.Execute(
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task<IEnumerable<ModuleRuntimeInfo>> GetModules<T>(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 ModuleList moduleList = await this.Execute(
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task StartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StartModuleAsync(this.Version.Name, name), $"start module {name}");
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task StopModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StopModuleAsync(this.Version.Name, name), $"stop module {name}");
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task UpdateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, null, MapToModuleSpec(moduleSpec)), $"update module {moduleSpec.Name}");
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task UpdateAndStartModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, true, MapToModuleSpec(moduleSpec)), $"update and start module {moduleSpec.Name}");
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_01_30
 
         public override async Task PrepareUpdateAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.PrepareUpdateModuleAsync(this.Version.Name, moduleSpec.Name, MapToModuleSpec(moduleSpec)), $"prepare update for module {moduleSpec.Name}");

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2019_10_22/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2019_10_22/ModuleManagementHttpClient.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task<Identity> CreateIdentityAsync(string name, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task<Identity> UpdateIdentityAsync(string name, string generationId, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task DeleteIdentityAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteIdentityAsync(this.Version.Name, name), $"Delete identity for {name}");
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task<IEnumerable<Identity>> GetIdentities()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 IdentityList identityList = await this.Execute(() => edgeletHttpClient.ListIdentitiesAsync(this.Version.Name), $"List identities");
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task CreateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.CreateModuleAsync(this.Version.Name, MapToModuleSpec(moduleSpec)), $"Create module {moduleSpec.Name}");
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task DeleteModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteModuleAsync(this.Version.Name, name), $"Delete module {name}");
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task RestartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task<SystemInfo> GetSystemInfoAsync(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemInfo systemInfo = await this.Execute(
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task<IEnumerable<ModuleRuntimeInfo>> GetModules<T>(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 ModuleList moduleList = await this.Execute(
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task StartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StartModuleAsync(this.Version.Name, name), $"start module {name}");
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task StopModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StopModuleAsync(this.Version.Name, name), $"stop module {name}");
@@ -162,7 +162,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task UpdateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, null, MapToModuleSpec(moduleSpec)), $"update module {moduleSpec.Name}");
@@ -171,7 +171,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task UpdateAndStartModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, true, MapToModuleSpec(moduleSpec)), $"update and start module {moduleSpec.Name}");
@@ -180,7 +180,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task PrepareUpdateAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.PrepareUpdateModuleAsync(this.Version.Name, moduleSpec.Name, MapToModuleSpec(moduleSpec)), $"prepare update for module {moduleSpec.Name}");
@@ -189,7 +189,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_10_22
 
         public override async Task ReprovisionDeviceAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.ReprovisionDeviceAsync(this.Version.Name), "reprovision the device");

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2019_11_05/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2019_11_05/ModuleManagementHttpClient.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task<Identity> CreateIdentityAsync(string name, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task<Identity> UpdateIdentityAsync(string name, string generationId, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task DeleteIdentityAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteIdentityAsync(this.Version.Name, name), $"Delete identity for {name}");
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task<IEnumerable<Identity>> GetIdentities()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 IdentityList identityList = await this.Execute(() => edgeletHttpClient.ListIdentitiesAsync(this.Version.Name), $"List identities");
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task CreateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.CreateModuleAsync(this.Version.Name, MapToModuleSpec(moduleSpec)), $"Create module {moduleSpec.Name}");
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task DeleteModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteModuleAsync(this.Version.Name, name), $"Delete module {name}");
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task RestartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(
@@ -121,7 +121,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task<SystemInfo> GetSystemInfoAsync(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemInfo systemInfo = await this.Execute(
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task<SystemResources> GetSystemResourcesAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemResources systemResources = await this.Execute(
@@ -146,7 +146,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task<IEnumerable<ModuleRuntimeInfo>> GetModules<T>(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 ModuleList moduleList = await this.Execute(
@@ -158,7 +158,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task StartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StartModuleAsync(this.Version.Name, name), $"start module {name}");
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task StopModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StopModuleAsync(this.Version.Name, name), $"stop module {name}");
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task UpdateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, null, MapToModuleSpec(moduleSpec)), $"update module {moduleSpec.Name}");
@@ -185,7 +185,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task UpdateAndStartModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, true, MapToModuleSpec(moduleSpec)), $"update and start module {moduleSpec.Name}");
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task PrepareUpdateAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.PrepareUpdateModuleAsync(this.Version.Name, moduleSpec.Name, MapToModuleSpec(moduleSpec)), $"prepare update for module {moduleSpec.Name}");
@@ -203,7 +203,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2019_11_05
 
         public override async Task ReprovisionDeviceAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.ReprovisionDeviceAsync(this.Version.Name), "reprovision the device");

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2020_07_07/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2020_07_07/ModuleManagementHttpClient.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task<Identity> CreateIdentityAsync(string name, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task<Identity> UpdateIdentityAsync(string name, string generationId, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task DeleteIdentityAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteIdentityAsync(this.Version.Name, name), $"Delete identity for {name}");
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task<IEnumerable<Identity>> GetIdentities()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 IdentityList identityList = await this.Execute(() => edgeletHttpClient.ListIdentitiesAsync(this.Version.Name), $"List identities");
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task CreateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.CreateModuleAsync(this.Version.Name, MapToModuleSpec(moduleSpec)), $"Create module {moduleSpec.Name}");
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task DeleteModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteModuleAsync(this.Version.Name, name), $"Delete module {name}");
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task RestartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task<SystemInfo> GetSystemInfoAsync(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemInfo systemInfo = await this.Execute(
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task<SystemResources> GetSystemResourcesAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemResources systemResources = await this.Execute(
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task<Stream> GetSupportBundle(Option<string> since, Option<string> until, Option<string> iothubHostname, Option<bool> edgeRuntimeOnly, CancellationToken token)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 FileResponse response = await this.Execute(() => edgeletHttpClient.GetSupportBundleAsync(this.Version.Name, since.OrDefault(), until.OrDefault(), null, iothubHostname.OrDefault(), edgeRuntimeOnly.Map<bool?>(e => e).OrDefault()), "getting the support bundle");
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task<IEnumerable<ModuleRuntimeInfo>> GetModules<T>(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 ModuleList moduleList = await this.Execute(
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task StartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StartModuleAsync(this.Version.Name, name), $"start module {name}");
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task StopModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StopModuleAsync(this.Version.Name, name), $"stop module {name}");
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task UpdateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, null, MapToModuleSpec(moduleSpec)), $"update module {moduleSpec.Name}");
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task UpdateAndStartModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, true, MapToModuleSpec(moduleSpec)), $"update and start module {moduleSpec.Name}");
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task PrepareUpdateAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.PrepareUpdateModuleAsync(this.Version.Name, moduleSpec.Name, MapToModuleSpec(moduleSpec)), $"prepare update for module {moduleSpec.Name}");
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2020_07_07
 
         public override async Task ReprovisionDeviceAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.ReprovisionDeviceAsync(this.Version.Name), "reprovision the device");

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2021_12_07/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2021_12_07/ModuleManagementHttpClient.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task<Identity> CreateIdentityAsync(string name, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task<Identity> UpdateIdentityAsync(string name, string generationId, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task DeleteIdentityAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteIdentityAsync(this.Version.Name, name), $"Delete identity for {name}");
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task<IEnumerable<Identity>> GetIdentities()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 IdentityList identityList = await this.Execute(() => edgeletHttpClient.ListIdentitiesAsync(this.Version.Name), $"List identities");
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task CreateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.CreateModuleAsync(this.Version.Name, MapToModuleSpec(moduleSpec)), $"Create module {moduleSpec.Name}");
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task DeleteModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteModuleAsync(this.Version.Name, name), $"Delete module {name}");
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task RestartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task<SystemInfo> GetSystemInfoAsync(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemInfo systemInfo = await this.Execute(
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task<SystemResources> GetSystemResourcesAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemResources systemResources = await this.Execute(
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task<Stream> GetSupportBundle(Option<string> since, Option<string> until, Option<string> iothubHostname, Option<bool> edgeRuntimeOnly, CancellationToken token)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 FileResponse response = await this.Execute(() => edgeletHttpClient.GetSupportBundleAsync(this.Version.Name, since.OrDefault(), until.OrDefault(), null, iothubHostname.OrDefault(), edgeRuntimeOnly.Map<bool?>(e => e).OrDefault()), "getting the support bundle");
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task<IEnumerable<ModuleRuntimeInfo>> GetModules<T>(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 ModuleList moduleList = await this.Execute(
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task StartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StartModuleAsync(this.Version.Name, name), $"start module {name}");
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task StopModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StopModuleAsync(this.Version.Name, name), $"stop module {name}");
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task UpdateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, null, MapToModuleSpec(moduleSpec)), $"update module {moduleSpec.Name}");
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task UpdateAndStartModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, true, MapToModuleSpec(moduleSpec)), $"update and start module {moduleSpec.Name}");
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task PrepareUpdateAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.PrepareUpdateModuleAsync(this.Version.Name, moduleSpec.Name, MapToModuleSpec(moduleSpec)), $"prepare update for module {moduleSpec.Name}");
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2021_12_07
 
         public override async Task ReprovisionDeviceAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.ReprovisionDeviceAsync(this.Version.Name), "reprovision the device");

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2022_08_03/ModuleManagementHttpClient.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/version_2022_08_03/ModuleManagementHttpClient.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task<Identity> CreateIdentityAsync(string name, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task<Identity> UpdateIdentityAsync(string name, string generationId, string managedBy)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.Identity identity = await this.Execute(
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task DeleteIdentityAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteIdentityAsync(this.Version.Name, name), $"Delete identity for {name}");
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task<IEnumerable<Identity>> GetIdentities()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 IdentityList identityList = await this.Execute(() => edgeletHttpClient.ListIdentitiesAsync(this.Version.Name), $"List identities");
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task CreateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.CreateModuleAsync(this.Version.Name, MapToModuleSpec(moduleSpec)), $"Create module {moduleSpec.Name}");
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task DeleteModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.DeleteModuleAsync(this.Version.Name, name), $"Delete module {name}");
@@ -112,7 +112,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task RestartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(
@@ -123,7 +123,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task<SystemInfo> GetSystemInfoAsync(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemInfo systemInfo = await this.Execute(
@@ -136,7 +136,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task<SystemResources> GetSystemResourcesAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 GeneratedCode.SystemResources systemResources = await this.Execute(
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task<Stream> GetSupportBundle(Option<string> since, Option<string> until, Option<string> iothubHostname, Option<bool> edgeRuntimeOnly, CancellationToken token)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 FileResponse response = await this.Execute(() => edgeletHttpClient.GetSupportBundleAsync(this.Version.Name, since.OrDefault(), until.OrDefault(), null, iothubHostname.OrDefault(), edgeRuntimeOnly.Map<bool?>(e => e).OrDefault()), "getting the support bundle");
@@ -160,7 +160,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task<IEnumerable<ModuleRuntimeInfo>> GetModules<T>(CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 ModuleList moduleList = await this.Execute(
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task StartModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StartModuleAsync(this.Version.Name, name), $"start module {name}");
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task StopModuleAsync(string name)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.StopModuleAsync(this.Version.Name, name), $"stop module {name}");
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task UpdateModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, null, MapToModuleSpec(moduleSpec)), $"update module {moduleSpec.Name}");
@@ -199,7 +199,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task UpdateAndStartModuleAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.UpdateModuleAsync(this.Version.Name, moduleSpec.Name, true, MapToModuleSpec(moduleSpec)), $"update and start module {moduleSpec.Name}");
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task PrepareUpdateAsync(ModuleSpec moduleSpec)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.PrepareUpdateModuleAsync(this.Version.Name, moduleSpec.Name, MapToModuleSpec(moduleSpec)), $"prepare update for module {moduleSpec.Name}");
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Version_2022_08_03
 
         public override async Task ReprovisionDeviceAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new EdgeletHttpClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri) };
                 await this.Execute(() => edgeletHttpClient.ReprovisionDeviceAsync(this.Version.Name), "reprovision the device");

--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Edgelet/versioning/ModuleManagementHttpClientVersioned.cs
@@ -52,6 +52,12 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
 
         protected ApiVersion Version { get; }
 
+        protected HttpClient GetHttpClient()
+        {
+            // add 1s to timeout so it doesn't call httpclient timeout before TimeoutAfter
+            return HttpClientHelper.GetHttpClient(this.ManagementUri, this.operationTimeout + TimeSpan.FromSeconds(1));
+        }
+
         public abstract Task<Identity> CreateIdentityAsync(string name, string managedBy);
 
         public abstract Task<Identity> UpdateIdentityAsync(string name, string generationId, string managedBy);
@@ -88,7 +94,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Versioning
 
         public virtual async Task<Stream> GetModuleLogs(string module, bool follow, Option<int> tail, Option<string> since, Option<string> until, Option<bool> includeTimestamp, CancellationToken cancellationToken)
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.ManagementUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 string baseUrl = HttpClientHelper.GetBaseUrl(this.ManagementUri).TrimEnd('/');
                 var logsUrl = new StringBuilder();

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/HttpClientHelper.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/HttpClientHelper.cs
@@ -14,21 +14,33 @@ namespace Microsoft.Azure.Devices.Edge.Util
 
         public static HttpClient GetHttpClient(Uri serverUri)
         {
+            return GetHttpClient(serverUri, Option.None<TimeSpan>());
+        }
+
+        public static HttpClient GetHttpClient(Uri serverUri, TimeSpan timeout)
+        {
+            return GetHttpClient(serverUri, Option.Some(timeout));
+        }
+
+        static HttpClient GetHttpClient(Uri serverUri, Option<TimeSpan> timeout)
+        {
             HttpClient client;
 
             if (serverUri.Scheme.Equals(HttpScheme, StringComparison.OrdinalIgnoreCase) || serverUri.Scheme.Equals(HttpsScheme, StringComparison.OrdinalIgnoreCase))
             {
                 client = new HttpClient();
-                return client;
             }
-
-            if (serverUri.Scheme.Equals(UnixScheme, StringComparison.OrdinalIgnoreCase))
+            else if (serverUri.Scheme.Equals(UnixScheme, StringComparison.OrdinalIgnoreCase))
             {
                 client = new HttpClient(new HttpUdsMessageHandler(serverUri));
-                return client;
+            }
+            else
+            {
+                throw new InvalidOperationException("ProviderUri scheme is not supported");
             }
 
-            throw new InvalidOperationException("ProviderUri scheme is not supported");
+            timeout.Map(t => client.Timeout = t);
+            return client;
         }
 
         public static string GetBaseUrl(Uri serverUri)

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/WorkloadClientVersioned.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/WorkloadClientVersioned.cs
@@ -2,6 +2,7 @@
 namespace Microsoft.Azure.Devices.Edge.Util.Edged
 {
     using System;
+    using System.Net.Http;
     using System.Net.Sockets;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Util.TransientFaultHandling;
@@ -40,6 +41,12 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged
         protected string ModuleId { get; }
 
         protected string ModuleGenerationId { get; }
+
+        protected HttpClient GetHttpClient()
+        {
+            // add 1s to timeout so it doesn't call httpclient timeout before TimeoutAfter
+            return HttpClientHelper.GetHttpClient(this.WorkloadUri, this.operationTimeout + TimeSpan.FromSeconds(1));
+        }
 
         public abstract Task<ServerCertificateResponse> CreateServerCertificateAsync(string hostname, DateTime expiration);
 

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2018_06_28/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2018_06_28/WorkloadClient.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2018_06_28
                 Expiration = expiration
             };
 
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 CertificateResponse result = await this.Execute(() => edgeletHttpClient.CreateServerCertificateAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "CreateServerCertificateAsync");
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2018_06_28
 
         public override async Task<string> GetTrustBundleAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 TrustBundleResponse result = await this.Execute(() => edgeletHttpClient.TrustBundleAsync(this.Version.Name), "TrustBundleAsync");
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2018_06_28
                 Plaintext = Encoding.UTF8.GetBytes(plainText),
                 InitializationVector = Encoding.UTF8.GetBytes(initializationVector)
             };
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 EncryptResponse result = await this.Execute(() => edgeletHttpClient.EncryptAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "Encrypt");
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2018_06_28
                 Ciphertext = Convert.FromBase64String(encryptedText),
                 InitializationVector = Encoding.UTF8.GetBytes(initializationVector)
             };
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 DecryptResponse result = await this.Execute(() => edgeletHttpClient.DecryptAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "Decrypt");
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2018_06_28
                 Data = Encoding.UTF8.GetBytes(data)
             };
 
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 SignResponse response = await this.Execute(() => edgeletHttpClient.SignAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, signRequest), "SignAsync");

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2019_01_30/WorkloadClient.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
                 Expiration = expiration
             };
 
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 CertificateResponse result = await this.Execute(() => edgeletHttpClient.CreateServerCertificateAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "CreateServerCertificateAsync");
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
 
         public override async Task<string> GetTrustBundleAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 TrustBundleResponse result = await this.Execute(() => edgeletHttpClient.TrustBundleAsync(this.Version.Name), "TrustBundleAsync");
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
                 Plaintext = Encoding.UTF8.GetBytes(plainText),
                 InitializationVector = Encoding.UTF8.GetBytes(initializationVector)
             };
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 EncryptResponse result = await this.Execute(() => edgeletHttpClient.EncryptAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "Encrypt");
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
                 Ciphertext = Convert.FromBase64String(encryptedText),
                 InitializationVector = Encoding.UTF8.GetBytes(initializationVector)
             };
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 DecryptResponse result = await this.Execute(() => edgeletHttpClient.DecryptAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "Decrypt");
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2019_01_30
                 Data = Encoding.UTF8.GetBytes(data)
             };
 
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 SignResponse response = await this.Execute(() => edgeletHttpClient.SignAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, signRequest), "SignAsync");

--- a/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2020_07_07/WorkloadClient.cs
+++ b/edge-util/src/Microsoft.Azure.Devices.Edge.Util/edged/version_2020_07_07/WorkloadClient.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2020_07_07
                 Expiration = expiration
             };
 
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 CertificateResponse result = await this.Execute(() => edgeletHttpClient.CreateServerCertificateAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "CreateServerCertificateAsync");
@@ -43,7 +43,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2020_07_07
 
         public override async Task<string> GetTrustBundleAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 TrustBundleResponse result = await this.Execute(() => edgeletHttpClient.TrustBundleAsync(this.Version.Name), "TrustBundleAsync");
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2020_07_07
 
         public override async Task<string> GetManifestTrustBundleAsync()
         {
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 ManifestTrustBundleResponse result = await this.Execute(() => edgeletHttpClient.ManifestTrustBundleAsync(this.Version.Name), "ManifestTrustBundleAsync");
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2020_07_07
                 Plaintext = Encoding.UTF8.GetBytes(plainText),
                 InitializationVector = Encoding.UTF8.GetBytes(initializationVector)
             };
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 EncryptResponse result = await this.Execute(() => edgeletHttpClient.EncryptAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "Encrypt");
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2020_07_07
                 Ciphertext = Convert.FromBase64String(encryptedText),
                 InitializationVector = Encoding.UTF8.GetBytes(initializationVector)
             };
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 DecryptResponse result = await this.Execute(() => edgeletHttpClient.DecryptAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, request), "Decrypt");
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Edged.Version_2020_07_07
                 Data = Encoding.UTF8.GetBytes(data)
             };
 
-            using (HttpClient httpClient = HttpClientHelper.GetHttpClient(this.WorkloadUri))
+            using (HttpClient httpClient = this.GetHttpClient())
             {
                 var edgeletHttpClient = new HttpWorkloadClient(httpClient) { BaseUrl = HttpClientHelper.GetBaseUrl(this.WorkloadUri) };
                 SignResponse response = await this.Execute(() => edgeletHttpClient.SignAsync(this.Version.Name, this.ModuleId, this.ModuleGenerationId, signRequest), "SignAsync");


### PR DESCRIPTION
Calls to workload api and management api have a default timeout of 5 minutes, but the underlying HttpClient that is used has the timeout as 100s by default. Change is to set the timeout of HttpClient as 5min + 1s, extra 1s was added to make sure that the TimeoutAfter runs and still wanted to use HttpClient Timeout in case TimeoutAfter doesn't cancel the operation.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  
