### PR TITLE
Use up-to-date, maintained agent images in pipelines

### DIFF
--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -90,8 +90,8 @@ jobs:
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
     variables:
-      edgelet.artifact.name: 'iotedged-ubuntu18.04-amd64'
-      aziotis.artifact.name: 'packages_ubuntu-18.04_amd64'
+      edgelet.artifact.name: 'iotedged-ubuntu22.04-amd64'
+      aziotis.artifact.name: 'packages_ubuntu-22.04_amd64'
       aziotis.package.filter: 'aziot-identity-service_*_amd64.deb'
     steps:
       - task: Bash@3

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -88,7 +88,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-msmoby
+        - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
     variables:
       edgelet.artifact.name: 'iotedged-ubuntu18.04-amd64'
       aziotis.artifact.name: 'packages_ubuntu-18.04_amd64'

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -367,7 +367,7 @@ jobs:
     pool:
       name: $(pool.linux.arm.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-mariner-2.0-arm64
+        - ImageOverride -equals agent-aziotedge-mariner-2.0-arm64-msmoby
 
     variables:
       os: linux

--- a/builds/e2e/templates/lock-test-agents.yaml
+++ b/builds/e2e/templates/lock-test-agents.yaml
@@ -9,7 +9,7 @@ jobs:
     pool:
       name: $(pool.linux.name)
       demands:
-        - ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker
+        - ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby
     steps:
       - template: nested-get-secrets.yaml
       - script: scripts/linux/nestedAgentLock.sh -a "$(agent.group)" -b "$(Build.BuildId)" -n ${{ parameters['testRunnerCount'] }} -u ${{ parameters['upstream.protocol'] }}

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -516,13 +516,13 @@ stages:
       displayName: Release Artifact Smoke Tests
       strategy:
         matrix:
-          Ubuntu1804-amd64:
+          Ubuntu2204-amd64:
             pool_name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
             agent_demands: 'ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby'
             os: ubuntu22.04
             arch: amd64
             ext: deb
-          Ubuntu1804-arm64:
+          Ubuntu2204-arm64:
             pool_name: 'Azure-IoT-Edge-1ES-Hosted-Linux-Arm64'
             agent_demands: 'ImageOverride -equals agent-aziotedge-ubuntu-22.04-arm64-msmoby'
             os: ubuntu22.04

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -518,14 +518,14 @@ stages:
         matrix:
           Ubuntu1804-amd64:
             pool_name: 'Azure-IoT-Edge-1ES-Hosted-Linux'
-            agent_demands: 'ImageOverride -equals agent-aziotedge-ubuntu-18.04-docker'
-            os: ubuntu18.04
+            agent_demands: 'ImageOverride -equals agent-aziotedge-ubuntu-22.04-msmoby'
+            os: ubuntu22.04
             arch: amd64
             ext: deb
           Ubuntu1804-arm64:
             pool_name: 'Azure-IoT-Edge-1ES-Hosted-Linux-Arm64'
-            agent_demands: 'ImageOverride -equals agent-aziotedge-ubuntu-18.04-arm64'
-            os: ubuntu18.04
+            agent_demands: 'ImageOverride -equals agent-aziotedge-ubuntu-22.04-arm64-msmoby'
+            os: ubuntu22.04
             arch: arm64
             ext: deb
 
@@ -584,11 +584,11 @@ stages:
 
           if [[ "$(os)" == "ubuntu"* ]]; then
           # Ubuntu
-            if [[ "$(os)" == *"20.04" ]]; then
+            if [[ "$(os)" == *"22.04" ]]; then
+              setup-config-apt "https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb"
+            elif [[ "$(os)" == *"20.04" ]]; then
               setup-focal-source-apt
               setup-config-apt "https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb"
-            elif [[ "$(os)" == *"18.04" ]]; then
-              setup-config-apt "https://packages.microsoft.com/config/ubuntu/18.04/multiarch/packages-microsoft-prod.deb"
             else
               echo "Unsupported OS: $(os)"
               exit 1;

--- a/builds/misc/templates/build-packages.yaml
+++ b/builds/misc/templates/build-packages.yaml
@@ -249,7 +249,7 @@ stages:
         pool:
           name: $(pool.linux.arm.name)
           demands:
-          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64
+          - ImageOverride -equals agent-aziotedge-ubuntu-20.04-arm64-docker
           - DiskSizeGiB -equals 100 # EFLOW requires ~85GB to build the edgelet artifacts
           - WorkFolder -equals /mnt/storage/_work
         strategy:


### PR DESCRIPTION
Some of our CI/test/release pipelines are using 1ES-hosted agent images which are either outdated or unmaintained. To clarify, the "unmaintained" images still receive OS security patches, but they were originally built by hand and are not managed by our internal automated processes.
- CI build uses an unmaintained agent image to build Mariner 2.0 arm64
- Connectivity tests use outdated agent images
- End-to-end tests use an unmaintained agent image to test Mariner 2.0 arm64
- Nested end-to-end tests use an outdated agent image for some early test setup logic
- Package release pipeline uses an outdated agent image and an unmaintained agent image for post-release smoke tests

This change updates outdated agent images to the latest Ubuntu, and updates unmaintained agent images to their maintained equivalents.

To test, I ran each of the affected pipelines and confirmed they run/pass using the updated agent images. Note that I couldn't test the updates to the end-to-end tests and the package release pipeline change because the impacted jobs are currently disabled.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.