### PR TITLE
Update ESRP Codesign

### DIFF
--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -39,230 +39,134 @@ stages:
         # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).
         - template: ../templates/force-dotnet21.yaml
         # Code Sign
-        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3
           displayName: "Edge Agent Code Sign"
           inputs:
-            ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+            ConnectedServiceName: "aziotedge-pmc-v4-prod"
             FolderPath: $(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Agent.Service
             Pattern: Microsoft.Azure.Devices.Edge.*.dll
             SessionTimeout: 20
             inlineOperation: |
-                [
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolSign",
-                      "parameters": [
-                      {
-                          "parameterName": "OpusName",
-                          "parameterValue": "Microsoft"
-                      },
-                      {
-                          "parameterName": "OpusInfo",
-                          "parameterValue": "http://www.microsoft.com"
-                      },
-                      {
-                          "parameterName": "Append",
-                          "parameterValue": "/as"
-                      },
-                      {
-                          "parameterName": "FileDigest",
-                          "parameterValue": "/fd \"SHA256\""
-                      },
-                      {
-                          "parameterName": "PageHash",
-                          "parameterValue": "/NPH"
-                      },
-                      {
-                          "parameterName": "TimeStamp",
-                          "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                  },
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolVerify",
-                      "parameters": [
-                      {
-                          "parameterName": "VerifyAll",
-                          "parameterValue": "/all"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
+              [
+                {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolSign",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {
+                  "OpusName": "Microsoft",
+                  "OpusInfo": "https://www.microsoft.com",
+                  "FileDigest": "/fd SHA256",
+                  "PageHash": "/NPH",
+                  "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
                   }
-                ]
+                },
+                {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolVerify",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {}
+                }
+              ]
             signConfigType: inlineSignParams
-        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3
           displayName: "Edge Hub Code Sign"
           inputs:
-            ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+            ConnectedServiceName: "aziotedge-pmc-v4-prod"
             FolderPath: $(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Hub.Service
             Pattern: "Microsoft.Azure.Devices.Edge.*.dll,Microsoft.Azure.Devices.Routing.*.dll"
             SessionTimeout: 20
             inlineOperation: |
-                [
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolSign",
-                      "parameters": [
-                      {
-                          "parameterName": "OpusName",
-                          "parameterValue": "Microsoft"
-                      },
-                      {
-                          "parameterName": "OpusInfo",
-                          "parameterValue": "http://www.microsoft.com"
-                      },
-                      {
-                          "parameterName": "Append",
-                          "parameterValue": "/as"
-                      },
-                      {
-                          "parameterName": "FileDigest",
-                          "parameterValue": "/fd \"SHA256\""
-                      },
-                      {
-                          "parameterName": "PageHash",
-                          "parameterValue": "/NPH"
-                      },
-                      {
-                          "parameterName": "TimeStamp",
-                          "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                  },
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolVerify",
-                      "parameters": [
-                      {
-                          "parameterName": "VerifyAll",
-                          "parameterValue": "/all"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
+              [
+                {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolSign",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {
+                  "OpusName": "Microsoft",
+                  "OpusInfo": "https://www.microsoft.com",
+                  "FileDigest": "/fd SHA256",
+                  "PageHash": "/NPH",
+                  "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
                   }
-                ]
+                },
+                {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolVerify",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {}
+                }
+              ]
             signConfigType: inlineSignParams
-        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3
           displayName: "Temp Sensor Code Sign"
           inputs:
-            ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+            ConnectedServiceName: "aziotedge-pmc-v4-prod"
             FolderPath: $(Build.BinariesDirectory)/publish/SimulatedTemperatureSensor
             Pattern: "Microsoft.Azure.Devices.Edge.*.dll,SimulatedTemperatureSensor.dll"
             SessionTimeout: 20
             inlineOperation: |
-                [
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolSign",
-                      "parameters": [
-                      {
-                          "parameterName": "OpusName",
-                          "parameterValue": "Microsoft"
-                      },
-                      {
-                          "parameterName": "OpusInfo",
-                          "parameterValue": "http://www.microsoft.com"
-                      },
-                      {
-                          "parameterName": "Append",
-                          "parameterValue": "/as"
-                      },
-                      {
-                          "parameterName": "FileDigest",
-                          "parameterValue": "/fd \"SHA256\""
-                      },
-                      {
-                          "parameterName": "PageHash",
-                          "parameterValue": "/NPH"
-                      },
-                      {
-                          "parameterName": "TimeStamp",
-                          "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                  },
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolVerify",
-                      "parameters": [
-                      {
-                          "parameterName": "VerifyAll",
-                          "parameterValue": "/all"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
+              [
+                {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolSign",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {
+                  "OpusName": "Microsoft",
+                  "OpusInfo": "https://www.microsoft.com",
+                  "FileDigest": "/fd SHA256",
+                  "PageHash": "/NPH",
+                  "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
                   }
-                ]
+                },
+                {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolVerify",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {}
+                }
+              ]
             signConfigType: inlineSignParams
-        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3
           displayName: "Functions Binding Code Sign"
           inputs:
-            ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+            ConnectedServiceName: "aziotedge-pmc-v4-prod"
             FolderPath: $(Build.BinariesDirectory)/publish/Microsoft.Azure.WebJobs.Extensions.EdgeHub
             Pattern: Microsoft.Azure.WebJobs.Extensions*.dll
             SessionTimeout: 20
             inlineOperation: |
-                [
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolSign",
-                      "parameters": [
-                      {
-                          "parameterName": "OpusName",
-                          "parameterValue": "Microsoft"
-                      },
-                      {
-                          "parameterName": "OpusInfo",
-                          "parameterValue": "http://www.microsoft.com"
-                      },
-                      {
-                          "parameterName": "Append",
-                          "parameterValue": "/as"
-                      },
-                      {
-                          "parameterName": "FileDigest",
-                          "parameterValue": "/fd \"SHA256\""
-                      },
-                      {
-                          "parameterName": "PageHash",
-                          "parameterValue": "/NPH"
-                      },
-                      {
-                          "parameterName": "TimeStamp",
-                          "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
-                  },
-                  {
-                      "keyCode": "CP-230012",
-                      "operationSetCode": "SigntoolVerify",
-                      "parameters": [
-                      {
-                          "parameterName": "VerifyAll",
-                          "parameterValue": "/all"
-                      }
-                      ],
-                      "toolName": "sign",
-                      "toolVersion": "1.0"
+              [
+                {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolSign",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {
+                  "OpusName": "Microsoft",
+                  "OpusInfo": "https://www.microsoft.com",
+                  "FileDigest": "/fd SHA256",
+                  "PageHash": "/NPH",
+                  "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
                   }
-                ]
+                },
+                {
+                  "KeyCode": "CP-230012",
+                  "OperationCode": "SigntoolVerify",
+                  "ToolName": "sign",
+                  "ToolVersion": "1.0",
+                  "Parameters": {}
+                }
+              ]
             signConfigType: inlineSignParams
-        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+        - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3
           displayName: "Functions Binding nuget package Sign"
           inputs:
-            ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+            ConnectedServiceName: "aziotedge-pmc-v4-prod"
             FolderPath: $(Build.BinariesDirectory)/publish
             Pattern: Microsoft.Azure.WebJobs.Extensions*.nupkg
             inlineOperation: |

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -35,9 +35,6 @@ stages:
             packagesToPack: "**/Microsoft.Azure.WebJobs.Extensions.EdgeHub.csproj"
             versionEnvVar: version
             versioningScheme: byEnvVar
-        # The code sign task requires .NET Core 2.1.
-        # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).
-        - template: ../templates/force-dotnet21.yaml
         # Code Sign
         - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3
           displayName: "Edge Agent Code Sign"
@@ -187,8 +184,6 @@ stages:
                   }
                 ]
             signConfigType: inlineSignParams
-        # We're done with code signing, so remove dotnet version override
-        - template: ../templates/restore-default-dotnet.yaml
         - bash: |
             mkdir $(Build.ArtifactStagingDirectory)/publish-linux && \
             mv $(Build.BinariesDirectory)/publish/{CACertificates,scripts,*.nupkg} \

--- a/builds/release/metrics-collector-images-release.yaml
+++ b/builds/release/metrics-collector-images-release.yaml
@@ -28,10 +28,6 @@ jobs:
         -c Release
     displayName: Build
 
-  # The code sign task requires .NET Core 2.1.
-  # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).
-  - template: ../templates/force-dotnet21.yaml
-  # Code Sign
   - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
     displayName: "Metrics Collector Code Sign"
     inputs:
@@ -87,8 +83,6 @@ jobs:
             }
           ]
       signConfigType: inlineSignParams
-  # We're done with code signing, so remove dotnet version override
-  - template: ../templates/restore-default-dotnet.yaml
 
   - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
     displayName: Generate SBOM

--- a/builds/release/refresh-core-images.yaml
+++ b/builds/release/refresh-core-images.yaml
@@ -273,10 +273,10 @@ stages:
         path: $(Build.BinariesDirectory)/publish/Microsoft.Azure.WebJobs.Extensions.EdgeHub
         pattern: Microsoft.Azure.WebJobs.Extensions*.dll
 
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3
       displayName: Sign Functions Binding nuget package
       inputs:
-        ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+        ConnectedServiceName: "aziotedge-pmc-v4-prod"
         FolderPath: $(Build.BinariesDirectory)/publish
         Pattern: Microsoft.Azure.WebJobs.Extensions*.nupkg
         inlineOperation: |

--- a/builds/release/refresh-core-images.yaml
+++ b/builds/release/refresh-core-images.yaml
@@ -244,10 +244,6 @@ stages:
         versionEnvVar: version
         versioningScheme: byEnvVar
 
-    # The code sign task requires .NET Core 2.1.
-    # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).
-    - template: ../templates/force-dotnet21.yaml
-
     # Code Sign
     - template: templates/dotnet-code-sign.yaml
       parameters:
@@ -297,9 +293,6 @@ stages:
             }
           ]
         signConfigType: inlineSignParams
-
-    # We're done with code signing, so remove dotnet version override
-    - template: ../templates/restore-default-dotnet.yaml
 
     - task: PublishBuildArtifacts@1
       displayName: Publish .NET Artifacts

--- a/builds/release/refresh-metrics-collector-images.yaml
+++ b/builds/release/refresh-metrics-collector-images.yaml
@@ -223,19 +223,11 @@ stages:
           -c Release
       displayName: Build
 
-    # The code sign task requires .NET Core 2.1.
-    # TODO: Investigate why we have to toggle primary installs on linux, when we didn't have to do this on windows (now removed).
-    - template: ../templates/force-dotnet21.yaml
-
-    # Code Sign
     - template: templates/dotnet-code-sign.yaml
       parameters:
         name: Sign Metrics Collector
         path: $(Build.BinariesDirectory)/publish/Microsoft.Azure.Devices.Edge.Azure.Monitor
         pattern: Microsoft.Azure.Devices.Edge.Azure.Monitor*.dll
-
-    # We're done with code signing, so remove dotnet version override
-    - template: ../templates/restore-default-dotnet.yaml
 
     - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
       displayName: Generate SBOM

--- a/builds/release/templates/dotnet-code-sign.yaml
+++ b/builds/release/templates/dotnet-code-sign.yaml
@@ -10,58 +10,34 @@ parameters:
     default: ''
 
 steps:
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@3
   displayName: ${{ parameters.name }}
   inputs:
-    ConnectedServiceName: "Azure IoT Edge Code Sign 2"
+    ConnectedServiceName: "aziotedge-pmc-v4-prod"
     FolderPath: ${{ parameters.path }}
     Pattern: ${{ parameters.pattern }}
     SessionTimeout: 20
     inlineOperation: |
       [
         {
-            "keyCode": "CP-230012",
-            "operationSetCode": "SigntoolSign",
-            "parameters": [
-            {
-                "parameterName": "OpusName",
-                "parameterValue": "Microsoft"
-            },
-            {
-                "parameterName": "OpusInfo",
-                "parameterValue": "http://www.microsoft.com"
-            },
-            {
-                "parameterName": "Append",
-                "parameterValue": "/as"
-            },
-            {
-                "parameterName": "FileDigest",
-                "parameterValue": "/fd \"SHA256\""
-            },
-            {
-                "parameterName": "PageHash",
-                "parameterValue": "/NPH"
-            },
-            {
-                "parameterName": "TimeStamp",
-                "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-            }
-            ],
-            "toolName": "sign",
-            "toolVersion": "1.0"
+          "KeyCode": "CP-230012",
+          "OperationCode": "SigntoolSign",
+          "ToolName": "sign",
+          "ToolVersion": "1.0",
+          "Parameters": {
+          "OpusName": "Microsoft",
+          "OpusInfo": "https://www.microsoft.com",
+          "FileDigest": "/fd SHA256",
+          "PageHash": "/NPH",
+          "TimeStamp": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+          }
         },
         {
-            "keyCode": "CP-230012",
-            "operationSetCode": "SigntoolVerify",
-            "parameters": [
-            {
-                "parameterName": "VerifyAll",
-                "parameterValue": "/all"
-            }
-            ],
-            "toolName": "sign",
-            "toolVersion": "1.0"
+          "KeyCode": "CP-230012",
+          "OperationCode": "SigntoolVerify",
+          "ToolName": "sign",
+          "ToolVersion": "1.0",
+          "Parameters": {}
         }
       ]
     signConfigType: inlineSignParams

--- a/builds/templates/force-dotnet21.yaml
+++ b/builds/templates/force-dotnet21.yaml
@@ -1,7 +1,0 @@
-# Add a global.json file to the root of the source code directory. This will override .NET's
-# default behavior when determining which version of the runtime to use. Instead, .NET will
-# use the version we specify here.
-steps:
-  - bash: |
-      dotnet new globaljson --force --sdk-version 2.1
-    displayName: Use .NET Core 2.1

--- a/builds/templates/restore-default-dotnet.yaml
+++ b/builds/templates/restore-default-dotnet.yaml
@@ -1,7 +1,0 @@
-# Remove the global.json file from the root of the source code directory, if it exists. This will
-# remove any overrides, allowing .NET to use its default behavior (use latest) when determining
-# which version of the runtime to use.
-steps:
-  - bash: |
-      rm -f -v global.json
-    displayName: Restore default .NET version


### PR DESCRIPTION
Cherry-pick 239bf48e13ee54b24a8200995b2002f60f762dc7.

Also, this change removes the pipeline template that forces .NET to version 2.1 for the code signing step. Since we upgraded the version of the code signing task we use in the pipeline, this step is no longer required.