### PR TITLE
Fix Mariner Builds

### DIFF
--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -306,10 +306,9 @@ stages:
           # build iot-identity-service here since they cannot build native aarch64 packages
           - bash: |
               set -ex
-              git clone --recurse-submodules https://github.com/Azure/iot-identity-service.git
+              git clone --recurse-submodules --branch release/1.4 https://github.com/Azure/iot-identity-service.git
               pushd iot-identity-service
               packageVersion=$(git tag | grep 1.4.[0-9]*$ | sort --version-sort -r | head -1)
-              git checkout --recurse-submodules "$packageVersion"
               sudo docker run --rm \
                 -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
                 -e "ARCH=$PACKAGE_ARCH" \

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -162,11 +162,11 @@ stages:
         displayName: Mariner_Linux
         condition: or(eq(variables['build.linux.mariner'], ''), eq(variables['build.linux.mariner'], true))
         pool:
-          # We are using Linux image that lives in Windows pool. The Windows pool by default uses Standard_D4s_v3 SKU.
-          # EFLOW requires ~85GB to build the edgelet artifacts.
-          name: $(pool.windows.name)
+          name: $(pool.linux.name)
           demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker-large-disk
+          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
+          - DiskSizeGiB -equals 100 # EFLOW requires ~85GB to build the edgelet artifacts
+          - WorkFolder -equals /mnt/storage/_work
         strategy:
           matrix:
             CBL-Mariner2.0-amd64:
@@ -250,6 +250,8 @@ stages:
           name: $(pool.linux.arm.name)
           demands:
           - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64
+          - DiskSizeGiB -equals 100 # EFLOW requires ~85GB to build the edgelet artifacts
+          - WorkFolder -equals /mnt/storage/_work
         strategy:
           matrix:
             CBL-Mariner2.0-aarch64:

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -309,6 +309,7 @@ stages:
               git clone --recurse-submodules https://github.com/Azure/iot-identity-service.git
               pushd iot-identity-service
               packageVersion=$(git tag | grep 1.4.[0-9]*$ | sort --version-sort -r | head -1)
+              git checkout --recurse-submodules "$packageVersion"
               sudo docker run --rm \
                 -v "$(Build.SourcesDirectory)/iot-identity-service:/src" \
                 -e "ARCH=$PACKAGE_ARCH" \

--- a/edgelet/build/linux/package-mariner.sh
+++ b/edgelet/build/linux/package-mariner.sh
@@ -36,10 +36,10 @@ apt-get update -y
 apt-get install -y \
     cmake curl gcc g++ git jq make pkg-config \
     libclang1 libssl-dev llvm-dev \
-    cpio genisoimage golang-1.17-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
+    cpio genisoimage golang-1.19-go qemu-utils pigz python3-pip python3-distutils rpm tar wget
 
 rm -f /usr/bin/go
-ln -vs /usr/lib/go-1.17/bin/go /usr/bin/go
+ln -vs /usr/lib/go-1.19/bin/go /usr/bin/go
 if [ -f /.dockerenv ]; then
     mv /.dockerenv /.dockerenv.old
 fi


### PR DESCRIPTION
Cherry-pick 3b4f9e58ae17b9c32df6e685a66dbb9bbebe7083.

Also, when we build iot-identity-service for Mariner arm64, we are currently building Azure/iot-identity-service@main and tagging it as 1.4.x. This is fine for builds in Azure/iotedge@main, but for Azure/iotedge@release/1.4 we want to build Azure/iot-identity-service@release/1.4. This change checks out the release branch before building.

To test, I ran the CI Build pipeline and confirmed the Mariner builds (amd64, arm64) pass.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.