### PR TITLE
Connectivity Tests: Bump Support Bundle Retries

### DIFF
--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -307,7 +307,7 @@ function get_support_bundle_logs(){
 
     while [ "$RETRY_COUNT" -lt "$MAX_RETRIES" ] && [ "$DID_SUCCEED" = false ]; do
         DID_TIMEOUT=false
-        timeout 600 iotedge support-bundle -o $working_folder/support/iotedge_support_bundle.zip --since "$time" || DID_TIMEOUT=true
+        timeout 180 iotedge support-bundle -o $working_folder/support/iotedge_support_bundle.zip --since "$time" || DID_TIMEOUT=true
 
         if [ "$DID_TIMEOUT" = true ]; then
             RETRY_COUNT=$((RETRY_COUNT + 1))

--- a/scripts/linux/trcE2ETest.sh
+++ b/scripts/linux/trcE2ETest.sh
@@ -301,7 +301,7 @@ function get_support_bundle_logs(){
     mkdir -p $working_folder/support
     time=$(echo $test_start_time | sed 's/ /T/' | sed 's/$/Z/')
 
-    MAX_RETRIES=4
+    MAX_RETRIES=10
     RETRY_COUNT=0
     DID_SUCCEED=false
 


### PR DESCRIPTION
Weirdly, we see a run where support bundle retries are exhausted. Bumping the retries to 10.


## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
