### PR TITLE
Remove schedule trigger from connectivity pipeline

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -16,12 +16,6 @@ schedules:
     include:
     - release/1.4
   always: true
-- cron: "0 0 * * 2"
-  displayName: Weekly run release/1.1
-  branches:
-    include:
-    - release/1.1
-  always: true
 
 variables:
   DisableDockerDetector: true


### PR DESCRIPTION
Support ended for the release/1.1 branch in December 2022. I'm removing the schedule trigger from the connectivity pipeline's YAML so it won't run anymore.