### PR TITLE
Remove Java header comment

### DIFF
--- a/edge-util/src/es6numberserializer/NumberFastDToABuilder.cs
+++ b/edge-util/src/es6numberserializer/NumberFastDToABuilder.cs
@@ -1,5 +1,4 @@
-/* -*- Mode: java; tab-width: 8; indent-tabs-mode: nil; c-basic-offset: 4 -*-
- *
+/*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */


### PR DESCRIPTION
The CodeQL analayzer for our GitHub repo is detecting one of our C# files (edge-util/src/es6numberserializer/NumberFastDToABuilder.cs) as Java because a comment in the file's header overrides the heuristic. This change removes the comment so that the file is correctly identified as C#.

To test, I ran the [github-linguist](https://github.com/github-linguist/linguist) tool locally (this is the tool CodeQL uses) and confirmed that, with this change, no Java files are detected.

BEFORE:
```bash
azureuser@damonb-amd64-1-vm:~/iotedge$ github-linguist
74.23%  9531426    C#
21.50%  2761148    Rust
3.58%   459096     Shell
0.37%   47878      PowerShell
0.12%   15563      Dockerfile
0.11%   13615      Makefile
0.04%   5689       ANTLR
0.03%   4142       Java
0.02%   2536       Roff
```
AFTER:
```bash
~/iotedge$ github-linguist
74.26%  9535490    C#
21.50%  2761148    Rust
3.58%   459096     Shell
0.37%   47878      PowerShell
0.12%   15563      Dockerfile
0.11%   13615      Makefile
0.04%   5689       ANTLR
0.02%   2536       Roff
```

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.