### PR TITLE
Move remaining pipelines to 1ES agents

### DIFF
--- a/builds/checkin/api-proxy.yaml
+++ b/builds/checkin/api-proxy.yaml
@@ -12,7 +12,9 @@ jobs:
 ################################################################################
     displayName: Check pipeline preconditions (changes ARE in builds or edge-modules/api-proxy-module or mqtt/edgelet-client)
     pool:
-      vmImage: "ubuntu-18.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
       - bash: |
           git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(rust-toolchain\.toml|builds|edge-modules/api-proxy-module|mqtt/edgelet-client)'
@@ -30,7 +32,9 @@ jobs:
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
-      vmImage: "ubuntu-18.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
       - script: echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
         displayName: Set env variables

--- a/builds/checkin/compatibility-tool-checkin.yaml
+++ b/builds/checkin/compatibility-tool-checkin.yaml
@@ -10,7 +10,9 @@ jobs:
   ##############################################################################
     displayName: Check pipeline preconditions (changes ARE in platform compatibility script tool)
     pool:
-      vmImage: "ubuntu-20.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
       - checkout: self
         submodules: false
@@ -31,7 +33,9 @@ jobs:
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
-      vmImage: "ubuntu-20.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
       - checkout: self
         submodules: false

--- a/builds/checkin/edgelet.yaml
+++ b/builds/checkin/edgelet.yaml
@@ -11,7 +11,9 @@ jobs:
 ################################################################################
     displayName: Check pipeline preconditions (changes ARE in builds or edgelet)
     pool:
-      vmImage: "ubuntu-18.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
       - bash: |
           git log -m -1 --name-only --first-parent --pretty="" | egrep -i '^(rust-toolchain\.toml|builds|edgelet)'
@@ -29,7 +31,9 @@ jobs:
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
-      vmImage: "ubuntu-18.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
       - script: echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
         displayName: Set env variables
@@ -47,7 +51,9 @@ jobs:
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
-      vmImage: "ubuntu-18.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     variables:
       IOTEDGE_HOMEDIR: /tmp
     steps:
@@ -76,7 +82,9 @@ jobs:
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
-      vmImage: "ubuntu-18.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     variables:
       IOTEDGE_HOMEDIR: /tmp
     steps:
@@ -105,7 +113,9 @@ jobs:
     dependsOn: check_run_pipeline
     condition: eq(dependencies.check_run_pipeline.outputs['check_files.RUN_PIPELINE'], 'true')
     pool:
-      vmImage: "ubuntu-18.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
       - script: echo "##vso[task.setvariable variable=NO_VALGRIND;]true"
         displayName: Set env variables
@@ -125,7 +135,9 @@ jobs:
     variables:
       coverage.goal: 30
     pool:
-      vmImage: "ubuntu-18.04"
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     steps:
       - script: |
           echo "##vso[task.setvariable variable=IOTEDGE_HOMEDIR;]/tmp"

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -14,7 +14,9 @@ jobs:
     displayName: Linux
     timeoutInMinutes: 120
     pool:
-      vmImage: ubuntu-18.04
+      name: $(pool.linux.name)
+      demands:
+        - ImageOverride -equals agent-aziotedge-ubuntu-20.04-msmoby
     variables:
       testEnvironment: linux
     steps:

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -29,8 +29,6 @@ stages:
     jobs:
     - job: linux
       displayName: Linux
-      pool:
-        vmImage: 'ubuntu-18.04'
       strategy:
         matrix:
           Centos75-amd64:


### PR DESCRIPTION
We still have a few Azure DevOps pipelines in our codebase the use Microsoft-hosted agents, and most of them are using "ubuntu18.04" which will be deprecated soon. This change updates the remaining references to Ubuntu 20.04 1ES agents.

To test, I ran the affected pipelines against the PR (except the release pipeline, but it is very similar to the edgelet part of the CI build, which already uses Ubuntu 20.04 1ES agents) and confirmed that they succeed.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.