### PR TITLE
Simplify some jq logic in refresh-core-images.yaml

### DIFF
--- a/builds/release/refresh-core-images.yaml
+++ b/builds/release/refresh-core-images.yaml
@@ -80,8 +80,7 @@ stages:
           --argjson dn '["diagnostics"]' \
           --argjson an '["amd64","arm32v7","arm64v8"]' '
             def filter: [
-              ($cn[] | "\(.):\($cv)"), ($dn[] | "\(.):\($dv)") | . as $n | $an[]
-                | "mcr.microsoft.com/azureiotedge-\($n)-linux-\(.)"
+              "mcr.microsoft.com/azureiotedge-\("\($cn[]):\($cv)", "\($dn[]):\($dv)")-linux-\($an[])"
             ];
             [ .[] | select(.product == $p and .version == $cv) | .images[] ] | contains(filter)
           ' $(Pipeline.Workspace)/detect-image-updates/image-updates/updates.json


### PR DESCRIPTION
In another PR that cherry-picks d7322af6f93d7f0c2e66c189a5c624f6afeeec22 to main, @onalante-msft pointed out some jq logic that could be simplified. I'm applying that suggestion to release/1.4 first, then I'll cherry-pick both commits to main.

I tested the jq logic locally and confirmed that it produces the same results as before (actually, it produces the array of docker image tags in a different order than the existing code, but order isn't important).

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.