### PR TITLE
Support new image structure in auto-detect pipeline

### DIFF
--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -36,58 +36,90 @@ steps:
     set -euo pipefail
 
     branch="${BUILD_SOURCEBRANCH#refs/heads/}"
+    echo "Filtering product-versions.json for images on branch '$branch'"
 
     # transform product-versions.json into a list of images for each product in this branch
     images_json=$(cat product-versions.json | jq --arg registry "$REGISTRY" --arg branch "$branch" '
-      def is_image: has("type") and .type == "dockerImage";
-      def platforms: .componentTypes[] | select(.name == "dockerImage") | .platforms[] | { os, arch: .arch[] | . };
       [
-        .channels[] | .products[] | select(
-          .components | any(is_image and .repo == "Azure/iotedge" and .branch == $branch)
-        ) | {
+        .channels[] | .products[] | {
           product: .id, version, images: [
-            platforms as $platforms | .components[] | select(is_image) | . as { $name, $version } | $platforms
-              | @text "\($registry)/\($name):\($version)-\(.os)-\(.arch)"
-          ] | sort
+            .components[]
+              | select(has("type") and .type == "dockerImage" and .repo == "Azure/iotedge" and .branch == $branch)
+              | "\($registry)/\(.name):\(.version)"
+          ]
         }
-      ] | unique
+      ] | unique | map(select(.images | length != 0))
     ')
+
+    # $images_json contains something like:
+    # [
+    #   {
+    #     "product": "aziot-edge",
+    #     "version": "1.4.9",
+    #     "images": [
+    #       "mcr.microsoft.com/azureiotedge-agent:1.4.9",
+    #       "mcr.microsoft.com/azureiotedge-hub:1.4.9",
+    #       "mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.4.9",
+    #       "mcr.microsoft.com/azureiotedge-diagnostics:1.4.9"
+    #     ]
+    #   },
+    #   {
+    #     "product": "api-proxy",
+    #     "version": "1.1.3",
+    #     "images": [
+    #       "mcr.microsoft.com/azureiotedge-api-proxy:1.1.3"
+    #     ]
+    #   }
+    # ]
+
+    images=( $(echo "$images_json" | jq -r '[ .[].images ] | flatten | join("\n")') )
+    echo "Found ${#images[@]} images"
+
+    # $images contains something like:
+    # mcr.microsoft.com/azureiotedge-agent:1.4.9
+    # mcr.microsoft.com/azureiotedge-hub:1.4.9
+    # mcr.microsoft.com/azureiotedge-simulated-temperature-sensor:1.4.9
+    # mcr.microsoft.com/azureiotedge-diagnostics:1.4.9
+    # mcr.microsoft.com/azureiotedge-api-proxy:1.1.3
 
     # use build metadata present in each published image to determine if it is out of date
     remove=( )
-    images=( $(echo "$images_json" | jq -r '[ .[].images ] | flatten | join("\n")') )
     for image in ${images[@]}
     do
       echo "image: $image"
 
-      # This command assumes that the $image has a manifest, not a manifest list.
-      # In other words, $image is _not_ a multi-arch image.
-      read base_image current_digest <<< $(\
-        docker buildx imagetools inspect $image --format "{{json .BuildInfo}}" |
-        jq -r '@text "\(.sources[0].ref) \(.sources[0].pin)"'
-      )
+      # This command assumes that $image is a manifest list, i.e., a mutli-platform image.
+      base_images=( $(
+        docker buildx imagetools inspect --format "{{json .Provenance}}" $image | jq -r '
+          . as $doc | [
+            keys[] | $doc[.] | [
+              .SLSA // halt | .materials[] | select(.uri | startswith("pkg:docker/docker/dockerfile") | not)
+            ] | if length == 1 then first else (
+              "Error: inspect command found more than one base image in provenance materials\n\(.)" | halt_error
+            ) end | "\(.uri | sub("pkg:docker/(?<i>.+)@(?<t>.+)\\?.+"; "\(.i):\(.t)")),sha256:\(.digest.sha256)"
+          ] | unique | .[]
+        '
+      ) )
 
