### PR TITLE
Nested E2E: Reduce schedule to once a week

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -1,8 +1,9 @@
 trigger: none
 pr: none
 
-# Following branches (main, release/1.4, release/1.1) all run weekly at different
-# days of the week.
+# Following branches (main, release/1.4) all run scheduled tests weekly. This
+# occurs at different days of the week across nested e2e and connectivity
+# pipelines.
 schedules:
 - cron: "0 0 * * 0"
   displayName: Weekly run main

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -1,22 +1,6 @@
 trigger: none
 pr: none
 
-# Test agents are shared, so schedules must be coordinated to avoid conflicts:
-# - main and release/1.4 run daily, but are offset from each other by 12 hours
-schedules:
-- cron: "0 0 * * *"
-  displayName: Daily run main
-  branches:
-    include:
-    - main
-  always: true
-- cron: "0 12 * * *"
-  displayName: Daily run release/1.4
-  branches:
-    include:
-    - release/1.4
-  always: true
-
 # Following branches (main, release/1.4) all run scheduled tests weekly. This
 # occurs at different days of the week across nested e2e and connectivity
 # pipelines.

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -17,6 +17,23 @@ schedules:
     - release/1.4
   always: true
 
+# Following branches (main, release/1.4) all run scheduled tests weekly. This
+# occurs at different days of the week across nested e2e and connectivity
+# pipelines.
+schedules:
+- cron: "0 0 * * 3"
+  displayName: Weekly run main
+  branches:
+    include:
+    - main
+  always: true
+- cron: "0 0 * * 4"
+  displayName: Weekly run release/1.4
+  branches:
+    include:
+    - release/1.4
+  always: true
+
 variables:
   DisableDockerDetector: true
   # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or


### PR DESCRIPTION
Reducing nested e2e schedule to once per week.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [x] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
