### PR TITLE
Use 1ES-hosted pools in .NET Core checkin pipeline

### DIFF
--- a/CodeCoverage.runsettings
+++ b/CodeCoverage.runsettings
@@ -1,151 +1,20 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<!-- File name extension must be .runsettings -->
 <RunSettings>
   <DataCollectionRunSettings>
     <DataCollectors>
-      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <DataCollector friendlyName="XPlat Code Coverage">
         <Configuration>
-          <CodeCoverage>
-            <!--  
-Additional paths to search for .pdb (symbol) files. Symbols must be found for modules to be instrumented.  
-If .pdb files are in the same folder as the .dll or .exe files, they are automatically found. Otherwise, specify them here.  
-Note that searching for symbols increases code coverage runtime. So keep this small and local.  
--->
-            <!--             
-            <SymbolSearchPaths>                
-                   <Path>C:\Users\User\Documents\Visual Studio 2012\Projects\ProjectX\bin\Debug</Path>  
-                   <Path>\\mybuildshare\builds\ProjectX</Path>  
-            </SymbolSearchPaths>  
--->
-
-            <!--  
-About include/exclude lists:  
-Empty "Include" clauses imply all; empty "Exclude" clauses imply none.  
-Each element in the list is a regular expression (ECMAScript syntax). See http://msdn.microsoft.com/library/2k3te2cs.aspx.  
-An item must first match at least one entry in the include list to be included.  
-Included items must then not match any entries in the exclude list to remain included.  
--->
-
-            <!-- Match assembly file paths: -->
-            <ModulePaths>
-              <Include>
-                <ModulePath>.*\.dll$</ModulePath>
-                <ModulePath>.*\.exe$</ModulePath>
-              </Include>
-              <Exclude>
-                <!-- test/prod dependencies -->
-                <ModulePath>.*windowsazure\..*</ModulePath>
-                <ModulePath>.*moq\..*</ModulePath>
-                <ModulePath>.*app.metrics.*\..*</ModulePath>
-                <ModulePath>.*autofac.*</ModulePath>
-                <ModulePath>.*fluentassertions.*</ModulePath>
-                <ModulePath>.*microsoft.codeanalysis\..*</ModulePath>
-                <ModulePath>.*microsoft.identitymodel\..*</ModulePath>
-                <ModulePath>.*newtonsoft\..*</ModulePath>
-                <ModulePath>.*nito\..*</ModulePath>
-                <ModulePath>.*nunit.framework\..*</ModulePath>
-                <ModulePath>.*nunit3.testadapter\..*</ModulePath>
-                <ModulePath>.*prometheus-net.*</ModulePath>
-                <ModulePath>.*protobuf-net.*</ModulePath>
-                <ModulePath>.*stackexchange\..*</ModulePath>
-                <ModulePath>.*system.identitymodel\..*</ModulePath>
-                <ModulePath>.*system.reactive.*</ModulePath>
-                <ModulePath>.*system.linq.async.*</ModulePath>
-                <ModulePath>.*xunit\..*</ModulePath>
-                <ModulePath>.*edgex509authdownstreamdevice.*\..*</ModulePath>
-                <ModulePath>.*edgedownstreamdevice.*\..*</ModulePath>
-                <!-- test binaries -->
-                <ModulePath>.*test\..*</ModulePath>
-                <!-- test/sample edge modules -->
-                <ModulePath>.*cloudtodevicemessagetester\..*</ModulePath>
-                <ModulePath>.*deploymenttester\..*</ModulePath>
-                <ModulePath>.*directmethodreceiver\..*</ModulePath>
-                <ModulePath>.*directmethodsender\..*</ModulePath>
-                <ModulePath>.*edgehubrestarttester\..*</ModulePath>
-                <ModulePath>.*iotedgequickstart\..*</ModulePath>
-                <ModulePath>.*leafdevice\..*</ModulePath>
-                <ModulePath>.*load-gen\..*</ModulePath>
-                <ModulePath>.*metricscollector\..*</ModulePath>
-                <ModulePath>.*metricsvalidator\..*</ModulePath>
-                <ModulePath>.*numberlogger\..*</ModulePath>
-                <ModulePath>.*modulerestarter\..*</ModulePath>
-                <ModulePath>.*networkcontroller\..*</ModulePath>
-                <ModulePath>.*relayer\..*</ModulePath>
-                <ModulePath>.*simulatedtemperaturesensor\..*</ModulePath>
-                <ModulePath>.*temperaturefilter\..*</ModulePath>
-                <ModulePath>.*testanalyzer\..*</ModulePath>
-                <ModulePath>.*testresultcoordinator\..*</ModulePath>
-                <ModulePath>.*twintester\..*</ModulePath>
-                <ModulePath>.*microsoft.azure.webjobs.*</ModulePath>
-              </Exclude>
-            </ModulePaths>
-
-            <!-- Match fully qualified names of functions: -->
-            <!-- (Use "\." to delimit namespaces in C# or Visual Basic, "::" in C++.)  -->
-            <Functions>
-              <Exclude>
-                <Function>^Fabrikam\.UnitTest\..*</Function>
-                <Function>^std::.*</Function>
-                <Function>^ATL::.*</Function>
-                <Function>.*::__GetTestMethodInfo.*</Function>
-                <Function>^Microsoft::VisualStudio::CppCodeCoverageFramework::.*</Function>
-                <Function>^Microsoft::VisualStudio::CppUnitTestFramework::.*</Function>
-              </Exclude>
-            </Functions>
-
-            <!-- Match attributes on any code element: -->
-            <Attributes>
-              <Exclude>
-                <!-- Don't forget "Attribute" at the end of the name -->
-                <Attribute>^System\.Diagnostics\.DebuggerHiddenAttribute$</Attribute>
-                <Attribute>^System\.Diagnostics\.DebuggerNonUserCodeAttribute$</Attribute>
-                <Attribute>^System\.Runtime\.CompilerServices.CompilerGeneratedAttribute$</Attribute>
-                <Attribute>^System\.CodeDom\.Compiler.GeneratedCodeAttribute$</Attribute>
-                <Attribute>^System\.Diagnostics\.CodeAnalysis.ExcludeFromCodeCoverageAttribute$</Attribute>
-              </Exclude>
-            </Attributes>
-
-            <!-- Match the path of the source files in which each method is defined: -->
-            <Sources>
-              <Exclude>
-                <Source>.*\\atlmfc\\.*</Source>
-                <Source>.*\\vctools\\.*</Source>
-                <Source>.*\\public\\sdk\\.*</Source>
-                <Source>.*\\microsoft sdks\\.*</Source>
-                <Source>.*\\vc\\include\\.*</Source>
-                <Source>.*\\edge-util\\src\\es6numberserializer\\.*</Source>
-                <Source>.*\\edge-util\\src\\jsoncanonicalizer\\.*</Source>
-              </Exclude>
-            </Sources>
-
-            <!-- Match the company name property in the assembly: -->
-            <CompanyNames>
-              <Exclude>
-                <CompanyName>.*microsoft.*</CompanyName>
-              </Exclude>
-            </CompanyNames>
-
-            <!-- Match the public key token of a signed assembly: -->
-            <PublicKeyTokens>
-              <!-- Exclude Visual Studio extensions: -->
-              <Exclude>
-                <PublicKeyToken>^B77A5C561934E089$</PublicKeyToken>
-                <PublicKeyToken>^B03F5F7F11D50A3A$</PublicKeyToken>
-                <PublicKeyToken>^31BF3856AD364E35$</PublicKeyToken>
-                <PublicKeyToken>^89845DCD8080CC91$</PublicKeyToken>
-                <PublicKeyToken>^71E9BCE111E9429C$</PublicKeyToken>
-                <PublicKeyToken>^8F50407C4E9E73B6$</PublicKeyToken>
-                <PublicKeyToken>^E361AF139669C375$</PublicKeyToken>
-              </Exclude>
-            </PublicKeyTokens>
-
-            <!-- We recommend you do not change the following values: -->
-            <UseVerifiableInstrumentation>True</UseVerifiableInstrumentation>
-            <AllowLowIntegrityProcesses>True</AllowLowIntegrityProcesses>
-            <CollectFromChildProcesses>True</CollectFromChildProcesses>
-            <CollectAspDotNet>False</CollectAspDotNet>
-
-          </CodeCoverage>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+          <Include>
+            [Microsoft.Azure.Devices.Edge.*]*,
+            [Microsoft.Azure.Devices.Routing.Core]*,
+            [Microsoft.Azure.WebJobs.Extensions.EdgeHub]*,
+          </Include>
+          <Exclude>
+            [Microsoft.Azure.Devices.Edge.*Test]*,
+            [Microsoft.Azure.Devices.Edge.*Test.Common]*,
+            [Microsoft.Azure.Devices.Edge.ModuleUtil]*,
+          </Exclude>
         </Configuration>
       </DataCollector>
     </DataCollectors>

--- a/builds/checkin/dotnet.yaml
+++ b/builds/checkin/dotnet.yaml
@@ -2,111 +2,106 @@ trigger: none
 pr:
   branches:
     include:
-      - main
-      - release/*
+    - main
+    - release/*
 
 jobs:
 ################################################################################
-  - job: check_run_pipeline
+- job: check_run_pipeline
 ################################################################################
-    displayName: Check pipeline preconditions (changes ARE NOT in either edgelet, docs, or mqtt folder)
-    pool:
-      vmImage: "ubuntu-20.04"
-    steps:
-      - bash: |
-          git log -m -1 --name-only --first-parent --pretty="" | egrep -i -v '^(edgelet|doc|mqtt)'
-          if [[ $? == 0 ]]; then
-            echo "Detected changes outside of edgelet, docs and mqtt folders"
-            echo "##vso[task.setvariable variable=RUN_PIPELINE;isOutput=true]TRUE"
-          fi
-        displayName: Check changes in sources
-        name: check_files
+  displayName: Check pipeline preconditions (changes ARE NOT in either edgelet, docs, or mqtt folder)
+  pool:
+    name: $(pool.linux.name)
+    demands:
+    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+  steps:
+  - bash: |
+      git log -m -1 --name-only --first-parent --pretty="" | egrep -i -v '^(edgelet|doc|mqtt)'
+      if [[ $? == 0 ]]; then
+        echo "Detected changes outside of edgelet, docs and mqtt folders"
+        echo "##vso[task.setvariable variable=RUN_PIPELINE;isOutput=true]TRUE"
+      fi
+    displayName: Check changes in sources
+    name: check_files
 
 ################################################################################
-  - job: linux_amd64
+- job: linux_amd64
 ################################################################################
-    displayName: Linux amd64
-    dependsOn: check_run_pipeline
-    condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
-    pool:
-      vmImage: "ubuntu-20.04"
-    steps:
-      - task: Bash@3
-        displayName: Install Prerequisites
-        inputs:
-          filePath: scripts/linux/installPrereqs.sh
-      - task: Bash@3
-        displayName: Build
-        inputs:
-          filePath: scripts/linux/buildBranch.sh
-          arguments: -c "$(configuration)"
-      - task: Bash@3
-        displayName: Test
-        inputs:
-          filePath: scripts/linux/runTests.sh
-          arguments: '"--filter Category=Unit&Category!=GetLogsTests"'
-      - task: Bash@3
-        displayName: Run GetLogsTests Tests
-        inputs:
-          filePath: scripts/linux/runTests.sh
-          arguments: '"--filter Category=GetLogsTests"'
-      - task: PublishTestResults@2
-        displayName: Publish Test Results
-        inputs:
-          testRunner: VSTest
-          testResultsFiles: "**/TestResults/*.trx"
-        condition: succeededOrFailed()
+  displayName: Linux amd64
+  dependsOn: check_run_pipeline
+  condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
+  pool:
+    name: $(pool.linux.name)
+    demands:
+    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+  steps:
+  - script: scripts/linux/installPrereqs.sh
+    displayName: Install Prerequisites
+  - script: scripts/linux/buildBranch.sh -c '$(configuration)'
+    displayName: Build
+  - script: scripts/linux/runTests.sh '--filter Category=Unit&Category!=GetLogsTests'
+    displayName: Test
+  - script: scripts/linux/runTests.sh '--filter Category=GetLogsTests'
+    displayName: Run GetLogsTests Tests
+  - task: PublishTestResults@2
+    displayName: Publish Test Results
+    inputs:
+      testRunner: VSTest
+      testResultsFiles: '**/TestResults/*.trx'
+    condition: succeededOrFailed()
 
 ################################################################################
-  - job: code_coverage
+- job: code_coverage
 ################################################################################
-    displayName: Code coverage
-    dependsOn: check_run_pipeline
-    condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
-    variables:
-      coverage.goal: 60
-    pool:
-      vmImage: windows-2022
-    steps:
-      - task: DotNetCoreCLI@2
-        displayName: Build
-        inputs:
-          command: build
-          arguments: '-o target'
-      - task: VSTest@2
-        displayName: Run unit tests with code coverage
-        inputs:
-          testSelector: testAssemblies
-          testAssemblyVer2: |
-            target\*Test.dll
-          testFiltercriteria: Category=Unit&Category!=GetLogsTests
-          runInParallel: true
-          runTestsInIsolation: true
-          codeCoverageEnabled: true
-          runSettingsFile: CodeCoverage.runsettings
-          publishRunAttachments: true
-      - task: VSTest@2
-        displayName: Run GetLogsTests unit tests with code coverage
-        inputs:
-          testSelector: testAssemblies
-          testAssemblyVer2: |
-            target\*Test.dll
-          testFiltercriteria: Category=GetLogsTests
-          runInParallel: true
-          runTestsInIsolation: true
-          codeCoverageEnabled: true
-          runSettingsFile: CodeCoverage.runsettings
-          publishRunAttachments: true
-      - task: PublishTestResults@2
-        displayName: Publish code coverage
-        inputs:
-          testRunner: VSTest
-          testResultsFiles: '$(Agent.TempDirectory)/TestResults/*.trx'
-        condition: succeededOrFailed()
-      - task: mspremier.BuildQualityChecks.QualityChecks-task.BuildQualityChecks@5
-        displayName: 'Check build quality'
-        inputs:
-          checkCoverage: true
-          coverageFailOption: fixed
-          coverageType: lines
-          coverageThreshold: $(coverage.goal)
+  displayName: Code coverage
+  dependsOn: check_run_pipeline
+  condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
+  variables:
+    coverage.goal: 50
+  pool:
+    name: $(pool.linux.name)
+    demands:
+    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
+  steps:
+  - script: scripts/linux/installPrereqs.sh
+    displayName: Install Prerequisites
+  - script: |
+      dotnet test \
+        --logger trx \
+        --results-directory '$(Agent.TempDirectory)' \
+        --filter 'Category=Unit&Category!=GetLogsTests' \
+        --collect 'xplat code coverage' \
+        --settings CodeCoverage.runsettings
+    displayName: Run unit tests with code coverage
+  - script: |
+      dotnet test 'edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test' \
+        --logger trx \
+        --results-directory '$(Agent.TempDirectory)' \
+        --filter 'Category=GetLogsTests' \
+        --collect 'xplat code coverage' \
+        --settings CodeCoverage.runsettings
+    displayName: Run GetLogsTests unit tests with code coverage
+    condition: succeededOrFailed()
+  - script: |
+      dotnet new tool-manifest
+      dotnet tool install dotnet-reportgenerator-globaltool
+      dotnet tool run reportgenerator \
+        -reports:$(Agent.TempDirectory)/**/coverage.cobertura.xml \
+        -targetdir:$(Build.SourcesDirectory) \
+        -reporttypes:"Cobertura"
+    displayName: Generate coverage report
+    condition: succeededOrFailed()
+  - task: PublishCodeCoverageResults@1
+    displayName: Publish coverage report
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(Build.SourcesDirectory)/Cobertura.xml'
+    condition: succeededOrFailed()
+  - task: BuildQualityChecks@8
+    displayName: 'Check build quality'
+    inputs:
+      checkCoverage: true
+      coverageFailOption: fixed
+      coverageType: branch
+      coverageThreshold: $(coverage.goal)
+    condition: succeededOrFailed()

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/Microsoft.Azure.Devices.Edge.Agent.Core.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Core.Test/Microsoft.Azure.Devices.Edge.Agent.Core.Test.csproj
@@ -9,10 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test/Microsoft.Azure.Devices.Edge.Agent.Diagnostics.Test.csproj
@@ -9,10 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Docker.Test.csproj
@@ -9,10 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Docker.Test.csproj
@@ -8,10 +8,14 @@
     <Configurations>Debug;Release;CheckInBuild</Configurations>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test.csproj
@@ -10,10 +10,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleIdentityLifecycleManagerTest.cs
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test/ModuleIdentityLifecycleManagerTest.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Edgelet.Test
             // Assert
             Assert.True(modulesIdentities.Count() == 1);
             Assert.True(modulesIdentities.TryGetValue(Name, out IModuleIdentity moduleIdentity));
-            Assert.Equal(moduleIdentity.ModuleId, Name);
+            Assert.Equal(Name, moduleIdentity.ModuleId);
             Assert.IsType<IdentityProviderServiceCredentials>(moduleIdentity.Credentials);
             Assert.Equal(EdgeletUri.ToString(), ((IdentityProviderServiceCredentials)moduleIdentity.Credentials).ProviderUri);
             Assert.Equal(Option.None<string>(), ((IdentityProviderServiceCredentials)moduleIdentity.Credentials).Version);

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test/Microsoft.Azure.Devices.Edge.Agent.Integration.Test.csproj
@@ -11,10 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.csproj
+++ b/edge-agent/test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test/Microsoft.Azure.Devices.Edge.Agent.IoTHub.Test.csproj
@@ -9,10 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test.csproj
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test/Microsoft.Azure.Devices.Edge.Hub.Amqp.Test.csproj
@@ -10,10 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/CloudConnectionProviderTest.cs
@@ -627,7 +627,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test
                     .GetProperty("AuthenticationChain", BindingFlags.NonPublic | BindingFlags.Instance)
                     .GetValue(transportSettings);
 
-                Assert.Equal(authChain, expectedAuthChain);
+                Assert.Equal(expectedAuthChain, authChain);
 
                 switch (expectedTransportSettings)
                 {

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test.csproj
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test/Microsoft.Azure.Devices.Edge.Hub.CloudProxy.Test.csproj
@@ -11,10 +11,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/Microsoft.Azure.Devices.Edge.Hub.Core.Test.csproj
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Core.Test/Microsoft.Azure.Devices.Edge.Hub.Core.Test.csproj
@@ -10,10 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Cloud2DeviceTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Cloud2DeviceTest.cs
@@ -215,11 +215,11 @@ namespace Microsoft.Azure.Devices.Edge.Hub.E2E.Test
             if (receivedMessage != null)
             {
                 string messageData = Encoding.ASCII.GetString(receivedMessage.GetBytes());
-                Assert.Equal(messageData, payload);
+                Assert.Equal(payload, messageData);
                 Assert.Equal(1, receivedMessage.Properties.Count);
                 KeyValuePair<string, string> prop = receivedMessage.Properties.Single();
-                Assert.Equal(prop.Key, MessagePropertyName);
-                Assert.Equal(prop.Value, p1Value);
+                Assert.Equal(MessagePropertyName, prop.Key);
+                Assert.Equal(p1Value, prop.Value);
 
                 await deviceClient.CompleteAsync(receivedMessage);
             }

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test.csproj
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test/Microsoft.Azure.Devices.Edge.Hub.E2E.Test.csproj
@@ -11,10 +11,10 @@
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.1" />
     <PackageReference Include="JetBrains.Annotations" Version="2018.3.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/Microsoft.Azure.Devices.Edge.Hub.Http.Test.csproj
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Http.Test/Microsoft.Azure.Devices.Edge.Hub.Http.Test.csproj
@@ -9,10 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/DeviceIdentityProviderTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/DeviceIdentityProviderTest.cs
@@ -7,10 +7,8 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Hub.Core.Identity;
-    using Microsoft.Azure.Devices.Edge.Util;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Microsoft.Azure.Devices.ProtocolGateway.Identity;
-    using Microsoft.Azure.Devices.Routing.Core.Query.Builtins;
     using Moq;
     using Xunit;
 

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MessagingServiceClientTest.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
     using System.Diagnostics;
     using System.Linq;
     using System.Text;
-    using System.Threading;
     using System.Threading.Tasks;
     using DotNetty.Buffers;
     using Microsoft.Azure.Devices.Edge.Hub.Core;

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test.csproj
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test.csproj
@@ -8,10 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MqttUsernameParserTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/MqttUsernameParserTest.cs
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace Microsoft.Azure.Devices.Edge.Hub.Core.Test
+namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
 {
     using System.Collections.Generic;
-    using Microsoft.Azure.Devices.Edge.Hub.Mqtt;
+    using Microsoft.Azure.Devices.Edge.Hub.Core;
     using Microsoft.Azure.Devices.Edge.Util.Test.Common;
     using Xunit;
 

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/SessionStateTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test/SessionStateTest.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Devices.Edge.Hub.Mqtt.Test
             Assert.True(registrations[MethodPostTopicPrefix]);
             Assert.NotNull(subs);
             Assert.Equal(1, subs.Count);
-            Assert.Equal(subs[0].TopicFilter, MethodPostTopicPrefix);
+            Assert.Equal(MethodPostTopicPrefix, subs[0].TopicFilter);
         }
 
         [Fact]

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Service.Test/Microsoft.Azure.Devices.Edge.Hub.Service.Test.csproj
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Edge.Hub.Service.Test/Microsoft.Azure.Devices.Edge.Hub.Service.Test.csproj
@@ -9,10 +9,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/Microsoft.Azure.Devices.Routing.Core.Test.csproj
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/Microsoft.Azure.Devices.Routing.Core.Test.csproj
@@ -10,10 +10,14 @@
 
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/ClosedEndpointExecutorFactory.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/endpoints/ClosedEndpointExecutorFactory.cs
@@ -5,7 +5,6 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Endpoints
     using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
     using Microsoft.Azure.Devices.Routing.Core.Endpoints;
-    using NUnit.Framework;
 
     /// <summary>
     /// Returns closed executors using the underlying factory

--- a/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/query/QueryValueTest.cs
+++ b/edge-hub/core/test/Microsoft.Azure.Devices.Routing.Core.Test/query/QueryValueTest.cs
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Devices.Routing.Core.Test.Query
             var noneQueryValue = new QueryValue(null, QueryValueType.None);
 
             // Check Undefined to Undefined comparison always returns -1
-            Assert.Equal(QueryValue.Undefined.CompareTo(QueryValue.Undefined), -1);
+            Assert.Equal(-1, QueryValue.Undefined.CompareTo(QueryValue.Undefined));
 
             // Check any other None comparisons are reflexive.
             Assert.Equal(QueryValue.Undefined.CompareTo(noneQueryValue), -1 * noneQueryValue.CompareTo(QueryValue.Undefined));

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test/Microsoft.Azure.Devices.Edge.Storage.RocksDb.Test.csproj
@@ -10,10 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/Microsoft.Azure.Devices.Edge.Storage.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Storage.Test/Microsoft.Azure.Devices.Edge.Storage.Test.csproj
@@ -10,13 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="protobuf-net" Version="2.4.0" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test.Common/Microsoft.Azure.Devices.Edge.Util.Test.Common.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="..\..\..\netcoreappVersion.props" />
+  <Import Project="..\..\..\netstandardVersion.props" />
 
   <PropertyGroup>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
@@ -16,8 +16,8 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="4.5.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="5.4.0" />
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
+    <PackageReference Include="xunit.assert" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/CompressionTest.cs
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/CompressionTest.cs
@@ -183,7 +183,7 @@ namespace Microsoft.Azure.Devices.Edge.Util.Test
             Assert.NotNull(decompressedBytes);
             Assert.Equal(decompressedBytes.Length, payload.Length);
             string decompressedPayload = Encoding.UTF8.GetString(decompressedBytes);
-            Assert.Equal(decompressedPayload, TestCompressionString);
+            Assert.Equal(TestCompressionString, decompressedPayload);
         }
     }
 }

