### PR TITLE
snapping: add docker permissions to configure hook

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -145,6 +145,7 @@ hooks:
   configure:
     plugs:
       - aziotctl-executables
+      - docker
       - hostname-control
       - identity-service
       - log-observe


### PR DESCRIPTION
This (in conjunction with proper runtime interface connections) should resolve the check failures.