### PR TITLE
Add a pipeline to auto-refresh Metrics Collector

### DIFF
--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -92,5 +92,5 @@ steps:
         -t 'edge-agent/docker/manifest.yaml.template' \
         -v '$(version)' \
         --tags '$(tags)'
-    displayName: Build Edge Agent Manifest
+    displayName: Build Image Manifest - ${{ parameters.name }}
     condition: and(ne('${{ parameters.manifestTemplate }}', ''), succeeded())

--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -89,7 +89,7 @@ steps:
       scripts/linux/buildManifest.sh \
         -r '$(registry.address)' \
         -n microsoft \
-        -t 'edge-agent/docker/manifest.yaml.template' \
+        -t '${{ parameters.manifestTemplate }}' \
         -v '$(version)' \
         --tags '$(tags)'
     displayName: Build Image Manifest - ${{ parameters.name }}

--- a/builds/misc/templates/image-linux.yaml
+++ b/builds/misc/templates/image-linux.yaml
@@ -88,9 +88,9 @@ steps:
   - script: |
       scripts/linux/buildManifest.sh \
         -r '$(registry.address)' \
-        -n microsoft \
+        -n '${{ parameters.namespace }}' \
         -t '${{ parameters.manifestTemplate }}' \
-        -v '$(version)' \
+        -v '${{ parameters.version }}' \
         --tags '$(tags)'
     displayName: Build Image Manifest - ${{ parameters.name }}
     condition: and(ne('${{ parameters.manifestTemplate }}', ''), succeeded())

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -35,9 +35,7 @@ steps:
     #!/bin/bash
     set -euo pipefail
 
-    # TODO: replace hard-coded branch assignment with commented-out assignment (below)
-    branch='main'
-    # branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+    branch="${BUILD_SOURCEBRANCH#refs/heads/}"
 
     # transform product-versions.json into a list of images for each product in this branch
     images_json=$(cat product-versions.json | jq --arg registry "$REGISTRY" --arg branch "$branch" '
@@ -54,9 +52,6 @@ steps:
         }
       ] | unique
     ')
-
-    echo "Images for branch '$branch':"
-    echo "$images_json" | jq '.'
 
     # use build metadata present in each published image to determine if it is out of date
     remove=( )

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -53,6 +53,9 @@ steps:
       ] | unique
     ')
 
+    echo "Images for branch '$branch':"
+    echo "$images_json" | jq '.'
+
     # use build metadata present in each published image to determine if it is out of date
     remove=( )
     images=( $(echo "$images_json" | jq -r '[ .[].images ] | flatten | join("\n")') )

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -35,7 +35,9 @@ steps:
     #!/bin/bash
     set -euo pipefail
 
