### PR TITLE
Update iotedge tool for prefer_module_identity_cache

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,9 +19,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
+checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
 dependencies = [
  "memchr",
 ]
@@ -73,9 +82,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+checksum = "c677ab05e09154296dd37acecd46420c17b9713e8366facafa8fc0885167cf4c"
 dependencies = [
  "anstyle",
  "windows-sys",
@@ -83,19 +92,19 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "8c6f84b74db2535ebae81eede2f39b947dcbf01d093ae5f791e5dd414a1bf289"
 
 [[package]]
 name = "async-trait"
-version = "0.1.68"
+version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -118,7 +127,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -131,7 +140,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -140,7 +149,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -183,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -197,7 +206,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -208,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -221,7 +230,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -236,7 +245,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -251,7 +260,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -264,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "serde",
 ]
@@ -272,7 +281,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -282,7 +291,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -300,7 +309,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "http-common",
  "libc",
@@ -310,7 +319,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "pkcs11",
  "serde",
@@ -320,7 +329,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "http-common",
  "serde",
@@ -329,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -349,6 +358,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,6 +389,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "block-buffer"
@@ -405,14 +435,17 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "async-trait",
  "chrono",
@@ -453,31 +486,30 @@ dependencies = [
 
 [[package]]
 name = "chrono-humanize"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32dce1ea1988dbdf9f9815ff11425828523bd2a134ec0805d2ac8af26ee6096e"
+checksum = "799627e6b4d27827a814e837b9d8a504832086081806d45b1afa34dc982b023b"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "clap"
-version = "4.3.8"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
+checksum = "c27cdf28c0f604ba3f512b0c9a409f8de8513e4816705deb0498b627e7c3a3fd"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.3.8"
+version = "4.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
+checksum = "08a9f1ab5e9f01a9b81f202e8562eb9a10de70abf9eaeac1be465c28b75aa4aa"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "once_cell",
  "strsim",
@@ -511,7 +543,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "serde",
  "toml",
@@ -525,9 +557,9 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e69e28e9f7f77debdedbaafa2866e1de9ba56df55a8bd7cfc724c25a09987c"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -596,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0558d22a7b463ed0241e993f76f09f30b126687447751a8638587b864e4b3944"
+checksum = "0209d94da627ab5605dcccf08bb18afa5009cfbef48d8a8b7d7bdbc79be25c5e"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -606,40 +638,49 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab8bfa2e259f8ee1ce5e97824a3c55ec4404a0d772ca7fa96bf19f0752a046eb"
+checksum = "177e3443818124b357d8e76f53be906d60937f0d3a90773a664fa63fa253e621"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.1"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29a358ff9f12ec09c3e61fef9b5a9902623a695a46a917b07f269bff1445611a"
+checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.4.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
+checksum = "6943ae99c34386c84a470c499d3414f66502a41340aa895406e0d2e4a207b91d"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -867,9 +908,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "env_logger"
@@ -886,24 +927,24 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bffebc5d80432c9b140ee17875ff173a8ab62faad5b257da912bd2f6c1c0a1"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2b0c2380453a92ea8b6c8e5f64ecaafccddde8ceab55ff7a8ac1029f894569"
+checksum = "da96524cc884f6558f1769b6c46686af2fe8e8b4cd253bd5a3cdba8181b8e070"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -922,9 +963,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "c6c98ee8095e9d1dcbf2fcc6d95acccb90d1c81db1e44725c6a984b1dbdfb010"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1016,7 +1057,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1071,6 +1112,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
 name = "h2"
 version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,7 +1155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -1137,18 +1184,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hex"
@@ -1181,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -1213,9 +1251,9 @@ checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
 name = "httpdate"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
@@ -1250,7 +1288,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.4.9",
  "tokio",
  "tower-service",
  "tracing",
@@ -1353,17 +1391,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "iotedge"
 version = "0.1.0"
 dependencies = [
@@ -1416,21 +1443,20 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.1",
- "io-lifetimes",
+ "hermit-abi 0.3.2",
  "rustix",
  "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
@@ -1470,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.8"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
@@ -1486,14 +1512,14 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.19"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
+checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "env_logger",
  "log",
@@ -1561,7 +1587,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
@@ -1590,21 +1616,30 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
+checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.2.6",
+ "hermit-abi 0.3.2",
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1615,11 +1650,11 @@ checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.55"
+version = "0.10.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
+checksum = "729b745ad4a5575dd06a3e1af1414bd330ee561c01b3899eb584baeaa8def17e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "foreign-types",
  "libc",
@@ -1631,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "cc",
 ]
@@ -1655,14 +1690,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.90"
+version = "0.9.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
+checksum = "866b5f16f90776b9bb8dc1e1802ac6f0513de3a7a7465867bfbc563dc737faac"
 dependencies = [
  "cc",
  "libc",
@@ -1673,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1682,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1729,9 +1764,9 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
 
 [[package]]
 name = "pin-utils"
@@ -1742,7 +1777,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1759,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 
 [[package]]
 name = "pkg-config"
@@ -1799,18 +1834,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.63"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.28"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ab9c7eadfd8df19006f1cf1a4aed13540ed5cbc047010ece5826e10825488"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -1873,14 +1908,26 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.8.4"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
+checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1889,19 +1936,24 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
 name = "rustix"
-version = "0.37.20"
+version = "0.38.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
+checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
 dependencies = [
- "bitflags",
+ "bitflags 2.4.0",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys",
@@ -1909,41 +1961,41 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.164"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.164"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.99"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
+checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
 dependencies = [
  "itoa",
  "ryu",
@@ -1972,7 +2024,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with_macros",
- "time 0.3.22",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -1984,7 +2036,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2054,9 +2106,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
@@ -2066,6 +2118,16 @@ checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -2108,9 +2170,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.22"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2efbeae7acf4eabd6bcdcbd11c92f45231ddda7539edc7806bd1a04a03b24616"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2175,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#33825efda701ae451cf6bb5e0f8b92f924c42acd"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",
@@ -2193,22 +2255,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+checksum = "d9207952ae1a003f42d3d5e892dac3c6ba42aa6ac0c79a6a91a2b5cb4253e75c"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.40"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+checksum = "f1728216d3244de4f14f14f8c15c79be1a7c67867d28d69b719690e2a19fb445"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2224,10 +2286,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "itoa",
  "serde",
  "time-core",
@@ -2242,9 +2305,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -2266,11 +2329,11 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.28.2"
+version = "1.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7b1cfd2aa4011f2de74c2c4c63665e27a71006b0a192dcd2710272e73dfa2"
+checksum = "40de3a2ba249dcb097e01be5e67a5ff53cf250397715a071a81543e8a832a920"
 dependencies = [
- "autocfg",
+ "backtrace",
  "bytes",
  "libc",
  "mio",
@@ -2278,7 +2341,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.3",
  "tokio-macros",
  "windows-sys",
 ]
@@ -2291,7 +2354,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2322,9 +2385,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.5"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebafdf5ad1220cb59e7d17cf4d2c72015297b75b19a10472f99b89225089240"
+checksum = "c17e963a819c331dcacd7ab957d80bc2b9a9c1e71c804826d2f283dd65306542"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2343,9 +2406,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.11"
+version = "0.19.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266f016b7f039eec8a1a80dfe6156b633d208b9fccca5e4db1d6775b0c4e34a7"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
  "indexmap 2.0.0",
  "serde",
@@ -2387,7 +2450,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2419,9 +2482,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -2516,7 +2579,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -2538,7 +2601,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.22",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -2600,9 +2663,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "d1eeca1c172a285ee6c2c84c341ccea837e7c01b12fbb2d0fe3c9e550ce49ec8"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -2615,51 +2678,51 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "b10d0c968ba7f6166195e13d593af609ec2e3d24f916f081690695cf5eaffb2f"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "571d8d4e62f26d4932099a9efe89660e8bd5087775a2ab5cdd8b747b811f1058"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "2229ad223e178db5fbbc8bd8d3835e51e566b8474bfca58d2e6150c48bb723cd"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "600956e2d840c194eedfc5d18f8242bc2e17c7775b6684488af3a9fff6fe3287"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "ea99ff3f8b49fb7a8e0d305e5aec485bd068c2ba691b6e277d29eaeac945868a"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "8f1a05a1ece9a7a0d5a7ccf30ba2c33e3a61a30e042ffd247567d1de1d94120d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "d419259aba16b663966e29e6d7c6ecfa0bb8425818bb96f6f1f3c3eb71a6e7b9"
 
 [[package]]
 name = "winnow"
-version = "0.4.7"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca0ace3845f0d96209f0375e6d367e3eb87eb65d27d445bdc9f1843a26f39448"
+checksum = "83817bbecf72c73bad717ee86820ebf286203d2e04c3951f3cd538869c897364"
 dependencies = [
  "memchr",
 ]

--- a/edgelet/contrib/config/linux/template.toml
+++ b/edgelet/contrib/config/linux/template.toml
@@ -44,6 +44,20 @@
 # allow_elevated_docker_permissions = false
 
 # ==============================================================================
+# Module identity cache preference
+# ==============================================================================
+#
+# The default behavior is to request module identities from IoT Hub and fall back to a
+# cached backup if the Hub request fails. This keeps identities in sync with IoT Hub,
+# but results in extra requests to Hub that may not be necessary depending on use case.
+#
+# Setting prefer_module_identity_cache to true reverses the behavior so that the cached
+# identities are preferred to IoT Hub requests. Requests to Hub are still made if identities
+# are not found in the cache.
+#
+# prefer_module_identity_cache = false
+
+# ==============================================================================
 # Provisioning
 # ==============================================================================
 

--- a/edgelet/iotedge/src/config/import/mod.rs
+++ b/edgelet/iotedge/src/config/import/mod.rs
@@ -388,6 +388,8 @@ fn execute_inner(
 
             aziot_max_requests: Default::default(),
 
+            prefer_module_identity_cache: Default::default(),
+
             aziot_keys: Default::default(),
 
             preloaded_keys: Default::default(),

--- a/edgelet/iotedge/src/config/mp.rs
+++ b/edgelet/iotedge/src/config/mp.rs
@@ -72,6 +72,8 @@ To reconfigure IoT Edge, run:
 
             aziot_max_requests: Default::default(),
 
+            prefer_module_identity_cache: Default::default(),
+
             aziot_keys: Default::default(),
 
             preloaded_keys: Default::default(),

--- a/edgelet/iotedge/test-files/config/ca-certs-est/identityd.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs-est/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/ca-certs-local-ca/identityd.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs-local-ca/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/ca-certs/identityd.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/ca-certs/super-config.toml
+++ b/edgelet/iotedge/test-files/config/ca-certs/super-config.toml
@@ -1,6 +1,7 @@
 trust_bundle_cert = "file:///var/secrets/trusted-ca.pem"
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/ca-quickstart-custom/identityd.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart-custom/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/ca-quickstart/identityd.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/ca-quickstart/super-config.toml
+++ b/edgelet/iotedge/test-files/config/ca-quickstart/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/identityd.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/complex-agent-spec/super-config.toml
+++ b/edgelet/iotedge/test-files/config/complex-agent-spec/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/identityd.toml
+++ b/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/super-config.toml
+++ b/edgelet/iotedge/test-files/config/dps-no-reprovisioning-flags/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key-no-pad/identityd.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key-no-pad/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key-no-pad/super-config.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key-no-pad/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "Dynamic"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/identityd.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-symmetric-key/super-config.toml
+++ b/edgelet/iotedge/test-files/config/dps-symmetric-key/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "Dynamic"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-tpm/identityd.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-tpm/super-config.toml
+++ b/edgelet/iotedge/test-files/config/dps-tpm/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "Dynamic"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-x509/identityd.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/dps-x509/super-config.toml
+++ b/edgelet/iotedge/test-files/config/dps-x509/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "Dynamic"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "dps"

--- a/edgelet/iotedge/test-files/config/imported-master-encryption-key/identityd.toml
+++ b/edgelet/iotedge/test-files/config/imported-master-encryption-key/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/imported-master-encryption-key/super-config.toml
+++ b/edgelet/iotedge/test-files/config/imported-master-encryption-key/super-config.toml
@@ -1,6 +1,7 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 imported_master_encryption_key = "/tmp/master-encryption-key"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/identityd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/manual-connection-string-2/super-config.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-2/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/manual-connection-string-no-pad/identityd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string-no-pad/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/manual-connection-string/identityd.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/manual-connection-string/super-config.toml
+++ b/edgelet/iotedge/test-files/config/manual-connection-string/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/manual-x509/identityd.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/manual-x509/super-config.toml
+++ b/edgelet/iotedge/test-files/config/manual-x509/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "Dynamic"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/moby-runtime-network-2/identityd.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-network-2/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/moby-runtime-network-2/super-config.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-network-2/super-config.toml
@@ -1,6 +1,7 @@
 trust_bundle_cert = "file:///var/secrets/trusted-ca.pem"
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/moby-runtime-network/identityd.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-network/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/moby-runtime-network/super-config.toml
+++ b/edgelet/iotedge/test-files/config/moby-runtime-network/super-config.toml
@@ -1,6 +1,7 @@
 trust_bundle_cert = "file:///var/secrets/trusted-ca.pem"
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/nested-edge/identityd.toml
+++ b/edgelet/iotedge/test-files/config/nested-edge/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 max_requests = 40
 
 [provisioning]

--- a/edgelet/iotedge/test-files/config/nested-edge/super-config.toml
+++ b/edgelet/iotedge/test-files/config/nested-edge/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 parent_hostname = "my-upstream-device"
 
 [provisioning]

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/identityd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/super-config.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-both-custom/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/identityd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varlib/super-config.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varlib/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/identityd.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/not-socket-activated-varrun/super-config.toml
+++ b/edgelet/iotedge/test-files/config/not-socket-activated-varrun/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/identityd.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/identityd.toml
@@ -3,6 +3,7 @@
 
 hostname = "my-device"
 homedir = "/var/lib/aziot/identityd"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"

--- a/edgelet/iotedge/test-files/config/socket-activated-one-custom/super-config.toml
+++ b/edgelet/iotedge/test-files/config/socket-activated-one-custom/super-config.toml
@@ -1,5 +1,6 @@
 auto_reprovisioning_mode = "OnErrorOnly"
 hostname = "my-device"
+prefer_module_identity_cache = false
 
 [provisioning]
 source = "manual"


### PR DESCRIPTION
Update the iotedge tool for the new option introduced in https://github.com/Azure/iot-identity-service/pull/543