### PR TITLE
Fix variable reference in packages release script

### DIFF
--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -157,15 +157,15 @@ stages:
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
     jobs:
-    # - deployment: safe_guard
-    #   environment: 'Azure-IoT-Edge-Core Release Env'
-    #   displayName: Get Approval
-    #   strategy:
-    #     runOnce:
-    #       deploy:
-    #         steps:
-    #           - bash: |
-    #               echo "Approval Complete"
+    - deployment: safe_guard
+      environment: 'Azure-IoT-Edge-Core Release Env'
+      displayName: Get Approval
+      strategy:
+        runOnce:
+          deploy:
+            steps:
+              - bash: |
+                  echo "Approval Complete"
     - job: linux
       displayName: Linux
       strategy:

--- a/builds/misc/packages-release.yaml
+++ b/builds/misc/packages-release.yaml
@@ -157,15 +157,15 @@ stages:
       demands:
         - ImageOverride -equals agent-aziotedge-ubuntu-20.04-docker
     jobs:
-    - deployment: safe_guard
-      environment: 'Azure-IoT-Edge-Core Release Env'
-      displayName: Get Approval
-      strategy:
-        runOnce:
-          deploy:
-            steps:
-              - bash: |
-                  echo "Approval Complete"
+    # - deployment: safe_guard
+    #   environment: 'Azure-IoT-Edge-Core Release Env'
+    #   displayName: Get Approval
+    #   strategy:
+    #     runOnce:
+    #       deploy:
+    #         steps:
+    #           - bash: |
+    #               echo "Approval Complete"
     - job: linux
       displayName: Linux
       strategy:

--- a/scripts/linux/publishReleasePackages.sh
+++ b/scripts/linux/publishReleasePackages.sh
@@ -152,7 +152,7 @@ sudo rm -rf $WDIR/private-key.pem || true
 sudo rm -f $SETTING_FILE || true
 
 #Download Secrets - Requires az login and proper subscription to be selected
-az keyvault secret download --vault-name $(kv.name.release) \
+az keyvault secret download --vault-name $KV_NAME_RELEASE \
     -n iotedge-pmc-client-auth-prod \
     -o tsv \
     --query 'value' \


### PR DESCRIPTION
A script in our packages release pipeline referenced a variable using ADO pipeline variable syntax, which isn't available within a bash script. ADO makes pipeline variables available to bash scripts as environment variables with a certain naming convention, so I fixed the script by using that syntax instead.

I ran the release pipeline and confirmed that it succeeded.

## Azure IoT Edge PR checklist:

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines and Best Practices
- [X] I have read the [contribution guidelines](https://github.com/azure/iotedge#contributing).
- [X] Title of the pull request is clear and informative.
- [X] Description of the pull request includes a concise summary of the enhancement or bug fix.

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
- Description of the pull request includes 
	- [X] concise summary of tests added/modified
	- [X] local testing done.