### PR TITLE
Fix Mariner builds

### DIFF
--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -162,11 +162,11 @@ stages:
         displayName: Mariner_Linux
         condition: or(eq(variables['build.linux.mariner'], ''), eq(variables['build.linux.mariner'], true))
         pool:
-          # We are using Linux image that lives in Windows pool. The Windows pool by default uses Standard_D4s_v3 SKU.
-          # EFLOW requires ~85GB to build the edgelet artifacts.
-          name: $(pool.windows.name)
+          name: $(pool.linux.name)
           demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker-large-disk
+          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+          - DiskSizeGiB -equals 100 # EFLOW requires ~85GB to build the edgelet artifacts
+          - WorkFolder -equals /mnt/storage/_work
         strategy:
           matrix:
             CBL-Mariner2.0-amd64:
@@ -250,6 +250,8 @@ stages:
           name: $(pool.linux.arm.name)
           demands:
           - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64
+          - DiskSizeGiB -equals 100 # EFLOW requires ~85GB to build the edgelet artifacts
+          - WorkFolder -equals /mnt/storage/_work
         strategy:
           matrix:
             CBL-Mariner2.0-aarch64:

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -36,10 +36,10 @@ apt-get update -y
 apt-get install -y \
     cmake curl gcc g++ git jq make pkg-config \
     libclang1 libssl-dev llvm-dev \
-    cpio genisoimage golang-1.21-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+    cpio genisoimage golang-1.19-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
 rm -f /usr/bin/go
-ln -vs /usr/lib/go-1.21/bin/go /usr/bin/go
+ln -vs /usr/lib/go-1.19/bin/go /usr/bin/go
 if [ -f /.dockerenv ]; then
     mv /.dockerenv /.dockerenv.old
 fi

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -39,7 +39,7 @@ apt-get install -y \
     cpio genisoimage golang-1.21-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
 rm -f /usr/bin/go
-ln -vs /usr/lib/go-1.17/bin/go /usr/bin/go
+ln -vs /usr/lib/go-1.21/bin/go /usr/bin/go
 if [ -f /.dockerenv ]; then
     mv /.dockerenv /.dockerenv.old
 fi

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -36,7 +36,7 @@ apt-get update -y
 apt-get install -y \
     cmake curl gcc g++ git jq make pkg-config \
     libclang1 libssl-dev llvm-dev \
-    cpio genisoimage golang-1.17-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+    cpio genisoimage golang-1.21-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
 rm -f /usr/bin/go
 ln -vs /usr/lib/go-1.17/bin/go /usr/bin/go


### PR DESCRIPTION
Mariner builds have started failing recently because they install an older version of go that fails a recently-introduced version check (see microsoft/CBL-Mariner#5960 and microsoft/CBL-Mariner#5981).

This change updates the version of go we're using. It also replaces the agent images used for Mariner builds, from one-off, unmaintained images to our standard agent images (with enough disk space to complete the build).

To test, I ran the CI Build pipeline and confirmed the Mariner builds (amd64, arm64) pass.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.