-      if [ "$base_image" == 'null' ]
-      then
-        echo "'$image' does not contain Docker BuildInfo metadata. Skipping..."
-        remove+=( "$image" )
-        continue
-      fi
+      # $base_images contains entries in the form of:
+      # mcr.microsoft.com/dotnet/runtime@6.0-alpine,sha256:b7a9b8fbdb096327a1e05cda40d40afbec54b96e1a6a1bb7577e67344f9d99e4
 
-      latest_digest="sha256:$(docker buildx imagetools inspect --raw $base_image | shasum --algorithm 256 | awk '{print$1}')"
+      for base_info in ${base_images[@]}; do
+        IFS=',' read base_image current_digest <<< "$base_info"
+        latest_digest="$(docker buildx imagetools inspect $base_image --format '{{json .Manifest}}' | jq -r '.digest')"
 
-      echo -e "  base:\t\t$base_image\n  current:\t$current_digest\n  latest:\t$latest_digest"
-
-      if [ "$current_digest" != 'null' ] && [ "$current_digest" != "$latest_digest" ]
-      then
-        echo "  ## NEEDS UPDATE ##"
-      else
-        remove+=( "$image" )
-      fi
+        echo -e "  base:\t\t$base_image\n  current:\t$current_digest\n  latest:\t$latest_digest"
+        if [ -n "$current_digest" ] && [ "$current_digest" != "$latest_digest" ]
+        then
+          echo "  ## NEEDS UPDATE ##"
+        else
+          remove+=( "$image" )
+        fi
+      done
     done
 
     # filter up-to-date images out of the list
-    remove_json=$(printf '%s\n' "${remove[@]}" | jq -R '.' | jq -s '.')
+    remove_json=$(printf '%s\n' "${remove[@]}" | jq -R '.' | jq -s '. | unique')
     images_json=$(echo "$images_json" | jq --argjson remove "$remove_json" '
       [ .[] | { product, version, images: (.images - $remove) } | select(.images | length != 0) ]
     ')

--- a/builds/release/refresh-core-images.yaml
+++ b/builds/release/refresh-core-images.yaml
@@ -73,16 +73,15 @@ stages:
         # 'dotnet/aspnet' and some are 'dotnet/runtime'. If this pipeline happens to run, e.g.,
         # after dotnet/runtime gets updated but before dotnet/aspnet gets updated, then we'll end up
         # releasing twice in quick succession. To mitigate this problem, we'll wait until *all* the
-        # images/architectures we build in this pipeline are flagged for update.
+        # images we build in this pipeline are flagged for update.
         continue=$(jq \
           --arg p "$product" \
           --arg cv "$prev_core_version" \
           --arg dv "$prev_diag_version" \
           --argjson cn '["agent","hub","simulated-temperature-sensor"]' \
-          --argjson dn '["diagnostics"]' \
-          --argjson an '["amd64","arm32v7","arm64v8"]' '
+          --argjson dn '["diagnostics"]' '
             def filter: [
-              "mcr.microsoft.com/azureiotedge-\("\($cn[]):\($cv)", "\($dn[]):\($dv)")-linux-\($an[])"
+              "mcr.microsoft.com/azureiotedge-\("\($cn[]):\($cv)", "\($dn[]):\($dv)")"
             ];
             [ .[] | select(.product == $p and .version == $cv) | .images[] ] | contains(filter)
           ' $(Pipeline.Workspace)/detect-image-updates/image-updates/updates.json


### PR DESCRIPTION
Cherry-pick a0f89a381d025cdaa38ff02ff495208d1ba50674.

To test, I ran the auto-detect pipeline and core images auto-refresh pipeline in a test environment and confirmed they behave as expected. I didn't go as far as forcing an image update; the auto-detect pipeline simply ran through the logic and determined there were no images to update. The core images auto-refesh pipeline was triggered as expected and quit when it determined there was no work to be done. This scenario required the least effort and tested most of the changes. Via inspection, I have reasonable confidence in the remaining changes. I also tested all of the jq statements in isolation, to ensure they parse and/or generate the expected JSON.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.