### PR TITLE
Iotedge Check: Timeout for aka.ms latest version http request

### DIFF
--- a/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
+++ b/edgelet/iotedge/src/check/checks/aziot_edged_version.rs
@@ -1,8 +1,12 @@
+use std::time::Duration;
+
 use anyhow::{anyhow, Context};
 use regex::Regex;
 
 use crate::check::{Check, CheckResult, Checker, CheckerMeta};
 use crate::error::{Error, FetchLatestVersionsReason};
+
+const AKA_MS_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[derive(Default, serde::Serialize)]
 pub(crate) struct AziotEdgedVersion {
@@ -53,12 +57,21 @@ impl AziotEdgedVersion {
                 req
             };
 
-            let res = client
-                .request(req)
-                .await
-                .context(Error::FetchLatestVersions(
-                    FetchLatestVersionsReason::GetResponse,
-                ))?;
+            let res = tokio::time::timeout(AKA_MS_HTTP_REQUEST_TIMEOUT, client.request(req)).await;
+            let res = match res {
+                Ok(Ok(res)) => res,
+                Ok(Err(e)) => {
+                    return Err(e).context(Error::FetchLatestVersions(
+                        FetchLatestVersionsReason::GetResponse,
+                    ));
+                }
+                Err(e) => {
+                    return Err(e).context(Error::FetchLatestVersions(
+                        FetchLatestVersionsReason::RequestTimeout,
+                    ));
+                }
+            };
+
             match res.status() {
                 status_code if status_code.is_redirection() => {
                     uri = res

--- a/edgelet/iotedge/src/error.rs
+++ b/edgelet/iotedge/src/error.rs
@@ -61,6 +61,7 @@ pub enum Error {
 
 #[derive(Clone, Copy, Debug)]
 pub enum FetchLatestVersionsReason {
+    RequestTimeout,
     CreateClient,
     GetResponse,
     InvalidOrMissingLocationHeader,
@@ -72,6 +73,7 @@ impl fmt::Display for FetchLatestVersionsReason {
         match self {
             FetchLatestVersionsReason::CreateClient => write!(f, "could not create HTTP client"),
             FetchLatestVersionsReason::GetResponse => write!(f, "could not send HTTP request"),
+            FetchLatestVersionsReason::RequestTimeout => write!(f, "HTTP request timed out"),
             FetchLatestVersionsReason::InvalidOrMissingLocationHeader => write!(
                 f,
                 "redirect response has invalid or missing location header"


### PR DESCRIPTION
Implement timeout feature for iotedge latest version check. Tested manually. Example of failure:
```
Configuration checks
--------------------
√ aziot-edged configuration is well-formed - OK
√ configuration up-to-date with config.toml - OK
√ container engine is installed and functional - OK
× configuration has correct URIs for daemon mgmt endpoint - Error
    Unable to find image 'mcr.microsoft.com/azureiotedge-diagnostics:1.4.920230303.5' locally
    docker: Error response from daemon: manifest for mcr.microsoft.com/azureiotedge-diagnostics:1.4.920230303.5 not found: manifest unknown: manifest tagged by "1.4.920230303.5" is not found.
    See 'docker run --help'.
× aziot-edge package is up-to-date - Error
    Error while fetching latest versions of edge components: HTTP request timed out
× container time is close to host time - Error
    Could not query local time inside container
```

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [x] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
