### PR TITLE
Fix temp sensor tags in publish pipeline

### DIFF
--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -192,16 +192,14 @@ jobs:
 
             - bash: |
                 VERSION=$(cat $BUILD_SOURCESDIRECTORY/versionInfo.json | grep -oP '^\s*\"version\":\s*\"\K(?<version>\d*\.\d*\.\d*)')
-                TAGS=$(echo "${VERSION%.*}")
-
-                TAGS_STR=$(echo "['$TAGS']")
-                TEMP_SENSOR_TAGS_STR=$(echo "['$TAGS','latest']")
+                TAGS=$(echo "${VERSION%.*}" | jq -Rc '[.]')
+                TEMP_SENSOR_TAGS=$(echo $TAGS | jq -c '. + ["latest"]')
 
                 echo "Version: $VERSION"
-                echo "tags : $TAGS_STR"
+                echo "tags : $TAGS"
 
-                echo "##vso[task.setvariable variable=tags;]$TAGS_STR"
-                echo "##vso[task.setvariable variable=tempSensor.tags;]$TEMP_SENSOR_TAGS_STR"
+                echo "##vso[task.setvariable variable=tags;]$TAGS"
+                echo "##vso[task.setvariable variable=tempSensor.tags;]$TEMP_SENSOR_TAGS"
               displayName: Set Version and Tags
 
             - script: |


### PR DESCRIPTION
We recently updated buildManifest.sh to expect the --tags argument in proper JSON format (e.g., `["1.4", "latest"]`). Previously tags were in sorta-kinda JSON (e.g., `['1.4', 'latest']`, single quotes instead of double). When running the publish pipeline I discovered that it still sent the --tags arg to buildManifest.sh in the old format. This change updates the pipeline to use the new format.

I tested the script changes locally to ensure they produce the right value for the --tags argument.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [X] local testing done.