### PR TITLE
metrics-collector - split D2C messages greater than limit

### DIFF
--- a/edge-modules/metrics-collector/src/Constants.cs
+++ b/edge-modules/metrics-collector/src/Constants.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Azure.Devices.Edge.Azure.Monitor
         public const string DefaultLogAnalyticsWorkspaceDomainPrefixOds = ".ods.opinsights.";
         public const string DefaultLogAnalyticsWorkspaceDomainPrefixOms = ".oms.opinsights.";
         public const string ProductInfo = "IoTEdgeMetricsCollectorModule";
+        public static readonly int MaxMessageSize = 255000;
     }
 }


### PR DESCRIPTION
We currently use metrics-collector configured with environment variable `IoTMessage` to send metrics as D2C messages upstream to IoT Hub. The current version of metrics-collector does not split D2C messages, even if they are greater than the D2C message limit (256KB). This results in us currently getting a MessageTooLargeException when trying to scrape our custom modules in addition to edgeHub and edgeAgent.  This PR adds functionality to split D2C messages before sending upstream if messages are greater than limit.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [x] local testing done. 