### PR TITLE
Enable CodeQL in Build CI pipeline

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -17,12 +17,6 @@ schedules:
     include:
     - release/1.4
   always: true
-- cron: "0 0 * * 2"
-  displayName: Weekly run release/1.1
-  branches:
-    include:
-    - release/1.1
-  always: true
 
 variables:
   DisableDockerDetector: true

--- a/builds/misc/ci-build.yaml
+++ b/builds/misc/ci-build.yaml
@@ -6,7 +6,7 @@ trigger:
       - release/*
 pr: none
 
-// Build every Monday @ 8AM PDT so that the latest build is never more than a week old.
+# Build every Monday @ 8AM PDT so that the latest build is never more than a week old.
 schedules:
 - cron: "0 15 * * 1"
   displayName: Weekly build Monday morning

--- a/builds/misc/ci-build.yaml
+++ b/builds/misc/ci-build.yaml
@@ -6,6 +6,16 @@ trigger:
       - release/*
 pr: none
 
+// Build every Monday @ 8AM PDT so that the latest build is never more than a week old.
+schedules:
+- cron: "0 15 * * 1"
+  displayName: Weekly build Monday morning
+  branches:
+    include:
+    - main
+    - release/1.4
+  always: true
+
 variables:
   DisableDockerDetector: true
 

--- a/builds/misc/templates/build-images.yaml
+++ b/builds/misc/templates/build-images.yaml
@@ -54,6 +54,8 @@ stages:
     jobs:
     - job: BuildDotnetComponents
       displayName: Build Dotnet Components
+      variables:
+        Codeql.Enabled: true
       steps:
       - script: scripts/linux/buildBranch.sh -c $(Build.Configuration) --no-rocksdb-bin
         name: build


### PR DESCRIPTION
Per Microsoft policy, we need to run CodeQL static analysis regularly in our builds. It will run automatically in main if we simply set a variable on the job where the actual build occurs. This change does that. It also sets up a weekly scheduled run, in part to make sure that CodeQL runs on a regular basis. Note this PR sets up the schedule for main and release/1.4 branches, but it will need to be cherry-picked to the release/1.4 branch for the schedule to take effect there.

I also made an unrelated change: I removed the release/1.1 branch from the connectivity pipeline's weekly schedule, as that version of the product has been out of support for six months.

To test, I ran the Build CI pipeline against this PR and confirmed that it passes. CodeQL will run when it gets merged to main.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.