### PR TITLE
Give Metrics Collector release task access to registry

### DIFF
--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -335,6 +335,14 @@ stages:
         http_proxy: $(Agent.ProxyUrl)
         https_proxy: $(Agent.ProxyUrl)
 
+    # Added for the `docker buildx imagetools inspect` command in the following pwsh task. If we ever remove the
+    # workaround then we can remove this as well.
+    - task: Docker@2
+      displayName: Docker login
+      inputs:
+        command: login
+        containerRegistry: $(service-connection.registry.release)
+
     - pwsh: |
         $caCertScriptPath = Convert-Path '$(Build.SourcesDirectory)/tools/CACertificates'
         $rootCaCertificatePath = Convert-Path '$(certsDir)/rsa_root_ca.cert.pem';


### PR DESCRIPTION
A recent change (2254c5e4d0dab7cadd9da066fe302410611aac7d) to a Metrics Collector release pipeline calls `docker buildx imagetools inspect` against an image in an internal Docker registry. The call fails because it can't access the registry. This update adds a Docker login task to give it access.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.