### PR TITLE
Enable 1ES-hosted Ubuntu 22.04 amd64 agent

### DIFF
--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -195,8 +195,9 @@ jobs:
     displayName: Ubuntu 22.04 on amd64
 
     pool:
-      name: $(pool.custom.name)
-      demands: ubu2204-e2e-tests
+      name: $(pool.linux.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
 
     variables:
       os: linux
@@ -218,9 +219,11 @@ jobs:
   - job: ubuntu_2204_arm64v8
 ################################################################################
     displayName: Ubuntu 22.04 on arm64v8
+
     pool:
-      name: $(pool.custom.name)
-      demands: ubu2204-arm64-e2e-tests
+      name: $(pool.linux.arm.name)
+      demands:
+      - ImageOverride -equals agent-aziotedge-ubuntu-22.04-arm64-msmoby
 
     variables:
       os: linux

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -205,7 +205,6 @@ jobs:
       artifactName: iotedged-ubuntu22.04-amd64
       identityServiceArtifactName: packages_ubuntu-22.04_amd64
       identityServicePackageFilter: aziot-identity-service_*_amd64.deb
-      verbose: true
 
     timeoutInMinutes: 90
 
@@ -231,7 +230,6 @@ jobs:
       artifactName: iotedged-ubuntu22.04-aarch64
       identityServiceArtifactName: packages_ubuntu-22.04_aarch64
       identityServicePackageFilter: aziot-identity-service_*_arm64.deb
-      verbose: true
 
     timeoutInMinutes: 90
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -220,9 +220,8 @@ jobs:
     displayName: Ubuntu 22.04 on arm64v8
 
     pool:
-      name: $(pool.linux.arm.name)
-      demands:
-      - ImageOverride -equals agent-aziotedge-ubuntu-22.04-arm64-msmoby
+      name: $(pool.custom.name)
+      demands: ubu2204-arm64-e2e-tests
 
     variables:
       os: linux


### PR DESCRIPTION
We tried to enable 1ES-hosted Ubuntu 22.04 agents (amd64 and arm64) in the end-to-end test pipeline a few months back, but we had to revert to custom agents because 1ES support for Ubuntu 22.04 wasn't quite there yet. Problems with amd64 have been resolved, so this change reintroduces the Ubuntu 22.04 amd64 1ES-hosted agent to the pipeline. This will allow us to decommision the corresponding custom agent and shed the associated overhead. Ubuntu 22.04 arm64 is still not ready, so we'll continue to use a custom agent there.

To test, I verified that the end-to-end test pipeline successfully uses a 1ES-hosted Ubuntu 22.04 amd64 agent.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.