### PR TITLE
Fix manifest image build, pt. II

### DIFF
--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -91,9 +91,9 @@ steps:
   - script: |
       scripts/linux/buildManifest.sh \
         -r '$(registry.address)' \
-        -n microsoft \
+        -n '${{ parameters.namespace }}' \
         -t '${{ parameters.manifestTemplate }}' \
-        -v '$(version)' \
+        -v '${{ parameters.version }}' \
         --tags '$(tags)'
     displayName: Build Image Manifest - ${{ parameters.name }}
     condition: and(ne('${{ parameters.manifestTemplate }}', ''), succeeded())


### PR DESCRIPTION
This is effectively a missed change from #6847. In the Docker image build template, there are two other arguments to `buildManifest.sh` that should be drawing from the parameters but are not. This change updates the template to use the `namespace` and `version` parameters. Without this fix, we fail to build the diagnostics module's manifest list when its version doesn't match the latest core runtime modules.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.