### PR TITLE
Remove socket path if it is a directory instead of a file

### DIFF
--- a/edgelet/Cargo.lock
+++ b/edgelet/Cargo.lock
@@ -127,7 +127,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 [[package]]
 name = "aziot-cert-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-key-common",
@@ -140,7 +140,7 @@ dependencies = [
 [[package]]
 name = "aziot-cert-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-key-common",
  "serde",
@@ -149,7 +149,7 @@ dependencies = [
 [[package]]
 name = "aziot-certd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "cert-renewal",
  "hex",
@@ -192,7 +192,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -206,7 +206,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 name = "aziot-identity-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-cert-common-http",
  "aziot-identity-common",
@@ -230,7 +230,7 @@ dependencies = [
 [[package]]
 name = "aziot-identityd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-identity-common",
  "cert-renewal",
@@ -245,7 +245,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -260,7 +260,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-client-async"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-key-common",
  "aziot-key-common-http",
@@ -273,7 +273,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "serde",
 ]
@@ -281,7 +281,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-common-http"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-key-common",
  "http-common",
@@ -291,7 +291,7 @@ dependencies = [
 [[package]]
 name = "aziot-key-openssl-engine"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-key-client",
  "aziot-key-common",
@@ -309,7 +309,7 @@ dependencies = [
 [[package]]
 name = "aziot-keyd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "http-common",
  "libc",
@@ -319,7 +319,7 @@ dependencies = [
 [[package]]
 name = "aziot-keys-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "pkcs11",
  "serde",
@@ -329,7 +329,7 @@ dependencies = [
 [[package]]
 name = "aziot-tpmd-config"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "http-common",
  "serde",
@@ -338,7 +338,7 @@ dependencies = [
 [[package]]
 name = "aziotctl-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "anyhow",
  "aziot-certd-config",
@@ -445,7 +445,7 @@ dependencies = [
 [[package]]
 name = "cert-renewal"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "async-trait",
  "chrono",
@@ -543,7 +543,7 @@ dependencies = [
 [[package]]
 name = "config-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "serde",
  "toml",
@@ -1219,7 +1219,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "async-trait",
  "base64 0.21.2",
@@ -1519,7 +1519,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 [[package]]
 name = "logger"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "env_logger",
  "log",
@@ -1666,7 +1666,7 @@ dependencies = [
 [[package]]
 name = "openssl-build"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "cc",
 ]
@@ -1708,7 +1708,7 @@ dependencies = [
 [[package]]
 name = "openssl-sys2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "openssl-build",
  "openssl-sys",
@@ -1717,7 +1717,7 @@ dependencies = [
 [[package]]
 name = "openssl2"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "foreign-types",
  "foreign-types-shared",
@@ -1777,7 +1777,7 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "pkcs11"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "foreign-types-shared",
  "lazy_static",
@@ -1794,7 +1794,7 @@ dependencies = [
 [[package]]
 name = "pkcs11-sys"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 
 [[package]]
 name = "pkg-config"
@@ -2237,7 +2237,7 @@ dependencies = [
 [[package]]
 name = "test-common"
 version = "0.1.0"
-source = "git+https://github.com/Azure/iot-identity-service?branch=main#61f903baa4083921d7cee63671829c58b97464f9"
+source = "git+https://github.com/Azure/iot-identity-service?branch=main#60e2b18e9461c63a36328b0f0aa07167d2a34a62"
 dependencies = [
  "aziot-identity-common",
  "aziot-identity-common-http",


### PR DESCRIPTION
Updates edgelet's iot-identity-service dependency to the commit that added the fix for a bug causing socket file removal to fail when attempted on a directory instead of a file. See Azure/iot-identity-service#545 for more details.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [x] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [x] Title of the pull request is clear and informative.
- [x] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [ ] concise summary of tests added/modified
	- [ ] local testing done.  

### Draft PRs
- Open the PR in `Draft` mode if it is:
	- Work in progress or not intended to be merged.
	- Encountering multiple pipeline failures and working on fixes.

_Note: We use the kodiakhq bot to merge PRs once the necessary checks and approvals are in place. When it merges a PR, kodiakhq converts the PR title to the commit title, PR description to the commit description, and squashes all the commits in the PR to a single commit. The net effect is that entire PR becomes a single commit. Please follow the best practices mentioned [here](https://chris.beams.io/posts/git-commit/#:~:text=The%20seven%20rules%20of%20a%20great%20Git%20commit,what%20and%20why%20vs.%20how%20For%20example%3A%20) for the PR title and description_
