### PR TITLE
Prepare for release 1.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# 1.4.7 (2023-01-10)
+
+## Edge Agent
+### Bug fixes
+* Update to Newtonsoft.Json 13.0.2 ( [f2b95bf](https://github.com/Azure/iotedge/commit/f2b95bf4a069af7e30ad6c5ff2eac25f450d2f3a) )
+
+## Edge Hub
+### Bug fixes
+* Update to Newtonsoft.Json 13.0.2 ( [f2b95bf](https://github.com/Azure/iotedge/commit/f2b95bf4a069af7e30ad6c5ff2eac25f450d2f3a) )
+
+## Base image updates
+
+The following Docker images were updated because their base images changed:
+* azureiotedge-agent
+* azureiotedge-hub
+* azureiotedge-simulated-temperature-sensor
+* azureiotedge-diagnostics (remains at version 1.4.3 to match the daemon)
+
 # 1.4.6 (2022-12-30)
 
 The following Docker images were updated because their base images changed:

--- a/versionInfo.json
+++ b/versionInfo.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.6",
+  "version": "1.4.7",
   "build": "BUILDNUMBER",
   "commit": "COMMITID"
 }


### PR DESCRIPTION
An update was released today for .NET 6.0. Normally, this means that our auto-refresh pipeline would detect updated base images and automatically create a 1.4.7 release. However, I temporarily disabled the auto-refresh pipeline and created a release commit for two reasons:
1. We updated our Newtonsoft.Json Nuget dependency some time back to take a security fix, and we'd like to get that into the release.
2. There have been some minor fixes to the auto-refresh pipeline itself, which I'd like to exercise with this release.

Once this is merged, I'll manually run the auto-refresh pipeline to complete the release. Then I'll re-enable the pipeline schedule.