--- a/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/Microsoft.Azure.Devices.Edge.Util.Test.csproj
+++ b/edge-util/test/Microsoft.Azure.Devices.Edge.Util.Test/Microsoft.Azure.Devices.Edge.Util.Test.csproj
@@ -11,10 +11,14 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/scripts/linux/installPrereqs.sh
+++ b/scripts/linux/installPrereqs.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 
-# Installs the pre-reqs (currently only libsnappy) on the machine.
-
-echo Install Libsnappy
 sudo apt-get update
-sudo apt-get install -y libsnappy1v5
+sudo apt-get install -y libsnappy1v5 libc6-dev
 
 exit 0

--- a/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Device.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
     using Serilog;
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/DeviceWithCustomCertificates.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
     [EndToEnd]

--- a/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/EdgeAgentDirectMethods.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using Newtonsoft.Json;
     using NUnit.Framework;
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/Image.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Image.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
     using Serilog;
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/IoTEdgeCheck.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
     using Serilog;
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Metrics.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using Newtonsoft.Json;
     using NUnit.Framework;
 

--- a/test/Microsoft.Azure.Devices.Edge.Test/Microsoft.Azure.Devices.Edge.Test.csproj
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Microsoft.Azure.Devices.Edge.Test.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.14.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />

--- a/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Module.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
     [EndToEnd]

