### PR TITLE
Use newer tooling to copy image between registries

### DIFF
--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -515,7 +515,6 @@ stages:
         do
           from="$(registry.address)/microsoft/azureiotedge-metrics-collector:$(version)-linux-$arch"
           to="$(registry.address)/public/azureiotedge-metrics-collector:$(version)-linux-$arch"
-          echo $"\n$from --> $to"
           scripts/linux/moveImage.sh --from "$from" --to "$to"
         done
       displayName: Publish Metrics Collector images

--- a/scripts/linux/moveImage.sh
+++ b/scripts/linux/moveImage.sh
@@ -5,12 +5,14 @@
 # It assumes that the caller is logged into both registries
 ###############################################################################
 
-set -e
+set -euo pipefail
 
 ###############################################################################
 # Define Environment Variables
 ###############################################################################
 SCRIPT_NAME=$(basename $0)
+FROM_IMAGE=
+TO_IMAGE=
 
 ###############################################################################
 # Print usage information pertaining to this script and exit
@@ -56,12 +58,12 @@ process_args()
         fi
     done
 
-    if [[ -z ${FROM_IMAGE} ]]; then
+    if [[ -z "$FROM_IMAGE" ]]; then
         echo "From image invalid"
         print_help_and_exit
     fi
 
-    if [[ -z ${TO_IMAGE} ]]; then
+    if [[ -z "$TO_IMAGE" ]]; then
         echo "To image invalid"
         print_help_and_exit
     fi
@@ -72,15 +74,5 @@ process_args()
 ###############################################################################
 process_args "$@"
 
-echo "Pulling $FROM_IMAGE"
-docker pull $FROM_IMAGE
-[ $? -eq 0 ] || exit $?
-
-echo "Tagging image: $TO_IMAGE"
-docker tag $FROM_IMAGE $TO_IMAGE
-[ $? -eq 0 ] || exit $?
-
-echo "Pushing image: $TO_IMAGE"
-docker push $TO_IMAGE
-[ $? -eq 0 ] || exit $?
-
+echo "Copy $FROM_IMAGE to $TO_IMAGE"
+docker buildx imagetools create --tag "$TO_IMAGE" "$FROM_IMAGE"


### PR DESCRIPTION
Our script to copy an image from one registry to another uses the push/tag/pull pattern, which works fine in simple scenarios. But with recent changes to the structure of our Docker images (specifically, our arch-specific images are now technically multi-arch images with a single architecture in them, because of the way Docker now embeds provenance attestation information in images), it is better to use newer tooling that seamlessly handles all the variations.

This change replaces the docker pull, tag, and push calls in moveImage.sh with a single call to `docker buildx imagetools create`.

To test, I ran the script locally on my machine and confirmed that an image was copied between two of our internal registries.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [X] local testing done.