### PR TITLE
Upgrade Functions sample to remove dependency on .NET Core 3.1

### DIFF
--- a/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
+++ b/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <!--
       We have a transitive dependency on System.Net.Http via Microsoft.NET.Sdk.Functions/3.0.13.
       Use an explicit reference here to override the version and fix a vulnerability. See


### PR DESCRIPTION
The Azure Functions module sample hasn't been updated in a while. It still depends on a .NET Core 3.1-based version of the Microsoft.NET.Sdk.Functions package. To remove our dependency on .NET Core 3.1 (which is out of support), this change upgrades the package to the latest version, which is based on .NET 6.0.

To test, I ran CI Build to get the bits, and then ran the end-to-end test pipeline. The test "TempFilterFunc" tests basic functionality of this sample.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.