### PR TITLE
Fix running and expected running values in edgeAgent metrics

### DIFF
--- a/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/metrics/DeploymentMetrics.cs
+++ b/edge-agent/src/Microsoft.Azure.Devices.Edge.Agent.Core/metrics/DeploymentMetrics.cs
@@ -114,8 +114,8 @@ namespace Microsoft.Azure.Devices.Edge.Agent.Core.Metrics
 
             /* handle edgeAgent specially */
             this.edgeAgent.Value.AddPoint(true);
-            this.running.Set(this.edgeAgent.Value.ExpectedTime.TotalSeconds, new[] { this.edgeAgent.Value.Name, true.ToString() });
-            this.expectedRunning.Set(this.edgeAgent.Value.RunningTime.TotalSeconds, new[] { this.edgeAgent.Value.Name, true.ToString() });
+            this.expectedRunning.Set(this.edgeAgent.Value.ExpectedTime.TotalSeconds, new[] { this.edgeAgent.Value.Name, true.ToString() });
+            this.running.Set(this.edgeAgent.Value.RunningTime.TotalSeconds, new[] { this.edgeAgent.Value.Name, true.ToString() });
 
             /* Add points for all other modules found */
             foreach (Availability availability in this.availabilities)


### PR DESCRIPTION
edgeAgent metrics for expected and actual running were reversed


### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

