### PR TITLE
Fix metrics collector release in main

### DIFF
--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -10,9 +10,6 @@ parameters:
   manifestTemplate: ''
 
 steps:
-  - checkout: self
-    fetchDepth: 0
-
   - task: DownloadBuildArtifacts@0
     displayName: Download artifacts
     condition: and(succeeded(), ${{ parameters.download_artifacts }})


### PR DESCRIPTION
Azure Pipelines recently had a bug where they changed the default checkout behavior to fetch depth = 1, which is more performant but can cause problems with merges. They rolled back the change, but in the meantime, I added `fetchDepth: 0` in many places to mitigate. Adding it to the images-linux.yaml template causes a problem with the metrics collector release pipeline. I'm not sure if the problem is another bug in Azure Pipelines or not, but regardless they've rolled back their original change so I'm able to revert images-linux.yaml.

I ran the metrics collector release pipeline and the Build CI pipeline to confirm that the problem is fixed and doesn't appear to cause regressions in other pipelines.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.