### PR TITLE
Purge Cargo.lock files from Mariner vendor dir

### DIFF
--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -103,6 +103,7 @@ cargo vendor vendor
 # Purge Cargo.lock files from dependencies. These files are not necessary and will cause
 # Component Governance to incorrectly scan them for issues.
 find "$CARGO_HOME/registry/src/" -name "Cargo.lock" -exec echo "Deleting {}" \; -exec rm {} \;
+find "${BUILD_REPOSITORY_LOCALPATH}/vendor/" -name "Cargo.lock" -exec echo "Deleting {}" \; -exec rm {} \;
 
 # Configure Cargo to use vendored the deps
 mkdir .cargo


### PR DESCRIPTION
Cargo.lock files present in the vendor directory will cause Component Governance to incorrectly scan those dependencies. Remove these files to prevent this.