### PR TITLE
Fix manifest lists in Docker image build template

### DIFF
--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -92,8 +92,8 @@ steps:
       scripts/linux/buildManifest.sh \
         -r '$(registry.address)' \
         -n microsoft \
-        -t 'edge-agent/docker/manifest.yaml.template' \
+        -t '${{ parameters.manifestTemplate }}' \
         -v '$(version)' \
         --tags '$(tags)'
-    displayName: Build Edge Agent Manifest
+    displayName: Build Image Manifest - ${{ parameters.name }}
     condition: and(ne('${{ parameters.manifestTemplate }}', ''), succeeded())


### PR DESCRIPTION
Our Docker image build template (image-linux.yaml) was recently modified to optionally build the manifest list too, as an optimization. But due to a copy/paste error, the template always builds the manifest list for Edge Agent instead of honoring the `manifestTemplate` param. This change fixes that problem. Note that currently, this feature is only being used for the auto-refresh builds.

I confirmed in a test environment that these changes have the desired effect.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.