### PR TITLE
Fix test JSON and RHEL package build

### DIFF
--- a/builds/e2e/templates/nested-create-identity.yaml
+++ b/builds/e2e/templates/nested-create-identity.yaml
@@ -11,7 +11,7 @@ steps:
     inputs:
       targetType: inline
       script: |
-        set -e
+        set -ex
 
         echo "Extracting hub name from connection string"
         #extract full hub name

--- a/builds/e2e/templates/nested-create-identity.yaml
+++ b/builds/e2e/templates/nested-create-identity.yaml
@@ -11,7 +11,7 @@ steps:
     inputs:
       targetType: inline
       script: |
-        set -ex
+        set -e
 
         echo "Extracting hub name from connection string"
         #extract full hub name

--- a/e2e_deployment_files/nestededge_isa95_smoke_test_BaseDeployment.json
+++ b/e2e_deployment_files/nestededge_isa95_smoke_test_BaseDeployment.json
@@ -17,8 +17,10 @@
               "image": "$upstream:443/microsoft/azureiotedge-agent:<Build.BuildNumber>-linux-<Architecture>",
               "createOptions": "{\"HostConfig\":{\"LogConfig\":{\"Type\":\"json-file\",\"Config\":{\"max-size\":\"4m\",\"max-file\":\"7\",\"compress\":\"true\"}}}}"
             },
-            "https_proxy": {
-              "value": "<proxyAddress>"
+            "env": {
+              "https_proxy": {
+                "value": "<proxyAddress>"
+              }
             }
           },
           "edgeHub": {

--- a/edgelet/build/linux/package.sh
+++ b/edgelet/build/linux/package.sh
@@ -142,7 +142,7 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
                 git make rpm-build \
                 gcc gcc-c++ \
                 libcurl-devel libuuid-devel openssl-devel &&
-            git config --global --add safe.directory '*'
+            git config --global --add safe.directory \'*\'
         '
         ;;
 

--- a/edgelet/build/linux/package.sh
+++ b/edgelet/build/linux/package.sh
@@ -142,6 +142,7 @@ case "$PACKAGE_OS.$PACKAGE_ARCH" in
                 git make rpm-build \
                 gcc gcc-c++ \
                 libcurl-devel libuuid-devel openssl-devel &&
+            git config --global --add safe.directory '*'
         '
         ;;
 


### PR DESCRIPTION
The JSON config we deploy in our ISA95 pipeline has an invalid entry--Edge agent's `https_proxy` environment variable should be embedded inside an `env` object, but it isn't. I recently upgraded the azure-iot extension to Azure CLI on one of the test agents, and newer versions of the extension validate the JSON config before sending it to IoT Hub, so the tests started failing. To test, I confirmed that the ISA95 smoke test pipeline passes with this change.

This also fixes a problem that cropped up yesterday in our RHEL 9 packages builds. We build inside an RHEL 9 container, and git received a major update in the container's backing image which caused a `git archive` call to fail because the container's user (uid 0) is different from the mounted source folder's owner (uid 1000). I added a git config update that skips the folder ownership check and allows the build to continue. To test, I confirmed that the CI Build pipeline now builds RHEL 9 packages.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.