-    branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+    # TODO: replace hard-coded branch assignment with commented-out assignment (below)
+    branch='main'
+    # branch="${BUILD_SOURCEBRANCH#refs/heads/}"
 
     # transform product-versions.json into a list of images for each product in this branch
     images_json=$(cat product-versions.json | jq --arg registry "$REGISTRY" --arg branch "$branch" '

--- a/builds/release/metrics-collector-images-publish.yaml
+++ b/builds/release/metrics-collector-images-publish.yaml
@@ -8,7 +8,7 @@ variables:
 resources:
   pipelines:
   - pipeline: stage-metrics-collector
-    source: 'Stage Metrics Collector Images'
+    source: 'Metrics Collector - Stage Images'
     trigger: true
 
 pool:

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -4,22 +4,16 @@ trigger: none
 resources:
   pipelines:
   - pipeline: detect-image-updates
-    source: 'damonbarry.Detect Image Updates'
+    source: 'Detect Image Updates'
     trigger:
       branches:
         include:
-        - auto-refresh-mc
-    # trigger:
-    #   branches:
-    #     include:
-    #     - main
-    #     - release/1.4
+        - main
   repositories:
   - repository: product
     type: github
-    # TODO: Change back to Azure/azure-iotedge before merging
-    endpoint: github.com_damonbarry
-    name: damonbarry/azure-iotedge
+    endpoint: Azure/azure-iotedge
+    name: Azure/azure-iotedge
 
 variables:
   DisableDockerDetector: true
@@ -73,11 +67,8 @@ stages:
         product='metrics-collector'
         echo "Filtering on { product: $product, version: $previous_version }..."
 
-        # The images we build from this pipeline all target .NET Alpine base images, but some are
-        # 'dotnet/aspnet' and some are 'dotnet/runtime'. If this pipeline happens to run, e.g.,
-        # after dotnet/runtime gets updated but before dotnet/aspnet gets updated, then we'll end up
-        # releasing twice in quick succession. To mitigate this problem, we'll wait until *all* the
-        # images/architectures we build in this pipeline are flagged for update.
+        # We won't proceed with the release until *all* the images/architectures we build in this
+        # pipeline are flagged for update, to avoid doing multiple releases in quick succession.
         continue=$(jq \
           --arg p "$product" \
           --arg v "$previous_version" \

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -1,0 +1,554 @@
+pr: none
+trigger: none
+
+resources:
+  pipelines:
+  - pipeline: detect-image-updates
+    source: 'Detect Image Updates'
+    trigger:
+      branches:
+        include:
+        - release/1.4
+  repositories:
+  - repository: product
+    type: github
+    endpoint: Azure/azure-iotedge
+    name: Azure/azure-iotedge
+
+variables:
+  DisableDockerDetector: true
+
+stages:
+################################################################################
+- stage: PrepareRelease
+################################################################################
+  displayName: Prepare for release
+  dependsOn: []
+
+  # The project repo must meet some prerequisites before the release pipeline can continue:
+  #  1. edge-modules/metrics-collector/CHANGELOG.md and
+  #     edge-modules/metrics-collector/src/config/versionInfo.json must be updated
+  #  2. A release commit (usually including the changes in the previous step) must be pushed
+  #  3. The release commit must be tagged with the version (e.g., metrics-collector-1.1.0)
+  #
+  # This stage ensures the above requirements are fulfilled by running one of two mutually-exclusive
+  # jobs depending on how the run was triggered. If it was triggered automatically when the
+  # detect-image-updates pipeline completed, then the PipelineTrigger job runs and makes all
+  # necessary file updates, commits, and tags to prepare for the release. If the pipeline was
+  # triggered manually, then the ManualTrigger job runs. It assumes the prerequisites have already
+  # been met, and checks to ensure it has everything it needs to continue.
+
+  pool:
+    name: $(pool.linux.name)
+    demands:
+    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+
+  jobs:
+  - job: PipelineTrigger
+    displayName: Trigger on base image updates
+    condition: eq(variables['Build.Reason'], 'ResourceTrigger')
+
+    steps:
+    - checkout: self
+      fetchDepth: 0
+
+    - download: detect-image-updates
+      displayName: Download image list from triggering pipeline
+
+    - script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        echo 'Updates:'
+        cat $(Pipeline.Workspace)/detect-image-updates/image-updates/updates.json
+
+        . scripts/linux/release-tools.sh
+        previous_version=$(TAG_PREFIX='metrics-collector-' get_nearest_version)
+        product='metrics-collector'
+        echo "Filtering on { product: $product, version: $previous_version }..."
+
+        # The images we build from this pipeline all target .NET Alpine base images, but some are
+        # 'dotnet/aspnet' and some are 'dotnet/runtime'. If this pipeline happens to run, e.g.,
+        # after dotnet/runtime gets updated but before dotnet/aspnet gets updated, then we'll end up
+        # releasing twice in quick succession. To mitigate this problem, we'll wait until *all* the
+        # images/architectures we build in this pipeline are flagged for update.
+        continue=$(jq \
+          --arg p "$product" \
+          --arg v "$previous_version" \
+          --argjson an '["metrics-collector"]' \
+          --argjson aa '["amd64","arm32v7","arm64v8"]' '
+            def filter: [
+              $an[] | . as $n | $aa[] | "mcr.microsoft.com/azureiotedge-\($n):\($v)-linux-\(.)"
+            ];
+            [ .[] | select(.product == $p and .version == $v) | .images[] ] | contains(filter)
+          ' $(Pipeline.Workspace)/detect-image-updates/image-updates/updates.json
+        )
+
+        echo "Continue with release? $continue"
+        echo "##vso[task.setvariable variable=continue;isOutput=true]$continue"
+      displayName: Filter image list for core images
+      name: filter
+
+    - task: AzureKeyVault@1
+      displayName: Get secrets
+      condition: and(succeeded(), eq(variables['filter.continue'], 'true'))
+      inputs:
+        azureSubscription: $(az.subscription)
+        keyVaultName: $(kv.name)
+        secretsFilter: TestGitHubAccessToken
+
+    - script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        . scripts/linux/release-tools.sh
+
+        GIT_EMAIL='$(service-account.email)' \
+        BRANCH="${BUILD_SOURCEBRANCH#refs/heads/}" \
+        make_project_release_commit_for_metrics_collector_image_refresh
+        get_metrics_collector_release_info
+
+        changelog=$(echo "$OUTPUTS" | jq -rc '.changelog')
+        next=$(echo "$OUTPUTS" | jq -rc '.version')
+        prev=$(echo "$OUTPUTS" | jq -rc '.previous_version')
+        tags=$(echo "$OUTPUTS" | jq -rc '.tags')
+
+        echo "##vso[task.setvariable variable=changelog;isOutput=true]$changelog"
+        echo "##vso[task.setvariable variable=version;isOutput=true]$next"
+        echo "##vso[task.setvariable variable=previous_version;isOutput=true]$prev"
+        echo "##vso[task.setvariable variable=tags;isOutput=true]$tags"
+      displayName: Create a release commit
+      name: commit
+      condition: and(succeeded(), eq(variables['filter.continue'], 'true'))
+      env:
+        GITHUB_TOKEN: "$(TestGitHubAccessToken)"
+
+  - job: ManualTrigger
+    displayName: Manually trigger pipeline to update images
+    condition: eq(variables['Build.Reason'], 'Manual')
+
+    steps:
+    - checkout: self
+      fetchDepth: 0
+
+    - script: |
+        #!/bin/bash
+        set -euo pipefail
+        
+        # this script assumes the following steps have already been taken:
+        # - a release commit has been pushed to the project repo, and is reachable from this run's
+        #   source commit
+        # - the release commit was tagged with the new version
+        # - the project repo's edge-modules/metrics-collector/CHANGELOG.md has been updated with
+        #   information about the new release
+
+        . scripts/linux/release-tools.sh
+        get_metrics_collector_release_info
+
+        changelog=$(echo "$OUTPUTS" | jq -rc '.changelog')
+        next=$(echo "$OUTPUTS" | jq -rc '.version')
+        prev=$(echo "$OUTPUTS" | jq -rc '.previous_version')
+        tags=$(echo "$OUTPUTS" | jq -rc '.tags')
+
+        echo "##vso[task.setvariable variable=changelog;isOutput=true]$changelog"
+        echo "##vso[task.setvariable variable=version;isOutput=true]$next"
+        echo "##vso[task.setvariable variable=previous_version;isOutput=true]$prev"
+        echo "##vso[task.setvariable variable=tags;isOutput=true]$tags"
+      displayName: Determine versions
+      name: commit
+
+    - script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        # If Metrics Collector has already been published to mcr.microsoft.com at the given version,
+        # we'll assume there's a mistake (e.g., forgot to create and/or tag a new release commit)
+        # and abort the release.
+        image='mcr.microsoft.com/azureiotedge-metrics-collector:$(commit.version)'
+        if docker buildx imagetools inspect "$image" >/dev/null 2>&1; then
+          echo "Error: $image already exists but shouldn't"
+          exit 1
+        fi
+
+        # Create a filter.continue task variable to match the PipelineTrigger job, but hard-code it
+        # to true so the pipeline will always run subsequent stages in the manual case.
+        echo "##vso[task.setvariable variable=continue;isOutput=true]true"
+      displayName: Continue if the proposed version was not already released
+      name: filter
+
+################################################################################
+- stage: Build
+################################################################################
+  displayName: Build Metrics Collector
+  dependsOn: PrepareRelease
+
+  condition: |
+    and(
+      succeeded(),
+      or(
+        eq(dependencies.PrepareRelease.outputs['PipelineTrigger.filter.continue'], 'true'),
+        eq(dependencies.PrepareRelease.outputs['ManualTrigger.filter.continue'], 'true')
+      )
+    )
+
+  pool:
+    name: $(pool.linux.name)
+    demands:
+    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+
+  variables:
+    ${{ if eq(variables['Build.Reason'], 'Manual') }}:
+      version: $[ stageDependencies.PrepareRelease.ManualTrigger.outputs['commit.version'] ]
+      tags: $[ stageDependencies.PrepareRelease.ManualTrigger.outputs['commit.tags'] ]
+    ${{ else }}:
+      version: $[ stageDependencies.PrepareRelease.PipelineTrigger.outputs['commit.version'] ]
+      tags: $[ stageDependencies.PrepareRelease.PipelineTrigger.outputs['commit.tags'] ]
+
+  jobs:
+  - job: BuildDotnetComponents
+    displayName: .NET components
+
+    steps:
+    - checkout: self
+      fetchDepth: 0
+
+    - script: |
+        git checkout $(version)
+      displayName: Check out the new release commit
+
+  - script: |
+      dotnet publish edge-modules/metrics-collector/src/Microsoft.Azure.Devices.Edge.Azure.Monitor.csproj \
+        -o '$(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Azure.Monitor' \
+        -c Release
+    displayName: Build ($(Build.Configuration))
+
+    # The code sign task requires .NET Core 2.1.
+    # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).
+    - template: ../templates/force-dotnet21.yaml
+
+    # Code Sign
+    - template: templates/dotnet-code-sign.yaml
+      parameters:
+        name: Sign Metrics Collector
+        path: $(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Azure.Monitor
+        pattern: Microsoft.Azure.Devices.Edge.Azure.Monitor*.dll
+
+    # We're done with code signing, so remove dotnet version override
+    - template: ../templates/restore-default-dotnet.yaml
+
+    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+      displayName: Generate SBOM
+      inputs:
+        BuildDropPath: '$(Build.BinariesDirectory)/publish'
+
+    - template: ../misc/templates/image-linux.yaml
+      parameters:
+        name: Metrics Collector
+        imageName: azureiotedge-metrics-collector
+        project: Microsoft.Azure.Devices.Edge.Azure.Monitor
+        version: $(version)
+        download_artifacts: false
+        manifestTemplate: 'edge-modules/metrics-collector/docker/manifest.yaml.template'
+
+################################################################################
+- stage: Test
+################################################################################
+  displayName: Test Metrics Collector
+  condition: succeeded('Build')
+
+  dependsOn:
+  - PrepareRelease
+  - Build
+
+  variables:
+    ${{ if eq(variables['Build.Reason'], 'Manual') }}:
+      version: $[ stageDependencies.PrepareRelease.ManualTrigger.outputs['commit.version'] ]
+    ${{ else }}:
+      version: $[ stageDependencies.PrepareRelease.PipelineTrigger.outputs['commit.version'] ]
+
+  jobs:
+  - job: test
+    displayName: Test Linux
+
+    variables:
+      os: linux
+
+    strategy:
+      matrix:
+        arm32v7:
+          pool: $(pool.linux.arm.name)
+          # Since this pipeline is about testing the Metrics Collector Docker image for release
+          # and not our host components, we'll run the arm32v7 Docker image on an arm64v8 host
+          # OS, with arm64v8 host components, for speed and convenience.
+          agent: agent-aziotedge-ubuntu-20.04-arm64-docker
+          arch: arm32v7
+        arm64v8:
+          pool: $(pool.linux.arm.name)
+          agent: agent-aziotedge-ubuntu-20.04-arm64-docker
+          arch: arm64v8
+        amd64:
+          pool: $(pool.linux.name)
+          agent: agent-aziotedge-ubuntu-20.04-msmoby
+          arch: amd64
+
+    pool:
+      name: $(pool)
+      demands:
+      - ImageOverride -equals $(agent)
+
+    steps:
+    - checkout: self
+      fetchDepth: 0
+
+    - task: AzureKeyVault@1
+      displayName: Get secrets
+      inputs:
+        azureSubscription: $(az.subscription)
+        keyVaultName: $(kv.name)
+        secretsFilter: >-
+          ReleaseContainerRegistryPassword,
+          TestEventHubCompatibleEndpoint,
+          TestIotHubConnectionString,
+          TestIotHubResourceId,
+          TestRootCaCertificate,
+          TestRootCaKey,
+          TestRootCaPassword
+
+    - pwsh: |
+        $certsDir = '$(System.ArtifactsDirectory)/certs'
+        New-Item "$certsDir" -ItemType Directory -Force | Out-Null
+        $env:ROOT_CERT | Out-File -Encoding Utf8 "$certsDir/rsa_root_ca.cert.pem"
+        $env:ROOT_KEY | Out-File -Encoding Utf8 "$certsDir/rsa_root_ca.key.pem"
+        Write-Output "##vso[task.setvariable variable=certsDir]$certsDir"
+      displayName: Install CA keys
+      env:
+        ROOT_CERT: $(TestRootCaCertificate)
+        ROOT_KEY: $(TestRootCaKey)
+    
+    - pwsh: |
+        $testDir = '$(Build.SourcesDirectory)/test/Microsoft.Azure.Devices.Edge.Test'
+        dotnet build -c $(Build.Configuration) $testDir
+    
+        $binDir = Convert-Path "$testDir/bin/$(Build.Configuration)/net6.0"
+        Write-Output "##vso[task.setvariable variable=binDir]$binDir"
+      displayName: Build tests
+      env:
+        http_proxy: $(Agent.ProxyUrl)
+        https_proxy: $(Agent.ProxyUrl)
+
+    - pwsh: |
+        $caCertScriptPath = Convert-Path '$(Build.SourcesDirectory)/tools/CACertificates'
+        $rootCaCertificatePath = Convert-Path '$(certsDir)/rsa_root_ca.cert.pem';
+        $rootCaPrivateKeyPath = Convert-Path '$(certsDir)/rsa_root_ca.key.pem';
+        $runtimeVersion=$(cat versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K\d+\.\d+')
+        $edgeAgentImage = "mcr.microsoft.com/azureiotedge-agent:$runtimeVersion";
+        $edgeHubImage = "mcr.microsoft.com/azureiotedge-hub:$runtimeVersion";
+        $metricsCollectorImage = "$(registry.address)/microsoft/azureiotedge-metrics-collector:$(version)-$(os)-$(arch)"
+
+        echo "Edge Agent image: $edgeAgentImage"
+        echo "Edge Hub image: $edgeHubImage"
+        echo "Metrics Collector image: $metricsCollectorImage"
+    
+        $context = @{
+          nestededge = 'false';
+          isa95Tag = 'false';
+          edgeAgentImage = "$edgeAgentImage";
+          edgeHubImage = "$edgeHubImage";
+          metricsCollectorImage = "$metricsCollectorImage";
+          iotHubResourceId = "$env:IOT_HUB_RESOURCE_ID";
+          registries = @(
+            @{
+              address = '$(registry.address)';
+              username = '$(registry.username)';
+            }
+          );
+          caCertScriptPath = "$caCertScriptPath";
+          rootCaCertificatePath = "$rootCaCertificatePath";
+          rootCaPrivateKeyPath = "$rootCaPrivateKeyPath";
+          logFile = Join-Path '$(binDir)' 'testoutput.log';
+          verbose = '$(verbose)';
+          getSupportBundle = 'true';
+          teardownTimeoutMinutes = 10;
+        }
+    
+        if ('$(arch)' -eq 'arm32v7')
+        {
+          $context['optimizeForPerformance'] = 'false'
+          $context['setupTimeoutMinutes'] = 10
+          $context['teardownTimeoutMinutes'] = 10
+          $context['testTimeoutMinutes'] = 10
+        }
+    
+        if ($env:AGENT_PROXYURL)
+        {
+          $context['testRunnerProxy'] = $env:AGENT_PROXYURL
+          $context['edgeProxy'] = $env:AGENT_PROXYURL
+        }
+        
+        $context | ConvertTo-Json | Out-File -Encoding Utf8 '$(binDir)/context.json'
+        Get-Content -Path '$(binDir)/context.json'
+      displayName: Create test arguments file (context.json)
+      env:
+        IOT_HUB_RESOURCE_ID: $(TestIotHubResourceId)
+
+    - script: |
+        sudo --preserve-env dotnet test '$(binDir)/Microsoft.Azure.Devices.Edge.Test.dll' \
+          --no-build \
+          --logger 'trx' \
+          --filter 'MetricsCollector'
+      displayName: Run tests
+      env:
+        E2E_EVENT_HUB_ENDPOINT: $(TestEventHubCompatibleEndpoint)
+        E2E_IOT_HUB_CONNECTION_STRING: $(TestIotHubConnectionString)
+        E2E_REGISTRIES__0__PASSWORD: $(ReleaseContainerRegistryPassword)
+        E2E_ROOT_CA_PASSWORD: $(TestRootCaPassword)
+
+    - task: PublishTestResults@2
+      displayName: Publish test results
+      inputs:
+        testRunner: vstest
+        testResultsFiles: '**/*.trx'
+        searchFolder: $(Build.SourcesDirectory)/TestResults
+        testRunTitle: End-to-end tests ($(Build.BuildNumber) $(System.JobDisplayName))
+        buildPlatform: $(arch)
+      condition: succeededOrFailed()
+
+    - pwsh: |
+        $logDir = '$(Build.ArtifactStagingDirectory)/logs'
+        New-Item $logDir -ItemType Directory -Force | Out-Null
+        Out-File "$logDir/$(Build.DefinitionName)-$(Build.BuildNumber)"
+        Copy-Item "$(Build.SourcesDirectory)/TestResults" "$logDir/" -Recurse
+        # The setup fixtures run outside the scope of any test, so their logs (*-[test|device]-*.log)
+        # aren't included in the TRX. Copy them manually here.
+        Copy-Item '$(binDir)/context.json' "$logDir/"
+        Copy-Item "$(binDir)/*-test-*.log" "$logDir/"
+        Copy-Item "$(binDir)/*-device-*.log" "$logDir/"
+        Copy-Item "$(binDir)/testoutput.log" "$logDir/"
+        Copy-Item "$(binDir)/supportbundle*" "$logDir/"
+        $artifactSuffix = '$(Build.BuildNumber)-$(System.PhaseName)' -replace '_','-'
+        Write-Output "##vso[task.setvariable variable=artifactSuffix]$artifactSuffix"
+      displayName: Collect Logs
+      condition: always()
+
+    - task: PublishBuildArtifacts@1
+      displayName: Publish logs
+      inputs:
+        PathtoPublish: $(Build.ArtifactStagingDirectory)/logs
+        ArtifactName: logs-end-to-end-$(artifactSuffix)
+      condition: always()
+
+################################################################################
+- stage: Publish
+################################################################################
+  displayName: Publish Metrics Collector
+  condition: succeeded('Test')
+
+  dependsOn:
+  - PrepareRelease
+  - Test
+
+  variables:
+    ${{ if eq(variables['Build.Reason'], 'Manual') }}:
+      changelog: $[ stageDependencies.PrepareRelease.ManualTrigger.outputs['commit.changelog'] ]
+      tags: $[ stageDependencies.PrepareRelease.ManualTrigger.outputs['commit.tags'] ]
+      version: $[ stageDependencies.PrepareRelease.ManualTrigger.outputs['commit.version'] ]
+      version.previous: $[ stageDependencies.PrepareRelease.ManualTrigger.outputs['commit.previous_version'] ]
+    ${{ else }}:
+      changelog: $[ stageDependencies.PrepareRelease.PipelineTrigger.outputs['commit.changelog'] ]
+      tags: $[ stageDependencies.PrepareRelease.PipelineTrigger.outputs['commit.tags'] ]
+      version: $[ stageDependencies.PrepareRelease.PipelineTrigger.outputs['commit.version'] ]
+      version.previous: $[ stageDependencies.PrepareRelease.PipelineTrigger.outputs['commit.previous_version'] ]
+
+  jobs:
+  - job: publish
+    displayName: Publish Linux
+
+    steps:
+    - checkout: self
+      fetchDepth: 0
+    - checkout: product
+      fetchDepth: 0
+
+    - task: Docker@2
+      displayName: Docker login
+      inputs:
+        command: login
+        containerRegistry: $(service-connection.registry.release)
+
+    - script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        for arch in 'amd64' 'arm32v7' 'arm64v8'
+        do
+          from="$(registry.address)/microsoft/azureiotedge-metrics-collector:$(version)-linux-$arch"
+          to="$(registry.address)/public/azureiotedge-metrics-collector:$(version)-linux-$arch"
+          echo $"\n$from --> $to"
+          scripts/linux/moveImage.sh --from "$from" --to "$to"
+        done
+      displayName: Publish core images
+      workingDirectory: iotedge
+
+    - script: |
+        scripts/linux/buildManifest.sh \
+          -r '$(registry.address)' \
+          -v $(version) \
+          -t edge-modules/metrics-collector/docker/manifest.yaml.template \
+          -n public \
+          --tags '$(tags)'
+      displayName: Publish Manifest
+      workingDirectory: iotedge
+
+    - task: AzureKeyVault@1
+      displayName: Get secrets
+      inputs:
+        azureSubscription: $(az.subscription)
+        keyVaultName: $(kv.name)
+        secretsFilter: TestGitHubAccessToken
+
+    - script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        BRANCH="${BUILD_SOURCEBRANCH#refs/heads/}"
+
+        . scripts/linux/release-tools.sh
+        create_github_release_page_for_metrics_collector_in_project_repo
+      displayName: Create GitHub release page in project repo
+      env:
+        VERSION: $(version)
+        GITHUB_TOKEN: $(TestGitHubAccessToken)
+        REPO_NAME: $(repo.project.name)
+      workingDirectory: iotedge
+
+    - script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        # update product-versions.json
+        echo "$(jq '
+          def product: .channels[] | .products[] | select(
+            .id=="metrics-collector" and .version=="$(version.previous)"
+          );
+          def metrics_collector: product | .components[] | select(
+            .name=="azureiotedge-metrics-collector"
+          );
+          (metrics_collector).version |= "$(version)"
+            | (product).version |= "$(version)"
+        ' product-versions.json )" > product-versions.json
+        git add product-versions.json
+
+        # configure git
+        git config user.email '$(service-account.email)'
+        git config user.name 'IoT Edge Bot'
+        origin_url="$(git config --get remote.origin.url)"
+        origin_url="${origin_url/#https:\/\//https:\/\/$GITHUB_TOKEN@}" # add token to URL
+
+        # commit changes and push
+        git commit -m 'Bump metrics collector in product-versions.json'
+        git push "$origin_url" "HEAD:$PRODUCT_REPO_BRANCH"
+      displayName: Update product-versions.json in product repo
+      env:
+        GITHUB_TOKEN: $(TestGitHubAccessToken)
+        PRODUCT_REPO_BRANCH: main
+      workingDirectory: azure-iotedge

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -4,7 +4,7 @@ trigger: none
 resources:
   pipelines:
   - pipeline: detect-image-updates
-    source: 'Detect Image Updates'
+    source: 'damonbarry.Detect Image Updates'
     trigger:
       branches:
         include:

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -218,11 +218,11 @@ stages:
         git checkout $(version)
       displayName: Check out the new release commit
 
-  - script: |
-      dotnet publish edge-modules/metrics-collector/src/Microsoft.Azure.Devices.Edge.Azure.Monitor.csproj \
-        -o '$(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Azure.Monitor' \
-        -c Release
-    displayName: Build ($(Build.Configuration))
+    - script: |
+        dotnet publish edge-modules/metrics-collector/src/Microsoft.Azure.Devices.Edge.Azure.Monitor.csproj \
+          -o '$(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Azure.Monitor' \
+          -c Release
+      displayName: Build ($(Build.Configuration))
 
     # The code sign task requires .NET Core 2.1.
     # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -277,6 +277,7 @@ stages:
 
     variables:
       os: linux
+      verbose: false
 
     strategy:
       matrix:

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -90,7 +90,7 @@ stages:
 
         echo "Continue with release? $continue"
         echo "##vso[task.setvariable variable=continue;isOutput=true]$continue"
-      displayName: Filter image list for core images
+      displayName: Filter image list for Metrics Collector images
       name: filter
 
     - task: AzureKeyVault@1
@@ -490,7 +490,7 @@ stages:
           echo $"\n$from --> $to"
           scripts/linux/moveImage.sh --from "$from" --to "$to"
         done
-      displayName: Publish core images
+      displayName: Publish Metrics Collector images
       workingDirectory: iotedge
 
     - script: |
@@ -549,7 +549,7 @@ stages:
         origin_url="${origin_url/#https:\/\//https:\/\/$GITHUB_TOKEN@}" # add token to URL
 
         # commit changes and push
-        git commit -m 'Bump metrics collector in product-versions.json'
+        git commit -m 'Bump Metrics Collector in product-versions.json'
         git push "$origin_url" "HEAD:$PRODUCT_REPO_BRANCH"
       displayName: Update product-versions.json in product repo
       env:

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -5,10 +5,13 @@ resources:
   pipelines:
   - pipeline: detect-image-updates
     source: 'Detect Image Updates'
-    trigger:
-      branches:
-        include:
-        - release/1.4
+    trigger: true
+    # TODO: replace above trigger with below trigger
+    # trigger:
+    #   branches:
+    #     include:
+    #     - main
+    #     - release/1.4
   repositories:
   - repository: product
     type: github

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -75,10 +75,9 @@ stages:
         continue=$(jq \
           --arg p "$product" \
           --arg v "$previous_version" \
-          --argjson an '["metrics-collector"]' \
-          --argjson aa '["amd64","arm32v7","arm64v8"]' '
+          --argjson an '["amd64","arm32v7","arm64v8"]' '
             def filter: [
-              $an[] | . as $n | $aa[] | "mcr.microsoft.com/azureiotedge-\($n):\($v)-linux-\(.)"
+              "mcr.microsoft.com/azureiotedge-metrics-collector:\($v)-linux-\($an[])"
             ];
             [ .[] | select(.product == $p and .version == $v) | .images[] ] | contains(filter)
           ' $(Pipeline.Workspace)/detect-image-updates/image-updates/updates.json

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -5,8 +5,10 @@ resources:
   pipelines:
   - pipeline: detect-image-updates
     source: 'Detect Image Updates'
-    trigger: true
-    # TODO: replace above trigger with below trigger
+    trigger:
+      branches:
+        include:
+        - auto-refresh-mc
     # trigger:
     #   branches:
     #     include:

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -217,7 +217,7 @@ stages:
       fetchDepth: 0
 
     - script: |
-        git checkout $(version)
+        git checkout metrics-collector-$(version)
       displayName: Check out the new release commit
 
     - script: |

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -17,8 +17,9 @@ resources:
   repositories:
   - repository: product
     type: github
-    endpoint: Azure/azure-iotedge
-    name: Azure/azure-iotedge
+    # TODO: Change back to Azure/azure-iotedge before merging
+    endpoint: damonbarry/azure-iotedge
+    name: damonbarry/azure-iotedge
 
 variables:
   DisableDockerDetector: true

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -516,7 +516,8 @@ stages:
         #!/bin/bash
         set -euo pipefail
 
-        BRANCH="${BUILD_SOURCEBRANCH#refs/heads/}"
+        COMMITISH="${BUILD_SOURCEBRANCH#refs/heads/}"
+        COMMITISH="${BUILD_SOURCEBRANCH#refs/tags/}"
 
         . scripts/linux/release-tools.sh
         create_github_release_page_for_metrics_collector_in_project_repo

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -519,6 +519,11 @@ stages:
         COMMITISH="${BUILD_SOURCEBRANCH#refs/heads/}"
         COMMITISH="${BUILD_SOURCEBRANCH#refs/tags/}"
 
+        # deserialize the changelog
+        printf -v CHANGELOG '$(changelog)'
+        # Remove 1st line (header) because GitHub Release page has its own header
+        CHANGELOG="$(echo "$CHANGELOG" | tail -n +2 -)"
+
         . scripts/linux/release-tools.sh
         create_github_release_page_for_metrics_collector_in_project_repo
       displayName: Create GitHub release page in project repo

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -453,6 +453,11 @@ stages:
   - PrepareRelease
   - Test
 
+  pool:
+    name: $(pool.linux.name)
+    demands:
+    - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+
   variables:
     ${{ if eq(variables['Build.Reason'], 'Manual') }}:
       changelog: $[ stageDependencies.PrepareRelease.ManualTrigger.outputs['commit.changelog'] ]

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -18,7 +18,7 @@ resources:
   - repository: product
     type: github
     # TODO: Change back to Azure/azure-iotedge before merging
-    endpoint: damonbarry/azure-iotedge
+    endpoint: github.com_damonbarry
     name: damonbarry/azure-iotedge
 
 variables:

--- a/builds/release/templates/publish-core-images.yaml
+++ b/builds/release/templates/publish-core-images.yaml
@@ -168,7 +168,7 @@ jobs:
       BRANCH="${BUILD_SOURCEBRANCH#refs/heads/}"
 
       . scripts/linux/release-tools.sh
-      create_github_release_page_in_project_repo
+      create_github_release_page_for_core_images_in_project_repo
     displayName: Create GitHub release page in project repo
     env:
       CORE_VERSION: ${{ parameters['version.core'] }} 

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -465,7 +465,7 @@ create_github_release_page_for_core_images_in_project_repo() {
 # variables are empty, or if GitHub returns an error.
 #
 # Globals
-#   BRANCH       Optional. If not given, defaults to current branch (e.g., 'release/1.4')
+#   COMMITISH    Optional. If not given, defaults to current branch (e.g., 'release/1.4')
 #   VERSION      Required. Version of Metrics Collector module for this release
 #   GITHUB_TOKEN Required. The Authorization token passed to GitHub
 #   REPO_NAME    Required. The GitHub project repository, as 'org/repo'
@@ -479,15 +479,15 @@ create_github_release_page_for_metrics_collector_in_project_repo() {
     return 1
   fi
 
-  local branch=${BRANCH:-$(git branch --show-current)}
+  local commitish=${COMMITISH:-$(git branch --show-current)}
 
   local body="$CHANGELOG"
 
-  local data=$(jq -nc --arg version "$VERSION" --arg branch "$branch" --arg body "$body" '
+  local data=$(jq -nc --arg version "$VERSION" --arg commitish "$commitish" --arg body "$body" '
     {
       tag_name: $version,
       name: @text "Metrics Collector \($version)",
-      target_commitish: $branch,
+      target_commitish: $commitish,
       body: $body
     }
   ')

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -488,7 +488,8 @@ create_github_release_page_for_metrics_collector_in_project_repo() {
       tag_name: metrics-collector-$version,
       name: @text "Metrics Collector \($version)",
       target_commitish: $commitish,
-      body: $body
+      body: $body,
+      make_latest: false
     }
   ')
 

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -485,8 +485,8 @@ create_github_release_page_for_metrics_collector_in_project_repo() {
 
   local data=$(jq -nc --arg version "$VERSION" --arg commitish "$commitish" --arg body "$body" '
     {
-      tag_name: metrics-collector-$version,
-      name: @text "Metrics Collector \($version)",
+      tag_name: "metrics-collector-\($version)",
+      name: "Metrics Collector \($version)",
       target_commitish: $commitish,
       body: $body,
       make_latest: false

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -466,6 +466,7 @@ create_github_release_page_for_core_images_in_project_repo() {
 #
 # Globals
 #   COMMITISH    Optional. If not given, defaults to current branch (e.g., 'release/1.4')
+#   CHANGELOG    Required. Changelog text to add to the Release page.
 #   VERSION      Required. Version of Metrics Collector module for this release
 #   GITHUB_TOKEN Required. The Authorization token passed to GitHub
 #   REPO_NAME    Required. The GitHub project repository, as 'org/repo'
@@ -474,7 +475,7 @@ create_github_release_page_for_core_images_in_project_repo() {
 #   None
 #
 create_github_release_page_for_metrics_collector_in_project_repo() {
-  if [[ -z "$VERSION" || -z "$GITHUB_TOKEN" || -z "$REPO_NAME" ]]; then
+  if [[ -z "$CHANGELOG" || -z "$VERSION" || -z "$GITHUB_TOKEN" || -z "$REPO_NAME" ]]; then
     echo 'Error: One or more required arguments are empty'
     return 1
   fi

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -44,9 +44,9 @@ get_push_url() {
 }
 
 #
-# Echoes the first tag of format $PREFIXn.n* reachable from $COMMIT. If the $TAG_PREFIX variable is
-# not set, it will default to none (''). If the $COMMIT variable is not set, it will default to
-# 'HEAD'. Returns exit status 1 if no tag can be found.
+# Echoes the first tag of format ${TAG_PREFIX}n.n* reachable from $COMMIT. If the $TAG_PREFIX
+# variable is not set, it will default to no prefix (''). If the $COMMIT variable is not set, it
+# will default to 'HEAD'. Returns exit status 1 if no tag can be found.
 #
 get_nearest_version() {
   local commit=${COMMIT:-HEAD}

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -195,7 +195,7 @@ make_project_release_commit_for_metrics_collector_image_refresh() {
 
   # checkout code at current release version
   local prev=$(TAG_PREFIX="$git_tag_prefix" get_nearest_version)
-  git checkout "$prev"
+  git checkout "${git_tag_prefix}${prev}"
 
   # determine new version
   IFS='.' read -a parts <<< "$prev"

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -301,9 +301,11 @@ get_project_release_info() {
 #                }
 #
 get_metrics_collector_release_info() {
+  local git_tag_prefix='metrics-collector-'
+
   # get the new version and the previous version
-  local next=$(TAG_PREFIX='metrics-collector-' get_nearest_version)
-  local prev=$(TAG_PREFIX='metrics-collector-' COMMIT="$next~" get_nearest_version)
+  local next=$(TAG_PREFIX="$git_tag_prefix" get_nearest_version)
+  local prev=$(TAG_PREFIX="$git_tag_prefix" COMMIT="${git_tag_prefix}${next}~" get_nearest_version)
 
   # determine docker tags
   IFS='.' read -a parts <<< "$next"
@@ -331,7 +333,7 @@ get_metrics_collector_release_info() {
       changelog: $changelog,
       version: $next,
       previous_version: $prev,
-      tags: $docker_tags
+      tags: $tags
     }')
 }
 

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -481,12 +481,11 @@ create_github_release_page_for_metrics_collector_in_project_repo() {
   fi
 
   local commitish=${COMMITISH:-$(git branch --show-current)}
-
   local body="$CHANGELOG"
 
   local data=$(jq -nc --arg version "$VERSION" --arg commitish "$commitish" --arg body "$body" '
     {
-      tag_name: $version,
+      tag_name: metrics-collector-$version,
       name: @text "Metrics Collector \($version)",
       target_commitish: $commitish,
       body: $body

--- a/scripts/linux/release-tools.sh
+++ b/scripts/linux/release-tools.sh
@@ -489,7 +489,7 @@ create_github_release_page_for_metrics_collector_in_project_repo() {
       name: "Metrics Collector \($version)",
       target_commitish: $commitish,
       body: $body,
-      make_latest: false
+      make_latest: "false"
     }
   ')
 


### PR DESCRIPTION
This change builds on work from 6e3ac3cf117e9f1b1de5b1e4e4014214923f189b and 81f2633c3dc4d7f5d8abc525d9223d07493a2cf4.

The Metrics Collector Docker images all target .NET 6.0 Alpine base images. When those images change, often due to important security updates, we need to respond quickly by refreshing our own images. Doing so allows our users to keep their deployments up to date.

This change introduces a fully automated release pipeline (`refresh-metrics-collector-images.yaml`) for our Metrics Collector images. It is patterned after the core images refresh pipeline (`refresh-core-images.yaml`), and there may be opportunities to refactor common code in the future. It is triggered when the detection pipeline (`detect-image-updates.yaml`) completes for the main branch and will refresh and release new images if required.

To test, I ran the detection and refresh pipelines many times in a non-prod environment and confirmed the results.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.