### PR TITLE
Fix core refresh pipeline

### DIFF
--- a/builds/release/templates/publish-core-images.yaml
+++ b/builds/release/templates/publish-core-images.yaml
@@ -79,6 +79,10 @@ jobs:
       #!/bin/bash
       set -euo pipefail
 
+      # in case commits were made after this pipeline started but before we arrived here, sync to
+      # the tip of the branch
+      git checkout "$PRODUCT_REPO_BRANCH"
+
       # update product-versions.json
       echo "$(jq '
         def product: .channels[] | .products[] | select(
@@ -97,6 +101,16 @@ jobs:
           | (product).version |= "${{ parameters['version.core'] }}"
       ' product-versions.json )" > product-versions.json
       git add product-versions.json
+
+      # determine whether this is an LTS release, and save that info for later
+      is_lts="$(jq '
+        [
+          .channels[] | .products[] | select(
+            .id=="aziot-edge" and .version=="${{ parameters['version.core'] }}"
+          ) | .name | contains("LTS")
+        ] | any
+      ' product-versions.json)"
+      echo "##vso[task.setvariable variable=is_lts]$is_lts"
 
       # configure git
       git config user.email '$(service-account.email)'
@@ -130,10 +144,11 @@ jobs:
       echo "##vso[task.setvariable variable=release_url]$RELEASE_URL"
     displayName: Create GitHub release page in product repo
     env:
+      BRANCH: main
       CORE_VERSION: ${{ parameters['version.core'] }}
       DIAG_VERSION: ${{ parameters['version.diagnostics'] }}
       GITHUB_TOKEN: $(TestGitHubAccessToken)
-      BRANCH: main
+      IS_LTS: $(is_lts)
       REPO_NAME: $(repo.product.name)
     workingDirectory: iotedge
 
@@ -149,6 +164,7 @@ jobs:
     env:
       CORE_VERSION: ${{ parameters['version.core'] }} 
       GITHUB_TOKEN: $(TestGitHubAccessToken)
+      IS_LTS: $(is_lts)
       RELEASE_URL: $(release_url)
       REPO_NAME: $(repo.project.name)
     workingDirectory: iotedge


### PR DESCRIPTION
We currently have two auto-refresh pipelines
- Core images (edgeAgent, edgeHub, tempSensor, diagnostics) operates out of the release/1.4 branch
- Metrics collector operates out of main

Because of this separation, the two pipelines are able to operate independently, with one exception: they both need to update `product-versions.json` in the Azure/azure-iotedge repo.

Both pipelines were triggered yesterday at roughly the same time due to an update in the .NET Alpine base images. The metrics collector pipeline updated `product-versions.json` first, so by the time the core images pipeline tried to update it, it was no longer updating the head commit and the push failed to merge.

This change fixes the problem by syncing the latest changes before updating the JSON file. I suppose we could also add some retry logic in case a commit goes in during the brief period that the task is running, but that's very unlikely.

I also fixed a minor bug where the GitHub release pages should have "LTS" in the title but didn't.

To test, I ran the isolated changes in a local bash shell to ensure they work as expected. I didn't take the time to set up a full test environment. Worst case scenario is that the release pipeline will fail (like it already did last night), and the few remaining steps would need to be completed manually.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.