### PR TITLE
Fix ISA95 smoke test pipeline

### DIFF
--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -21,7 +21,7 @@ variables:
   DisableDockerDetector: true
   itProxy: http://10.16.8.4:3128
   otProxy: http://10.16.5.4:3128
-  ressourceGroup: nested-edge-isa95
+  resourceGroup: nested-edge-isa95
   otProxyName: "otproxy"
 
 resources:

--- a/builds/e2e/templates/nested-isa95-lock.yaml
+++ b/builds/e2e/templates/nested-isa95-lock.yaml
@@ -26,7 +26,6 @@ steps:
             --query '[].id'
         )
         echo "$nic_resource"
-        echo ''
         network_interface=$(echo "$nic_resource" | sed -n 's/.*\/\(.*\)/\1/p')
         echo "Network Interface: $network_interface"
         echo ''

--- a/builds/e2e/templates/nested-isa95-lock.yaml
+++ b/builds/e2e/templates/nested-isa95-lock.yaml
@@ -19,7 +19,7 @@ steps:
         echo "Network Interface: $network_interface"
         echo ""
         echo "Get Network Security Group"
-        nicListNsg=$(az network nic list-effective-nsg -g $(ressourceGroup) -n $network_interface  --query 'value[0].networkSecurityGroup')
+        nicListNsg=$(az network nic list-effective-nsg -g $(ressourceGroup) -n $network_interface --query 'value[?contains(keys(association), `networkInterface`)].networkSecurityGroup')
         echo "$nicListNsg"
         tmp=$(echo $nicListNsg | jq -r '.id')
         nsgName=$(echo "$tmp" | sed -n 's/.*\/\(.*\)/\1/p')

--- a/builds/e2e/templates/nested-isa95-lock.yaml
+++ b/builds/e2e/templates/nested-isa95-lock.yaml
@@ -23,7 +23,7 @@ steps:
             --resource-group '$(resourceGroup)' \
             --vm-name '${{ parameters.agentName }}' \
             --output tsv \
-            --query '[].id' | jq -r '.[]'
+            --query '[].id'
         )
         echo "$nic_resource"
         echo ''

--- a/builds/e2e/templates/nested-isa95-lock.yaml
+++ b/builds/e2e/templates/nested-isa95-lock.yaml
@@ -2,34 +2,51 @@ parameters:
   agentName: ''
   lvl: ''
 
-steps: 
+steps:
   - task: Bash@3
     name: isa95_lock_lvl${{ parameters.lvl }}
     displayName: 'Locking network of ${{ parameters.agentName }}'
     inputs:
       targetType: inline
-      script: |     
-        az login --service-principal -p $(edgebuild-service-principal-secret) -u $(servicePrincipal.clientId) --tenant $(servicePrincipal.tenantId)
+      script: |
+        set -e
 
-        echo "Get Network Interface"
-        tmp=$(az vm nic list --resource-group $(ressourceGroup) --vm-name ${{ parameters.agentName }} --query '[].id' | jq -r '.[]')
-        echo "$tmp"
-        echo ""
-        network_interface=$(echo "$tmp" | sed -n 's/.*\/\(.*\)/\1/p')
+        az login \
+          --service-principal \
+          --password '$(edgebuild-service-principal-secret)' \
+          --username '$(servicePrincipal.clientId)' \
+          --tenant '$(servicePrincipal.tenantId)'
+
+        echo 'Get Network Interface'
+        nic_resource=$(
+          az vm nic list \
+            --resource-group '$(resourceGroup)' \
+            --vm-name '${{ parameters.agentName }}' \
+            --output tsv \
+            --query '[].id' | jq -r '.[]'
+        )
+        echo "$nic_resource"
+        echo ''
+        network_interface=$(echo "$nic_resource" | sed -n 's/.*\/\(.*\)/\1/p')
         echo "Network Interface: $network_interface"
-        echo ""
-        echo "Get Network Security Group"
-        nicListNsg=$(az network nic list-effective-nsg -g $(ressourceGroup) -n $network_interface --query 'value[?contains(keys(association), `networkInterface`)].networkSecurityGroup')
-        echo "$nicListNsg"
-        tmp=$(echo $nicListNsg | jq -r '.id')
-        nsgName=$(echo "$tmp" | sed -n 's/.*\/\(.*\)/\1/p')
+        echo ''
+        echo 'Get Network Security Group'
+        nsg_resource=$(
+          az network nic list-effective-nsg \
+            --resource-group '$(resourceGroup)' \
+            --name "$network_interface" \
+            --output tsv \
+            --query 'value[?contains(keys(association), `networkInterface`)].networkSecurityGroup | [0].id'
+        )
+        echo "$nsg_resource"
+        nsgName=$(echo "$nsg_resource" | sed -n 's/.*\/\(.*\)/\1/p')
         echo "Network Security Group: $nsgName"
 
-        echo "lock VMs"
+        echo 'lock VMs'
         az network nsg rule create \
-          --resource-group $(ressourceGroup) \
-          --nsg-name $nsgName \
-          --name "Lock_network" \
+          --resource-group '$(resourceGroup)' \
+          --nsg-name "$nsgName" \
+          --name 'Lock_network' \
           --direction Outbound \
           --protocol '*' \
           --priority 250 \

--- a/builds/e2e/templates/nested-isa95-unlock.yaml
+++ b/builds/e2e/templates/nested-isa95-unlock.yaml
@@ -9,9 +9,13 @@ steps:
     inputs:
       targetType: inline
       script: |     
-        az login --service-principal -p $(edgebuild-service-principal-secret) -u $(servicePrincipal.clientId) --tenant $(servicePrincipal.tenantId)
+        az login \
+          --service-principal \
+          --password '$(edgebuild-service-principal-secret)' \
+          --username '$(servicePrincipal.clientId)' \
+          --tenant '$(servicePrincipal.tenantId)'
  
         az network nsg rule delete \
-        --resource-group $(ressourceGroup) \
-        --nsg-name ${{ parameters.nsgName }} \
-        --name "Lock_network"
+          --resource-group '$(resourceGroup)' \
+          --nsg-name '${{ parameters.nsgName }}' \
+          --name 'Lock_network'


### PR DESCRIPTION
In the setup scripts for the ISA95 smoke test pipeline, an Azure CLI command makes a bad assumption about the returned JSON, causing it to fail. The run does not abort at that point, but later when the corresponding cleanup scripts attempt to undo the earlier setup operation, that call fails and aborts the run with an error.

This change (1) forces the run to abort if the setup commands fail, and (2) fixes the setup command so that it can handle the more complex JSON result we're seeing. I also did some clean up and formatting of the command syntax for consistency.

To test, I ran the ISA95 Smoke Test pipeline, confirmed that it passed, and that the lock/unlock network scripts behaved as expected.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.