### PR TITLE
Upgrade to Rust 1.65

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -85,7 +85,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -128,7 +128,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -167,12 +167,13 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
  "http-common",
  "libc",
+ "openssl",
  "serde",
  "serde_json",
  "url",
@@ -181,7 +182,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -196,7 +197,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -209,7 +210,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "serde",
 ]
@@ -217,7 +218,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -227,7 +228,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -245,7 +246,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "http-common",
  "libc",
@@ -255,7 +256,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "pkcs11",
  "serde",
@@ -265,7 +266,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "http-common",
  "serde",
@@ -274,7 +275,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -350,7 +351,7 @@ checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "async-trait",
  "aziot-cert-client-async",
@@ -439,7 +440,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "serde",
  "toml",
@@ -1053,7 +1054,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "async-trait",
  "base64",
@@ -1330,7 +1331,7 @@ dependencies = [
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "env_logger",
  "log",
@@ -1483,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "cc",
 ]
@@ -1526,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1535,7 +1536,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1601,7 +1602,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1618,7 +1619,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 
 [[package]]
 name = "pkg-config"
@@ -1992,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#f66c155113cce5089d398376d16b206f7973d6f6"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#0720c1c2c882a7c6a1c8b8811e40db1d7131b9dc"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",

--- a/edgelet/edgelet-core/src/module.rs
+++ b/edgelet/edgelet-core/src/module.rs
@@ -609,7 +609,7 @@ mod tests {
 
     #[test]
     fn module_config_empty_name_fails() {
-        let name = "".to_string();
+        let name = String::new();
         ModuleSpec::new(
             name,
             "docker".to_string(),

--- a/edgelet/edgelet-settings/src/docker/config.rs
+++ b/edgelet/edgelet-settings/src/docker/config.rs
@@ -136,8 +136,7 @@ mod tests {
 
     #[test]
     fn empty_image_fails() {
-        DockerConfig::new("".to_string(), ContainerCreateBody::new(), None, None, true)
-            .unwrap_err();
+        DockerConfig::new(String::new(), ContainerCreateBody::new(), None, None, true).unwrap_err();
     }
 
     #[test]

--- a/edgelet/edgelet-settings/src/docker/network.rs
+++ b/edgelet/edgelet-settings/src/docker/network.rs
@@ -176,7 +176,7 @@ mod tests {
 
     #[test]
     fn moby_network_name() {
-        let moby_network_with_no_name = MobyNetwork::Name("".to_string());
+        let moby_network_with_no_name = MobyNetwork::Name(String::new());
 
         let moby_1 = "name-1";
         let moby_network_with_name = MobyNetwork::Name(moby_1.to_string());

--- a/edgelet/edgelet-utils/src/yaml_file_source.rs
+++ b/edgelet/edgelet-utils/src/yaml_file_source.rs
@@ -45,7 +45,7 @@ impl Source for YamlFileSource {
             YamlFileSource::String(s) => Cow::Borrowed(&**s),
         };
 
-        let docs = YamlLoader::load_from_str(&*contents)
+        let docs = YamlLoader::load_from_str(&contents)
             .map_err(|err| ConfigError::Foreign(Box::new(err)))?;
 
         let mut docs = docs.into_iter();

--- a/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
+++ b/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
@@ -131,7 +131,7 @@ impl AziotEdgedVersion {
             return Err(anyhow!(
                 "aziot-edged returned {}, stderr = {}",
                 output.status,
-                String::from_utf8_lossy(&*output.stderr),
+                String::from_utf8_lossy(&output.stderr),
             )
             .context("Could not spawn aziot-edged process"));
         }

--- a/edgelet/iotedge/src/check/checks/container_connect_upstream.rs
+++ b/edgelet/iotedge/src/check/checks/container_connect_upstream.rs
@@ -143,15 +143,15 @@ impl ContainerConnectUpstream {
         let port = self.upstream_port.as_port().to_string();
 
         if self.use_container_runtime_network {
-            args.extend(&["--network", network_name]);
+            args.extend(["--network", network_name]);
         }
 
         if check.parent_hostname.is_some() {
-            args.extend(&["-v", &map_volume]);
+            args.extend(["-v", &map_volume]);
         }
 
         self.diagnostics_image_name = Some(check.diagnostics_image_name.clone());
-        args.extend(&[
+        args.extend([
             &diagnostics_image_name,
             "dotnet",
             "IotedgeDiagnosticsDotnet.dll",
@@ -163,14 +163,14 @@ impl ContainerConnectUpstream {
         ]);
 
         if check.parent_hostname.is_some() {
-            args.extend(&["--isNested", "true"]);
-            args.extend(&["--workload_uri", &workload_uri]);
+            args.extend(["--isNested", "true"]);
+            args.extend(["--workload_uri", &workload_uri]);
         }
 
         if &port == "443" {
             self.proxy = check.proxy_uri.clone();
             if let Some(proxy) = &check.proxy_uri {
-                args.extend(&["--proxy", proxy.as_str()]);
+                args.extend(["--proxy", proxy.as_str()]);
             }
         }
 

--- a/edgelet/iotedge/src/check/checks/mod.rs
+++ b/edgelet/iotedge/src/check/checks/mod.rs
@@ -56,7 +56,7 @@ where
     })?;
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&*output.stderr).into_owned();
+        let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
         let err = anyhow::anyhow!("docker returned {}, stderr = {}", output.status, stderr,);
         return Err((Some(stderr), err));
     }

--- a/edgelet/iotedge/src/check/checks/proxy_settings.rs
+++ b/edgelet/iotedge/src/check/checks/proxy_settings.rs
@@ -28,30 +28,24 @@ impl ProxySettings {
 
         // Pull the proxy address from the aziot-edged settings
         // for Edge Agent's environment variables.
-        let edge_agent_proxy_uri = match settings.base.agent.env().get("https_proxy") {
-            Some(edge_agent_proxy_uri) => edge_agent_proxy_uri.clone(),
-            None => "".into(),
-        };
+        let edge_agent_proxy_uri = settings
+            .base
+            .agent
+            .env()
+            .get("https_proxy")
+            .cloned()
+            .unwrap_or_default();
 
         // Pull local service env variables for Moby, Identity Daemon and Edge Daemon
-        let moby_proxy_uri = match check.docker_proxy.clone() {
-            Some(moby_proxy_uri) => moby_proxy_uri,
-            None => "".into(),
-        };
+        let moby_proxy_uri = check.docker_proxy.clone().unwrap_or_default();
 
-        let edge_daemon_proxy_uri = match check.aziot_edge_proxy.clone() {
-            Some(edge_daemon_proxy_uri) => edge_daemon_proxy_uri,
-            None => "".into(),
-        };
+        let edge_daemon_proxy_uri = check.aziot_edge_proxy.clone().unwrap_or_default();
 
-        let identity_daemon_proxy_uri = match check.aziot_identity_proxy.clone() {
-            Some(identity_daemon_proxy_uri) => identity_daemon_proxy_uri,
-            None => "".into(),
-        };
+        let identity_daemon_proxy_uri = check.aziot_identity_proxy.clone().unwrap_or_default();
 
-        if edge_agent_proxy_uri.eq(&moby_proxy_uri)
-            && edge_agent_proxy_uri.eq(&edge_daemon_proxy_uri)
-            && edge_agent_proxy_uri.eq(&identity_daemon_proxy_uri)
+        if edge_agent_proxy_uri == moby_proxy_uri
+            && edge_agent_proxy_uri == edge_daemon_proxy_uri
+            && edge_agent_proxy_uri == identity_daemon_proxy_uri
         {
             CheckResult::Ok
         } else {

--- a/edgelet/iotedge/src/client.rs
+++ b/edgelet/iotedge/src/client.rs
@@ -220,7 +220,7 @@ impl MgmtModule {
         {
             docker_config.image().to_owned()
         } else {
-            "".to_owned()
+            String::new()
         };
 
         Self { details, image }

--- a/edgelet/iotedge/src/config/apply.rs
+++ b/edgelet/iotedge/src/config/apply.rs
@@ -205,7 +205,7 @@ async fn execute_inner(
         .map_err(|err| format!("{:?}", err))?;
 
     let old_identityd_path = Path::new("/etc/aziot/identityd/config.d/00-super.toml");
-    if let Ok(old_identity_config) = std::fs::read(&old_identityd_path) {
+    if let Ok(old_identity_config) = std::fs::read(old_identityd_path) {
         if let Ok(aziot_identityd_config::Settings { hostname, .. }) =
             toml::from_slice(&old_identity_config)
         {

--- a/edgelet/iotedge/src/config/mp.rs
+++ b/edgelet/iotedge/src/config/mp.rs
@@ -105,7 +105,7 @@ To reconfigure IoT Edge, run:
         .map_err(|err| format!("could not query current user information: {}", err))?
         .ok_or("could not query current user information")?;
 
-    common_config::write_file(&out_config_file, &config, &user, 0o0600)
+    common_config::write_file(out_config_file, &config, &user, 0o0600)
         .map_err(|err| format!("{:?}", err))?;
 
     println!("Azure IoT Edge has been configured successfully!");

--- a/edgelet/support-bundle/src/shell_util.rs
+++ b/edgelet/support-bundle/src/shell_util.rs
@@ -27,10 +27,10 @@ pub async fn write_check(
     }
 
     let mut check = Command::new(iotedge);
-    check.arg("check").args(&["-o", "json"]);
+    check.arg("check").args(["-o", "json"]);
 
     if let Some(host_name) = iothub_hostname {
-        check.args(&["--iothub-hostname", &host_name]);
+        check.args(["--iothub-hostname", &host_name]);
     }
     let check = check.output().await.context(Error::SupportBundle)?;
 
@@ -60,7 +60,7 @@ where
     );
 
     let mut inspect = Command::new("docker");
-    inspect.arg("inspect").arg(&module_name);
+    inspect.arg("inspect").arg(module_name);
     let inspect = inspect.output().await;
 
     let (file_name, output) = if let Ok(result) = inspect {
@@ -96,8 +96,8 @@ where
 
 pub async fn get_docker_networks() -> Result<Vec<String>, Error> {
     let mut inspect = Command::new("docker");
-    inspect.args(&["network", "ls"]);
-    inspect.args(&["--format", "{{.Name}}"]);
+    inspect.args(["network", "ls"]);
+    inspect.args(["--format", "{{.Name}}"]);
     let inspect = inspect.output().await;
 
     let result = if let Ok(result) = inspect {
@@ -134,7 +134,7 @@ where
     );
     let mut inspect = Command::new("docker");
 
-    inspect.args(&["network", "inspect", network_name, "-v"]);
+    inspect.args(["network", "inspect", network_name, "-v"]);
     let inspect = inspect.output().await;
 
     let (file_name, output) = if let Ok(result) = inspect {
@@ -197,11 +197,11 @@ where
         let mut command = Command::new("journalctl");
         command
             .arg("-a")
-            .args(&["-u", unit])
-            .args(&["-S", &since_time.format("%F %T").to_string()])
+            .args(["-u", unit])
+            .args(["-S", &since_time.format("%F %T").to_string()])
             .arg("--no-pager");
         if let Some(until) = until_time {
-            command.args(&["-U", &until.format("%F %T").to_string()]);
+            command.args(["-U", &until.format("%F %T").to_string()]);
         }
 
         command.output().await

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.64"
+channel = "1.65"


### PR DESCRIPTION
This is our monthly toolchain upgrade to the latest stable version. Since the primary artifacts of this repository are binaries, we want to be tracking Rust compiler releases closely in the event a stdlib vulnerability is found. We do not pin to "stable", however, since that has caused pipeline breakage when some code patterns are made illegal (like in the upgrade from 1.47 to 1.48 [^0]) or, more often, clippy lints are added.

- `clippy::explicit_auto_deref`: remove redundant dereferences
- `clippy::manual_string_new`: replace `"".to_owned()` with `String::new()` and `.unwrap_or_default()`
- `clippy::needless_borrow`: remove unnecessary borrows

Switching to `let .. else` where appropriate was skipped in the interest of keeping the changeset small.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

[^0]: https://github.com/rust-lang/rust/blob/1.48.0/RELEASES.md#compatibility-notes
  Namely, the point on `mem::uninitialized`.