### PR TITLE
Upgrade Functions sample to remove dependency on .NET Core 3.1

### DIFF
--- a/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
+++ b/edge-modules/functions/samples/EdgeHubTrigger-Csharp/EdgeHubTriggerCSharp.csproj
@@ -19,8 +19,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.2.0" />
     <!--
       We have a transitive dependency on System.Net.Http via Microsoft.NET.Sdk.Functions/3.0.13.
       Use an explicit reference here to override the version and fix a vulnerability. See


### PR DESCRIPTION
Cherry-pick 2f4abb22fee706c201f138442ac9622efbb68f01.