--- a/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PlugAndPlay.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using Microsoft.Azure.Devices.Shared;
     using Microsoft.VisualStudio.TestPlatform.ObjectModel;
     using NUnit.Framework;

--- a/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/PriorityQueues.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common;
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
     using NUnit.Framework;

--- a/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/Provisioning.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Certs;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
     [EndToEnd]

--- a/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/X509Device.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Devices.Edge.Test
     using Microsoft.Azure.Devices.Edge.Test.Common.Config;
     using Microsoft.Azure.Devices.Edge.Test.Helpers;
     using Microsoft.Azure.Devices.Edge.Util;
-    using Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit;
     using NUnit.Framework;
 
     [EndToEnd]

--- a/test/Microsoft.Azure.Devices.Edge.Test/helpers/EndToEndAttribute.cs
+++ b/test/Microsoft.Azure.Devices.Edge.Test/helpers/EndToEndAttribute.cs
@@ -1,5 +1,5 @@
 // Copyright (c) Microsoft. All rights reserved.
-namespace Microsoft.Azure.Devices.Edge.Util.Test.Common.NUnit
+namespace Microsoft.Azure.Devices.Edge.Test.Helpers
 {
     using System;
     using global::NUnit.Framework;

--- a/test/modules/Modules.Test/Modules.Test.csproj
+++ b/test/modules/Modules.Test/Modules.Test.csproj
@@ -9,11 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Cherry-pick aa82555f8efb5ec0f27593d6dec48b523fce887e from `main`