### PR TITLE
Patch vulnerabilities in Metrics Collector dependencies

### DIFF
--- a/edge-modules/metrics-collector/src/Microsoft.Azure.Devices.Edge.Azure.Monitor.csproj
+++ b/edge-modules/metrics-collector/src/Microsoft.Azure.Devices.Edge.Azure.Monitor.csproj
@@ -14,6 +14,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Devices.Client" Version="1.36.6" />
+    <!--
+      We have a transitive dependency on System.Net.Http via Microsoft.Azure.Devices.Client/1.36.6.
+      Use an explicit reference here to override the version and fix a vulnerability. See
+      https://github.com/advisories/GHSA-7jgj-8wvc-jh57.
+    -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="2.0.2" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="5.0.0" />
@@ -27,7 +33,13 @@
     <PackageReference Include="Portable.BouncyCastle" Version="1.8.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="SharpZipLib" Version="1.3.3" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.13.1" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.21.0" />
+    <!--
+      We have a transitive dependency on System.Drawing.Common via Microsoft.ApplicationInsights.WorkerService/2.21.0.
+      Use an explicit reference here to override the version and fix a vulnerability. See
+      https://github.com/advisories/GHSA-rxg9-xrhp-64gj.
+    -->
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This change patches the following vulnerabilities:
```
   [net6.0]:
   Transitive Package           Resolved   Severity   Advisory URL
   > System.Data.SqlClient      4.3.1      Moderate   https://github.com/advisories/GHSA-8g2p-5pqh-5jmc
   > System.Drawing.Common      4.7.0      Critical   https://github.com/advisories/GHSA-rxg9-xrhp-64gj
   > System.Net.Http            4.3.0      High       https://github.com/advisories/GHSA-7jgj-8wvc-jh57
   > System.Net.Security        4.3.0      Moderate   https://github.com/advisories/GHSA-ch6p-4jcm-h8vh
                                           High       https://github.com/advisories/GHSA-6xh7-4v2w-36q6
                                           High       https://github.com/advisories/GHSA-qhqf-ghgh-x2m4
                                           Moderate   https://github.com/advisories/GHSA-j8f4-2w4p-mhjc
```

To test, I did the following from a command line and confirmed no vulnerabilities were detected:
```sh
cd ~/iotedge/edge-modules/metrics-collector/src
dotnet nuget locals all --clear
dotnet build
dotnet list package --include-transitive --vulnerable
```

I also confirmed that unit tests, integration tests, and end-to-end tests all pass.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.