### PR TITLE
Fix iotedge restart command with workload sockets (#6891)

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -1931,9 +1931,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7434af0dc1cbd59268aa98b4c22c131c0584d2232f6fb166efb993e2832e896a"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -2302,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb2e075f03b3d66d8d8785356224ba688d2906a371015e225beeb65ca92c740"
+checksum = "7e267c18a719545b481171952a79f8c25c80361463ba44bc7fa9eba7c742ef4f"
 dependencies = [
  "bytes",
  "futures-core",

--- a/edgelet/iotedge/src/client.rs
+++ b/edgelet/iotedge/src/client.rs
@@ -60,8 +60,22 @@ impl ModuleRuntime for MgmtClient {
     type Module = MgmtModule;
     type ModuleRegistry = Self;
 
-    async fn restart(&self, id: &str) -> anyhow::Result<()> {
-        let path = format!("/modules/{}/restart?api-version={}", id, API_VERSION);
+    async fn start(&self, id: &str) -> anyhow::Result<()> {
+        let path = format!("/modules/{}/start?api-version={}", id, API_VERSION);
+        let uri = self.get_uri(&path)?;
+
+        let request: HttpRequest<(), _> = HttpRequest::post(self.connector.clone(), &uri, None);
+
+        request
+            .no_content_response()
+            .await
+            .context(Error::ModuleRuntime)?;
+
+        Ok(())
+    }
+
+    async fn stop(&self, id: &str, _wait_before_kill: Option<Duration>) -> anyhow::Result<()> {
+        let path = format!("/modules/{}/stop?api-version={}", id, API_VERSION);
         let uri = self.get_uri(&path)?;
 
         let request: HttpRequest<(), _> = HttpRequest::post(self.connector.clone(), &uri, None);
@@ -146,10 +160,7 @@ impl ModuleRuntime for MgmtClient {
     async fn get(&self, _id: &str) -> anyhow::Result<(Self::Module, ModuleRuntimeState)> {
         unimplemented!()
     }
-    async fn start(&self, _id: &str) -> anyhow::Result<()> {
-        unimplemented!()
-    }
-    async fn stop(&self, _id: &str, _wait_before_kill: Option<Duration>) -> anyhow::Result<()> {
+    async fn restart(&self, _id: &str) -> anyhow::Result<()> {
         unimplemented!()
     }
     async fn remove(&self, _id: &str) -> anyhow::Result<()> {

--- a/edgelet/iotedge/src/restart.rs
+++ b/edgelet/iotedge/src/restart.rs
@@ -31,11 +31,24 @@ where
     W: Write + Send,
 {
     pub async fn execute(&self) -> anyhow::Result<()> {
-        let write = self.output.clone();
-        self.runtime.restart(&self.id).await?;
+        let mut output = String::new();
 
+        // A stop request must be sent to workload socket manager first.
+        // To properly restart, both the stop and start APIs must be called.
+        if let Err(err) = self.runtime.stop(&self.id, None).await {
+            output.push_str(&format!(
+                "warn: {} was not stopped gracefully: {}\n",
+                self.id, err
+            ));
+        }
+
+        self.runtime.start(&self.id).await?;
+        output.push_str(&format!("Restarted {}\n", self.id));
+
+        let write = self.output.clone();
         let mut w = write.lock().unwrap();
-        writeln!(w, "{}", self.id).context(Error::WriteToStdout)?;
+        write!(w, "{}", output).context(Error::WriteToStdout)?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
Fix the `iotedge restart` command so that it sends a stop request followed by a start request. This is necessary so that workload sockets are properly notified of the restart.