### PR TITLE
Don't run CodeQL in the release branch

### DIFF
--- a/builds/checkin/e2e-checkin.yaml
+++ b/builds/checkin/e2e-checkin.yaml
@@ -14,6 +14,7 @@ pr:
       - release/1.1-k8s-preview
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 resources:

--- a/builds/ci/dotnet.yaml
+++ b/builds/ci/dotnet.yaml
@@ -6,6 +6,7 @@ trigger:
       - release/*
 pr: none
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
   build.configuration: Release
   test.filter: Category=Integration&Category!=Stress

--- a/builds/e2e/connectivity.yaml
+++ b/builds/e2e/connectivity.yaml
@@ -25,6 +25,7 @@ schedules:
   always: true
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
   images.artifact.name.linux: 'core-linux'
 

--- a/builds/e2e/e2e.yaml
+++ b/builds/e2e/e2e.yaml
@@ -12,6 +12,7 @@ resources:
       - release/*
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
   # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
   # environments that are very similar to other platforms/environments in our matrix, Ubuntu 20.04

--- a/builds/e2e/isa-95-smoke-test.yaml
+++ b/builds/e2e/isa-95-smoke-test.yaml
@@ -18,6 +18,7 @@ schedules:
   always: true
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
   itProxy: http://10.16.8.4:3128
   otProxy: http://10.16.5.4:3128

--- a/builds/e2e/longhaul.yaml
+++ b/builds/e2e/longhaul.yaml
@@ -9,6 +9,7 @@ schedules:
   always: true
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
   images.artifact.name.linux: 'core-linux'
   vsts.project: $(System.TeamProjectId)

--- a/builds/e2e/nested-e2e.yaml
+++ b/builds/e2e/nested-e2e.yaml
@@ -19,6 +19,7 @@ schedules:
   always: true
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
   # A 'minimal' pipeline only runs one end-to-end test (TempSensor). This is useful for platforms or
   # environments that are very similar to other platforms/environments in our matrix, Ubuntu 20.04

--- a/builds/e2e/nested-longhaul.yaml
+++ b/builds/e2e/nested-longhaul.yaml
@@ -9,6 +9,7 @@ schedules:
   always: true
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 resources:

--- a/builds/misc/addons-publish.yaml
+++ b/builds/misc/addons-publish.yaml
@@ -3,6 +3,7 @@ trigger: none
 pr: none
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 jobs:

--- a/builds/misc/addons-release.yaml
+++ b/builds/misc/addons-release.yaml
@@ -3,6 +3,7 @@ trigger: none
 pr: none
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
   NugetSecurityAnalysisWarningLevel: warn
 

--- a/builds/misc/ci-build.yaml
+++ b/builds/misc/ci-build.yaml
@@ -7,6 +7,7 @@ trigger:
 pr: none
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 stages:

--- a/builds/misc/images-publish.yaml
+++ b/builds/misc/images-publish.yaml
@@ -2,6 +2,7 @@ trigger: none
 pr: none
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 resources:

--- a/builds/misc/images-release.yaml
+++ b/builds/misc/images-release.yaml
@@ -4,6 +4,7 @@ trigger: none
 pr: none
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -3,6 +3,7 @@ trigger: none
 pr: none
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 resources:

--- a/builds/release/detect-image-updates.yaml
+++ b/builds/release/detect-image-updates.yaml
@@ -19,8 +19,9 @@ resources:
     name: Azure/azure-iotedge
 
 variables:
-  NugetSecurityAnalysisWarningLevel: warn
+  Codeql.Enabled: false
   DisableDockerDetector: true
+  NugetSecurityAnalysisWarningLevel: warn
 
 pool:
   name: $(pool.linux.name)

--- a/builds/release/refresh-core-images.yaml
+++ b/builds/release/refresh-core-images.yaml
@@ -16,6 +16,7 @@ resources:
     name: Azure/azure-iotedge
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 stages:

--- a/builds/service/service-deployment.yaml
+++ b/builds/service/service-deployment.yaml
@@ -11,6 +11,7 @@ schedules:
   always: true
 
 variables:
+  Codeql.Enabled: false
   DisableDockerDetector: true
 
 pool:


### PR DESCRIPTION
Cherry-pick cc943a9bb3eda9da9dea3c232acae420702b1872.

Note that we didn't cherry-pick d64b4d2f9460b41cb36054f533da82d3a1e0e697 because we're only going to run CodeQL in the main branch, per the internal recommendation.