### PR TITLE
[edgelet] Enable >4GB files in support_bundle ZIP writer

### DIFF
--- a/edgelet/support-bundle/src/support_bundle.rs
+++ b/edgelet/support-bundle/src/support_bundle.rs
@@ -81,7 +81,11 @@ async fn write_all<W>(
 where
     W: Write + Seek + Send,
 {
-    let file_options = FileOptions::default().compression_method(CompressionMethod::Deflated);
+    let file_options = FileOptions::default()
+        .compression_method(CompressionMethod::Deflated)
+        // NOTE: Without this option, uncompressed file sizes are
+        // limited to 4GB.
+        .large_file(true);
 
     // Get Check
     zip_writer


### PR DESCRIPTION
Readers will require ZIP64 support[^1].  Without this, generating a
support bundle for devices with large amounts of logs in the requested
time period will fail.

[^1]: https://docs.rs/zip/0.6.3/zip/write/struct.FileOptions.html#method.large_file

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  