### PR TITLE
Fix Metrics Collector release

### DIFF
--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -347,7 +347,27 @@ stages:
         echo "Edge Agent image: $edgeAgentImage"
         echo "Edge Hub image: $edgeHubImage"
         echo "Metrics Collector image: $metricsCollectorImage"
-    
+
+        # Workaround a problem that cropped up recently when Docker changed its manifest format to support provenance
+        # attestation. Our arch-specific images used to be manifests but now they're manifest lists with two entries,
+        # one pointing to the arch-specific manifest and the other pointing to provenance data. Because of this change,
+        # when the host device tries to run the image, it attempts to match the host platform against the platform of
+        # the arch-specific manifest in the list. In the case of arm32v7 where we were running on arm64v8 hosts to avoid
+        # using raspberry pis in release pipelines, 'arm64/v8' != 'arm/v7' so the host device can't start the container.
+        # The workaround is to extract the pointer to the arch-specific manifest from the list (sha256 hash), and refer
+        # to that instead.
+        $sha = docker buildx imagetools inspect --format '{{json .Manifest}}' $metricsCollectorImage |
+          jq -r '
+            .manifests[] |
+            select(\"arm/v7\" == ([.platform | (.architecture, .variant // empty)] | join(\"/\"))) |
+            .digest
+          '
+        if ($sha)
+        {
+          $metricsCollectorImage = "$(registry.address)/microsoft/azureiotedge-metrics-collector@$sha"
+          echo "OVERRIDE Metrics Collector image: $metricsCollectorImage"
+        }
+
         $context = @{
           nestededge = 'false';
           isa95Tag = 'false';


### PR DESCRIPTION
This change works around a problem that is specific to some of our release pipelines, which, prior to publishing the images, test arm32v7 Docker images on arm64v8 hosts to avoid using Raspberry Pis.

The problem, which cropped up recently when Docker changed its manifest format to support provenance attestation, is this: our arch-specific Docker images used to be manifests but now they're manifest lists with two entries, one pointing to the arch-specific manifest and the other pointing to provenance data. Because of this change, when the test agent's Docker daemon pulls the image, it sees the manifest list and attempts to select the appropriate manifest by matching a platform in the list to the host platform. Since we're testing arm32v7 images on arm64v8 hosts, 'arm/v7' != 'arm64/v8' and the host device can't pull the image.

The workaround is to extract the pointer to the arch-specific manifest from the list (sha256 hash) and refer to that instead.

To test, I made similar logic changes in the end-to-end test pipeline and confirmed that it worked as desired.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.